### PR TITLE
Require Vagrant version 1.7.0 or later

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,6 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+Vagrant.require_version ">= 1.7.0"
+
 Vagrant.configure(2) do |config|
   config.vm.box = ENV['VAGRANT_BOX_NAME'] || 'aws_vagrant_box'
 


### PR DESCRIPTION
Which introduced the `config.ssh.insert_key` option and enabled it by
default. We rely on this to replace the default insecure public key in the
concourse/lite AMI and we go to some additional effort in 67295ed to remove
any other keys.

You'll now get a more explanatory error message if you're using an older
version, rather than the following:

    ==> default: Mounting /var/vcap/data/garden on to ephemeral disk...
    ==> default: Setting up concourse basic auth as admin : ******
    Permission denied (publickey).
    Setting up SSH tunnel to concourse...
    Permission denied (publickey).