### PR TITLE
[#113996483] Ensure all components have consolidated logging

### DIFF
--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -6,6 +6,10 @@ meta:
   release:
     name: cf
 
+  logsearch_shipper:
+    release:
+      name: "logsearch-shipper"
+
   etcd_consul_service: ["etcd.service.cf.internal"]
 
   consul_servers: (( grab jobs.consul_z1.networks.cf1.static_ips jobs.consul_z2.networks.cf2.static_ips jobs.consul_z3.networks.cf3.static_ips ))
@@ -43,6 +47,8 @@ meta:
     release: (( grab meta.release.name ))
   - name: route_registrar
     release: (( grab meta.release.name ))
+  - release: "logsearch-shipper"
+    name: (( grab meta.logsearch_shipper.release.name ))
 
   api_worker_templates:
   - name: cloud_controller_worker
@@ -53,18 +59,24 @@ meta:
     release: (( grab meta.consul_templates.consul_agent.release ))
   - name: nfs_mounter
     release: (( grab meta.release.name ))
+  - release: "logsearch-shipper"
+    name: (( grab meta.logsearch_shipper.release.name ))
 
   clock_templates:
   - name: cloud_controller_clock
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
+  - release: "logsearch-shipper"
+    name: (( grab meta.logsearch_shipper.release.name ))
 
   consul_templates:
   - name: consul_agent
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
+  - release: "logsearch-shipper"
+    name: (( grab meta.logsearch_shipper.release.name ))
 
   etcd_templates:
   - name: etcd
@@ -75,7 +87,8 @@ meta:
     release: (( grab meta.release.name ))
   - name: consul_agent
     release: (( grab meta.release.name ))
-
+  - release: "logsearch-shipper"
+    name: (( grab meta.logsearch_shipper.release.name ))
 
   ha_proxy_templates:
   - name: haproxy
@@ -84,6 +97,8 @@ meta:
     release: (( grab meta.release.name ))
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
+  - release: "logsearch-shipper"
+    name: (( grab meta.logsearch_shipper.release.name ))
 
   loggregator_templates:
   - name: doppler
@@ -94,6 +109,8 @@ meta:
     release: (( grab meta.release.name ))
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
+  - release: "logsearch-shipper"
+    name: (( grab meta.logsearch_shipper.release.name ))
 
   loggregator_trafficcontroller_routes:
   - name: doppler
@@ -105,6 +122,7 @@ meta:
     uris:
     - (( concat "loggregator." properties.domain ))
 
+
   loggregator_trafficcontroller_templates:
   - name: loggregator_trafficcontroller
     release: (( grab meta.release.name ))
@@ -114,6 +132,8 @@ meta:
     release: (( grab meta.release.name ))
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
+  - release: "logsearch-shipper"
+    name: (( grab meta.logsearch_shipper.release.name ))
 
   nats_templates:
   - name: nats
@@ -132,6 +152,8 @@ meta:
     release: (( grab meta.release.name ))
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
+  - release: "logsearch-shipper"
+    name: (( grab meta.logsearch_shipper.release.name ))
 
   postgres_templates:
   - name: postgres
@@ -140,6 +162,8 @@ meta:
     release: (( grab meta.release.name ))
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
+  - release: "logsearch-shipper"
+    name: (( grab meta.logsearch_shipper.release.name ))
 
   router_templates:
   - name: gorouter
@@ -148,6 +172,8 @@ meta:
     release: (( grab meta.release.name ))
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
+  - release: "logsearch-shipper"
+    name: (( grab meta.logsearch_shipper.release.name ))
 
   stats_templates:
   - name: collector
@@ -156,6 +182,8 @@ meta:
     release: (( grab meta.release.name ))
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
+  - release: "logsearch-shipper"
+    name: (( grab meta.logsearch_shipper.release.name ))
 
   uaa_routes:
   - name: uaa
@@ -179,6 +207,8 @@ meta:
     release: (( grab meta.release.name ))
   - name: statsd-injector
     release: (( grab meta.release.name ))
+  - release: "logsearch-shipper"
+    name: (( grab meta.logsearch_shipper.release.name ))
 
 jobs:
   - name: consul_z1

--- a/manifests/cf-manifest/deployments/050-logsearch.yml
+++ b/manifests/cf-manifest/deployments/050-logsearch.yml
@@ -326,5 +326,7 @@ properties:
     port: 2514
     transport: relp
   logsearch:
+    metrics:
+      enabled: false
     logs:
       server: (( concat jobs.ingestor.networks.cf1.static_ips.[0] ":5514" ))

--- a/manifests/cf-manifest/deployments/050-logsearch.yml
+++ b/manifests/cf-manifest/deployments/050-logsearch.yml
@@ -3,6 +3,10 @@ releases:
   url: https://bosh.io/d/github.com/logsearch/logsearch-boshrelease?v=200.0.0
   version: 200.0.0
   sha1: 527c35db31cd66810accf128ceffee4f5fde80c3
+- name: logsearch-shipper
+  url: https://bosh.io/d/github.com/logsearch/logsearch-shipper-boshrelease?v=4
+  version: 4
+  sha1: c92ce357c5e1e77a4fb7944d58a1971c7aee06b0
 
 disk_pools:
 - name: elasticsearch_master
@@ -179,6 +183,7 @@ jobs:
     logstash_parser:
       filters:
       - metrics: /var/vcap/packages/logsearch-config/logstash-filters-metric.conf
+
     nats_to_syslog:
       nats:
         subject: ">"
@@ -320,3 +325,6 @@ properties:
     address: (( grab jobs.ingestor.networks.cf1.static_ips.[0] ))
     port: 2514
     transport: relp
+  logsearch:
+    logs:
+      server: (( concat jobs.ingestor.networks.cf1.static_ips.[0] ":5514" ))


### PR DESCRIPTION
[Ensure all components have consolidated logging](https://www.pivotaltracker.com/story/show/113996483)

## What

Acceptance criteria:

if it logs and it is a system component
then its logs should appear in logsearch
or there should be a story to implement the logs

After reviewing our logsearch implementation we found that we are not logging all events most notably we are missing the all the logs under `/var/vcap/*/*.log` 

This PR 
Installs and configures [logsearch-shipper-boshrelease](https://github.com/logsearch/logsearch-shipper-boshrelease)
to ensure all the logs under `/var/vcap/*/*.log` are sent to logsearch
ingestor. This commit is fairly large because it is non-breaking.

## How this PR should be reviewed

I've drafted this PR to be reviewed in the following context:

* I would like to:
  * Install the logsearch-shipper bosh release
  * Add the logsearch-shipper to each node
  * Configure the logsearch-shipper to send logs to the logsearch ingestor node
  * Disable Metrics collection and metrics field tagging because we are not going to use them 

## How to Review this PR

Deploy or update your existing deployment. Create ssh tunnel via deployer concourse to kibana:
ssh -L 5601:10.0.16.49:5601 -i $session/id_rsa vcap@$DEPLOYER_CONCOURSE. You should be able to browse logs and see them appearing in real time.
You can also connect to one of the nodes and verify that the logs are being parsed by the logsearch-shipper process.


## Who can review this PR

This PR can be reviewed by a android who is dreaming of electric sheep if a product of the Tyrell corporation can not be found then any member of the corp team will do with the exception of @actionjack and @tmower