### PR TITLE
[#111303414] Use IAM role in bootstrap-concourse machine

### DIFF
--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -89,8 +89,6 @@ jobs:
         image: docker:///governmentpaas/curl-ssl
         params:
           AWS_DEFAULT_REGION: {{aws_region}}
-          AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-          AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
         inputs:
           - name: paas-cf
         outputs:
@@ -110,10 +108,6 @@ jobs:
         params:
           TF_VAR_env: {{deploy_env}}
           AWS_DEFAULT_REGION: {{aws_region}}
-          AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-          AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
-          TF_VAR_AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-          TF_VAR_AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
         inputs:
           - name: paas-cf
           - name: bucket-state
@@ -133,9 +127,6 @@ jobs:
     - task: s3init-concourse
       config:
         image: docker:///governmentpaas/curl-ssl
-        params:
-          AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-          AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
         run:
           path: sh
           args:
@@ -168,8 +159,6 @@ jobs:
         - name: paas-cf
         params:
           AWS_DEFAULT_REGION: {{aws_region}}
-          AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-          AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
         run:
           path: sh
           args:
@@ -193,10 +182,6 @@ jobs:
           VAGRANT_IP: {{vagrant_ip}}
           TF_VAR_env: {{deploy_env}}
           AWS_DEFAULT_REGION: {{aws_region}}
-          AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-          AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
-          TF_VAR_AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-          TF_VAR_AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
         run:
           path: sh
           args:
@@ -254,10 +239,6 @@ jobs:
           VAGRANT_IP: {{vagrant_ip}}
           TF_VAR_env: {{deploy_env}}
           AWS_DEFAULT_REGION: {{aws_region}}
-          AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-          AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
-          TF_VAR_AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-          TF_VAR_AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
         run:
           path: sh
           args:
@@ -442,10 +423,6 @@ jobs:
         params:
           TF_VAR_env: {{deploy_env}}
           AWS_DEFAULT_REGION: {{aws_region}}
-          AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-          AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
-          TF_VAR_AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-          TF_VAR_AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
         run:
           path: sh
           args:
@@ -471,10 +448,6 @@ jobs:
         params:
           TF_VAR_env: {{deploy_env}}
           AWS_DEFAULT_REGION: {{aws_region}}
-          AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-          AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
-          TF_VAR_AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-          TF_VAR_AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
         run:
           path: sh
           args:

--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -296,8 +296,6 @@ jobs:
     - task: create-concourse-secrets
       config:
         params:
-          aws_access_key_id: {{aws_access_key_id}}
-          aws_secret_access_key: {{aws_secret_access_key}}
           concourse_atc_password: {{concourse_atc_password}}
         outputs:
           - name: concourse-secrets
@@ -310,8 +308,6 @@ jobs:
             cat > concourse-secrets/concourse-secrets.yml << EOF
             ---
             secrets:
-              aws_access_key_id: ${aws_access_key_id}
-              aws_secret_access_key: ${aws_secret_access_key}
               concourse_atc_password: ${concourse_atc_password}
             EOF
             ls -l concourse-secrets/concourse-secrets.yml

--- a/concourse/pipelines/destroy-deployer.yml
+++ b/concourse/pipelines/destroy-deployer.yml
@@ -132,10 +132,6 @@ jobs:
         - name: concourse-terraform-state
         params:
           AWS_DEFAULT_REGION: {{aws_region}}
-          AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-          AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
-          TF_VAR_AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-          TF_VAR_AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
           TF_VAR_env: {{deploy_env}}
         run:
           path: sh
@@ -168,10 +164,6 @@ jobs:
         params:
             TF_VAR_env: {{deploy_env}}
             AWS_DEFAULT_REGION: {{aws_region}}
-            AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-            AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
-            TF_VAR_AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-            TF_VAR_AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
         inputs:
           - name: paas-cf
           - name: vpc-terraform-state
@@ -203,10 +195,6 @@ jobs:
           params:
               TF_VAR_env: {{deploy_env}}
               AWS_DEFAULT_REGION: {{aws_region}}
-              AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-              AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
-              TF_VAR_AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-              TF_VAR_AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
           inputs:
             - name: paas-cf
             - name: bucket-terraform-state

--- a/manifests/concourse-base.yml
+++ b/manifests/concourse-base.yml
@@ -24,7 +24,7 @@ resource_pools:
     cloud_properties:
       instance_type: t2.medium
       availability_zone: (( grab terraform_outputs.zone0 ))
-      iam_instance_profile: bosh-bootstrap
+      iam_instance_profile: deployer-concourse
       elbs:
       - (( grab terraform_outputs.concourse_elb_name ))
       ephemeral_disk:

--- a/manifests/concourse-base.yml
+++ b/manifests/concourse-base.yml
@@ -114,8 +114,7 @@ cloud_provider:
 
   properties:
     aws:
-      access_key_id: (( grab secrets.aws_access_key_id ))
-      secret_access_key: (( grab secrets.aws_secret_access_key ))
+      credentials_source: env_or_profile
       default_key_name: (( grab terraform_outputs.key_pair_name ))
       default_security_groups:
       - (( grab terraform_outputs.concourse_security_group ))

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -31,6 +31,9 @@ Vagrant.configure(2) do |config|
     # "Concourse Vagrant" security group
     aws.security_groups = ['sg-ee21a597']
 
+    # Add IAM role to allow access to necessary AWS APIs
+    aws.iam_instance_profile_name = 'bootstrap-concourse'
+
     # We will rely on vagrant generating a ssh key, but this must be the ubuntu user, as the vagrant user does not exist on the vm
     override.ssh.username = "ubuntu"
 


### PR DESCRIPTION
## What

Remove most usage of access keys  from the bootstrap-concourse pipelines.

## Detail

This updates the `{create,destroy}-deployer` pipelines to use IAM profiles for Terraform and the s3init scripts

The only thing left using access keys after this is the concourse resources themselves. These will be switched over to use profiles in another story.

This PR is the companion to https://github.gds/government-paas/terraform-iam/pull/5 which defines the roles in use here.  I've manually created roles with matching permissions in the trial account so that this can be tested.

## How to review

Deploy a new concourse-lite instance (it'll need to be newly provisioned from this branch in order to be given the necessary role):

```
BRANCH=bootstrap_concourse_role ./vagrant/deploy.sh $DEPLOY_ENV
```

Run both the create-deployer and destroy-deployer pipelines and verify that they successfully create/destroy everything.

## Who can review

Anyone but me.