### PR TITLE
[#112788839] Consolidate etcd clusters

### DIFF
--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -6,6 +6,7 @@ meta:
   release:
     name: cf
 
+
   consul_servers: (( grab jobs.consul_z1.networks.cf1.static_ips jobs.consul_z2.networks.cf2.static_ips ))
 
   nfs_client_ranges:
@@ -65,9 +66,9 @@ meta:
 
   etcd_templates:
   - name: etcd
-    release: (( grab meta.release.name ))
+    release: etcd
   - name: etcd_metrics_server
-    release: (( grab meta.release.name ))
+    release: etcd
   - name: metron_agent
     release: (( grab meta.release.name ))
   - name: consul_agent
@@ -226,8 +227,6 @@ jobs:
         agent:
           services:
             etcd: {}
-    update:
-      max_in_flight: 1
 
   - name: etcd_z2
     templates: (( grab meta.etcd_templates ))
@@ -244,8 +243,6 @@ jobs:
         agent:
           services:
             etcd: {}
-    update:
-      max_in_flight: 1
 
   - name: stats_z1
     templates: (( grab meta.stats_templates ))

--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -70,6 +70,9 @@ meta:
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
+  - name: consul_agent
+    release: (( grab meta.release.name ))
+
 
   ha_proxy_templates:
   - name: haproxy

--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -222,6 +222,12 @@ jobs:
     properties:
       metron_agent:
         zone: z1
+      consul:
+        agent:
+          services:
+            etcd: {}
+    update:
+      max_in_flight: 1
 
   - name: etcd_z2
     templates: (( grab meta.etcd_templates ))
@@ -234,6 +240,12 @@ jobs:
     properties:
       metron_agent:
         zone: z2
+      consul:
+        agent:
+          services:
+            etcd: {}
+    update:
+      max_in_flight: 1
 
   - name: stats_z1
     templates: (( grab meta.stats_templates ))

--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -600,7 +600,6 @@ jobs:
             auctioneer: {}
             bbs: {}
             cc_uploader: {}
-            etcd: {}
             file_server: {}
             nsync: {}
             ssh_proxy: {}
@@ -626,7 +625,6 @@ jobs:
             auctioneer: {}
             bbs: {}
             cc_uploader: {}
-            etcd: {}
             file_server: {}
             nsync: {}
             ssh_proxy: {}
@@ -649,7 +647,6 @@ jobs:
       consul:
         agent:
           services:
-            etcd: {}
             bbs: {}
       metron_agent:
         zone: z1
@@ -665,7 +662,6 @@ jobs:
       consul:
         agent:
           services:
-            etcd: {}
             bbs: {}
       metron_agent:
         zone: z2

--- a/manifests/cf-manifest/deployments/040-cf-properties.yml
+++ b/manifests/cf-manifest/deployments/040-cf-properties.yml
@@ -435,8 +435,6 @@ base_job_templates:
     - name: file_server
       release: diego
   database:
-    - name: etcd
-      release: etcd
     - name: bbs
       release: diego
     - name: consul_agent
@@ -454,8 +452,6 @@ base_job_templates:
       release: diego
     - name: consul_agent
       release: cf
-    - name: etcd
-      release: etcd
     - name: file_server
       release: diego
     - name: metron_agent


### PR DESCRIPTION
[Reconcile etcd config/clusters](https://www.pivotaltracker.com/story/show/112788839)

## What

We have two different types of etcd jobs, which appear to be part of the same cluster but use a different configuration. We should reconcile these into a single cluster of the same configuration.

## How this PR should be reviewed

This PR should be reviewed in the following context:
* I want to
  * Add a consul agent to the existing etcd cluster so I can resolve it as `etcd.service.cf.internal`
  * I want to apply the correct base configuration to the etcd configuration so it will start up cleanly
  * I want to remove the legacy etcd cluster from the co-located machines
  * I want to bump the version of etcd to 18 so it's [compatible](https://github.com/cloudfoundry-incubator/diego-cf-compatibility/blob/master/compatibility-v2.csv) with Diego and the CF release at the moment we are using the version of etcd bundled with CF release 225 (which is 14).

## How to review this PR

* To review this PR deploy a new environment and run smoke tests against it,
* You can also ssh into an etcd node and run `dig etcd.service.cf.internal` to see if it resolves correctly and check the etcd service is running using `monit summary` and check the etc logs under `/var/vcap/sys/log`

**tip!** you can cherry pick @alext 's parallel VM commit to deploy faster `git cherry-pick 9b56c7798874d6f9d006900e8019bc0011a767bc`

## Who should review this PR

Anyone except @keymon and @actionjack