### PR TITLE
[#111778374] Remove use of access keys in deployer concourse pipelines

### DIFF
--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -68,9 +68,6 @@ jobs:
       - task: s3init
         config:
           image: docker:///governmentpaas/curl-ssl
-          params:
-            AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-            AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
           run:
             path: sh
             args:

--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -134,10 +134,10 @@ jobs:
               . terraform-variables/bosh.tfvars.sh
 
               terraform apply -state=cf-tfstate/cf.tfstate -state-out=cf.tfstate paas-cf/terraform/cloudfoundry
-
-      - put: cf-tfstate
-        params:
-          file: terraform/cf.tfstate
+        ensure:
+          put: cf-tfstate
+          params:
+            file: terraform/cf.tfstate
 
   - name: generate-manifest
     serial_groups: [ deploy ]

--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -122,8 +122,6 @@ jobs:
           params:
             TF_VAR_env: {{deploy_env}}
             AWS_DEFAULT_REGION: {{aws_region}}
-            TF_VAR_AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-            TF_VAR_AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
           inputs:
             - name: terraform-variables
             - name: paas-cf

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -85,8 +85,6 @@ jobs:
           image: docker:///governmentpaas/docker-terraform
           params:
             AWS_DEFAULT_REGION: {{aws_region}}
-            TF_VAR_AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
-            TF_VAR_AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
           inputs:
             - name: terraform-variables
             - name: paas-cf


### PR DESCRIPTION
This removes the remaining usage of access keys in the deployer-concourse pipelines

This does not cover removing them from the concourse resources themselves (covered in a separate story), or from the cloudfoundry manifest (also covered in a separate story).

This relies on some additional permissions that are defined in https://github.gds/government-paas/terraform-iam/pull/6, and have been manually applied to the trial account.

## How to review

Run the create-microbosh and deploy-cloudfoundry pipelines from this branch and verify that they run successfully.

Run the corresponding destroy pipelines and verify that they also work as expected.

## Who can review

Anyone but me.