### PR TITLE
[#114385219] Update deployer concourse

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -29,6 +29,7 @@ jobs:
     - get: paas-cf
     - task: delete-deployment
       config:
+        platform: linux
         inputs:
         - name: delete-timer
         - name: bosh-secrets

--- a/concourse/pipelines/create-microbosh.yml
+++ b/concourse/pipelines/create-microbosh.yml
@@ -141,9 +141,12 @@ jobs:
     - try:
         task: generate
         config:
+          platform: linux
           image: docker:///governmentpaas/certstrap
           inputs:
           - name: bosh-CA
+          outputs:
+          - name: generate
           run:
             path: sh
             args:
@@ -154,6 +157,7 @@ jobs:
                 certstrap init --passphrase "" --common-name bosh-CA
                 cd out
                 tar -cvzf ../bosh-CA.tar.gz bosh-CA.*
+                cp ../bosh-CA.tar.gz ../generate
               else
                 echo "The CA cert already exists, skipping generation..."
                 exit 1
@@ -177,6 +181,7 @@ jobs:
     - get: bosh-tfstate
     - task: terraform-variables
       config:
+        platform: linux
         image: docker:///ruby#2.2.3-slim
         run:
           path: sh
@@ -198,6 +203,7 @@ jobs:
         - name: terraform-variables
     - task: terraform-apply
       config:
+        platform: linux
         image: docker:///governmentpaas/terraform
         params:
           DEPLOY_ENV: {{deploy_env}}
@@ -216,7 +222,9 @@ jobs:
             . terraform-variables/concourse.tfvars.sh
 
             terraform apply -var env={{deploy_env}} -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
-              -state=bosh-tfstate/bosh.tfstate -state-out=bosh.tfstate paas-cf/terraform/bosh
+              -state=bosh-tfstate/bosh.tfstate -state-out=terraform-apply/bosh.tfstate paas-cf/terraform/bosh
+        outputs:
+        - name: terraform-apply
       ensure:
         put: bosh-tfstate
         params:
@@ -243,6 +251,7 @@ jobs:
       passed: [generate-CA-certs]
     - task: terraform_outputs
       config:
+        platform: linux
         image: docker:///ruby#2.2.3-slim
         run:
           path: sh
@@ -264,6 +273,7 @@ jobs:
         - name: terraform-outputs
     - task: bosh-cert
       config:
+        platform: linux
         image: docker:///alpine#3.3
         run:
           path: sh
@@ -272,12 +282,15 @@ jobs:
           - -c
           - |
             tar -xzf bosh-CA/bosh-CA.tar.gz
-            paas-cf/concourse/scripts/file-to-yaml.sh secrets bosh_ca_cert bosh-CA.crt > bosh-ca-cert.yml
+            paas-cf/concourse/scripts/file-to-yaml.sh secrets bosh_ca_cert bosh-CA.crt > bosh-cert/bosh-ca-cert.yml
         inputs:
         - name: paas-cf
         - name: bosh-CA
+        outputs:
+        - name: bosh-cert
     - task: render-manifest
       config:
+        platform: linux
         image: docker:///governmentpaas/spruce
         params:
           BOSH_MANIFEST_STUBS: |
@@ -318,6 +331,7 @@ jobs:
 
     - task: bosh-init-microbosh
       config:
+        platform: linux
         image: docker:///governmentpaas/bosh-init
         run:
           path: sh
@@ -330,11 +344,14 @@ jobs:
             chmod 400 bosh-manifest/.ssh/id_rsa
             cp bosh-init-state/bosh-manifest-state.json bosh-manifest/bosh-manifest-state.json
             bosh-init deploy bosh-manifest/bosh-manifest.yml
+            cp bosh-manifest/bosh-manifest-state.json bosh-init-microbosh/bosh-manifest-state.json
         inputs:
         - name: bosh-manifest
         - name: bosh-init-state
         - name: ssh-private-key
+        outputs:
+        - name: bosh-init-microbosh
       ensure:
         put: bosh-init-state
         params:
-          file: bosh-init-microbosh/bosh-manifest/bosh-manifest-state.json
+          file: bosh-init-microbosh/bosh-manifest-state.json

--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -91,6 +91,7 @@ jobs:
         trigger: {{auto_deploy}}
       - task: init
         config:
+          platform: linux
           image: docker:///governmentpaas/curl-ssl
           run:
             path: sh
@@ -162,6 +163,7 @@ jobs:
 
       - task: terraform-variables
         config:
+          platform: linux
           image: docker:///ruby
           inputs:
             - name: paas-cf
@@ -176,16 +178,18 @@ jobs:
             - -c
             - |
               ruby paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
-              < vpc-tfstate/vpc.tfstate > vpc.tfvars.sh
+              < vpc-tfstate/vpc.tfstate > terraform-variables/vpc.tfvars.sh
               ruby paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
-              < concourse-tfstate/concourse.tfstate > concourse.tfvars.sh
+              < concourse-tfstate/concourse.tfstate > terraform-variables/concourse.tfvars.sh
               ruby paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
-              < bosh-tfstate/bosh.tfstate > bosh.tfvars.sh
+              < bosh-tfstate/bosh.tfstate > terraform-variables/bosh.tfvars.sh
               ruby paas-cf/concourse/scripts/extract_tf_vars_from_yaml.rb \
-              < cf-secrets/cf-secrets.yml > cf-secrets.tfvars.sh
-
+              < cf-secrets/cf-secrets.yml > terraform-variables/cf-secrets.tfvars.sh
+          outputs:
+            - name: terraform-variables
       - task: terraform
         config:
+          platform: linux
           image: docker:///governmentpaas/terraform
           params:
             TF_VAR_env: {{deploy_env}}
@@ -206,7 +210,9 @@ jobs:
               . terraform-variables/cf-secrets.tfvars.sh
 
               terraform apply -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
-                -state=cf-tfstate/cf.tfstate -state-out=cf.tfstate paas-cf/terraform/cloudfoundry
+                -state=cf-tfstate/cf.tfstate -state-out=terraform/cf.tfstate paas-cf/terraform/cloudfoundry
+          outputs:
+            - name: terraform
         ensure:
           put: cf-tfstate
           params:
@@ -227,11 +233,13 @@ jobs:
             - |
               SCPATH="./paas-cf/concourse/scripts"
               SCFILE="extract_tf_vars_from_terraform_state.rb"
-              $SCPATH/$SCFILE < cf-tfstate/cf.tfstate > cf.tfstate.sh
-              ls -l cf.tfstate.sh
-
+              $SCPATH/$SCFILE < cf-tfstate/cf.tfstate > extract-cf-terraform-outputs/cf.tfstate.sh
+              ls -l extract-cf-terraform-outputs/cf.tfstate.sh
+          outputs:
+            - name: extract-cf-terraform-outputs
       - task: init-db
         config:
+          platform: linux
           image: docker:///governmentpaas/psql
           inputs:
             - name: terraform-variables
@@ -263,6 +271,7 @@ jobs:
           passed: ['terraform']
       - task: terraform-variables
         config:
+          platform: linux
           image: docker:///ruby#2.2-slim
           inputs:
             - name: paas-cf
@@ -274,9 +283,12 @@ jobs:
             - -c
             - |
               ruby paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
-                < cf-tfstate/cf.tfstate > cf.tfvars.sh
+                < cf-tfstate/cf.tfstate > terraform-variables/cf.tfvars.sh
+          outputs:
+            - name: terraform-variables
       - task: generate-cf-certs
         config:
+          platform: linux
           image: docker:///governmentpaas/certstrap
           inputs:
           - name: bosh-CA
@@ -329,11 +341,14 @@ jobs:
         - get: cf-secrets
       - task: cf-certs-yaml
         config:
+          platform: linux
           image: docker:///governmentpaas/certstrap
           inputs:
           - name: bosh-CA
           - name: paas-cf
           - name: cf-certs
+          outputs:
+          - name: cf-certs-yaml
           run:
             path: sh
             args:
@@ -357,6 +372,7 @@ jobs:
               echo "Generating uaa_jwt_signing public key from private key"
               openssl rsa -pubout -in uaa_jwt_signing.key -out uaa_jwt_verification.pem
               paas-cf/concourse/scripts/file-to-yaml.sh secrets uaa_jwt_verification_key uaa_jwt_verification.pem  > uaa_jwt_verification_key.yml
+              cp *.yml cf-certs-yaml
 
       - task: extract-terraform-outputs
         config:
@@ -368,6 +384,8 @@ jobs:
             - name: bosh-tfstate
             - name: concourse-tfstate
             - name: cf-tfstate
+          outputs:
+            - name: extract-terraform-outputs
           run:
             path: sh
             args:
@@ -377,7 +395,7 @@ jobs:
               SCPATH="./paas-cf/concourse/scripts"
               SCFILE="extract_terraform_state_to_yaml.rb"
               for state in vpc bosh concourse cf; do
-                $SCPATH/$SCFILE < $state-tfstate/$state.tfstate > $state.yml
+                $SCPATH/$SCFILE < $state-tfstate/$state.tfstate > extract-terraform-outputs/$state.yml
               done
 
       - task: generate-manifest
@@ -394,13 +412,15 @@ jobs:
             - name: extract-terraform-outputs
             - name: cf-secrets
             - name: cf-certs-yaml
+          outputs:
+            - name: generate-manifest
           run:
             path: sh
             args:
             - -e
             - -c
             - |
-              ./paas-cf/manifests/cf-manifest/build_manifest.sh $MANIFEST_STUBS > cf-manifest.yml
+              ./paas-cf/manifests/cf-manifest/build_manifest.sh $MANIFEST_STUBS > generate-manifest/cf-manifest.yml
       - put: cf-manifest
         params:
           file: generate-manifest/cf-manifest.yml
@@ -421,12 +441,14 @@ jobs:
         - get: bosh-secrets
       - task: cf-deploy
         config:
+          platform: linux
           image: docker:///governmentpaas/bosh-cli
           inputs:
           - name: paas-cf
           - name: cf-manifest
           - name: bosh-secrets
-          platform: linux
+          outputs:
+          - name: cf-deploy
           run:
             path: sh
             args:
@@ -434,8 +456,8 @@ jobs:
             - -c
             - |
               ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
-              sed -e "s/^director_uuid:.*/director_uuid: $(bosh status --uuid)/" < cf-manifest/cf-manifest.yml > cf-manifest.yml
-              bosh deployment cf-manifest.yml
+              sed -e "s/^director_uuid:.*/director_uuid: $(bosh status --uuid)/" < cf-manifest/cf-manifest.yml > cf-deploy/cf-manifest.yml
+              bosh deployment cf-deploy/cf-manifest.yml
               bosh -n deploy
 
       - put: cf-manifest
@@ -460,6 +482,7 @@ jobs:
       - get: bosh-CA
     - task: generate-test-config
       config:
+        platform: linux
         inputs:
         - name: cf-release
         - name: paas-cf
@@ -489,6 +512,7 @@ jobs:
 
     - task: run-tests
       config:
+        platform: linux
         inputs:
         - name: paas-cf
         - name: cf-release
@@ -533,6 +557,7 @@ jobs:
       - get: bosh-CA
     - task: generate-test-config
       config:
+        platform: linux
         inputs:
         - name: cf-release
         - name: paas-cf
@@ -562,6 +587,7 @@ jobs:
 
     - task: run-tests
       config:
+        platform: linux
         inputs:
         - name: paas-cf
         - name: cf-release
@@ -605,6 +631,7 @@ jobs:
       - get: bosh-CA
     - task: generate-test-config
       config:
+        platform: linux
         inputs:
           - name: paas-cf
           - name: cf-manifest
@@ -622,6 +649,7 @@ jobs:
               > test-config/config.json
     - task: run-tests
       config:
+        platform: linux
         inputs:
           - name: paas-cf
           - name: test-config

--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -534,10 +534,6 @@ jobs:
             ln -snf $(pwd)/test-config/config.json /var/vcap/jobs/smoke-tests/bin/config.json
             ln -snf $(pwd)/test-config/run /var/vcap/jobs/smoke-tests/bin/run
             ln -snf /usr/local/go /var/vcap/packages/golang1.4
-            cd cf-release
-            git checkout v{{cf-release-version}}
-            git submodule update --checkout src/smoke-tests/
-            cd ..
             ln -snf $(pwd)/cf-release/src/smoke-tests /var/vcap/packages/smoke-tests/src/github.com/cloudfoundry/cf-smoke-tests
             /var/vcap/jobs/smoke-tests/bin/run
 
@@ -609,10 +605,6 @@ jobs:
             ln -snf $(pwd)/test-config/config.json /var/vcap/jobs/acceptance-tests/bin/config.json
             ln -snf $(pwd)/test-config/run /var/vcap/jobs/acceptance-tests/bin/run
             ln -snf /usr/local/go /var/vcap/packages/golang1.4
-            cd cf-release
-            git checkout v{{cf-release-version}}
-            git submodule update --checkout src/github.com/cloudfoundry/cf-acceptance-tests/
-            cd ..
             sed -i 's/bits=@"%s"/bits=@%s/' cf-release/src/github.com/cloudfoundry/cf-acceptance-tests/helpers/v3_helpers/v3.go
             ln -snf $(pwd)/cf-release/src/github.com/cloudfoundry/cf-acceptance-tests /var/vcap/packages/acceptance-tests/src/github.com/cloudfoundry/
             /var/vcap/jobs/acceptance-tests/bin/run

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -57,6 +57,7 @@ jobs:
         - get: paas-cf
       - task: delete-deployment
         config:
+          platform: linux
           inputs:
           - name: bosh-secrets
           - name: paas-cf
@@ -89,6 +90,7 @@ jobs:
 
       - task: terraform-variables
         config:
+          platform: linux
           image: docker:///ruby#2.2.3-slim
           inputs:
             - name: paas-cf
@@ -103,19 +105,22 @@ jobs:
             - -c
             - |
               ruby paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
-              < cf-tfstate/cf.tfstate > cf.tfvars.sh
-              ls -l cf.tfvars.sh
+              < cf-tfstate/cf.tfstate > terraform-variables/cf.tfvars.sh
+              ls -l terraform-variables/cf.tfvars.sh
               ruby paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
-              < concourse-tfstate/concourse.tfstate > concourse.tfvars.sh
-              ls -l concourse.tfvars.sh
+              < concourse-tfstate/concourse.tfstate > terraform-variables/concourse.tfvars.sh
+              ls -l terraform-variables/concourse.tfvars.sh
               ruby paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
-              < vpc-tfstate/vpc.tfstate > vpc.tfvars.sh
-              ls -l vpc.tfvars.sh
+              < vpc-tfstate/vpc.tfstate > terraform-variables/vpc.tfvars.sh
+              ls -l terraform-variables/vpc.tfvars.sh
               ruby paas-cf/concourse/scripts/extract_tf_vars_from_yaml.rb \
-              < cf-secrets/cf-secrets.yml > cf-secrets.tfvars.sh
-              ls -l cf-secrets.tfvars.sh
+              < cf-secrets/cf-secrets.yml > terraform-variables/cf-secrets.tfvars.sh
+              ls -l terraform-variables/cf-secrets.tfvars.sh
+          outputs:
+            - name: terraform-variables
       - task: cf-terraform-destroy
         config:
+          platform: linux
           image: docker:///governmentpaas/terraform
           params:
             AWS_DEFAULT_REGION: {{aws_region}}
@@ -135,7 +140,9 @@ jobs:
               . terraform-variables/cf-secrets.tfvars.sh
 
               terraform destroy -force -var env={{deploy_env}} -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
-                -state=cf-tfstate/cf.tfstate -state-out=cf.tfstate paas-cf/terraform/cloudfoundry
+                -state=cf-tfstate/cf.tfstate -state-out=cf-terraform-destroy/cf.tfstate paas-cf/terraform/cloudfoundry
+          outputs:
+            - name: cf-terraform-destroy
         ensure:
           put: cf-tfstate
           params:

--- a/concourse/pipelines/destroy-microbosh.yml
+++ b/concourse/pipelines/destroy-microbosh.yml
@@ -74,6 +74,7 @@ jobs:
     - get: bosh-manifest
     - task: bosh-init-microbosh
       config:
+        platform: linux
         image: docker:///governmentpaas/bosh-init
         run:
           path: sh
@@ -84,16 +85,21 @@ jobs:
             cp bosh-init-state/bosh-manifest-state.json bosh-manifest/bosh-manifest-state.json
             bosh-init delete bosh-manifest/bosh-manifest.yml
             # If the delete is successful, the file will be missing
-            [ -f "bosh-manifest/bosh-manifest-state.json" ] || \
-                cp paas-cf/concourse/init_files/bosh-init-state.json.tpl bosh-manifest/bosh-manifest-state.json
+            if [ -f "bosh-manifest/bosh-manifest-state.json" ] ; then
+                cp bosh-manifest/bosh-manifest-state.json bosh-init-microbosh/bosh-manifest-state.json
+            else
+                cp paas-cf/concourse/init_files/bosh-init-state.json.tpl bosh-init-microbosh/bosh-manifest-state.json
+            fi
         inputs:
         - name: paas-cf
         - name: bosh-manifest
         - name: bosh-init-state
+        outputs:
+        - name: bosh-init-microbosh
       ensure:
         put: bosh-init-state
         params:
-          file: bosh-init-microbosh/bosh-manifest/bosh-manifest-state.json
+          file: bosh-init-microbosh/bosh-manifest-state.json
 
   - name: bosh-terraform-destroy
     serial: true
@@ -107,6 +113,7 @@ jobs:
     - get: bosh-tfstate
     - task: terraform-variables
       config:
+        platform: linux
         image: docker:///governmentpaas/bosh-init
         run:
           path: sh
@@ -128,6 +135,7 @@ jobs:
         - name: terraform-variables
     - task: terraform-destroy
       config:
+        platform: linux
         image: docker:///governmentpaas/terraform
         params:
           DEPLOY_ENV: {{deploy_env}}
@@ -146,7 +154,9 @@ jobs:
             . terraform-variables/concourse.tfvars.sh
 
             terraform destroy -force -var env={{deploy_env}} -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
-              -state=bosh-tfstate/bosh.tfstate -state-out=bosh.tfstate paas-cf/terraform/bosh
+              -state=bosh-tfstate/bosh.tfstate -state-out=terraform-destroy/bosh.tfstate paas-cf/terraform/bosh
+        outputs:
+        - name: terraform-destroy
       ensure:
         put: bosh-tfstate
         params:

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -29,7 +29,7 @@ pipeline_trigger_file: ${trigger_file}
 branch_name: ${BRANCH:-master}
 aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
 debug: ${DEBUG:-}
-cf-release-version: ${cf_release_version}
+cf-release-version: v${cf_release_version}
 EOF
 }
 

--- a/manifests/concourse-base.yml
+++ b/manifests/concourse-base.yml
@@ -78,7 +78,7 @@ jobs:
 
     properties:
       atc:
-        external_url: ""
+        external_url: (( concat "https://" terraform_outputs.concourse_dns_name ))
         basic_auth_username: admin
         basic_auth_password: (( grab secrets.concourse_atc_password ))
         postgresql:

--- a/manifests/concourse-base.yml
+++ b/manifests/concourse-base.yml
@@ -6,8 +6,8 @@ releases:
     url: https://bosh.io/d/github.com/concourse/concourse?v=0.74.0
     sha1: c99ef709e9d4468ac25cca31dd5be1444417011d
   - name: garden-linux
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/garden-linux-release?v=0.328.0
-    sha1: 539822f9f2b18ccf51e72e42e03b297f934ea3fe
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/garden-linux-release?v=0.334.0
+    sha1: 85170c5089fa4ff317f139c2f1da024860dbea85
   # When updating the version of the CPI here, the version used in the
   # bosh-init container must also be updated so that the cached CPI compile
   # will be used.
@@ -98,6 +98,7 @@ jobs:
       garden:
         listen_network: tcp
         listen_address: 0.0.0.0:7777
+        graph_cleanup_threshold_in_mb: 3072
       groundcrew:
         tsa:
           host: 127.0.0.1

--- a/manifests/concourse-base.yml
+++ b/manifests/concourse-base.yml
@@ -19,8 +19,8 @@ resource_pools:
   - name: concourse
     network: concourse
     stemcell:
-      url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3197
-      sha1: 89a2210b8caf3884855d7db6d48b8863202c7783
+      url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3200
+      sha1: 9ec6f6affe369f3364eb0db55266a513d3298080
     cloud_properties:
       instance_type: t2.medium
       availability_zone: (( grab terraform_outputs.zone0 ))

--- a/manifests/concourse-base.yml
+++ b/manifests/concourse-base.yml
@@ -3,8 +3,8 @@ name: concourse
 
 releases:
   - name: concourse
-    url: https://bosh.io/d/github.com/concourse/concourse?v=0.70.0
-    sha1: bbec7785856a5c8ba5f05b106ea79821b620bbc9
+    url: https://bosh.io/d/github.com/concourse/concourse?v=0.74.0
+    sha1: c99ef709e9d4468ac25cca31dd5be1444417011d
   - name: garden-linux
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/garden-linux-release?v=0.328.0
     sha1: 539822f9f2b18ccf51e72e42e03b297f934ea3fe
@@ -78,6 +78,7 @@ jobs:
 
     properties:
       atc:
+        external_url: ""
         basic_auth_username: admin
         basic_auth_password: (( grab secrets.concourse_atc_password ))
         postgresql:

--- a/terraform/concourse/outputs.tf
+++ b/terraform/concourse/outputs.tf
@@ -13,3 +13,7 @@ output "concourse_security_group_id" {
 output "concourse_elb_name" {
   value = "${aws_elb.concourse.name}"
 }
+
+output "concourse_dns_name" {
+  value = "${aws_route53_record.deployer-concourse.name}"
+}


### PR DESCRIPTION
## What

[Upgrade Concourse](https://www.pivotaltracker.com/n/projects/1275640/stories/114385219)

This PR updates deployer concourse to version 0.74 (this includes updates to stemcell and garden linux). In the new concourse version, each task has to have platform defined. Moreover, you can't input whole task any more, but have to define task outputs explicitly. This PR also contains minimal changes to pipelines to satisfy these new requirements. The pipeline update commits have been split into logical chunks, so that it is not a single huge commit: update bosh pipelines, update CF delete pipelines and update main CF pipeline.

## How to review

Switch to this branch, apply against your existing environment (update works fine and preserves all your changes/pipelines from previous concourse). Or you can deploy new. After deployment, you should be able to admire the shiny new mustard-yellow/pea green concourse theme. Run the pipelines and verify they still work like before upgrading. I suggest testing the create pipelines first and destroy last (preferably, destroy CF first and then destroy bosh) - this saves time.

## Who can review

Someone else than me.