### PR TITLE
[#109878560] Secure external access to concourse

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The `destroy-deployer` pipeline will destroy the previous created objects.
 
 Once the `create-deployer` pipeline finished successful, you can:
 
-* Point the browser to `http://${DEPLOY_ENV}-concourse.cf.paas.alphagov.co.uk:8080/`
+* Point the browser to `https://${DEPLOY_ENV}-concourse.cf.paas.alphagov.co.uk/`
 * Login with username `admin` and password as `$CONCOURSE_ATC_PASSWORD` above
 
 You can add a new target in to use the `fly` command with:
@@ -108,7 +108,7 @@ $(./vagrant/environment.sh $DEPLOY_ENV) # get the credentials
 export FLY_TARGET=$DEPLOY_ENV
 
 echo -e "admin\n${CONCOURSE_ATC_PASSWORD}" | \
-   fly -t $FLY_TARGET login -c http://${DEPLOY_ENV}-concourse.cf.paas.alphagov.co.uk:8080
+   fly -t $FLY_TARGET login -k -c https://${DEPLOY_ENV}-concourse.cf.paas.alphagov.co.uk
 ```
 
 ### Microbosh deployment from concourse bootstrap

--- a/manifests/concourse-base.yml
+++ b/manifests/concourse-base.yml
@@ -22,6 +22,8 @@ resource_pools:
       instance_type: t2.medium
       availability_zone: (( grab terraform_outputs.zone0 ))
       iam_instance_profile: bosh-bootstrap
+      elbs:
+      - (( grab terraform_outputs.concourse_elb_name ))
 
 disk_pools:
   - name: db

--- a/terraform/concourse/elastic_ip.tf
+++ b/terraform/concourse/elastic_ip.tf
@@ -1,11 +1,3 @@
 resource "aws_eip" "concourse" {
   vpc = true
 }
-
-resource "aws_route53_record" "concourse" {
-  zone_id = "${var.dns_zone_id}"
-  name = "${var.env}-concourse.${var.dns_zone_name}."
-  type = "A"
-  ttl = "60"
-  records = ["${aws_eip.concourse.public_ip}"]
-}

--- a/terraform/concourse/elb.tf
+++ b/terraform/concourse/elb.tf
@@ -1,0 +1,57 @@
+resource "aws_elb" "concourse" {
+  name            = "${var.env}-concourse"
+  subnets         = ["${var.subnet0_id}"]
+  security_groups = ["${aws_security_group.concourse-elb.id}"]
+
+  health_check {
+    target              = "TCP:8080"
+    interval            = 5
+    timeout             = 2
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+  }
+
+  listener {
+    instance_port       = 8080
+    instance_protocol   = "http"
+    lb_port             = 443
+    lb_protocol         = "https"
+    ssl_certificate_id  = "${var.concourse_elb_cert_arn}"
+  }
+
+  tags {
+    Name = "${var.env}-concourse-elb"
+  }
+}
+
+resource "aws_security_group" "concourse-elb" {
+  name        = "${var.env}-concourse-elb"
+  description = "Concourse ELB security group"
+  vpc_id      = "${var.vpc_id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    cidr_blocks     = ["${split(",", var.office_cidrs)}"]
+  }
+
+  tags {
+    Name = "${var.env}-concourse-elb"
+  }
+}
+
+resource "aws_route53_record" "concourse" {
+  zone_id = "${var.dns_zone_id}"
+  name    = "${var.env}-concourse.${var.dns_zone_name}."
+  type    = "CNAME"
+  ttl     = "60"
+  records = ["${aws_elb.concourse.dns_name}"]
+}

--- a/terraform/concourse/outputs.tf
+++ b/terraform/concourse/outputs.tf
@@ -9,3 +9,7 @@ output "concourse_security_group" {
 output "concourse_security_group_id" {
   value = "${aws_security_group.concourse.id}"
 }
+
+output "concourse_elb_name" {
+  value = "${aws_elb.concourse.name}"
+}

--- a/terraform/concourse/security_group.tf
+++ b/terraform/concourse/security_group.tf
@@ -11,16 +11,16 @@ resource "aws_security_group" "concourse" {
   }
 
   ingress {
-    from_port = 8080
-    to_port   = 8080
-    protocol  = "tcp"
-    cidr_blocks = ["${compact(concat(split(",", var.office_cidrs), var.vagrant_cidr))}"]
+    from_port       = 8080
+    to_port         = 8080
+    protocol        = "tcp"
+    security_groups = ["${aws_security_group.concourse-elb.id}"]
   }
 
   ingress {
-    from_port = 6868
-    to_port   = 6868
-    protocol  = "tcp"
+    from_port   = 6868
+    to_port     = 6868
+    protocol    = "tcp"
     cidr_blocks = ["${compact(concat(split(",", var.office_cidrs), var.vagrant_cidr))}"]
   }
 

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -60,3 +60,8 @@ variable "microbosh_static_private_ip" {
   description = "Microbosh internal IP"
   default     = "10.0.0.6"
 }
+
+variable "concourse_elb_cert_arn" {
+  description = "Concourse ELB certificate ARN"
+  default     = "arn:aws:iam::988997429095:server-certificate/wildcard-cf-paas"
+}


### PR DESCRIPTION
# What
Allow external access to Concourse via HTTPS only.

We create an ELB with HTTPS in front of Concourse and close external access to Concourse via HTTP 8080.

The default certificate used is the wildcard self-signed certificate stored in `paas-pass` and uploaded manually to AWS.

# How to review
* Build a new Concourse and connect to `https://${DEPLOY_ENV}-concourse.cf.paas.alphagov.co.uk/`.
* Check that insecure access via HTTP 8080 is closed.
* Note: the certificate is self-signed so fly won't accept it unless you login with the -k option

# Who can review
Anyone but @actionjack or @saliceti