### PR TITLE
[#112135729] README: Replace `fly` with `${FLY_CMD}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ DEPLOY_ENV=<deploy-env>
 $(./vagrant/environment.sh $DEPLOY_ENV) # get the credentials
 
 echo -e "admin\n${CONCOURSE_ATC_PASSWORD}" | \
-   fly -t ${DEPLOY_ENV} login -k -c "https://${DEPLOY_ENV}-concourse.cf.paas.alphagov.co.uk"
+   ${FLY_CMD} -t ${DEPLOY_ENV} login -k -c "https://${DEPLOY_ENV}-concourse.cf.paas.alphagov.co.uk"
 ```
 
 #### SSH to deployed Concourse and microbosh


### PR DESCRIPTION
### What

In 6b0ef65 and 2e1cc94 we stopped recommending that people download the
`fly` binary to `/usr/local/bin`. Instead `vagrant/deploy.sh` downloads the
binary into your PWD and sets `FLY_CMD`. This command in the README is the
last reference to a `fly` binary on your `PATH`.

### How to test

Run the commands in the modified codeblock.

### Who can review

Anyone but @dcarley