### PR TITLE
[#109515840] Remove TF_VAR_ environment vars from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Provide AWS access keys as environment variables, plus the corresponding terrafo
 ```
 export AWS_ACCESS_KEY_ID=XXXXXXXXXX
 export AWS_SECRET_ACCESS_KEY=YYYYYYYYYY
-export TF_VAR_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
-export TF_VAR_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
 ```
 
 ## Usage


### PR DESCRIPTION
I don't think that these are needed. I suspect that they were copied from the
alphagov/cf-terraform instructions, where we ran Terraform locally on our own
machines.

We're now running Terraform from within Concourse and setting the environment
variables for each task in the pipeline:

        params:
          DEPLOY_ENV: {{deploy_env}}
          AWS_DEFAULT_REGION: {{aws_region}}
          AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
          AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
          TF_VAR_AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
          TF_VAR_AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}

The prefixed and non-prefixed environment variables within in the task are both
set from `vars` that are passed from non-prefixed environment variables on your
local machine:

    ➜  paas-cf git:(remove_tf_var) ✗ ack AWS_ concourse/scripts/deploy-pipeline.sh
    aws_region=${AWS_DEFAULT_REGION:-eu-west-1}
    --var "aws_access_key_id=${AWS_ACCESS_KEY_ID}" \
    --var "aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}" \