### PR TITLE
[#113910983] Prevent network ACL's flapping

### DIFF
--- a/terraform/cloudfoundry/network_acls_cell_in.tf
+++ b/terraform/cloudfoundry/network_acls_cell_in.tf
@@ -1,6 +1,6 @@
 resource "aws_network_acl_rule" "90_local_in" {
     network_acl_id = "${aws_network_acl.cell.id}"
-    protocol = -1
+    protocol = "all"
     rule_number = 90
     rule_action = "allow"
     cidr_block = "${var.vpc_cidr}"

--- a/terraform/cloudfoundry/network_acls_cell_out.tf
+++ b/terraform/cloudfoundry/network_acls_cell_out.tf
@@ -1,6 +1,6 @@
 resource "aws_network_acl_rule" "100_internet_cell_out" {
     network_acl_id = "${aws_network_acl.cell.id}"
-    protocol = -1
+    protocol = "all"
     rule_number = 100
     rule_action = "allow"
     cidr_block = "0.0.0.0/0"

--- a/terraform/cloudfoundry/network_acls_cf_in.tf
+++ b/terraform/cloudfoundry/network_acls_cf_in.tf
@@ -110,7 +110,7 @@ resource "aws_network_acl_rule" "80_etcd" {
 
 resource "aws_network_acl_rule" "90_cf_local_in" {
     network_acl_id = "${aws_network_acl.cf.id}"
-    protocol = -1
+    protocol = "all"
     rule_number = 90
     rule_action = "allow"
     cidr_block = "${var.cf_cidr_all}"
@@ -141,7 +141,7 @@ resource "aws_network_acl_rule" "110_bosh" {
 
 resource "aws_network_acl_rule" "115_router_in" {
     network_acl_id = "${aws_network_acl.cf.id}"
-    protocol = -1
+    protocol = "all"
     rule_number = 115
     rule_action = "allow"
     from_port = 1024
@@ -185,7 +185,7 @@ resource "aws_network_acl_rule" "120_local_drop" {
 
 resource "aws_network_acl_rule" "130_internet_cf_in" {
     network_acl_id = "${aws_network_acl.cf.id}"
-    protocol = -1
+    protocol = "all"
     rule_number = 130
     rule_action = "allow"
     cidr_block = "0.0.0.0/0"

--- a/terraform/cloudfoundry/network_acls_cf_out.tf
+++ b/terraform/cloudfoundry/network_acls_cf_out.tf
@@ -1,6 +1,6 @@
 resource "aws_network_acl_rule" "100_internet_cf_out" {
     network_acl_id = "${aws_network_acl.cf.id}"
-    protocol = -1
+    protocol = "all"
     rule_number = 100
     rule_action = "allow"
     cidr_block = "0.0.0.0/0"


### PR DESCRIPTION
## What

The mapping from `-1` to `all` is broken in terraform acl rules and only works one-way. This means that whenever terraform polls AWS for changes it finds that `-1` (aws) != `all` (statefile). Changing this to `all` in our configuration stops this from occurring.

Open terraform issue is here:
https://github.com/hashicorp/terraform/issues/5226

## How to review

Redeploy a platform, the network acl's should NOT be destroyed and recreated. Do it a couple of times to be sure.

If the PR functions the apply should look like this:

`
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
`

## Who can review

Anybody except @actionjack and @jonty, who have gazed inside terraform and will never be the same again.