### PR TITLE
[#110238314] s3init supports instance profile

### DIFF
--- a/concourse/pipelines/create-microbosh.yml
+++ b/concourse/pipelines/create-microbosh.yml
@@ -96,9 +96,6 @@ jobs:
     - task: bosh-manifest-state.json
       config:
         image: docker:///governmentpaas/toolbox
-        params:
-          AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-          AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
         run:
           path: sh
           args:
@@ -119,9 +116,6 @@ jobs:
     - task: bosh-secrets.yml
       config:
         image: docker:///governmentpaas/toolbox
-        params:
-          AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-          AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
         run:
           path: sh
           args:

--- a/concourse/scripts/s3init.sh
+++ b/concourse/scripts/s3init.sh
@@ -4,12 +4,29 @@ bucket=$1
 file=$2
 init_file=$3
 
+# Attempt to use instance profile if keys not configured
+if [[ -z "${AWS_SECRET_ACCESS_KEY}" ]] && [[ -z ${AWS_ACCESS_KEY_ID} ]] ; then
+  meta_url="http://169.254.169.254/latest/meta-data/iam/security-credentials/"
+  profile_name=$(curl -s ${meta_url})
+  instance_profile=$(curl -s ${meta_url}/${profile_name})
+
+      AWS_ACCESS_KEY_ID=$(echo "${instance_profile}" | awk -F\" '$2 == "AccessKeyId"     { print $4 }')
+     AWS_SECURITY_TOKEN=$(echo "${instance_profile}" | awk -F\" '$2 == "Token"           { print $4 }')
+  AWS_SECRET_ACCESS_KEY=$(echo "${instance_profile}" | awk -F\" '$2 == "SecretAccessKey" { print $4 }')
+
+  [[ -z "${AWS_SECURITY_TOKEN}" ]] && echo "Could not obtain AWS_SECURITY_TOKEN from instance profile" && exit 105
+fi
+
 [[ -z "${bucket}" ]]    && echo "Must provide bucket name"    && exit 100
 [[ -z "${file}" ]]      && echo "Must provide file name"      && exit 101
 [[ -z "${init_file}" ]] && echo "Must provide init file path" && exit 102
+[[ -z "${AWS_ACCESS_KEY_ID}"     ]] && echo "AWS_ACCESS_KEY_ID nor specified or present in instance profile"     && exit 103
+[[ -z "${AWS_SECRET_ACCESS_KEY}" ]] && echo "AWS_SECRET_ACCESS_KEY nor specified or present in instance profile" && exit 104
 
 aws_path=/
 content_type='application/x-compressed-tar'
+acl="x-amz-acl:private"
+security_token="x-amz-security-token:${AWS_SECURITY_TOKEN}"
 region=eu-west-1
 host=${bucket}.s3-${region}.amazonaws.com
 
@@ -20,27 +37,28 @@ sign() {
 
 put() {
   date=$(date +"%a, %d %b %Y %T %z")
-  acl="x-amz-acl:private"
-  string="PUT\n\n$content_type\n$date\n$acl\n/$bucket$aws_path$file"
+  string="PUT\n\n${content_type}\n${date}\n${acl}\n${security_token}\n/${bucket}${aws_path}${file}"
   signature=$(sign "${string}")
   curl -i -s -X PUT -T ${init_file} \
-    -H "Host: $bucket.s3.amazonaws.com" \
-    -H "Date: $date" \
-    -H "Content-Type: $content_type" \
-    -H "$acl" \
-    -H "Authorization: AWS ${AWS_ACCESS_KEY_ID}:$signature" \
-    "https://${host}$aws_path$file"
+    -H "Host: ${bucket}.s3.amazonaws.com" \
+    -H "Date: ${date}" \
+    -H "Content-Type: ${content_type}" \
+    -H "${acl}" \
+    -H "${security_token}" \
+    -H "Authorization: AWS ${AWS_ACCESS_KEY_ID}:${signature}" \
+    "https://${host}${aws_path}${file}"
 }
 
 get() {
   date=$(date +"%a, %d %b %Y %T %z")
-  string="GET\n\n${contentType}\n${date}\n/$bucket$aws_path$file"
+  string="GET\n\n${content_type}\n${date}\n${security_token}\n/${bucket}${aws_path}${file}"
   signature=$(sign "${string}")
   curl -v -i -s -H "Host: ${bucket}.s3.amazonaws.com" \
     -H "Date: ${date}" \
-    -H "Content-Type: ${contentType}" \
+    -H "Content-Type: ${content_type}" \
+    -H "${security_token}" \
     -H "Authorization: AWS ${AWS_ACCESS_KEY_ID}:${signature}" \
-    https://${host}/${file}
+    "https://${host}/${file}"
 }
 
 response=$(get)


### PR DESCRIPTION
## What
[Use IAM profiles/roles in new Concourse pipeline](https://www.pivotaltracker.com/projects/1275640/stories/110238314)
Enhance s3init script to support using instance profile provided credentials.
Remove explicit usage of AWS credentials in the create bosh init pipeline.

## Testing
Deploy concourse and bosh init pipeline. Run `bootstrap-s3-state` job. Watch the output and check the bucket for objects being created/not updated.

## Who
Anyone but @mtekel