### PR TITLE
[#112670769] move bosh password fetch to pipeline

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -6,16 +6,25 @@ resources:
       stop: 6:00 -0000
       interval: 2h
 
+  - name: bosh-secrets
+    type: s3-iam
+    source:
+      bucket: {{state_bucket}}
+      region_name: {{aws_region}}
+      versioned_file: bosh-secrets.yml
+
 jobs:
   - name: delete
     serial: true
     plan:
     - get: delete-timer
       trigger: true
+    - get: bosh-secrets
     - task: delete-deployment
       config:
         inputs:
         - name: delete-timer
+        - name: bosh-secrets
         image: docker:///concourse/bosh-deployment-resource
         run:
           path: sh
@@ -23,4 +32,5 @@ jobs:
           - -e
           - -c
           - |
-            bosh -n -t https://10.0.0.6:25555 -u admin -p {{bosh_password}} delete deployment {{deploy_env}}
+            bosh_password=$(awk '$1~/bosh_admin_password/ {print $2}' bosh-secrets/bosh-secrets.yml)
+            bosh -n -t https://10.0.0.6:25555 -u admin -p "${bosh_password}" delete deployment {{deploy_env}}

--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -1,13 +1,4 @@
 resources:
-  - name: cf-deployment
-    type: bosh-deployment
-    source:
-      target: https://10.0.0.6:25555
-      username: admin
-      password: {{bosh_password}}
-      deployment: {{deploy_env}}
-      ignore_ssl: true
-
   - name: paas-cf
     type: git
     source:
@@ -234,118 +225,173 @@ jobs:
     serial: true
     plan:
       - aggregate:
+        - get: paas-cf
+          passed: ['generate-manifest']
+        - get: cf-manifest
+          passed: ['generate-manifest']
+          trigger: true
+        - get: bosh-secrets
+      - aggregate:
         - task: stemcell-tarball
           config:
             params:
-              STEMCELL_VERSION: {{stemcell-version}}
-            image: docker:///governmentpaas/curl-ssl
+              VERSION: {{stemcell-version}}
+              NAME: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
+              URL: https://bosh.io/d/stemcells/"${NAME}"?v="${VERSION}"
+              BOSH_PASSWORD: {{bosh_password}}
+              TYPE: stemcell
+            image: docker:///concourse/bosh-deployment-resource
             platform: linux
-            run:
-              path: sh
-              args: ["-c", "curl -L -J -o stemcell.tgz https://s3.amazonaws.com/bosh-jenkins-artifacts/bosh-stemcell/aws/light-bosh-stemcell-${STEMCELL_VERSION}-aws-xen-hvm-ubuntu-trusty-go_agent.tgz"]
-
-        - task: cf-release-tarball
-          config:
-            params:
-              RELEASE_VERSION: {{cf-release-version}}
-              URL: https://bosh.io/d/github.com/cloudfoundry/cf-release?v=${RELEASE_VERSION}
-            platform: linux
-            image: docker:///governmentpaas/curl-ssl
+            inputs:
+            - name: paas-cf
+            - name: bosh-secrets
             run:
               path: sh
               args:
-                - -e
-                - -c
-                - |
-                  eval curl -f -L -o release.tgz ${URL}
+              - -e
+              - -c
+              - |
+                ./paas-cf/concourse/scripts/bosh_ensure_uploaded.sh
+        - task: cf-release-tarball
+          config:
+            params:
+              VERSION: {{cf-release-version}}
+              NAME: cf
+              URL: https://bosh.io/d/github.com/cloudfoundry/cf-release?v="${VERSION}"
+              BOSH_PASSWORD: {{bosh_password}}
+              TYPE: release
+            image: docker:///concourse/bosh-deployment-resource
+            platform: linux
+            inputs:
+            - name: paas-cf
+            - name: bosh-secrets
+            run:
+              path: sh
+              args:
+              - -e
+              - -c
+              - |
+                ./paas-cf/concourse/scripts/bosh_ensure_uploaded.sh
 
         - task: nginx-release-tarball
           config:
             params:
-              RELEASE_VERSION: {{nginx-release-version}}
-              URL: https://s3.amazonaws.com/nginx-release/nginx-${RELEASE_VERSION}.tgz
+              VERSION: {{nginx-release-version}}
+              NAME: nginx
+              URL: https://s3.amazonaws.com/nginx-release/nginx-"${VERSION}".tgz
+              BOSH_PASSWORD: {{bosh_password}}
+              TYPE: release
+            image: docker:///concourse/bosh-deployment-resource
             platform: linux
-            image: docker:///governmentpaas/curl-ssl
+            inputs:
+            - name: paas-cf
+            - name: bosh-secrets
             run:
               path: sh
               args:
-                - -e
-                - -c
-                - |
-                  eval curl -f -L -o release.tgz ${URL}
+              - -e
+              - -c
+              - |
+                ./paas-cf/concourse/scripts/bosh_ensure_uploaded.sh
 
         - task: diego-release-tarball
           config:
             params:
-              RELEASE_VERSION: {{diego-release-version}}
-              URL: https://bosh.io/d/github.com/cloudfoundry-incubator/diego-release?v=${RELEASE_VERSION}
+              VERSION: {{diego-release-version}}
+              NAME: diego
+              URL: https://bosh.io/d/github.com/cloudfoundry-incubator/diego-release?v="${VERSION}"
+              BOSH_PASSWORD: {{bosh_password}}
+              TYPE: release
+            image: docker:///concourse/bosh-deployment-resource
             platform: linux
-            image: docker:///governmentpaas/curl-ssl
+            inputs:
+            - name: paas-cf
+            - name: bosh-secrets
             run:
               path: sh
               args:
-                - -e
-                - -c
-                - |
-                  eval curl -f -L -o release.tgz ${URL}
+              - -e
+              - -c
+              - |
+                ./paas-cf/concourse/scripts/bosh_ensure_uploaded.sh
 
         - task: garden-release-tarball
           config:
             params:
-              RELEASE_VERSION: {{garden-release-version}}
-              URL: https://bosh.io/d/github.com/cloudfoundry-incubator/garden-linux-release?v=${RELEASE_VERSION}
+              VERSION: {{garden-release-version}}
+              NAME: garden-linux
+              URL: https://bosh.io/d/github.com/cloudfoundry-incubator/garden-linux-release?v="${VERSION}"
+              BOSH_PASSWORD: {{bosh_password}}
+              TYPE: release
+            image: docker:///concourse/bosh-deployment-resource
             platform: linux
-            image: docker:///governmentpaas/curl-ssl
+            inputs:
+            - name: paas-cf
+            - name: bosh-secrets
             run:
               path: sh
               args:
-                - -e
-                - -c
-                - |
-                  eval curl -f -L -o release.tgz ${URL}
+              - -e
+              - -c
+              - |
+                ./paas-cf/concourse/scripts/bosh_ensure_uploaded.sh
 
         - task: etcd-release-tarball
           config:
             params:
-              RELEASE_VERSION: {{etcd-release-version}}
-              URL: https://bosh.io/d/github.com/cloudfoundry-incubator/etcd-release?v=${RELEASE_VERSION}
+              VERSION: {{etcd-release-version}}
+              NAME: etcd
+              URL: https://bosh.io/d/github.com/cloudfoundry-incubator/etcd-release?v="${VERSION}"
+              BOSH_PASSWORD: {{bosh_password}}
+              TYPE: release
+            image: docker:///concourse/bosh-deployment-resource
             platform: linux
-            image: docker:///governmentpaas/curl-ssl
+            inputs:
+            - name: paas-cf
+            - name: bosh-secrets
             run:
               path: sh
               args:
-                - -e
-                - -c
-                - |
-                  eval curl -f -L -o release.tgz ${URL}
+              - -e
+              - -c
+              - |
+                ./paas-cf/concourse/scripts/bosh_ensure_uploaded.sh
 
-        - get: cf-manifest
-          passed: ['generate-manifest']
-          trigger: true
+      - task: cf-deploy
+        config:
+          image: docker:///concourse/bosh-deployment-resource
+          inputs:
+          - name: cf-manifest
+          - name: bosh-secrets
+          platform: linux
+          run:
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              bosh -u admin -p {{bosh_password}} target https://10.0.0.6:25555
+              bosh login admin {{bosh_password}}
+              sed -e "s/^director_uuid:.*/director_uuid: $(bosh status --uuid)/" < cf-manifest/cf-manifest.yml > cf-manifest.yml
+              bosh deployment cf-manifest.yml
+              bosh -n deploy
 
-      - put: cf-deployment
+      - put: cf-manifest
         params:
-          manifest: cf-manifest/cf-manifest.yml
-          stemcells:
-            - stemcell-tarball/stemcell.tgz
-          releases:
-            - cf-release-tarball/release.tgz
-            - nginx-release-tarball/release.tgz
-            - diego-release-tarball/release.tgz
-            - garden-release-tarball/release.tgz
-            - etcd-release-tarball/release.tgz
+          file: cf-deploy/cf-manifest.yml
 
   - name: smoke-tests
     plan:
-    - get: cf-manifest
-      passed: ['deploy']
-    - get: cf-deployment
-      passed: ['deploy']
-      trigger: true
+    - aggregate:
+      - get: cf-manifest
+        passed: ['deploy']
+        trigger: true
+      - get: bosh-secrets
     - task: smoke-tests
       config:
         inputs:
         - name: cf-manifest
+        - name: bosh-secrets
         image: docker:///concourse/bosh-deployment-resource
         run:
           path: sh
@@ -355,22 +401,22 @@ jobs:
           - |
             bosh -u admin -p {{bosh_password}} target https://10.0.0.6:25555
             bosh login admin {{bosh_password}}
-            sed "s/^director_uuid:.*/director_uuid: $(bosh status --uuid)/" < cf-manifest/cf-manifest.yml > cf-manifest.yml
-            bosh deployment cf-manifest.yml
+            bosh deployment cf-manifest/cf-manifest.yml
             bosh -n \
               run errand smoke_tests \
               --download-logs --logs-dir .
 
   - name: acceptance-tests
     plan:
-    - get: cf-manifest
-      passed: ['deploy']
-    - get: cf-deployment
-      passed: ['deploy']
+    - aggregate:
+      - get: cf-manifest
+        passed: ['deploy']
+      - get: bosh-secrets
     - task: acceptance-tests
       config:
         inputs:
         - name: cf-manifest
+        - name: bosh-secrets
         image: docker:///concourse/bosh-deployment-resource
         run:
           path: sh
@@ -380,8 +426,7 @@ jobs:
           - |
             bosh -u admin -p {{bosh_password}} target https://10.0.0.6:25555
             bosh login admin {{bosh_password}}
-            sed "s/^director_uuid:.*/director_uuid: $(bosh status --uuid)/" < cf-manifest/cf-manifest.yml > cf-manifest.yml
-            bosh deployment cf-manifest.yml
+            bosh deployment cf-manifest/cf-manifest.yml
             bosh -n \
               run errand acceptance_tests \
               --download-logs --logs-dir .

--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -47,6 +47,13 @@ resources:
       region_name: {{aws_region}}
       versioned_file: cf-secrets.yml
 
+  - name: bosh-secrets
+    type: s3-iam
+    source:
+      bucket: {{state_bucket}}
+      region_name: {{aws_region}}
+      versioned_file: bosh-secrets.yml
+
 jobs:
   - name: s3init
     serial_groups: [ deploy ]
@@ -238,7 +245,6 @@ jobs:
               VERSION: {{stemcell-version}}
               NAME: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
               URL: https://bosh.io/d/stemcells/"${NAME}"?v="${VERSION}"
-              BOSH_PASSWORD: {{bosh_password}}
               TYPE: stemcell
             image: docker:///concourse/bosh-deployment-resource
             platform: linux
@@ -251,6 +257,7 @@ jobs:
               - -e
               - -c
               - |
+                BOSH_PASSWORD=$(awk '$1~/bosh_admin_password/ {print $2}' bosh-secrets/bosh-secrets.yml) \
                 ./paas-cf/concourse/scripts/bosh_ensure_uploaded.sh
         - task: cf-release-tarball
           config:
@@ -258,7 +265,6 @@ jobs:
               VERSION: {{cf-release-version}}
               NAME: cf
               URL: https://bosh.io/d/github.com/cloudfoundry/cf-release?v="${VERSION}"
-              BOSH_PASSWORD: {{bosh_password}}
               TYPE: release
             image: docker:///concourse/bosh-deployment-resource
             platform: linux
@@ -271,6 +277,7 @@ jobs:
               - -e
               - -c
               - |
+                BOSH_PASSWORD=$(awk '$1~/bosh_admin_password/ {print $2}' bosh-secrets/bosh-secrets.yml) \
                 ./paas-cf/concourse/scripts/bosh_ensure_uploaded.sh
 
         - task: nginx-release-tarball
@@ -279,7 +286,6 @@ jobs:
               VERSION: {{nginx-release-version}}
               NAME: nginx
               URL: https://s3.amazonaws.com/nginx-release/nginx-"${VERSION}".tgz
-              BOSH_PASSWORD: {{bosh_password}}
               TYPE: release
             image: docker:///concourse/bosh-deployment-resource
             platform: linux
@@ -292,6 +298,7 @@ jobs:
               - -e
               - -c
               - |
+                BOSH_PASSWORD=$(awk '$1~/bosh_admin_password/ {print $2}' bosh-secrets/bosh-secrets.yml) \
                 ./paas-cf/concourse/scripts/bosh_ensure_uploaded.sh
 
         - task: diego-release-tarball
@@ -300,7 +307,6 @@ jobs:
               VERSION: {{diego-release-version}}
               NAME: diego
               URL: https://bosh.io/d/github.com/cloudfoundry-incubator/diego-release?v="${VERSION}"
-              BOSH_PASSWORD: {{bosh_password}}
               TYPE: release
             image: docker:///concourse/bosh-deployment-resource
             platform: linux
@@ -313,6 +319,7 @@ jobs:
               - -e
               - -c
               - |
+                BOSH_PASSWORD=$(awk '$1~/bosh_admin_password/ {print $2}' bosh-secrets/bosh-secrets.yml) \
                 ./paas-cf/concourse/scripts/bosh_ensure_uploaded.sh
 
         - task: garden-release-tarball
@@ -321,7 +328,6 @@ jobs:
               VERSION: {{garden-release-version}}
               NAME: garden-linux
               URL: https://bosh.io/d/github.com/cloudfoundry-incubator/garden-linux-release?v="${VERSION}"
-              BOSH_PASSWORD: {{bosh_password}}
               TYPE: release
             image: docker:///concourse/bosh-deployment-resource
             platform: linux
@@ -334,6 +340,7 @@ jobs:
               - -e
               - -c
               - |
+                BOSH_PASSWORD=$(awk '$1~/bosh_admin_password/ {print $2}' bosh-secrets/bosh-secrets.yml) \
                 ./paas-cf/concourse/scripts/bosh_ensure_uploaded.sh
 
         - task: etcd-release-tarball
@@ -342,7 +349,6 @@ jobs:
               VERSION: {{etcd-release-version}}
               NAME: etcd
               URL: https://bosh.io/d/github.com/cloudfoundry-incubator/etcd-release?v="${VERSION}"
-              BOSH_PASSWORD: {{bosh_password}}
               TYPE: release
             image: docker:///concourse/bosh-deployment-resource
             platform: linux
@@ -355,6 +361,7 @@ jobs:
               - -e
               - -c
               - |
+                BOSH_PASSWORD=$(awk '$1~/bosh_admin_password/ {print $2}' bosh-secrets/bosh-secrets.yml) \
                 ./paas-cf/concourse/scripts/bosh_ensure_uploaded.sh
 
       - task: cf-deploy
@@ -370,8 +377,9 @@ jobs:
             - -e
             - -c
             - |
-              bosh -u admin -p {{bosh_password}} target https://10.0.0.6:25555
-              bosh login admin {{bosh_password}}
+              bosh_password=$(awk '$1~/bosh_admin_password/ {print $2}' bosh-secrets/bosh-secrets.yml)
+              bosh -u admin -p "${bosh_password}" target https://10.0.0.6:25555
+              bosh login admin "${bosh_password}"
               sed -e "s/^director_uuid:.*/director_uuid: $(bosh status --uuid)/" < cf-manifest/cf-manifest.yml > cf-manifest.yml
               bosh deployment cf-manifest.yml
               bosh -n deploy
@@ -399,8 +407,9 @@ jobs:
           - -e
           - -c
           - |
-            bosh -u admin -p {{bosh_password}} target https://10.0.0.6:25555
-            bosh login admin {{bosh_password}}
+            bosh_password=$(awk '$1~/bosh_admin_password/ {print $2}' bosh-secrets/bosh-secrets.yml)
+            bosh -u admin -p "${bosh_password}" target https://10.0.0.6:25555
+            bosh login admin "${bosh_password}"
             bosh deployment cf-manifest/cf-manifest.yml
             bosh -n \
               run errand smoke_tests \
@@ -424,8 +433,9 @@ jobs:
           - -e
           - -c
           - |
-            bosh -u admin -p {{bosh_password}} target https://10.0.0.6:25555
-            bosh login admin {{bosh_password}}
+            bosh_password=$(awk '$1~/bosh_admin_password/ {print $2}' bosh-secrets/bosh-secrets.yml)
+            bosh -u admin -p "${bosh_password}" target https://10.0.0.6:25555
+            bosh login admin "${bosh_password}"
             bosh deployment cf-manifest/cf-manifest.yml
             bosh -n \
               run errand acceptance_tests \

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -26,13 +26,23 @@ resources:
       region_name: {{aws_region}}
       key: trigger-tf-destroy
 
+  - name: bosh-secrets
+    type: s3-iam
+    source:
+      bucket: {{state_bucket}}
+      region_name: {{aws_region}}
+      versioned_file: bosh-secrets.yml
+
 jobs:
   - name: delete-deployment
     serial_groups: [ destroy ]
     serial: true
     plan:
+      - get: bosh-secrets
       - task: delete-deployment
         config:
+          inputs:
+          - name: bosh-secrets
           image: docker:///concourse/bosh-deployment-resource
           run:
             path: sh
@@ -40,7 +50,8 @@ jobs:
             - -e
             - -c
             - |
-              bosh -n -t https://10.0.0.6:25555 -u admin -p {{bosh_password}} delete deployment {{deploy_env}}
+              bosh_password=$(awk '$1~/bosh_admin_password/ {print $2}' bosh-secrets/bosh-secrets.yml)
+              bosh -n -t https://10.0.0.6:25555 -u admin -p "${bosh_password}" delete deployment {{deploy_env}}
       - put: trigger-tf-destroy
         params: {bump: patch}
 

--- a/concourse/scripts/bosh_ensure_uploaded.sh
+++ b/concourse/scripts/bosh_ensure_uploaded.sh
@@ -1,0 +1,15 @@
+#! /bin/sh
+set -e -u 
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+
+bosh -u admin -p "${BOSH_PASSWORD}" target https://10.0.0.6:25555 >/dev/null
+bosh login admin "${BOSH_PASSWORD}" >/dev/null
+
+existing_version=$("${script_dir}"/bosh_list_"${TYPE}"s.rb | awk -v name="${NAME}" -F"/" '$1 ~ name {print $2}')
+
+if [[ "${existing_version}" != "${VERSION}" ]]; then
+  eval bosh upload "${TYPE}" "${URL}"
+else
+  echo "${NAME}/${VERSION} is already uploaded"
+fi

--- a/concourse/scripts/bosh_list_releases.rb
+++ b/concourse/scripts/bosh_list_releases.rb
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+require 'rubygems'
+require 'cli'
+bosh_cli = Bosh::Cli::Command::Base.new.director
+bosh_cli.list_releases.each { |r|
+    r['release_versions'].each { |v|
+        puts "#{r['name']}/#{v['version']}"
+    }
+};

--- a/concourse/scripts/bosh_list_stemcells.rb
+++ b/concourse/scripts/bosh_list_stemcells.rb
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+require 'rubygems'
+require 'cli'
+bosh_cli = Bosh::Cli::Command::Base.new.director
+bosh_cli.list_stemcells.each { |s| puts "#{s['name']}/#{s['version']}" } ;

--- a/concourse/scripts/deploy-cloudfoundry.sh
+++ b/concourse/scripts/deploy-cloudfoundry.sh
@@ -11,8 +11,6 @@ config_autodelete="${SCRIPT_DIR}/../pipelines/autodelete-cloudfoundry.yml"
 
 [[ -z "${env}" ]] && echo "Must provide environment name" && exit 100
 
-bosh_password=$("$SCRIPT_DIR"/s3get.sh "${env}-state" bosh-secrets.yml > /dev/null && awk '$1~/bosh_admin_password/ {print $2}' bosh-secrets.yml)
-
 generate_vars_file() {
    set -u # Treat unset variables as an error when substituting
    cat <<EOF
@@ -22,7 +20,6 @@ deploy_env: ${env}
 state_bucket: ${env}-state
 branch_name: ${BRANCH:-master}
 aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
-bosh_password: ${bosh_password}
 stemcell-version: ${STEMCELL_VERSION:-3104}
 cf-release-version: ${CF_RELEASE_VERSION:-225}
 nginx-release-version: ${NIGNX_RELEASE_VERSION:-2}


### PR DESCRIPTION
# What
We prefer to get BOSH password in the pipeline to avoid unnecessary downloads of bosh-secrets.yml to local PC. This PR removes local download and moves password extraction logic to use Concourse resource.  Pivotal card: [Move BOSH password fetch to inside pipeline](https://www.pivotaltracker.com/story/show/112670769)

Please notice that [[#112581575] skip release download](https://github.com/alphagov/paas-cf/pull/82) needs to be merged first.

# How to test 

```
BRANCH=112670769_move_bosh_password_to_pipeline concourse/scripts/deploy-cloudfoundry.sh <env_name>
```

- Trigger the build manually from Concourse GUI

# Who can review

Anyone but @combor