### PR TITLE
[#110662576] Move deployment to new Dev account

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ When complete you should:
 1. Access the UI from a browser with the same credentials as your
   *Bootstrap Concourse*.
 
-  - `https://deployer.${DEPLOY_ENV}.cf.paas.alphagov.co.uk/`
+  - `https://deployer.${DEPLOY_ENV}.dev.paas.alphagov.co.uk/`
 
 1. Add a new target to the `fly` CLI utility:
 
@@ -115,7 +115,7 @@ DEPLOY_ENV=<deploy-env>
 $(./vagrant/environment.sh $DEPLOY_ENV) # get the credentials
 
 echo -e "admin\n${CONCOURSE_ATC_PASSWORD}" | \
-   ${FLY_CMD} -t ${DEPLOY_ENV} login -k -c "https://deployer.${DEPLOY_ENV}.cf.paas.alphagov.co.uk"
+   ${FLY_CMD} -t ${DEPLOY_ENV} login -k -c "https://deployer.${DEPLOY_ENV}.dev.paas.alphagov.co.uk"
 ```
 
 ### Destroy
@@ -180,6 +180,24 @@ used within the pipeline. This is useful for development and code review:
 ```
 BRANCH=$(git rev-parse --abbrev-ref HEAD) <script>.sh
 ```
+
+## Optionally deploy to a different AWS account
+
+By default the scripts will deploy to the dev account. To deploy to a different
+account, you'll need to export AWS access keys and secrets for the account, and
+then set the `AWS_ACCOUNT` environment variable. eg to deploy/use the trial account:
+
+```
+export AWS_ACCESS_KEY_ID=your_trial_access_key
+export AWS_SECRET_ACCESS_KEY=your_trial_secret_key
+export AWS_ACCOUNT=trial
+```
+
+Due to the isolation between AWS accounts, when switching accounts, it's
+necessary to start with a comletely new deployment.
+
+**Note:** Different AWS accounts use different DNS names, so it'll be necessary
+to adjust some of the instructions above accordingly.
 
 ## Sharing your Bootstrap Concourse
 

--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -112,7 +112,7 @@ jobs:
             if [ -f bucket-state/bucket.tfstate ]; then
               cp bucket-state/bucket.tfstate .
             fi
-            terraform apply -state=bucket.tfstate -var-file=paas-cf/terraform/{{account}}.tfvars \
+            terraform apply -state=bucket.tfstate -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
               paas-cf/terraform/bucket
       on_success:
         put: bucket-terraform-state
@@ -185,7 +185,7 @@ jobs:
           - |
             cp ssh-keygen/id_rsa.pub paas-cf/terraform/vpc
             terraform_params=${VAGRANT_IP:+-var vagrant_cidr=$VAGRANT_IP/32}
-            terraform apply ${terraform_params} -var-file=paas-cf/terraform/{{account}}.tfvars \
+            terraform apply ${terraform_params} -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
               -state=vpc-terraform-state/vpc.tfstate -state-out=vpc.tfstate paas-cf/terraform/vpc
       ensure:
         put: vpc-terraform-state
@@ -271,7 +271,7 @@ jobs:
             . vpc-terraform-outputs/tfvars.sh
             terraform_params=${VAGRANT_IP:+-var vagrant_cidr=$VAGRANT_IP/32}
             terraform apply ${terraform_params} \
-              -var-file=paas-cf/terraform/{{account}}.tfvars \
+              -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
               -state=concourse-terraform-state/concourse.tfstate \
               -state-out=concourse.tfstate \
               paas-cf/terraform/concourse
@@ -457,7 +457,7 @@ jobs:
           - -c
           - |
             terraform apply -target=aws_security_group.office-access-ssh \
-              -var-file=paas-cf/terraform/{{account}}.tfvars \
+              -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
               -target=aws_subnet.infra \
               -state=vpc-terraform-state/vpc.tfstate -state-out=vpc.tfstate \
               paas-cf/terraform/vpc
@@ -486,7 +486,7 @@ jobs:
             . vpc-terraform-outputs/tfvars.sh
             terraform apply -target=aws_security_group.concourse \
               -state=concourse-terraform-state/concourse.tfstate -state-out=concourse.tfstate \
-              -var-file=paas-cf/terraform/{{account}}.tfvars paas-cf/terraform/concourse
+              -var-file=paas-cf/terraform/{{aws_account}}.tfvars paas-cf/terraform/concourse
       ensure:
         put: concourse-terraform-state
         params:

--- a/concourse/pipelines/create-microbosh.yml
+++ b/concourse/pipelines/create-microbosh.yml
@@ -181,7 +181,7 @@ jobs:
             . terraform-variables/vpc.tfvars.sh
             . terraform-variables/concourse.tfvars.sh
 
-            terraform apply -var env={{deploy_env}} -var-file=paas-cf/terraform/{{account}}.tfvars \
+            terraform apply -var env={{deploy_env}} -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
               -state=bosh-tfstate/bosh.tfstate -state-out=bosh.tfstate paas-cf/terraform/bosh
       ensure:
         put: bosh-tfstate

--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -128,7 +128,7 @@ jobs:
               . terraform-variables/concourse.tfvars.sh
               . terraform-variables/bosh.tfvars.sh
 
-              terraform apply -var-file=paas-cf/terraform/{{account}}.tfvars \
+              terraform apply -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
                 -state=cf-tfstate/cf.tfstate -state-out=cf.tfstate paas-cf/terraform/cloudfoundry
         ensure:
           put: cf-tfstate

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -102,7 +102,7 @@ jobs:
             - |
               . terraform-variables/cf.tfvars.sh
               . terraform-variables/vpc.tfvars.sh
-              terraform destroy -force -var env={{deploy_env}} -var-file=paas-cf/terraform/{{account}}.tfvars \
+              terraform destroy -force -var env={{deploy_env}} -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
                 -state=cf-tfstate/cf.tfstate -state-out=cf.tfstate paas-cf/terraform/cloudfoundry
         ensure:
           put: cf-tfstate

--- a/concourse/pipelines/destroy-deployer.yml
+++ b/concourse/pipelines/destroy-deployer.yml
@@ -130,7 +130,7 @@ jobs:
             . vpc-terraform-outputs/tfvars.sh
             touch concourse.crt concourse.key
             terraform destroy -force \
-              -var-file=paas-cf/terraform/{{account}}.tfvars \
+              -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
               -state=concourse-terraform-state/concourse.tfstate \
               -state-out=concourse.tfstate \
               paas-cf/terraform/concourse
@@ -167,7 +167,7 @@ jobs:
           - -c
           - |
             touch paas-cf/terraform/vpc/id_rsa.pub
-            terraform destroy -force -var-file=paas-cf/terraform/{{account}}.tfvars \
+            terraform destroy -force -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
               -state=vpc-terraform-state/vpc.tfstate -state-out=vpc.tfstate paas-cf/terraform/vpc
       ensure:
         put: vpc-terraform-state
@@ -198,5 +198,5 @@ jobs:
             - -e
             - -c
             - |
-              terraform destroy -force -var-file=paas-cf/terraform/{{account}}.tfvars \
+              terraform destroy -force -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
                 -state=bucket-terraform-state/bucket.tfstate paas-cf/terraform/bucket

--- a/concourse/pipelines/destroy-microbosh.yml
+++ b/concourse/pipelines/destroy-microbosh.yml
@@ -145,7 +145,7 @@ jobs:
             . terraform-variables/vpc.tfvars.sh
             . terraform-variables/concourse.tfvars.sh
 
-            terraform destroy -force -var env={{deploy_env}} -var-file=paas-cf/terraform/{{account}}.tfvars \
+            terraform destroy -force -var env={{deploy_env}} -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
               -state=bosh-tfstate/bosh.tfstate -state-out=bosh.tfstate paas-cf/terraform/bosh
       ensure:
         put: bosh-tfstate

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -13,7 +13,7 @@ generate_vars_file() {
    set -u # Treat unset variables as an error when substituting
    cat <<EOF
 ---
-account: ${AWS_ACCOUNT:-dev}
+aws_account: ${AWS_ACCOUNT:-dev}
 deploy_env: ${env}
 state_bucket: ${env}-state
 branch_name: ${BRANCH:-master}

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -13,7 +13,7 @@ generate_vars_file() {
    set -u # Treat unset variables as an error when substituting
    cat <<EOF
 ---
-aws_account: ${AWS_ACCOUNT:-dev}
+aws_account: ${AWS_ACCOUNT:-trial}
 deploy_env: ${env}
 state_bucket: ${env}-state
 branch_name: ${BRANCH:-master}

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -13,7 +13,7 @@ generate_vars_file() {
    set -u # Treat unset variables as an error when substituting
    cat <<EOF
 ---
-aws_account: ${AWS_ACCOUNT:-trial}
+aws_account: ${AWS_ACCOUNT:-dev}
 deploy_env: ${env}
 state_bucket: ${env}-state
 branch_name: ${BRANCH:-master}

--- a/concourse/scripts/pipelines-deployer.sh
+++ b/concourse/scripts/pipelines-deployer.sh
@@ -10,7 +10,7 @@ generate_vars_file() {
    set -u # Treat unset variables as an error when substituting
    cat <<EOF
 ---
-aws_account: ${AWS_ACCOUNT:-trial}
+aws_account: ${AWS_ACCOUNT:-dev}
 vagrant_ip: ${VAGRANT_IP}
 deploy_env: ${env}
 tfstate_bucket: bucket=${env}-state

--- a/concourse/scripts/pipelines-deployer.sh
+++ b/concourse/scripts/pipelines-deployer.sh
@@ -10,7 +10,7 @@ generate_vars_file() {
    set -u # Treat unset variables as an error when substituting
    cat <<EOF
 ---
-aws_account: ${AWS_ACCOUNT:-dev}
+aws_account: ${AWS_ACCOUNT:-trial}
 vagrant_ip: ${VAGRANT_IP}
 deploy_env: ${env}
 tfstate_bucket: bucket=${env}-state

--- a/concourse/scripts/pipelines-deployer.sh
+++ b/concourse/scripts/pipelines-deployer.sh
@@ -10,7 +10,7 @@ generate_vars_file() {
    set -u # Treat unset variables as an error when substituting
    cat <<EOF
 ---
-account: ${AWS_ACCOUNT:-dev}
+aws_account: ${AWS_ACCOUNT:-dev}
 vagrant_ip: ${VAGRANT_IP}
 deploy_env: ${env}
 tfstate_bucket: bucket=${env}-state

--- a/concourse/scripts/pipelines-microbosh.sh
+++ b/concourse/scripts/pipelines-microbosh.sh
@@ -10,7 +10,7 @@ generate_vars_file() {
    set -u # Treat unset variables as an error when substituting
    cat <<EOF
 ---
-account: ${AWS_ACCOUNT:-dev}
+aws_account: ${AWS_ACCOUNT:-dev}
 deploy_env: ${env}
 state_bucket: ${env}-state
 pipeline_trigger_file: ${trigger_file}

--- a/concourse/scripts/pipelines-microbosh.sh
+++ b/concourse/scripts/pipelines-microbosh.sh
@@ -10,7 +10,7 @@ generate_vars_file() {
    set -u # Treat unset variables as an error when substituting
    cat <<EOF
 ---
-aws_account: ${AWS_ACCOUNT:-trial}
+aws_account: ${AWS_ACCOUNT:-dev}
 deploy_env: ${env}
 state_bucket: ${env}-state
 pipeline_trigger_file: ${trigger_file}

--- a/concourse/scripts/pipelines-microbosh.sh
+++ b/concourse/scripts/pipelines-microbosh.sh
@@ -10,7 +10,7 @@ generate_vars_file() {
    set -u # Treat unset variables as an error when substituting
    cat <<EOF
 ---
-aws_account: ${AWS_ACCOUNT:-dev}
+aws_account: ${AWS_ACCOUNT:-trial}
 deploy_env: ${env}
 state_bucket: ${env}-state
 pipeline_trigger_file: ${trigger_file}

--- a/manifests/bosh-manifest/deployments/020-compiled-package-cache.yml
+++ b/manifests/bosh-manifest/deployments/020-compiled-package-cache.yml
@@ -5,7 +5,7 @@ jobs:
       provider: s3
       options:
         credentials_source: env_or_profile
-        bucket_name: shared-cf-bosh-blobstore
+        bucket_name: (( grab terraform_outputs.compiled_cache_bucket_name ))
         host: (( grab terraform_outputs.compiled_cache_bucket_host ))
 
 

--- a/manifests/bosh-manifest/reference-bosh-manifest.yml
+++ b/manifests/bosh-manifest/reference-bosh-manifest.yml
@@ -66,7 +66,7 @@ jobs:
       provider: dav
     compiled_package_cache:
       options:
-        bucket_name: shared-cf-bosh-blobstore
+        bucket_name: shared-cf-bosh-blobstore-unit-test
         credentials_source: env_or_profile
         host: s3-eu-west-1.amazonaws.com
       provider: s3

--- a/manifests/bosh-manifest/spec/fixtures/bosh-terraform-outputs.yml
+++ b/manifests/bosh-manifest/spec/fixtures/bosh-terraform-outputs.yml
@@ -3,6 +3,7 @@ terraform_outputs:
   bosh_security_group: bosh_security_group
   bosh_subnet_id: subnet-bosh
   compiled_cache_bucket_host: s3-eu-west-1.amazonaws.com
+  compiled_cache_bucket_name: shared-cf-bosh-blobstore-unit-test
   default_security_group: bosh_default_sg
   environment: test
   microbosh_static_private_ip: 10.0.0.6

--- a/manifests/bosh-manifest/spec/reference_comparison_spec.rb
+++ b/manifests/bosh-manifest/spec/reference_comparison_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe "comparing with reference" do
 
   specify "the output matches reference manifest" do
     expect(
-      manifest_with_defaults.reject {|k,v| %w(meta lamb_meta).include?(k) }.to_yaml
+      manifest_with_defaults.to_yaml
     ).to eq(
-      reference_manifest.reject {|k,v| k == "meta" }.to_yaml
+      reference_manifest.to_yaml
     )
   end
 end

--- a/manifests/cf-manifest/spec/fixtures/terraform/terraform-outputs.yml
+++ b/manifests/cf-manifest/spec/fixtures/terraform/terraform-outputs.yml
@@ -4,9 +4,9 @@ terraform_outputs:
   cf2_subnet_id: subnet-23456781
   cell1_subnet_id: subnet-09876543
   cell2_subnet_id: subnet-98765432
-  cf_root_domain: unit-test.cf.paas.example.com
-  cf_apps_domain: unit-test.cf-apps.paas.example.com
-  system_dns_zone_name: cf.paas.example.com
+  cf_root_domain: unit-test.dev.paas.example.com
+  cf_apps_domain: unit-test.dev-apps.paas.example.com
+  system_dns_zone_name: dev.paas.example.com
   elb_name: unit-test-cf-router-elb
   environment: unit-test
   region: sealand-1

--- a/terraform/bosh/outputs.tf
+++ b/terraform/bosh/outputs.tf
@@ -37,3 +37,7 @@ output "microbosh_static_public_ip" {
 output "compiled_cache_bucket_host" {
   value = "s3-${var.region}.amazonaws.com"
 }
+
+output "compiled_cache_bucket_name" {
+  value = "shared-cf-bosh-blobstore-${var.aws_account}"
+}

--- a/terraform/dev.tfvars
+++ b/terraform/dev.tfvars
@@ -1,0 +1,5 @@
+aws_account = "dev"
+system_dns_zone_id = "Z1TAH54WN7GPLT"
+system_dns_zone_name = "dev.paas.alphagov.co.uk"
+apps_dns_zone_id = "Z2M760FEEY23BS"
+apps_dns_zone_name = "dev-apps.paas.alphagov.co.uk"

--- a/terraform/dev.tfvars
+++ b/terraform/dev.tfvars
@@ -1,3 +1,4 @@
+aws_account = "dev"
 system_dns_zone_id = "Z3SI0PSH6KKVH4"
 system_dns_zone_name = "cf.paas.alphagov.co.uk"
 apps_dns_zone_id = "Z1Z5PS9NS78JFE"

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -1,3 +1,7 @@
+variable "aws_account" {
+  description = "the AWS account being deployed to"
+}
+
 variable "env" {
   description = "Environment name"
 }

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -1,3 +1,4 @@
+aws_account = "prod"
 system_dns_zone_id = "updateme_prod_system_zone_id"
 system_dns_zone_name = "updateme_prod_system_zone_name"
 apps_dns_zone_id = "updateme_prod_apps_zone_id"

--- a/terraform/trial.tfvars
+++ b/terraform/trial.tfvars
@@ -1,4 +1,4 @@
-aws_account = "dev"
+aws_account = "trial"
 system_dns_zone_id = "Z3SI0PSH6KKVH4"
 system_dns_zone_name = "cf.paas.alphagov.co.uk"
 apps_dns_zone_id = "Z1Z5PS9NS78JFE"

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -3,6 +3,15 @@
 
 Vagrant.require_version ">= 1.8.0"
 
+AWS_ACCOUNT = ENV.fetch("AWS_ACCOUNT", "trial")
+AWS_ACCOUNT_DATA = {
+  "trial" => {
+    :subnet_id => "subnet-b2e3a488", # us-east-1e in default VPC, 172.31.0.0/20 range
+    :security_group => "sg-ee21a597", # "Concourse Vagrant" security group
+  },
+}
+AWS_ACCOUNT_VARIABLES = AWS_ACCOUNT_DATA.fetch(AWS_ACCOUNT)
+
 Vagrant.configure(2) do |config|
   config.vm.box = ENV['VAGRANT_BOX_NAME'] || 'aws_vagrant_box'
 
@@ -30,11 +39,8 @@ Vagrant.configure(2) do |config|
     # Only HVM instances with ephemeral disks can be used
     aws.instance_type = 'm3.large'
 
-    # us-east-1e in default VPC, 172.31.0.0/20 range
-    aws.subnet_id = 'subnet-b2e3a488'
-
-    # "Concourse Vagrant" security group
-    aws.security_groups = ['sg-ee21a597']
+    aws.subnet_id = AWS_ACCOUNT_VARIABLES.fetch(:subnet_id)
+    aws.security_groups = [AWS_ACCOUNT_VARIABLES.fetch(:security_group)]
 
     # Add IAM role to allow access to necessary AWS APIs
     aws.iam_instance_profile_name = 'bootstrap-concourse'

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -3,7 +3,7 @@
 
 Vagrant.require_version ">= 1.8.0"
 
-AWS_ACCOUNT = ENV.fetch("AWS_ACCOUNT", "trial")
+AWS_ACCOUNT = ENV.fetch("AWS_ACCOUNT", "dev")
 AWS_ACCOUNT_DATA = {
   "trial" => {
     :subnet_id => "subnet-b2e3a488", # us-east-1e in default VPC, 172.31.0.0/20 range

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -9,6 +9,10 @@ AWS_ACCOUNT_DATA = {
     :subnet_id => "subnet-b2e3a488", # us-east-1e in default VPC, 172.31.0.0/20 range
     :security_group => "sg-ee21a597", # "Concourse Vagrant" security group
   },
+  "dev" => {
+    :subnet_id => "subnet-d55defe8", # us-east-1e in default VPC, 172.31.32.0/20 range
+    :security_group => "sg-99e0c0e0", # "Bootstrap Concourse" security group
+  },
 }
 AWS_ACCOUNT_VARIABLES = AWS_ACCOUNT_DATA.fetch(AWS_ACCOUNT)
 


### PR DESCRIPTION

**What**

We want to use the new AWS Dev account rather than the trial account

**How this PR should be reviewed**

This PR should be reviewed in the following context:

* Updating a deployment from master on the trial account with this branch works correctly
* A new deployment suceeeds on the dev account


**How to test this PR**

In the trial account:

Check master out
```
export BRANCH=master
```

Follow the deployment process, or use an existing deployment
Check this branch out

```
export BRANCH=$(git rev-parse --abbrev-ref HEAD)
```

Update the cloud foundry pipelines and check deployment still works sucessfully

In the dev account: 

Alex created some users on the dev accounts on 27/11/2015 - login with these details, and create some access keys.

NB: the concourse url has changed from
```
<env>-concourse.cf.paas.alphagov.co.uk
deployer.<env>.cf.paas.alphagov.co.uk
```

Use these access keys when deploying to the new account
Check the branch out

```
export AWS_ACCOUNT=dev # optional as this is the default, but being explicit
export BRANCH=$(git rev-parse --abbrev-ref HEAD)
```

Follow the deployment process





**Who should review this PR**

* Anyone but @alext or @timmow