### PR TITLE
[#110234556] Stop using the insecure deployer

### DIFF
--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -152,6 +152,26 @@ jobs:
       passed: [init-bucket]
     - get: vpc-terraform-state
 
+    - task: ssh-keygen
+      config:
+        image: docker:///governmentpaas/curl-ssl
+        inputs:
+        - name: paas-cf
+        params:
+          AWS_DEFAULT_REGION: {{aws_region}}
+          AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
+          AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
+        run:
+          path: sh
+          args:
+          - -e
+          - -c
+          - |
+            apk add --update openssh
+            ssh-keygen -t rsa -b 4096 -f generated_id_rsa -N ''
+            ./paas-cf/concourse/scripts/s3init.sh {{state_bucket}} id_rsa generated_id_rsa
+            ./paas-cf/concourse/scripts/s3init.sh {{state_bucket}} id_rsa.pub generated_id_rsa.pub
+
     - task: deploy-vpc
       config:
         platform: linux
@@ -159,6 +179,7 @@ jobs:
         inputs:
         - name: paas-cf
         - name: vpc-terraform-state
+        - name: ssh-keygen
         params:
           VAGRANT_IP: {{vagrant_ip}}
           TF_VAR_env: {{deploy_env}}
@@ -173,6 +194,7 @@ jobs:
           - -e
           - -c
           - |
+            cp ssh-keygen/id_rsa.pub paas-cf/terraform/vpc
             terraform_params=${VAGRANT_IP:+-var vagrant_cidr=$VAGRANT_IP/32}
             terraform apply ${terraform_params} -state=vpc-terraform-state/vpc.tfstate -state-out=vpc.tfstate paas-cf/terraform/vpc
       ensure:
@@ -337,6 +359,7 @@ jobs:
       trigger: true
       passed: [concourse-prepare-deploy]
     - get: concourse-bosh-state
+    - get: ssh-private-key
     - get: concourse-manifest
       passed: [concourse-prepare-deploy]
 

--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -70,6 +70,15 @@ resources:
       versioned_file: concourse.yml
       region_name: {{aws_region}}
 
+  - name: ssh-private-key
+    type: s3
+    source:
+      bucket: {{state_bucket}}
+      access_key_id: {{aws_access_key_id}}
+      secret_access_key: {{aws_secret_access_key}}
+      versioned_file: id_rsa
+      region_name: {{aws_region}}
+
 jobs:
   - name: init-bucket
     serial: true
@@ -370,14 +379,14 @@ jobs:
         inputs:
         - name: concourse-manifest
         - name: concourse-bosh-state
-        params: {private_ssh_key: {{private_ssh_key}} }
+        - name: ssh-private-key
         run:
           path: sh
           args:
           - -e
           - -c
           - |
-            echo -n "${private_ssh_key}" > id_rsa
+            cp ssh-private-key/id_rsa id_rsa
             chmod 400 id_rsa
             ls -l id_rsa
             cp -v concourse-bosh-state/concourse-state.json .

--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -451,7 +451,6 @@ jobs:
           args:
           - -e
           - -c
-          - -x
           - |
             terraform apply -target=aws_security_group.office-access-ssh \
               -state=vpc-terraform-state/vpc.tfstate -state-out=vpc.tfstate \
@@ -481,7 +480,6 @@ jobs:
           args:
           - -e
           - -c
-          - -x
           - |
             . vpc-terraform-outputs/tfvars.sh
             terraform apply -target=aws_security_group.concourse \

--- a/concourse/pipelines/create-microbosh.yml
+++ b/concourse/pipelines/create-microbosh.yml
@@ -77,6 +77,15 @@ resources:
       secret_access_key: {{aws_secret_access_key}}
       key: {{pipeline_trigger_file}}
 
+  - name: ssh-private-key
+    type: s3
+    source:
+      bucket: {{state_bucket}}
+      access_key_id: {{aws_access_key_id}}
+      secret_access_key: {{aws_secret_access_key}}
+      versioned_file: id_rsa
+      region_name: {{aws_region}}
+
 jobs:
   - name: init
     serial: true
@@ -191,10 +200,12 @@ jobs:
       trigger: true
       passed: [bosh-terraform]
     - get: paas-cf
+    - get: vpc-tfstate
     - get: bosh-tfstate
       passed: [bosh-terraform]
     - get: bosh-secrets
     - get: bosh-init-state
+    - get: ssh-private-key
     - task: terraform_outputs
       config:
         image: docker:///ruby#2.2.3-slim
@@ -205,11 +216,15 @@ jobs:
           - -e
           - |
             ruby paas-cf/concourse/scripts/extract_terraform_state_to_yaml.rb \
+              < vpc-tfstate/vpc.tfstate \
+              > terraform-outputs/vpc.terraform-outputs.yml
+            ruby paas-cf/concourse/scripts/extract_terraform_state_to_yaml.rb \
               < bosh-tfstate/bosh.tfstate \
-              > terraform-outputs/terraform-outputs.yml
+              > terraform-outputs/bosh.terraform-outputs.yml
         inputs:
         - name: paas-cf
         - name: bosh-tfstate
+        - name: vpc-tfstate
         outputs:
         - name: terraform-outputs
     - task: render-manifest
@@ -225,7 +240,8 @@ jobs:
 
             ./build_manifest.sh \
               ../../../bosh-secrets/bosh-secrets.yml \
-              ../../../terraform-outputs/terraform-outputs.yml \
+              ../../../terraform-outputs/bosh.terraform-outputs.yml \
+              ../../../terraform-outputs/vpc.terraform-outputs.yml \
               > ../../../bosh-manifest/bosh-manifest.yml
 
             /bin/cat ../../../bosh-manifest/bosh-manifest.yml
@@ -249,7 +265,7 @@ jobs:
           - -c
           - |
             mkdir -p bosh-manifest/.ssh
-            echo {{private_ssh_key}} >> bosh-manifest/.ssh/id_rsa
+            cp ssh-private-key/id_rsa bosh-manifest/.ssh/id_rsa
             chmod 400 bosh-manifest/.ssh/id_rsa
             cp bosh-init-state/bosh-manifest-state.json bosh-manifest/bosh-manifest-state.json
             bosh-init deploy bosh-manifest/bosh-manifest.yml
@@ -257,6 +273,7 @@ jobs:
         - name: paas-cf
         - name: bosh-manifest
         - name: bosh-init-state
+        - name: ssh-private-key
       on_success:
         put: bosh-init-state
         params:

--- a/concourse/pipelines/destroy-deployer.yml
+++ b/concourse/pipelines/destroy-deployer.yml
@@ -77,7 +77,6 @@ jobs:
         inputs:
         - name: concourse-manifest
         - name: concourse-bosh-state
-        params: {private_ssh_key: {{private_ssh_key}} }
         run:
           path: sh
           args:

--- a/concourse/scripts/create-deployer.sh
+++ b/concourse/scripts/create-deployer.sh
@@ -26,8 +26,6 @@ aws_access_key_id: ${AWS_ACCESS_KEY_ID}
 aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
 concourse_atc_password: ${CONCOURSE_ATC_PASSWORD}
 log_level: ${LOG_LEVEL:-}
-private_ssh_key: |
-$(cat ~/.ssh/insecure-deployer | sed 's/^/  /')
 EOF
 }
 

--- a/concourse/scripts/create-microbosh.sh
+++ b/concourse/scripts/create-microbosh.sh
@@ -24,8 +24,6 @@ branch_name: ${BRANCH:-master}
 aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
 aws_access_key_id: ${AWS_ACCESS_KEY_ID}
 aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
-private_ssh_key: |
-$(cat ~/.ssh/insecure-deployer | sed 's/^/  /')
 debug: ${DEBUG:-}
 EOF
 }

--- a/concourse/scripts/destroy-deployer.sh
+++ b/concourse/scripts/destroy-deployer.sh
@@ -24,8 +24,6 @@ aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
 aws_access_key_id: ${AWS_ACCESS_KEY_ID}
 aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
 log_level: ${LOG_LEVEL:-}
-private_ssh_key: |
-$(cat ~/.ssh/insecure-deployer | sed 's/^/  /')
 EOF
 }
 

--- a/concourse/scripts/destroy-microbosh.sh
+++ b/concourse/scripts/destroy-microbosh.sh
@@ -24,8 +24,6 @@ branch_name: ${BRANCH:-master}
 aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
 aws_access_key_id: ${AWS_ACCESS_KEY_ID}
 aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
-private_ssh_key: |
-$(cat ~/.ssh/insecure-deployer | sed 's/^/  /')
 debug: ${DEBUG:-}
 EOF
 }

--- a/manifests/concourse-base.yml
+++ b/manifests/concourse-base.yml
@@ -113,7 +113,7 @@ cloud_provider:
     aws:
       access_key_id: (( grab secrets.aws_access_key_id ))
       secret_access_key: (( grab secrets.aws_secret_access_key ))
-      default_key_name: insecure-deployer
+      default_key_name: (( grab terraform_outputs.key_pair_name ))
       default_security_groups:
       - (( grab terraform_outputs.concourse_security_group ))
       - (( grab terraform_outputs.ssh_security_group ))

--- a/terraform/bosh/outputs.tf
+++ b/terraform/bosh/outputs.tf
@@ -37,8 +37,3 @@ output "microbosh_static_public_ip" {
 output "compiled_cache_bucket_host" {
 	value = "s3-${var.region}.amazonaws.com"
 }
-
-# TODO: Generate a key pair per installation
-output "key_pair_name" {
-	value = "${var.key_pair_name}"
-}

--- a/terraform/bosh/variables.tf
+++ b/terraform/bosh/variables.tf
@@ -10,9 +10,3 @@ variable "concourse_security_group_id" {
   description = "id of the security group for the concourse VM which deploys bosh with bosh-init"
 }
 
-# TODO: Implement a way to upload ssh keys
-variable "key_pair_name" {
-  description = "SSH Key Pair name to be used to launch EC2 instances"
-  default     = "insecure-deployer"
-}
-

--- a/terraform/vpc/outputs.tf
+++ b/terraform/vpc/outputs.tf
@@ -42,3 +42,7 @@ output "zone2" {
   value = "${var.zones.zone2}"
 }
 
+output "key_pair_name" {
+  value = "${aws_key_pair.env_key_pair.key_name}"
+}
+

--- a/terraform/vpc/ssh-key-pair.tf
+++ b/terraform/vpc/ssh-key-pair.tf
@@ -1,0 +1,4 @@
+resource "aws_key_pair" "env_key_pair" {
+  key_name = "${var.env}_key_pair"
+  public_key = "${file("${path.module}/id_rsa.pub")}"
+}


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/109897246

**What**

We want to stop using the insecure deployer key

**How this PR should be reviewed**


This PR should reviewed in the following context:

* We are no longer using the insecure deployer key for deployer vm
* It is still possible to ssh to the deployer vm

**How to test this PR**

 1. Check the branch out
 2. run the deployment as described in the README.

You can check the PR as you deploy, so:

Once the concourse deployed is created (`create-deployer` pipeline):

 * check your concourse/0 vm does not use the insecure-deployer keypair by checking in the AWS interface.
 * Verify you can ssh into the concourse vm: Find and download the `id_rsa` in the s3 state bucket, then ssh to the instance using this key. You can reuse the `s3get.sh` script:
    ```
./concourse/scripts/s3get.sh ${DEPLOY_ENV}-state id_rsa && chmod 400 id_rsa && ssh-add ./id_rsa
ssh vcap@<concourse_ip> -v -A  
```

   There should be a debug message indicating the SSH key used to login:
    ```
debug1: Offering RSA public key: /home/keymon/gds/paas-cf/id_rsa
debug1: Server accepts key: pkalg ssh-rsa blen 535
debug1: Authentication succeeded (publickey).
```

Once `create-microbosh` finishes, check the same for `bosh/0`. In this case, you must SSH from the concourse machine with agent forwarding (option `-A`)

```
ssh -v vcap@10.0.0.6
```

Finally, once Cloud Foundry is deployed you can check the same in the deployed VMs. Check the IP in the AWS console.

**Who should review this PR**

* Anyone but @keymon or @timmow  or @mtekel