### PR TITLE
[#108966132] Use a separate domain for deployed apps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ When complete you should:
 1. Access the UI from a browser with the same credentials as your
   *Bootstrap Concourse*.
 
-  - `https://${DEPLOY_ENV}-concourse.cf.paas.alphagov.co.uk/`
+  - `https://deployer.${DEPLOY_ENV}.cf.paas.alphagov.co.uk/`
 
 1. Add a new target to the `fly` CLI utility:
 
@@ -115,7 +115,7 @@ DEPLOY_ENV=<deploy-env>
 $(./vagrant/environment.sh $DEPLOY_ENV) # get the credentials
 
 echo -e "admin\n${CONCOURSE_ATC_PASSWORD}" | \
-   ${FLY_CMD} -t ${DEPLOY_ENV} login -k -c "https://${DEPLOY_ENV}-concourse.cf.paas.alphagov.co.uk"
+   ${FLY_CMD} -t ${DEPLOY_ENV} login -k -c "https://deployer.${DEPLOY_ENV}.cf.paas.alphagov.co.uk"
 ```
 
 ### Destroy

--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -246,7 +246,7 @@ jobs:
             . vpc-terraform-outputs/tfvars.sh
             openssl req -x509 -newkey rsa:2048 -keyout concourse.key \
               -out concourse.crt -days 365 -nodes -subj \
-              "/C=UK/ST=London/L=London/O=GDS/CN={{deploy_env}}-concourse.${TF_VAR_dns_zone_name}"
+              "/C=UK/ST=London/L=London/O=GDS/CN={{deploy_env}}-concourse.${TF_VAR_system_dns_zone_name}"
             tar czvf concourse-cert.tar.gz concourse.crt concourse.key
 
     - task: terraform-apply

--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -246,7 +246,7 @@ jobs:
             . vpc-terraform-outputs/tfvars.sh
             openssl req -x509 -newkey rsa:2048 -keyout concourse.key \
               -out concourse.crt -days 365 -nodes -subj \
-              "/C=UK/ST=London/L=London/O=GDS/CN={{deploy_env}}-concourse.${TF_VAR_system_dns_zone_name}"
+              "/C=UK/ST=London/L=London/O=GDS/CN=deployer.{{deploy_env}}.${TF_VAR_system_dns_zone_name}"
             tar czvf concourse-cert.tar.gz concourse.crt concourse.key
 
     - task: terraform-apply

--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -769,10 +769,6 @@ properties:
   description: null
   ssl:
     skip_cert_verify: true
-  system_domain: (( grab properties.domain ))
-  system_domain_organization: ~
-  app_domains:
-    - (( grab properties.domain ))
 
   disk_quota_enabled: true
 

--- a/manifests/cf-manifest/deployments/aws/999-cf-stub.yml
+++ b/manifests/cf-manifest/deployments/aws/999-cf-stub.yml
@@ -40,7 +40,7 @@ properties:
   system_domain: (( grab terraform_outputs.cf_root_domain ))
   system_domain_organization: GDS
   app_domains:
-   - (( grab terraform_outputs.cf_root_domain ))
+   - (( grab terraform_outputs.cf_apps_domain ))
 
   cc:
     staging_upload_user: staging_upload_user

--- a/manifests/cf-manifest/spec/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/base_properties_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "base properties" do
 
   it "sets the app domains" do
     expect(properties["app_domains"]).to match_array([
-      terraform_fixture(:cf_root_domain),
+      terraform_fixture(:cf_apps_domain),
     ])
   end
 

--- a/manifests/cf-manifest/spec/fixtures/terraform/terraform-outputs.yml
+++ b/manifests/cf-manifest/spec/fixtures/terraform/terraform-outputs.yml
@@ -3,6 +3,7 @@ terraform_outputs:
   cf1_subnet_id: subnet-12345678
   cf2_subnet_id: subnet-23456781
   cf_root_domain: unit-test.cf.paas.example.com
+  cf_apps_domain: unit-test.cf-apps.paas.example.com
   system_dns_zone_name: cf.paas.example.com
   elb_name: unit-test-cf-router-elb
   environment: unit-test

--- a/manifests/cf-manifest/spec/fixtures/terraform/terraform-outputs.yml
+++ b/manifests/cf-manifest/spec/fixtures/terraform/terraform-outputs.yml
@@ -3,7 +3,7 @@ terraform_outputs:
   cf1_subnet_id: subnet-12345678
   cf2_subnet_id: subnet-23456781
   cf_root_domain: unit-test.cf.paas.example.com
-  dns_zone_name: cf.paas.example.com
+  system_dns_zone_name: cf.paas.example.com
   elb_name: unit-test-cf-router-elb
   environment: unit-test
   region: sealand-1

--- a/terraform/cloudfoundry/dns-records.tf
+++ b/terraform/cloudfoundry/dns-records.tf
@@ -1,14 +1,14 @@
-resource "aws_route53_record" "wildcard" {
-  zone_id = "${var.dns_zone_id}"
-  name = "*.${var.env}.${var.dns_zone_name}."
+resource "aws_route53_record" "system_wildcard" {
+  zone_id = "${var.system_dns_zone_id}"
+  name = "*.${var.env}.${var.system_dns_zone_name}."
   type = "CNAME"
   ttl = "60"
   records = ["${aws_elb.router.dns_name}"]
 }
 
 resource "aws_route53_record" "sshproxy" {
-  zone_id = "${var.dns_zone_id}"
-  name = "ssh.${var.env}.${var.dns_zone_name}."
+  zone_id = "${var.system_dns_zone_id}"
+  name = "ssh.${var.env}.${var.system_dns_zone_name}."
   type = "CNAME"
   ttl = "60"
   records = ["${aws_elb.ssh-proxy-router.dns_name}"]

--- a/terraform/cloudfoundry/dns-records.tf
+++ b/terraform/cloudfoundry/dns-records.tf
@@ -13,3 +13,11 @@ resource "aws_route53_record" "sshproxy" {
   ttl = "60"
   records = ["${aws_elb.ssh-proxy-router.dns_name}"]
 }
+
+resource "aws_route53_record" "apps_wildcard" {
+  zone_id = "${var.apps_dns_zone_id}"
+  name = "*.${var.env}.${var.apps_dns_zone_name}."
+  type = "CNAME"
+  ttl = "60"
+  records = ["${aws_elb.router.dns_name}"]
+}

--- a/terraform/cloudfoundry/outputs.tf
+++ b/terraform/cloudfoundry/outputs.tf
@@ -14,6 +14,10 @@ output "cf_root_domain" {
   value = "${var.env}.${var.system_dns_zone_name}"
 }
 
+output "cf_apps_domain" {
+  value = "${var.env}.${var.apps_dns_zone_name}"
+}
+
 output "elb_name" {
   value = "${aws_elb.router.name}"
 }

--- a/terraform/cloudfoundry/outputs.tf
+++ b/terraform/cloudfoundry/outputs.tf
@@ -11,7 +11,7 @@ output "ssh_elb_name" {
 }
 
 output "cf_root_domain" {
-  value = "${var.env}.${var.dns_zone_name}"
+  value = "${var.env}.${var.system_dns_zone_name}"
 }
 
 output "elb_name" {

--- a/terraform/concourse/elb.tf
+++ b/terraform/concourse/elb.tf
@@ -54,9 +54,9 @@ resource "aws_security_group" "concourse-elb" {
   }
 }
 
-resource "aws_route53_record" "concourse" {
+resource "aws_route53_record" "deployer-concourse" {
   zone_id = "${var.system_dns_zone_id}"
-  name    = "${var.env}-concourse.${var.system_dns_zone_name}."
+  name    = "deployer.${var.env}.${var.system_dns_zone_name}."
   type    = "CNAME"
   ttl     = "60"
   records = ["${aws_elb.concourse.dns_name}"]

--- a/terraform/concourse/elb.tf
+++ b/terraform/concourse/elb.tf
@@ -55,8 +55,8 @@ resource "aws_security_group" "concourse-elb" {
 }
 
 resource "aws_route53_record" "concourse" {
-  zone_id = "${var.dns_zone_id}"
-  name    = "${var.env}-concourse.${var.dns_zone_name}."
+  zone_id = "${var.system_dns_zone_id}"
+  name    = "${var.env}-concourse.${var.system_dns_zone_name}."
   type    = "CNAME"
   ttl     = "60"
   records = ["${aws_elb.concourse.dns_name}"]

--- a/terraform/dev.tfvars
+++ b/terraform/dev.tfvars
@@ -1,2 +1,2 @@
-dns_zone_id = "Z3SI0PSH6KKVH4"
-dns_zone_name = "cf.paas.alphagov.co.uk"
+system_dns_zone_id = "Z3SI0PSH6KKVH4"
+system_dns_zone_name = "cf.paas.alphagov.co.uk"

--- a/terraform/dev.tfvars
+++ b/terraform/dev.tfvars
@@ -1,2 +1,4 @@
 system_dns_zone_id = "Z3SI0PSH6KKVH4"
 system_dns_zone_name = "cf.paas.alphagov.co.uk"
+apps_dns_zone_id = "Z1Z5PS9NS78JFE"
+apps_dns_zone_name = "cf-apps.paas.alphagov.co.uk"

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -56,12 +56,12 @@ variable "vagrant_cidr" {
   default     = ""
 }
 
-variable "dns_zone_id" {
-  description = "Amazon Route53 DNS zone identifier. Different per account."
+variable "system_dns_zone_id" {
+  description = "Amazon Route53 DNS zone identifier for the system components. Different per account."
 }
 
-variable "dns_zone_name" {
-  description = "Amazon Route53 DNS zone name. Differs per account."
+variable "system_dns_zone_name" {
+  description = "Amazon Route53 DNS zone name for the system components. Differs per account."
 }
 
 variable "microbosh_static_private_ip" {

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -64,6 +64,14 @@ variable "system_dns_zone_name" {
   description = "Amazon Route53 DNS zone name for the system components. Differs per account."
 }
 
+variable "apps_dns_zone_id" {
+  description = "Amazon Route53 DNS zone identifier for hosted apps. Different per account."
+}
+
+variable "apps_dns_zone_name" {
+  description = "Amazon Route53 DNS zone name for hosted apps. Differs per account."
+}
+
 variable "microbosh_static_private_ip" {
   description = "Microbosh internal IP"
   default     = "10.0.0.6"

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -1,2 +1,4 @@
 system_dns_zone_id = "updateme_prod_system_zone_id"
 system_dns_zone_name = "updateme_prod_system_zone_name"
+apps_dns_zone_id = "updateme_prod_apps_zone_id"
+apps_dns_zone_name = "updateme_proc_apps_zone_name"

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -1,2 +1,2 @@
-dns_zone_id = "updateme_production_zone_id"
-dns_zone_name = "updateme_production_zone_name"
+system_dns_zone_id = "updateme_prod_system_zone_id"
+system_dns_zone_name = "updateme_prod_system_zone_name"

--- a/terraform/vpc/outputs.tf
+++ b/terraform/vpc/outputs.tf
@@ -42,6 +42,6 @@ output "infra_subnet_ids" {
   value = "${join(",", aws_subnet.infra.*.id)}"
 }
 
-output "dns_zone_name" {
-  value = "${var.dns_zone_name}"
+output "system_dns_zone_name" {
+  value = "${var.system_dns_zone_name}"
 }


### PR DESCRIPTION
## What

In order to prevent apps from potentially overwriting the routes for system components we want apps to be served from a different domain.

## Details

This uses the new domain (`cf-apps.paas.alphagov.co.uk`) for hosting apps deployed to Cloudfoundry. This domain has already been created in the trial account, and had DNS delegated.

This PR does not include changing SSL certs used to serve apps (they'll still use the self-signed `*.cf.paas.alphagov.co.uk` cert). This will be addressed in another PR.

As part of this change we've also changed the hostname for the deployer-concourse to `deployer.<env>.cf.paas.alphagov.co.uk` to bring it inline with other components and disambiguate from the bootstrap-concourse.

## How to review

Deploy a complete environment from this branch, and verify that it all works correctly. Push an app to the deployment, and verify that it is served correctly from the new domain.

Verify that it's possible to push an app called "api" and that it won't affect the system functionality.

Verify that it's not possible to create an app on the system domain when not in the system CF org (called "GDS").

## Who can review

Anyone but @timmow and myself.