### PR TITLE
[#108441598] Initial commit to create bastion host

### DIFF
--- a/tf/aws-vpc.tf
+++ b/tf/aws-vpc.tf
@@ -1,0 +1,11 @@
+provider "aws" {
+  region      = "${var.region}"
+}
+
+resource "aws_vpc" "default" {
+  cidr_block = "${var.vpc_cidr}"
+  enable_dns_hostnames = true
+  tags {
+    Name = "${var.env}-paas"
+  }
+}

--- a/tf/bastion.tf
+++ b/tf/bastion.tf
@@ -1,0 +1,26 @@
+resource "aws_instance" "bastion" {
+  ami = "${lookup(var.ubuntu_amis, var.region)}"
+  instance_type = "t2.micro"
+  subnet_id = "${aws_subnet.infra.0.id}"
+  private_ip = "10.0.0.4"
+  associate_public_ip_address = true
+  vpc_security_group_ids = ["${aws_security_group.bastion.id}"]
+  key_name = "${aws_key_pair.cloudfoundry.key_name}"
+  source_dest_check = false
+  user_data = "#cloud-config\nhostname: ${var.env}-bastion"
+
+  root_block_device = {
+    volume_type = "gp2"
+    volume_size = 100
+  }
+
+  tags = {
+    Name = "${var.env}-bastion"
+  }
+
+  connection {
+    user = "ubuntu"
+    key_file = "~/.ssh/id_rsa"
+  }
+
+}

--- a/tf/dns-records.tf
+++ b/tf/dns-records.tf
@@ -1,0 +1,7 @@
+resource "aws_route53_record" "bastion" {
+  zone_id = "${var.dns_zone_id}"
+  name = "${var.env}-bastion.${var.dns_zone_name}."
+  type = "A"
+  ttl = "60"
+  records = ["${aws_instance.bastion.public_ip}"]
+}

--- a/tf/globals.tf
+++ b/tf/globals.tf
@@ -1,0 +1,13 @@
+variable "env" {
+  description = "Environment name"
+}
+
+variable "office_cidrs" {
+  description = "CSV of CIDR addresses for our office which will be trusted"
+  default     = "80.194.77.90/32,80.194.77.100/32"
+}
+
+variable "ssh_user" {
+  description = "Username used to ssh into VMs."
+  default     = "ubuntu"
+}

--- a/tf/infra-subnet.tf
+++ b/tf/infra-subnet.tf
@@ -1,0 +1,37 @@
+resource "aws_internet_gateway" "default" {
+  vpc_id = "${aws_vpc.default.id}"
+}
+
+resource "aws_route_table" "internet" {
+  vpc_id = "${aws_vpc.default.id}"
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.default.id}"
+  }
+}
+
+resource "aws_route_table" "infra" {
+  vpc_id = "${aws_vpc.default.id}"
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.default.id}"
+  }
+}
+
+resource "aws_subnet" "infra" {
+  count             = 2
+  vpc_id            = "${aws_vpc.default.id}"
+  cidr_block        = "${lookup(var.infra_cidrs, concat("zone", count.index))}"
+  availability_zone = "${lookup(var.zones, concat("zone", count.index))}"
+  map_public_ip_on_launch = true
+  depends_on = ["aws_internet_gateway.default"]
+  tags {
+    Name = "${var.env}-infra-subnet-${count.index}"
+  }
+}
+
+resource "aws_route_table_association" "infra" {
+  count = 2
+  subnet_id = "${element(aws_subnet.infra.*.id, count.index)}"
+  route_table_id = "${aws_route_table.infra.id}"
+}

--- a/tf/key-pair.tf
+++ b/tf/key-pair.tf
@@ -1,0 +1,4 @@
+resource "aws_key_pair" "cloudfoundry" {
+  key_name = "${var.env}-key" 
+  public_key = "${file("~/.ssh/id_rsa.pub")}"
+}

--- a/tf/outputs.tf
+++ b/tf/outputs.tf
@@ -1,0 +1,32 @@
+output "bastion_ip" {
+  value = "${aws_instance.bastion.public_ip}"
+}
+
+output "environment" {
+	value = "${var.env}"
+}
+
+output "zone0" {
+	value = "${var.zones.zone0}"
+}
+
+output "zone1" {
+	value = "${var.zones.zone1}"
+}
+
+output "region" {
+	value = "${var.region}"
+}
+
+output "dns_zone_name" {
+        value = "${var.dns_zone_name}"
+}
+
+
+output "aws_secret_access_key" {
+	value = "${var.AWS_SECRET_ACCESS_KEY}"
+}
+
+output "aws_access_key_id" {
+       value = "${var.AWS_ACCESS_KEY_ID}"
+}

--- a/tf/security-groups.tf
+++ b/tf/security-groups.tf
@@ -1,0 +1,24 @@
+resource "aws_security_group" "bastion" {
+  name = "${var.env}-bastion"
+  description = "Security group for bastion that allows NAT traffic and SSH connections from the office and jenkins"
+  vpc_id = "${aws_vpc.default.id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+
+  ingress {
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+    cidr_blocks = ["${split(",", var.office_cidrs)}"]
+  }
+
+  tags {
+    Name = "${var.env}-bastion"
+  }
+}

--- a/tf/variables.tf
+++ b/tf/variables.tf
@@ -1,0 +1,83 @@
+variable "region"     {
+  description = "AWS region"
+  default     = "eu-west-1"
+}
+
+variable "zones" {
+  description = "AWS availability zones"
+  default     = {
+    zone0 = "eu-west-1a"
+    zone1 = "eu-west-1b"
+    zone2 = "eu-west-1c"
+  }
+}
+
+variable "vpc_cidr" {
+  description = "CIDR for VPC"
+  default     = "10.0.0.0/16"
+}
+
+variable "infra_cidrs" {
+  description = "CIDR for infrastructure subnet indexed by AZ"
+  default     = {
+    zone0 = "10.0.0.0/24"
+    zone1 = "10.0.1.0/24"
+    zone2 = "10.0.2.0/24"
+  }
+}
+
+variable "ubuntu_amis" {
+  description = "Base AMI to launch the instances with"
+  default = {
+    eu-west-1 = "ami-234ecc54"
+    eu-central-1 = "ami-9a380b87"
+  }
+}
+
+
+variable "health_check_interval" {
+  description = "Interval between requests for load balancer health checks"
+  default     = 5
+}
+
+variable "health_check_timeout" {
+  description = "Timeout of requests for load balancer health checks"
+  default     = 2
+}
+
+variable "health_check_healthy" {
+  description = "Threshold to consider load balancer healthy"
+  default     = 2
+}
+
+variable "health_check_unhealthy" {
+  description = "Threshold to consider load balancer unhealthy"
+  default     = 2
+}
+
+variable "elb_idle_timeout" {
+  description = "Timeout idle connections after 300 seconds"
+  default     = 300
+}
+
+variable "dns_zone_id" {
+  description = "Amazon Route53 DNS zone identifier"
+  default = "Z3SI0PSH6KKVH4"
+}
+
+variable "dns_zone_name" {
+  description = "Amazon Route53 DNS zone name"
+  default     = "dev.paas.alphagov.co.uk"
+}
+
+# Terraform currently only has limited support for reading environment variables
+# Variables for use with terraform must be prefexed with 'TF_VAR_'
+# These two variables are passed in as environment variables named:
+# TF_VAR_AWS_ACCESS_KEY_ID and TF_VAR_AWS_SECRET_ACCESS_KEY respectively
+variable "AWS_ACCESS_KEY_ID" {
+  description = "AWS access key to be pass to the bosh CPI"
+}
+
+variable "AWS_SECRET_ACCESS_KEY" {
+  description = "AWS secret access key to be pass to the bosh CPI"
+}


### PR DESCRIPTION
# What
This creates a new-style bastion host, without NAT and using our own SSH keys rather than insecure-deployer.

It should be noted that it will automatically upload your SSH public key to amazon and assumes that your key is called ```~/.ssh/id_rsa``` and ```~/.ssh/id_rsa.pub```.

# Details
- Bastion host is created and hostname configured correctly.
- User data is used to pass hostname to cloud-init.
- Also we now use user ssh keys which are uploaded by terraform.
- NAT was removed.

# How to test

``` terraform apply -var env=piotr -state=piotr.tfstate```
```terraform destroy -var env=piotr -state=piotr.tfstate -var force_destroy=true```

# Who can test

Anyone but @combor and @Jonty  