### PR TITLE
[#112411703] Fix Rate Limit exceeded error on AWS when running BOSH

### DIFF
--- a/manifests/bosh-manifest/deployments/010-bosh-template.yml
+++ b/manifests/bosh-manifest/deployments/010-bosh-template.yml
@@ -22,8 +22,8 @@ name: bosh
 
 releases:
 - name: bosh
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=236
-  sha1: 88dd60313dbd7dd832faa44c90493ffa6cd85448
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=253
+  sha1: 940956a23b642af3bb24b3cac37c4da746d6f9a9
 
 
 disk_pools:

--- a/manifests/bosh-manifest/deployments/aws/010-bosh-aws-cpi.yml
+++ b/manifests/bosh-manifest/deployments/aws/010-bosh-aws-cpi.yml
@@ -3,8 +3,9 @@ releases:
 # bosh-init container must also be updated so that the cached CPI compile
 # will be used.
 - name: bosh-aws-cpi
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=36
-  sha1: db2a6c6cdd5ff9f77bf083e10118fa72e1f5e181
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=44
+  sha1: a1fe03071e8b9bf1fa97a4022151081bf144c8bc
+
 
 jobs:
 - name: bosh

--- a/manifests/bosh-manifest/deployments/aws/090-bosh-aws-stub.yml
+++ b/manifests/bosh-manifest/deployments/aws/090-bosh-aws-stub.yml
@@ -10,11 +10,13 @@ meta:
       default_key_name: (( grab meta.aws.common.default_key_name ))
       default_security_groups: (( grab meta.aws.common.default_security_groups ))
       region: (( grab meta.aws.common.region ))
+      max_retries: 8
     bosh_properties:
       credentials_source: env_or_profile
       default_key_name: (( grab meta.aws.common.default_key_name ))
       default_security_groups: (( grab meta.aws.common.default_security_groups ))
       region: (( grab meta.aws.common.region ))
+      max_retries: 8
 
   bosh_private_ip: (( grab terraform_outputs.microbosh_static_private_ip ))
   bosh_public_ip: (( grab terraform_outputs.microbosh_static_public_ip ))

--- a/manifests/bosh-manifest/reference-bosh-manifest.yml
+++ b/manifests/bosh-manifest/reference-bosh-manifest.yml
@@ -171,8 +171,8 @@ releases:
   sha1: 88dd60313dbd7dd832faa44c90493ffa6cd85448
   url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=236
 - name: bosh-aws-cpi
-  sha1: db2a6c6cdd5ff9f77bf083e10118fa72e1f5e181
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=36
+  sha1: a1fe03071e8b9bf1fa97a4022151081bf144c8bc
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=44
 resource_pools:
 - cloud_properties:
     availability_zone: eu-west-1a

--- a/manifests/bosh-manifest/reference-bosh-manifest.yml
+++ b/manifests/bosh-manifest/reference-bosh-manifest.yml
@@ -168,8 +168,8 @@ properties:
       -----END RSA PRIVATE KEY-----
 releases:
 - name: bosh
-  sha1: 88dd60313dbd7dd832faa44c90493ffa6cd85448
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=236
+  sha1: 940956a23b642af3bb24b3cac37c4da746d6f9a9
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=253
 - name: bosh-aws-cpi
   sha1: a1fe03071e8b9bf1fa97a4022151081bf144c8bc
   url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=44

--- a/manifests/bosh-manifest/reference-bosh-manifest.yml
+++ b/manifests/bosh-manifest/reference-bosh-manifest.yml
@@ -8,6 +8,7 @@ cloud_provider:
       default_key_name: ssh_key_pair
       default_security_groups:
       - bosh_default_sg
+      max_retries: 8
       region: eu-west-1
     blobstore:
       path: /var/vcap/micro_bosh/data/cache
@@ -50,6 +51,7 @@ jobs:
       default_key_name: ssh_key_pair
       default_security_groups:
       - bosh_default_sg
+      max_retries: 8
       region: eu-west-1
     blobstore:
       address: 10.0.0.6

--- a/manifests/concourse-base.yml
+++ b/manifests/concourse-base.yml
@@ -12,8 +12,8 @@ releases:
   # bosh-init container must also be updated so that the cached CPI compile
   # will be used.
   - name: bosh-aws-cpi
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=36
-    sha1: db2a6c6cdd5ff9f77bf083e10118fa72e1f5e181
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=44
+    sha1: a1fe03071e8b9bf1fa97a4022151081bf144c8bc
 
 resource_pools:
   - name: concourse


### PR DESCRIPTION
[Follow up PR for 107477038 - Rate Limit exceeded on AWS when running BOSH](https://www.pivotaltracker.com/story/show/112411703)

## What

**Acceptance Criteria**
We have upgrade to latest bosh release, and test that we are not hitting rate limit.

## How this PR should be reviewed

This PR should be reviewed in the following context:
* I want to:
  * Use a newer version of the [bosh-aws-cpi](https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/releases/tag/v44) release that exposes the `AWS` `max_retries` option
  * Use a newer version of the [bosh release](https://bosh.io/releases/github.com/cloudfoundry/bosh?version=253) release that has  v2.1.1 (tag v44) of bosh-aws-release gem that exposes the `AWS` `max_retries` option
  * Set max retries so that the cloud provider and bosh-init will both try 8 times before failing
  * Update reference file for rspec tests so they won't fail.

## How this PR should be tested

* **Nota bene** [The PR against Docker container for bosh-init](https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/21) needs to be merged in before this is PR is tested.
* Update your microbosh using the `create-microbosh` job on your deployer concourse installation,
* Create and delete you cloud foundry deployment several times to test that you do not receive the `Error 100: Unknown CPI error 'Unknown' with message 'Request limit exceeded.'` error

## Who should review this PR

* Any leprechaun, pixie or sprite if we can not find any legendary creature from Irish folklore then any member of the core tean will do with the exception of @combor or @actionjack who worked on this PR.