### PR TITLE
[#110234556] Fix bosh secret generation

### DIFF
--- a/concourse/pipelines/create-microbosh.yml
+++ b/concourse/pipelines/create-microbosh.yml
@@ -121,8 +121,8 @@ jobs:
           - -e
           - -c
           - |
-            ./paas-cf/concourse/scripts/generate-bosh-secrets.sh > ./bosh-secrets.yml
-            ./paas-cf/concourse/scripts/s3init.sh {{state_bucket}} bosh-secrets.yml ./bosh-secrets.yml
+            ./paas-cf/concourse/scripts/generate-bosh-secrets.sh > ./generated-bosh-secrets.yml
+            ./paas-cf/concourse/scripts/s3init.sh {{state_bucket}} bosh-secrets.yml ./generated-bosh-secrets.yml
         inputs:
         - name: paas-cf
 


### PR DESCRIPTION
s3init currently also downloads the file. That's why your init file
and main file name have to be different files. Otherwise you'll over-
write your init file in the checking process and instead initialize
with the file containing S3 API reply.