### PR TITLE
Reorder the pipelines in the bootstrap concourse

### DIFF
--- a/vagrant/deploy.sh
+++ b/vagrant/deploy.sh
@@ -42,9 +42,9 @@ fi
 echo -e "${CONCOURSE_ATC_USER}\n${CONCOURSE_ATC_PASSWORD}" | \
   $FLY_CMD login -t "${FLY_TARGET}" --concourse-url "${CONCOURSE_URL}"
 
-"${SCRIPT_DIR}"/../concourse/scripts/concourse-lite-self-terminate.sh "${DEPLOY_ENV}"
 "${SCRIPT_DIR}"/../concourse/scripts/create-deployer.sh "${DEPLOY_ENV}"
 "${SCRIPT_DIR}"/../concourse/scripts/destroy-deployer.sh "${DEPLOY_ENV}"
+"${SCRIPT_DIR}"/../concourse/scripts/concourse-lite-self-terminate.sh "${DEPLOY_ENV}"
 
 echo
 echo "Concourse auth is ${CONCOURSE_ATC_USER} : ${CONCOURSE_ATC_PASSWORD}"


### PR DESCRIPTION
Concourse lists the pipelines in the side menu in the order they were
added. It also shows the first pipeline in the list when you visit the
root URL.  Given the first pipeline that's normally used is the
create-deployer one, it makes sense for this one to be first in the
list.