### PR TITLE
[#111758188] Add NAT gateway to web security group

### DIFF
--- a/terraform/cloudfoundry/security-groups.tf
+++ b/terraform/cloudfoundry/security-groups.tf
@@ -28,6 +28,24 @@ resource "aws_security_group" "web" {
     ]
   }
 
+  ingress {
+    from_port = 80
+    to_port   = 80
+    protocol  = "tcp"
+    cidr_blocks = [
+      "${formatlist("%s/32", aws_eip.cf.*.public_ip)}"
+    ]
+  }
+
+  ingress {
+    from_port = 443
+    to_port   = 443
+    protocol  = "tcp"
+    cidr_blocks = [
+      "${formatlist("%s/32", aws_eip.cf.*.public_ip)}"
+    ]
+  }
+
   tags {
     Name = "${var.env}-cf-web"
   }


### PR DESCRIPTION
# What

As a part of "[Test that the CF deployment is basically sound](https://www.pivotaltracker.com/n/projects/1275640)" story we are rising this PR to fix Diego logging.

# Details 
NAT gateway IP is not included in inbound rules for web access security
group. All requests from internal components are being resolved to
external api IP. To allow connections between multiple CF services we
have to allow such traffic.

# How to test

You need to have working CF deployment.

- push your app
```
echo hello > index.html && cf push static -b staticfile_buildpack
```

- tail for logs
```
cf logs static
```

- request your index file
```
curl static.piotr.cf.paas.alphagov.co.uk
```

You should see access logs appearing on your screen.

# Who can test

Anyone but @combor and @mtekel  