### PR TITLE
[#109030954 #109540406] Use sh instead of bash for tf-destroy.sh

### DIFF
--- a/concourse/scripts/tf-destroy.sh
+++ b/concourse/scripts/tf-destroy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 [[ -z "${DEPLOY_ENV}" ]]    && echo "DEPLOY_ENV not set"    && exit 100

--- a/concourse/tasks/tf-destroy.yml
+++ b/concourse/tasks/tf-destroy.yml
@@ -4,7 +4,7 @@ platform: linux
 image: docker:///governmentpaas/docker-terraform
 
 run:
-  path: bash
+  path: sh
   args:
   - -c
   - paas-cf/concourse/scripts/tf-destroy.sh


### PR DESCRIPTION
We changed the Terraform container to use Alpine Linux instead of Ubuntu in
alphagov/paas-docker-terraform#6 which doesn't contain `bash` and causes the
destroy pipeline to fail:

    ➜  paas-cf git:(master) ./concourse/scripts/destroy.sh dcarley
    …
    unpaused 'destroy-cf'
    using version of resource found in cache
    using version of resource found in cache
    initializing with docker:///governmentpaas/docker-terraform
    running bash -c paas-cf/concourse/scripts/tf-destroy.sh
    proc_starter: ExecAsUser: system: program 'bash' was not found in $PATH: exec: "bash": executable file not found in $PATH
    failed

So we need to use plain `sh` instead. There aren't any `bash` specific features
in this script. Technically the shebang could be left, because calling `sh -c`
bypasses it, but we should keep them the same for consistency.

---

You'll need to specify a branch to test this, because the task fetches a new copy of the repo from git:
```
./concourse/scripts/deploy.sh <env>
BRANCH=destroy_bash_alpine ./concourse/scripts/destroy.sh <env>
```