### PR TITLE
[#113159679] Use non-default vcap passwords for Deployer Concourse and BOSH

### DIFF
--- a/manifests/bosh-manifest/deployments/aws/000-bosh-infrastructure.yml
+++ b/manifests/bosh-manifest/deployments/aws/000-bosh-infrastructure.yml
@@ -10,7 +10,9 @@ resource_pools:
     ephemeral_disk: {size: 40_000, type: gp2}
     availability_zone: (( grab terraform_outputs.zone0 ))
     iam_instance_profile: bosh-director
-
+  env:
+    bosh:
+      password: (( grab secrets.bosh_vcap_password ))
 disk_pools:
 - name: disks
   cloud_properties:
@@ -29,5 +31,3 @@ networks:
       - (( grab terraform_outputs.bosh_security_group ))
 - name: public
   type: vip
-
-

--- a/manifests/bosh-manifest/reference-bosh-manifest.yml
+++ b/manifests/bosh-manifest/reference-bosh-manifest.yml
@@ -183,6 +183,9 @@ resource_pools:
       type: gp2
     iam_instance_profile: bosh-director
     instance_type: t2.medium
+  env:  
+    bosh:
+      password: BOSH_VCAP_PASSWORD
   name: vms
   network: private
   stemcell:

--- a/manifests/bosh-manifest/scripts/generate-bosh-secrets.rb
+++ b/manifests/bosh-manifest/scripts/generate-bosh-secrets.rb
@@ -13,6 +13,7 @@ generator = SecretGenerator.new({
   "bosh_blobstore_director_password" => :simple,
   "bosh_hm_director_password" => :simple,
   "bosh_admin_password" => :simple,
+  "bosh_vcap_password" => :sha512_crypted,
 })
 
 OptionParser.new do |opts|

--- a/manifests/bosh-manifest/spec/fixtures/bosh-secrets.yml
+++ b/manifests/bosh-manifest/spec/fixtures/bosh-secrets.yml
@@ -8,3 +8,4 @@ secrets:
   bosh_blobstore_director_password: BOSH_BLOBSTORE_DIRECTOR_PASSWORD
   bosh_hm_director_password: BOSH_HM_DIRECTOR_PASSWORD
   bosh_admin_password: BOSH_ADMIN_PASSWORD
+  bosh_vcap_password: BOSH_VCAP_PASSWORD

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -30,6 +30,9 @@ resource_pools:
       ephemeral_disk:
         size: 50240
         type: gp2
+    env:
+      bosh:
+        password: (( grab secrets.concourse_vcap_password ))
 
 disk_pools:
   - name: db
@@ -129,4 +132,3 @@ cloud_provider:
       mbus: (( concat "https://mbus:" secrets.concourse_nats_password "@0.0.0.0:6868" ))
     blobstore: {provider: local, path: /var/vcap/micro_bosh/data/cache}
     ntp: [0.pool.ntp.org, 1.pool.ntp.org]
-

--- a/manifests/concourse-manifest/scripts/generate-concourse-secrets.rb
+++ b/manifests/concourse-manifest/scripts/generate-concourse-secrets.rb
@@ -6,6 +6,7 @@ require File.expand_path("../../../shared/lib/secret_generator", __FILE__)
 
 generator = SecretGenerator.new({
   "concourse_nats_password" => :simple,
+  "concourse_vcap_password" => :sha512_crypted,
 })
 
 OptionParser.new do |opts|


### PR DESCRIPTION
[Use non-default vcap passwords for Deployer Concourse and BOSH](https://www.pivotaltracker.com/story/show/113159679)

## What 

**Acceptance critera**
As a pipeline improvement you should not be able to SSH to the Deployer Concourse or BOSH machines with the default user and password.

## How to Review this PR

This PR has been written in the following context:

* I would like to:
  * Create and use a new Concourse VCAP password
  * Create and use a new BOSH VCAP password

## How to test this PR

* Deploy a new environment and `ssh` to the deployer conconcourse and use su to log into the super user account using the passwords in defined in `bosh-secrets.yml` & `concourse-secrets.yml` in your s3 state bucket

## Who should merge this PR

[Whosoever holds the merge button PR, if he be worthy, shall possess the power of Github Merger](http://marvel.wikia.com/wiki/Mjolnir), except @actionjack, @jimconner  and @saliceti .