### PR TITLE
[#111760326] use custom s3 and semver resources with iam support

### DIFF
--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -17,65 +17,51 @@ resources:
       branch: {{branch_name}}
 
   - name: build-all-trigger
-    type: semver
+    type: semver-iam
     source:
       bucket: {{state_bucket}}
       region_name: {{aws_region}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       key: build-all-trigger
 
   - name: bucket-terraform-state
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
       region_name: {{aws_region}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: bucket.tfstate
 
   - name: vpc-terraform-state
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: vpc.tfstate
       region_name: {{aws_region}}
 
   - name: concourse-terraform-state
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: concourse.tfstate
       region_name: {{aws_region}}
 
   - name: concourse-bosh-state
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: concourse-state.json
       region_name: {{aws_region}}
 
   - name: concourse-manifest
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: concourse.yml
       region_name: {{aws_region}}
 
   - name: ssh-private-key
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: id_rsa
       region_name: {{aws_region}}
 

--- a/concourse/pipelines/create-microbosh.yml
+++ b/concourse/pipelines/create-microbosh.yml
@@ -6,83 +6,65 @@ resources:
       branch: {{branch_name}}
 
   - name: vpc-tfstate
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
       region_name: {{aws_region}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: vpc.tfstate
 
   - name: bosh-tfstate
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
       region_name: {{aws_region}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: bosh.tfstate
 
   - name: concourse-tfstate
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: concourse.tfstate
       region_name: eu-west-1
 
   - name: bosh-init-state
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
       region_name: {{aws_region}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: bosh-manifest-state.json
 
   - name: bosh-manifest
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
       region_name: {{aws_region}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: bosh-manifest.yml
 
   - name: bosh-secrets
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
       region_name: {{aws_region}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: bosh-secrets.yml
 
   - name: terraform-updated
-    type: semver
+    type: semver-iam
     source:
       bucket: {{state_bucket}}
       region_name: {{aws_region}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       key: terraform-updated
 
   - name: pipeline-trigger
-    type: semver
+    type: semver-iam
     source:
       bucket: {{state_bucket}}
       region_name: {{aws_region}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       key: {{pipeline_trigger_file}}
 
   - name: ssh-private-key
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: id_rsa
       region_name: {{aws_region}}
 

--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -15,57 +15,45 @@ resources:
       branch: {{branch_name}}
 
   - name: vpc-tfstate
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
       region_name: {{aws_region}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: vpc.tfstate
 
   - name: bosh-tfstate
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
       region_name: {{aws_region}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: bosh.tfstate
 
   - name: concourse-tfstate
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: concourse.tfstate
       region_name: eu-west-1
 
   - name: cf-tfstate
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: cf.tfstate
       region_name: eu-west-1
 
   - name: cf-manifest
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
       region_name: {{aws_region}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: cf-manifest.yml
 
   - name: cf-secrets
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
       region_name: {{aws_region}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: cf-secrets.yml
 
 jobs:

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -6,30 +6,24 @@ resources:
       branch: {{branch_name}}
 
   - name: cf-tfstate
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: cf.tfstate
       region_name: {{aws_region}}
 
   - name: vpc-tfstate
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: vpc.tfstate
       region_name: {{aws_region}}
 
   - name: trigger-tf-destroy
-    type: semver
+    type: semver-iam
     source:
       bucket: {{state_bucket}}
       region_name: {{aws_region}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       key: trigger-tf-destroy
 
 jobs:

--- a/concourse/pipelines/destroy-deployer.yml
+++ b/concourse/pipelines/destroy-deployer.yml
@@ -7,56 +7,44 @@ resources:
       branch: {{branch_name}}
 
   - name: bucket-terraform-state
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
       region_name: {{aws_region}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: bucket.tfstate
 
   - name: vpc-terraform-state
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
       region_name: {{aws_region}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: vpc.tfstate
 
   - name: destroy-all-trigger
-    type: semver
+    type: semver-iam
     source:
       bucket: {{state_bucket}}
       region_name: {{aws_region}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       key: destroy-trigger
 
   - name: concourse-manifest
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: concourse.yml
       region_name: {{aws_region}}
 
   - name: concourse-terraform-state
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: concourse.tfstate
       region_name: {{aws_region}}
 
   - name: concourse-bosh-state
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: concourse-state.json
       region_name: {{aws_region}}
 

--- a/concourse/pipelines/destroy-microbosh.yml
+++ b/concourse/pipelines/destroy-microbosh.yml
@@ -6,65 +6,51 @@ resources:
       branch: {{branch_name}}
 
   - name: vpc-tfstate
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
       region_name: {{aws_region}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: vpc.tfstate
 
   - name: bosh-tfstate
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
       region_name: {{aws_region}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: bosh.tfstate
 
   - name: bosh-init-state
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
       region_name: {{aws_region}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: bosh-manifest-state.json
 
   - name: bosh-manifest
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
       region_name: {{aws_region}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: bosh-manifest.yml
 
   - name: bosh-secrets
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
       region_name: {{aws_region}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: bosh-secrets.yml
 
   - name: pipeline-trigger
-    type: semver
+    type: semver-iam
     source:
       bucket: {{state_bucket}}
       region_name: {{aws_region}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       key: {{pipeline_trigger_file}}
 
   - name: concourse-tfstate
-    type: s3
+    type: s3-iam
     source:
       bucket: {{state_bucket}}
-      access_key_id: {{aws_access_key_id}}
-      secret_access_key: {{aws_secret_access_key}}
       versioned_file: concourse.tfstate
       region_name: {{aws_region}}
 

--- a/concourse/scripts/create-deployer.sh
+++ b/concourse/scripts/create-deployer.sh
@@ -22,8 +22,6 @@ tfstate_bucket: bucket=${env}-state
 state_bucket: ${env}-state
 branch_name: ${BRANCH:-master}
 aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
-aws_access_key_id: ${AWS_ACCESS_KEY_ID}
-aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
 concourse_atc_password: ${CONCOURSE_ATC_PASSWORD}
 log_level: ${LOG_LEVEL:-}
 EOF

--- a/concourse/scripts/create-microbosh.sh
+++ b/concourse/scripts/create-microbosh.sh
@@ -22,8 +22,6 @@ pipeline_name: ${pipeline}
 pipeline_trigger_file: ${pipeline}.trigger
 branch_name: ${BRANCH:-master}
 aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
-aws_access_key_id: ${AWS_ACCESS_KEY_ID}
-aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
 debug: ${DEBUG:-}
 EOF
 }

--- a/concourse/scripts/destroy-cloudfoundry.sh
+++ b/concourse/scripts/destroy-cloudfoundry.sh
@@ -20,8 +20,6 @@ state_bucket: ${env}-state
 pipeline_name: ${pipeline}
 branch_name: ${BRANCH:-master}
 aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
-aws_access_key_id: ${AWS_ACCESS_KEY_ID}
-aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
 bosh_password: ${bosh_password}
 debug: ${DEBUG:-}
 EOF

--- a/concourse/scripts/destroy-deployer.sh
+++ b/concourse/scripts/destroy-deployer.sh
@@ -21,8 +21,6 @@ tfstate_bucket: bucket=${env}-state
 state_bucket: ${env}-state
 branch_name: ${BRANCH:-master}
 aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
-aws_access_key_id: ${AWS_ACCESS_KEY_ID}
-aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
 log_level: ${LOG_LEVEL:-}
 EOF
 }

--- a/concourse/scripts/destroy-microbosh.sh
+++ b/concourse/scripts/destroy-microbosh.sh
@@ -22,8 +22,6 @@ pipeline_name: ${pipeline}
 pipeline_trigger_file: ${pipeline}.trigger
 branch_name: ${BRANCH:-master}
 aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
-aws_access_key_id: ${AWS_ACCESS_KEY_ID}
-aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
 debug: ${DEBUG:-}
 EOF
 }

--- a/manifests/concourse-base.yml
+++ b/manifests/concourse-base.yml
@@ -100,6 +100,9 @@ jobs:
       groundcrew:
         tsa:
           host: 127.0.0.1
+        additional_resource_types:
+          - { type: s3-iam, image: "docker:///governmentpaas/s3-resource" }
+          - { type: semver-iam, image: "docker:///governmentpaas/semver-resource" }
 
 cloud_provider:
   template: {name: aws_cpi, release: bosh-aws-cpi}

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-Vagrant.require_version ">= 1.7.0"
+Vagrant.require_version ">= 1.8.0"
 
 Vagrant.configure(2) do |config|
   config.vm.box = ENV['VAGRANT_BOX_NAME'] || 'aws_vagrant_box'

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -6,10 +6,15 @@ Vagrant.require_version ">= 1.7.0"
 Vagrant.configure(2) do |config|
   config.vm.box = ENV['VAGRANT_BOX_NAME'] || 'aws_vagrant_box'
 
-  config.vm.provision "shell" do |s|
-    s.privileged = true
-    s.path = "concourse_post_deploy.sh"
-    s.args = "#{ENV['CONCOURSE_ATC_USER']} #{ENV['CONCOURSE_ATC_PASSWORD']}"
+  Dir.glob("./post-deploy.d/*").sort.each do |post_deploy_file|
+    config.vm.provision "shell" do |s|
+      s.privileged = true
+      s.env = ENV.select {
+        |key| ['CONCOURSE_ATC_PASSWORD', 'CONCOURSE_ATC_USER'].include? key
+      }
+      s.name = post_deploy_file
+      s.path = post_deploy_file
+    end
   end
 
   config.vm.provider :aws do |aws, override|

--- a/vagrant/post-deploy.d/00-remove-insecure-keys.sh
+++ b/vagrant/post-deploy.d/00-remove-insecure-keys.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+echo "Removing packer ssh key..."
+sed -i '/ vagrant$/ ! { d }' /root/.ssh/authorized_keys /home/*/.ssh/authorized_keys
+
+

--- a/vagrant/post-deploy.d/10-mount-additional-ephemeral-disk.sh
+++ b/vagrant/post-deploy.d/10-mount-additional-ephemeral-disk.sh
@@ -1,8 +1,5 @@
-#!/bin/bash
+#!/bin/bash -e
 gardenDir="/var/vcap/data/garden"
-
-echo "Removing packer ssh key..."
-sed -i '/ vagrant$/ ! { d }' /root/.ssh/authorized_keys /home/*/.ssh/authorized_keys
 
 # This assumes you are running on an instance with attached ephemeral disk as current (0.70) concourse image does
 echo "Mounting ${gardenDir} on to ephemeral disk..."
@@ -21,10 +18,3 @@ mount /dev/xvdb ${gardenDir}
 
 /var/vcap/bosh/bin/monit restart garden
 
-
-echo "Setting up concourse basic auth as $1 : $2"
-sed "s/--development-mode//g" -i /var/vcap/jobs/atc/bin/atc_ctl      # dev mode disables all auth
-sed "s/--basic-auth-username.*/--basic-auth-username \'$1\' \\\/" -i /var/vcap/jobs/atc/bin/atc_ctl
-sed "s/--basic-auth-password.*/--basic-auth-password \'$2\' \\\/" -i /var/vcap/jobs/atc/bin/atc_ctl
-
-/var/vcap/bosh/bin/monit restart atc

--- a/vagrant/post-deploy.d/10-mount-additional-ephemeral-disk.sh
+++ b/vagrant/post-deploy.d/10-mount-additional-ephemeral-disk.sh
@@ -1,20 +1,21 @@
 #!/bin/bash -e
 gardenDir="/var/vcap/data/garden"
 
-# This assumes you are running on an instance with attached ephemeral disk as current (0.70) concourse image does
-echo "Mounting ${gardenDir} on to ephemeral disk..."
-cp -R ${gardenDir}/* /mnt
-umount /mnt
+if ! mount | grep -q $gardenDir; then
+    # This assumes you are running on an instance with attached ephemeral disk as current (0.70) concourse image does
+    echo "Mounting ${gardenDir} on to ephemeral disk..."
+    cp -R ${gardenDir}/* /mnt
+    umount /mnt
 
-# Unmount all aufs mounts
-mounts=$(cat /proc/mounts | grep /var/vcap/data/garden/aufs_graph/aufs/mnt | awk '{print $2}')
-[[ -n "${mounts}" ]] && echo ${mounts} | xargs umount
+    # Unmount all aufs mounts
+    mounts=$(cat /proc/mounts | grep /var/vcap/data/garden/aufs_graph/aufs/mnt | awk '{print $2}')
+    [[ -n "${mounts}" ]] && echo ${mounts} | xargs umount
 
-# Only lazy unmount works here
-umount -l /var/vcap/data/garden/aufs_graph/aufs
+    # Only lazy unmount works here
+    umount -l /var/vcap/data/garden/aufs_graph/aufs
 
-# Mount ephemeral storage as garden data
-mount /dev/xvdb ${gardenDir}
+    # Mount ephemeral storage as garden data
+    mount /dev/xvdb ${gardenDir}
 
-/var/vcap/bosh/bin/monit restart garden
-
+    /var/vcap/bosh/bin/monit restart garden
+fi

--- a/vagrant/post-deploy.d/20-setup-basic-auth.sh
+++ b/vagrant/post-deploy.d/20-setup-basic-auth.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -u
+set -e
+echo "Setting up concourse basic auth as ${CONCOURSE_ATC_USER}: ${CONCOURSE_ATC_PASSWORD}"
+sed "s/--development-mode//g" -i /var/vcap/jobs/atc/bin/atc_ctl      # dev mode disables all auth
+sed "s/--basic-auth-username.*/--basic-auth-username \'${CONCOURSE_ATC_USER}\' \\\/" -i /var/vcap/jobs/atc/bin/atc_ctl
+sed "s/--basic-auth-password.*/--basic-auth-password \'${CONCOURSE_ATC_PASSWORD}\' \\\/" -i /var/vcap/jobs/atc/bin/atc_ctl
+/var/vcap/bosh/bin/monit restart atc
+

--- a/vagrant/post-deploy.d/30-add-custom-resources.py
+++ b/vagrant/post-deploy.d/30-add-custom-resources.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+import json
+import subprocess
+
+config_file = '/var/vcap/jobs/groundcrew/config/worker.json'
+
+with open(config_file,'r') as f:
+    config = json.load(f)
+
+    config["resource_types"].extend([
+        { "type": "s3-iam", "image": "docker:///governmentpaas/s3-resource" },
+        { "type": "semver-iam", "image": "docker:///governmentpaas/semver-resource" }
+    ])
+
+    # Remove any duplicates hashing by type. via http://stackoverflow.com/a/11092590
+    config["resource_types"] = {v['type']:v for v in config["resource_types"]}.values()
+
+with open(config_file,'w') as f:
+    json.dump(config, f)
+
+subprocess.check_call(["/var/vcap/bosh/bin/monit", "restart", "beacon"])
+


### PR DESCRIPTION
[#111760326 Use custom resources for S3 & Semver using IAM profiles](https://www.pivotaltracker.com/story/show/111760326)

# What

We'd like to use custom resources for S3 and Semver because this will allow us to use IAM profiles for provisioning. We will use the images generated automatically in docker hub: https://hub.docker.com/r/governmentpaas/s3-resource/builds/ and https://hub.docker.com/r/governmentpaas/semver-resource/builds/, which where setup in https://github.com/alphagov/paas-s3-resource/pull/2 and https://github.com/alphagov/paas-semver-resource/pull/3

We will also stop using static AWS credentials in the pipelines for these resources.

# Context

This PR should be reviewed in this context:

 * I want to add the new resources in concourse lite, using a shell provisioner to change the required configuration. Before that, we refactor how post-deployment scripts are executed in vagrant to make it easier to add/remove steps.
 * I want to configure the new resources in the "deployer" concourse, by changing the manifest to include the required configuration.
 * I want to remove the credentials used by this resources in all the pipelines, and not even pass it as variables. The only exception is the `deploy-cloudfoundry` pipeline, which needs the credentials to setup S3 access for the cloud-controller.

# How to test this PR

Follow the steps described in the README.md deploying **from scratch** (at least, destroy and recreate vagrant, as concourse deployer will be redeployed).

Remember to specifying the current branch by exporting or passing the `$BRANCH` variable: 

```
export BRANCH=$(git rev-parse --abbrev-ref HEAD)
```

It is not required to wait until the cloudfoundry deploy job finish, as the CF deployment has not being changed.

# Who? 

Anyone but @dcarley or @keymon

