### PR TITLE
[#111523754] Cloudfoundry instance profiles

### DIFF
--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -205,26 +205,6 @@ jobs:
                 $SCPATH/$SCFILE < $state-tfstate/$state.tfstate > $state.yml
               done
 
-      - task: create-aws-secrets
-        config:
-          params:
-            aws_access_key_id: {{aws_access_key_id}}
-            aws_secret_access_key: {{aws_secret_access_key}}
-          run:
-            path: sh
-            args:
-            - -e
-            - -c
-            - |
-              cat > aws-secrets.yml << EOF
-              ---
-              secrets:
-                aws_access_key_id: ${aws_access_key_id}
-                aws_secret_access_key: ${aws_secret_access_key}
-              EOF
-              ls -l aws-secrets.yml
-
-
       - task: generate-manifest
         config:
           platform: linux
@@ -232,12 +212,10 @@ jobs:
           params:
             TERRAFORM_OUTPUTS: "extract-terraform-outputs/*.yml"
             MANIFESTS_DIR: "./paas-cf/manifests/cf-manifest"
-            AWS_SECRETS: "create-aws-secrets/aws-secrets.yml"
             SECRETS: "cf-secrets/cf-secrets.yml"
           inputs:
             - name: paas-cf
             - name: extract-terraform-outputs
-            - name: create-aws-secrets
             - name: cf-secrets
           run:
             path: sh

--- a/concourse/scripts/deploy-cloudfoundry.sh
+++ b/concourse/scripts/deploy-cloudfoundry.sh
@@ -20,8 +20,6 @@ state_bucket: ${env}-state
 pipeline_name: ${pipeline}
 branch_name: ${BRANCH:-master}
 aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
-aws_access_key_id: ${AWS_ACCESS_KEY_ID}
-aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
 bosh_password: ${bosh_password}
 stemcell-version: ${STEMCELL_VERSION:-3104}
 cf-release-version: ${CF_RELEASE_VERSION:-225}

--- a/manifests/cf-manifest/build_manifest.sh
+++ b/manifests/cf-manifest/build_manifest.sh
@@ -5,7 +5,6 @@ set -e
 manifests_dir=${MANIFESTS_DIR:-"./"}
 terraform_outputs=${TERRAFORM_OUTPUTS:-"${manifests_dir}/outputs/terraform-outputs.yml"}
 secrets=${SECRETS:-"${manifests_dir}/outputs/cf-secrets.yml"}
-aws_secrets=${AWS_SECRETS:-"${manifests_dir}/outputs/aws-secrets.yml"}
 ssl_certs=${SSL_CERTS:-"${manifests_dir}/outputs/cf-ssl-certificates.yml"}
 
 spruce merge \
@@ -16,5 +15,4 @@ spruce merge \
   ${manifests_dir}/deployments/aws/*.yml \
   ${terraform_outputs} \
   ${secrets} \
-  ${aws_secrets} \
-  ${ssl_certs} 
+  ${ssl_certs}

--- a/manifests/cf-manifest/deployments/020-cf-resource-pools.yml
+++ b/manifests/cf-manifest/deployments/020-cf-resource-pools.yml
@@ -29,6 +29,16 @@ resource_pools:
     stemcell: (( grab meta.stemcell ))
     env: (( grab meta.default_env ))
 
+  - name: api_z1
+    network: cf1
+    stemcell: (( grab meta.stemcell ))
+    env: (( grab meta.default_env ))
+
+  - name: api_z2
+    network: cf2
+    stemcell: (( grab meta.stemcell ))
+    env: (( grab meta.default_env ))
+
   - name: router_z1
     network: "cf1"
     stemcell: (( grab meta.stemcell ))

--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -329,7 +329,7 @@ jobs:
   - name: api_z1
     templates: (( grab meta.api_templates ))
     instances: 1
-    resource_pool: large_z1
+    resource_pool: api_z1
     persistent_disk: 0
     networks:
       - name: cf1
@@ -349,7 +349,7 @@ jobs:
   - name: api_z2
     templates: (( grab meta.api_templates ))
     instances: 1
-    resource_pool: large_z2
+    resource_pool: api_z2
     persistent_disk: 0
     networks:
       - name: cf2

--- a/manifests/cf-manifest/deployments/040-cf-properties.yml
+++ b/manifests/cf-manifest/deployments/040-cf-properties.yml
@@ -94,19 +94,19 @@ properties:
     broker_client_max_async_poll_duration_minutes: ~
 
     resource_pool:
-      resource_directory_key: (( concat properties.domain "-cc-resources" ))
+      resource_directory_key: (( concat meta.environment "-cf-resources" ))
       fog_connection: ~
       cdn: ~
 
     packages:
-      app_package_directory_key: (( concat properties.domain "-cc-packages" ))
+      app_package_directory_key: (( concat meta.environment "-cf-packages" ))
       fog_connection: ~
       cdn: ~
       max_package_size: 1073741824
       max_valid_packages_stored: ~
 
     droplets:
-      droplet_directory_key: (( concat properties.domain "-cc-droplets" ))
+      droplet_directory_key: (( concat meta.environment "-cf-droplets" ))
       fog_connection: ~
       cdn: ~
       max_staged_droplets_stored: ~
@@ -124,7 +124,7 @@ properties:
         record_sql: "obfuscated"
 
     buildpacks:
-      buildpack_directory_key: (( concat properties.domain "-cc-buildpacks" ))
+      buildpack_directory_key: (( concat meta.environment "-cf-buildpacks" ))
       fog_connection: ~
       cdn: ~
     quota_definitions: (( grab meta.default_quota_definitions ))

--- a/manifests/cf-manifest/deployments/aws/000-cf-infrastructure.yml
+++ b/manifests/cf-manifest/deployments/aws/000-cf-infrastructure.yml
@@ -102,6 +102,24 @@ resource_pools:
         type: gp2
       availability_zone: (( grab meta.zones.z2 ))
 
+  - name: api_z1
+    cloud_properties:
+      instance_type: m3.medium
+      iam_instance_profile: cf-cloudcontroller
+      ephemeral_disk:
+        size: 65_536
+        type: gp2
+      availability_zone: (( grab meta.zones.z1 ))
+
+  - name: api_z2
+    cloud_properties:
+      instance_type: m3.medium
+      iam_instance_profile: cf-cloudcontroller
+      ephemeral_disk:
+        size: 65_536
+        type: gp2
+      availability_zone: (( grab meta.zones.z2 ))
+
   - name: router_z1
     cloud_properties:
       instance_type: c3.large

--- a/manifests/cf-manifest/deployments/aws/000-cf-infrastructure.yml
+++ b/manifests/cf-manifest/deployments/aws/000-cf-infrastructure.yml
@@ -5,8 +5,7 @@ meta:
 
   fog_config:
     provider: AWS
-    aws_access_key_id: (( grab secrets.aws_access_key_id ))
-    aws_secret_access_key: (( grab secrets.aws_secret_access_key ))
+    use_iam_profile: true
     region: (( grab terraform_outputs.region ))
 
   stemcell: (( grab meta.default_stemcell ))

--- a/manifests/cf-manifest/spec/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/base_properties_spec.rb
@@ -29,8 +29,7 @@ RSpec.describe "base properties" do
     shared_examples "a component with an AWS connection" do
       let(:fog_connection) { subject.fetch("fog_connection") }
 
-      specify { expect(fog_connection).to include("aws_access_key_id" => aws_secrets_fixture["secrets"]["aws_access_key_id"]) }
-      specify { expect(fog_connection).to include("aws_secret_access_key" => aws_secrets_fixture["secrets"]["aws_secret_access_key"]) }
+      specify { expect(fog_connection).to include("use_iam_profile" => true) }
       specify { expect(fog_connection).to include("region" => terraform_fixture(:region)) }
       specify { expect(fog_connection).to include("provider" => "AWS") }
     end

--- a/manifests/cf-manifest/spec/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/base_properties_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "base properties" do
 
       it_behaves_like "a component with an AWS connection"
 
-      it { is_expected.to include("buildpack_directory_key" => "#{terraform_fixture(:cf_root_domain)}-cc-buildpacks") }
+      it { is_expected.to include("buildpack_directory_key" => "#{terraform_fixture(:environment)}-cf-buildpacks") }
     end
 
     describe "droplets" do
@@ -47,7 +47,7 @@ RSpec.describe "base properties" do
 
       it_behaves_like "a component with an AWS connection"
 
-      it { is_expected.to include("droplet_directory_key" => "#{terraform_fixture(:cf_root_domain)}-cc-droplets") }
+      it { is_expected.to include("droplet_directory_key" => "#{terraform_fixture(:environment)}-cf-droplets") }
     end
 
     describe "packages" do
@@ -55,7 +55,7 @@ RSpec.describe "base properties" do
 
       it_behaves_like "a component with an AWS connection"
 
-      it { is_expected.to include("app_package_directory_key" => "#{terraform_fixture(:cf_root_domain)}-cc-packages") }
+      it { is_expected.to include("app_package_directory_key" => "#{terraform_fixture(:environment)}-cf-packages") }
     end
 
     describe "resource_pool" do
@@ -63,7 +63,7 @@ RSpec.describe "base properties" do
 
       it_behaves_like "a component with an AWS connection"
 
-      it { is_expected.to include("resource_directory_key" => "#{terraform_fixture(:cf_root_domain)}-cc-resources") }
+      it { is_expected.to include("resource_directory_key" => "#{terraform_fixture(:environment)}-cf-resources") }
     end
   end
 

--- a/manifests/cf-manifest/spec/fixtures/aws-secrets.yml
+++ b/manifests/cf-manifest/spec/fixtures/aws-secrets.yml
@@ -1,4 +1,0 @@
----
-secrets:
-  aws_access_key_id: STUB_AWS_ACCESS_KEY
-  aws_secret_access_key: STUB_AWS_SECRET_KEY

--- a/manifests/cf-manifest/spec/resource_pools_spec.rb
+++ b/manifests/cf-manifest/spec/resource_pools_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "resource_pools" do
     small
     medium
     large
+    api
     router
   )
   ERRAND_POOL_NAMES = %w(

--- a/manifests/cf-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/cf-manifest/spec/support/manifest_helpers.rb
@@ -12,10 +12,6 @@ module ManifestHelpers
     @@fixture.fetch(key.to_s)
   end
 
-  def aws_secrets_fixture
-    @@aws_fixture ||= YAML.load(File.read("spec/fixtures/aws-secrets.yml"))
-  end
-
   private
 
   def load_default_manifest
@@ -23,7 +19,6 @@ module ManifestHelpers
       {
         "TERRAFORM_OUTPUTS" => File.expand_path("../../fixtures/terraform-outputs.yml", __FILE__),
         "SECRETS"           => File.expand_path("../../fixtures/cf-secrets.yml", __FILE__),
-        "AWS_SECRETS"       => File.expand_path("../../fixtures/aws-secrets.yml", __FILE__),
         "SSL_CERTS"         => File.expand_path("../../fixtures/cf-ssl-certificates.yml", __FILE__),
       },
       File.expand_path("../../../build_manifest.sh", __FILE__),


### PR DESCRIPTION
# What
Avoid requiring AWS access keys in Cloud Foundry and use IAM profile instead. This applies to the cloud controller so it can read and write from S3 buckets.

Also fixes an issue with the bucket names in the CF manifest.

# How to review
Deploy Cloud Foundry from scratch. It should deploy successfully and be able to read and write to S3 buckets. For example you can check it has created content in bucket `<environment>-cf-buildpacks`.

You should be able to reuse an existing Cloud foundry. Delete the buckets first and run the full pipeline, including Terraform.

# Who can review
Anyone but @alext or @saliceti