### PR TITLE
[#114854977] Update merged pipeline/task name for bosh-cli

### DIFF
--- a/concourse/scripts/bosh-cli.sh
+++ b/concourse/scripts/bosh-cli.sh
@@ -19,7 +19,7 @@ trap 'rm -f "${OUTPUT_FILE}"' EXIT
 
 $FLY_CMD -t "${FLY_TARGET}" \
   execute \
-  --inputs-from=deploy-cloudfoundry/deploy \
+  --inputs-from=create-bosh-cloudfoundry/cf-deploy \
   --config="${SCRIPT_DIR}/../pipelines/bosh-cli/bosh-cli.yml" \
   | tee "${OUTPUT_FILE}"
 


### PR DESCRIPTION
## What

The pipeline and task that this takes inputs from was renamed when the BOSH
and CF pipelines were merged in 6849a99^...9196f4f which caused this to
error:

    ➜  paas-cf git:(master) ./concourse/scripts/bosh-cli.sh
    error: build inputs not found

It's worth noting that it still won't work correctly because the version of
`fly` that is downloaded from the Bootstrap Concourse is older than the
Deployer Concourse is running after the upgrade in f72219d. It will hang with:

    Logged in as `admin'
    Target set to `my-bosh'
    Deployment set to `/tmp/build/e55deab7/cf-manifest-with-uuid.yml'
    succeeded
    1: build id: 76, type: , name:
    2: build id: 76, type: , name:
    3: build id: 76, type: , name:
    4: build id: 76, type: , name:

There is a story currently in play to ensure that we use the right version of
`fly` for either Concourse (if they are different). In the meantime you can
upgrade `fly` using:

    ${FLY_CMD} -t ${DEPLOY_ENV} sync

## How to review

1. Run the `create-bosh-cloudfoundry` pipeline.
1. Run `./concourse/scripts/bosh-cli.sh` and get a shell with access to BOSH CLI.

## Who can review

Not @dcarley