### PR TITLE
[#108441228] Add pipelines to automatically delete cloudfoundry deployment and concourse-lite at night

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,11 @@ This pipeline will:
  * build the cloudfoundry manifests
  * use these manifests and microbosh instance to deploy cloudfoundry
  * Setup the cloud controller IAM role to `cf-cloudcontroller`. It must be allowed to access the S3 buckets `*-cf-resources`, `*-cf-packages`, `*-cf-droplets`, `*-cf-buildpacks`.
- * Implement a job to automatically delete the deployment overnight.
 
- To setup destroy pipeline you have to execute:
+An additional pipeline `autodelete-cloudfoundry` is setup to automatically
+delete the environment at night.
+
+To setup destroy pipeline you have to execute:
 
  ```
  ./concourse/scripts/destroy-cloudfoundry.sh <environment_name>
@@ -298,10 +300,8 @@ stop environments and VMs at night:
    pipeline `self-terminate` which will be triggered at night and
    terminate the concourse-lite vagrant instance.
 
- * **Delete Cloud Foundry deployment**: The `deploy-cloudfoundry` pipeline
-   includes a job called `destroy` which will be triggered every night to
-   delete the specific deployment.
-
+ * **Delete Cloud Foundry deployment**: The `autodelete-cloudfoundry` pipeline
+   will be triggered every night to delete the specific deployment.
 
 In all cases, to prevent this from happening, you can simply pause the
 pipelines or its resources or jobs.

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ This pipeline will:
  * build the cloudfoundry manifests
  * use these manifests and microbosh instance to deploy cloudfoundry
  * Setup the cloud controller IAM role to `cf-cloudcontroller`. It must be allowed to access the S3 buckets `*-cf-resources`, `*-cf-packages`, `*-cf-droplets`, `*-cf-buildpacks`.
+ * Implement a job to automatically delete the deployment overnight.
 
  To setup destroy pipeline you have to execute:
 
@@ -287,3 +288,22 @@ If not, you can learn the credentials from the `atc` process arguments:
     * For vagrant bootstrap concourse-lite: `cd vagrant && vagrant ssh`
     * [For deployer concourse](#ssh-to-deployed-concourse-and-microbosh)
  2. Get the password from `atc` arguments: `ps -fea | sed -n 's/.*--basic-auth[-]password \([^ ]*\).*/\1/p'`
+
+## Overnight deletion of environments
+
+In order to avoid unnecessary costs in AWS, there is some logic to
+stop environments and VMs at night:
+
+ * **Terminate vagrant concourse-lite VM**: concourse-lite will have a
+   pipeline `self-terminate` which will be triggered at night and
+   terminate the concourse-lite vagrant instance.
+
+ * **Delete Cloud Foundry deployment**: The `deploy-cloudfoundry` pipeline
+   includes a job called `destroy` which will be triggered every night to
+   delete the specific deployment.
+
+
+In all cases, to prevent this from happening, you can simply pause the
+pipelines or its resources or jobs.
+
+Note that the *concourse deployer* and *microbosh* VMs will be kept running.

--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -1,0 +1,26 @@
+resources:
+  - name: delete-timer
+    type: time
+    source:
+      start: 20:00 -0000
+      stop: 6:00 -0000
+      interval: 2h
+
+jobs:
+  - name: delete
+    serial: true
+    plan:
+    - get: delete-timer
+      trigger: true
+    - task: delete-deployment
+      config:
+        inputs:
+        - name: delete-timer
+        image: docker:///concourse/bosh-deployment-resource
+        run:
+          path: sh
+          args:
+          - -e
+          - -c
+          - |
+            bosh -n -t https://10.0.0.6:25555 -u admin -p {{bosh_password}} delete deployment {{deploy_env}}

--- a/concourse/pipelines/concourse-lite-self-terminate.yml
+++ b/concourse/pipelines/concourse-lite-self-terminate.yml
@@ -1,0 +1,31 @@
+resources:
+  - name: delete-timer
+    type: time
+    source:
+      start: 20:00 -0000
+      stop: 21:00 -0000
+      interval: 24h
+
+jobs:
+  - name: delete
+    serial: true
+    plan:
+    - get: delete-timer
+      trigger: true
+    - task: delete-deployment
+      config:
+        inputs:
+        - name: delete-timer
+        image: docker:///governmentpaas/awscli
+        run:
+          path: sh
+          args:
+          - -e
+          - -c
+          - |
+            export AWS_AVAILIABILITY_ZONE=$(curl -qs http://169.254.169.254/latest/meta-data/placement/availability-zone)
+            export AWS_DEFAULT_REGION="${AWS_AVAILIABILITY_ZONE%%[a-z]}"
+            export AWS_INSTANCE_ID=$(curl -qs http://169.254.169.254/latest/meta-data/instance-id)
+
+            aws ec2 terminate-instances --instance-ids ${AWS_INSTANCE_ID}
+

--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -63,11 +63,6 @@ resources:
       stop: 21:00 -0000
       interval: 24h
 
-  - name: deploy-timestamp
-    type: time
-    source:
-      interval: 24h
-
 jobs:
   - name: s3init
     serial_groups: [ deploy ]
@@ -345,16 +340,12 @@ jobs:
             - diego-release-tarball/release.tgz
             - garden-release-tarball/release.tgz
             - etcd-release-tarball/release.tgz
-        ensure:
-          put: deploy-timestamp
 
   - name: delete
     serial: true
     plan:
     - get: delete-timer
       trigger: true
-    - get: deploy-timestamp
-      passed: [ deploy ]
     - task: delete-deployment
       config:
         inputs:

--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -56,6 +56,18 @@ resources:
       region_name: {{aws_region}}
       versioned_file: cf-secrets.yml
 
+  - name: delete-timer
+    type: time
+    source:
+      start: 20:00 -0000
+      stop: 21:00 -0000
+      interval: 24h
+
+  - name: deploy-timestamp
+    type: time
+    source:
+      interval: 24h
+
 jobs:
   - name: s3init
     serial_groups: [ deploy ]
@@ -333,3 +345,25 @@ jobs:
             - diego-release-tarball/release.tgz
             - garden-release-tarball/release.tgz
             - etcd-release-tarball/release.tgz
+        ensure:
+          put: deploy-timestamp
+
+  - name: delete
+    serial: true
+    plan:
+    - get: delete-timer
+      trigger: true
+    - get: deploy-timestamp
+      passed: [ deploy ]
+    - task: delete-deployment
+      config:
+        inputs:
+        - name: delete-timer
+        image: docker:///concourse/bosh-deployment-resource
+        run:
+          path: sh
+          args:
+          - -e
+          - -c
+          - |
+            bosh -n -t https://10.0.0.6:25555 -u admin -p {{bosh_password}} delete deployment {{deploy_env}}

--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -60,8 +60,8 @@ resources:
     type: time
     source:
       start: 20:00 -0000
-      stop: 21:00 -0000
-      interval: 24h
+      stop: 6:00 -0000
+      interval: 2h
 
 jobs:
   - name: s3init

--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -56,13 +56,6 @@ resources:
       region_name: {{aws_region}}
       versioned_file: cf-secrets.yml
 
-  - name: delete-timer
-    type: time
-    source:
-      start: 20:00 -0000
-      stop: 6:00 -0000
-      interval: 2h
-
 jobs:
   - name: s3init
     serial_groups: [ deploy ]
@@ -340,21 +333,3 @@ jobs:
             - diego-release-tarball/release.tgz
             - garden-release-tarball/release.tgz
             - etcd-release-tarball/release.tgz
-
-  - name: delete
-    serial: true
-    plan:
-    - get: delete-timer
-      trigger: true
-    - task: delete-deployment
-      config:
-        inputs:
-        - name: delete-timer
-        image: docker:///concourse/bosh-deployment-resource
-        run:
-          path: sh
-          args:
-          - -e
-          - -c
-          - |
-            bosh -n -t https://10.0.0.6:25555 -u admin -p {{bosh_password}} delete deployment {{deploy_env}}

--- a/concourse/scripts/concourse-lite-self-terminate.sh
+++ b/concourse/scripts/concourse-lite-self-terminate.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+set -u
+
+SCRIPT_DIR=$(cd $(dirname $0) && pwd)
+FLY_CMD=${FLY_CMD:-fly}
+
+env=${DEPLOY_ENV:-$1}
+pipeline="self-terminate"
+config="${SCRIPT_DIR}/../pipelines/concourse-lite-self-terminate.yml"
+
+[[ -z "${env}" ]] && echo "Must provide environment name" && exit 100
+
+generate_vars_file() {
+   set -u # Treat unset variables as an error when substituting
+   cat <<EOF
+---
+deploy_env: ${env}
+log_level: ${LOG_LEVEL:-}
+EOF
+}
+
+generate_vars_file > /dev/null # Check for missing vars
+
+bash "${SCRIPT_DIR}/deploy-pipeline.sh" \
+   "${env}" "${pipeline}" "${config}" <(generate_vars_file)
+
+$FLY_CMD -t "${FLY_TARGET}" unpause-pipeline --pipeline "${pipeline}"
+

--- a/vagrant/deploy.sh
+++ b/vagrant/deploy.sh
@@ -37,6 +37,7 @@ fi
 echo -e "${CONCOURSE_ATC_USER}\n${CONCOURSE_ATC_PASSWORD}" | \
   $FLY_CMD login -t "${FLY_TARGET}" --concourse-url "${CONCOURSE_URL}"
 
+"${SCRIPT_DIR}"/../concourse/scripts/concourse-lite-self-terminate.sh "${DEPLOY_ENV}"
 "${SCRIPT_DIR}"/../concourse/scripts/create-deployer.sh "${DEPLOY_ENV}"
 "${SCRIPT_DIR}"/../concourse/scripts/destroy-deployer.sh "${DEPLOY_ENV}"
 


### PR DESCRIPTION
[#108441228 Automatically shutdown dev environments at night / weekends](https://www.pivotaltracker.com/story/show/108441228)

## Dependencies

The PR https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/14 should be merged first and we should update the container used in `./concourse/pipelines/ticking-time-bomb.yml`

## What

Given the size of a deployed Cloud Foundry environment and the associated cost of the VMs we want to shut down all development environments at night and over weekends to minimise the overall cost of infrastructure. 

It is acceptable to leave a small number of machines running (e.g. BOSH and Concourse) if this expedites the recovery of the development environment in the morning.

## Context

This PR should be reviewed in this context:

 * I want to add a job to delete the cloudfoundry deployment:
   * it will be triggered at 20:00 GMT
   * will be ready to run whenever we deploy CF
   * it will try to delete the deployment regardless if the last deployment was successful or not.

 * I want to add a pipeline to terminate the concourse-lite and triggered at 20:00 GMT

## How to test this PR?

Vagrant:

 1. Start a vagrant instance as described in the `README.md`: `./vagrant/deploy.sh <env>`
 2. Change the times in the resource `destroy-timer` in `./concourse/pipelines/ticking-time-bomb.yml`, to a window that includes the current time.
 3. Rerun `./vagrant/deploy.sh <env>` to see the changes.
 4. Go to http://localhost:8080/pipelines/ticking-time-bomb and observe how concourse-lite commits suicide :smile: 

For Cloud Foundry deployment:

 1. Follow the guidelines in the `README.md` to fully deploy CF.
     * It does not need to finish successfully
     * you can even cancel the deploy tasks during the deployment to save time if you want.
 2. Change the times in the resource `delete-timer` in `./concourse/pipelines/deploy-cloudfoundry.yml`, to a window that includes the current time.
 3. Upload the pipeline again: 
     ```
export FLY_TARGET=$DEPLOY_ENV
./concourse/scripts/deploy-cloudfoundry.sh $DEPLOY_ENV
```
 4. The `delete` task should be triggered and delete the deployment.

# who?

Anyone but @keymon or @actionjack 