### PR TITLE
[#114186797]  template render: use default only if value == nil

### DIFF
--- a/tests/bosh-template-renderer/render_lib.rb
+++ b/tests/bosh-template-renderer/render_lib.rb
@@ -28,7 +28,7 @@ class Hash
       prop_key = "properties.#{key}"
       default = val["default"]
       if not default.nil?
-        if not self.dig(prop_key)
+        if self.dig(prop_key).nil?
           self.dig_add(prop_key, default)
         end
       end

--- a/tests/bosh-template-renderer/spec/render_lib_spec.rb
+++ b/tests/bosh-template-renderer/spec/render_lib_spec.rb
@@ -98,6 +98,13 @@ properties:
     expect(result).to eq("a.b.c is foo and a.b.d is foobar")
   end
 
+  it "does not override a false value with the default" do
+    template = "a.b.c is <%= p('a.b.c') %> and a.b.d is <%= p('a.b.d') %>"
+    example_manifest_with_false = example_manifest.sub('foo', 'false')
+    result = render_template(template, YAML.load(example_spec), YAML.load(example_manifest_with_false))
+    expect(result).to eq("a.b.c is false and a.b.d is foobar")
+  end
+
   it "uses a normalised version of the manifest which allows discover external_ip" do
     template = %q{<%
 def discover_external_ip


### PR DESCRIPTION
What
----

When rendering a template, check if the manifest value is nil, not if it
evaluates false. If not, we cannot define 'false' as a value in the
manifest.

This fixes a minor bug.

How to test
-----------

A test has been added to the code. Do `make test`

Who?
----

Anyone but @keymon