### PR TITLE
[#112135729] Simplify README pt1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ and [BOSH][] manifests that allow provisioning of [CloudFoundry][] on AWS.
 [BOSH]: https://bosh.io/
 [CloudFoundry]: https://www.cloudfoundry.org/
 
+## Glossary
+
+- Environment: a single Cloud Foundry installation and its supporting
+  infrastructure.
+- Bootstrap Concourse: is responsible for creating or destroying a *Deployer
+  Concourse* to an *environment*. You don't need to keep this once you
+  have a *Deployer Concourse* running.
+- Deployer Concourse: is responsible for deploying everything else within
+  its *environment*, e.g. BOSH and CloudFoundry. It should be kept running
+  while that *environment* exists.
+
 ## Usage
 
 ### Concourse deployer bootstrap

--- a/README.md
+++ b/README.md
@@ -222,20 +222,6 @@ This pipeline will
 
 # Additional notes
 
-## Vagrant bootstrap concourse-lite requirements
-
-In order to use vagrant concourse-lite on AWS, there are requirements
-on the AWS account:
-
-* Existence of a default VPC and subnet.
-* A default security group, which restricts access to the office only
-  to port 22 (ssh).
-* A IAM role to be assigned to the VM, which allows:
-  * Provision EC2 resources to setup the initial VPC and concourse.
-  * Access to S3 buckets for state storage (usually named `*-state`)
-
-All these objects are currently hardcoded in `vagrant/Vagrantfile`
-
 ## SSH tunnel to vagrant concourse-lite and share access to instance
 
 Instead of allowing a non secure HTTP connection via the internet to the

--- a/README.md
+++ b/README.md
@@ -10,14 +10,6 @@ and [BOSH][] manifests that allow provisioning of [CloudFoundry][] on AWS.
 [BOSH]: https://bosh.io/
 [CloudFoundry]: https://www.cloudfoundry.org/
 
-## Getting started
-
-You need the following prerequisites before you will be able to deploy first pipeline.
-
-* [Vagrant](https://www.vagrantup.com/)
-* [AWS Vagrant plugin](https://github.com/mitchellh/vagrant-aws)
-* AWS Access and credentials
-
 ## Usage
 
 ### Concourse deployer bootstrap

--- a/README.md
+++ b/README.md
@@ -2,10 +2,13 @@
 
 # paas-cf
 
-This repository contains [Concourse](http://concourse.ci/) pipelines and
-related [Terraform](https://terraform.io/) and [BOSH](https://bosh.io/) manifests
-that allow provisioning of [CloudFoundy](https://www.cloudfoundry.org/) on AWS.
+This repository contains [Concourse][] pipelines and related [Terraform][]
+and [BOSH][] manifests that allow provisioning of [CloudFoundry][] on AWS.
 
+[Concourse]: http://concourse.ci/
+[Terraform]: https://terraform.io/
+[BOSH]: https://bosh.io/
+[CloudFoundry]: https://www.cloudfoundry.org/
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -87,38 +87,6 @@ echo -e "admin\n${CONCOURSE_ATC_PASSWORD}" | \
    ${FLY_CMD} -t ${DEPLOY_ENV} login -k -c "https://${DEPLOY_ENV}-concourse.cf.paas.alphagov.co.uk"
 ```
 
-#### SSH to deployed Concourse and microbosh
-
-In the `create-deployer` pipeline when creating the initial VPC,
-a keypair is generated and uploaded to AWS to be used by deployed instances.
-`bosh-init` needs this key to be able to create a SSH tunnel to
-forward some ports to the agent of the new VM.
-
-Both public and private keys are also uploaded to S3 to be consumed by
-other jobs in the pipelines as resources and/or by us for troubleshooting.
-
-To manually ssh to the deployed concourse, learn its IP via AWS console and
-download the `id_rsa` file from the s3 state bucket.
-
-For example:
-
-```
-./concourse/scripts/s3get.sh "${DEPLOY_ENV}-state" id_rsa && \
-chmod 400 id_rsa && \
-ssh-add $(pwd)/id_rsa
-
-ssh vcap@<concourse_ip>
-```
-
-If you get a "Too many authentication failures for vcap" message it is likely that you've got too many keys registered with your ssh-agent and it will fail to authenticate before trying the correct key - generally it will only allow three keys to be tried before disconnecting you. You can list all the keys registered with your ssh-agent with `ssh-add -l` and remove unwanted keys with `ssh-add -d PATH_TO_KEY`.
-
-microbosh is deployed to use the same SSH key, although is not publicly
-accessible. But you can use the concourse host as a jumpbox:
-
-```
-ssh -o ProxyCommand="ssh -W%h:%p %r@<concourse_ip>" vcap@10.0.0.6
-```
-
 ## BOSH and Cloud Foundry
 
 ### Microbosh deployment from concourse bootstrap
@@ -238,6 +206,38 @@ override the working branch for development and review:
 ```
 # Optionally pass the current branch for the git resources
 export BRANCH=$(git rev-parse --abbrev-ref HEAD)
+```
+
+#### SSH to deployed Concourse and microbosh
+
+In the `create-deployer` pipeline when creating the initial VPC,
+a keypair is generated and uploaded to AWS to be used by deployed instances.
+`bosh-init` needs this key to be able to create a SSH tunnel to
+forward some ports to the agent of the new VM.
+
+Both public and private keys are also uploaded to S3 to be consumed by
+other jobs in the pipelines as resources and/or by us for troubleshooting.
+
+To manually ssh to the deployed concourse, learn its IP via AWS console and
+download the `id_rsa` file from the s3 state bucket.
+
+For example:
+
+```
+./concourse/scripts/s3get.sh "${DEPLOY_ENV}-state" id_rsa && \
+chmod 400 id_rsa && \
+ssh-add $(pwd)/id_rsa
+
+ssh vcap@<concourse_ip>
+```
+
+If you get a "Too many authentication failures for vcap" message it is likely that you've got too many keys registered with your ssh-agent and it will fail to authenticate before trying the correct key - generally it will only allow three keys to be tried before disconnecting you. You can list all the keys registered with your ssh-agent with `ssh-add -l` and remove unwanted keys with `ssh-add -d PATH_TO_KEY`.
+
+microbosh is deployed to use the same SSH key, although is not publicly
+accessible. But you can use the concourse host as a jumpbox:
+
+```
+ssh -o ProxyCommand="ssh -W%h:%p %r@<concourse_ip>" vcap@10.0.0.6
 ```
 
 ## Concourse credentials


### PR DESCRIPTION
### What

Rewrite the Bootstrap Concourse and Deployer Concourse sections of the README so that they're easier to read. See the commit messages for more details. The second to last commit is quite large, but due to restructuring it wasn't easy to break it down any further. If this gets merged then I'll do the same to the BOSH and Cloud Foundry sections.

### How to test

View the rendered README file in the branch.

### Who can review

Not @dcarley