### PR TITLE
[#109823030] destroy concourse pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,16 @@ fly login --concourse-url http://192.168.100.4:8080 sync
 ### Deploy the deployer concourse
 
 ```
-./concourse/scripts/create-deployer.sh
+CONCOURSE_ATC_PASSWORD=atcpassword CONCOURSE_DB_PASSWORD=dbpassword ./concourse/scripts/create-deployer.sh env_name
+```
+
+* CONCOURSE_DB_PASSWORD is the RDS database password. It must be 8 characters long minimum
+* CONCOURSE_ATC_PASSWORD is the deployed Concourse web interface password
+
+Also, you can specify log level and branch by setting LOG_LEVEL and BRANCH variables.
+
+```
+BRANCH=branch_name LOG_LEVEL=DEBUG CONCOURSE_ATC_PASSWORD=atcpassword CONCOURSE_DB_PASSWORD=dbpassword ./concourse/scripts/create-deployer.sh env_name
 ```
 
 This script will:
@@ -58,10 +67,21 @@ This script will:
 - Use Terraform to create a VPC, subnet and security group inside AWS
 - bosh-init is used to deploy a full-blown Concourse instance inside AWS
 
+### Login to deployed Concourse
+
+* Point the browser to http://"environment"-concourse.cf.paas.alphagov.co.uk:8080/
+* Login with username admin and password as CONCOURSE_ATC_PASSWORD above
+
 ### Destroy the deployer concourse
 
 ```
-./concourse/scripts/destroy-deployer.sh
+./concourse/scripts/destroy-deployer.sh env_name
+```
+
+or
+
+```
+LOG_LEVEL=DEBUG BRANCH=branch_name ./concourse/scripts/destroy-deployer.sh env_name
 ```
 
 Will destroy the resources created in the previous run.

--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -4,7 +4,9 @@ groups:
   jobs:
   - init-bucket
   - vpc
-  - concourse
+  - concourse-terraform
+  - concourse-prepare-deploy
+  - concourse-deploy
 
 resources:
   - name: paas-cf
@@ -29,7 +31,7 @@ resources:
       access_key_id: {{aws_access_key_id}}
       secret_access_key: {{aws_secret_access_key}}
       versioned_file: vpc.tfstate
-      region_name: eu-west-1
+      region_name: {{aws_region}}
 
   - name: concourse-terraform-state
     type: s3
@@ -38,7 +40,7 @@ resources:
       access_key_id: {{aws_access_key_id}}
       secret_access_key: {{aws_secret_access_key}}
       versioned_file: concourse.tfstate
-      region_name: eu-west-1
+      region_name: {{aws_region}}
 
   - name: concourse-bosh-state
     type: s3
@@ -47,7 +49,16 @@ resources:
       access_key_id: {{aws_access_key_id}}
       secret_access_key: {{aws_secret_access_key}}
       versioned_file: concourse-state.json
-      region_name: eu-west-1
+      region_name: {{aws_region}}
+
+  - name: concourse-manifest
+    type: s3
+    source:
+      bucket: {{state_bucket}}
+      access_key_id: {{aws_access_key_id}}
+      secret_access_key: {{aws_secret_access_key}}
+      versioned_file: concourse.yml
+      region_name: {{aws_region}}
 
 jobs:
   - name: init-bucket
@@ -56,10 +67,9 @@ jobs:
     - get: paas-cf
     - task: create-init-bucket
       config:
-        platform: linux
         image: docker:///governmentpaas/docker-terraform
         params:
-          DEPLOY_ENV: {{deploy_env}}
+          TF_VAR_env: {{deploy_env}}
           AWS_DEFAULT_REGION: {{aws_region}}
           AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
           AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
@@ -71,7 +81,7 @@ jobs:
           - -c
           - |
             cd paas-cf/terraform/bucket
-            terraform apply -var env={{deploy_env}} 2>&1 | tee ./terraform.output
+            terraform apply 2>&1 | tee ./terraform.output
             terraform remote config -backend=s3 -backend-config={{tfstate_bucket}} -backend-config="key=bucket.tfstate"
             grep -q BucketAlreadyOwnedByYou ./terraform.output && exit 0
             grep -q "Creation complete" ./terraform.output && exit 0
@@ -111,7 +121,7 @@ jobs:
         platform: linux
         image: docker:///governmentpaas/docker-terraform
         params:
-          DEPLOY_ENV: {{deploy_env}}
+          TF_VAR_env: {{deploy_env}}
           AWS_DEFAULT_REGION: {{aws_region}}
           AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
           AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
@@ -125,11 +135,11 @@ jobs:
           - |
             cd paas-cf/terraform/vpc
             terraform remote config -backend=s3 -backend-config={{tfstate_bucket}} -backend-config="key=vpc.tfstate"
-            terraform apply -var env={{deploy_env}}
+            terraform apply
         inputs:
         - name: paas-cf
 
-  - name: concourse
+  - name: concourse-terraform
     serial: true
     plan:
     - get: paas-cf
@@ -139,11 +149,10 @@ jobs:
       passed: [vpc]
     - get: vpc-terraform-state
     - get: concourse-terraform-state
-    - get: concourse-bosh-state
 
-    - task: vpc-terraform-outputs
+    - task: vpc-terraform-outputs-to-sh
       config:
-        image: docker:///governmentpaas/bosh-init
+        image: docker:///ruby#2.2.3-slim
         inputs:
         - name: paas-cf
         - name: vpc-terraform-state
@@ -160,11 +169,6 @@ jobs:
             > vpc-terraform-outputs/tfvars.sh
             ls -l vpc-terraform-outputs/tfvars.sh
             cat vpc-terraform-outputs/tfvars.sh
-            ruby paas-cf/concourse/scripts/extract_terraform_state_to_yaml.rb \
-            < vpc-terraform-state/vpc.tfstate \
-            > vpc-terraform-outputs/vpc-terraform-outputs.yml
-            ls -l vpc-terraform-outputs/vpc-terraform-outputs.yml
-            cat vpc-terraform-outputs/vpc-terraform-outputs.yml
 
     - task: terraform-apply
       config:
@@ -173,7 +177,7 @@ jobs:
         - name: paas-cf
         - name: vpc-terraform-outputs
         params:
-          DEPLOY_ENV: {{deploy_env}}
+          TF_VAR_env: {{deploy_env}}
           AWS_DEFAULT_REGION: {{aws_region}}
           AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
           AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
@@ -189,16 +193,28 @@ jobs:
             . vpc-terraform-outputs/tfvars.sh
             cd paas-cf/terraform/concourse
             terraform remote config -backend=s3 -backend-config={{tfstate_bucket}} -backend-config="key=concourse.tfstate"
-            terraform apply -var env={{deploy_env}}
+            terraform apply
 
-    - task: concourse-terraform-outputs
+  - name: concourse-prepare-deploy
+    serial: true
+    plan:
+    - get: paas-cf
+      passed: [concourse-terraform]
+    - get: build-all-trigger
+      trigger: true
+      passed: [concourse-terraform]
+    - get: vpc-terraform-state
+    - get: concourse-terraform-state
+
+    - task: terraform-outputs-to-yaml
       config:
-        image: docker:///governmentpaas/bosh-init
+        image: docker:///ruby#2.2.3-slim
         inputs:
         - name: paas-cf
         - name: concourse-terraform-state
+        - name: vpc-terraform-state
         outputs:
-        - name: concourse-terraform-outputs
+        - name: terraform-outputs
         run:
           path: sh
           args:
@@ -206,10 +222,16 @@ jobs:
           - -c
           - |
             ruby paas-cf/concourse/scripts/extract_terraform_state_to_yaml.rb \
+            < vpc-terraform-state/vpc.tfstate \
+            > terraform-outputs/vpc-terraform-outputs.yml
+            ls -l terraform-outputs/vpc-terraform-outputs.yml
+            cat terraform-outputs/vpc-terraform-outputs.yml
+
+            ruby paas-cf/concourse/scripts/extract_terraform_state_to_yaml.rb \
             < concourse-terraform-state/concourse.tfstate \
-            > concourse-terraform-outputs/concourse-terraform-outputs.yml
-            ls -l concourse-terraform-outputs/concourse-terraform-outputs.yml
-            cat concourse-terraform-outputs/concourse-terraform-outputs.yml
+            > terraform-outputs/concourse-terraform-outputs.yml
+            ls -l terraform-outputs/concourse-terraform-outputs.yml
+            cat terraform-outputs/concourse-terraform-outputs.yml
 
     - task: create-concourse-secrets
       config:
@@ -218,7 +240,6 @@ jobs:
           aws_secret_access_key: {{aws_secret_access_key}}
           concourse_atc_password: {{concourse_atc_password}}
           concourse_db_password: {{concourse_db_password}}
-          private_ssh_key: {{private_ssh_key}}
         outputs:
           - name: concourse-secrets
         run:
@@ -236,9 +257,6 @@ jobs:
               concourse_db_password: ${concourse_db_password}
             EOF
             ls -l concourse-secrets/concourse-secrets.yml
-            echo -n "${private_ssh_key}" > concourse-secrets/id_rsa
-            chmod 400 concourse-secrets/id_rsa
-            ls -l concourse-secrets/id_rsa
 
     - task: generate-concourse-manifest
       config:
@@ -246,8 +264,7 @@ jobs:
         inputs:
         - name: paas-cf
         - name: concourse-secrets
-        - name: concourse-terraform-outputs
-        - name: vpc-terraform-outputs
+        - name: terraform-outputs
         outputs:
         - name: concourse-manifest
         run:
@@ -258,43 +275,49 @@ jobs:
           - |
             spruce merge --prune terraform_outputs --prune secrets \
               paas-cf/manifests/concourse-base.yml concourse-secrets/concourse-secrets.yml \
-              concourse-terraform-outputs/concourse-terraform-outputs.yml \
-              vpc-terraform-outputs/vpc-terraform-outputs.yml \
+              terraform-outputs/concourse-terraform-outputs.yml \
+              terraform-outputs/vpc-terraform-outputs.yml \
               > concourse-manifest/concourse.yml
             ls -l concourse-manifest/concourse.yml
 
-    - task: deploy-concourse
+    - put: concourse-manifest
+      params:
+        from: concourse-manifest/concourse.yml
+
+  - name: concourse-deploy
+    serial: true
+    plan:
+    - get: build-all-trigger
+      trigger: true
+      passed: [concourse-prepare-deploy]
+    - get: concourse-bosh-state
+    - get: concourse-manifest
+      passed: [concourse-prepare-deploy]
+
+    - task: concourse-deploy
       timeout: 30m
       config:
         image: docker:///governmentpaas/bosh-init
         inputs:
         - name: concourse-manifest
-        - name: concourse-secrets
         - name: concourse-bosh-state
-        outputs:
-        - name: run
+        params: {private_ssh_key: {{private_ssh_key}} }
         run:
           path: sh
           args:
           - -e
           - -c
           - |
-            cp -av concourse-secrets/id_rsa run/
-            cp -v concourse-manifest/concourse.yml run/
-            cp -v concourse-bosh-state/concourse-state.json run/
-            cd run
+            echo -n "${private_ssh_key}" > id_rsa
+            chmod 400 id_rsa
+            ls -l id_rsa
+            cp -v concourse-bosh-state/concourse-state.json .
+            cp -v concourse-manifest/concourse.yml .
+            export BOSH_INIT_LOG_LEVEL={{log_level}}
             bosh-init deploy concourse.yml
+            rm concourse-manifest/concourse.yml
+            rm id_rsa
       ensure:
-        task: save-state
-        config:
-          inputs:
-          - name: run
-          outputs:
-          - name: concourse-bosh-state-out
-          run:
-            path: cp
-            args: [ "run/concourse-state.json", "concourse-bosh-state-out/" ]
-
-    - put: concourse-bosh-state
-      params:
-        from: concourse-bosh-state-out/concourse-state.json
+        put: concourse-bosh-state
+        params:
+          from: /concourse-deploy/concourse-state.json

--- a/concourse/pipelines/destroy-deployer.yml
+++ b/concourse/pipelines/destroy-deployer.yml
@@ -6,7 +6,7 @@ resources:
       uri: https://github.com/alphagov/paas-cf
       branch: {{branch_name}}
 
-  - name: tf-state-bucket
+  - name: bucket-terraform-state
     type: s3
     source:
       bucket: {{state_bucket}}
@@ -15,7 +15,7 @@ resources:
       secret_access_key: {{aws_secret_access_key}}
       versioned_file: bucket.tfstate
 
-  - name: tf-state-vpc
+  - name: vpc-terraform-state
     type: s3
     source:
       bucket: {{state_bucket}}
@@ -24,7 +24,7 @@ resources:
       secret_access_key: {{aws_secret_access_key}}
       versioned_file: vpc.tfstate
 
-  - name: trigger-bucket-destroy
+  - name: destroy-all-trigger
     type: semver
     source:
       bucket: {{state_bucket}}
@@ -33,51 +33,169 @@ resources:
       secret_access_key: {{aws_secret_access_key}}
       key: destroy-trigger
 
+  - name: concourse-manifest
+    type: s3
+    source:
+      bucket: {{state_bucket}}
+      access_key_id: {{aws_access_key_id}}
+      secret_access_key: {{aws_secret_access_key}}
+      versioned_file: concourse.yml
+      region_name: {{aws_region}}
+
+  - name: concourse-terraform-state
+    type: s3
+    source:
+      bucket: {{state_bucket}}
+      access_key_id: {{aws_access_key_id}}
+      secret_access_key: {{aws_secret_access_key}}
+      versioned_file: concourse.tfstate
+      region_name: {{aws_region}}
+
+  - name: concourse-bosh-state
+    type: s3
+    source:
+      bucket: {{state_bucket}}
+      access_key_id: {{aws_access_key_id}}
+      secret_access_key: {{aws_secret_access_key}}
+      versioned_file: concourse-state.json
+      region_name: {{aws_region}}
+
 jobs:
+  - name: destroy-concourse
+    serial: true
+    plan:
+    - get: paas-cf
+    - get: concourse-manifest
+    - get: concourse-bosh-state
+    - get: vpc-terraform-state
+
+    - task: destroy-concourse
+      timeout: 30m
+      config:
+        image: docker:///governmentpaas/bosh-init
+        inputs:
+        - name: concourse-manifest
+        - name: concourse-bosh-state
+        params: {private_ssh_key: {{private_ssh_key}} }
+        run:
+          path: sh
+          args:
+          - -e
+          - -c
+          - |
+            cp -v concourse-bosh-state/concourse-state.json .
+            [ "$(cat concourse-bosh-state/concourse-state.json)" = "{}" ] \
+              && echo Concourse bosh state empty, assuming already destroyed \
+              && exit 0
+            echo -n "${private_ssh_key}" > id_rsa
+            chmod 400 id_rsa
+            ls -l id_rsa
+            cp -v concourse-manifest/concourse.yml .
+            export BOSH_INIT_LOG_LEVEL={{log_level}}
+            bosh-init delete concourse.yml
+            [ -f concourse-state.json ] \
+              || echo '{}' > concourse-state.json
+            rm concourse-manifest/concourse.yml
+            rm id_rsa
+      ensure:
+        put: concourse-bosh-state
+        params:
+          from: /destroy-concourse/concourse-state.json
+
+    - task: vpc-terraform-outputs-to-sh
+      config:
+        image: docker:///ruby#2.2.3-slim
+        inputs:
+        - name: paas-cf
+        - name: vpc-terraform-state
+        outputs:
+        - name: vpc-terraform-outputs
+        run:
+          path: sh
+          args:
+          - -e
+          - -c
+          - |
+            ruby paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
+            < vpc-terraform-state/vpc.tfstate \
+            > vpc-terraform-outputs/tfvars.sh
+            ls -l vpc-terraform-outputs/tfvars.sh
+            cat vpc-terraform-outputs/tfvars.sh
+
+    - task: destroy-concourse-terraform
+      config:
+        image: docker:///governmentpaas/docker-terraform
+        inputs:
+        - name: paas-cf
+        - name: vpc-terraform-outputs
+        params:
+          AWS_DEFAULT_REGION: {{aws_region}}
+          AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
+          AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
+          TF_VAR_AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
+          TF_VAR_AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
+          TF_VAR_env: {{deploy_env}}
+          TF_VAR_concourse_db_password: fake_password
+        run:
+          path: sh
+          args:
+          - -e
+          - -c
+          - |
+            . vpc-terraform-outputs/tfvars.sh
+            cd paas-cf/terraform/concourse
+            terraform remote config -backend=s3 -backend-config={{tfstate_bucket}} -backend-config="key=concourse.tfstate"
+            terraform destroy -force
+
+    - put: destroy-all-trigger
+      params: {bump: patch}
+
   - name: destroy-vpc
     serial: true
     plan:
-      - get: paas-cf
-      - get: tf-state-vpc
-      - task: tf-destroy-vpc
-        file: paas-cf/concourse/tasks/tf-destroy.yml
-        config:
-          params:
-              DEPLOY_ENV: {{deploy_env}}
-              AWS_DEFAULT_REGION: {{aws_region}}
-              AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-              AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
-              TF_VAR_AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-              TF_VAR_AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
-              TF_FILES_PATH: paas-cf/terraform/vpc
-              TF_STATE_PATH: tf-state-vpc/vpc.tfstate
-          inputs:
-            - name: paas-cf
-            - name: tf-state-vpc
-      - put: trigger-bucket-destroy
-        params: {bump: patch}
+    - get: paas-cf
+      passed: [destroy-concourse]
+    - get: vpc-terraform-state
+    - get: destroy-all-trigger
+      trigger: true
+      passed: [destroy-concourse]
+    - task: tf-destroy-vpc
+      file: paas-cf/concourse/tasks/tf-destroy.yml
+      config:
+        params:
+            TF_VAR_env: {{deploy_env}}
+            AWS_DEFAULT_REGION: {{aws_region}}
+            AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
+            AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
+            TF_VAR_AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
+            TF_VAR_AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
+            TF_FILES_PATH: paas-cf/terraform/vpc
+            TF_STATE_PATH: vpc-terraform-state/vpc.tfstate
+        inputs:
+          - name: paas-cf
+          - name: vpc-terraform-state
 
   - name: destroy-init-bucket
     serial: true
     plan:
       - get: paas-cf
-      - get: tf-state-bucket
-      - get: trigger-bucket-destroy
+        passed: [destroy-vpc]
+      - get: bucket-terraform-state
+      - get: destroy-all-trigger
         trigger: true
         passed: [destroy-vpc]
       - task: tf-destroy-init-bucket
         file: paas-cf/concourse/tasks/tf-destroy.yml
         config:
           params:
-              DEPLOY_ENV: {{deploy_env}}
+              TF_VAR_env: {{deploy_env}}
               AWS_DEFAULT_REGION: {{aws_region}}
               AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
               AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
               TF_VAR_AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
               TF_VAR_AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
               TF_FILES_PATH: paas-cf/terraform/bucket
-              TF_STATE_PATH: tf-state-bucket/bucket.tfstate
+              TF_STATE_PATH: bucket-terraform-state/bucket.tfstate
           inputs:
             - name: paas-cf
-            - name: tf-state-bucket
-
+            - name: bucket-terraform-state

--- a/concourse/scripts/create-deployer.sh
+++ b/concourse/scripts/create-deployer.sh
@@ -24,6 +24,7 @@ aws_access_key_id: ${AWS_ACCESS_KEY_ID}
 aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
 concourse_db_password: ${CONCOURSE_DB_PASSWORD}
 concourse_atc_password: ${CONCOURSE_ATC_PASSWORD}
+log_level: ${LOG_LEVEL:-}
 private_ssh_key: |
 $(cat ~/.ssh/insecure-deployer | sed 's/^/  /')
 EOF
@@ -34,8 +35,10 @@ generate_vars_file > /dev/null # Check for missing vars
 bash "${SCRIPT_DIR}/deploy-pipeline.sh" \
    "${env}" "${pipeline}" "${config}" <(generate_vars_file)
 
-fly unpause-pipeline --pipeline "${pipeline}"
-curl "${ATC_URL}/pipelines/${pipeline}/jobs/init-bucket/builds" -X POST
+fly -t "${FLY_TARGET}" unpause-pipeline --pipeline "${pipeline}"
+
+# Start pipeline
+# curl "${ATC_URL}/pipelines/${pipeline}/jobs/init-bucket/builds" -X POST
 
 cat <<EOF
 You can watch the last vpc deploy job by running the command below.

--- a/concourse/scripts/create-deployer.sh
+++ b/concourse/scripts/create-deployer.sh
@@ -2,17 +2,37 @@
 set -e
 
 SCRIPT_DIR=$(cd $(dirname $0) && pwd)
+ATC_URL=${ATC_URL:-"http://192.168.100.4:8080"}
+FLY_TARGET=${FLY_TARGET:-$ATC_URL}
 
 env=${DEPLOY_ENV-$1}
 pipeline="cf-deploy"
 config="${SCRIPT_DIR}/../pipelines/create-deployer.yml"
 
 [[ -z "${env}" ]] && echo "Must provide environment name" && exit 100
-bash "${SCRIPT_DIR}/deploy-pipeline.sh" "${env}" "${pipeline}" "${config}"
 
+generate_vars_file() {
+   set -u # Treat unset variables as an error when substituting
+   cat <<EOF
+---
+deploy_env: ${env}
+tfstate_bucket: bucket=${env}-state
+state_bucket: ${env}-state
+branch_name: ${BRANCH:-master}
+aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
+aws_access_key_id: ${AWS_ACCESS_KEY_ID}
+aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+concourse_db_password: ${CONCOURSE_DB_PASSWORD}
+concourse_atc_password: ${CONCOURSE_ATC_PASSWORD}
+private_ssh_key: |
+$(cat ~/.ssh/insecure-deployer | sed 's/^/  /')
+EOF
+}
 
-export ATC_URL=${ATC_URL:-"http://192.168.100.4:8080"}
-export fly_target=${FLY_TARGET:-tutorial}
+generate_vars_file > /dev/null # Check for missing vars
+
+bash "${SCRIPT_DIR}/deploy-pipeline.sh" \
+   "${env}" "${pipeline}" "${config}" <(generate_vars_file)
 
 fly unpause-pipeline --pipeline "${pipeline}"
 curl "${ATC_URL}/pipelines/${pipeline}/jobs/init-bucket/builds" -X POST
@@ -21,5 +41,5 @@ cat <<EOF
 You can watch the last vpc deploy job by running the command below.
 You might need to wait a few moments before the latest build starts.
 
-fly -t "${fly_target}" watch -j "${pipeline}/vpc"
+fly -t "${FLY_TARGET}" watch -j "${pipeline}/vpc"
 EOF

--- a/concourse/scripts/create-deployer.sh
+++ b/concourse/scripts/create-deployer.sh
@@ -6,7 +6,7 @@ ATC_URL=${ATC_URL:-"http://192.168.100.4:8080"}
 FLY_TARGET=${FLY_TARGET:-$ATC_URL}
 
 env=${DEPLOY_ENV-$1}
-pipeline="cf-deploy"
+pipeline="create-deployer"
 config="${SCRIPT_DIR}/../pipelines/create-deployer.yml"
 
 [[ -z "${env}" ]] && echo "Must provide environment name" && exit 100

--- a/concourse/scripts/deploy-pipeline.sh
+++ b/concourse/scripts/deploy-pipeline.sh
@@ -1,39 +1,49 @@
 #!/bin/bash
 set -e
 
-env=${DEPLOY_ENV:-$1}
-pipeline=${PIPELINE:-$2}
-config=${PIPELINE_CONFIG:-$3}
-concourse_db_password=${CONCOURSE_DB_PASSWORD:-$4}
-concourse_atc_password=${CONCOURSE_ATC_PASSWORD:-$5}
-[[ -z "${env}" ]]                     && echo "Must provide environment name"       && exit 100
-[[ -z "${pipeline}" ]]                && echo "Must provide pipeline name"          && exit 101
-[[ -z "${config}" ]]                  && echo "Must provide pipeline config file"   && exit 102
-[[ -z "${concourse_db_password}" ]]   && echo "Must provide concourse db password"  && exit 103
-[[ -z "${concourse_atc_password}" ]]  && echo "Must provide concourse ATC password" && exit 104
+SCRIPT=$0
 
-branch_name=${BRANCH:-master}
-aws_region=${AWS_DEFAULT_REGION:-eu-west-1}
+usage() {
+   cat <<EOF
+Usage:
+
+   $SCRIPT <env> <pipeline> <config> <varsfile>
+
+Being:
+
+   env			environment name
+   pipeline		pipeline name
+   config		config for the pipeline
+   varsfile     concourse variables to pass to the pipeline
+
+EOF
+   exit 1
+}
+
+if [ $# -lt 4 ]; then
+   usage
+fi
+
+env=$1; shift
+pipeline=$1; shift
+config=$1; shift
+varsfile=$1; shift
 
 export ATC_URL=${ATC_URL:-"http://192.168.100.4:8080"}
-export fly_target=${FLY_TARGET:-tutorial}
-echo "Concourse API target ${fly_target}"
+export FLY_TARGET=${FLY_TARGET:-$ATC_URL}
+
+echo "Concourse API target ${FLY_TARGET}"
 echo "Concourse API $ATC_URL"
 echo "AWS Region ${aws_region}"
-echo "Branch ${branch_name}"
-echo
+
 echo "Deployment ${env}"
 echo "Pipeline ${pipeline}"
 echo "Config file ${config}"
 
-yes y | fly -t "${fly_target}" set-pipeline --config "${config}" --pipeline "${pipeline}" \
---var "deploy_env=${env}" \
---var "tfstate_bucket=bucket=${env}-state" \
---var "state_bucket=${env}-state" \
---var "branch_name=${branch_name}" \
---var "aws_region=${aws_region}" \
---var "aws_access_key_id=${AWS_ACCESS_KEY_ID}" \
---var "aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}" \
---var "concourse_db_password=${concourse_db_password}" \
---var "concourse_atc_password=${concourse_atc_password}" \
---var="private_ssh_key=$(cat ~/.ssh/insecure-deployer)"
+yes y | \
+   fly -t "${FLY_TARGET}" \
+   set-pipeline \
+   --config "${config}" \
+   --pipeline "${pipeline}" \
+   --load-vars-from "${varsfile}"
+

--- a/concourse/scripts/tf-destroy.sh
+++ b/concourse/scripts/tf-destroy.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 set -e
 
-[[ -z "${DEPLOY_ENV}" ]]    && echo "DEPLOY_ENV not set"    && exit 100
+[[ -z "${TF_VAR_env}" ]]    && echo "TF_VAR_env not set"    && exit 100
 [[ -z "${TF_STATE_PATH}" ]] && echo "TF_STATE_PATH not set" && exit 101
 [[ -z "${TF_FILES_PATH}" ]] && echo "TF_FILES_PATH not set" && exit 102
 
 cp "${TF_STATE_PATH}" "${TF_FILES_PATH}"/tf-destroy.tfstate
 cd "${TF_FILES_PATH}"
-terraform destroy -var env="${DEPLOY_ENV}" -force -state=tf-destroy.tfstate
+terraform destroy -force -state=tf-destroy.tfstate
 

--- a/terraform/concourse/security_group.tf
+++ b/terraform/concourse/security_group.tf
@@ -25,6 +25,6 @@ resource "aws_security_group" "concourse" {
   }
 
   tags {
-    Name = "${var.env}-concourse-rds"
+    Name = "${var.env}-concourse"
   }
 }


### PR DESCRIPTION
# What

This PR adds more steps to destroy deployer pipeline. Right now it will:

- get terraform and bosh-init states from S3 bucket associated to specified environment 
- destroy deployer Concourse using bosh-init
- destroy RDS, subnet etc. using terraform
- destroy VPC using terraform
- delete state bucket

We had to refactor create Concourse pipeline to be able to get generated deployment manifest and also fix bugs. 
 
# How to test 

Provision concourse environment first. If you have concourse provisioned already you have to run it anyway to export deployment manifest.

```
BRANCH=109823030_destroy_concourse LOG_LEVEL=DEBUG \
  CONCOURSE_ATC_PASSWORD=atcpassword CONCOURSE_DB_PASSWORD=dbpassword \
  ./concourse/scripts/create-deployer.sh env_name
```
Try to destroy it:

```
LOG_LEVEL=DEBUG BRANCH=109823030_destroy_concourse \
./concourse/scripts/destroy-deployer.sh env_name
```

# Who can test 
Anyone but @saliceti and @combor

# Know issues
## bosh-init cannot unmount the disk
Sometimes `bosh-init` gets stuck on `Unmounting disk 'vol-41293e82'...`
There was an issue opened: https://github.com/concourse/concourse/issues/167
It may be solved in the latest Concourse.
Workaround:

```
ssh vcap@<environment>-concourse.cf.paas.alphagov.co.uk
sudo su -
[default CF root password]
# losetup -a
/dev/loop0: [ca12]:12 (/var/vcap/data/root_tmp)
/dev/loop1: [ca51]:393218 (/var/vcap/store/baggageclaim/volumes.img)
# losetup -d /dev/loop1
# umount /dev/loop1
Broadcast message from root@1ac47e71-7246-4d15-47e9-e9a61d9449d3
  (unknown) at 10:53 ...

The system is going down for power off NOW!
```

## bosh-init deployment takes a lot of time
If you hit a timeout just rerun the job. It should finish properly.