### PR TITLE
[#114186797] Do not get `bosh-secrets` in smoke/acceptance tests

### DIFF
--- a/concourse/pipelines/deploy-cloudfoundry.yml
+++ b/concourse/pipelines/deploy-cloudfoundry.yml
@@ -456,7 +456,6 @@ jobs:
         passed: ['deploy']
       - get: cf-manifest
         passed: ['deploy']
-      - get: bosh-secrets
       - get: bosh-CA
     - task: generate-test-config
       config:
@@ -493,7 +492,6 @@ jobs:
         - name: paas-cf
         - name: cf-release
         - name: cf-manifest
-        - name: bosh-secrets
         - name: test-config
         - name: bosh-CA
         image: docker:///governmentpaas/cf-acceptance-tests
@@ -529,7 +527,6 @@ jobs:
       - get: cf-manifest
         passed: ['deploy']
         trigger: true
-      - get: bosh-secrets
       - get: bosh-CA
     - task: generate-test-config
       config:
@@ -566,7 +563,6 @@ jobs:
         - name: paas-cf
         - name: cf-release
         - name: cf-manifest
-        - name: bosh-secrets
         - name: test-config
         - name: bosh-CA
         image: docker:///governmentpaas/cf-acceptance-tests


### PR DESCRIPTION
what
----

Continuation of #127

As we run the smoke tests and acceptance tests as tasks in concourse,
we don't need to start a errand, so we don't need to login in bosh,
so we don't need bosh-secrets in these tasks anymore.

How to tests
------------

Simply run the smoke and acceptance tests

Who?
----

Anyone but @keymon