### PR TITLE
[#115403711] ACLs: allow all from infra to cf subnets

### DIFF
--- a/terraform/cloudfoundry/network_acls_cf_in.tf
+++ b/terraform/cloudfoundry/network_acls_cf_in.tf
@@ -161,35 +161,11 @@ resource "aws_network_acl_rule" "116_router_consul_in" {
     egress = false
 }
 
-resource "aws_network_acl_rule" "117_kibana_and_es" {
-    network_acl_id = "${aws_network_acl.cf.id}"
-    protocol = "tcp"
-    rule_number = 117
-    rule_action = "allow"
-    from_port = 5601
-    to_port = 9300
-    cidr_block = "${var.infra_cidr_all}"
-    egress = false
-}
-
-resource "aws_network_acl_rule" "118_ingestor_syslog" {
+resource "aws_network_acl_rule" "119_allow_all_from_infra" {
     network_acl_id = "${aws_network_acl.cf.id}"
     protocol = "tcp"
     rule_number = 118
     rule_action = "allow"
-    from_port = 2514
-    to_port = 5514
-    cidr_block = "${var.infra_cidr_all}"
-    egress = false
-}
-
-resource "aws_network_acl_rule" "118_graphite" {
-    network_acl_id = "${aws_network_acl.cf.id}"
-    protocol = "tcp"
-    rule_number = 118
-    rule_action = "allow"
-    from_port = 3000
-    to_port = 3001
     cidr_block = "${var.infra_cidr_all}"
     egress = false
 }


### PR DESCRIPTION
What?
-----

We have several rules to enable different traffic from infra to CF,
mainly to allow create SSH tunnels to access some internal services
(syslog, kibana, graphite).

Recently we merged two PR which define conflicting ACL numbers:
118_ingestor_syslog and 118_graphite both had the same ACL rule
number.

Re-numbering one, e.g. from 118_graphite to 119_graphite, will fix the
conflict, but we will have other error: `The maximum number of network
acl entries has been reached`

Finally we decided to simply allow all traffic from the infra network,
as some of the rules open wide ranges of ports to workaround the
previously described issues and the infra network has machines with
broad permissions to change AWS objects (bosh and concourse). We
also decided replace ACLs with security groups in the future.

How to test it
--------------

Apply this, cf-terraform should pass.

You can also check if you can connect from concourse to kibana, graphite...

Who?
---

Anyone but @keymon or @henrytk