### PR TITLE
Fix concourse terraform state version pinning.

### DIFF
--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -121,10 +121,6 @@ jobs:
               paas-cf/concourse/scripts/s3init.sh {{state_bucket}} cf.tfstate paas-cf/concourse/init_files/terraform.tfstate.tpl
           inputs:
           - name: paas-cf
-      - put: cf-tfstate
-        params:
-          file: init/cf.tfstate
-
   - name: terraform
     serial_groups: [ deploy ]
     serial: true
@@ -132,12 +128,11 @@ jobs:
       - aggregate:
         - get: paas-cf
           passed: ['init']
+          trigger: true
         - get: vpc-tfstate
         - get: concourse-tfstate
         - get: bosh-tfstate
         - get: cf-tfstate
-          passed: ['init']
-          trigger: true
       - task: terraform-variables
         config:
           image: docker:///ruby

--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -1,4 +1,12 @@
 resources:
+
+  - name: pipeline-trigger
+    type: semver-iam
+    source:
+      bucket: {{state_bucket}}
+      region_name: {{aws_region}}
+      key: {{pipeline_trigger_file}}
+
   - name: paas-cf
     type: git
     source:
@@ -121,6 +129,8 @@ jobs:
               paas-cf/concourse/scripts/s3init.sh {{state_bucket}} cf.tfstate paas-cf/concourse/init_files/terraform.tfstate.tpl
           inputs:
           - name: paas-cf
+      - put: pipeline-trigger
+        params: {bump: patch}
   - name: terraform
     serial_groups: [ deploy ]
     serial: true
@@ -128,6 +138,8 @@ jobs:
       - aggregate:
         - get: paas-cf
           passed: ['init']
+        - get: pipeline-trigger
+          passed: [ 'init' ]
           trigger: true
         - get: vpc-tfstate
         - get: concourse-tfstate

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -19,12 +19,12 @@ resources:
       versioned_file: vpc.tfstate
       region_name: {{aws_region}}
 
-  - name: trigger-tf-destroy
+  - name: pipeline-trigger
     type: semver-iam
     source:
       bucket: {{state_bucket}}
       region_name: {{aws_region}}
-      key: trigger-tf-destroy
+      key: {{pipeline_trigger_file}}
 
   - name: bosh-secrets
     type: s3-iam
@@ -52,7 +52,7 @@ jobs:
             - |
               bosh_password=$(awk '$1~/bosh_admin_password/ {print $2}' bosh-secrets/bosh-secrets.yml)
               bosh -n -t https://10.0.0.6:25555 -u admin -p "${bosh_password}" delete deployment {{deploy_env}}
-      - put: trigger-tf-destroy
+      - put: pipeline-trigger
         params: {bump: patch}
 
   - name: terraform-destroy
@@ -60,7 +60,7 @@ jobs:
     serial: true
     plan:
       - aggregate:
-        - get: trigger-tf-destroy
+        - get: pipeline-trigger
           passed: ['delete-deployment']
           trigger: true
         - get: paas-cf

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -16,6 +16,7 @@ generate_vars_file() {
 aws_account: ${AWS_ACCOUNT:-dev}
 deploy_env: ${env}
 state_bucket: ${env}-state
+pipeline_trigger_file: ${trigger_file}
 branch_name: ${BRANCH:-master}
 aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
 stemcell-version: ${STEMCELL_VERSION:-3104}
@@ -28,9 +29,11 @@ debug: ${DEBUG:-}
 EOF
 }
 
-generate_vars_file > /dev/null # Check for missing vars
 
 for ACTION in deploy destroy; do
+  trigger_file="${ACTION}-cloudfoundry.trigger"
+  generate_vars_file > /dev/null # Check for missing vars
+
   bash "${SCRIPT_DIR}/deploy-pipeline.sh" \
     "${env}" "${ACTION}-cloudfoundry" \
     "${SCRIPT_DIR}/../pipelines/${ACTION}-cloudfoundry.yml" \
@@ -38,6 +41,7 @@ for ACTION in deploy destroy; do
 done
 
 if [ ! "${DISABLE_AUTODELETE:-}" ]; then
+   trigger_file="autodelete-cloudfoundry.trigger"
    bash "${SCRIPT_DIR}/deploy-pipeline.sh" \
 	  "${env}" "${pipeline_autodelete}" "${config_autodelete}" <(generate_vars_file)
 


### PR DESCRIPTION
It's important that every terraform run uses the latest state file so
that it has an accurate reflection of what's been created etc.

Previously, the `cf.tfstate` used in the deploy-cloudfoundry pipeline was
pinned to the version that has passed the `init` step. This meant that
if a terraform run failed for any reason (eg AWS rate limit), and the
job was restarted, it would not use the updated statefile that included
the partial changes made in the previous run.

This changes the pipeline to use a non-pinned version of the statefile
to ensure it always uses the latest.

It also stops the `init` job from `put`ing the resource (leaving
`s3init.sh` to do the writing). This makes this pipeline consistent with
the others.

## How to review

Deploy cloudfoundry using this pipeline, and verify that it works. Trigger a second run of the terraform job (without triggering the init job), and verify that it uses the latest statefile, and doesn't attempt to make any changes.

## Who can review

Anyone but myself