### PR TITLE
[#110238314] Ensure that terraform uses IAM roles

### DIFF
--- a/concourse/pipelines/destroy-microbosh.yml
+++ b/concourse/pipelines/destroy-microbosh.yml
@@ -144,10 +144,6 @@ jobs:
         params:
           DEPLOY_ENV: {{deploy_env}}
           AWS_DEFAULT_REGION: {{aws_region}}
-          AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-          AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
-          TF_VAR_AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-          TF_VAR_AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
         run:
           path: sh
           args:


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/110238314

## What
Ensure that terraform uses IAM to destory Microbosh.

Not much to do here since only the Destroy microbosh uses AWS Credentials at the moment so we've fixed that

## How this PR should be reviewed

This PR has been written in the following context:
* I want to:
  * Use the IAM Profile rather than my AWS Credentials to securely manage AWS resources

## How to test this PR

* Follow the [README]( https://github.com/alphagov/paas-cf#usage) up to `Destroy a microbosh with bosh-init from concourse` 

## Who should review this PR

* Any man, woman or child who is connected to the internet except @actionjack and @mtekel who worked on this PR.