### PR TITLE
[#112135729] Remove pipeline_name var from BOSH/CF scripts

### DIFF
--- a/concourse/scripts/create-microbosh.sh
+++ b/concourse/scripts/create-microbosh.sh
@@ -15,7 +15,6 @@ generate_vars_file() {
 ---
 deploy_env: ${env}
 state_bucket: ${env}-state
-pipeline_name: ${pipeline}
 pipeline_trigger_file: ${pipeline}.trigger
 branch_name: ${BRANCH:-master}
 aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}

--- a/concourse/scripts/deploy-cloudfoundry.sh
+++ b/concourse/scripts/deploy-cloudfoundry.sh
@@ -19,7 +19,6 @@ generate_vars_file() {
 ---
 deploy_env: ${env}
 state_bucket: ${env}-state
-pipeline_name: ${pipeline}
 branch_name: ${BRANCH:-master}
 aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
 bosh_password: ${bosh_password}

--- a/concourse/scripts/destroy-cloudfoundry.sh
+++ b/concourse/scripts/destroy-cloudfoundry.sh
@@ -17,7 +17,6 @@ generate_vars_file() {
 ---
 deploy_env: ${env}
 state_bucket: ${env}-state
-pipeline_name: ${pipeline}
 branch_name: ${BRANCH:-master}
 aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
 bosh_password: ${bosh_password}

--- a/concourse/scripts/destroy-microbosh.sh
+++ b/concourse/scripts/destroy-microbosh.sh
@@ -15,7 +15,6 @@ generate_vars_file() {
 ---
 deploy_env: ${env}
 state_bucket: ${env}-state
-pipeline_name: ${pipeline}
 pipeline_trigger_file: ${pipeline}.trigger
 branch_name: ${BRANCH:-master}
 aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}


### PR DESCRIPTION
## What

This variable doesn't appear to be used by the pipeline YAML files. Removing
it will make it simpler to combine the create and destroy scripts.

    ➜  paas-cf git:(master) ack pipeline_name
    concourse/scripts/create-microbosh.sh
    18:pipeline_name: ${pipeline}

    concourse/scripts/deploy-cloudfoundry.sh
    22:pipeline_name: ${pipeline}

    concourse/scripts/destroy-cloudfoundry.sh
    20:pipeline_name: ${pipeline}

    concourse/scripts/destroy-microbosh.sh
    18:pipeline_name: ${pipeline}

## How to test

Ensure that you have a Deployer Concourse with all of the pipelines deployed from `master`. Change to this branch and re-deploy the pipelines:
```
./concourse/scripts/create-microbosh.sh
./concourse/scripts/deploy-cloudfoundry.sh
./concourse/scripts/destroy-cloudfoundry.sh
./concourse/scripts/destroy-microbosh.sh
```

You should observe no changes (diff output) to the pipeline configuration.

## Who can review

Not @dcarley