### PR TITLE
[#112610295] Revert "Avoid new cert / ELB error"

### DIFF
--- a/terraform/concourse/elb.tf
+++ b/terraform/concourse/elb.tf
@@ -2,10 +2,6 @@ resource "aws_iam_server_certificate" "concourse" {
   name = "${var.env}-concourse"
   certificate_body = "${file("concourse.crt")}"
   private_key = "${file("concourse.key")}"
-
-  provisioner "local-exec" {
-    command = "sleep 10"
-  }
 }
 
 resource "aws_elb" "concourse" {


### PR DESCRIPTION
## What

This reverts commit f46ff52b653b80b1ef538207121bfd20192bfde7.

When alphagov/paas-docker-terraform#10 is merged to upgrade Terraform to
0.6.10 then we no longer need this workaround.

## How to test

alphagov/paas-docker-terraform#10 should be merged first. But if you want to test both together than you can temporarily change all of your pipelines to use the container built from the branch (be sure to undo this later with `git checkout -p`):
```
gsed -ri 's/(docker-terraform)/\1#terraform_0.6.10/' concourse/pipelines/*
```

Deploy the pipelines to the Bootstrap Concourse machine to use this BRANCH:
```
BRANCH=112610295-terraform_elb_sleep ./vagrant/deploy.sh
```

Run both the `create-deployer` and `destroy-deployer` pipelines and confirm that they complete successfully. It's the `concourse-terraform` task that we're changing here.

## Who can review

Not @dcarley