### PR TITLE
[#109897246] Stop vagrant using the insecure deployer key

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ export AWS_SECRET_ACCESS_KEY=YYYYYYYYYY
 
 #### SSH credentials
 
-You must use a ssh-agent with the `insecure-deployer` private key added, so
-that vagrant can SSH to the new created VM.
+You must have insecure-deployer private key present in `~/.ssh/insecure-deployer` location, 
+as it is being used by pipeline creation scripts.
 
 #### Deployment of bootstrap concourse-lite
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -29,8 +29,7 @@ Vagrant.configure(2) do |config|
     # "Concourse Vagrant" security group
     aws.security_groups = ['sg-ee21a597']
 
-    # Could be replaced by key per user in the future. But would require each user's key to be in AWS.
-    aws.keypair_name = 'insecure-deployer'
+    # We will rely on vagrant generating a ssh key, but this must be the ubuntu user, as the vagrant user does not exist on the vm
     override.ssh.username = "ubuntu"
 
     # Fix issue on osx: https://github.com/mitchellh/vagrant/issues/5401#issuecomment-115240904

--- a/vagrant/concourse_post_deploy.sh
+++ b/vagrant/concourse_post_deploy.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 gardenDir="/var/vcap/data/garden"
 
+echo "Removing packer ssh key..."
+sed -i '/ vagrant$/ ! { d }' /root/.ssh/authorized_keys /home/*/.ssh/authorized_keys
+
 # This assumes you are running on an instance with attached ephemeral disk as current (0.70) concourse image does
 echo "Mounting ${gardenDir} on to ephemeral disk..."
 cp -R ${gardenDir}/* /mnt


### PR DESCRIPTION
**What**

We want to stop using the insecure deployer key

**How this PR should be reviewed**

This PR should reviewed in the following context:

* We are no longer using the insecure deployer key
* It is still possible to ssh to your deployed vagrant machine
* We are not using the vagrant insecure default public key

**How to test this PR**
Check the branch out, run the deployment script.

```
export VAGRANT_LOG=info
./vagrant/deploy.sh
```
Verify the following appears in the log messages

```
Key inserted! Disconnecting and reconnecting using new SSH key...
```

verify you can ssh to the vagrant instance

```
(cd vagrant && vagrant ssh)
```

Verify the insecure deployer key does not appear in the /home/ubuntu/.ssh/authorized_keys file

```
cat .ssh/authorized_keys
```

**Who should review this PR**

* Anyone but me or @mtekel