### PR TITLE
[#113257145] Fix etcd cluster

### DIFF
--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -6,6 +6,7 @@ meta:
   release:
     name: cf
 
+  etcd_consul_service: ["etcd.service.cf.internal"]
 
   consul_servers: (( grab jobs.consul_z1.networks.cf1.static_ips jobs.consul_z2.networks.cf2.static_ips ))
 
@@ -90,18 +91,24 @@ meta:
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
+  - name: consul_agent
+    release: (( grab meta.consul_templates.consul_agent.release ))
 
   nfs_templates:
   - name: debian_nfs_server
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
+  - name: consul_agent
+    release: (( grab meta.consul_templates.consul_agent.release ))
 
   postgres_templates:
   - name: postgres
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
+  - name: consul_agent
+    release: (( grab meta.consul_templates.consul_agent.release ))
 
   router_templates:
   - name: gorouter
@@ -116,6 +123,8 @@ meta:
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
+  - name: consul_agent
+    release: (( grab meta.consul_templates.consul_agent.release ))
 
   uaa_routes:
   - name: uaa
@@ -735,7 +744,7 @@ properties:
 
   loggregator:
     etcd:
-      machines: (( grab properties.etcd.machines ))
+      machines: (( grab meta.etcd_consul_service ))
 
   doppler_endpoint:
     shared_secret: (( grab properties.loggregator_endpoint.shared_secret ))

--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -158,6 +158,40 @@ jobs:
       metron_agent:
         zone: z1
 
+  - name: etcd_z1
+    templates: (( grab meta.etcd_templates ))
+    instances: 1
+    persistent_disk: 10024
+    resource_pool: medium_z1
+    networks:
+      - name: cf1
+        static_ips:
+    update:
+      serial: true
+    properties:
+      metron_agent:
+        zone: z1
+      consul:
+        agent:
+          services:
+            etcd: {}
+
+  - name: etcd_z2
+    templates: (( grab meta.etcd_templates ))
+    instances: 2
+    persistent_disk: 10024
+    resource_pool: medium_z2
+    networks:
+      - name: cf2
+        static_ips:
+    properties:
+      metron_agent:
+        zone: z2
+      consul:
+        agent:
+          services:
+            etcd: {}
+
   - name: consul_z2
     templates: (( grab meta.consul_templates ))
     instances: 1
@@ -211,38 +245,6 @@ jobs:
     properties:
       metron_agent:
         zone: z2
-
-  - name: etcd_z1
-    templates: (( grab meta.etcd_templates ))
-    instances: 2
-    persistent_disk: 10024
-    resource_pool: medium_z1
-    networks:
-      - name: cf1
-        static_ips:
-    properties:
-      metron_agent:
-        zone: z1
-      consul:
-        agent:
-          services:
-            etcd: {}
-
-  - name: etcd_z2
-    templates: (( grab meta.etcd_templates ))
-    instances: 1
-    persistent_disk: 10024
-    resource_pool: medium_z2
-    networks:
-      - name: cf2
-        static_ips:
-    properties:
-      metron_agent:
-        zone: z2
-      consul:
-        agent:
-          services:
-            etcd: {}
 
   - name: stats_z1
     templates: (( grab meta.stats_templates ))

--- a/manifests/cf-manifest/deployments/035-cf-jobs-loggregator.yml
+++ b/manifests/cf-manifest/deployments/035-cf-jobs-loggregator.yml
@@ -12,6 +12,8 @@ lamb_meta:
     release: (( grab lamb_meta.release.name ))
   - name: metron_agent
     release: (( grab lamb_meta.release.name ))
+  - name: consul_agent
+    release: (( grab meta.consul_templates.consul_agent.release ))
 
   loggregator_trafficcontroller_templates:
   - name: loggregator_trafficcontroller
@@ -20,6 +22,8 @@ lamb_meta:
     release: (( grab lamb_meta.release.name ))
   - name: route_registrar
     release: (( grab lamb_meta.release.name ))
+  - name: consul_agent
+    release: (( grab meta.consul_templates.consul_agent.release ))
 
 jobs:
 - name: loggregator_z1

--- a/manifests/cf-manifest/deployments/040-cf-properties.yml
+++ b/manifests/cf-manifest/deployments/040-cf-properties.yml
@@ -276,7 +276,7 @@ properties:
       auctioneer:
         api_url: http://auctioneer.service.cf.internal:9016
       etcd:
-        machines: ["etcd.service.cf.internal"]
+        machines: (( grab meta.etcd_consul_service ))
         ca_cert: (( grab meta.secrets.consul_ca_cert ))
         client_cert: (( grab secrets.consul_agent_cert ))
         client_key: (( grab secrets.consul_agent_key ))

--- a/manifests/cf-manifest/deployments/aws/000-cf-infrastructure.yml
+++ b/manifests/cf-manifest/deployments/aws/000-cf-infrastructure.yml
@@ -297,16 +297,16 @@ jobs:
         static_ips: (( static_ips(27, 28, 29) ))
 
   - name: etcd_z1
-    instances: 2
-    networks:
-      - name: cf1
-        static_ips: (( static_ips(10, 25) ))
-
-  - name: etcd_z2
     instances: 1
     networks:
-      - name: cf2
+      - name: cf1
         static_ips: (( static_ips(9) ))
+
+  - name: etcd_z2
+    instances: 2
+    networks:
+      - name: cf2
+        static_ips: (( static_ips(10, 25) ))
 
   - name: smoke_tests
     instances: 1


### PR DESCRIPTION
# What
We observed failures in etcd clustering that were due to a race condition caused by  https://github.com/alphagov/paas-cf/pull/94 and https://github.com/alphagov/paas-cf/pull/93 together.
We now force one etcd node to build before the others. Also, we standardise on DNS resolution via consul to connect to etcd.

# How to review
Build a new cloud foundry. It should pass smoke tests.

You can also test if the etcd cluster is complete. On an etcd node, run:

```
# /var/vcap/jobs/etcd/packages/etcd/etcdctl member list
3bb81497205219e5: name=etcd-z1-0 peerURLs=http://10.0.10.20:7001 clientURLs=http://10.0.10.20:4001
426443662bae1c80: name=etcd-z1-1 peerURLs=http://10.0.10.35:7001 clientURLs=http://10.0.10.35:4001
f2b470f31458c77f: name=etcd-z2-0 peerURLs=http://10.0.11.19:7001 clientURLs=http://10.0.11.19:4001
```
It should return 3 nodes.

# Who can review
Anyone but @saliceti or @mtekel 

