### PR TITLE
[#113996323] Add Logsearch

### DIFF
--- a/manifests/cf-manifest/deployments/050-logsearch.yml
+++ b/manifests/cf-manifest/deployments/050-logsearch.yml
@@ -275,7 +275,6 @@ jobs:
   release: logsearch
   templates:
   - {name: parser, release: logsearch}
-  - {name: elasticsearch, release: logsearch}
   resource_pool: parser
   instances: 1
   networks:

--- a/manifests/cf-manifest/deployments/050-logsearch.yml
+++ b/manifests/cf-manifest/deployments/050-logsearch.yml
@@ -1,0 +1,323 @@
+releases:
+- name: logsearch
+  url: https://bosh.io/d/github.com/logsearch/logsearch-boshrelease?v=200.0.0
+  version: 200.0.0
+  sha1: 527c35db31cd66810accf128ceffee4f5fde80c3
+
+disk_pools:
+- name: elasticsearch_master
+  disk_size: 102400
+  cloud_properties:
+    type: gp2
+
+- name: elasticsearch_data
+  disk_size: 102400
+  cloud_properties:
+    type: gp2
+
+- name: queue
+  disk_size: 102400
+  cloud_properties:
+    type: gp2
+
+- name: cluster_monitor
+  disk_size: 102400
+  cloud_properties:
+    type: gp2
+
+resource_pools:
+- name: elasticsearch_master
+  network: cf1
+  stemcell: (( grab meta.stemcell ))
+  env: (( grab meta.default_env ))
+  cloud_properties:
+    availability_zone: eu-west-1a
+    instance_type: t2.micro
+
+- name: elasticsearch_data
+  network: cf1
+  stemcell: (( grab meta.stemcell ))
+  env: (( grab meta.default_env ))
+  cloud_properties:
+    availability_zone: eu-west-1a
+    instance_type: t2.micro
+
+- name: ingestor
+  network: cf1
+  stemcell: (( grab meta.stemcell ))
+  env: (( grab meta.default_env ))
+  cloud_properties:
+    availability_zone: eu-west-1a
+    instance_type: t2.micro
+
+- name: queue
+  network: cf1
+  stemcell: (( grab meta.stemcell ))
+  env: (( grab meta.default_env ))
+  cloud_properties:
+    availability_zone: eu-west-1a
+    instance_type: t2.small
+
+- name: parser
+  network: cf1
+  stemcell: (( grab meta.stemcell ))
+  env: (( grab meta.default_env ))
+  cloud_properties:
+    availability_zone: eu-west-1a
+    instance_type: t2.micro
+
+- name: kibana
+  network: cf1
+  stemcell: (( grab meta.stemcell ))
+  env: (( grab meta.default_env ))
+  cloud_properties:
+    availability_zone: eu-west-1a
+    instance_type: t2.micro
+
+- name: maintenance
+  network: cf1
+  stemcell: (( grab meta.stemcell ))
+  env: (( grab meta.default_env ))
+  cloud_properties:
+    availability_zone: eu-west-1a
+    instance_type: t2.micro
+
+- name: cluster_monitor
+  network: cf1
+  stemcell: (( grab meta.stemcell ))
+  env: (( grab meta.default_env ))
+  cloud_properties:
+    availability_zone: eu-west-1a
+    instance_type: m4.large
+
+- name: haproxy
+  network: cf1
+  stemcell: (( grab meta.stemcell ))
+  env: (( grab meta.default_env ))
+  cloud_properties:
+    availability_zone: eu-west-1a
+    instance_type: t2.micro
+
+jobs:
+- name: elasticsearch_master
+  release: logsearch
+  templates:
+  - {name: elasticsearch, release: logsearch}
+  resource_pool: elasticsearch_master
+  update:
+    serial: true
+  instances: 1
+  networks:
+  - name: cf1
+    static_ips: (( static_ips(0) ))
+  persistent_disk_pool: elasticsearch_master
+  properties:
+    elasticsearch:
+      node:
+        allow_master: true
+        allow_data: false
+  update:
+    serial: false
+    canaries: 1
+    max_in_flight: 1
+
+- name: haproxy
+  instances: 0
+  release: logsearch
+  templates:
+  - { name: haproxy, release: logsearch }
+  resource_pool: haproxy
+  networks:
+  - name: cf1
+  update:
+    serial: false
+    canaries: 1
+    max_in_flight: 1
+  properties:
+    haproxy:
+      backend_servers: (( grab jobs.ingestor.networks.[0].static_ips ))
+
+- name: cluster_monitor
+  instances: 0
+  release: logsearch
+  templates:
+  - { release: logsearch, name: queue }
+  - { release: logsearch, name: parser }
+  - { release: logsearch, name: ingestor_syslog }
+  - { release: logsearch, name: elasticsearch }
+  - { release: logsearch, name: elasticsearch_config }
+  - { release: logsearch, name: curator }
+  - { release: logsearch, name: kibana }
+  - { release: logsearch, name: nats_to_syslog }
+  resource_pool: cluster_monitor
+  networks:
+  - name: cf1
+  persistent_disk_pool: cluster_monitor
+  properties:
+    kibana:
+      elasticsearch: 127.0.0.1:9200
+      port: 5601
+    elasticsearch:
+      master_hosts: [127.0.0.1]
+      cluster_name: monitor
+      node:
+        allow_master: true
+        allow_data: true
+    redis:
+      host: 127.0.0.1
+    curator:
+      elasticsearch_host: 127.0.0.1
+      elasticsearch_port: 9200
+      purge_logs:
+        retention_period: 7
+    elasticsearch_config:
+      elasticsearch:
+        host: 127.0.0.1
+        port: 9200
+      bulk_data_files: []
+      templates:
+      - shards-and-replicas: "{ \"template\" : \"*\", \"order\" : 99, \"settings\" : { \"number_of_shards\" : 1, \"number_of_replicas\" : 0 } }"
+      - index_template: /var/vcap/packages/logsearch-config/default-mappings.json
+    logstash_parser:
+      filters:
+      - metrics: /var/vcap/packages/logsearch-config/logstash-filters-metric.conf
+    nats_to_syslog:
+      nats:
+        subject: ">"
+        user: nats
+        password: nats-password
+        port: 4222
+        machines: [10.0.0.6]
+      debug: true
+      syslog:
+        host: 127.0.0.1
+        port: 514
+    logstash_ingestor:
+      syslog:
+        port: 514
+  update:
+    serial: false
+    canaries: 1
+    max_in_flight: 1
+
+- name: queue
+  release: logsearch
+  templates:
+  - {name: queue, release: logsearch}
+  resource_pool: queue
+  instances: 1
+  networks:
+  - name: cf1
+    static_ips: (( static_ips(3) ))
+  persistent_disk_pool: queue
+  update:
+    serial: true
+    canaries: 1
+    max_in_flight: 1
+
+- name: kibana
+  release: logsearch
+  templates:
+  - {name: kibana, release: logsearch}
+  instances: 1
+  resource_pool: kibana
+  networks:
+  - name: cf1
+  update:
+    serial: false
+    canaries: 1
+    max_in_flight: 1
+
+- name: elasticsearch_data
+  release: logsearch
+  templates:
+  - {name: elasticsearch, release: logsearch}
+  resource_pool: elasticsearch_data
+  update:
+    serial: true
+  instances: 2
+  networks:
+  - name: cf1
+    static_ips: (( static_ips(16, 17) ))
+  persistent_disk_pool: elasticsearch_data
+  properties:
+    elasticsearch:
+      node:
+        allow_master: false
+        allow_data: true
+  update:
+    serial: false
+    canaries: 1
+    max_in_flight: 1
+
+- name: ingestor
+  release: logsearch
+  templates:
+  - {name: ingestor_syslog, release: logsearch}
+  - {name: ingestor_relp, release: logsearch}
+  resource_pool: ingestor
+  instances: 1
+  networks:
+  - name: cf1
+    default: [gateway, dns]
+    static_ips: (( static_ips(2) ))
+  properties:
+    logstash_ingestor:
+      debug: false
+      relp:
+        port: ~
+  update:
+    serial: false
+    canaries: 1
+    max_in_flight: 1
+
+- name: parser
+  release: logsearch
+  templates:
+  - {name: parser, release: logsearch}
+  - {name: elasticsearch, release: logsearch}
+  resource_pool: parser
+  instances: 1
+  networks:
+  - name: cf1
+    static_ips: (( static_ips(4) ))
+  update:
+    serial: false
+    canaries: 1
+    max_in_flight: 4
+
+- name: maintenance
+  instances: 1
+  release: logsearch
+  templates:
+  - {name: elasticsearch_config, release: logsearch}
+  - {name: curator, release: logsearch}
+  resource_pool: maintenance
+  networks:
+  - name: cf1
+  update:
+    serial: false
+    canaries: 1
+    max_in_flight: 1
+
+properties:
+  curator:
+    elasticsearch_host: (( grab jobs.elasticsearch_master.networks.cf1.static_ips.[0] ))
+  logstash_parser:
+    debug: false
+  logstash_ingestor:
+    debug: false
+  redis:
+    host: (( grab jobs.queue.networks.cf1.static_ips.[0] ))
+  elasticsearch:
+    log_level: DEBUG
+    master_hosts: (( grab jobs.elasticsearch_master.networks.cf1.static_ips ))
+    cluster_name: logsearch
+    exec: ~
+  kibana:
+    elasticsearch: (( concat jobs.elasticsearch_master.networks.cf1.static_ips.[0] ":9200" ))
+  elasticsearch_config:
+    elasticsearch:
+      host: (( grab jobs.elasticsearch_master.networks.cf1.static_ips.[0] ))
+    templates:
+      - index_template: /var/vcap/packages/logsearch-config/default-mappings.json

--- a/manifests/cf-manifest/deployments/050-logsearch.yml
+++ b/manifests/cf-manifest/deployments/050-logsearch.yml
@@ -64,7 +64,7 @@ resource_pools:
   env: (( grab meta.default_env ))
   cloud_properties:
     availability_zone: eu-west-1a
-    instance_type: t2.micro
+    instance_type: m3.medium
 
 - name: kibana
   network: cf1

--- a/manifests/cf-manifest/deployments/050-logsearch.yml
+++ b/manifests/cf-manifest/deployments/050-logsearch.yml
@@ -104,8 +104,6 @@ jobs:
   templates:
   - {name: elasticsearch, release: logsearch}
   resource_pool: elasticsearch_master
-  update:
-    serial: true
   instances: 1
   networks:
   - name: cf1
@@ -233,8 +231,6 @@ jobs:
   templates:
   - {name: elasticsearch, release: logsearch}
   resource_pool: elasticsearch_data
-  update:
-    serial: true
   instances: 2
   networks:
   - name: cf1

--- a/manifests/cf-manifest/deployments/050-logsearch.yml
+++ b/manifests/cf-manifest/deployments/050-logsearch.yml
@@ -320,3 +320,7 @@ properties:
       host: (( grab jobs.elasticsearch_master.networks.cf1.static_ips.[0] ))
     templates:
       - index_template: /var/vcap/packages/logsearch-config/default-mappings.json
+  syslog_daemon_config:
+    address: (( grab jobs.ingestor.networks.cf1.static_ips.[0] ))
+    port: 2514
+    transport: relp

--- a/manifests/cf-manifest/deployments/050-logsearch.yml
+++ b/manifests/cf-manifest/deployments/050-logsearch.yml
@@ -182,10 +182,10 @@ jobs:
     nats_to_syslog:
       nats:
         subject: ">"
-        user: nats
-        password: nats-password
-        port: 4222
-        machines: [10.0.0.6]
+        user: (( grab properties.nats.user ))
+        password: (( grab properties.nats.password ))
+        port: (( grab properties.nats.port ))
+        machines: (( grab properties.nats.machines ))
       debug: true
       syslog:
         host: 127.0.0.1

--- a/terraform/cloudfoundry/network_acls_cf_in.tf
+++ b/terraform/cloudfoundry/network_acls_cf_in.tf
@@ -161,6 +161,17 @@ resource "aws_network_acl_rule" "116_router_consul_in" {
     egress = false
 }
 
+resource "aws_network_acl_rule" "117_kibana" {
+    network_acl_id = "${aws_network_acl.cf.id}"
+    protocol = "tcp"
+    rule_number = 117
+    rule_action = "allow"
+    from_port = 5601
+    to_port = 5601
+    cidr_block = "${var.infra_cidr_all}"
+    egress = false
+}
+
 resource "aws_network_acl_rule" "120_local_drop" {
     network_acl_id = "${aws_network_acl.cf.id}"
     protocol = "tcp"


### PR DESCRIPTION
## What
[Log aggregation platform](https://www.pivotaltracker.com/n/projects/1275640/stories/113996323)

Add default logsearch deployment to our CF. We have decided to make this a part of main CF deployment for the sake of simplicity. Otherwise we'd have to update concourse pipelines and template generation scripts to deploy multiple releases, which was out of scope of this story.

## How to review

Deploy or update your existing deployment. Create ssh tunnel via deployer concourse to kibana:
`ssh -L 5601:10.0.16.49:5601 -i session/id_rsa vcap@$DEPLOYER_CONCOURSE`. You should be able to browse logs and see them appearing in real time.

## Who can review

The [Scarlet Pimpernel](https://en.wikipedia.org/wiki/The_Scarlet_Pimpernel) because _They seek him here, they seek him there_ if he can not be found any member of the core team can merge this PR with the exception of @actionjack and @mtekel 