### PR TITLE
Fix put of bosh state in create/destroy microbosh pipelines

### DIFF
--- a/concourse/pipelines/create-microbosh.yml
+++ b/concourse/pipelines/create-microbosh.yml
@@ -260,5 +260,5 @@ jobs:
       on_success:
         put: bosh-init-state
         params:
-          file: bosh-manifest/bosh-manifest-state.json
+          file: bosh-init-microbosh/bosh-manifest/bosh-manifest-state.json
 

--- a/concourse/pipelines/destroy-microbosh.yml
+++ b/concourse/pipelines/destroy-microbosh.yml
@@ -107,7 +107,7 @@ jobs:
       ensure:
         put: bosh-init-state
         params:
-          file: bosh-manifest/bosh-manifest-state.json
+          file: bosh-init-microbosh/bosh-manifest/bosh-manifest-state.json
 
   - name: bosh-terraform-destroy
     serial: true


### PR DESCRIPTION
I suspect this was broken by 05b309d.

This was erroring in the destroy pipeline with a missing file error, and
was failing to upload the updates state in the create pipeline. This is
due to an incorrect path in the put that was pointing at the output of
the `get` step, and not the output of the task itself.

Each concourse job runs in a working directory. Within that, a directory
is created for each get and task. For each input to a task, the
corresponding directory is copied from the working directory into the
task's directory before the task is run (additionally, each output is
copied from the tasks directory up to the working directory after the
task has run).  Because these tasks modify files in their directory, and
don't have any outputs, it's necessary to reference the file within the
tasks directory, and not at the top level.