### PR TITLE
[#110234556] Stop using the insecure deployer - concourse / deployer

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,17 @@ echo -e "admin\n${CONCOURSE_ATC_PASSWORD}" | \
    fly -t $FLY_TARGET login -k -c https://${DEPLOY_ENV}-concourse.cf.paas.alphagov.co.uk
 ```
 
+#### ssh to deployed Concourse
+
+During the deploy process, a keypair is created in aws to create the instance
+with. This is uploaded to s3 and then discarded, to avoid the private key being
+left anywhere in the pipeline. To ssh to the instance, find its ip in the
+console and download the deployer-key file from the s3 state bucket, then run
+
+```
+ssh -i <deployer-key-file-from-state-bucket> vcap@${DEPLOY_ENV}-concourse.cf.paas.alphagov.co.uk
+```
+
 ### Microbosh deployment from concourse bootstrap
 
 These pipelines will deploy/destroy a microbosh using bosh-init.

--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -339,6 +339,48 @@ jobs:
     - get: concourse-bosh-state
     - get: concourse-manifest
       passed: [concourse-prepare-deploy]
+    - get: paas-cf
+    - task: generate-key-and-add-to-ec2
+      config:
+        image: docker:///governmentpaas/docker-terraform
+        inputs:
+        - name: paas-cf
+        outputs:
+        - name: bosh-init-key
+        params:
+          AWS_DEFAULT_REGION: {{aws_region}}
+          AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
+          AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
+          DEPLOY_ENV: {{deploy_env}}
+        run:
+          path: sh
+          args:
+          - -e
+          - -c
+          - |
+            ssh-keygen -t rsa -b 4096 -f bosh-init-key/id_rsa -N ''
+            sed "s/<SED_KEY_NAME>/${DEPLOY_ENV}-deployer/" paas-cf/terraform/bosh-init-keys/dummy.state > /tmp/dummy.state
+            terraform apply -state /tmp/dummy.state -var key-name="${DEPLOY_ENV}-deployer" paas-cf/terraform/bosh-init-keys
+    - task: upload-concourse-ssh-key-to-s3
+      config:
+        image: docker:///governmentpaas/curl-ssl
+        inputs:
+        - name: paas-cf
+        - name: bosh-init-key
+        params:
+          AWS_DEFAULT_REGION: {{aws_region}}
+          AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
+          AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
+        run:
+          path: sh
+          args:
+          - -e
+          - -c
+          - |
+            cd bosh-init-key
+            cp id_rsa deployer-key
+            ../paas-cf/concourse/scripts/s3put.sh {{state_bucket}} deployer-key
+            rm deployer-key
 
     - task: concourse-deploy
       timeout: 30m
@@ -347,14 +389,14 @@ jobs:
         inputs:
         - name: concourse-manifest
         - name: concourse-bosh-state
-        params: {private_ssh_key: {{private_ssh_key}} }
+        - name: bosh-init-key
         run:
           path: sh
           args:
           - -e
           - -c
           - |
-            echo -n "${private_ssh_key}" > id_rsa
+            cp bosh-init-key/id_rsa id_rsa
             chmod 400 id_rsa
             ls -l id_rsa
             cp -v concourse-bosh-state/concourse-state.json .

--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -461,7 +461,6 @@ jobs:
           args:
           - -e
           - -c
-          - -x
           - |
             terraform apply -target=aws_security_group.office-access-ssh \
               -state=vpc-terraform-state/vpc.tfstate -state-out=vpc.tfstate \
@@ -491,7 +490,6 @@ jobs:
           args:
           - -e
           - -c
-          - -x
           - |
             . vpc-terraform-outputs/tfvars.sh
             terraform apply -target=aws_security_group.concourse \

--- a/concourse/pipelines/destroy-deployer.yml
+++ b/concourse/pipelines/destroy-deployer.yml
@@ -77,7 +77,6 @@ jobs:
         inputs:
         - name: concourse-manifest
         - name: concourse-bosh-state
-        params: {private_ssh_key: {{private_ssh_key}} }
         run:
           path: sh
           args:
@@ -88,9 +87,9 @@ jobs:
             [ "$(cat concourse-bosh-state/concourse-state.json)" = "{}" ] \
               && echo Concourse bosh state empty, assuming already destroyed \
               && exit 0
-            echo -n "${private_ssh_key}" > id_rsa
+            touch id_rsa
             chmod 400 id_rsa
-            ls -l id_rsa
+
             cp -v concourse-manifest/concourse.yml .
             export BOSH_INIT_LOG_LEVEL={{log_level}}
             bosh-init delete concourse.yml
@@ -149,7 +148,26 @@ jobs:
         put: concourse-terraform-state
         params:
           file: destroy-concourse-terraform/concourse.tfstate
-
+    - task: delete-concourse-ec2-keypair
+      config:
+        image: docker:///governmentpaas/docker-terraform
+        inputs:
+        - name: paas-cf
+        params:
+          AWS_DEFAULT_REGION: {{aws_region}}
+          AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
+          AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
+          DEPLOY_ENV: {{deploy_env}}
+        run:
+          path: sh
+          args:
+          - -e
+          - -c
+          - |
+            sed "s/<SED_KEY_NAME>/${DEPLOY_ENV}-deployer/" paas-cf/terraform/bosh-init-keys/dummy.state > /tmp/dummy.state
+            mkdir bosh-init-key
+            touch bosh-init-key/id_rsa.pub
+            terraform destroy -state /tmp/dummy.state -var key-name="${DEPLOY_ENV}-deployer" -force paas-cf/terraform/bosh-init-keys
     - put: destroy-all-trigger
       params: {bump: patch}
 

--- a/concourse/scripts/create-deployer.sh
+++ b/concourse/scripts/create-deployer.sh
@@ -26,8 +26,6 @@ aws_access_key_id: ${AWS_ACCESS_KEY_ID}
 aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
 concourse_atc_password: ${CONCOURSE_ATC_PASSWORD}
 log_level: ${LOG_LEVEL:-}
-private_ssh_key: |
-$(cat ~/.ssh/insecure-deployer | sed 's/^/  /')
 EOF
 }
 

--- a/concourse/scripts/destroy-deployer.sh
+++ b/concourse/scripts/destroy-deployer.sh
@@ -24,8 +24,6 @@ aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
 aws_access_key_id: ${AWS_ACCESS_KEY_ID}
 aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
 log_level: ${LOG_LEVEL:-}
-private_ssh_key: |
-$(cat ~/.ssh/insecure-deployer | sed 's/^/  /')
 EOF
 }
 

--- a/concourse/scripts/s3put.sh
+++ b/concourse/scripts/s3put.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+bucket=$1
+file=$2
+
+# Attempt to use instance profile if keys not configured
+if [ -z "${AWS_SECRET_ACCESS_KEY}" ] && [ -z ${AWS_ACCESS_KEY_ID} ] ; then
+  meta_url="http://169.254.169.254/latest/meta-data/iam/security-credentials/"
+  profile_name=$(curl -s ${meta_url})
+  instance_profile=$(curl -s ${meta_url}/${profile_name})
+
+      AWS_ACCESS_KEY_ID=$(echo "${instance_profile}" | awk -F\" '$2 == "AccessKeyId"     { print $4 }')
+     AWS_SECURITY_TOKEN=$(echo "${instance_profile}" | awk -F\" '$2 == "Token"           { print $4 }')
+  AWS_SECRET_ACCESS_KEY=$(echo "${instance_profile}" | awk -F\" '$2 == "SecretAccessKey" { print $4 }')
+
+  [ -z "${AWS_SECURITY_TOKEN}" ] && echo "Could not obtain AWS_SECURITY_TOKEN from instance profile" && exit 105
+fi
+
+[ -z "${bucket}" ]    && echo "Must provide bucket name"    && exit 100
+[ -z "${file}" ]      && echo "Must provide file name"      && exit 101
+[ -z "${AWS_ACCESS_KEY_ID}"     ] && echo "AWS_ACCESS_KEY_ID nor specified or present in instance profile"     && exit 103
+[ -z "${AWS_SECRET_ACCESS_KEY}" ] && echo "AWS_SECRET_ACCESS_KEY nor specified or present in instance profile" && exit 104
+
+aws_path=/
+content_type='application/x-compressed-tar'
+acl="x-amz-acl:private"
+region=eu-west-1
+host=${bucket}.s3-${region}.amazonaws.com
+
+sign() {
+  string=$1
+  printf "${string}" | openssl sha1 -hmac "${AWS_SECRET_ACCESS_KEY}" -binary | base64
+}
+
+put() {
+  date=$(date +"%a, %d %b %Y %T %z")
+  string="PUT\n\n${content_type}\n${date}\n${acl}\n${AWS_SECURITY_TOKEN:+x-amz-security-token:$AWS_SECURITY_TOKEN\n}/${bucket}${aws_path}${file}"
+  signature=$(sign "${string}")
+  curl -i -s -X PUT -T ${file} \
+    -H "Host: ${bucket}.s3.amazonaws.com" \
+    -H "Date: ${date}" \
+    -H "Content-Type: ${content_type}" \
+    -H "${acl}" \
+    ${AWS_SECURITY_TOKEN:+-H "x-amz-security-token: ${AWS_SECURITY_TOKEN}"} \
+    -H "Authorization: AWS ${AWS_ACCESS_KEY_ID}:${signature}" \
+    "https://${host}${aws_path}${file}"
+}
+
+put

--- a/manifests/concourse-base.yml
+++ b/manifests/concourse-base.yml
@@ -110,7 +110,7 @@ cloud_provider:
     aws:
       access_key_id: (( grab secrets.aws_access_key_id ))
       secret_access_key: (( grab secrets.aws_secret_access_key ))
-      default_key_name: insecure-deployer
+      default_key_name: (( concat terraform_outputs.environment "-deployer" ))
       default_security_groups:
       - (( grab terraform_outputs.concourse_security_group ))
       - (( grab terraform_outputs.ssh_security_group ))

--- a/terraform/bosh-init-keys/dummy.state
+++ b/terraform/bosh-init-keys/dummy.state
@@ -1,0 +1,25 @@
+{
+    "version": 1,
+    "serial": 1,
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {},
+            "resources": {
+                "aws_key_pair.bosh-init": {
+                    "type": "aws_key_pair",
+                    "primary": {
+                        "id": "<SED_KEY_NAME>",
+                        "attributes": {
+                        },
+                        "meta": {
+                            "schema_version": "1"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/terraform/bosh-init-keys/keypair.tf
+++ b/terraform/bosh-init-keys/keypair.tf
@@ -1,0 +1,8 @@
+variable "key-name" {
+  description = "A name for the key to be uploaded to EC2 key pairs"
+}
+
+resource "aws_key_pair" "bosh-init" {
+  key_name = "${var.key-name}"
+  public_key = "${file("bosh-init-key/id_rsa.pub")}"
+}


### PR DESCRIPTION
> Note: There is an alternative implementation in #43 both should be compared and discussed.

**What**

We want to stop using the insecure deployer key

**How this PR should be reviewed**

This PR should reviewed in the following context:

* We are no longer using the insecure deployer key for deployer vm
* It is still possible to ssh to the deployer vm

**How to test this PR**
Check the branch out, run the deployment script.

```
export BRANCH=$(git rev-parse --abbrev-ref HEAD)
./vagrant/deploy.sh
```

Then run the create-deployer pipeline

When the create-deployer pipeline has finished, check your concourse/0 vm does not use the insecure-deployer keypair

Verify you can ssh into the concourse vm - Find and download the deployer-key in the s3 state bucket, then ssh to the instance using this key. 

```
ssh -i <deployer-key-file-from-state-bucket> vcap@{DEPLOY_ENV}-concourse.cf.paas.alphagov.co.uk
```

**Who should review this PR**

* Anyone but me or @mtekel