### PR TITLE
[#113159997] Fix concourse-deployer bosh-init state

### DIFF
--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -48,7 +48,7 @@ resources:
     type: s3-iam
     source:
       bucket: {{state_bucket}}
-      versioned_file: concourse-state.json
+      versioned_file: concourse-manifest-state.json
       region_name: {{aws_region}}
 
   - name: concourse-manifest
@@ -137,7 +137,7 @@ jobs:
           - |
             paas-cf/concourse/scripts/s3init.sh {{state_bucket}} vpc.tfstate paas-cf/concourse/init_files/terraform.tfstate.tpl
             paas-cf/concourse/scripts/s3init.sh {{state_bucket}} concourse.tfstate paas-cf/concourse/init_files/terraform.tfstate.tpl
-            paas-cf/concourse/scripts/s3init.sh {{state_bucket}} concourse-state.json paas-cf/concourse/init_files/bosh-init-state.json.tpl
+            paas-cf/concourse/scripts/s3init.sh {{state_bucket}} concourse-manifest-state.json paas-cf/concourse/init_files/bosh-init-state.json.tpl
             paas-cf/concourse/scripts/s3init.sh {{state_bucket}} concourse-cert.tar.gz paas-cf/concourse/init_files/empty.tar.gz
             paas-cf/concourse/scripts/s3init.sh {{state_bucket}} generated-concourse-secrets.yml paas-cf/concourse/init_files/zero_bytes
         inputs:
@@ -434,7 +434,7 @@ jobs:
             cp ssh-private-key/id_rsa id_rsa
             chmod 400 id_rsa
             ls -l id_rsa
-            cp -v concourse-bosh-state/concourse-state.json .
+            cp -v concourse-bosh-state/concourse-manifest-state.json .
             cp -v concourse-manifest/concourse-manifest.yml .
             export BOSH_INIT_LOG_LEVEL={{log_level}}
             bosh-init deploy concourse-manifest.yml
@@ -443,7 +443,7 @@ jobs:
       ensure:
         put: concourse-bosh-state
         params:
-          file: concourse-deploy/concourse-state.json
+          file: concourse-deploy/concourse-manifest-state.json
 
   - name: expunge-vagrant
     serial: true

--- a/concourse/pipelines/destroy-deployer.yml
+++ b/concourse/pipelines/destroy-deployer.yml
@@ -31,7 +31,7 @@ resources:
     type: s3-iam
     source:
       bucket: {{state_bucket}}
-      versioned_file: concourse.yml
+      versioned_file: concourse-manifest.yml
       region_name: {{aws_region}}
 
   - name: concourse-terraform-state
@@ -45,7 +45,7 @@ resources:
     type: s3-iam
     source:
       bucket: {{state_bucket}}
-      versioned_file: concourse-state.json
+      versioned_file: concourse-manifest-state.json
       region_name: {{aws_region}}
 
 jobs:
@@ -72,24 +72,24 @@ jobs:
           - -e
           - -c
           - |
-            cp -v concourse-bosh-state/concourse-state.json .
-            [ "$(cat concourse-bosh-state/concourse-state.json)" = "{}" ] \
+            cp -v concourse-bosh-state/concourse-manifest-state.json .
+            [ "$(cat concourse-bosh-state/concourse-manifest-state.json)" = "{}" ] \
               && echo Concourse bosh state empty, assuming already destroyed \
               && exit 0
             echo -n "${private_ssh_key}" > id_rsa
             chmod 400 id_rsa
             ls -l id_rsa
-            cp -v concourse-manifest/concourse.yml .
+            cp -v concourse-manifest/concourse-manifest.yml .
             export BOSH_INIT_LOG_LEVEL={{log_level}}
-            bosh-init delete concourse.yml
-            [ -f concourse-state.json ] \
-              || cp paas-cf/concourse/init_files/bosh-init-state.json.tpl concourse-state.json
-            rm concourse-manifest/concourse.yml
+            bosh-init delete concourse-manifest.yml
+            [ -f concourse-manifest-state.json ] \
+              || cp paas-cf/concourse/init_files/bosh-init-state.json.tpl concourse-manifest-state.json
+            rm concourse-manifest/concourse-manifest.yml
             rm id_rsa
       ensure:
         put: concourse-bosh-state
         params:
-          file: destroy-concourse/concourse-state.json
+          file: destroy-concourse/concourse-manifest-state.json
 
     - task: vpc-terraform-outputs-to-sh
       config:


### PR DESCRIPTION
## What
https://github.com/alphagov/paas-cf/pull/142 renamed the concourse manifest.
The related bosh-init state file is named after the manifest so it should have been renamed too.
Because of this the right state file wasn't uploaded and bosh-init would not be able to identify the deployed VM.
Also, it caused the CPI to be recompiled every time.

## How to review
* create a new concourse deployer
* the CPI shouldn't be recompiled
* re-run the `create-deployer` pipeline
* bosh-init should identify the concourse deployed above and not try to redeploy it

## Who can review
Anyone but me