### PR TITLE
[#114186797] Remove smoke/acceptance test errand defintions.

### DIFF
--- a/manifests/cf-manifest/deployments/900-cf-tests.yml
+++ b/manifests/cf-manifest/deployments/900-cf-tests.yml
@@ -1,25 +1,3 @@
-jobs:
-  - name: acceptance_tests
-    templates:
-    - name: acceptance-tests
-      release: (( grab meta.release.name ))
-    instances: 1
-    resource_pool: small_errand
-    lifecycle: errand
-    networks:
-      - name: cf1
-
-  - name: smoke_tests
-    templates:
-    - name: smoke-tests
-      release: (( grab meta.release.name ))
-    instances: 1
-    resource_pool: small_errand
-    lifecycle: errand
-    networks:
-      - name: cf1
-    properties: {}
-
 properties:
   acceptance_tests:
     api: (( grab meta.api_domain ))


### PR DESCRIPTION
## What

These are no longer needed now that we're running these tests in
concourse, and not in an errand. Left behind after #127.

## How to review

Deploy this branch, verify that the smoke and acceptance tests still run.

## Who can review

Anyone but myself