### PR TITLE
[#109515840] Fix typo in Vagrantfile vm.box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "concourse/liteconcourse/liteconcourse/lite"
+  config.vm.box = "concourse/lite"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs


### PR DESCRIPTION
Looks like a vim whoopsie that repeated the text three times. This was fixed
in #6, but the commits were lost just prior to merging.