### PR TITLE
[#111293784] Delete CF deployment from Concourse

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ This pipeline will:
    with an empty file.
  * Destroy the resources created by terraform.
 
-#### Deploy cloudfoundry with microbosh
+### Deploy and destroy cloudfoundry with microbosh
 ```
 # Optionally pass the current branch for the git resources
 export BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -177,6 +177,17 @@ This pipeline will:
    foundry
  * build the cloudfoundry manifests
  * use these manifests and microbosh instance to deploy cloudfoundry
+
+ To setup destroy pipeline you have to execute:
+
+ ```
+ ./concourse/scripts/destroy-cloudfoundry.sh <environment_name>
+```
+
+This pipeline will
+
+ * Connect to microbosh and delete CF deployment
+ * Use Terraform to destroy all the resources created by `deploy-cloudfoundry`
 
 # Additional notes
 

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -1,0 +1,107 @@
+resources:
+  - name: paas-cf
+    type: git
+    source:
+      uri: https://github.com/alphagov/paas-cf.git
+      branch: {{branch_name}}
+
+  - name: cf-tfstate
+    type: s3
+    source:
+      bucket: {{state_bucket}}
+      access_key_id: {{aws_access_key_id}}
+      secret_access_key: {{aws_secret_access_key}}
+      versioned_file: cf.tfstate
+      region_name: {{aws_region}}
+
+  - name: vpc-tfstate
+    type: s3
+    source:
+      bucket: {{state_bucket}}
+      access_key_id: {{aws_access_key_id}}
+      secret_access_key: {{aws_secret_access_key}}
+      versioned_file: vpc.tfstate
+      region_name: {{aws_region}}
+
+  - name: trigger-tf-destroy
+    type: semver
+    source:
+      bucket: {{state_bucket}}
+      region_name: {{aws_region}}
+      access_key_id: {{aws_access_key_id}}
+      secret_access_key: {{aws_secret_access_key}}
+      key: trigger-tf-destroy
+
+jobs:
+  - name: delete-deployment
+    serial_groups: [ destroy ]
+    serial: true
+    plan:
+      - task: delete-deplyment
+        config:
+          image: docker:///concourse/bosh-deployment-resource
+          run:
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              bosh -n -t https://10.0.0.6:25555 -u admin -p {{bosh_password}} delete deployment {{deploy_env}}
+      - put: trigger-tf-destroy
+        params: {bump: patch}
+
+  - name: terraform-destroy
+    serial_groups: [ destroy ]
+    serial: true
+    plan:
+      - aggregate:
+        - get: trigger-tf-destroy
+          passed: ['delete-deployment']
+          trigger: true
+        - get: paas-cf
+        - get: cf-tfstate
+        - get: vpc-tfstate
+      - task: terraform-variables
+        config:
+          image: docker:///ruby#2.2.3-slim
+          inputs:
+            - name: paas-cf
+            - name: cf-tfstate
+            - name: vpc-tfstate
+          run:
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              ruby paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
+              < cf-tfstate/cf.tfstate > cf.tfvars.sh
+              ls -l cf.tfvars.sh
+              ruby paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
+              < vpc-tfstate/vpc.tfstate > vpc.tfvars.sh
+              ls -l vpc.tfvars.sh
+      - task: cf-terraform-destroy
+        config:
+          image: docker:///governmentpaas/docker-terraform
+          params:
+            AWS_DEFAULT_REGION: {{aws_region}}
+            TF_VAR_AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
+            TF_VAR_AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
+          inputs:
+            - name: terraform-variables
+            - name: paas-cf
+            - name: cf-tfstate
+          run:
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              . terraform-variables/cf.tfvars.sh
+              . terraform-variables/vpc.tfvars.sh
+              terraform destroy -force -var env={{deploy_env}} -state=cf-tfstate/cf.tfstate \
+                -state-out=cf.tfstate paas-cf/terraform/cloudfoundry
+        ensure:
+          put: cf-tfstate
+          params:
+            file: cf-terraform-destroy/cf.tfstate

--- a/concourse/scripts/destroy-cloudfoundry.sh
+++ b/concourse/scripts/destroy-cloudfoundry.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR=$(cd "$(dirname $0)" && pwd)
+ATC_URL=${ATC_URL:-"http://192.168.100.4:8080"}
+FLY_TARGET=${FLY_TARGET:-$ATC_URL}
+
+env=${DEPLOY_ENV-$1}
+pipeline="destroy-cloudfoundry"
+config="${SCRIPT_DIR}/../pipelines/destroy-cloudfoundry.yml"
+bosh_password=$("$SCRIPT_DIR"/s3get.sh ${env}-state bosh-secrets.yml > /dev/null && awk '$1~/bosh_admin_password/ {print $2}' bosh-secrets.yml)
+[[ -z "${env}" ]] && echo "Must provide environment name" && exit 100
+
+generate_vars_file() {
+   set -u # Treat unset variables as an error when substituting
+   cat <<EOF
+---
+deploy_env: ${env}
+state_bucket: ${env}-state
+pipeline_name: ${pipeline}
+branch_name: ${BRANCH:-master}
+aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
+aws_access_key_id: ${AWS_ACCESS_KEY_ID}
+aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+bosh_password: ${bosh_password}
+debug: ${DEBUG:-}
+EOF
+}
+generate_vars_file > /dev/null # Check for missing vars
+
+bash "${SCRIPT_DIR}/deploy-pipeline.sh" \
+   "${env}" "${pipeline}" "${config}" <(generate_vars_file)
+
+fly -t "$FLY_TARGET" unpause-pipeline --pipeline "${pipeline}"
+
+


### PR DESCRIPTION
# What

Destroy the Cloudfoundry deployment that was created by [initiate CF deployment from Concourse](https://www.pivotaltracker.com/story/show/110234556) story.

# Details

This pipeline uses microbosh and provided environment  name to delete CF deployment. Next it pulls CF terraform state from s3 bucket and destroys all TF resources that were created by CF deployment pipeline. Last step is to upload TF state to state bucket. 

# How to test 

This assumes that you have a working CF deployment already and $FLY_TARGET exported.
```
BRANCH=111293784_cf_destroy concourse/scripts/destroy-cloudfoundry.sh <env_name>
```

# Who can test

Anyone but @combor and @saliceti  

