### PR TITLE
[#112135729] README: Restrict Travis CI badge to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://api.travis-ci.org/alphagov/paas-cf.svg)](https://travis-ci.org/alphagov/paas-cf)
+[![Build Status](https://api.travis-ci.org/alphagov/paas-cf.svg?branch=master)](https://travis-ci.org/alphagov/paas-cf)
 
 # paas-cf
 


### PR DESCRIPTION
At the moment it lists the last build, which may be a development branch
that is failing. We only really care about the stability of `master`.

![screen shot 2016-01-21 at 13 53 51](https://cloud.githubusercontent.com/assets/260438/12482239/73667518-c046-11e5-85ed-f7e0a5412ad5.png)
