### PR TITLE
Remove references to terraform vars from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You need the following prerequisites before you will be able to deploy first pip
 * Vagrant
 * AWS Access
 
-Provide AWS access keys as environment variables, plus the corresponding terraform variables.
+Provide AWS access keys as environment variables.
 ```
 export AWS_ACCESS_KEY_ID=XXXXXXXXXX
 export AWS_SECRET_ACCESS_KEY=YYYYYYYYYY


### PR DESCRIPTION
The variables themselves were removed in 278e081, but this reference to
them was left behind.