### PR TITLE
[#109515840] Add .vagrant/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/*.tfstate
+.vagrant/


### PR DESCRIPTION
Vagrant creates this when you bring a up a box using the `Vagrantfile` in
this repo. The directory contains state and should never be committed back.