### PR TITLE
[#114308825] Enable RDS secret rotation

### DIFF
--- a/manifests/cf-manifest/scripts/create-cf-dbs.sh
+++ b/manifests/cf-manifest/scripts/create-cf-dbs.sh
@@ -12,12 +12,15 @@ psql_adm() { psql -h "${db_address}" -U dbadmin "$@"; }
 
 # Create roles
 psql_adm -d postgres -c "SELECT rolname FROM pg_roles WHERE rolname = 'api'" \
-  | grep -q 'api' || psql_adm -d postgres \
-  -c "CREATE USER api WITH PASSWORD '${api_pass}' ROLE dbadmin"
+  | grep -q 'api' || psql_adm -d postgres -c "CREATE USER api WITH ROLE dbadmin"
+
 
 psql_adm -d postgres -c "SELECT rolname FROM pg_roles WHERE rolname = 'uaa'" \
-  | grep -q 'uaa' || psql_adm -d postgres \
-  -c "CREATE USER uaa WITH PASSWORD '${uaa_pass}' ROLE dbadmin"
+  | grep -q 'uaa' || psql_adm -d postgres -c "CREATE USER uaa WITH ROLE dbadmin"
+
+# Always update passwords
+psql_adm -d postgres -c "ALTER USER api WITH PASSWORD '${api_pass}'"
+psql_adm -d postgres -c "ALTER USER uaa WITH PASSWORD '${uaa_pass}'"
 
 for db in api uaa; do
 


### PR DESCRIPTION
## What

Enable updating of RDS passwords, so that we can rotate these secrets. Previously 'api' and 'uaa' roles were only created once and never changed aftewards, which skipped updating passwords if you have changed them in secrets.

## How to review

Deploy. Update `cf_db_api_password` and `cf_db_uaa_password` secrets (edit cf-secrets.yml, upload to bucket, apply - only UAA and CC jobs (cc, worker, clock) should be updated). Run smoke and acceptance tests. All should keep working.

## Who can review

not @mtekel or @combor 