### PR TITLE
Fix autodelete pipeline.

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -32,6 +32,7 @@ jobs:
         inputs:
         - name: delete-timer
         - name: bosh-secrets
+        - name: paas-cf
         image: docker:///governmentpaas/bosh-cli
         run:
           path: sh


### PR DESCRIPTION
The delete task was missing the paas-cf input, so couldn't find the
bosh-login script. This was missed in d282c21.