### PR TITLE
[#114193485] Pin expunge vagrant to paas-cf version

### DIFF
--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -413,6 +413,7 @@ jobs:
     serial: true
     plan:
     - get: paas-cf
+      passed: [concourse-prepare-deploy]
     - get: build-all-trigger
       trigger: true
       passed: [concourse-deploy]


### PR DESCRIPTION
## What
Use the same paas-cf version as was used in vpc terraform step.
This is because expunge vagrant step is directly related to vpc step, as it is just removing vagrant IP address from SGs, which was added there in the vpc job.

## How to review

* Spin up concourse lite, it can be an existing environment
* Pause the `concourse-prepare-deploy` job
* Start the pipeline
* Make a change in terraform that will break it, eg syntax error
* Push to the branch
* Unpause the job
* `expunge-vagrant` should be able to run because it is pinned to paas-cf with the working terraform

## Who can review
Anyone but @mtekel or me
