### PR TITLE
[#112499245] Enable rest of optional acceptance tests

### DIFF
--- a/manifests/cf-manifest/deployments/900-cf-tests.yml
+++ b/manifests/cf-manifest/deployments/900-cf-tests.yml
@@ -29,12 +29,14 @@ properties:
     admin_password: (( grab secrets.uaa_admin_password ))
     skip_ssl_validation: true
     backend: "diego"
-    skip_diego_unsupported_tests: true
-    include_route_services: true
-    include_tasks: true
     client_secret: (( grab secrets.uaa_clients_gorouter_secret ))
+    skip_diego_unsupported_tests: true
+    include_tasks: true
     include_v3: true
     include_security_groups: true
+    include_routing: true
+    skip_regex: 'routing.API'
+    include_route_services: false
 
   smoke_tests:
     api: (( grab meta.api_domain ))

--- a/manifests/cf-manifest/deployments/900-cf-tests.yml
+++ b/manifests/cf-manifest/deployments/900-cf-tests.yml
@@ -36,6 +36,10 @@ properties:
     include_security_groups: true
     include_routing: true
     skip_regex: 'routing.API'
+    include_internet_dependent: true
+    include_logging: true
+    include_operator: true
+    include_services: true
     include_route_services: false
 
   smoke_tests:


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/112499245

what?
-----

We want to enable all the interesting CAT tests that pass on our current setup. After analysing the tests, we can enable everything but the routing api tests.

Context
-------

In this PR we will:
 * Enable the routing tests, but skip the routing API and routing services ones. In latest versions of the acceptance tests, [these tests are moved to other suite](https://github.com/cloudfoundry/cf-acceptance-tests/commit/d7bb879c744295b91425a738c95589e565b6efb7)
 * Enable other suites: internet_dependent, logging, operator, and services … 

How to test?
-----------------

1. Deploy CF as described in the README.md (remember set the `$BRANCH` variable to this branch)
2. After `smoke_tests`, just trigger the `acceptance_tests`

Note that some tests are flaky and might fail (e.g. the security group tests).  Try rerunning and check if the same tests fail. 

But do not get blocked if the failing tests are from a different suite than the ones enabled in this PR.

You can see in the output the suites failed with a message like this: 
```
There were failures detected in the following suites:
	apps ./apps
```


Who?
----

Anyone but @keymon or @timmow