### PR TITLE
Pin concourse/lite version and remove comments

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,6 +3,8 @@
 
 Vagrant.configure(2) do |config|
   config.vm.box = "concourse/lite"
+  config.vm.box_version = "0.69.0"
+
   config.vm.provider "virtualbox" do |vb|
      vb.memory = "2048"
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,71 +1,9 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# All Vagrant configuration is done below. The "2" in Vagrant.configure
-# configures the configuration version (we support older styles for
-# backwards compatibility). Please don't change it unless you know what
-# you're doing.
 Vagrant.configure(2) do |config|
-  # The most common configuration options are documented and commented below.
-  # For a complete reference, please see the online documentation at
-  # https://docs.vagrantup.com.
-
-  # Every Vagrant development environment requires a box. You can search for
-  # boxes at https://atlas.hashicorp.com/search.
   config.vm.box = "concourse/lite"
-
-  # Disable automatic box update checking. If you disable this, then
-  # boxes will only be checked for updates when the user runs
-  # `vagrant box outdated`. This is not recommended.
-  # config.vm.box_check_update = false
-
-  # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine. In the example below,
-  # accessing "localhost:8080" will access port 80 on the guest machine.
-  # config.vm.network "forwarded_port", guest: 80, host: 8080
-
-  # Create a private network, which allows host-only access to the machine
-  # using a specific IP.
-  # config.vm.network "private_network", ip: "192.168.33.10"
-
-  # Create a public network, which generally matched to bridged network.
-  # Bridged networks make the machine appear as another physical device on
-  # your network.
-  # config.vm.network "public_network"
-
-  # Share an additional folder to the guest VM. The first argument is
-  # the path on the host to the actual folder. The second argument is
-  # the path on the guest to mount the folder. And the optional third
-  # argument is a set of non-required options.
-  # config.vm.synced_folder "../data", "/vagrant_data"
-
-  # Provider-specific configuration so you can fine-tune various
-  # backing providers for Vagrant. These expose provider-specific options.
-  # Example for VirtualBox:
-  #
   config.vm.provider "virtualbox" do |vb|
-  #   # Display the VirtualBox GUI when booting the machine
-  #   vb.gui = true
-  #
-  #   # Customize the amount of memory on the VM:
      vb.memory = "2048"
   end
-  #
-  # View the documentation for the provider you are using for more
-  # information on available options.
-
-  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
-  # such as FTP and Heroku are also available. See the documentation at
-  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
-  # config.push.define "atlas" do |push|
-  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
-  # end
-
-  # Enable provisioning with a shell script. Additional provisioners such as
-  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
-  # documentation for more information about their specific syntax and use.
-  # config.vm.provision "shell", inline: <<-SHELL
-  #   sudo apt-get update
-  #   sudo apt-get install -y apache2
-  # SHELL
 end


### PR DESCRIPTION
No story ID, because I'm on review duty.

#### Remove comments from Vagrantfile

These are like "getting started" instructions when you create a new
`Vagrantfile` with `vagrant init`. You can find the same information in the
Vagrant documentation so I don't think it's useful to clutter this file:

- https://docs.vagrantup.com/v2/

#### Pin concourse/lite version to 0.69.0

To ensure that we are all using the same version of Concourse. This is the
latest version box available from Atlas and I have tested it with the
`create-deployer` pipeline in `master`.

- https://atlas.hashicorp.com/concourse/boxes/lite

On important change, if you were using 0.68.0 previously, is that `fly hijack`
now sets the correct PWD and environment variables for a job. Which
makes debugging failed jobs much easier.