### PR TITLE
[#113432925] Ensure correct domain is used in Generated SSL Certs.

### DIFF
--- a/acceptance-tests/generate_test_config.rb
+++ b/acceptance-tests/generate_test_config.rb
@@ -15,7 +15,6 @@ config = {
   "admin_user" => "admin",
   "admin_password" => admin_password,
   "apps_domain" => apps_domain,
-  "skip_ssl_validation" => true,
   "use_http" => false,
 }
 puts config.to_json

--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -233,37 +233,11 @@ jobs:
             - |
               . terraform-variables/cf.tfvars.sh
 
-              CERTS_TO_GENERATE="
-              bosh-CA:bbs_server,bbs.service.cf.internal
-              bosh-CA:bbs_client,
-              bosh-CA:router_ssl,*.${TF_VAR_cf_root_domain},*.${TF_VAR_cf_apps_domain}
-              bosh-CA:uaa_jwt_signing,
-              bosh-CA:consul_server,server.dc1.cf.internal,server.dc2.cf.internal
-              bosh-CA:consul_agent,
-              "
-
-              mkdir out
-              echo "Extracting CA certs"
-              tar -xvzf bosh-CA/bosh-CA.tar.gz -C out
-
               mkdir certs
               echo "Extracting extant certs"
               tar -xvzf cf-certs/cf-certs.tar.gz -C certs
 
-              for cert_entry in ${CERTS_TO_GENERATE}; do
-                cert_info=$(eval echo ${cert_entry%%,*}) # eval to workaround poor concourse interpolation
-                ca=${cert_info%%:*}
-                cn=${cert_info#*:}
-                domains=$(eval echo ${cert_entry#*,})
-
-                if [ -f "certs/${cn}.crt" ]; then
-                  echo "Certificate ${cn} is already generated, skipping."
-                else
-                  certstrap request-cert --passphrase "" --common-name "${cn}" ${domains:+--domain "${domains}"}
-                  certstrap sign --CA "${ca}" --passphrase "" "${cn}"
-                  mv out/${cn}.* certs/
-                fi
-              done
+              ./paas-cf/concourse/scripts/generate-cf-certs.sh certs bosh-CA/bosh-CA.tar.gz
 
               cd certs
               echo "Creating updated cert tarball"

--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -195,10 +195,26 @@ jobs:
     plan:
       - aggregate:
         - get: paas-cf
-          passed: ['init']
+          passed: ['terraform']
           trigger: true
         - get: bosh-CA
         - get: cf-certs
+        - get: cf-tfstate
+          passed: ['terraform']
+      - task: terraform-variables
+        config:
+          image: docker:///ruby#2.2-slim
+          inputs:
+            - name: paas-cf
+            - name: cf-tfstate
+          run:
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              ruby paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
+                < cf-tfstate/cf.tfstate > cf.tfvars.sh
       - task: generate-cf-certs
         config:
           image: docker:///governmentpaas/certstrap
@@ -206,23 +222,26 @@ jobs:
           - name: bosh-CA
           - name: paas-cf
           - name: cf-certs
+          - name: terraform-variables
           outputs:
           - name: updated-cf-certs
-          params:
-            CERTS_TO_GENERATE: |
-              bosh-CA:bbs_server,bbs.service.cf.internal
-              bosh-CA:bbs_client,
-              bosh-CA:router_ssl,*.${DEPLOY_ENV}.cf.paas.alphagov.co.uk
-              bosh-CA:uaa_jwt_signing,
-              bosh-CA:consul_server,server.dc1.cf.internal,server.dc2.cf.internal
-              bosh-CA:consul_agent,
-            DEPLOY_ENV: {{deploy_env}}
           run:
             path: sh
             args:
             - -e
             - -c
             - |
+              . terraform-variables/cf.tfvars.sh
+
+              CERTS_TO_GENERATE="
+              bosh-CA:bbs_server,bbs.service.cf.internal
+              bosh-CA:bbs_client,
+              bosh-CA:router_ssl,*.${TF_VAR_cf_root_domain},*.${TF_VAR_cf_apps_domain}
+              bosh-CA:uaa_jwt_signing,
+              bosh-CA:consul_server,server.dc1.cf.internal,server.dc2.cf.internal
+              bosh-CA:consul_agent,
+              "
+
               mkdir out
               echo "Extracting CA certs"
               tar -xvzf bosh-CA/bosh-CA.tar.gz -C out
@@ -259,7 +278,7 @@ jobs:
     plan:
       - aggregate:
         - get: paas-cf
-          passed: [init]
+          passed: ['generate-cf-certs']
         - get: bosh-CA
           passed: ['generate-cf-certs']
         - get: cf-certs
@@ -268,7 +287,7 @@ jobs:
         - get: bosh-tfstate
         - get: concourse-tfstate
         - get: cf-tfstate
-          passed: ['terraform']
+          passed: ['generate-cf-certs']
           trigger: true
         - get: cf-secrets
       - task: cf-certs-yaml

--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -348,7 +348,7 @@ jobs:
     plan:
       - aggregate:
         - get: paas-cf
-          passed: [init]
+          passed: ['generate-manifest']
         - get: cf-manifest
           passed: ['generate-manifest']
           trigger: true

--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -564,6 +564,7 @@ jobs:
       - get: cf-manifest
         passed: ['deploy']
         trigger: true
+      - get: bosh-CA
     - task: generate-test-config
       config:
         inputs:
@@ -586,6 +587,7 @@ jobs:
         inputs:
           - name: paas-cf
           - name: test-config
+          - name: bosh-CA
         image: docker:///governmentpaas/cf-acceptance-tests
         run:
           path: sh
@@ -593,5 +595,10 @@ jobs:
           - -e
           - -c
           - |
+            echo "Adding bosh-CA to root certificates"
+            tar -xf bosh-CA/bosh-CA.tar.gz -C /usr/local/share/ca-certificates bosh-CA.crt
+            update-ca-certificates
+
+            echo "Running tests"
             export CONFIG="$(pwd)/test-config/config.json"
             ./paas-cf/acceptance-tests/run_tests.sh

--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -69,47 +69,12 @@ resources:
       region_name: {{aws_region}}
       versioned_file: bosh-CA.tar.gz
 
-  - name: bbs_server-cert
+  - name: cf-certs
     type: s3-iam
     source:
       bucket: {{state_bucket}}
       region_name: {{aws_region}}
-      versioned_file: bbs_server-cert.tar.gz
-
-  - name: bbs_client-cert
-    type: s3-iam
-    source:
-      bucket: {{state_bucket}}
-      region_name: {{aws_region}}
-      versioned_file: bbs_client-cert.tar.gz
-
-  - name: consul_server-cert
-    type: s3-iam
-    source:
-      bucket: {{state_bucket}}
-      region_name: {{aws_region}}
-      versioned_file: consul_server-cert.tar.gz
-
-  - name: consul_agent-cert
-    type: s3-iam
-    source:
-      bucket: {{state_bucket}}
-      region_name: {{aws_region}}
-      versioned_file: consul_agent-cert.tar.gz
-
-  - name: router_ssl-cert
-    type: s3-iam
-    source:
-      bucket: {{state_bucket}}
-      region_name: {{aws_region}}
-      versioned_file: router_ssl-cert.tar.gz
-
-  - name: uaa_jwt_signing-cert
-    type: s3-iam
-    source:
-      bucket: {{state_bucket}}
-      region_name: {{aws_region}}
-      versioned_file: uaa_jwt_signing-cert.tar.gz
+      versioned_file: cf-certs.tar.gz
 
 jobs:
   - name: init
@@ -127,6 +92,7 @@ jobs:
             - -c
             - |
               paas-cf/concourse/scripts/s3init.sh {{state_bucket}} cf.tfstate paas-cf/concourse/init_files/terraform.tfstate.tpl
+              paas-cf/concourse/scripts/s3init.sh {{state_bucket}} cf-certs.tar.gz paas-cf/concourse/init_files/empty.tar.gz
           inputs:
           - name: paas-cf
       - put: pipeline-trigger
@@ -232,12 +198,16 @@ jobs:
           passed: ['init']
           trigger: true
         - get: bosh-CA
+        - get: cf-certs
       - task: generate-cf-certs
         config:
           image: docker:///governmentpaas/certstrap
           inputs:
           - name: bosh-CA
           - name: paas-cf
+          - name: cf-certs
+          outputs:
+          - name: updated-cf-certs
           params:
             CERTS_TO_GENERATE: |
               bosh-CA:bbs_server,bbs.service.cf.internal
@@ -254,26 +224,34 @@ jobs:
             - -c
             - |
               mkdir out
-              for ca_tgz in */*-CA.tar.gz; do
-                tar -xzf $ca_tgz -C out
-              done
+              echo "Extracting CA certs"
+              tar -xvzf bosh-CA/bosh-CA.tar.gz -C out
+
+              mkdir certs
+              echo "Extracting extant certs"
+              tar -xvzf cf-certs/cf-certs.tar.gz -C certs
+
               for cert_entry in ${CERTS_TO_GENERATE}; do
                 cert_info=$(eval echo ${cert_entry%%,*}) # eval to workaround poor concourse interpolation
                 ca=${cert_info%%:*}
                 cn=${cert_info#*:}
                 domains=$(eval echo ${cert_entry#*,})
 
-                if ! paas-cf/concourse/scripts/s3init.sh {{state_bucket}} ${cn}-cert.tar.gz ; then
-                  certstrap request-cert --passphrase "" --common-name "${cn}" ${domains:+--domain "${domains}"}
-                  certstrap sign --CA $ca --passphrase "" "${cn}"
-                  cd out
-                  tar -cvzf ../${cn}-cert.tar.gz ${cn}.*
-                  ../paas-cf/concourse/scripts/s3init.sh {{state_bucket}} ${cn}-cert.tar.gz ../${cn}-cert.tar.gz
-                  cd ..
-                else
+                if [ -f "certs/${cn}.crt" ]; then
                   echo "Certificate ${cn} is already generated, skipping."
+                else
+                  certstrap request-cert --passphrase "" --common-name "${cn}" ${domains:+--domain "${domains}"}
+                  certstrap sign --CA "${ca}" --passphrase "" "${cn}"
+                  mv out/${cn}.* certs/
                 fi
               done
+
+              cd certs
+              echo "Creating updated cert tarball"
+              tar -cvzf ../updated-cf-certs/cf-certs.tar.gz .
+      - put: cf-certs
+        params:
+          file: updated-cf-certs/cf-certs.tar.gz
 
   - name: generate-manifest
     serial_groups: [ deploy ]
@@ -283,12 +261,9 @@ jobs:
         - get: paas-cf
           passed: [init]
         - get: bosh-CA
-        - get: bbs_server-cert
-        - get: bbs_client-cert
-        - get: consul_server-cert
-        - get: consul_agent-cert
-        - get: router_ssl-cert
-        - get: uaa_jwt_signing-cert
+          passed: ['generate-cf-certs']
+        - get: cf-certs
+          passed: ['generate-cf-certs']
         - get: vpc-tfstate
         - get: bosh-tfstate
         - get: concourse-tfstate
@@ -296,45 +271,34 @@ jobs:
           passed: ['terraform']
           trigger: true
         - get: cf-secrets
-      - task: cf-certs
-        config:
-          image: docker:///alpine#3.3
-          inputs:
-          - name: bosh-CA
-          - name: paas-cf
-          - name: bbs_server-cert
-          - name: bbs_client-cert
-          - name: consul_server-cert
-          - name: consul_agent-cert
-          - name: router_ssl-cert
-          - name: uaa_jwt_signing-cert
-          run:
-            path: sh
-            args:
-            - -e
-            - -c
-            - |
-              for cert in *-cert *-CA; do
-                cn=${cert%%-cert}
-                yaml_key_name=$(echo ${cn} | tr A-Z- a-z_)
-
-                tar -xzf ${cert}/${cert}.tar.gz
-                paas-cf/concourse/scripts/file-to-yaml.sh secrets ${yaml_key_name}_key ${cn}.key  > ${cn}_key.yml
-                paas-cf/concourse/scripts/file-to-yaml.sh secrets ${yaml_key_name}_cert ${cn}.crt  > ${cn}_cert.yml
-              done
-      - task: uaa_jwt_verification_key
+      - task: cf-certs-yaml
         config:
           image: docker:///governmentpaas/certstrap
           inputs:
+          - name: bosh-CA
           - name: paas-cf
-          - name: uaa_jwt_signing-cert
+          - name: cf-certs
           run:
             path: sh
             args:
             - -e
             - -c
             - |
-              tar -xzf uaa_jwt_signing-cert/uaa_jwt_signing-cert.tar.gz
+              echo "Extracting CA certs"
+              tar -xzvf bosh-CA/bosh-CA.tar.gz
+              echo "Extracting CloudFoundry certs"
+              tar -xzvf cf-certs/cf-certs.tar.gz
+
+              for file in *.crt; do
+                cn=${file%.crt}
+                yaml_key_name=$(echo ${cn} | tr A-Z- a-z_)
+
+                echo "Converting ${cn} certs to YAML"
+                paas-cf/concourse/scripts/file-to-yaml.sh secrets ${yaml_key_name}_key ${cn}.key  > ${cn}_key.yml
+                paas-cf/concourse/scripts/file-to-yaml.sh secrets ${yaml_key_name}_cert ${cn}.crt  > ${cn}_cert.yml
+              done
+
+              echo "Generating uaa_jwt_signing public key from private key"
               openssl rsa -pubout -in uaa_jwt_signing.key -out uaa_jwt_verification.pem
               paas-cf/concourse/scripts/file-to-yaml.sh secrets uaa_jwt_verification_key uaa_jwt_verification.pem  > uaa_jwt_verification_key.yml
 
@@ -368,14 +332,12 @@ jobs:
             MANIFEST_STUBS: |
               ./extract-terraform-outputs/*.yml
               ./cf-secrets/cf-secrets.yml
-              ./cf-certs/*.yml
-              ./uaa_jwt_verification_key/uaa_jwt_verification_key.yml
+              ./cf-certs-yaml/*.yml
           inputs:
             - name: paas-cf
             - name: extract-terraform-outputs
             - name: cf-secrets
-            - name: cf-certs
-            - name: uaa_jwt_verification_key
+            - name: cf-certs-yaml
           run:
             path: sh
             args:

--- a/concourse/scripts/generate-cf-certs.sh
+++ b/concourse/scripts/generate-cf-certs.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+set -e
+set -u
+
+CERTS_DIR=$(cd "$1" && pwd)
+CA_TARBALL="$2"
+CA_NAME="bosh-CA"
+
+# shellcheck disable=SC2154
+# Allow referencing unassigned variables (set -u catches problems)
+ROUTER_DOMAINS="*.${TF_VAR_cf_root_domain},*.${TF_VAR_cf_apps_domain}"
+
+CERTS_TO_GENERATE="
+bbs_server,bbs.service.cf.internal
+bbs_client,
+router_ssl,${ROUTER_DOMAINS}
+uaa_jwt_signing,
+consul_server,server.dc1.cf.internal,server.dc2.cf.internal
+consul_agent,
+"
+
+WORKING_DIR="$(mktemp -dt generate-cf-certs.XXXXXX)"
+trap 'rm -rf "${WORKING_DIR}"' EXIT
+
+mkdir "${WORKING_DIR}/out"
+echo "Extracting ${CA_NAME} cert"
+tar -xvzf "${CA_TARBALL}" -C "${WORKING_DIR}/out"
+
+cd "${WORKING_DIR}"
+for cert_entry in ${CERTS_TO_GENERATE}; do
+  cn=${cert_entry%%,*}
+  domains=${cert_entry#*,}
+
+  if [ -f "${CERTS_DIR}/${cn}.crt" ]; then
+    echo "Certificate ${cn} is already generated, skipping."
+  else
+    # shellcheck disable=SC2086
+    # We don't need/want to quote the domains bit (fixed in newer shellcheck versions)
+    certstrap request-cert --passphrase "" --common-name "${cn}" ${domains:+--domain "${domains}"}
+    certstrap sign --CA "${CA_NAME}" --passphrase "" "${cn}"
+    mv "out/${cn}.key" "${CERTS_DIR}/"
+    mv "out/${cn}.csr" "${CERTS_DIR}/"
+    mv "out/${cn}.crt" "${CERTS_DIR}/"
+  fi
+done

--- a/manifests/cf-manifest/deployments/900-cf-tests.yml
+++ b/manifests/cf-manifest/deployments/900-cf-tests.yml
@@ -27,7 +27,7 @@ properties:
     system_domain: (( grab properties.system_domain ))
     admin_user: "admin"
     admin_password: (( grab secrets.uaa_admin_password ))
-    skip_ssl_validation: true
+    skip_ssl_validation: false
     backend: "diego"
     client_secret: (( grab secrets.uaa_clients_gorouter_secret ))
     skip_diego_unsupported_tests: true
@@ -51,4 +51,4 @@ properties:
     space: "SMOKE_TESTS"
     use_existing_org: false
     use_existing_space: false
-    skip_ssl_validation: true
+    skip_ssl_validation: false


### PR DESCRIPTION
# What

Replace hardcoded domain name used for router certificate generation with dynamic names based upon cf_root_domain and cf_apps_domain terraform variables.
In order to simplify the concourse pipelines, certificates are now all stored within a single tarball which is extracted by subsequent pipeline stages.

### How to test

* Deploy an environment as normal by following the instructions in the README.md 
* Confirm that smoke tests complete successfully during deployment.
* Try pushing an app to be extra-sure that things are OK.
* Examine the certificate details for https://api.<env>.dev.paas.alphagov.co.uk and confirm that both cf_root_domain and cf_apps_domain are listed as subject-alternative-name fields within the certificate.

### Who can review

Anyone on the team except @alext or myself