### PR TITLE
[#114233261] Automated failure testing for key components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,3 +61,4 @@ disable_auto_delete:
 deploy_pipelines:
 	concourse/scripts/pipelines-microbosh.sh
 	concourse/scripts/pipelines-cloudfoundry.sh
+	concourse/scripts/pipelines-failure-testing.sh

--- a/concourse/pipelines/failure-testing.yml
+++ b/concourse/pipelines/failure-testing.yml
@@ -1,0 +1,257 @@
+resources:
+  - name: paas-cf
+    type: git
+    source:
+      uri: https://github.com/alphagov/paas-cf.git
+      branch: {{branch_name}}
+
+  - name: pipeline-trigger
+    type: semver-iam
+    source:
+      bucket: {{state_bucket}}
+      region_name: {{aws_region}}
+      key: {{pipeline_trigger_file}}
+
+  - name: bosh-secrets
+    type: s3-iam
+    source:
+      bucket: {{state_bucket}}
+      region_name: {{aws_region}}
+      versioned_file: bosh-secrets.yml
+
+  - name: cf-release
+    type: git
+    source:
+      uri: https://github.com/cloudfoundry/cf-release
+      tag_filter: {{cf-release-version}}
+
+  - name: cf-manifest
+    type: s3-iam
+    source:
+      bucket: {{state_bucket}}
+      region_name: {{aws_region}}
+      versioned_file: cf-manifest.yml
+
+  - name: bosh-CA
+    type: s3-iam
+    source:
+      bucket: {{state_bucket}}
+      region_name: {{aws_region}}
+      versioned_file: bosh-CA.tar.gz
+
+jobs:
+  - name: cloud-controller
+    serial_groups: [ failure ]
+    serial: true
+    plan:
+    - aggregate:
+      - get: cf-release
+        params:
+          submodules:
+          - src/smoke-tests
+      - get: paas-cf
+      - get: cf-manifest
+      - get: bosh-secrets
+      - get: bosh-CA
+      - put: pipeline-trigger
+        params: {bump: patch}
+    - task: get-instance-id
+      file: paas-cf/concourse/tasks/get-instance-id.yml
+      config:
+        params:
+          VM_NAME: api_z1/0
+    - task: kill-instance
+      file: paas-cf/concourse/tasks/kill-instance.yml
+    - task: generate-test-config
+      file: paas-cf/concourse/tasks/generate-test-config.yml
+    - task: run-tests
+      file: paas-cf/concourse/tasks/run-tests.yml
+      ensure:
+        task: recover
+        file: paas-cf/concourse/tasks/recover.yml
+
+  - name: colocated
+    serial_groups: [ failure ]
+    serial: true
+    plan:
+    - aggregate:
+      - get: cf-release
+        params:
+          submodules:
+          - src/smoke-tests
+      - get: paas-cf
+      - get: cf-manifest
+      - get: bosh-secrets
+      - get: bosh-CA
+      - get: pipeline-trigger
+        passed: ['cloud-controller']
+        trigger: true
+    - task: get-instance-id
+      file: paas-cf/concourse/tasks/get-instance-id.yml
+      config:
+        params:
+          VM_NAME: colocated_z1
+    - task: kill-instance
+      file: paas-cf/concourse/tasks/kill-instance.yml
+    - task: generate-test-config
+      file: paas-cf/concourse/tasks/generate-test-config.yml
+    - task: run-tests
+      file: paas-cf/concourse/tasks/run-tests.yml
+      ensure:
+        task: recover
+        file: paas-cf/concourse/tasks/recover.yml
+
+  - name: nats
+    serial_groups: [ failure ]
+    serial: true
+    plan:
+    - aggregate:
+      - get: cf-release
+        params:
+          submodules:
+          - src/smoke-tests
+      - get: paas-cf
+      - get: cf-manifest
+      - get: bosh-secrets
+      - get: bosh-CA
+      - get: pipeline-trigger
+        passed: ['colocated']
+        trigger: true
+    - task: get-instance-id
+      file: paas-cf/concourse/tasks/get-instance-id.yml
+      config:
+        params:
+          VM_NAME: nats_z1
+    - task: kill-instance
+      file: paas-cf/concourse/tasks/kill-instance.yml
+    - task: generate-test-config
+      file: paas-cf/concourse/tasks/generate-test-config.yml
+    - task: run-tests
+      file: paas-cf/concourse/tasks/run-tests.yml
+      ensure:
+        task: recover
+        file: paas-cf/concourse/tasks/recover.yml
+
+  - name: router
+    serial_groups: [ failure ]
+    serial: true
+    plan:
+    - aggregate:
+      - get: cf-release
+        params:
+          submodules:
+          - src/smoke-tests
+      - get: paas-cf
+      - get: cf-manifest
+      - get: bosh-secrets
+      - get: bosh-CA
+      - get: pipeline-trigger
+        passed: ['nats']
+        trigger: true
+    - task: get-instance-id
+      file: paas-cf/concourse/tasks/get-instance-id.yml
+      config:
+        params:
+          VM_NAME: router_z1
+    - task: kill-instance
+      file: paas-cf/concourse/tasks/kill-instance.yml
+    - task: generate-test-config
+      file: paas-cf/concourse/tasks/generate-test-config.yml
+    - task: run-tests
+      file: paas-cf/concourse/tasks/run-tests.yml
+      ensure:
+        task: recover
+        file: paas-cf/concourse/tasks/recover.yml
+
+  - name: etcd
+    serial_groups: [ failure ]
+    serial: true
+    plan:
+    - aggregate:
+      - get: cf-release
+        params:
+          submodules:
+          - src/smoke-tests
+      - get: paas-cf
+      - get: cf-manifest
+      - get: bosh-secrets
+      - get: bosh-CA
+      - get: pipeline-trigger
+        passed: ['router']
+        trigger: true
+    - task: get-instance-id
+      file: paas-cf/concourse/tasks/get-instance-id.yml
+      config:
+        params:
+          VM_NAME: etcd_z1
+    - task: kill-instance
+      file: paas-cf/concourse/tasks/kill-instance.yml
+    - task: generate-test-config
+      file: paas-cf/concourse/tasks/generate-test-config.yml
+    - task: run-tests
+      file: paas-cf/concourse/tasks/run-tests.yml
+      ensure:
+        task: recover
+        file: paas-cf/concourse/tasks/recover.yml
+
+  - name: consul
+    serial_groups: [ failure ]
+    serial: true
+    plan:
+    - aggregate:
+      - get: cf-release
+        params:
+          submodules:
+          - src/smoke-tests
+      - get: paas-cf
+      - get: cf-manifest
+      - get: bosh-secrets
+      - get: bosh-CA
+      - get: pipeline-trigger
+        passed: ['etcd']
+        trigger: true
+    - task: get-instance-id
+      file: paas-cf/concourse/tasks/get-instance-id.yml
+      config:
+        params:
+          VM_NAME: consul_z1
+    - task: kill-instance
+      file: paas-cf/concourse/tasks/kill-instance.yml
+    - task: generate-test-config
+      file: paas-cf/concourse/tasks/generate-test-config.yml
+    - task: run-tests
+      file: paas-cf/concourse/tasks/run-tests.yml
+      ensure:
+        task: recover
+        file: paas-cf/concourse/tasks/recover.yml
+
+  - name: cell
+    serial_groups: [ failure ]
+    serial: true
+    plan:
+    - aggregate:
+      - get: cf-release
+        params:
+          submodules:
+          - src/smoke-tests
+      - get: paas-cf
+      - get: cf-manifest
+      - get: bosh-secrets
+      - get: bosh-CA
+      - get: pipeline-trigger
+        passed: ['consul']
+        trigger: true
+    - task: get-instance-id
+      file: paas-cf/concourse/tasks/get-instance-id.yml
+      config:
+        params:
+          VM_NAME: cell_z1
+    - task: kill-instance
+      file: paas-cf/concourse/tasks/kill-instance.yml
+    - task: generate-test-config
+      file: paas-cf/concourse/tasks/generate-test-config.yml
+    - task: run-tests
+      file: paas-cf/concourse/tasks/run-tests.yml
+      ensure:
+        task: recover
+        file: paas-cf/concourse/tasks/recover.yml

--- a/concourse/scripts/pipelines-failure-testing.sh
+++ b/concourse/scripts/pipelines-failure-testing.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+env=${DEPLOY_ENV-$1}
+
+[[ -z "${env}" ]] && echo "Must provide environment name" && exit 100
+
+extract_cf_version(){
+  set -u
+  manifest=$1
+  ruby -e "require 'yaml'; \
+    puts YAML.load(STDIN.read)['releases'].select { |item| item['name'] == 'cf' }.first['version']" < "$manifest"
+}
+
+cf_release_version=$(extract_cf_version "${SCRIPT_DIR}"/../../manifests/cf-manifest/deployments/000-base-cf-deployment.yml)
+
+generate_vars_file() {
+   set -u # Treat unset variables as an error when substituting
+   cat <<EOF
+---
+aws_account: ${AWS_ACCOUNT:-dev}
+deploy_env: ${env}
+state_bucket: ${env}-state
+pipeline_trigger_file: ${trigger_file}
+branch_name: ${BRANCH:-master}
+aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
+debug: ${DEBUG:-}
+cf-release-version: v${cf_release_version}
+EOF
+}
+
+trigger_file="failure-testing.trigger"
+generate_vars_file > /dev/null # Check for missing vars
+
+bash "${SCRIPT_DIR}/deploy-pipeline.sh" \
+  "${env}" "failure-testing" \
+  "${SCRIPT_DIR}"/../pipelines/failure-testing.yml \
+  <(generate_vars_file) 

--- a/concourse/tasks/generate-test-config.yml
+++ b/concourse/tasks/generate-test-config.yml
@@ -1,0 +1,28 @@
+---
+inputs:
+- name: cf-release
+- name: paas-cf
+- name: cf-manifest
+outputs:
+- name: test-config
+image: docker:///governmentpaas/bosh-cli
+platform: linux
+run:
+  path: sh
+  args:
+  - -e
+  - -c
+  - |
+    ./paas-cf/tests/bosh-template-renderer/render.rb \
+      ./cf-release/jobs/smoke-tests/templates/run.erb \
+      ./cf-release/jobs/smoke-tests/spec \
+      ./cf-manifest/cf-manifest.yml \
+        > ./test-config/run
+
+    chmod +x ./test-config/run
+
+    ./paas-cf/tests/bosh-template-renderer/render.rb \
+      ./cf-release/jobs/smoke-tests/templates/config.json.erb \
+      ./cf-release/jobs/smoke-tests/spec \
+      ./cf-manifest/cf-manifest.yml \
+        > ./test-config/config.json

--- a/concourse/tasks/get-instance-id.yml
+++ b/concourse/tasks/get-instance-id.yml
@@ -1,0 +1,16 @@
+---
+inputs:
+- name: bosh-secrets
+- name: paas-cf
+outputs:
+- name: instance-id
+image: docker:///governmentpaas/bosh-cli
+platform: linux
+run:
+  path: sh
+  args:
+  - -e
+  - -c
+  - |
+    ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
+    bosh vms --details | awk -v vmname=$VM_NAME -F'|' '$2 ~ vmname {print $7}' > instance-id/id

--- a/concourse/tasks/kill-instance.yml
+++ b/concourse/tasks/kill-instance.yml
@@ -1,0 +1,13 @@
+---
+inputs:
+- name: instance-id
+image: docker:///governmentpaas/awscli
+platform: linux
+run:
+  path: sh
+  args:
+  - -e
+  - -c
+  - |
+    aws ec2 terminate-instances --region eu-west-1 --instance-ids $(cat instance-id/id)
+    sleep 30

--- a/concourse/tasks/recover.yml
+++ b/concourse/tasks/recover.yml
@@ -1,0 +1,15 @@
+inputs:
+- name: paas-cf
+- name: bosh-secrets
+- name: cf-manifest
+image: docker:///governmentpaas/bosh-cli
+platform: linux
+run:
+  path: sh
+  args:
+  - -e
+  - -c
+  - |
+    ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
+    bosh deployment cf-manifest/cf-manifest.yml
+    bosh cck --auto

--- a/concourse/tasks/run-tests.yml
+++ b/concourse/tasks/run-tests.yml
@@ -1,0 +1,25 @@
+---
+inputs:
+- name: paas-cf
+- name: cf-release
+- name: cf-manifest
+- name: test-config
+- name: bosh-CA
+image: docker:///governmentpaas/cf-acceptance-tests
+platform: linux
+run:
+  path: sh
+  args:
+  - -e
+  - -c
+  - |
+    echo "Adding bosh-CA to root certificates"
+    tar -xf bosh-CA/bosh-CA.tar.gz -C /usr/local/share/ca-certificates bosh-CA.crt
+    update-ca-certificates
+    mkdir -p /var/vcap/jobs/smoke-tests/bin/ /var/vcap/packages/smoke-tests/src/github.com/cloudfoundry
+    ln -snf $(pwd)/test-config/config.json /var/vcap/jobs/smoke-tests/bin/config.json
+    ln -snf $(pwd)/test-config/run /var/vcap/jobs/smoke-tests/bin/run
+    ln -snf /usr/local/go /var/vcap/packages/golang1.4
+    ln -snf $(pwd)/cf-release/src/smoke-tests /var/vcap/packages/smoke-tests/src/github.com/cloudfoundry/cf-smoke-tests
+    /var/vcap/jobs/smoke-tests/bin/run
+


### PR DESCRIPTION

[Automated failure testing for key components](https://www.pivotaltracker.com/story/show/114233261)

## What

 Acceptance criteria:
 
- Should remove component one by one
- Should test the most essential functions still work
- Tests should be green at the end of the story
- If there are important components that don't produce green tests if killed, then separate stories to fix these should be spun off

This PR creates a separate failure testing pipeline that will delete core component vm's and test if the service still operates and passes the smoke tests.

## How this PR should be reviewed

I've drafted this PR to be reviewed in the following context:

* I would like to:
  * Create a `concourse` pipeline that terminates the following job nodes and runs smoketests:
     *  cloud-controller
     *  colocated
     *  nats
     *  router
     *  etcd
     *  consul
     *  cell
  *  We have added sleeps to ensure that the Virtual machines have time to terminate and for the platform to heal itself before running smoke tests
  * Create a shell script to create the `failure-testing` pipeline
  * Add the failure tests to `deploy_pipelines` Makefile goal

## How to Review this PR

Deploy or update your concourse deployer and trigger the the `failure-testing` pipeline.

## Who can review this PR

This PR can be reviewed by a team of inebriated [satyrs](https://en.wikipedia.org/wiki/Satyr) if troup of tipsy legendary creatures can not be found in a nearby public house then any sober member of the core team will do with the exception of @actionjack and @combor.