### PR TITLE
[#110234556] Fix error when running vpc terraform destroy due missing id_rsa.pub file

### DIFF
--- a/concourse/pipelines/destroy-deployer.yml
+++ b/concourse/pipelines/destroy-deployer.yml
@@ -180,6 +180,7 @@ jobs:
           - -e
           - -c
           - |
+            touch paas-cf/terraform/vpc/id_rsa.pub
             terraform destroy -force -state=vpc-terraform-state/vpc.tfstate -state-out=vpc.tfstate paas-cf/terraform/vpc
       ensure:
         put: vpc-terraform-state


### PR DESCRIPTION
what
----

In #43 a bug has been introduced causing the destroy-deployer pipeline fail with:

```
There are warnings and/or errors related to your configuration. Please
fix these before continuing.

Errors:

  * file: open /tmp/build/965b4427-bcc6-4015-57f4-4bf3980ef0e6/paas-cf/terraform/vpc/id_rsa.pub: no such file or directory in:

  ${file("${path.module}/id_rsa.pub")}
```

The reason is that VPC terraform destroy requires a id_rsa.pub file

Terraform will read from the id_rsa.pub, even when destroying because
the file is read during variable interpolation. If the
file is missing, it will fail.

Because that, we need to create a dummy file with the same name.

how to review
-------------

Try to run `destroy-deployer`  pipeline

who
---

anyone but @keymon