### PR TITLE
[#109035334] Implement acceptance and smoke tests

### DIFF
--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -359,3 +359,28 @@ jobs:
             bosh -n \
               run errand smoke_tests \
               --download-logs --logs-dir .
+
+  - name: acceptance-tests
+    plan:
+    - get: cf-manifest
+      passed: ['deploy']
+    - get: cf-deployment
+      passed: ['deploy']
+    - task: acceptance-tests
+      config:
+        inputs:
+        - name: cf-manifest
+        image: docker:///concourse/bosh-deployment-resource
+        run:
+          path: sh
+          args:
+          - -e
+          - -c
+          - |
+            bosh -u admin -p {{bosh_password}} target https://10.0.0.6:25555
+            bosh login admin {{bosh_password}}
+            sed "s/^director_uuid:.*/director_uuid: $(bosh status --uuid)/" < cf-manifest/cf-manifest.yml > cf-manifest.yml
+            bosh deployment cf-manifest.yml
+            bosh -n \
+              run errand acceptance_tests \
+              --download-logs --logs-dir .

--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -333,3 +333,29 @@ jobs:
             - diego-release-tarball/release.tgz
             - garden-release-tarball/release.tgz
             - etcd-release-tarball/release.tgz
+
+  - name: smoke-tests
+    plan:
+    - get: cf-manifest
+      passed: ['deploy']
+    - get: cf-deployment
+      passed: ['deploy']
+      trigger: true
+    - task: smoke-tests
+      config:
+        inputs:
+        - name: cf-manifest
+        image: docker:///concourse/bosh-deployment-resource
+        run:
+          path: sh
+          args:
+          - -e
+          - -c
+          - |
+            bosh -u admin -p {{bosh_password}} target https://10.0.0.6:25555
+            bosh login admin {{bosh_password}}
+            sed "s/^director_uuid:.*/director_uuid: $(bosh status --uuid)/" < cf-manifest/cf-manifest.yml > cf-manifest.yml
+            bosh deployment cf-manifest.yml
+            bosh -n \
+              run errand smoke_tests \
+              --download-logs --logs-dir .

--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -910,6 +910,18 @@ properties:
   collector:
 
   acceptance_tests:
+    api: (( grab meta.api_domain ))
+    apps_domain: (( grab properties.app_domains[0] ))
+    system_domain: (( grab properties.system_domain ))
+    admin_user: "admin"
+    admin_password: (( grab secrets.uaa_admin_password ))
+    skip_ssl_validation: true
+    backend: "diego"
+    skip_diego_unsupported_tests: true
+    include_route_services: true
+    include_tasks: true
+    client_secret: (( grab secrets.uaa_clients_gorouter_secret ))
+    include_v3: true
 
   smoke_tests:
     api: (( grab meta.api_domain ))

--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -488,27 +488,6 @@ jobs:
         zone: z2
     update: {}
 
-  - name: acceptance_tests
-    templates:
-    - name: acceptance-tests
-      release: (( grab meta.release.name ))
-    instances: 1
-    resource_pool: small_errand
-    lifecycle: errand
-    networks:
-      - name: cf1
-
-  - name: smoke_tests
-    templates:
-    - name: smoke-tests
-      release: (( grab meta.release.name ))
-    instances: 0
-    resource_pool: small_errand
-    lifecycle: errand
-    networks:
-      - name: cf1
-    properties: {}
-
 # Diego
 
   - name: access_z1
@@ -908,28 +887,3 @@ properties:
   nfs_server: (( grab meta.nfs_server ))
 
   collector:
-
-  acceptance_tests:
-    api: (( grab meta.api_domain ))
-    apps_domain: (( grab properties.app_domains[0] ))
-    system_domain: (( grab properties.system_domain ))
-    admin_user: "admin"
-    admin_password: (( grab secrets.uaa_admin_password ))
-    skip_ssl_validation: true
-    backend: "diego"
-    skip_diego_unsupported_tests: true
-    include_route_services: true
-    include_tasks: true
-    client_secret: (( grab secrets.uaa_clients_gorouter_secret ))
-    include_v3: true
-
-  smoke_tests:
-    api: (( grab meta.api_domain ))
-    apps_domain: (( grab properties.app_domains[0] ))
-    user: "admin"
-    password: (( grab secrets.uaa_admin_password ))
-    org: "SMOKE_TESTS"
-    space: "SMOKE_TESTS"
-    use_existing_org: false
-    use_existing_space: false
-    skip_ssl_validation: true

--- a/manifests/cf-manifest/deployments/900-cf-tests.yml
+++ b/manifests/cf-manifest/deployments/900-cf-tests.yml
@@ -1,0 +1,47 @@
+jobs:
+  - name: acceptance_tests
+    templates:
+    - name: acceptance-tests
+      release: (( grab meta.release.name ))
+    instances: 1
+    resource_pool: small_errand
+    lifecycle: errand
+    networks:
+      - name: cf1
+
+  - name: smoke_tests
+    templates:
+    - name: smoke-tests
+      release: (( grab meta.release.name ))
+    instances: 0
+    resource_pool: small_errand
+    lifecycle: errand
+    networks:
+      - name: cf1
+    properties: {}
+
+properties:
+  acceptance_tests:
+    api: (( grab meta.api_domain ))
+    apps_domain: (( grab properties.app_domains[0] ))
+    system_domain: (( grab properties.system_domain ))
+    admin_user: "admin"
+    admin_password: (( grab secrets.uaa_admin_password ))
+    skip_ssl_validation: true
+    backend: "diego"
+    skip_diego_unsupported_tests: true
+    include_route_services: true
+    include_tasks: true
+    client_secret: (( grab secrets.uaa_clients_gorouter_secret ))
+    include_v3: true
+
+  smoke_tests:
+    api: (( grab meta.api_domain ))
+    apps_domain: (( grab properties.app_domains[0] ))
+    user: "admin"
+    password: (( grab secrets.uaa_admin_password ))
+    org: "SMOKE_TESTS"
+    space: "SMOKE_TESTS"
+    use_existing_org: false
+    use_existing_space: false
+    skip_ssl_validation: true


### PR DESCRIPTION
[#109035334 Implement acceptance tests on the CF deployment](https://www.pivotaltracker.com/story/show/109035334)

What
----

The objective is to implement a set of acceptance tests to ensure that the deployment was successful and that the platform functions as expected. Given that we have started with a vanilla install, we should be able to use the existing CF acceptance tests and we will build on these as we add functionality.

Context
-------

The PR should be reviewed in this context:

 * I want to add the required configuration to run the basic acceptance tests.
 * I want to add a job that runs the smoke tests after deployment and is triggered
   automatically after any successful deployment.
 * I want to add a job that runs the acceptance tests after deployment, altough
   not triggered automaticaly.

How to test it?
---------------

Apply the pipelines from this branch and deploy CF as described in the README.md.

Remember set the variable BRANCH:

```
export BRANCH=$(git rev-parse --abbrev-ref HEAD)
```

Run the jobs `smoke-tests` and `acceptance-tests`.

`acceptance-tests` might have some tests failing due timeouts, but it is not
in the scope of this story fix that.

Who?
----

Anyone but @keymon or @combor