### PR TITLE
[#114385219] Upgrade Concourse - bootstrap concourse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/*.tfstate
 vagrant/.vagrant/
+vagrant/.kernel-updated
 fly

--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -79,7 +79,8 @@ jobs:
     - get: paas-cf
     - task: try-fetch-bucket-state
       config:
-        image: docker:///governmentpaas/awscli
+        platform: linux
+        image: docker:///ubuntu
         params:
           AWS_DEFAULT_REGION: {{aws_region}}
         inputs:
@@ -98,6 +99,7 @@ jobs:
 
     - task: create-init-bucket
       config:
+        platform: linux
         image: docker:///governmentpaas/terraform
         params:
           TF_VAR_env: {{deploy_env}}
@@ -105,6 +107,8 @@ jobs:
         inputs:
           - name: paas-cf
           - name: bucket-state
+        outputs:
+          - name: create-init-bucket
         run:
           path: sh
           args:
@@ -113,7 +117,7 @@ jobs:
             if [ -f bucket-state/bucket.tfstate ]; then
               cp bucket-state/bucket.tfstate .
             fi
-            terraform apply -state=bucket.tfstate -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
+            terraform apply -state=bucket.tfstate -state-out=create-init-bucket/bucket.tfstate -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
               paas-cf/terraform/bucket
       on_success:
         put: bucket-terraform-state
@@ -121,6 +125,7 @@ jobs:
           file: create-init-bucket/bucket.tfstate
     - task: s3init-concourse
       config:
+        platform: linux
         image: docker:///governmentpaas/curl-ssl
         run:
           path: sh
@@ -150,9 +155,12 @@ jobs:
 
     - task: ssh-keygen
       config:
+        platform: linux
         image: docker:///governmentpaas/curl-ssl
         inputs:
         - name: paas-cf
+        outputs:
+        - name: ssh-keygen
         params:
           AWS_DEFAULT_REGION: {{aws_region}}
         run:
@@ -162,9 +170,10 @@ jobs:
           - -c
           - |
             apk add --update openssh
+            cd ssh-keygen
             ssh-keygen -t rsa -b 4096 -f generated_id_rsa -N ''
-            ./paas-cf/concourse/scripts/s3init.sh {{state_bucket}} id_rsa generated_id_rsa
-            ./paas-cf/concourse/scripts/s3init.sh {{state_bucket}} id_rsa.pub generated_id_rsa.pub
+            ../paas-cf/concourse/scripts/s3init.sh {{state_bucket}} id_rsa generated_id_rsa
+            ../paas-cf/concourse/scripts/s3init.sh {{state_bucket}} id_rsa.pub generated_id_rsa.pub
 
     - task: deploy-vpc
       config:
@@ -174,6 +183,8 @@ jobs:
         - name: paas-cf
         - name: vpc-terraform-state
         - name: ssh-keygen
+        outputs:
+        - name: deploy-vpc
         params:
           VAGRANT_IP: {{vagrant_ip}}
           TF_VAR_env: {{deploy_env}}
@@ -187,7 +198,7 @@ jobs:
             cp ssh-keygen/id_rsa.pub paas-cf/terraform/vpc
             terraform_params=${VAGRANT_IP:+-var vagrant_cidr=$VAGRANT_IP/32}
             terraform apply ${terraform_params} -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
-              -state=vpc-terraform-state/vpc.tfstate -state-out=vpc.tfstate paas-cf/terraform/vpc
+              -state=vpc-terraform-state/vpc.tfstate -state-out=deploy-vpc/vpc.tfstate paas-cf/terraform/vpc
       ensure:
         put: vpc-terraform-state
         params:
@@ -208,6 +219,7 @@ jobs:
 
     - task: vpc-terraform-outputs-to-sh
       config:
+        platform: linux
         image: docker:///ruby#2.2.3-slim
         inputs:
         - name: paas-cf
@@ -228,10 +240,13 @@ jobs:
 
     - task: generate-concourse-cert
       config:
+        platform: linux
         image: docker:///governmentpaas/curl-ssl
         inputs:
         - name: concourse-cert
         - name: vpc-terraform-outputs
+        outputs:
+        - name: generate-concourse-cert
         run:
           path: sh
           args:
@@ -249,15 +264,19 @@ jobs:
               -out concourse.crt -days 365 -nodes -subj \
               "/C=UK/ST=London/L=London/O=GDS/CN=deployer.{{deploy_env}}.${TF_VAR_system_dns_zone_name}"
             tar czvf concourse-cert.tar.gz concourse.crt concourse.key
+            cp concourse-cert.tar.gz concourse.crt concourse.key generate-concourse-cert/
 
     - task: terraform-apply
       config:
+        platform: linux
         image: docker:///governmentpaas/terraform
         inputs:
         - name: paas-cf
         - name: vpc-terraform-outputs
         - name: concourse-terraform-state
         - name: generate-concourse-cert
+        outputs:
+          - name: terraform-apply
         params:
           VAGRANT_IP: {{vagrant_ip}}
           TF_VAR_env: {{deploy_env}}
@@ -274,7 +293,7 @@ jobs:
             terraform apply ${terraform_params} \
               -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
               -state=concourse-terraform-state/concourse.tfstate \
-              -state-out=concourse.tfstate \
+              -state-out=terraform-apply/concourse.tfstate \
               paas-cf/terraform/concourse
       ensure:
         put: concourse-terraform-state
@@ -300,6 +319,7 @@ jobs:
 
     - task: terraform-outputs-to-yaml
       config:
+        platform: linux
         image: docker:///ruby#2.2.3-slim
         inputs:
         - name: paas-cf
@@ -327,6 +347,7 @@ jobs:
 
     - task: create-concourse-secrets
       config:
+        platform: linux
         params:
           concourse_atc_password: {{concourse_atc_password}}
         outputs:
@@ -346,6 +367,7 @@ jobs:
 
     - task: generate-concourse-manifest
       config:
+        platform: linux
         image: docker:///governmentpaas/spruce
         inputs:
         - name: paas-cf
@@ -384,11 +406,14 @@ jobs:
     - task: concourse-deploy
       timeout: 30m
       config:
+        platform: linux
         image: docker:///governmentpaas/bosh-init
         inputs:
         - name: concourse-manifest
         - name: concourse-bosh-state
         - name: ssh-private-key
+        outputs:
+        - name: concourse-deploy
         run:
           path: sh
           args:
@@ -404,6 +429,7 @@ jobs:
             bosh-init deploy concourse.yml
             rm concourse-manifest/concourse.yml
             rm id_rsa
+            cp concourse-state.json concourse-deploy
       ensure:
         put: concourse-bosh-state
         params:
@@ -424,6 +450,7 @@ jobs:
 
     - task: vpc-terraform-outputs-to-sh
       config:
+        platform: linux
         image: docker:///ruby#2.2.3-slim
         inputs:
         - name: paas-cf
@@ -449,6 +476,8 @@ jobs:
         inputs:
         - name: paas-cf
         - name: vpc-terraform-state
+        outputs:
+        - name: remove-vagrant-IP-from-ssh-SG
         params:
           TF_VAR_env: {{deploy_env}}
           AWS_DEFAULT_REGION: {{aws_region}}
@@ -461,7 +490,7 @@ jobs:
             terraform apply -target=aws_security_group.office-access-ssh \
               -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
               -target=aws_subnet.infra \
-              -state=vpc-terraform-state/vpc.tfstate -state-out=vpc.tfstate \
+              -state=vpc-terraform-state/vpc.tfstate -state-out=remove-vagrant-IP-from-ssh-SG/vpc.tfstate \
               paas-cf/terraform/vpc
       ensure:
         put: vpc-terraform-state
@@ -476,6 +505,8 @@ jobs:
         - name: paas-cf
         - name: vpc-terraform-outputs
         - name: concourse-terraform-state
+        outputs:
+        - name: remove-vagrant-IP-from-concourse-SG
         params:
           TF_VAR_env: {{deploy_env}}
           AWS_DEFAULT_REGION: {{aws_region}}
@@ -487,7 +518,7 @@ jobs:
           - |
             . vpc-terraform-outputs/tfvars.sh
             terraform apply -target=aws_security_group.concourse \
-              -state=concourse-terraform-state/concourse.tfstate -state-out=concourse.tfstate \
+              -state=concourse-terraform-state/concourse.tfstate -state-out=remove-vagrant-IP-from-concourse-SG/concourse.tfstate \
               -var-file=paas-cf/terraform/{{aws_account}}.tfvars paas-cf/terraform/concourse
       ensure:
         put: concourse-terraform-state

--- a/concourse/pipelines/destroy-deployer.yml
+++ b/concourse/pipelines/destroy-deployer.yml
@@ -61,11 +61,14 @@ jobs:
     - task: destroy-concourse
       timeout: 30m
       config:
+        platform: linux
         image: docker:///governmentpaas/bosh-init
         inputs:
         - name: paas-cf
         - name: concourse-manifest
         - name: concourse-bosh-state
+        outputs:
+        - name: destroy-concourse
         run:
           path: sh
           args:
@@ -86,6 +89,7 @@ jobs:
               || cp paas-cf/concourse/init_files/bosh-init-state.json.tpl concourse-state.json
             rm concourse-manifest/concourse.yml
             rm id_rsa
+            cp concourse-state.json destroy-concourse
       ensure:
         put: concourse-bosh-state
         params:
@@ -93,6 +97,7 @@ jobs:
 
     - task: vpc-terraform-outputs-to-sh
       config:
+        platform: linux
         image: docker:///ruby#2.2.3-slim
         inputs:
         - name: paas-cf
@@ -113,11 +118,14 @@ jobs:
 
     - task: destroy-concourse-terraform
       config:
+        platform: linux
         image: docker:///governmentpaas/terraform
         inputs:
         - name: paas-cf
         - name: vpc-terraform-outputs
         - name: concourse-terraform-state
+        outputs:
+        - name: concourse-terraform-state-out
         params:
           AWS_DEFAULT_REGION: {{aws_region}}
           TF_VAR_env: {{deploy_env}}
@@ -132,12 +140,12 @@ jobs:
             terraform destroy -force \
               -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
               -state=concourse-terraform-state/concourse.tfstate \
-              -state-out=concourse.tfstate \
+              -state-out=concourse-terraform-state-out/concourse.tfstate \
               paas-cf/terraform/concourse
       ensure:
         put: concourse-terraform-state
         params:
-          file: destroy-concourse-terraform/concourse.tfstate
+          file: concourse-terraform-state-out/concourse.tfstate
 
     - put: destroy-all-trigger
       params: {bump: patch}
@@ -153,6 +161,7 @@ jobs:
       passed: [destroy-concourse]
     - task: tf-destroy-vpc
       config:
+        platform: linux
         image: docker:///governmentpaas/terraform
         params:
             TF_VAR_env: {{deploy_env}}
@@ -160,6 +169,8 @@ jobs:
         inputs:
           - name: paas-cf
           - name: vpc-terraform-state
+        outputs:
+          - name: tf-destroy-vpc
         run:
           path: sh
           args:
@@ -168,7 +179,7 @@ jobs:
           - |
             touch paas-cf/terraform/vpc/id_rsa.pub
             terraform destroy -force -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
-              -state=vpc-terraform-state/vpc.tfstate -state-out=vpc.tfstate paas-cf/terraform/vpc
+              -state=vpc-terraform-state/vpc.tfstate -state-out=tf-destroy-vpc/vpc.tfstate paas-cf/terraform/vpc
       ensure:
         put: vpc-terraform-state
         params:
@@ -185,6 +196,7 @@ jobs:
         passed: [destroy-vpc]
       - task: tf-destroy-init-bucket
         config:
+          platform: linux
           image: docker:///governmentpaas/terraform
           params:
               TF_VAR_env: {{deploy_env}}

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -37,7 +37,7 @@ Vagrant.configure(2) do |config|
     aws.tags = { 'Name' => (ENV['DEPLOY_ENV'] || ENV['USER']) + " concourse" }
 
     # The Concourse AMI is currently only available in us-east-1, this is v. 0.70
-    aws.ami = 'ami-5c104436'
+    aws.ami = 'ami-c6112dac'
     aws.region = 'us-east-1'
 
     # Only HVM instances with ephemeral disks can be used

--- a/vagrant/deploy.sh
+++ b/vagrant/deploy.sh
@@ -16,6 +16,11 @@ if ! vagrant box list | grep -qe "^${VAGRANT_BOX_NAME} "; then
 fi
 
 vagrant up
+if [ ! -f .kernel-updated ]; then
+  echo 'waiting for vagrant box to reboot'
+  sleep 60
+fi
+touch .kernel-updated
 
 VAGRANT_IP=$(vagrant ssh -- curl -qs http://169.254.169.254/latest/meta-data/public-ipv4)
 export VAGRANT_IP

--- a/vagrant/destroy.sh
+++ b/vagrant/destroy.sh
@@ -22,3 +22,4 @@ fi
 
 # 3. Destroy bootstrap concourse
 vagrant destroy -f
+rm .kernel-updated

--- a/vagrant/post-deploy.d/10-mount-additional-ephemeral-disk.sh
+++ b/vagrant/post-deploy.d/10-mount-additional-ephemeral-disk.sh
@@ -16,6 +16,8 @@ if ! mount | grep -q $gardenDir; then
 
     # Mount ephemeral storage as garden data
     mount /dev/xvdb ${gardenDir}
+    fstabline="/dev/xvdb\t${gardenDir}\tauto\tdefaults\t0\t0\n"
+    grep --silent "$(echo -e $fstabline)" /etc/fstab || echo -e $fstabline >> /etc/fstab
 
     /var/vcap/bosh/bin/monit restart garden
 fi

--- a/vagrant/post-deploy.d/20-setup-basic-auth.sh
+++ b/vagrant/post-deploy.d/20-setup-basic-auth.sh
@@ -2,6 +2,7 @@
 set -u
 set -e
 echo "Setting up concourse basic auth as ${CONCOURSE_ATC_USER}: ${CONCOURSE_ATC_PASSWORD}"
+sed "s/--external-url.*/--external-url \'\' \\\/" -i /var/vcap/jobs/atc/bin/atc_ctl # Remove hardcoded auth redirect IP
 sed "s/--development-mode//g" -i /var/vcap/jobs/atc/bin/atc_ctl      # dev mode disables all auth
 sed "s/--basic-auth-username.*/--basic-auth-username \'${CONCOURSE_ATC_USER}\' \\\/" -i /var/vcap/jobs/atc/bin/atc_ctl
 sed "s/--basic-auth-password.*/--basic-auth-password \'${CONCOURSE_ATC_PASSWORD}\' \\\/" -i /var/vcap/jobs/atc/bin/atc_ctl

--- a/vagrant/post-deploy.d/40-upgrade-kernel.sh
+++ b/vagrant/post-deploy.d/40-upgrade-kernel.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+kernel_updated_file=/root/kernel-updated
+if [ ! -f $kernel_updated_file ] ; then
+  apt-get update
+  DEBIAN_FRONTEND=noninteractive apt-get install linux-generic-lts-vivid -y
+  old_kernel_version=$(uname -r)
+  new_kernel_version=$(find /boot/vmlinuz-3.19* | sed -E 's/.*(3.19)/\1/')
+  sed -i'' "s/$old_kernel_version/$new_kernel_version/g" /boot/grub/menu.lst
+  update-grub
+  touch $kernel_updated_file
+  reboot
+fi


### PR DESCRIPTION
**What**

A new version of Concourse has been released, we should update to latest version.


**How this PR should be reviewed**

Destroy any existing deployment or use a new environment name

Check this branch out and run the `vagrant/deploy.sh` script, and run the `create-deployer` and `destroy-deployer` pipelines and check all is working.

To make this work, we had to upgrade the kernel on the concourse vm, as the AMI concourse provide uses an older kernel version that doesnt support the new version of the garden linux release included. This means we also need to make the additional disk mount persist across reboots. There are more details on this in the individual commit messages.

Concourse are planning on [upgrading the AMIs](https://www.pivotaltracker.com/n/projects/1059262/stories/114892073) however its not clear when they will be upgraded.

**Who should review this PR**

* Anyone  except me or @mtekel