### PR TITLE
[#112499245] Enable the security groups acceptance test

### DIFF
--- a/manifests/cf-manifest/deployments/900-cf-tests.yml
+++ b/manifests/cf-manifest/deployments/900-cf-tests.yml
@@ -34,6 +34,7 @@ properties:
     include_tasks: true
     client_secret: (( grab secrets.uaa_clients_gorouter_secret ))
     include_v3: true
+    include_security_groups: true
 
   smoke_tests:
     api: (( grab meta.api_domain ))


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/112499245

Requisites
----------

The PR #75 and #80  must be merge before this one. After merge, rebase
this branch.

what
----

We want to enable the acceptance tests that work on our current setup.
security groups is one of them

Scope
-----

Enables the seurity group acceptance tests in the acceptance test
errand.

This test requires garden to restrict traffic (PR #80) by default and a
working loggregator. Note that the loggregator might have problems if
the environment is deployed in parallel. Check the comments in the story.

How to test it?
--------------

Deploy CF and run trigger the acceptance_tests in the pipeline.

This test requires garden to restrict traffic (PR #80) by default and a
working loggregator. Note that the loggregator might have problems if
the environment is deployed in parallel. Check the comments in the story.

Apart of that, they should succeed. If not, check the outputs and verify that
the tests that failed are these ones. Sometimes some other acceptance tests
fail due timeouts.

Who?
----

Anyone but @keymon or @timmow