### PR TITLE
[#112876059] Deployment deletion failures

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -31,6 +31,15 @@ jobs:
           args:
           - -e
           - -c
+          # The following sleep monstrosity deterministically sleeps for a
+          # period of time between 0-20mins in order to prevent all our
+          # deletion jobs running at the same time. See the commit message for
+          # how it works.
           - |
+            sum=$(echo {{deploy_env}} | md5sum);
+            short=${sum:0:15};
+            decimal=$((0x$short));
+            sleeptime=$((${decimal##-} % 60*20));
+            echo "Sleeping for $sleeptime seconds before deletion.."; sleep $sleeptime && 
             bosh_password=$(awk '$1~/bosh_admin_password/ {print $2}' bosh-secrets/bosh-secrets.yml)
             bosh -n -t https://10.0.0.6:25555 -u admin -p "${bosh_password}" delete deployment {{deploy_env}}

--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -42,4 +42,4 @@ jobs:
             sleeptime=$((${decimal##-} % 60*20));
             echo "Sleeping for $sleeptime seconds before deletion.."; sleep $sleeptime && 
             bosh_password=$(awk '$1~/bosh_admin_password/ {print $2}' bosh-secrets/bosh-secrets.yml)
-            bosh -n -t https://10.0.0.6:25555 -u admin -p "${bosh_password}" delete deployment {{deploy_env}}
+            bosh -n -t https://10.0.0.6:25555 -u admin -p "${bosh_password}" delete deployment {{deploy_env}} --force


### PR DESCRIPTION
This PR makes deployment auto-deletion more robust in two ways:

* By deterministically delaying the deletion based on the environment name we ensure that fewer environments will not be auto-deleting at the same time, thus making us less likely to hit the AWS per-account rate limit.
* By using `--force` we cause bosh to attempt to remove the deployment even when some conditions are not met.

# How to test
Run the `autodelete-cloudfoundry` pipeline on a deployed environment - you should see `Sleeping for X seconds before deletion..` appear in the log, and the deletion will proceed X many seconds later.

# Who can review
Not @jonty or @timmow, who thinks this story was too easy and would like harder ones.