### PR TITLE
Fix concourse deployer disk space

### DIFF
--- a/manifests/concourse-base.yml
+++ b/manifests/concourse-base.yml
@@ -30,7 +30,7 @@ resource_pools:
 
 disk_pools:
   - name: db
-    disk_size: 10240
+    disk_size: 40960
     cloud_properties:
       type: gp2
 

--- a/manifests/concourse-base.yml
+++ b/manifests/concourse-base.yml
@@ -20,13 +20,13 @@ resource_pools:
       sha1: a096b1f64482d130adc74c0cd4076fb4f5623e87
     cloud_properties:
       instance_type: t2.medium
+      ephemeral_disk:
+        size: 40960
+        type: gp2
       availability_zone: (( grab terraform_outputs.zone0 ))
       iam_instance_profile: bosh-bootstrap
       elbs:
       - (( grab terraform_outputs.concourse_elb_name ))
-      ephemeral_disk:
-        size: 50240
-        type: gp2
 
 disk_pools:
   - name: db


### PR DESCRIPTION
### What
There are 2 issues with disk space on the deployer:
* ephemeral disk definition was for some reason not correctly propagated into the concourse manifest. Moved the definition to a bit different place and it is now correctly rendered. Concourse doesn't seem to use that disk too much though, but it's better to have space available...

* the containers are stored on the persistent disk. So it's that one that needs to be big. Increased size. Current pipeline uses 11G, so 40GB should be enough.

### Testing
Deploy deployer concourse or apply against existing. SSH into instance to check disk space, you should see st. like:
```
vcap@7741a213-37e4-4304-7c63-49671ee209c3:/home/vcap# df -h
Filesystem      Size  Used Avail Use% Mounted on
/dev/xvda1      2.9G  1.9G  850M  70% /
none            4.0K     0  4.0K   0% /sys/fs/cgroup
udev            2.0G  4.0K  2.0G   1% /dev
tmpfs           396M  356K  395M   1% /run
none            5.0M     0  5.0M   0% /run/lock
none            2.0G  1.1M  2.0G   1% /run/shm
none            100M     0  100M   0% /run/user
/dev/xvdb2       36G   11G   23G  32% /var/vcap/data
tmpfs           1.0M   36K  988K   4% /var/vcap/data/sys/run
/dev/loop0      120M  1.6M  115M   2% /tmp
/dev/xvdg1       40G  108M   38G   1% /var/vcap/store
/dev/loop1       36G   17M   34G   1% /var/vcap/data/baggageclaim/volumes
cgroup          2.0G     0  2.0G   0% /tmp/garden-/cgroup
```

### Who
Not me