### PR TITLE
[#109878560] TCP+SSL in ELB allows websockets for concourse

### DIFF
--- a/terraform/concourse/elb.tf
+++ b/terraform/concourse/elb.tf
@@ -13,9 +13,9 @@ resource "aws_elb" "concourse" {
 
   listener {
     instance_port       = 8080
-    instance_protocol   = "http"
+    instance_protocol   = "tcp"
     lb_port             = 443
-    lb_protocol         = "https"
+    lb_protocol         = "ssl"
     ssl_certificate_id  = "${var.concourse_elb_cert_arn}"
   }
 


### PR DESCRIPTION
[#109878560 Secure access to the Deployer Concourse ](https://www.pivotaltracker.com/story/show/109878560)

# What 

When running `fly hijack` command, it promotes the connection to
WebSockets for the interactive communication.

But ELB using HTTP/HTTPS protocols do not support WebSockets, so the
feature is broken.

The solution is to use the protocols SSL for LoadBalancer protocol and
TCP for the instance protocol.

# Context

This PR changes the protocols for the ELB used for SSL termination in front of concourse.

# How to test this

> Note: you can apply this change over a already deployed concourse by changing the variable `export BRANCH=$(git rev-parse --abbrev-ref HEAD)` and running again `./vagrant/deploy.sh <env>` to apply the changes in terraform.

 1. Deploy concourse as described in the README. Remember change the BRANCH variable: `export BRANCH=$(git rev-parse --abbrev-ref HEAD)`
 2. Run at least one job of the deploy-microbosh pipeline (see README)
 3. run `fly hijack` on one job, for instance:   `fly -t $FLY_TARGET hijack -j create-microbosh/init  sh`
 4. check that you can interactively operate inside of the container (move around, execute a pair of commands).

# Who?

Anyone but @keymon
```