### PR TITLE
Don't trigger create-microbosh from paas-cf

### DIFF
--- a/concourse/pipelines/create-microbosh.yml
+++ b/concourse/pipelines/create-microbosh.yml
@@ -81,8 +81,6 @@ jobs:
   - name: init
     serial: true
     plan:
-    - get: paas-cf
-      trigger: true
     - put: pipeline-trigger
       params: {bump: patch}
 


### PR DESCRIPTION
We don't (yet) want this pipeline to be triggered on every commit to
git. This is different to all the other pipelines and therefore causes
surprise.