### PR TITLE
[#114308825] Enable NATS password rotation

### DIFF
--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -243,6 +243,28 @@ jobs:
       metron_agent:
         zone: z2
 
+  - name: nats_z1
+    templates: (( grab meta.nats_templates ))
+    instances: 1
+    resource_pool: medium_z1
+    networks:
+      - name: cf1
+        static_ips:
+    properties:
+      metron_agent:
+        zone: z1
+
+  - name: nats_z2
+    templates: (( grab meta.nats_templates ))
+    instances: 1
+    resource_pool: medium_z2
+    networks:
+      - name: cf2
+        static_ips:
+    properties:
+      metron_agent:
+        zone: z2
+
   - name: etcd_z1
     templates: (( grab meta.etcd_templates ))
     instances: 1
@@ -323,28 +345,6 @@ jobs:
           z2: (( grab jobs.router_z2.networks.router2.static_ips ))
       metron_agent:
         zone: z1
-
-  - name: nats_z1
-    templates: (( grab meta.nats_templates ))
-    instances: 1
-    resource_pool: medium_z1
-    networks:
-      - name: cf1
-        static_ips:
-    properties:
-      metron_agent:
-        zone: z1
-
-  - name: nats_z2
-    templates: (( grab meta.nats_templates ))
-    instances: 1
-    resource_pool: medium_z2
-    networks:
-      - name: cf2
-        static_ips:
-    properties:
-      metron_agent:
-        zone: z2
 
   - name: stats_z1
     templates: (( grab meta.stats_templates ))

--- a/manifests/cf-manifest/spec/jobs_spec.rb
+++ b/manifests/cf-manifest/spec/jobs_spec.rb
@@ -1,0 +1,71 @@
+RSpec.describe "the global update block" do
+
+  let(:manifest) { manifest_with_defaults }
+
+  describe "in order to run parallel deployment by default" do
+    it "has serial false" do
+      expect(manifest["update"]["serial"]).to be false
+    end
+  end
+
+end
+
+RSpec.describe "the jobs definitions block" do
+
+  let(:jobs) { manifest_with_defaults["jobs"] }
+
+  def get_job(job_name)
+    jobs.select{ |j| j["name"] == job_name}.first
+  end
+
+  def is_serial(job_name)
+    job = get_job(job_name)
+    job["update"]["serial"]
+  end
+
+  def ordered(job1_name, job2_name)
+    i1 = jobs.index{ |j| j["name"] == job1_name }
+    i2 = jobs.index{ |j| j["name"] == job2_name }
+    i1 < i2
+  end
+
+  describe "in order to enforce etcd dependency on NATS" do
+    it "has etcd_z1 serial" do
+      expect(is_serial("etcd_z1")).to be true
+    end
+
+    it "has nats_z1 before etcd_z1" do
+      expect(ordered("nats_z1", "etcd_z1")).to be true
+    end
+
+    it "has nats_z2 before etcd_z1" do
+      expect(ordered("nats_z2", "etcd_z1")).to be true
+    end
+  end
+
+  describe "in order to start one etcd master for consensus" do
+    it "has etcd_z1 serial" do
+      expect(is_serial("etcd_z1")).to be true
+    end
+
+    it "has etcd_z1 before etcd_z2" do
+      expect(ordered("etcd_z1", "etcd_z2")).to be true
+    end
+
+    it "has etcd_z1 before etcd_z3" do
+      expect(ordered("etcd_z1", "etcd_z3")).to be true
+    end
+  end
+
+  describe "in order to start one consul master for consensus" do
+    it "has consul_z1 serial" do
+      expect(is_serial("consul_z1")).to be true
+    end
+
+    specify "has consul_z1 first" do
+      expect(jobs[0]["name"]).to eq("consul_z1")
+    end
+  end
+
+
+end


### PR DESCRIPTION
## What

Enable updating of NATS password, so that we can rotate this secret. Do this by ensuring that the NATS jobs get updated (and deployed) concurrently with ETCD. This lets ETCD jobs connect to NATS using the new password. Otherwise they get stuck waiting for NATS to be updated, but which was configured to update after ETCD has finished updating.

## How to review

Deploy. Update `nats_password` (edit cf-secrets.yml, upload to bucket, apply). Run smoke and acceptance tests. All should keep working.

## Who can review

not @mtekel or @combor 