### PR TITLE
[#109035334] IAM for api_workers as well

### DIFF
--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -383,7 +383,7 @@ jobs:
   - name: api_worker_z1
     templates: (( grab meta.api_worker_templates ))
     instances: 1
-    resource_pool: small_z1
+    resource_pool: api_z1
     persistent_disk: 0
     networks:
       - name: cf1
@@ -396,7 +396,7 @@ jobs:
   - name: api_worker_z2
     templates: (( grab meta.api_worker_templates ))
     instances: 1
-    resource_pool: small_z2
+    resource_pool: api_z2
     persistent_disk: 0
     networks:
       - name: cf2


### PR DESCRIPTION
api_worker instances need access to AWS as well, as they are essentially
part of CF API and need to do same tasks as api instances. Moreover,
some tasks (like handling `cf copy-source`) are exclusive to workers and
will fail without IAM role. Thus change instance type to same as API.

`cf copy-source` is used in acceptance tests, so without this PR they fail on that test.