### PR TITLE
[#112503409] separate subnet for cell

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
   - 2.2.3
 env:
   global:
-    - TF_VERSION="0.6.8"
+    - TF_VERSION="0.6.10"
     - SPRUCE_VERSION="0.13.0"
 
 addons:

--- a/manifests/cf-manifest/deployments/020-cf-resource-pools.yml
+++ b/manifests/cf-manifest/deployments/020-cf-resource-pools.yml
@@ -93,12 +93,12 @@ resource_pools:
     env: (( grab meta.default_env ))
 
   - name: cell_z1
-    network: cf1
+    network: cell1
     stemcell: (( grab meta.stemcell ))
     env: (( grab meta.default_env ))
 
   - name: cell_z2
-    network: cf2
+    network: cell2
     stemcell: (( grab meta.stemcell ))
     env: (( grab meta.default_env ))
 

--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -594,10 +594,10 @@ jobs:
 
   - name: cell_z1
     templates: (( grab base_job_templates.cell ))
-    instances: 0
+    instances: 1
     resource_pool: cell_z1
     networks:
-      - name: cf1
+      - name: cell1
     update:
       serial: false
       max_in_flight: 1
@@ -610,10 +610,10 @@ jobs:
 
   - name: cell_z2
     templates: (( grab base_job_templates.cell ))
-    instances: 0
+    instances: 1
     resource_pool: cell_z2
     networks:
-      - name: cf2
+      - name: cell2
     update:
       serial: false
       max_in_flight: 1

--- a/manifests/cf-manifest/deployments/040-cf-properties.yml
+++ b/manifests/cf-manifest/deployments/040-cf-properties.yml
@@ -444,8 +444,6 @@ base_job_templates:
     - name: metron_agent
       release: cf
   colocated:
-    - name: rep
-      release: diego
     - name: auctioneer
       release: diego
     - name: bbs
@@ -460,13 +458,9 @@ base_job_templates:
       release: etcd
     - name: file_server
       release: diego
-    - name: garden
-      release: garden-linux
     - name: metron_agent
       release: cf
     - name: nsync
-      release: diego
-    - name: rootfses
       release: diego
     - name: route_emitter
       release: diego

--- a/manifests/cf-manifest/deployments/aws/999-cf-stub.yml
+++ b/manifests/cf-manifest/deployments/aws/999-cf-stub.yml
@@ -35,6 +35,27 @@ networks:
       cloud_properties:
         subnet: (( grab terraform_outputs.cf2_subnet_id ))
 
+- name: cell1
+  subnets:
+    - range: 10.0.20.0/24
+      reserved:
+        - 10.0.20.2 - 10.0.20.3
+      gateway: 10.0.20.1
+      dns:
+        - 10.0.0.2
+      cloud_properties:
+        subnet: (( grab terraform_outputs.cell1_subnet_id ))
+- name: cell2
+  subnets:
+    - range: 10.0.21.0/24
+      reserved:
+        - 10.0.21.2 - 10.0.21.3
+      gateway: 10.0.21.1
+      dns:
+        - 10.0.0.2
+      cloud_properties:
+        subnet: (( grab terraform_outputs.cell2_subnet_id ))
+
 properties:
   domain: (( grab terraform_outputs.cf_root_domain ))
   system_domain: (( grab terraform_outputs.cf_root_domain ))

--- a/manifests/cf-manifest/spec/fixtures/terraform/terraform-outputs.yml
+++ b/manifests/cf-manifest/spec/fixtures/terraform/terraform-outputs.yml
@@ -2,6 +2,8 @@
 terraform_outputs:
   cf1_subnet_id: subnet-12345678
   cf2_subnet_id: subnet-23456781
+  cell1_subnet_id: subnet-09876543
+  cell2_subnet_id: subnet-98765432
   cf_root_domain: unit-test.cf.paas.example.com
   dns_zone_name: cf.paas.example.com
   elb_name: unit-test-cf-router-elb

--- a/manifests/cf-manifest/spec/networks_spec.rb
+++ b/manifests/cf-manifest/spec/networks_spec.rb
@@ -3,6 +3,8 @@ RSpec.describe "networks" do
   CF_NETWORK_NAMES = %w(
     cf1
     cf2
+    cell1
+    cell2
   )
 
   let(:networks) { manifest_with_defaults.fetch("networks") }

--- a/terraform/cloudfoundry/cell-subnet.tf
+++ b/terraform/cloudfoundry/cell-subnet.tf
@@ -1,10 +1,10 @@
-resource "aws_subnet" "cf" {
+resource "aws_subnet" "cell" {
   count             = "${var.zone_count}"
   vpc_id            = "${var.vpc_id}"
-  cidr_block        = "${lookup(var.cf_cidrs, concat("zone", count.index))}"
+  cidr_block        = "${lookup(var.cell_cidrs, concat("zone", count.index))}"
   availability_zone = "${lookup(var.zones, concat("zone", count.index))}"
   map_public_ip_on_launch = false
   tags {
-    Name = "${var.env}-cf-subnet-${count.index}"
+    Name = "${var.env}-cell-subnet-${count.index}"
   }
 }

--- a/terraform/cloudfoundry/nat.tf
+++ b/terraform/cloudfoundry/nat.tf
@@ -24,3 +24,8 @@ resource "aws_route_table_association" "internet" {
   route_table_id = "${element(aws_route_table.internet.*.id, count.index)}"
 }
 
+resource "aws_route_table_association" "cell_internet" {
+  count          = "${var.zone_count}"
+  subnet_id      = "${element(aws_subnet.cell.*.id, count.index)}"
+  route_table_id = "${element(aws_route_table.internet.*.id, count.index)}"
+}

--- a/terraform/cloudfoundry/outputs.tf
+++ b/terraform/cloudfoundry/outputs.tf
@@ -6,6 +6,14 @@ output "cf2_subnet_id" {
   value = "${aws_subnet.cf.1.id}"
 }
 
+output "cell1_subnet_id" {
+  value = "${aws_subnet.cell.0.id}"
+}
+
+output "cell2_subnet_id" {
+  value = "${aws_subnet.cell.1.id}"
+}
+
 output "ssh_elb_name" {
   value = "${aws_elb.ssh-proxy-router.name}"
 }

--- a/terraform/cloudfoundry/variables.tf
+++ b/terraform/cloudfoundry/variables.tf
@@ -7,6 +7,15 @@ variable "cf_cidrs" {
   }
 }
 
+variable "cell_cidrs" {
+  description = "CIDR for cell subnet indexed by AZ"
+  default     = {
+    zone0 = "10.0.20.0/24"
+    zone1 = "10.0.21.0/24"
+    zone2 = "10.0.22.0/24"
+  }
+}
+
 variable "health_check_interval" {
   description = "Interval between requests for load balancer health checks"
   default     = 5


### PR DESCRIPTION
# What 

This PR adds separation for Diego Cell. It creates new Cell subnet and moves its components from colocated VM to dedicated one. 

# Details

- new cell subnet per AZ, ranges from 10.0.20.0 to 10.0.22.0
- separation of rep, garden and rootfs from collocated VM to dedicated one
- new route table association as we need internet to access API and for apps
- extension of tests to include new networks
- Terraform version bump to reflect version in TF container

# How to test 

Use this branch to deploy new CF instance. Run smoke and acceptance tests.

Note that some acceptance tests may fail as they are known to be flaky.

# Who can test 
Anyone but @combor and @jimconner 
