### PR TITLE
destroy-microbosh: BOSH delete trigger Terraform

### DIFF
--- a/concourse/pipelines/destroy-microbosh.yml
+++ b/concourse/pipelines/destroy-microbosh.yml
@@ -101,6 +101,7 @@ jobs:
     - get: paas-cf
     - get: bosh-init-state
       passed: [ bosh-init-delete ]
+      trigger: true
     - get: vpc-tfstate
     - get: concourse-tfstate
     - get: bosh-tfstate


### PR DESCRIPTION
## What

The `bosh-terraform-destroy` job in the `destroy-microbosh` pipeline wasn't
being triggered after `bosh-init-delete` had completed. This left you with a
partial environment, until you manually trigger the `bosh-terraform-destroy`
job manually. This was noted in the "pipelines improvements" story and has
surprised me a few times.

We're going to have a story later to look at the `init` and trigger patterns
in all pipelines. This commit just concentrates on making it work, rather
than standardising any of the patterns currently in use.

NB: There is no story for this. I came across this while debugging another issue.

## How to test

1. Run the `create-microbosh` pipeline.
1. Run the `destroy-microbosh` pipeline.
1. Confirm that all of the jobs (bit boxes) have completed and are green.

## Who can review

Not @dcarley