### PR TITLE
[#109060102] Use specific containers in concourse tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,9 @@ export CONCOURSE_ATC_PASSWORD=atcpassword # change me
 export FLY_TARGET=$DEPLOY_ENV
 
 echo -e "admin\n${CONCOURSE_ATC_PASSWORD}" | \
-   fly -t remote login -c http://${DEPLOY_ENV}-concourse.cf.paas.alphagov.co.uk:8080 sync
+   fly -t $FLY_TARGET login -c http://${DEPLOY_ENV}-concourse.cf.paas.alphagov.co.uk:8080
 
+fly -t $FLY_TARGET sync
 ```
 ### Microbosh deployment
 

--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -90,7 +90,7 @@ jobs:
           - name: paas-cf
     - task: s3init-concourse
       config:
-        image: docker:///governmentpaas/toolbox
+        image: docker:///governmentpaas/curl-ssl
         params:
           AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
           AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}

--- a/concourse/pipelines/create-microbosh.yml
+++ b/concourse/pipelines/create-microbosh.yml
@@ -95,7 +95,7 @@ jobs:
     - get: paas-cf
     - task: bosh-manifest-state.json
       config:
-        image: docker:///governmentpaas/toolbox
+        image: docker:///governmentpaas/curl-ssl
         run:
           path: sh
           args:
@@ -115,7 +115,7 @@ jobs:
     - get: paas-cf
     - task: bosh-secrets.yml
       config:
-        image: docker:///governmentpaas/toolbox
+        image: docker:///governmentpaas/curl-ssl
         run:
           path: sh
           args:
@@ -138,7 +138,7 @@ jobs:
     - get: concourse-tfstate
     - task: terraform-variables
       config:
-        image: docker:///governmentpaas/bosh-init
+        image: docker:///ruby#2.2.3-slim
         run:
           path: sh
           args:
@@ -194,7 +194,7 @@ jobs:
     - get: bosh-init-state
     - task: terraform_outputs
       config:
-        image: docker:///governmentpaas/bosh-init
+        image: docker:///ruby#2.2.3-slim
         run:
           path: sh
           args:

--- a/concourse/scripts/s3init.sh
+++ b/concourse/scripts/s3init.sh
@@ -31,7 +31,7 @@ host=${bucket}.s3-${region}.amazonaws.com
 
 sign() {
   string=$1
-  echo -en "${string}" | openssl sha1 -hmac "${AWS_SECRET_ACCESS_KEY}" -binary | base64
+  /bin/echo -e -n "${string}" | openssl sha1 -hmac "${AWS_SECRET_ACCESS_KEY}" -binary | base64
 }
 
 put() {

--- a/concourse/scripts/s3init.sh
+++ b/concourse/scripts/s3init.sh
@@ -1,11 +1,11 @@
-#!/bin/bash
+#!/bin/sh
 set -x
 bucket=$1
 file=$2
 init_file=$3
 
 # Attempt to use instance profile if keys not configured
-if [[ -z "${AWS_SECRET_ACCESS_KEY}" ]] && [[ -z ${AWS_ACCESS_KEY_ID} ]] ; then
+if [ -z "${AWS_SECRET_ACCESS_KEY}" ] && [ -z ${AWS_ACCESS_KEY_ID} ] ; then
   meta_url="http://169.254.169.254/latest/meta-data/iam/security-credentials/"
   profile_name=$(curl -s ${meta_url})
   instance_profile=$(curl -s ${meta_url}/${profile_name})
@@ -14,14 +14,14 @@ if [[ -z "${AWS_SECRET_ACCESS_KEY}" ]] && [[ -z ${AWS_ACCESS_KEY_ID} ]] ; then
      AWS_SECURITY_TOKEN=$(echo "${instance_profile}" | awk -F\" '$2 == "Token"           { print $4 }')
   AWS_SECRET_ACCESS_KEY=$(echo "${instance_profile}" | awk -F\" '$2 == "SecretAccessKey" { print $4 }')
 
-  [[ -z "${AWS_SECURITY_TOKEN}" ]] && echo "Could not obtain AWS_SECURITY_TOKEN from instance profile" && exit 105
+  [ -z "${AWS_SECURITY_TOKEN}" ] && echo "Could not obtain AWS_SECURITY_TOKEN from instance profile" && exit 105
 fi
 
-[[ -z "${bucket}" ]]    && echo "Must provide bucket name"    && exit 100
-[[ -z "${file}" ]]      && echo "Must provide file name"      && exit 101
-[[ -z "${init_file}" ]] && echo "Must provide init file path" && exit 102
-[[ -z "${AWS_ACCESS_KEY_ID}"     ]] && echo "AWS_ACCESS_KEY_ID nor specified or present in instance profile"     && exit 103
-[[ -z "${AWS_SECRET_ACCESS_KEY}" ]] && echo "AWS_SECRET_ACCESS_KEY nor specified or present in instance profile" && exit 104
+[ -z "${bucket}" ]    && echo "Must provide bucket name"    && exit 100
+[ -z "${file}" ]      && echo "Must provide file name"      && exit 101
+[ -z "${init_file}" ] && echo "Must provide init file path" && exit 102
+[ -z "${AWS_ACCESS_KEY_ID}"     ] && echo "AWS_ACCESS_KEY_ID nor specified or present in instance profile"     && exit 103
+[ -z "${AWS_SECRET_ACCESS_KEY}" ] && echo "AWS_SECRET_ACCESS_KEY nor specified or present in instance profile" && exit 104
 
 aws_path=/
 content_type='application/x-compressed-tar'
@@ -61,9 +61,9 @@ get() {
 }
 
 response=$(get)
-if $(echo ${response} | grep -q "200 OK"); then
+if echo ${response} | grep -q "200 OK"; then
   echo $file already exists in $bucket bucket.
-elif $(echo ${response} | grep -q "<Code>NoSuchKey</Code>"); then
+elif echo ${response} | grep -q "<Code>NoSuchKey</Code>"; then
   echo $file cannot be found in $bucket bucket. Creating empty json file.
   put
 else


### PR DESCRIPTION
[#109060102 Create bootstrap pipeline to deploy BOSH](https://www.pivotaltracker.com/story/show/109060102)

What
----

Using specific containers with the minimum dependencies will help to
understand and track the dependencies added to different tools.

Requirements
------------------

#24 should be merged first to cover a bugfix in s3init.sh

Scope
-----

We use the specific containers `curl-ssl` to do curl and openssl logic and
ruby 2.2.3 instead of the multipurpose toolbox.

We use sh instead of bash in s3init script as the curl-ssl container does
not include bash.

How to test this?
-----------------

Test both pipelines create-deployer and create-microbosh as described in the
README.

It can be pipelines in an already deployed environment, and it is not needed
to wait for the bosh-init tasks to finish, as we only want to test the
tasks modified in this PR.

Who?
---

anyone but @keymon