### PR TITLE
[#114188075] Fix triggers and serial in deploy-cloudfoundry pipeline

### DIFF
--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -162,6 +162,8 @@ jobs:
     plan:
       - get: paas-cf
         passed: ['init']
+      - get: pipeline-trigger
+        passed: [ 'init' ]
         trigger: true
 
       - task: generate
@@ -194,9 +196,11 @@ jobs:
   - name: generate-cf-certs
     plan:
       - aggregate:
+        - get: pipeline-trigger
+          passed: [ 'terraform' ]
+          trigger: true
         - get: paas-cf
           passed: ['terraform']
-          trigger: true
         - get: bosh-CA
         - get: cf-certs
         - get: cf-tfstate
@@ -251,6 +255,9 @@ jobs:
     serial: true
     plan:
       - aggregate:
+        - get: pipeline-trigger
+          passed: [ 'generate-cf-certs' ]
+          trigger: true
         - get: paas-cf
           passed: ['generate-cf-certs']
         - get: bosh-CA
@@ -347,6 +354,9 @@ jobs:
     serial: true
     plan:
       - aggregate:
+        - get: pipeline-trigger
+          passed: [ 'generate-manifest' ]
+          trigger: true
         - get: paas-cf
           passed: ['generate-manifest']
         - get: cf-manifest
@@ -379,6 +389,9 @@ jobs:
   - name: smoke-tests
     plan:
     - aggregate:
+      - get: pipeline-trigger
+        passed: [ 'deploy']
+        trigger: true
       - get: paas-cf
         passed: ['deploy']
       - get: cf-manifest
@@ -434,6 +447,9 @@ jobs:
   - name: custom-acceptance-tests
     plan:
     - aggregate:
+      - get: pipeline-trigger
+        passed: [ 'deploy']
+        trigger: true
       - get: paas-cf
         passed: ['deploy']
       - get: cf-manifest

--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -194,6 +194,8 @@ jobs:
               - generate/cf-secrets.yml
 
   - name: generate-cf-certs
+    serial_groups: [ deploy ]
+    serial: true
     plan:
       - aggregate:
         - get: pipeline-trigger


### PR DESCRIPTION
## What

#### Fix triggers in deploy-cloudfoundry pipeline

We have noticed that pipeline triggering mechanism is not consistent
across deploy pipeline and that terraform job is not triggering
generate-cf-certs job. In this commit we add pipeline-trigger semver
resource across entire pipeline to fix this problem.

Please note that this update has a side effect of triggering every job
that received pipeline-trigger during pipeline upload. It will happen
only for the first time. New trigger
resource is checking for new version and finds it in 'init' job so it
starts.

#### Serialize generate-cf-certs to prevent parallel runs

We have noticed that generate-cf-certs is missing serial groups
parameter that ensures serial execution of jobs in 'deploy' group. That
caused generate-cf-certs job to run in parallel with other jobs in some
edge case circumstances.

## How to review

1. Ensure that you have a Deployer Concourse and have run the `create-microbosh` pipeline before.
1. Checkout this branch:

        git checkout 114188075_fix_deploy_pipeline_trigger
1. Deploy the pipeline changes from the branch:

        BRANCH=$(git rev-parse --abbrev-ref HEAD) ./concourse/scripts/pipelines-cloudfoundry.sh
1. Note that some of the jobs may have triggered automatically per the commit message.
1. Start the `init` job in the `deploy-cloudfoundry` pipeline and check that *all* of the jobs run.
1. Repeat the last step again.

## Who can review

Not @combor or @dcarley.