### PR TITLE
[#111758188] Enable smoketests

### DIFF
--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -1,6 +1,8 @@
 meta:
   environment: ~
 
+  api_domain: (( concat "api." properties.domain ))
+
   release:
     name: cf
 
@@ -21,7 +23,7 @@ meta:
       component: CloudController
     port: (( grab properties.cc.external_port ))
     uris:
-    - (( concat "api." properties.domain ))
+    - (( grab meta.api_domain ))
 
   api_templates:
   - name: cloud_controller_ng

--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -912,3 +912,12 @@ properties:
   acceptance_tests:
 
   smoke_tests:
+    api: (( grab meta.api_domain ))
+    apps_domain: (( grab properties.app_domains[0] ))
+    user: "admin"
+    password: (( grab secrets.uaa_admin_password ))
+    org: "SMOKE_TESTS"
+    space: "SMOKE_TESTS"
+    use_existing_org: false
+    use_existing_space: false
+    skip_ssl_validation: true


### PR DESCRIPTION
### What
Clean up CF manifest system and app domains a bit. Ensure app domain is different from system domain (else you can deploy e.g. `api` called app, which then gets traffic meant for CF api). Add configuration for smoketests.

### Testing
Deploy or apply against existing evironment. After deployment, `bosh run errand smoke_tests`. They should pass. You can also run tests, `cd manifests/cf-manifest; bundle exec rspec`. They should also pass.

### Who
not @mtekel or @combor 