### PR TITLE
[#108441288] Remove unnecesary unpause in setup pipeline scripts

### DIFF
--- a/concourse/scripts/concourse-lite-self-terminate.sh
+++ b/concourse/scripts/concourse-lite-self-terminate.sh
@@ -3,7 +3,6 @@ set -e
 set -u
 
 SCRIPT_DIR=$(cd $(dirname $0) && pwd)
-FLY_CMD=${FLY_CMD:-fly}
 
 env=${DEPLOY_ENV:-$1}
 pipeline="self-terminate"
@@ -24,6 +23,3 @@ generate_vars_file > /dev/null # Check for missing vars
 
 bash "${SCRIPT_DIR}/deploy-pipeline.sh" \
    "${env}" "${pipeline}" "${config}" <(generate_vars_file)
-
-$FLY_CMD -t "${FLY_TARGET}" unpause-pipeline --pipeline "${pipeline}"
-

--- a/concourse/scripts/deploy-cloudfoundry.sh
+++ b/concourse/scripts/deploy-cloudfoundry.sh
@@ -36,19 +36,15 @@ generate_vars_file > /dev/null # Check for missing vars
 bash "${SCRIPT_DIR}/deploy-pipeline.sh" \
    "${env}" "${pipeline}" "${config}" <(generate_vars_file)
 
-fly -t "$FLY_TARGET" unpause-pipeline --pipeline "${pipeline}"
-
 if [ ! "${DISABLE_AUTODELETE:-}" ]; then
    bash "${SCRIPT_DIR}/deploy-pipeline.sh" \
 	  "${env}" "${pipeline_autodelete}" "${config_autodelete}" <(generate_vars_file)
-
-   fly -t "$FLY_TARGET" unpause-pipeline --pipeline "${pipeline_autodelete}"
 
    echo
    echo "WARNING: Pipeline to autodelete Cloud Foundry has been setup and enabled."
    echo "         To disable it, set DISABLE_AUTODELETE=1 or pause the pipeline."
 else
-   yes y | fly -t "$FLY_TARGET" destroy-pipeline --pipeline "${pipeline_autodelete}" || true
+   yes y | ${FLY_CMD:-fly} -t "$FLY_TARGET" destroy-pipeline --pipeline "${pipeline_autodelete}" || true
 
    echo
    echo "WARNING: Pipeline to autodelete Cloud Foundry has NOT been setup"


### PR DESCRIPTION
# What

As per #58, the script deplo-pipeline.sh will do the unpause for us, so it is no needed for the self-terminate concourse lite or
the deploy-cloudfoundry.

Also we are sure that deploy-cloudfoundry uses th right fly command path
for deleteing the autodelete pipeline.

# How to test this

Check #59 for instructions

# who? 

Anyone but @keymon

THIS PR IS ON FIRE!!!