### PR TITLE
[#111149770] Upgrade deployer Concourse to 0.70.0

### DIFF
--- a/manifests/concourse-base.yml
+++ b/manifests/concourse-base.yml
@@ -3,8 +3,8 @@ name: concourse
 
 releases:
   - name: concourse
-    url: https://bosh.io/d/github.com/concourse/concourse?v=0.68.0
-    sha1: 5b4ea4207fbafce212f8055c32cefe5519860acc
+    url: https://bosh.io/d/github.com/concourse/concourse?v=0.70.0
+    sha1: bbec7785856a5c8ba5f05b106ea79821b620bbc9
   - name: garden-linux
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/garden-linux-release?v=0.328.0
     sha1: 539822f9f2b18ccf51e72e42e03b297f934ea3fe


### PR DESCRIPTION
## What

In order to pull in the fix for concourse/concourse#167 which made
`bosh-init` hang when unmounting disks from the "Deployer Concourse"
instance if there were any changes to the manifest.

This now matches the version of concourse/lite that we're using for the
"Bootstrap Concourse". We shouldn't be affected by any of the
backwards-incompatible entries in the changelog, but you will want to run
`fly sync`:

- http://concourse.ci/release-notes.html#v0.70.0

## How to review

As a minimum:

1. Deploy the pipeline from this branch to your Bootstrap Concourse: `BRANCH=111149770-upgrade_deployer_concourse ./vagrant/deploy.sh`
1. Run the `create-deployer` pipeline from your Bootstrap Concourse.
1. Check that you can still login to the Deployer Concourse and that you can run a pipeline.

If you want to test whether it fixes the disk unmount issue, which probably isn't necessary, you can deploy from the `master` branch again and watch it rollback the Deployer Concourse to 0.68.0 without hanging.

## Who should review

Anyone except @dcarley