### PR TITLE
[#114080971] New makefile targets per environment 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
-.PHONY: test spec lint_yaml lint_terraform lint_shellcheck set_aws_count set_auto_trigger disable_auto_delete check-env-vars dev ci stage prod
+.PHONY: help test spec lint_yaml lint_terraform lint_shellcheck set_aws_count set_auto_trigger disable_auto_delete check-env-vars dev ci stage prod
+
+.DEFAULT_GOAL := help
+
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 SHELLCHECK=shellcheck
 YAMLLINT=yamllint
@@ -6,7 +11,7 @@ YAMLLINT=yamllint
 check-env-vars:
 	$(if ${DEPLOY_ENV},,$(error Must pass DEPLOY_ENV=<name>))
 
-test: spec lint_yaml lint_terraform lint_shellcheck
+test: spec lint_yaml lint_terraform lint_shellcheck ## Run linting tests
 
 spec:
 	cd manifests/bosh-manifest &&\
@@ -23,13 +28,13 @@ lint_terraform:
 lint_shellcheck:
 	find . -name '*.sh' -print0 | xargs -0 $(SHELLCHECK)
 
-dev: check-env-vars set_aws_account_dev deploy_pipelines
+dev: check-env-vars set_aws_account_dev deploy_pipelines ## Deploy Pipelines to Dev Environment
 
-ci: check-env-vars set_aws_account_ci set_auto_trigger disable_auto_delete deploy_pipelines
+ci: check-env-vars set_aws_account_ci set_auto_trigger disable_auto_delete deploy_pipelines  ## Deploy Pipelines to CI Environment
 
-stage: check-env-vars set_aws_account_stage disable_auto_delete set_auto_trigger deploy_pipelines
+stage: check-env-vars set_aws_account_stage disable_auto_delete set_auto_trigger deploy_pipelines  ## Deploy Pipelines to Staging Environment
 
-prod: check-env-vars set_aws_account_prod disable_auto_delete set_auto_trigger deploy_pipelines
+prod: check-env-vars set_aws_account_prod disable_auto_delete set_auto_trigger deploy_pipelines  ## Deploy Pipelines to Production Environment
 
 set_aws_account_dev:
 	$(eval export AWS_ACCOUNT=dev)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: test spec lint_yaml lint_terraform lint_shellcheck
+.PHONY: test spec lint_yaml lint_terraform lint_shellcheck set_aws_count set_auto_trigger disable_auto_delete check-env-vars dev ci stage prod
 
 SHELLCHECK=shellcheck
 YAMLLINT=yamllint
+
+check-env-vars:
+	$(if ${DEPLOY_ENV},,$(error Must pass DEPLOY_ENV=<name>))
 
 test: spec lint_yaml lint_terraform lint_shellcheck
 
@@ -19,3 +22,33 @@ lint_terraform:
 
 lint_shellcheck:
 	find . -name '*.sh' -print0 | xargs -0 $(SHELLCHECK)
+
+dev: check-env-vars set_aws_account_dev deploy_pipelines
+
+ci: check-env-vars set_aws_account_ci set_auto_trigger disable_auto_delete deploy_pipelines
+
+stage: check-env-vars set_aws_account_stage disable_auto_delete set_auto_trigger deploy_pipelines
+
+prod: check-env-vars set_aws_account_prod disable_auto_delete set_auto_trigger deploy_pipelines
+
+set_aws_account_dev:
+	$(eval export AWS_ACCOUNT=dev)
+
+set_aws_account_ci:
+	$(eval export AWS_ACCOUNT=ci)
+
+set_aws_account_stage:
+	$(eval export AWS_ACCOUNT=stage)
+
+set_aws_account_prod:
+	$(eval export AWS_ACCOUNT=prod)
+
+set_auto_trigger:
+	$(eval export ENABLE_AUTO_DEPLOY=true)
+
+disable_auto_delete:
+	$(eval export DISABLE_AUTODELETE=1)
+
+deploy_pipelines:
+	concourse/scripts/pipelines-microbosh.sh
+	concourse/scripts/pipelines-cloudfoundry.sh


### PR DESCRIPTION
## What

We want our Makefile to support a target per environment so for instance it would be possible to do `make dev` to upload DEV pipeline. Additionally we want help to be available as a default target. 

## How to review

Check whether prod,stage,ci and dev targets deploy pipelines with following config:

- Prod
  - multi AZ
  - AWS account PROD
- Staging
  - multi AZ
  - AWS account  STG
- Ci
 - AWS account CI
 - auto trigger on paas-cf
- Dev
  - AWS account DEV
  - autodelete

## Who can review

Anyone but @actionjack or @combor