### PR TITLE
[#109878560 #109897246] README: De-dupe incorrect SSH instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,5 +288,5 @@ If not, you can learn the credentials from the `atc` process arguments:
 
  1. Login on the concourse server:
     * For vagrant bootstrap concourse-lite: `cd vagrant && vagrant ssh`
-    * For deployer concourse: `ssh -l vcap ${DEPLOY_ENV}-concourse.cf.paas.alphagov.co.uk`
+    * [For deployer concourse](#ssh-to-deployed-concourse-and-microbosh)
  2. Get the password from `atc` arguments: `ps -fea | sed -n 's/.*--basic-auth[-]password \([^ ]*\).*/\1/p'`


### PR DESCRIPTION
These instructions were no longer working because:

- 48db141 changed the hostname from an EIP (which you could SSH to) to an
  ELB (which only forwards HTTP[S])
- 3a5e3f1 (and preceding commits) changed the SSH key that's used