### PR TITLE
[#112503901] Implement Custom Acceptance Test Framework

### DIFF
--- a/acceptance-tests/README.md
+++ b/acceptance-tests/README.md
@@ -1,0 +1,39 @@
+# Custom acceptance tests
+
+These are custom acceptance tests for the CF deployment that are run in
+addition to the [upstream acceptance
+tests](https://github.com/cloudfoundry/cf-acceptance-tests). These are
+automatically run from the deploy-cloudfoundry concourse pipeline after the
+concourse deploy.
+
+## Dependencies
+
+The tests have the following dependencies:
+* a recent [Go compiler](https://golang.org/dl/)
+* the [CF CLI](https://github.com/cloudfoundry/cli#downloads).
+* `curl`
+* [`godep`](https://github.com/tools/godep)
+
+When running on concourse, these use our [cf-cli
+container](https://hub.docker.com/r/governmentpaas/cf-cli/).
+
+## Running the tests
+
+You must set an environment variable `$CONFIG` which points to a JSON file that
+contains several pieces of data that will be used to configure the acceptance
+tests, e.g. telling the tests how to target your running Cloud Foundry
+deployment.
+
+Example:
+```json
+{
+  "api": "api.foo.cf.example.com",
+  "admin_user": "admin",
+  "admin_password": "secret",
+  "apps_domain": "foo.cf-apps.example.com",
+  "skip_ssl_validation": true,
+  "use_http": false
+}
+```
+
+Run the tests using the `run_tests.sh` script.

--- a/acceptance-tests/example_apps/static_app/index.html
+++ b/acceptance-tests/example_apps/static_app/index.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <h1>Hello World</h1>
+  </body>
+</html>

--- a/acceptance-tests/generate_test_config.rb
+++ b/acceptance-tests/generate_test_config.rb
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require 'yaml'
+
+manifest_file = ENV.fetch("CF_MANIFEST")
+manifest = YAML.load_file(manifest_file)
+
+admin_password = manifest.fetch("properties").fetch("acceptance_tests").fetch("admin_password")
+api_url = manifest.fetch("properties").fetch("cc").fetch("srv_api_uri")
+apps_domain = manifest.fetch("properties").fetch("app_domains").first
+
+config = {
+  "api" => api_url,
+  "admin_user" => "admin",
+  "admin_password" => admin_password,
+  "apps_domain" => apps_domain,
+  "skip_ssl_validation" => true,
+  "use_http" => false,
+}
+puts config.to_json

--- a/acceptance-tests/run_tests.sh
+++ b/acceptance-tests/run_tests.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+export GOPATH="${GOPATH}:${SCRIPT_DIR}"
+
+cd "${SCRIPT_DIR}/src/acceptance"
+godep restore
+go test

--- a/acceptance-tests/src/acceptance/Godeps/Godeps.json
+++ b/acceptance-tests/src/acceptance/Godeps/Godeps.json
@@ -6,6 +6,26 @@
 	],
 	"Deps": [
 		{
+			"ImportPath": "github.com/cloudfoundry-incubator/cf-test-helpers/cf",
+			"Rev": "28076d2e08da4cfeed911136cf5bdc0175b34b33"
+		},
+		{
+			"ImportPath": "github.com/cloudfoundry-incubator/cf-test-helpers/generator",
+			"Rev": "28076d2e08da4cfeed911136cf5bdc0175b34b33"
+		},
+		{
+			"ImportPath": "github.com/cloudfoundry-incubator/cf-test-helpers/helpers",
+			"Rev": "28076d2e08da4cfeed911136cf5bdc0175b34b33"
+		},
+		{
+			"ImportPath": "github.com/cloudfoundry-incubator/cf-test-helpers/runner",
+			"Rev": "28076d2e08da4cfeed911136cf5bdc0175b34b33"
+		},
+		{
+			"ImportPath": "github.com/nu7hatch/gouuid",
+			"Rev": "179d4d0c4d8d407a32af483c2354df1d2c91e6c3"
+		},
+		{
 			"ImportPath": "github.com/onsi/ginkgo",
 			"Comment": "v1.2.0-42-g07d85e6",
 			"Rev": "07d85e6b10c4289c7d612f9b13f45ba36f66d55b"

--- a/acceptance-tests/src/acceptance/Godeps/Godeps.json
+++ b/acceptance-tests/src/acceptance/Godeps/Godeps.json
@@ -1,0 +1,19 @@
+{
+	"ImportPath": "acceptance",
+	"GoVersion": "go1.5",
+	"Packages": [
+		"./..."
+	],
+	"Deps": [
+		{
+			"ImportPath": "github.com/onsi/ginkgo",
+			"Comment": "v1.2.0-42-g07d85e6",
+			"Rev": "07d85e6b10c4289c7d612f9b13f45ba36f66d55b"
+		},
+		{
+			"ImportPath": "github.com/onsi/gomega",
+			"Comment": "v1.0-83-gc72df92",
+			"Rev": "c72df929b80ef4930aaa75d5e486887ff2f3e06a"
+		}
+	]
+}

--- a/acceptance-tests/src/acceptance/Godeps/Readme
+++ b/acceptance-tests/src/acceptance/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.

--- a/acceptance-tests/src/acceptance/init_test.go
+++ b/acceptance-tests/src/acceptance/init_test.go
@@ -2,12 +2,50 @@ package acceptance_test
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
+)
+
+var (
+	DEFAULT_TIMEOUT      = 30 * time.Second
+	CF_PUSH_TIMEOUT      = 2 * time.Minute
+	LONG_CURL_TIMEOUT    = 2 * time.Minute
+	CF_JAVA_TIMEOUT      = 10 * time.Minute
+	DEFAULT_MEMORY_LIMIT = "256M"
+
+	context helpers.SuiteContext
+	config  helpers.Config
 )
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
+
+	config = helpers.LoadConfig()
+
+	if config.DefaultTimeout > 0 {
+		DEFAULT_TIMEOUT = config.DefaultTimeout * time.Second
+	}
+	if config.CfPushTimeout > 0 {
+		CF_PUSH_TIMEOUT = config.CfPushTimeout * time.Second
+	}
+	if config.LongCurlTimeout > 0 {
+		LONG_CURL_TIMEOUT = config.LongCurlTimeout * time.Second
+	}
+
+	context = helpers.NewContext(config)
+	environment := helpers.NewEnvironment(context)
+
+	BeforeSuite(func() {
+		environment.Setup()
+	})
+
+	AfterSuite(func() {
+		environment.Teardown()
+	})
+
 	RunSpecs(t, "Acceptance tests")
 }

--- a/acceptance-tests/src/acceptance/init_test.go
+++ b/acceptance-tests/src/acceptance/init_test.go
@@ -1,0 +1,13 @@
+package acceptance_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Acceptance tests")
+}

--- a/acceptance-tests/src/acceptance/simple_app_test.go
+++ b/acceptance-tests/src/acceptance/simple_app_test.go
@@ -1,0 +1,33 @@
+package acceptance_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+
+	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
+	"github.com/cloudfoundry-incubator/cf-test-helpers/generator"
+	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
+)
+
+var _ = Describe("A simple static app", func() {
+	var (
+		appName string
+	)
+
+	BeforeEach(func() {
+		appName = generator.PrefixedRandomName("CATS-APP-")
+		Expect(cf.Cf(
+			"push", appName,
+			"--no-start",
+			"-b", config.StaticFileBuildpackName,
+			"-p", "../../example_apps/static_app",
+			"-d", config.AppsDomain,
+		).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
+	})
+
+	It("can be queried", func() {
+		Expect(cf.Cf("start", appName).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+		Expect(helpers.CurlAppRoot(appName)).To(ContainSubstring("Hello World"))
+	})
+})

--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -593,3 +593,42 @@ jobs:
             bosh -n \
               run errand acceptance_tests \
               --download-logs --logs-dir .
+
+  - name: custom-acceptance-tests
+    plan:
+    - aggregate:
+      - get: paas-cf
+        passed: ['deploy']
+      - get: cf-manifest
+        passed: ['deploy']
+    - task: generate-test-config
+      config:
+        inputs:
+          - name: paas-cf
+          - name: cf-manifest
+        outputs:
+          - name: test-config
+        image: docker:///ruby#2.2-slim
+        run:
+          path: sh
+          args:
+          - -e
+          - -c
+          - |
+            export CF_MANIFEST=cf-manifest/cf-manifest.yml
+            ./paas-cf/acceptance-tests/generate_test_config.rb \
+              > test-config/config.json
+    - task: run-tests
+      config:
+        inputs:
+          - name: paas-cf
+          - name: test-config
+        image: docker:///governmentpaas/cf-acceptance-tests
+        run:
+          path: sh
+          args:
+          - -e
+          - -c
+          - |
+            export CONFIG="$(pwd)/test-config/config.json"
+            ./paas-cf/acceptance-tests/run_tests.sh

--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -601,6 +601,7 @@ jobs:
         passed: ['deploy']
       - get: cf-manifest
         passed: ['deploy']
+        trigger: true
     - task: generate-test-config
       config:
         inputs:

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -12,6 +12,13 @@ resources:
       versioned_file: cf.tfstate
       region_name: {{aws_region}}
 
+  - name: concourse-tfstate
+    type: s3-iam
+    source:
+      bucket: {{state_bucket}}
+      versioned_file: concourse.tfstate
+      region_name: {{aws_region}}
+
   - name: vpc-tfstate
     type: s3-iam
     source:
@@ -65,6 +72,7 @@ jobs:
           trigger: true
         - get: paas-cf
         - get: cf-tfstate
+        - get: concourse-tfstate
         - get: vpc-tfstate
       - task: terraform-variables
         config:
@@ -72,6 +80,7 @@ jobs:
           inputs:
             - name: paas-cf
             - name: cf-tfstate
+            - name: concourse-tfstate
             - name: vpc-tfstate
           run:
             path: sh
@@ -82,6 +91,9 @@ jobs:
               ruby paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
               < cf-tfstate/cf.tfstate > cf.tfvars.sh
               ls -l cf.tfvars.sh
+              ruby paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
+              < concourse-tfstate/concourse.tfstate > concourse.tfvars.sh
+              ls -l concourse.tfvars.sh
               ruby paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
               < vpc-tfstate/vpc.tfstate > vpc.tfvars.sh
               ls -l vpc.tfvars.sh
@@ -101,6 +113,7 @@ jobs:
             - -c
             - |
               . terraform-variables/cf.tfvars.sh
+              . terraform-variables/concourse.tfvars.sh
               . terraform-variables/vpc.tfvars.sh
               terraform destroy -force -var env={{deploy_env}} -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
                 -state=cf-tfstate/cf.tfstate -state-out=cf.tfstate paas-cf/terraform/cloudfoundry

--- a/terraform/cloudfoundry/security-groups.tf
+++ b/terraform/cloudfoundry/security-groups.tf
@@ -17,6 +17,7 @@ resource "aws_security_group" "web" {
     cidr_blocks = [
       "${split(",", var.web_access_cidrs)}",
       "${formatlist("%s/32", aws_eip.cf.*.public_ip)}",
+      "${var.concourse_elastic_ip}/32",
     ]
   }
 
@@ -27,6 +28,7 @@ resource "aws_security_group" "web" {
     cidr_blocks = [
       "${split(",", var.web_access_cidrs)}",
       "${formatlist("%s/32", aws_eip.cf.*.public_ip)}",
+      "${var.concourse_elastic_ip}/32",
     ]
   }
 

--- a/terraform/cloudfoundry/security-groups.tf
+++ b/terraform/cloudfoundry/security-groups.tf
@@ -15,7 +15,8 @@ resource "aws_security_group" "web" {
     to_port   = 80
     protocol  = "tcp"
     cidr_blocks = [
-      "${split(",", var.web_access_cidrs)}"
+      "${split(",", var.web_access_cidrs)}",
+      "${formatlist("%s/32", aws_eip.cf.*.public_ip)}",
     ]
   }
 
@@ -24,25 +25,8 @@ resource "aws_security_group" "web" {
     to_port   = 443
     protocol  = "tcp"
     cidr_blocks = [
-      "${split(",", var.web_access_cidrs)}"
-    ]
-  }
-
-  ingress {
-    from_port = 80
-    to_port   = 80
-    protocol  = "tcp"
-    cidr_blocks = [
-      "${formatlist("%s/32", aws_eip.cf.*.public_ip)}"
-    ]
-  }
-
-  ingress {
-    from_port = 443
-    to_port   = 443
-    protocol  = "tcp"
-    cidr_blocks = [
-      "${formatlist("%s/32", aws_eip.cf.*.public_ip)}"
+      "${split(",", var.web_access_cidrs)}",
+      "${formatlist("%s/32", aws_eip.cf.*.public_ip)}",
     ]
   }
 

--- a/terraform/cloudfoundry/variables.tf
+++ b/terraform/cloudfoundry/variables.tf
@@ -49,3 +49,7 @@ variable "cf_subnet_count" {
   description = "Number of CF subnets"
   default     = 2
 }
+
+variable "concourse_elastic_ip" {
+  description = "Public IP of the deployer-concourse machine"
+}


### PR DESCRIPTION
# What

We need to put in place a framework to run our own set of acceptance tests and fit it into the pipeline for deploying an environment. These are in addition to the upstream acceptance-tests.

## Details

These are implemented using [ginkgo](http://onsi.github.io/ginkgo/) so that we can reuse the [upstream test helpers](https://github.com/cloudfoundry-incubator/cf-test-helpers).

At the moment, the test only include a POC test that pushed a simple static app, and verifies that it works. This test can be removed once we've added some real tests here.

## How to review

Deploy cloudfoundry from this branch and verify that the deployment completes successfully, and that these acceptance tests are triggered, and pass.

## Who can review

Anyone but @actionjack and myself.