### PR TITLE
[#113158535] Change colocated instances to m3.medium

### DIFF
--- a/manifests/cf-manifest/deployments/aws/000-cf-infrastructure.yml
+++ b/manifests/cf-manifest/deployments/aws/000-cf-infrastructure.yml
@@ -213,12 +213,12 @@ resource_pools:
 
   - name: colocated_z1
     cloud_properties:
-      instance_type: r3.xlarge
+      instance_type: m3.medium
       availability_zone: (( grab meta.zones.z1 ))
 
   - name: colocated_z2
     cloud_properties:
-      instance_type: r3.xlarge
+      instance_type: m3.medium
       availability_zone: (( grab meta.zones.z2 ))
 
 


### PR DESCRIPTION
These are currently r3.xlarge instances, which is massivly overspec for
them now that the cells have been moved to separate machines. While
running the acceptance tests against an environment, the memory stats
look like:
```
             total       used       free     shared    buffers     cached
Mem:      31415272     762348   30652924        428      62032     343804
-/+ buffers/cache:     356512   31058760
Swap:     31415100          0   31415100
```
That's 700M of 32Gig. Additionally, when running the tests, the 5min
load average peaked at around 0.5, meaning there's plenty of CPU
headroom.

I considered reducing the size of the cell machines, but decided not to.
When running the tests as above, the memory stats were:
```
             total       used       free     shared    buffers     cached
Mem:      31415272   10807772   20607500        632     108352    9998904
-/+ buffers/cache:     700516   30714756
Swap:     31415100          0   31415100
```
and the 5min load peaked at around 1.5. Leaving them as r3.xlarge will
allow room for more apps to be deployed etc.

## How to review

Deploy cloudfoundry from the branch, and verify that the colocated machines are m3.medium instrances.

## Who can review

Anyone but myself.