### PR TITLE
[#112499245] Setup Garden to block all outgoing traffic to fix security groups.

### DIFF
--- a/manifests/cf-manifest/deployments/040-cf-properties.yml
+++ b/manifests/cf-manifest/deployments/040-cf-properties.yml
@@ -6,27 +6,6 @@ meta:
        total_services: 100
        non_basic_services_allowed: true
        total_routes: 1000
-  default_security_group_definitions:
-  - name: public_networks
-    rules:
-    - protocol: all
-      destination: 0.0.0.0-9.255.255.255
-    - protocol: all
-      destination: 11.0.0.0-169.253.255.255
-    - protocol: all
-      destination: 169.255.0.0-172.15.255.255
-    - protocol: all
-      destination: 172.32.0.0-192.167.255.255
-    - protocol: all
-      destination: 192.169.0.0-255.255.255.255
-  - name: dns
-    rules:
-    - protocol: tcp
-      destination: 0.0.0.0/0
-      ports: '53'
-    - protocol: udp
-      destination: 0.0.0.0/0
-      ports: '53'
 
 properties:
   app_ssh: ~
@@ -153,10 +132,6 @@ properties:
     install_buildpacks: (( grab properties.cc.system_buildpacks properties.cc.user_buildpacks ))
 
     stacks: ~
-
-    security_group_definitions: (( grab meta.default_security_group_definitions ))
-    default_running_security_groups: ["public_networks", "dns"]
-    default_staging_security_groups: ["public_networks", "dns"]
 
     allowed_cors_domains: []
     thresholds:
@@ -334,7 +309,7 @@ properties:
         client_cert: (( grab secrets.consul_agent_cert ))
         client_key: (( grab secrets.consul_agent_key ))
         require_ssl: false
-      cc: 
+      cc:
         base_url:  (( grab properties.cc.srv_api_uri ))
         basic_auth_password: (( grab properties.cc.internal_api_password ))
         staging_upload_user: (( grab properties.cc.staging_upload_user ))

--- a/manifests/cf-manifest/deployments/041-security-groups.yml
+++ b/manifests/cf-manifest/deployments/041-security-groups.yml
@@ -24,3 +24,7 @@ properties:
 
     default_running_security_groups: ["public_networks", "dns"]
     default_staging_security_groups: ["public_networks", "dns"]
+
+  garden:
+    deny_networks:
+      - 0.0.0.0/0

--- a/manifests/cf-manifest/deployments/041-security-groups.yml
+++ b/manifests/cf-manifest/deployments/041-security-groups.yml
@@ -1,0 +1,26 @@
+properties:
+  cc:
+    security_group_definitions:
+    - name: public_networks
+      rules:
+      - protocol: all
+        destination: 0.0.0.0-9.255.255.255
+      - protocol: all
+        destination: 11.0.0.0-169.253.255.255
+      - protocol: all
+        destination: 169.255.0.0-172.15.255.255
+      - protocol: all
+        destination: 172.32.0.0-192.167.255.255
+      - protocol: all
+        destination: 192.169.0.0-255.255.255.255
+    - name: dns
+      rules:
+      - protocol: tcp
+        destination: 0.0.0.0/0
+        ports: '53'
+      - protocol: udp
+        destination: 0.0.0.0/0
+        ports: '53'
+
+    default_running_security_groups: ["public_networks", "dns"]
+    default_staging_security_groups: ["public_networks", "dns"]


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/112499245

what?
-----

As part of investigating the acceptance tests, we discovered that the
security groups where not working as expected. Actually, we were not
blocking any traffic after migrating to diego.

The reason is some misconfiguration in the garden. The garden release
must be configure to block the traffic by default, and the security groups
will open access as needed.

Context
-------

In this PR we will:
 * Group all the security group configuration in one file to simplify the
   config management.
 * Block all traffic by default in garden


How to test this?
-----------------

Without the PR, the app containers can connect to any IP in the internal
network. With the PR, only public IPs.

 1. Deploy CF as described in the README.md
 2. start some application:
    ```
cf create-space -o GDS test
cf target -o "GDS" -s "test"

mkdir static && cd static
echo hello > index.html

cf push my_static_app -b staticfile_buildpack -p .
```
 3. SSH to the machine running the app using bosh ssh:
    ```
CONCOURSE_IP=...
ssh -i ~/gds/paas-cf/id_rsa -l vcap $CONCOURSE_IP -L 25555:10.0.0.6:25555 -fN
bosh target localhost
bosh ssh colocated_z1 --gateway_host $CONCOURSE_IP  --gateway_user vcap --gateway_identity_file ~/gds/paas-cf/id_rsa
```
 4. Login on the app garden container:
    ```
ps -fea |grep  bin/wsh  | sed -n 's|.*/\([^/]*\)/bin/w[s]h.*|\1|p' | head -n 1

/var/vcap/data/garden/depot/bcls1khbmhd/bin/wsh --socket /var/vcap/data/garden/depot/bcls1khbmhd/run/wshd.sock --user vcap bash
```
 5. Perform some network tets with curl:
    ```
curl http://www.google.com # should work

curl http://10.0.10.20:4001 # Change the IP with a etcd node ip from `bosh vms | grep etcd`. This should not work.
```

Who?
----

Anyone but @keymon or @timmow