### PR TITLE
Prefer wget to curl for installing Fly

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ vagrant up
 
     ```
 FLY_CMD_URL="http://192.168.100.4:8080/api/v1/cli?arch=amd64&platform=$(uname | tr '[:upper:]' '[:lower:]')"
-sudo curl $FLY_CMD_URL -o /usr/local/bin/fly && \
+sudo wget $FLY_CMD_URL -O /usr/local/bin/fly && \
 sudo chmod +x /usr/local/bin/fly
 ```
 


### PR DESCRIPTION
`curl` is not installed by default on the Ubuntu image specified by the `Vagrantfile`, so use `wget` which is already installed.

Without this change, I had to run `sudo apt-get update && sudo apt-get install curl` before I could install Fly.