### PR TITLE
[#113824903] Work around terraform diffs bug

### DIFF
--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -98,7 +98,7 @@ jobs:
 
     - task: create-init-bucket
       config:
-        image: docker:///governmentpaas/docker-terraform
+        image: docker:///governmentpaas/terraform
         params:
           TF_VAR_env: {{deploy_env}}
           AWS_DEFAULT_REGION: {{aws_region}}
@@ -169,7 +169,7 @@ jobs:
     - task: deploy-vpc
       config:
         platform: linux
-        image: docker:///governmentpaas/docker-terraform
+        image: docker:///governmentpaas/terraform
         inputs:
         - name: paas-cf
         - name: vpc-terraform-state
@@ -252,7 +252,7 @@ jobs:
 
     - task: terraform-apply
       config:
-        image: docker:///governmentpaas/docker-terraform
+        image: docker:///governmentpaas/terraform
         inputs:
         - name: paas-cf
         - name: vpc-terraform-outputs
@@ -444,7 +444,7 @@ jobs:
     - task: remove-vagrant-IP-from-ssh-SG
       config:
         platform: linux
-        image: docker:///governmentpaas/docker-terraform
+        image: docker:///governmentpaas/terraform
         inputs:
         - name: paas-cf
         - name: vpc-terraform-state
@@ -470,7 +470,7 @@ jobs:
     - task: remove-vagrant-IP-from-concourse-SG
       config:
         platform: linux
-        image: docker:///governmentpaas/docker-terraform
+        image: docker:///governmentpaas/terraform
         inputs:
         - name: paas-cf
         - name: vpc-terraform-outputs

--- a/concourse/pipelines/create-microbosh.yml
+++ b/concourse/pipelines/create-microbosh.yml
@@ -206,7 +206,7 @@ jobs:
         - name: terraform-variables
     - task: terraform-apply
       config:
-        image: docker:///governmentpaas/docker-terraform
+        image: docker:///governmentpaas/terraform
         params:
           DEPLOY_ENV: {{deploy_env}}
           AWS_DEFAULT_REGION: {{aws_region}}

--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -134,7 +134,7 @@ jobs:
               < bosh-tfstate/bosh.tfstate > bosh.tfvars.sh
       - task: terraform
         config:
-          image: docker:///governmentpaas/docker-terraform
+          image: docker:///governmentpaas/terraform
           params:
             TF_VAR_env: {{deploy_env}}
             AWS_DEFAULT_REGION: {{aws_region}}

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -103,7 +103,7 @@ jobs:
               ls -l vpc.tfvars.sh
       - task: cf-terraform-destroy
         config:
-          image: docker:///governmentpaas/docker-terraform
+          image: docker:///governmentpaas/terraform
           params:
             AWS_DEFAULT_REGION: {{aws_region}}
           inputs:

--- a/concourse/pipelines/destroy-deployer.yml
+++ b/concourse/pipelines/destroy-deployer.yml
@@ -113,7 +113,7 @@ jobs:
 
     - task: destroy-concourse-terraform
       config:
-        image: docker:///governmentpaas/docker-terraform
+        image: docker:///governmentpaas/terraform
         inputs:
         - name: paas-cf
         - name: vpc-terraform-outputs
@@ -153,7 +153,7 @@ jobs:
       passed: [destroy-concourse]
     - task: tf-destroy-vpc
       config:
-        image: docker:///governmentpaas/docker-terraform
+        image: docker:///governmentpaas/terraform
         params:
             TF_VAR_env: {{deploy_env}}
             AWS_DEFAULT_REGION: {{aws_region}}
@@ -185,7 +185,7 @@ jobs:
         passed: [destroy-vpc]
       - task: tf-destroy-init-bucket
         config:
-          image: docker:///governmentpaas/docker-terraform
+          image: docker:///governmentpaas/terraform
           params:
               TF_VAR_env: {{deploy_env}}
               AWS_DEFAULT_REGION: {{aws_region}}

--- a/concourse/pipelines/destroy-microbosh.yml
+++ b/concourse/pipelines/destroy-microbosh.yml
@@ -128,7 +128,7 @@ jobs:
         - name: terraform-variables
     - task: terraform-destroy
       config:
-        image: docker:///governmentpaas/docker-terraform
+        image: docker:///governmentpaas/terraform
         params:
           DEPLOY_ENV: {{deploy_env}}
           AWS_DEFAULT_REGION: {{aws_region}}

--- a/terraform/cloudfoundry/security-groups.tf
+++ b/terraform/cloudfoundry/security-groups.tf
@@ -10,13 +10,35 @@ resource "aws_security_group" "web" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  /* FIXME: Merge these two ingress block back together once */
+  /* https://github.com/hashicorp/terraform/issues/5301 is resolved. */
   ingress {
     from_port = 80
     to_port   = 80
     protocol  = "tcp"
     cidr_blocks = [
       "${split(",", var.web_access_cidrs)}",
+      "${var.concourse_elastic_ip}/32",
+    ]
+  }
+
+  ingress {
+    from_port = 80
+    to_port   = 80
+    protocol  = "tcp"
+    cidr_blocks = [
       "${formatlist("%s/32", aws_eip.cf.*.public_ip)}",
+    ]
+  }
+
+  /* FIXME: Merge these two ingress block back together once */
+  /* https://github.com/hashicorp/terraform/issues/5301 is resolved. */
+  ingress {
+    from_port = 443
+    to_port   = 443
+    protocol  = "tcp"
+    cidr_blocks = [
+      "${split(",", var.web_access_cidrs)}",
       "${var.concourse_elastic_ip}/32",
     ]
   }
@@ -26,9 +48,7 @@ resource "aws_security_group" "web" {
     to_port   = 443
     protocol  = "tcp"
     cidr_blocks = [
-      "${split(",", var.web_access_cidrs)}",
       "${formatlist("%s/32", aws_eip.cf.*.public_ip)}",
-      "${var.concourse_elastic_ip}/32",
     ]
   }
 


### PR DESCRIPTION
## What

Terraform currently throws an error with this specific combination of
interpolation functions when the EIPs' public IPs can't be known ahead of
time (ie when they're also being created in the same terraform run).
Splitting these into separate ingress blocks avoids runing into this
issue.  See hashicorp/terraform#5301 for more details.

This also includes @saliceti's change to use the new terraform container. This is so that I can upgrade this to use terraform 0.6.12. On earlier versions terraform will update the security group on every run when it's configured with multiple ingress blocks with matching port ranges. 

## How to review

Run the cloudfoundry terraform job against a clean environment (ie either a brand new deployment, or one that's had the cloudfoundry terraform destroy job run), and verify that it succeeds first time.

Additionally, point the terraform container at the branch with the updated version (`docker:///governmentpaas/terraform#bump_terraform`), and verify that the security group doesn't get updated on every run (it will be updated on the first run with the new version, but shouldn't be on subsequent runs).
## Who can review

Anyone but @dcarley or myself.