### PR TITLE
[#113265403] Optionally trigger builds from paas-cf master

### DIFF
--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -82,6 +82,7 @@ jobs:
     serial: true
     plan:
       - get: paas-cf
+        trigger: {{auto_deploy}}
       - task: init
         config:
           image: docker:///governmentpaas/curl-ssl

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -23,6 +23,12 @@ debug: ${DEBUG:-}
 EOF
 }
 
+generate_manifest_file() {
+   # This exists because concourse does not support boolean value interpolation by design
+   enable_auto_deploy=$([ "${ENABLE_AUTO_DEPLOY:-}" ] && echo "true" || echo "false")
+   sed -e "s/{{auto_deploy}}/${enable_auto_deploy}/" \
+       < "${SCRIPT_DIR}/../pipelines/${ACTION}-cloudfoundry.yml"
+}
 
 for ACTION in deploy destroy; do
   trigger_file="${ACTION}-cloudfoundry.trigger"
@@ -30,7 +36,7 @@ for ACTION in deploy destroy; do
 
   bash "${SCRIPT_DIR}/deploy-pipeline.sh" \
     "${env}" "${ACTION}-cloudfoundry" \
-    "${SCRIPT_DIR}/../pipelines/${ACTION}-cloudfoundry.yml" \
+    <(generate_manifest_file) \
     <(generate_vars_file)
 done
 


### PR DESCRIPTION
This will cause builds to automatically trigger from paas-cf if the environment variable `ENABLE_AUTO_DEPLOY=1` is set. We can be sure that the tests have already passed as we have master protection turned on, so the Travis build must have already passed.

# How to test
Deploy your development environment on this branch, then `fly get-pipeline deploy-cloudfoundry`. The jobs section should look like this:
````
jobs:
  - name: init
    serial_groups: [ deploy ]
    serial: true
    plan:
      - get: paas-cf
        trigger: false
      - task: init
        config:
...
````
Specifically you're looking for the `trigger: false` on `paas-cf`.

# Next steps
After this PR is merged the `ci` pipelines need to be updated using `./concourse/scripts/pipelines-cloudfoundry.sh` with `ENABLE_AUTO_DEPLOY=1` set.

# Who can review this
Not @jonty.