### PR TITLE
[#115403129] Build from tag in staging and production

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ or destroyed.
 
 ### Prerequisites
 
-You will need a recent version of [Vagrant installed][]. The exact version
+* You will need a recent version of [Vagrant installed][]. The exact version
 requirements are listed in the [`Vagrantfile`](vagrant/Vagrantfile).
 
 [Vagrant installed]: https://docs.vagrantup.com/v2/installation/index.html
@@ -44,7 +44,7 @@ Install the AWS plugin for Vagrant:
 vagrant plugin install vagrant-aws
 ```
 
-You must provide AWS access keys as environment variables:
+* You must provide AWS access keys as environment variables:
 
 ```
 export AWS_ACCESS_KEY_ID=XXXXXXXXXX
@@ -59,6 +59,12 @@ state files).
 
 [instance profiles]: http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html
 [aws-account-wide-terraform]: https://github.gds/government-paas/aws-account-wide-terraform
+
+* Declare you environment name using the variable DEPLOY_ENV. It must be 18 characters maximum and contain only alphanumeric characters and hyphens.
+
+```
+$ export DEPLOY_ENV=environment-name
+```
 
 ### Deploy
 
@@ -80,10 +86,10 @@ use to login.
 
 ### Destroy
 
-Run the following script, with the name of your existing environment:
+Run the following script:
 
 ```
-./vagrant/destroy.sh <deploy_env>
+./vagrant/destroy.sh
 ```
 
 ## Deployer Concourse
@@ -210,7 +216,7 @@ There's a script that starts an interactive session on the deployer concourse
 to allow running bosh CLI commands targeting MicroBOSH:
 
 ```
-./concourse/scripts/bosh-cli.sh $DEPLOY_ENV
+./concourse/scripts/bosh-cli.sh
 ```
 
 This connects you to a one-off task in concourse that's already logged into
@@ -258,9 +264,11 @@ based on the AWS credentials, the environment name and the application name.
 These credentials will also be used by the *Deployer Concourse*.
 
 If you are the owner of the environment with the original AWS credentials,
-run `./vagrant/environment.sh <deploy_env>` to get them again.
+run `TARGET_CONCOURSE=bootstrap ./concourse/scripts/environment.sh` to get them again.
 
-If not, you can learn the credentials from the `atc` process arguments:
+If not, it can be found in the `basic_auth_password` property of `concourse-manifest.yml` in the state bucket.
+
+You can also learn the credentials from the `atc` process arguments:
 
  1. SSH to the Concourse server:
     * For *Bootstrap Concourse*: `cd vagrant && vagrant ssh`

--- a/README.md
+++ b/README.md
@@ -62,11 +62,12 @@ state files).
 
 ### Deploy
 
-Run the following script with the name of your environment:
+Create the bootstrap Concourse with `make`. Select the target based on which AWS account you want to work with. For instance for a DEV bootstrap:
 
 ```
-./vagrant/deploy.sh <deploy_env>
+make dev-bootstrap
 ```
+`make help` will show all available options.
 
 NB: This will [auto-delete overnight](#overnight-deletion-of-environments)
 by default.
@@ -122,7 +123,7 @@ Deploy the pipeline configurations with `make`. Select the target based on which
 ```
 make dev
 ```
-if you want to deploy to DEV account. `make help` will show all available options. 
+if you want to deploy to DEV account.
 
 ### Deploy
 

--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -4,6 +4,7 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-cf.git
       branch: {{branch_name}}
+      tag_filter: {{paas_cf_tag_filter}}
 
   - name: delete-timer
     type: time

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -43,6 +43,7 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-cf.git
       branch: {{branch_name}}
+      tag_filter: {{paas_cf_tag_filter}}
 
   - name: graphite-statsd-boshrelease
     type: git

--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -15,6 +15,7 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-cf.git
       branch: {{branch_name}}
+      tag_filter: {{paas_cf_tag_filter}}
 
   - name: build-all-trigger
     type: semver-iam

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -4,6 +4,7 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-cf.git
       branch: {{branch_name}}
+      tag_filter: {{paas_cf_tag_filter}}
 
   - name: cf-tfstate
     type: s3-iam

--- a/concourse/pipelines/destroy-deployer.yml
+++ b/concourse/pipelines/destroy-deployer.yml
@@ -5,6 +5,7 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-cf
       branch: {{branch_name}}
+      tag_filter: {{paas_cf_tag_filter}}
 
   - name: bucket-terraform-state
     type: s3-iam

--- a/concourse/pipelines/destroy-microbosh.yml
+++ b/concourse/pipelines/destroy-microbosh.yml
@@ -4,6 +4,7 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-cf.git
       branch: {{branch_name}}
+      tag_filter: {{paas_cf_tag_filter}}
 
   - name: vpc-tfstate
     type: s3-iam

--- a/concourse/pipelines/failure-testing.yml
+++ b/concourse/pipelines/failure-testing.yml
@@ -4,6 +4,7 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-cf.git
       branch: {{branch_name}}
+      tag_filter: {{paas_cf_tag_filter}}
 
   - name: pipeline-trigger
     type: semver-iam

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -28,6 +28,7 @@ debug: ${DEBUG:-}
 cf-release-version: v${cf_release_version}
 cf_graphite_version: ${cf_graphite_version}
 cf_grafana_version: ${cf_grafana_version}
+paas_cf_tag_filter: ${PAAS_CF_TAG_FILTER:-}
 EOF
 }
 

--- a/concourse/scripts/pipelines-deployer.sh
+++ b/concourse/scripts/pipelines-deployer.sh
@@ -22,6 +22,7 @@ branch_name: ${BRANCH:-master}
 aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
 concourse_atc_password: ${CONCOURSE_ATC_PASSWORD}
 log_level: ${LOG_LEVEL:-}
+paas_cf_tag_filter: ${PAAS_CF_TAG_FILTER:-}
 EOF
 }
 

--- a/concourse/scripts/pipelines-failure-testing.sh
+++ b/concourse/scripts/pipelines-failure-testing.sh
@@ -29,6 +29,7 @@ branch_name: ${BRANCH:-master}
 aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
 debug: ${DEBUG:-}
 cf-release-version: v${cf_release_version}
+paas_cf_tag_filter: ${PAAS_CF_TAG_FILTER:-}
 EOF
 }
 


### PR DESCRIPTION
## What
Story: [Enable build from tag option](https://www.pivotaltracker.com/story/show/115403129)

Adds the tag_filter option on the paas-cf git resource in all the pipelines and creates predefined filters for staging and production.
This is controlled via make commands or can be set via the variable `$PAAS_CF_TAG_FILTER`

## How to review
* Build an environment, including bootstrap with different values for variable `$PAAS_CF_TAG_FILTER`
* Empty variable means no filter and all commits will pass
* To test for staging and prod, you can execute the targets `set_stage_tag_filter` or `set_prod_tag_filter` within the `dev` target.
* Push tags ([annotated tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging#Annotated-Tags) preferred). Patterns are [glob(7)](http://man7.org/linux/man-pages/man7/glob.7.html) compatible
* Observe the paas-cf resource only fetches the required commits
* Observe the bosh-cf pipeline is triggered

## Who can review
Anyone but me