### PR TITLE
[#113159997] Add the variable concourse_vcap_password to test

### DIFF
--- a/manifests/concourse-manifest/spec/fixtures/generated-concourse-secrets.yml
+++ b/manifests/concourse-manifest/spec/fixtures/generated-concourse-secrets.yml
@@ -1,3 +1,4 @@
 ---
 secrets:
   concourse_nats_password: CONCOURSE_NATS_PASSWORD
+  concourse_vcap_password: CONCOURSE_VCAP_PASSWORD


### PR DESCRIPTION
What?
-----

After merging #144 the build is failing because concourse manifest tests
fixtures are not including the recently added variable secrets.concourse_vcap_password,
which was added in a PR request merged just before.

This PR adds that value

How to test
-----------

`make test` and travis passes

Who?
----

Anyone but @keymon