### PR TITLE
[#1106592863] Deploy etcd and consul across 3 availability zones

### DIFF
--- a/manifests/cf-manifest/deployments/020-cf-resource-pools.yml
+++ b/manifests/cf-manifest/deployments/020-cf-resource-pools.yml
@@ -9,6 +9,11 @@ resource_pools:
     stemcell: (( grab meta.stemcell ))
     env: (( grab meta.default_env ))
 
+  - name: small_z3
+    network: cf3
+    stemcell: (( grab meta.stemcell ))
+    env: (( grab meta.default_env ))
+
   - name: medium_z1
     network: cf1
     stemcell: (( grab meta.stemcell ))

--- a/manifests/cf-manifest/deployments/020-cf-resource-pools.yml
+++ b/manifests/cf-manifest/deployments/020-cf-resource-pools.yml
@@ -19,6 +19,11 @@ resource_pools:
     stemcell: (( grab meta.stemcell ))
     env: (( grab meta.default_env ))
 
+  - name: medium_z3
+    network: cf3
+    stemcell: (( grab meta.stemcell ))
+    env: (( grab meta.default_env ))
+
   - name: large_z1
     network: cf1
     stemcell: (( grab meta.stemcell ))

--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -8,7 +8,7 @@ meta:
 
   etcd_consul_service: ["etcd.service.cf.internal"]
 
-  consul_servers: (( grab jobs.consul_z1.networks.cf1.static_ips jobs.consul_z2.networks.cf2.static_ips ))
+  consul_servers: (( grab jobs.consul_z1.networks.cf1.static_ips jobs.consul_z2.networks.cf2.static_ips jobs.consul_z3.networks.cf3.static_ips ))
 
   nfs_client_ranges:
     - (( grab networks.cf1.subnets.[0].range || nil ))
@@ -183,7 +183,7 @@ meta:
 jobs:
   - name: consul_z1
     templates: (( grab meta.consul_templates ))
-    instances: 2
+    instances: 1
     persistent_disk: 1024
     resource_pool: small_z1
     networks:
@@ -197,6 +197,21 @@ jobs:
           mode: server
       metron_agent:
         zone: z1
+
+  - name: consul_z2
+    templates: (( grab meta.consul_templates ))
+    instances: 1
+    persistent_disk: 1024
+    resource_pool: small_z2
+    networks:
+      - name: cf2
+        static_ips:
+    properties:
+      consul:
+        agent:
+          mode: server
+      metron_agent:
+        zone: z2
 
   - name: etcd_z1
     templates: (( grab meta.etcd_templates ))
@@ -215,6 +230,21 @@ jobs:
         agent:
           services:
             etcd: {}
+
+  - name: consul_z3
+    templates: (( grab meta.consul_templates ))
+    instances: 1
+    persistent_disk: 1024
+    resource_pool: small_z3
+    networks:
+      - name: cf3
+        static_ips:
+    properties:
+      consul:
+        agent:
+          mode: server
+      metron_agent:
+        zone: z3
 
   - name: etcd_z2
     templates: (( grab meta.etcd_templates ))
@@ -247,21 +277,6 @@ jobs:
         agent:
           services:
             etcd: {}
-
-  - name: consul_z2
-    templates: (( grab meta.consul_templates ))
-    instances: 1
-    persistent_disk: 1024
-    resource_pool: small_z2
-    networks:
-      - name: cf2
-        static_ips:
-    properties:
-      consul:
-        agent:
-          mode: server
-      metron_agent:
-        zone: z2
 
   - name: ha_proxy_z1
     templates: (( grab meta.ha_proxy_templates ))

--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -218,7 +218,7 @@ jobs:
 
   - name: etcd_z2
     templates: (( grab meta.etcd_templates ))
-    instances: 2
+    instances: 1
     persistent_disk: 10024
     resource_pool: medium_z2
     networks:
@@ -227,6 +227,22 @@ jobs:
     properties:
       metron_agent:
         zone: z2
+      consul:
+        agent:
+          services:
+            etcd: {}
+
+  - name: etcd_z3
+    templates: (( grab meta.etcd_templates ))
+    instances: 1
+    persistent_disk: 10024
+    resource_pool: medium_z3
+    networks:
+      - name: cf3
+        static_ips:
+    properties:
+      metron_agent:
+        zone: z3
       consul:
         agent:
           services:
@@ -789,7 +805,7 @@ properties:
     prof_port: 0
 
   etcd:
-    machines: (( grab jobs.etcd_z1.networks.cf1.static_ips jobs.etcd_z2.networks.cf2.static_ips ))
+    machines: (( grab jobs.etcd_z1.networks.cf1.static_ips jobs.etcd_z2.networks.cf2.static_ips jobs.etcd_z3.networks.cf3.static_ips ))
     require_ssl: false
     peer_require_ssl: false
 

--- a/manifests/cf-manifest/deployments/900-cf-tests.yml
+++ b/manifests/cf-manifest/deployments/900-cf-tests.yml
@@ -13,7 +13,7 @@ jobs:
     templates:
     - name: smoke-tests
       release: (( grab meta.release.name ))
-    instances: 0
+    instances: 1
     resource_pool: small_errand
     lifecycle: errand
     networks:

--- a/manifests/cf-manifest/deployments/aws/000-cf-infrastructure.yml
+++ b/manifests/cf-manifest/deployments/aws/000-cf-infrastructure.yml
@@ -227,85 +227,70 @@ resource_pools:
 # set up static IPs
 jobs:
   - name: nats_z1
-    instances: 1
     networks:
       - name: cf1
         static_ips: (( static_ips(1) ))
 
   - name: nats_z2
-    instances: 1
     networks:
       - name: cf2
         static_ips: (( static_ips(1) ))
 
   - name: router_z1
-    instances: 1
     networks:
       - name: router1
         static_ips: (( static_ips(1, 2 ,3 ,4, 5, 6, 7, 8) ))
 
   - name: router_z2
-    instances: 1
     networks:
       - name: router2
         static_ips: (( static_ips(1, 2 ,3 ,4, 5, 6, 7, 8) ))
 
   - name: postgres_z1
-    instances: 1
     networks:
       - name: cf1
         static_ips: (( static_ips(7) ))
 
   - name: loggregator_z1
-    instances: 0
     networks:
       - name: cf1
 
   - name: loggregator_z2
-    instances: 0
     networks:
       - name: cf2
 
   - name: doppler_z1
-    instances: 1
     networks:
       - name: cf1
 
   - name: doppler_z2
-    instances: 1
     networks:
       - name: cf2
 
   - name: loggregator_trafficcontroller_z1
-    instances: 1
     networks:
       - name: cf1
 
   - name: loggregator_trafficcontroller_z2
-    instances: 1
     networks:
       - name: cf2
 
   - name: consul_z1
-    instances: 2
     networks:
       - name: cf1
         static_ips: (( static_ips(27, 28, 29) ))
 
   - name: consul_z2
-    instances: 1
     networks:
       - name: cf2
         static_ips: (( static_ips(27, 28, 29) ))
 
   - name: etcd_z1
-    instances: 1
     networks:
       - name: cf1
         static_ips: (( static_ips(9) ))
 
   - name: etcd_z2
-    instances: 2
     networks:
       - name: cf2
         static_ips: (( static_ips(10, 25) ))

--- a/manifests/cf-manifest/deployments/aws/000-cf-infrastructure.yml
+++ b/manifests/cf-manifest/deployments/aws/000-cf-infrastructure.yml
@@ -2,6 +2,7 @@ meta:
   zones:
     z1: (( grab terraform_outputs.zone0 ))
     z2: (( grab terraform_outputs.zone1 ))
+    z3: (( grab terraform_outputs.zone2 ))
 
   fog_config:
     provider: AWS
@@ -80,6 +81,14 @@ resource_pools:
         size: 10_240
         type: gp2
       availability_zone: (( grab meta.zones.z2 ))
+
+  - name: medium_z3
+    cloud_properties:
+      instance_type: m3.medium
+      ephemeral_disk:
+        size: 10_240
+        type: gp2
+      availability_zone: (( grab meta.zones.z3 ))
 
   - name: large_z1
     cloud_properties:
@@ -293,4 +302,9 @@ jobs:
   - name: etcd_z2
     networks:
       - name: cf2
-        static_ips: (( static_ips(10, 25) ))
+        static_ips: (( static_ips(9) ))
+
+  - name: etcd_z3
+    networks:
+      - name: cf3
+        static_ips: (( static_ips(9) ))

--- a/manifests/cf-manifest/deployments/aws/000-cf-infrastructure.yml
+++ b/manifests/cf-manifest/deployments/aws/000-cf-infrastructure.yml
@@ -309,6 +309,3 @@ jobs:
     networks:
       - name: cf2
         static_ips: (( static_ips(10, 25) ))
-
-  - name: smoke_tests
-    instances: 1

--- a/manifests/cf-manifest/deployments/aws/000-cf-infrastructure.yml
+++ b/manifests/cf-manifest/deployments/aws/000-cf-infrastructure.yml
@@ -66,6 +66,14 @@ resource_pools:
         type: gp2
       availability_zone: (( grab meta.zones.z2 ))
 
+  - name: small_z3
+    cloud_properties:
+      instance_type: m3.medium
+      ephemeral_disk:
+        size: 10_240
+        type: gp2
+      availability_zone: (( grab meta.zones.z3 ))
+
   - name: medium_z1
     cloud_properties:
       instance_type: m3.medium
@@ -292,6 +300,11 @@ jobs:
   - name: consul_z2
     networks:
       - name: cf2
+        static_ips: (( static_ips(27, 28, 29) ))
+
+  - name: consul_z3
+    networks:
+      - name: cf3
         static_ips: (( static_ips(27, 28, 29) ))
 
   - name: etcd_z1

--- a/manifests/cf-manifest/deployments/aws/999-cf-stub.yml
+++ b/manifests/cf-manifest/deployments/aws/999-cf-stub.yml
@@ -34,6 +34,18 @@ networks:
         - 10.0.0.2
       cloud_properties:
         subnet: (( grab terraform_outputs.cf2_subnet_id ))
+- name: cf3
+  subnets:
+    - range: 10.0.18.0/24
+      reserved:
+        - 10.0.18.2 - 10.0.18.9
+      static:
+        - 10.0.18.10 - 10.0.18.40
+      gateway: 10.0.18.1
+      dns:
+        - 10.0.0.2
+      cloud_properties:
+        subnet: (( grab terraform_outputs.cf3_subnet_id ))
 
 - name: cell1
   subnets:

--- a/manifests/cf-manifest/spec/fixtures/terraform/terraform-outputs.yml
+++ b/manifests/cf-manifest/spec/fixtures/terraform/terraform-outputs.yml
@@ -2,6 +2,7 @@
 terraform_outputs:
   cf1_subnet_id: subnet-12345678
   cf2_subnet_id: subnet-23456781
+  cf3_subnet_id: subnet-34567812
   cell1_subnet_id: subnet-09876543
   cell2_subnet_id: subnet-98765432
   router1_subnet_id: subnet-09876543

--- a/manifests/cf-manifest/spec/fixtures/terraform/terraform-outputs.yml
+++ b/manifests/cf-manifest/spec/fixtures/terraform/terraform-outputs.yml
@@ -15,6 +15,7 @@ terraform_outputs:
   region: sealand-1
   zone0: sealand-1a
   zone1: sealand-1b
+  zone2: sealand-1c
   postgres_rds_address: 127.0.0.1
   postgres_rds_port: 5432
   ssh_elb_name: stub_ssh_elb

--- a/manifests/cf-manifest/spec/networks_spec.rb
+++ b/manifests/cf-manifest/spec/networks_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe "networks" do
   CF_NETWORK_NAMES = %w(
     cf1
     cf2
+    cf3
     cell1
     cell2
     router1

--- a/terraform/cloudfoundry/outputs.tf
+++ b/terraform/cloudfoundry/outputs.tf
@@ -6,6 +6,10 @@ output "cf2_subnet_id" {
   value = "${aws_subnet.cf.1.id}"
 }
 
+output "cf3_subnet_id" {
+  value = "${aws_subnet.cf.2.id}"
+}
+
 output "cell1_subnet_id" {
   value = "${aws_subnet.cell.0.id}"
 }

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -32,7 +32,7 @@ variable "zones" {
 
 variable "zone_count" {
   description = "Number of zones to use"
-  default = 2
+  default = 3
 }
 
 variable "infra_cidrs" {


### PR DESCRIPTION
## What

This adds subnets in a 3rd AZ, and configures etcd and consul to be deployed across all 3 zones.

## How to review

It's necessary to run a complete deployment because this is adding new subnets etc. Run all 3 pipelines in order - create-deployer, create-microbosh and deploy-cloudfoundry. Verify that the deployment works. Verify that the etcd and consul clusters are healthy, and are indeed spread across all 3 availability zones:

* etcd: `/var/vcap/packages/etcd/etcdctl member list` (on one of the etcd servers)
* consul: `/var/vcap/packages/consul/bin/consul members | grep server` (on one of the consul servers)

We have seen issues with the etcd cluster not being healthy after upgrading an existing deployment resulting on the loggregator_trafficcontroller jobs failing with an error contacting etcd. This will require either manual intervention to fix the cluster, or a re-deploy from scratch.

## Who can review

Anyone but @jimconner and myself.