### PR TITLE
[#112908839] Workflow for accessing Bosh using CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,21 @@ handled by `vagrant/deploy.sh`:
 ssh ubuntu@<bootstrap_concourse_ip> -L 8080:127.0.0.1:8080 -fN
 ```
 
+## Using the bosh cli and `bosh ssh`
+
+There's a script that starts an interactive session on the deployer concourse
+to allow running bosh CLI commands targeting MicroBOSH:
+
+```
+./concourse/scripts/bosh-cli.sh $DEPLOY_ENV
+```
+
+This connects you to a one-off task in concourse that's already logged into
+bosh and has the deployment set using the CF manifest.
+
+**Note:** `bosh ssh` no longer asks for a sudo password. By default it sets
+this to blank (just press enter when asked for the sudo password within the VM)
+
 ## SSH to Deployer Concourse and MicroBOSH
 
 In the `create-deployer` pipeline when creating the initial VPC,

--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -25,7 +25,7 @@ jobs:
         inputs:
         - name: delete-timer
         - name: bosh-secrets
-        image: docker:///concourse/bosh-deployment-resource
+        image: docker:///governmentpaas/bosh-cli
         run:
           path: sh
           args:

--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -1,4 +1,10 @@
 resources:
+  - name: paas-cf
+    type: git
+    source:
+      uri: https://github.com/alphagov/paas-cf.git
+      branch: {{branch_name}}
+
   - name: delete-timer
     type: time
     source:
@@ -20,6 +26,7 @@ jobs:
     - get: delete-timer
       trigger: true
     - get: bosh-secrets
+    - get: paas-cf
     - task: delete-deployment
       config:
         inputs:
@@ -40,6 +47,7 @@ jobs:
             short=${sum:0:15};
             decimal=$((0x$short));
             sleeptime=$((${decimal##-} % 60*20));
-            echo "Sleeping for $sleeptime seconds before deletion.."; sleep $sleeptime && 
-            bosh_password=$(awk '$1~/bosh_admin_password/ {print $2}' bosh-secrets/bosh-secrets.yml)
-            bosh -n -t https://10.0.0.6:25555 -u admin -p "${bosh_password}" delete deployment {{deploy_env}} --force
+            echo "Sleeping for $sleeptime seconds before deletion.."
+            sleep $sleeptime
+            ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
+            bosh -n delete deployment {{deploy_env}} --force

--- a/concourse/pipelines/bosh-cli/bosh-cli.yml
+++ b/concourse/pipelines/bosh-cli/bosh-cli.yml
@@ -4,6 +4,7 @@ platform: linux
 image: docker:///governmentpaas/bosh-cli
 
 inputs:
+  - name: paas-cf
   - name: cf-manifest
   - name: bosh-secrets
 run:
@@ -12,9 +13,8 @@ run:
   - -c
   - -e
   - |
-    bosh_password=$(awk '/bosh_admin_password/ { print $2 }' bosh-secrets/bosh-secrets.yml)
-    bosh -t 10.0.0.6 login admin "${bosh_password}"
-    bosh target 10.0.0.6
+    ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
+
     uuid=$(bosh status --uuid)
     sed -e "s/^director_uuid:.*$/director_uuid: ${uuid}/" cf-manifest/cf-manifest.yml > cf-manifest-with-uuid.yml
     bosh deployment ./cf-manifest-with-uuid.yml

--- a/concourse/pipelines/bosh-cli/bosh-cli.yml
+++ b/concourse/pipelines/bosh-cli/bosh-cli.yml
@@ -1,0 +1,20 @@
+---
+platform: linux
+
+image: docker:///governmentpaas/bosh-cli
+
+inputs:
+  - name: cf-manifest
+  - name: bosh-secrets
+run:
+  path: sh
+  args:
+  - -c
+  - -e
+  - |
+    bosh_password=$(awk '/bosh_admin_password/ { print $2 }' bosh-secrets/bosh-secrets.yml)
+    bosh -t 10.0.0.6 login admin "${bosh_password}"
+    bosh target 10.0.0.6
+    uuid=$(bosh status --uuid)
+    sed -e "s/^director_uuid:.*$/director_uuid: ${uuid}/" cf-manifest/cf-manifest.yml > cf-manifest-with-uuid.yml
+    bosh deployment ./cf-manifest-with-uuid.yml

--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -372,7 +372,7 @@ jobs:
               - -e
               - -c
               - |
-                BOSH_PASSWORD=$(awk '$1~/bosh_admin_password/ {print $2}' bosh-secrets/bosh-secrets.yml) \
+                ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
                 ./paas-cf/concourse/scripts/bosh_ensure_uploaded.sh
         - task: cf-release-tarball
           config:
@@ -392,7 +392,7 @@ jobs:
               - -e
               - -c
               - |
-                BOSH_PASSWORD=$(awk '$1~/bosh_admin_password/ {print $2}' bosh-secrets/bosh-secrets.yml) \
+                ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
                 ./paas-cf/concourse/scripts/bosh_ensure_uploaded.sh
 
         - task: nginx-release-tarball
@@ -413,7 +413,7 @@ jobs:
               - -e
               - -c
               - |
-                BOSH_PASSWORD=$(awk '$1~/bosh_admin_password/ {print $2}' bosh-secrets/bosh-secrets.yml) \
+                ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
                 ./paas-cf/concourse/scripts/bosh_ensure_uploaded.sh
 
         - task: diego-release-tarball
@@ -434,7 +434,7 @@ jobs:
               - -e
               - -c
               - |
-                BOSH_PASSWORD=$(awk '$1~/bosh_admin_password/ {print $2}' bosh-secrets/bosh-secrets.yml) \
+                ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
                 ./paas-cf/concourse/scripts/bosh_ensure_uploaded.sh
 
         - task: garden-release-tarball
@@ -455,7 +455,7 @@ jobs:
               - -e
               - -c
               - |
-                BOSH_PASSWORD=$(awk '$1~/bosh_admin_password/ {print $2}' bosh-secrets/bosh-secrets.yml) \
+                ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
                 ./paas-cf/concourse/scripts/bosh_ensure_uploaded.sh
 
         - task: etcd-release-tarball
@@ -476,13 +476,14 @@ jobs:
               - -e
               - -c
               - |
-                BOSH_PASSWORD=$(awk '$1~/bosh_admin_password/ {print $2}' bosh-secrets/bosh-secrets.yml) \
+                ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
                 ./paas-cf/concourse/scripts/bosh_ensure_uploaded.sh
 
       - task: cf-deploy
         config:
           image: docker:///governmentpaas/bosh-cli
           inputs:
+          - name: paas-cf
           - name: cf-manifest
           - name: bosh-secrets
           platform: linux
@@ -492,9 +493,7 @@ jobs:
             - -e
             - -c
             - |
-              bosh_password=$(awk '$1~/bosh_admin_password/ {print $2}' bosh-secrets/bosh-secrets.yml)
-              bosh -u admin -p "${bosh_password}" target https://10.0.0.6:25555
-              bosh login admin "${bosh_password}"
+              ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
               sed -e "s/^director_uuid:.*/director_uuid: $(bosh status --uuid)/" < cf-manifest/cf-manifest.yml > cf-manifest.yml
               bosh deployment cf-manifest.yml
               bosh -n deploy
@@ -506,6 +505,8 @@ jobs:
   - name: smoke-tests
     plan:
     - aggregate:
+      - get: paas-cf
+        passed: ['deploy']
       - get: cf-manifest
         passed: ['deploy']
         trigger: true
@@ -513,6 +514,7 @@ jobs:
     - task: smoke-tests
       config:
         inputs:
+        - name: paas-cf
         - name: cf-manifest
         - name: bosh-secrets
         image: docker:///governmentpaas/bosh-cli
@@ -522,9 +524,7 @@ jobs:
           - -e
           - -c
           - |
-            bosh_password=$(awk '$1~/bosh_admin_password/ {print $2}' bosh-secrets/bosh-secrets.yml)
-            bosh -u admin -p "${bosh_password}" target https://10.0.0.6:25555
-            bosh login admin "${bosh_password}"
+            ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
             bosh deployment cf-manifest/cf-manifest.yml
             bosh -n \
               run errand smoke_tests \
@@ -533,12 +533,15 @@ jobs:
   - name: acceptance-tests
     plan:
     - aggregate:
+      - get: paas-cf
+        passed: ['deploy']
       - get: cf-manifest
         passed: ['deploy']
       - get: bosh-secrets
     - task: acceptance-tests
       config:
         inputs:
+        - name: paas-cf
         - name: cf-manifest
         - name: bosh-secrets
         image: docker:///governmentpaas/bosh-cli
@@ -548,9 +551,7 @@ jobs:
           - -e
           - -c
           - |
-            bosh_password=$(awk '$1~/bosh_admin_password/ {print $2}' bosh-secrets/bosh-secrets.yml)
-            bosh -u admin -p "${bosh_password}" target https://10.0.0.6:25555
-            bosh login admin "${bosh_password}"
+            ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
             bosh deployment cf-manifest/cf-manifest.yml
             bosh -n \
               run errand acceptance_tests \

--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -361,7 +361,7 @@ jobs:
               NAME: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
               URL: https://bosh.io/d/stemcells/"${NAME}"?v="${VERSION}"
               TYPE: stemcell
-            image: docker:///concourse/bosh-deployment-resource
+            image: docker:///governmentpaas/bosh-cli
             platform: linux
             inputs:
             - name: paas-cf
@@ -381,7 +381,7 @@ jobs:
               NAME: cf
               URL: https://bosh.io/d/github.com/cloudfoundry/cf-release?v="${VERSION}"
               TYPE: release
-            image: docker:///concourse/bosh-deployment-resource
+            image: docker:///governmentpaas/bosh-cli
             platform: linux
             inputs:
             - name: paas-cf
@@ -402,7 +402,7 @@ jobs:
               NAME: nginx
               URL: https://s3.amazonaws.com/nginx-release/nginx-"${VERSION}".tgz
               TYPE: release
-            image: docker:///concourse/bosh-deployment-resource
+            image: docker:///governmentpaas/bosh-cli
             platform: linux
             inputs:
             - name: paas-cf
@@ -423,7 +423,7 @@ jobs:
               NAME: diego
               URL: https://bosh.io/d/github.com/cloudfoundry-incubator/diego-release?v="${VERSION}"
               TYPE: release
-            image: docker:///concourse/bosh-deployment-resource
+            image: docker:///governmentpaas/bosh-cli
             platform: linux
             inputs:
             - name: paas-cf
@@ -444,7 +444,7 @@ jobs:
               NAME: garden-linux
               URL: https://bosh.io/d/github.com/cloudfoundry-incubator/garden-linux-release?v="${VERSION}"
               TYPE: release
-            image: docker:///concourse/bosh-deployment-resource
+            image: docker:///governmentpaas/bosh-cli
             platform: linux
             inputs:
             - name: paas-cf
@@ -465,7 +465,7 @@ jobs:
               NAME: etcd
               URL: https://bosh.io/d/github.com/cloudfoundry-incubator/etcd-release?v="${VERSION}"
               TYPE: release
-            image: docker:///concourse/bosh-deployment-resource
+            image: docker:///governmentpaas/bosh-cli
             platform: linux
             inputs:
             - name: paas-cf
@@ -481,7 +481,7 @@ jobs:
 
       - task: cf-deploy
         config:
-          image: docker:///concourse/bosh-deployment-resource
+          image: docker:///governmentpaas/bosh-cli
           inputs:
           - name: cf-manifest
           - name: bosh-secrets
@@ -515,7 +515,7 @@ jobs:
         inputs:
         - name: cf-manifest
         - name: bosh-secrets
-        image: docker:///concourse/bosh-deployment-resource
+        image: docker:///governmentpaas/bosh-cli
         run:
           path: sh
           args:
@@ -541,7 +541,7 @@ jobs:
         inputs:
         - name: cf-manifest
         - name: bosh-secrets
-        image: docker:///concourse/bosh-deployment-resource
+        image: docker:///governmentpaas/bosh-cli
         run:
           path: sh
           args:

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -45,11 +45,14 @@ jobs:
     serial_groups: [ destroy ]
     serial: true
     plan:
-      - get: bosh-secrets
+      - aggregate:
+        - get: bosh-secrets
+        - get: paas-cf
       - task: delete-deployment
         config:
           inputs:
           - name: bosh-secrets
+          - name: paas-cf
           image: docker:///governmentpaas/bosh-cli
           run:
             path: sh
@@ -57,8 +60,8 @@ jobs:
             - -e
             - -c
             - |
-              bosh_password=$(awk '$1~/bosh_admin_password/ {print $2}' bosh-secrets/bosh-secrets.yml)
-              bosh -n -t https://10.0.0.6:25555 -u admin -p "${bosh_password}" delete deployment {{deploy_env}}
+              ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
+              bosh -n delete deployment {{deploy_env}}
       - put: pipeline-trigger
         params: {bump: patch}
 
@@ -71,6 +74,7 @@ jobs:
           passed: ['delete-deployment']
           trigger: true
         - get: paas-cf
+          passed: ['delete-deployment']
         - get: cf-tfstate
         - get: concourse-tfstate
         - get: vpc-tfstate

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -50,7 +50,7 @@ jobs:
         config:
           inputs:
           - name: bosh-secrets
-          image: docker:///concourse/bosh-deployment-resource
+          image: docker:///governmentpaas/bosh-cli
           run:
             path: sh
             args:

--- a/concourse/scripts/bosh-cli.sh
+++ b/concourse/scripts/bosh-cli.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+env=${1-${DEPLOY_ENV-}}
+if [ -z "${env}" ]; then
+  echo "Must specify DEPLOY_ENV as \$1 or environment variable"
+  exit 1
+fi
+
+FLY_TARGET=${FLY_TARGET:-$env}
+FLY_CMD=${FLY_CMD:-fly}
+
+OUTPUT_FILE=$(mktemp -t bosh-cli.XXXXXX)
+trap 'rm -f "${OUTPUT_FILE}"' EXIT
+
+$FLY_CMD -t "${FLY_TARGET}" \
+  execute \
+  --inputs-from=deploy-cloudfoundry/deploy \
+  --config="${SCRIPT_DIR}/../pipelines/bosh-cli/bosh-cli.yml" \
+  | tee "${OUTPUT_FILE}"
+
+BUILD_NUMBER=$(awk '/executing build/ { print $3 }' "${OUTPUT_FILE}")
+
+$FLY_CMD -t "${FLY_TARGET}" \
+  intercept \
+  --build="${BUILD_NUMBER}"\
+  --step=one-off \
+  sh

--- a/concourse/scripts/bosh_ensure_uploaded.sh
+++ b/concourse/scripts/bosh_ensure_uploaded.sh
@@ -3,9 +3,6 @@ set -e -u
 
 script_dir=$(cd "$(dirname "$0")" && pwd)
 
-bosh -u admin -p "${BOSH_PASSWORD}" target https://10.0.0.6:25555 >/dev/null
-bosh login admin "${BOSH_PASSWORD}" >/dev/null
-
 existing_version=$("${script_dir}/bosh_list_${TYPE}s.rb" | awk -v name="${NAME}" -F"/" '$1 ~ name {print $2}')
 
 if [ "${existing_version}" != "${VERSION}" ]; then

--- a/concourse/scripts/bosh_ensure_uploaded.sh
+++ b/concourse/scripts/bosh_ensure_uploaded.sh
@@ -8,7 +8,7 @@ bosh login admin "${BOSH_PASSWORD}" >/dev/null
 
 existing_version=$("${script_dir}/bosh_list_${TYPE}s.rb" | awk -v name="${NAME}" -F"/" '$1 ~ name {print $2}')
 
-if [[ "${existing_version}" != "${VERSION}" ]]; then
+if [ "${existing_version}" != "${VERSION}" ]; then
   eval bosh upload "${TYPE}" "${URL}"
 else
   echo "${NAME}/${VERSION} is already uploaded"

--- a/concourse/scripts/bosh_login.sh
+++ b/concourse/scripts/bosh_login.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -eu
+
+bosh_secrets_file=$1
+bosh_ip=${BOSH_IP-"10.0.0.6"}
+
+bosh_password=$(awk '/bosh_admin_password/ { print $2 }' "${bosh_secrets_file}")
+bosh -t "${bosh_ip}" login admin "${bosh_password}"
+bosh target "${bosh_ip}"

--- a/terraform/concourse/elb.tf
+++ b/terraform/concourse/elb.tf
@@ -8,6 +8,7 @@ resource "aws_elb" "concourse" {
   name            = "${var.env}-concourse"
   subnets         = ["${split(",", var.infra_subnet_ids)}"]
   security_groups = ["${aws_security_group.concourse-elb.id}"]
+  idle_timeout    = 600
 
   health_check {
     target              = "TCP:8080"


### PR DESCRIPTION
## What

We want to be able to easily use bosh cli commands (including `bosh ssh`) against our deployed µBOSH.

## Details

This adds a script that pushes a one-off task to concourse that sets up bosh credentials, target and deployment. It then intercepts (hijacks) that container to provide an interactive session with the bosh CLI available.

We've had to increase the `idle_timeout` for the concourse ELB to 600 seconds to prevent sessions being dropped after 60 seconds of inactivity.

This also updates all the pipelines that use the bosh CLI to use the new docker container instead of using the bosh deployment resource container in a way that wasn't intended.

## How to review

Re-run the create-deployer pipeline to apply the ELB timeout change. Deploy cloudfoundry.

Run the bosh cli script:
```
./concourse/scripts/bosh-cli.sh $DEPLOY_ENV
```
The bosh cli should be ready to use. It should already be logged in etc. so you can run `bosh vms`, and also `bosh ssh` to vms (See note in README about the blank sudo password)

## Who can review

Anyone but @jimconner and myself.