### PR TITLE
[#113996375] HA for Logsearch

### DIFF
--- a/manifests/cf-manifest/deployments/050-logsearch.yml
+++ b/manifests/cf-manifest/deployments/050-logsearch.yml
@@ -8,6 +8,17 @@ releases:
   version: 4
   sha1: c92ce357c5e1e77a4fb7944d58a1971c7aee06b0
 
+resource_pools:
+- name: ingestor_z1
+  network: cf1
+  stemcell: (( grab meta.stemcell ))
+  env: (( grab meta.default_env ))
+  cloud_properties:
+    availability_zone: eu-west-1a
+    instance_type: t2.micro
+    elbs:
+      - (( grab terraform_outputs.ingestor_elb_name ))
+
 disk_pools:
 - name: elasticsearch_master
   disk_size: 102400
@@ -91,7 +102,7 @@ jobs:
   templates:
   - {name: ingestor_syslog, release: logsearch}
   - {name: ingestor_relp, release: logsearch}
-  resource_pool: small_z1
+  resource_pool: ingestor_z1
   instances: 1
   networks:
   - name: cf1

--- a/manifests/cf-manifest/deployments/050-logsearch.yml
+++ b/manifests/cf-manifest/deployments/050-logsearch.yml
@@ -10,12 +10,22 @@ releases:
 
 resource_pools:
 - name: ingestor_z1
-  network: cf1
+  network: (( grab resource_pools.medium_z1.network ))
   stemcell: (( grab meta.stemcell ))
   env: (( grab meta.default_env ))
   cloud_properties:
-    availability_zone: eu-west-1a
-    instance_type: t2.micro
+    availability_zone: (( grab resource_pools.medium_z1.cloud_properties.availability_zone ))
+    instance_type: (( grab resource_pools.medium_z1.cloud_properties.instance_type ))
+    elbs:
+      - (( grab terraform_outputs.ingestor_elb_name ))
+
+- name: ingestor_z2
+  network: (( grab resource_pools.medium_z2.network ))
+  stemcell: (( grab meta.stemcell ))
+  env: (( grab meta.default_env ))
+  cloud_properties:
+    availability_zone: (( grab resource_pools.medium_z2.cloud_properties.availability_zone ))
+    instance_type: (( grab resource_pools.medium_z2.cloud_properties.instance_type ))
     elbs:
       - (( grab terraform_outputs.ingestor_elb_name ))
 
@@ -41,6 +51,90 @@ disk_pools:
     type: gp2
 
 jobs:
+- name: ingestor_z1
+  release: logsearch
+  templates:
+  - {name: ingestor_syslog, release: logsearch}
+  - {name: ingestor_relp, release: logsearch}
+  resource_pool: ingestor_z1
+  instances: 1
+  networks:
+  - name: cf1
+    default: [gateway, dns]
+    static_ips: (( static_ips(2) ))
+  update: (( grab properties.update ))
+  properties:
+    redis:
+      host: (( grab jobs.queue_z1.networks.cf1.static_ips.[0] ))
+
+- name: ingestor_z2
+  release: logsearch
+  templates:
+  - {name: ingestor_syslog, release: logsearch}
+  - {name: ingestor_relp, release: logsearch}
+  resource_pool: ingestor_z2
+  instances: 1
+  networks:
+  - name: cf2
+    default: [gateway, dns]
+    static_ips: (( static_ips(2) ))
+  update: (( grab properties.update ))
+  properties:
+    redis:
+      host: (( grab jobs.queue_z2.networks.cf2.static_ips.[0] ))
+
+- name: queue_z1
+  release: logsearch
+  templates:
+  - {name: queue, release: logsearch}
+  resource_pool: small_z1
+  instances: 1
+  networks:
+  - name: cf1
+    static_ips: (( static_ips(3) ))
+  persistent_disk_pool: queue
+  update: (( grab properties.update ))
+
+- name: queue_z2
+  release: logsearch
+  templates:
+  - {name: queue, release: logsearch}
+  resource_pool: small_z2
+  instances: 1
+  networks:
+  - name: cf2
+    static_ips: (( static_ips(3) ))
+  persistent_disk_pool: queue
+  update: (( grab properties.update ))
+
+- name: parser_z1
+  release: logsearch
+  templates:
+  - {name: parser, release: logsearch}
+  resource_pool: medium_z1
+  instances: 1
+  networks:
+  - name: cf1
+    static_ips: (( static_ips(4) ))
+  update: (( grab properties.update ))
+  properties:
+    redis:
+      host: (( grab jobs.queue_z1.networks.cf1.static_ips.[0] ))
+
+- name: parser_z2
+  release: logsearch
+  templates:
+  - {name: parser, release: logsearch}
+  resource_pool: medium_z2
+  instances: 1
+  networks:
+  - name: cf2
+    static_ips: (( static_ips(4) ))
+  update: (( grab properties.update ))
+  properties:
+    redis:
+      host: (( grab jobs.queue_z2.networks.cf2.static_ips.[0] ))
+
 - name: elasticsearch_master
   release: logsearch
   templates:
@@ -75,16 +169,27 @@ jobs:
         allow_data: true
   update: (( grab properties.update ))
 
-- name: queue
+
+- name: maintenance_z1
+  instances: 1
   release: logsearch
   templates:
-  - {name: queue, release: logsearch}
+  - {name: elasticsearch_config, release: logsearch}
+  - {name: curator, release: logsearch}
   resource_pool: small_z1
-  instances: 1
   networks:
   - name: cf1
-    static_ips: (( static_ips(3) ))
-  persistent_disk_pool: queue
+  update: (( grab properties.update ))
+  
+- name: maintenance_z2
+  instances: 1
+  release: logsearch
+  templates:
+  - {name: elasticsearch_config, release: logsearch}
+  - {name: curator, release: logsearch}
+  resource_pool: small_z2
+  networks:
+  - name: cf2
   update: (( grab properties.update ))
 
 - name: kibana
@@ -97,46 +202,13 @@ jobs:
   - name: cf1
   update: (( grab properties.update ))
 
-- name: ingestor
-  release: logsearch
-  templates:
-  - {name: ingestor_syslog, release: logsearch}
-  - {name: ingestor_relp, release: logsearch}
-  resource_pool: ingestor_z1
-  instances: 1
-  networks:
-  - name: cf1
-    default: [gateway, dns]
-    static_ips: (( static_ips(2) ))
-  update: (( grab properties.update ))
-
-- name: parser
-  release: logsearch
-  templates:
-  - {name: parser, release: logsearch}
-  resource_pool: medium_z1
-  instances: 1
-  networks:
-  - name: cf1
-    static_ips: (( static_ips(4) ))
-  update: (( grab properties.update ))
-
-- name: maintenance
-  instances: 1
-  release: logsearch
-  templates:
-  - {name: elasticsearch_config, release: logsearch}
-  - {name: curator, release: logsearch}
-  resource_pool: small_z1
-  networks:
-  - name: cf1
-  update: (( grab properties.update ))
-
 properties:
+  syslog_daemon_config:
+    address: (( grab terraform_outputs.ingestor_elb_dns_name ))
+    port: 2514
+    transport: relp
   curator:
     elasticsearch_host: (( grab jobs.elasticsearch_master.networks.cf1.static_ips.[0] ))
-  redis:
-    host: (( grab jobs.queue.networks.cf1.static_ips.[0] ))
   elasticsearch:
     master_hosts: (( grab jobs.elasticsearch_master.networks.cf1.static_ips ))
     cluster_name: logsearch
@@ -147,15 +219,11 @@ properties:
       host: (( grab jobs.elasticsearch_master.networks.cf1.static_ips.[0] ))
     templates:
       - index_template: /var/vcap/packages/logsearch-config/default-mappings.json
-  syslog_daemon_config:
-    address: (( grab jobs.ingestor.networks.cf1.static_ips.[0] ))
-    port: 2514
-    transport: relp
   logsearch:
     metrics:
       enabled: false
     logs:
-      server: (( concat jobs.ingestor.networks.cf1.static_ips.[0] ":5514" ))
+      server: (( concat terraform_outputs.ingestor_elb_dns_name ":5514" ))
   update:
     serial: false
     canaries: 1

--- a/manifests/cf-manifest/deployments/050-logsearch.yml
+++ b/manifests/cf-manifest/deployments/050-logsearch.yml
@@ -29,87 +29,12 @@ disk_pools:
   cloud_properties:
     type: gp2
 
-resource_pools:
-- name: elasticsearch_master
-  network: cf1
-  stemcell: (( grab meta.stemcell ))
-  env: (( grab meta.default_env ))
-  cloud_properties:
-    availability_zone: eu-west-1a
-    instance_type: t2.micro
-
-- name: elasticsearch_data
-  network: cf1
-  stemcell: (( grab meta.stemcell ))
-  env: (( grab meta.default_env ))
-  cloud_properties:
-    availability_zone: eu-west-1a
-    instance_type: t2.micro
-
-- name: ingestor
-  network: cf1
-  stemcell: (( grab meta.stemcell ))
-  env: (( grab meta.default_env ))
-  cloud_properties:
-    availability_zone: eu-west-1a
-    instance_type: t2.micro
-    elbs:
-      - (( grab terraform_outputs.ingestor_elb_name ))
-
-- name: queue
-  network: cf1
-  stemcell: (( grab meta.stemcell ))
-  env: (( grab meta.default_env ))
-  cloud_properties:
-    availability_zone: eu-west-1a
-    instance_type: t2.small
-
-- name: parser
-  network: cf1
-  stemcell: (( grab meta.stemcell ))
-  env: (( grab meta.default_env ))
-  cloud_properties:
-    availability_zone: eu-west-1a
-    instance_type: m3.medium
-
-- name: kibana
-  network: cf1
-  stemcell: (( grab meta.stemcell ))
-  env: (( grab meta.default_env ))
-  cloud_properties:
-    availability_zone: eu-west-1a
-    instance_type: t2.micro
-
-- name: maintenance
-  network: cf1
-  stemcell: (( grab meta.stemcell ))
-  env: (( grab meta.default_env ))
-  cloud_properties:
-    availability_zone: eu-west-1a
-    instance_type: t2.micro
-
-- name: cluster_monitor
-  network: cf1
-  stemcell: (( grab meta.stemcell ))
-  env: (( grab meta.default_env ))
-  cloud_properties:
-    availability_zone: eu-west-1a
-    instance_type: m4.large
-
-- name: haproxy
-  network: cf1
-  stemcell: (( grab meta.stemcell ))
-  env: (( grab meta.default_env ))
-  cloud_properties:
-    availability_zone: eu-west-1a
-    instance_type: t2.micro
-
 jobs:
 - name: elasticsearch_master
   release: logsearch
   templates:
   - {name: elasticsearch, release: logsearch}
-  resource_pool: elasticsearch_master
+  resource_pool: medium_z1
   instances: 1
   networks:
   - name: cf1
@@ -120,124 +45,13 @@ jobs:
       node:
         allow_master: true
         allow_data: false
-  update:
-    serial: false
-    canaries: 1
-    max_in_flight: 1
-
-- name: haproxy
-  instances: 0
-  release: logsearch
-  templates:
-  - { name: haproxy, release: logsearch }
-  resource_pool: haproxy
-  networks:
-  - name: cf1
-  update:
-    serial: false
-    canaries: 1
-    max_in_flight: 1
-  properties:
-    haproxy:
-      backend_servers: (( grab jobs.ingestor.networks.[0].static_ips ))
-
-- name: cluster_monitor
-  instances: 0
-  release: logsearch
-  templates:
-  - { release: logsearch, name: queue }
-  - { release: logsearch, name: parser }
-  - { release: logsearch, name: ingestor_syslog }
-  - { release: logsearch, name: elasticsearch }
-  - { release: logsearch, name: elasticsearch_config }
-  - { release: logsearch, name: curator }
-  - { release: logsearch, name: kibana }
-  - { release: logsearch, name: nats_to_syslog }
-  resource_pool: cluster_monitor
-  networks:
-  - name: cf1
-  persistent_disk_pool: cluster_monitor
-  properties:
-    kibana:
-      elasticsearch: 127.0.0.1:9200
-      port: 5601
-    elasticsearch:
-      master_hosts: [127.0.0.1]
-      cluster_name: monitor
-      node:
-        allow_master: true
-        allow_data: true
-    redis:
-      host: 127.0.0.1
-    curator:
-      elasticsearch_host: 127.0.0.1
-      elasticsearch_port: 9200
-      purge_logs:
-        retention_period: 7
-    elasticsearch_config:
-      elasticsearch:
-        host: 127.0.0.1
-        port: 9200
-      bulk_data_files: []
-      templates:
-      - shards-and-replicas: "{ \"template\" : \"*\", \"order\" : 99, \"settings\" : { \"number_of_shards\" : 1, \"number_of_replicas\" : 0 } }"
-      - index_template: /var/vcap/packages/logsearch-config/default-mappings.json
-    logstash_parser:
-      filters:
-      - metrics: /var/vcap/packages/logsearch-config/logstash-filters-metric.conf
-
-    nats_to_syslog:
-      nats:
-        subject: ">"
-        user: (( grab properties.nats.user ))
-        password: (( grab properties.nats.password ))
-        port: (( grab properties.nats.port ))
-        machines: (( grab properties.nats.machines ))
-      debug: true
-      syslog:
-        host: 127.0.0.1
-        port: 514
-    logstash_ingestor:
-      syslog:
-        port: 514
-  update:
-    serial: false
-    canaries: 1
-    max_in_flight: 1
-
-- name: queue
-  release: logsearch
-  templates:
-  - {name: queue, release: logsearch}
-  resource_pool: queue
-  instances: 1
-  networks:
-  - name: cf1
-    static_ips: (( static_ips(3) ))
-  persistent_disk_pool: queue
-  update:
-    serial: true
-    canaries: 1
-    max_in_flight: 1
-
-- name: kibana
-  release: logsearch
-  templates:
-  - {name: kibana, release: logsearch}
-  instances: 1
-  resource_pool: kibana
-  networks:
-  - name: cf1
-  update:
-    serial: false
-    canaries: 1
-    max_in_flight: 1
+  update: (( grab properties.update ))
 
 - name: elasticsearch_data
   release: logsearch
   templates:
   - {name: elasticsearch, release: logsearch}
-  resource_pool: elasticsearch_data
+  resource_pool: medium_z1
   instances: 2
   networks:
   - name: cf1
@@ -248,45 +62,53 @@ jobs:
       node:
         allow_master: false
         allow_data: true
-  update:
-    serial: false
-    canaries: 1
-    max_in_flight: 1
+  update: (( grab properties.update ))
+
+- name: queue
+  release: logsearch
+  templates:
+  - {name: queue, release: logsearch}
+  resource_pool: small_z1
+  instances: 1
+  networks:
+  - name: cf1
+    static_ips: (( static_ips(3) ))
+  persistent_disk_pool: queue
+  update: (( grab properties.update ))
+
+- name: kibana
+  release: logsearch
+  templates:
+  - {name: kibana, release: logsearch}
+  resource_pool: small_z1
+  instances: 1
+  networks:
+  - name: cf1
+  update: (( grab properties.update ))
 
 - name: ingestor
   release: logsearch
   templates:
   - {name: ingestor_syslog, release: logsearch}
   - {name: ingestor_relp, release: logsearch}
-  resource_pool: ingestor
+  resource_pool: small_z1
   instances: 1
   networks:
   - name: cf1
     default: [gateway, dns]
     static_ips: (( static_ips(2) ))
-  properties:
-    logstash_ingestor:
-      debug: false
-      relp:
-        port: ~
-  update:
-    serial: false
-    canaries: 1
-    max_in_flight: 1
+  update: (( grab properties.update ))
 
 - name: parser
   release: logsearch
   templates:
   - {name: parser, release: logsearch}
-  resource_pool: parser
+  resource_pool: medium_z1
   instances: 1
   networks:
   - name: cf1
     static_ips: (( static_ips(4) ))
-  update:
-    serial: false
-    canaries: 1
-    max_in_flight: 4
+  update: (( grab properties.update ))
 
 - name: maintenance
   instances: 1
@@ -294,28 +116,19 @@ jobs:
   templates:
   - {name: elasticsearch_config, release: logsearch}
   - {name: curator, release: logsearch}
-  resource_pool: maintenance
+  resource_pool: small_z1
   networks:
   - name: cf1
-  update:
-    serial: false
-    canaries: 1
-    max_in_flight: 1
+  update: (( grab properties.update ))
 
 properties:
   curator:
     elasticsearch_host: (( grab jobs.elasticsearch_master.networks.cf1.static_ips.[0] ))
-  logstash_parser:
-    debug: false
-  logstash_ingestor:
-    debug: false
   redis:
     host: (( grab jobs.queue.networks.cf1.static_ips.[0] ))
   elasticsearch:
-    log_level: DEBUG
     master_hosts: (( grab jobs.elasticsearch_master.networks.cf1.static_ips ))
     cluster_name: logsearch
-    exec: ~
   kibana:
     elasticsearch: (( concat jobs.elasticsearch_master.networks.cf1.static_ips.[0] ":9200" ))
   elasticsearch_config:
@@ -332,3 +145,7 @@ properties:
       enabled: false
     logs:
       server: (( concat jobs.ingestor.networks.cf1.static_ips.[0] ":5514" ))
+  update:
+    serial: false
+    canaries: 1
+    max_in_flight: 1

--- a/manifests/cf-manifest/deployments/050-logsearch.yml
+++ b/manifests/cf-manifest/deployments/050-logsearch.yml
@@ -120,6 +120,7 @@ jobs:
   properties:
     redis:
       host: (( grab jobs.queue_z1.networks.cf1.static_ips.[0] ))
+    logstash: (( grab properties.parser_logstash ))
 
 - name: parser_z2
   release: logsearch
@@ -134,8 +135,9 @@ jobs:
   properties:
     redis:
       host: (( grab jobs.queue_z2.networks.cf2.static_ips.[0] ))
+    logstash: (( grab properties.parser_logstash ))
 
-- name: elasticsearch_master
+- name: elasticsearch_master_z1
   release: logsearch
   templates:
   - {name: elasticsearch, release: logsearch}
@@ -149,26 +151,51 @@ jobs:
     elasticsearch:
       node:
         allow_master: true
-        allow_data: false
+        allow_data: true
+      discovery:
+        minimum_master_nodes: 2
+      master_hosts: (( grab properties.elasticsearch.master_hosts ))
   update: (( grab properties.update ))
 
-- name: elasticsearch_data
+- name: elasticsearch_master_z2
   release: logsearch
   templates:
   - {name: elasticsearch, release: logsearch}
-  resource_pool: medium_z1
-  instances: 2
+  resource_pool: medium_z2
+  instances: 1
   networks:
-  - name: cf1
-    static_ips: (( static_ips(16, 17) ))
-  persistent_disk_pool: elasticsearch_data
+  - name: cf2
+    static_ips: (( static_ips(0) ))
+  persistent_disk_pool: elasticsearch_master
   properties:
     elasticsearch:
       node:
-        allow_master: false
+        allow_master: true
         allow_data: true
+      discovery:
+        minimum_master_nodes: 2
+      master_hosts: (( grab properties.elasticsearch.master_hosts ))
   update: (( grab properties.update ))
 
+- name: elasticsearch_master_z3
+  release: logsearch
+  templates:
+  - {name: elasticsearch, release: logsearch}
+  resource_pool: medium_z3
+  instances: 1
+  networks:
+  - name: cf3
+    static_ips: (( static_ips(0) ))
+  persistent_disk_pool: elasticsearch_master
+  properties:
+    elasticsearch:
+      node:
+        allow_master: true
+        allow_data: true
+      discovery:
+        minimum_master_nodes: 2
+      master_hosts: (( grab properties.elasticsearch.master_hosts ))
+  update: (( grab properties.update ))
 
 - name: maintenance_z1
   instances: 1
@@ -207,16 +234,20 @@ properties:
     address: (( grab terraform_outputs.ingestor_elb_dns_name ))
     port: 2514
     transport: relp
+  parser_logstash:
+    output:
+      elasticsearch:
+        data_hosts: (( grab properties.elasticsearch.master_hosts ))
   curator:
-    elasticsearch_host: (( grab jobs.elasticsearch_master.networks.cf1.static_ips.[0] ))
+    elasticsearch_host: (( grab jobs.elasticsearch_master_z1.networks.cf1.static_ips.[0] ))
   elasticsearch:
-    master_hosts: (( grab jobs.elasticsearch_master.networks.cf1.static_ips ))
+    master_hosts: (( grab jobs.elasticsearch_master_z1.networks.cf1.static_ips jobs.elasticsearch_master_z2.networks.cf2.static_ips jobs.elasticsearch_master_z3.networks.cf3.static_ips ))
     cluster_name: logsearch
   kibana:
-    elasticsearch: (( concat jobs.elasticsearch_master.networks.cf1.static_ips.[0] ":9200" ))
+    elasticsearch: (( concat jobs.elasticsearch_master_z1.networks.cf1.static_ips.[0] ":9200" ))
   elasticsearch_config:
     elasticsearch:
-      host: (( grab jobs.elasticsearch_master.networks.cf1.static_ips.[0] ))
+      host: (( grab jobs.elasticsearch_master_z1.networks.cf1.static_ips.[0] ))
     templates:
       - index_template: /var/vcap/packages/logsearch-config/default-mappings.json
   logsearch:

--- a/manifests/cf-manifest/deployments/050-logsearch.yml
+++ b/manifests/cf-manifest/deployments/050-logsearch.yml
@@ -9,6 +9,36 @@ releases:
   sha1: c92ce357c5e1e77a4fb7944d58a1971c7aee06b0
 
 resource_pools:
+- name: elastic_master_z1
+  network: (( grab resource_pools.medium_z1.network ))
+  stemcell: (( grab meta.stemcell ))
+  env: (( grab meta.default_env ))
+  cloud_properties:
+    availability_zone: (( grab resource_pools.medium_z1.cloud_properties.availability_zone ))
+    instance_type: (( grab resource_pools.medium_z1.cloud_properties.instance_type ))
+    elbs:
+      - (( grab terraform_outputs.elastic_master_elb_name ))
+
+- name: elastic_master_z2
+  network: (( grab resource_pools.medium_z2.network ))
+  stemcell: (( grab meta.stemcell ))
+  env: (( grab meta.default_env ))
+  cloud_properties:
+    availability_zone: (( grab resource_pools.medium_z2.cloud_properties.availability_zone ))
+    instance_type: (( grab resource_pools.medium_z2.cloud_properties.instance_type ))
+    elbs:
+      - (( grab terraform_outputs.elastic_master_elb_name ))
+
+- name: elastic_master_z3
+  network: (( grab resource_pools.medium_z3.network ))
+  stemcell: (( grab meta.stemcell ))
+  env: (( grab meta.default_env ))
+  cloud_properties:
+    availability_zone: (( grab resource_pools.medium_z3.cloud_properties.availability_zone ))
+    instance_type: (( grab resource_pools.medium_z3.cloud_properties.instance_type ))
+    elbs:
+      - (( grab terraform_outputs.elastic_master_elb_name ))
+
 - name: ingestor_z1
   network: (( grab resource_pools.medium_z1.network ))
   stemcell: (( grab meta.stemcell ))
@@ -141,7 +171,7 @@ jobs:
   release: logsearch
   templates:
   - {name: elasticsearch, release: logsearch}
-  resource_pool: medium_z1
+  resource_pool: elastic_master_z1
   instances: 1
   networks:
   - name: cf1
@@ -161,7 +191,7 @@ jobs:
   release: logsearch
   templates:
   - {name: elasticsearch, release: logsearch}
-  resource_pool: medium_z2
+  resource_pool: elastic_master_z2
   instances: 1
   networks:
   - name: cf2
@@ -181,7 +211,7 @@ jobs:
   release: logsearch
   templates:
   - {name: elasticsearch, release: logsearch}
-  resource_pool: medium_z3
+  resource_pool: elastic_master_z3
   instances: 1
   networks:
   - name: cf3
@@ -239,15 +269,15 @@ properties:
       elasticsearch:
         data_hosts: (( grab properties.elasticsearch.master_hosts ))
   curator:
-    elasticsearch_host: (( grab jobs.elasticsearch_master_z1.networks.cf1.static_ips.[0] ))
+    elasticsearch_host: (( grab terraform_outputs.elastic_master_elb_dns_name ))
   elasticsearch:
     master_hosts: (( grab jobs.elasticsearch_master_z1.networks.cf1.static_ips jobs.elasticsearch_master_z2.networks.cf2.static_ips jobs.elasticsearch_master_z3.networks.cf3.static_ips ))
     cluster_name: logsearch
   kibana:
-    elasticsearch: (( concat jobs.elasticsearch_master_z1.networks.cf1.static_ips.[0] ":9200" ))
+    elasticsearch: (( concat terraform_outputs.elastic_master_elb_dns_name ":9200" ))
   elasticsearch_config:
     elasticsearch:
-      host: (( grab jobs.elasticsearch_master_z1.networks.cf1.static_ips.[0] ))
+      host: (( grab terraform_outputs.elastic_master_elb_dns_name ))
     templates:
       - index_template: /var/vcap/packages/logsearch-config/default-mappings.json
   logsearch:

--- a/manifests/cf-manifest/deployments/050-logsearch.yml
+++ b/manifests/cf-manifest/deployments/050-logsearch.yml
@@ -53,6 +53,8 @@ resource_pools:
   cloud_properties:
     availability_zone: eu-west-1a
     instance_type: t2.micro
+    elbs:
+      - (( grab terraform_outputs.ingestor_elb_name ))
 
 - name: queue
   network: cf1

--- a/manifests/cf-manifest/spec/fixtures/terraform/terraform-outputs.yml
+++ b/manifests/cf-manifest/spec/fixtures/terraform/terraform-outputs.yml
@@ -22,3 +22,4 @@ terraform_outputs:
   default_security_group: default_sg
   cf_rds_client_security_group: rds_client_sg
   cf_db_address: abcd.postgres.aws
+  ingestor_elb_name: stub_ingestor_elb

--- a/manifests/cf-manifest/spec/fixtures/terraform/terraform-outputs.yml
+++ b/manifests/cf-manifest/spec/fixtures/terraform/terraform-outputs.yml
@@ -24,3 +24,5 @@ terraform_outputs:
   cf_db_address: abcd.postgres.aws
   ingestor_elb_name: stub_ingestor_elb
   ingestor_elb_dns_name: stub_ingestor_elb_dns
+  elastic_master_elb_name: elastic_master_elb
+  elastic_master_elb_dns_name: elastic_master_elb_dns

--- a/manifests/cf-manifest/spec/fixtures/terraform/terraform-outputs.yml
+++ b/manifests/cf-manifest/spec/fixtures/terraform/terraform-outputs.yml
@@ -23,3 +23,4 @@ terraform_outputs:
   cf_rds_client_security_group: rds_client_sg
   cf_db_address: abcd.postgres.aws
   ingestor_elb_name: stub_ingestor_elb
+  ingestor_elb_dns_name: stub_ingestor_elb_dns

--- a/terraform/cloudfoundry/network_acls_cf_in.tf
+++ b/terraform/cloudfoundry/network_acls_cf_in.tf
@@ -161,13 +161,24 @@ resource "aws_network_acl_rule" "116_router_consul_in" {
     egress = false
 }
 
-resource "aws_network_acl_rule" "117_kibana" {
+resource "aws_network_acl_rule" "117_kibana_and_es" {
     network_acl_id = "${aws_network_acl.cf.id}"
     protocol = "tcp"
     rule_number = 117
     rule_action = "allow"
     from_port = 5601
-    to_port = 5601
+    to_port = 9300
+    cidr_block = "${var.infra_cidr_all}"
+    egress = false
+}
+
+resource "aws_network_acl_rule" "118_ingestor_syslog" {
+    network_acl_id = "${aws_network_acl.cf.id}"
+    protocol = "tcp"
+    rule_number = 118
+    rule_action = "allow"
+    from_port = 2514
+    to_port = 5514
     cidr_block = "${var.infra_cidr_all}"
     egress = false
 }

--- a/terraform/cloudfoundry/outputs.tf
+++ b/terraform/cloudfoundry/outputs.tf
@@ -49,3 +49,7 @@ output "cf_rds_client_security_group" {
 output "cf_db_address" {
   value = "${aws_db_instance.cf.address}"
 }
+
+output "ingestor_elb_name" {
+  value = "${aws_elb.ingestor_elb.name}"
+}

--- a/terraform/cloudfoundry/outputs.tf
+++ b/terraform/cloudfoundry/outputs.tf
@@ -53,3 +53,7 @@ output "cf_db_address" {
 output "ingestor_elb_name" {
   value = "${aws_elb.ingestor_elb.name}"
 }
+
+output "ingestor_elb_dns_name" {
+  value = "${aws_elb.ingestor_elb.dns_name}"
+}

--- a/terraform/cloudfoundry/outputs.tf
+++ b/terraform/cloudfoundry/outputs.tf
@@ -57,3 +57,11 @@ output "ingestor_elb_name" {
 output "ingestor_elb_dns_name" {
   value = "${aws_elb.ingestor_elb.dns_name}"
 }
+
+output "elastic_master_elb_name" {
+  value = "${aws_elb.es_master_elb.name}"
+}
+
+output "elastic_master_elb_dns_name" {
+  value = "${aws_elb.es_master_elb.dns_name}"
+}

--- a/terraform/cloudfoundry/routers.tf
+++ b/terraform/cloudfoundry/routers.tf
@@ -51,3 +51,36 @@ resource "aws_elb" "ssh-proxy-router" {
     lb_protocol = "tcp"
   }
 }
+
+resource "aws_elb" "ingestor_elb" {
+  name = "${var.env}-ingestor-elb"
+  subnets = ["${split(",", var.infra_subnet_ids)}"]
+  idle_timeout = "${var.elb_idle_timeout}"
+  cross_zone_load_balancing = "true"
+  internal = "true"
+  security_groups = [
+    "${aws_security_group.ingestor_elb.id}",
+  ]
+
+  health_check {
+    target = "TCP:5514"
+    interval = "${var.health_check_interval}"
+    timeout = "${var.health_check_timeout}"
+    healthy_threshold = "${var.health_check_healthy}"
+    unhealthy_threshold = "${var.health_check_unhealthy}"
+  }
+  listener {
+    instance_port = 5514
+    instance_protocol = "tcp"
+    lb_port = 5514
+    lb_protocol = "tcp"
+  }
+  listener {
+    instance_port = 2514
+    instance_protocol = "tcp"
+    lb_port = 2514
+    lb_protocol = "tcp"
+  }
+}
+
+

--- a/terraform/cloudfoundry/routers.tf
+++ b/terraform/cloudfoundry/routers.tf
@@ -84,3 +84,30 @@ resource "aws_elb" "ingestor_elb" {
 }
 
 
+resource "aws_elb" "es_master_elb" {
+  name = "${var.env}-cf-es-elb"
+  subnets = ["${split(",", var.infra_subnet_ids)}"]
+  idle_timeout = "${var.elb_idle_timeout}"
+  cross_zone_load_balancing = "true"
+  internal = "true"
+  security_groups = [
+    "${aws_security_group.elastic_master_elb.id}",
+  ]
+
+  health_check {
+    target = "TCP:9200"
+    interval = "${var.health_check_interval}"
+    timeout = "${var.health_check_timeout}"
+    healthy_threshold = "${var.health_check_healthy}"
+    unhealthy_threshold = "${var.health_check_unhealthy}"
+  }
+  listener {
+    instance_port = 9200
+    instance_protocol = "tcp"
+    lb_port = 9200
+    lb_protocol = "tcp"
+  }
+}
+
+
+

--- a/terraform/cloudfoundry/security-groups.tf
+++ b/terraform/cloudfoundry/security-groups.tf
@@ -123,6 +123,42 @@ resource "aws_security_group" "ingestor_elb" {
   }
 
   tags {
+    Name = "${var.env}-logsearch-elastic"
+  }
+}
+
+resource "aws_security_group" "elastic_master_elb" {
+  name = "${var.env}-elastic-cf"
+  description = "Security group for elastic master which allows TCP/9200 and TCP/9300"
+  vpc_id = "${var.vpc_id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 9200
+    to_port   = 9200
+    protocol  = "tcp"
+    cidr_blocks = [
+      "10.0.0.0/16"
+    ]
+  }
+
+  ingress {
+    from_port = 9300
+    to_port   = 9300
+    protocol  = "tcp"
+    cidr_blocks = [
+      "10.0.0.0/16"
+    ]
+  }
+
+  tags {
     Name = "${var.env}-logsearch-ingestor"
   }
 }
+

--- a/terraform/cloudfoundry/security-groups.tf
+++ b/terraform/cloudfoundry/security-groups.tf
@@ -144,7 +144,7 @@ resource "aws_security_group" "elastic_master_elb" {
     to_port   = 9200
     protocol  = "tcp"
     cidr_blocks = [
-      "10.0.0.0/16"
+      "${var.vpc_cidr}"
     ]
   }
 
@@ -153,7 +153,7 @@ resource "aws_security_group" "elastic_master_elb" {
     to_port   = 9300
     protocol  = "tcp"
     cidr_blocks = [
-      "10.0.0.0/16"
+      "${var.vpc_cidr}"
     ]
   }
 

--- a/terraform/cloudfoundry/security-groups.tf
+++ b/terraform/cloudfoundry/security-groups.tf
@@ -123,7 +123,7 @@ resource "aws_security_group" "ingestor_elb" {
   }
 
   tags {
-    Name = "${var.env}-logsearch-elastic"
+    Name = "${var.env}-logsearch-ingestor"
   }
 }
 
@@ -158,7 +158,7 @@ resource "aws_security_group" "elastic_master_elb" {
   }
 
   tags {
-    Name = "${var.env}-logsearch-ingestor"
+    Name = "${var.env}-logsearch-elastic"
   }
 }
 

--- a/terraform/cloudfoundry/security-groups.tf
+++ b/terraform/cloudfoundry/security-groups.tf
@@ -129,7 +129,7 @@ resource "aws_security_group" "ingestor_elb" {
 
 resource "aws_security_group" "elastic_master_elb" {
   name = "${var.env}-elastic-cf"
-  description = "Security group for elastic master which allows TCP/9200 and TCP/9300"
+  description = "Security group for elastic master which allows TCP/9200"
   vpc_id = "${var.vpc_id}"
 
   egress {
@@ -142,15 +142,6 @@ resource "aws_security_group" "elastic_master_elb" {
   ingress {
     from_port = 9200
     to_port   = 9200
-    protocol  = "tcp"
-    cidr_blocks = [
-      "${var.vpc_cidr}"
-    ]
-  }
-
-  ingress {
-    from_port = 9300
-    to_port   = 9300
     protocol  = "tcp"
     cidr_blocks = [
       "${var.vpc_cidr}"

--- a/terraform/cloudfoundry/security-groups.tf
+++ b/terraform/cloudfoundry/security-groups.tf
@@ -56,7 +56,6 @@ resource "aws_security_group" "web" {
     Name = "${var.env}-cf-web"
   }
 }
-
 resource "aws_security_group" "sshproxy" {
   name = "${var.env}-sshproxy-cf"
   description = "Security group for web that allows TCP/2222 for ssh-proxy from the office"
@@ -90,5 +89,40 @@ resource "aws_security_group" "cf_rds_client" {
 
   tags {
     Name = "${var.env}-cf-rds-client"
+  }
+}
+
+resource "aws_security_group" "ingestor_elb" {
+  name = "${var.env}-ingestor-cf"
+  description = "Security group for web that allows TCP/5514 for logsearch ingestor"
+  vpc_id = "${var.vpc_id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 2514
+    to_port   = 2514
+    protocol  = "tcp"
+    cidr_blocks = [
+      "${var.vpc_cidr}"
+    ]
+  }
+
+  ingress {
+    from_port = 5514
+    to_port   = 5514
+    protocol  = "tcp"
+    cidr_blocks = [
+      "${var.vpc_cidr}"
+    ]
+  }
+
+  tags {
+    Name = "${var.env}-logsearch-ingestor"
   }
 }


### PR DESCRIPTION
## What

The full write-up is available [on pivotal](https://www.pivotaltracker.com/projects/1275640/stories/113996375).

This PR ensures that we have one instance of each Logsearch component in both Z1 and Z2 with ELBs to balance across each of the relevant services. It also splits ES across Z1, Z2, and Z3, with one master and one data node in each zone.

## How to review

Spin up the cluster, then load kibana on `http://kibana.[$ENV].dev.paas.alphagov.co.uk`. You'll need to add a Kibana filter of `*`, then hit the Discover button. You should see data rolling in.

Head to the EC2 dashboard and kill an Ingestor node, you should still see data coming in. Do the same for a Kibana node and an Elasticsearch node. Everything should keep working.

If you kill a Parser node you'll still be getting data, but 50% of it will be missing unless the Ingestor is also killed. This is documented in the write-up.

## Who can review

Not @jonty or @jimconner, as Jim is on holiday and Jonty is taking one after resolving so many merge conflicts.