### PR TITLE
[#115251665] ELB for access to metrics

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -114,6 +114,13 @@ resources:
       region_name: {{aws_region}}
       versioned_file: concourse-manifest.yml
 
+  - name: metrics-cert
+    type: s3-iam
+    source:
+      bucket: {{state_bucket}}
+      region_name: {{aws_region}}
+      versioned_file: metrics-cert.tar.gz
+
   - name: bosh-manifest
     type: s3-iam
     source:
@@ -224,6 +231,7 @@ jobs:
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} bosh-manifest-state.json paas-cf/concourse/init_files/bosh-init-state.json.tpl
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} bosh-secrets.yml paas-cf/concourse/init_files/zero_bytes
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} bosh-CA.tar.gz paas-cf/concourse/init_files/empty.tar.gz
+                paas-cf/concourse/scripts/s3init.sh {{state_bucket}} metrics-cert.tar.gz paas-cf/concourse/init_files/empty.tar.gz
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} cf-secrets.yml paas-cf/concourse/init_files/zero_bytes
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} cf.tfstate paas-cf/concourse/init_files/terraform.tfstate.tpl
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} cf-certs.tar.gz paas-cf/concourse/init_files/empty.tar.gz
@@ -474,7 +482,41 @@ jobs:
             passed: ['generate-bosh-config']
             trigger: true
           - get: cf-secrets
-
+          - get: metrics-cert
+          - get: vpc-tfstate
+          - get: concourse-tfstate
+          - get: bosh-tfstate
+      - task: generate-metrics-certificates
+        config:
+          platform: linux
+          image: docker:///governmentpaas/curl-ssl
+          inputs:
+            - name: metrics-cert
+              path: existing-metrics-cert
+          outputs:
+            - name: generated-metrics-cert
+          params:
+            SYSTEM_DNS_ZONE_NAME: {{system_dns_zone_name}}
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                tar xzvf existing-metrics-cert/metrics-cert.tar.gz
+                if [ -f metrics.crt ] && [ -f metrics.key ]; then
+                  echo Certificate and private key already created, nothing to do
+                  cp existing-metrics-cert/metrics-cert.tar.gz generated-metrics-cert/.
+                  exit 0
+                fi
+                openssl req -x509 -newkey rsa:2048 -keyout metrics.key \
+                  -out metrics.crt -days 365 -nodes -subj \
+                  "/C=UK/ST=London/L=London/O=GDS/CN=metrics.{{deploy_env}}.${SYSTEM_DNS_ZONE_NAME}"
+                tar czvf generated-metrics-cert/metrics-cert.tar.gz metrics.crt metrics.key
+        on_success:
+          put: metrics-cert
+          params:
+            file: generated-metrics-cert/metrics-cert.tar.gz
       - task: generate-cf-secrets
         config:
           platform: linux
@@ -633,7 +675,6 @@ jobs:
           - get: bosh-tfstate
           - get: cf-tfstate
             passed: ['cf-terraform']
-
       - task: extract-terraform-outputs
         config:
           platform: linux

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -525,6 +525,7 @@ jobs:
             - name: paas-cf
             - name: cf-secrets
               path: existing-cf-secrets
+            - name: bosh-tfstate
           outputs:
             - name: generated-cf-secrets
           run:
@@ -556,6 +557,7 @@ jobs:
           - get: concourse-tfstate
           - get: bosh-tfstate
           - get: cf-tfstate
+          - get: metrics-cert
           - get: cf-secrets
             passed: ['generate-cf-secrets']
 
@@ -593,6 +595,8 @@ jobs:
             - name: terraform-variables
             - name: paas-cf
             - name: cf-tfstate
+            - name: metrics-cert
+
           outputs:
             - name: updated-tfstate
           params:
@@ -610,6 +614,7 @@ jobs:
                 . terraform-variables/concourse.tfvars.sh
                 . terraform-variables/bosh.tfvars.sh
                 . terraform-variables/cf-secrets.tfvars.sh
+                tar xzvf metrics-cert/metrics-cert.tar.gz -C .
 
                 terraform apply -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
                   -state=cf-tfstate/cf.tfstate -state-out=updated-tfstate/cf.tfstate paas-cf/terraform/cloudfoundry

--- a/manifests/cf-manifest/deployments/aws/055-graphite-stub.yml
+++ b/manifests/cf-manifest/deployments/aws/055-graphite-stub.yml
@@ -14,6 +14,8 @@ resource_pools:
         size: 65_536
         type: gp2
       availability_zone: (( grab meta.zones.z1 ))
+      elbs:
+        - (( grab terraform_outputs.metrics_elb_name ))
 
 jobs:
   - name: graphite_z1

--- a/manifests/cf-manifest/spec/fixtures/terraform/terraform-outputs.yml
+++ b/manifests/cf-manifest/spec/fixtures/terraform/terraform-outputs.yml
@@ -24,4 +24,3 @@ terraform_outputs:
   ingestor_elb_name: stub_ingestor_elb
   ingestor_elb_dns_name: stub_ingestor_elb_dns
   elastic_master_elb_name: elastic_master_elb
-  elastic_master_elb_dns_name: elastic_master_elb_dns

--- a/manifests/cf-manifest/spec/fixtures/terraform/terraform-outputs.yml
+++ b/manifests/cf-manifest/spec/fixtures/terraform/terraform-outputs.yml
@@ -24,3 +24,5 @@ terraform_outputs:
   ingestor_elb_name: stub_ingestor_elb
   ingestor_elb_dns_name: stub_ingestor_elb_dns
   elastic_master_elb_name: elastic_master_elb
+  elastic_master_elb_dns_name: elastic_master_elb_dns
+  metrics_elb_name: metrics_elb_name

--- a/terraform/cloudfoundry/dns-records.tf
+++ b/terraform/cloudfoundry/dns-records.tf
@@ -21,3 +21,11 @@ resource "aws_route53_record" "apps_wildcard" {
   ttl = "60"
   records = ["${aws_elb.router.dns_name}"]
 }
+
+resource "aws_route53_record" "metrics" {
+  zone_id = "${var.system_dns_zone_id}"
+  name = "metrics.${var.system_dns_zone_name}."
+  type = "CNAME"
+  ttl = "60"
+  records = ["${aws_elb.metrics_elb.dns_name}"]
+}

--- a/terraform/cloudfoundry/network_acls_cf_in.tf
+++ b/terraform/cloudfoundry/network_acls_cf_in.tf
@@ -166,6 +166,8 @@ resource "aws_network_acl_rule" "119_allow_all_from_infra" {
     protocol = "tcp"
     rule_number = 118
     rule_action = "allow"
+    from_port = 0
+    to_port = 65535
     cidr_block = "${var.infra_cidr_all}"
     egress = false
 }

--- a/terraform/cloudfoundry/outputs.tf
+++ b/terraform/cloudfoundry/outputs.tf
@@ -65,3 +65,8 @@ output "elastic_master_elb_name" {
 output "elastic_master_elb_dns_name" {
   value = "${aws_elb.es_master_elb.dns_name}"
 }
+
+output "metrics_elb_name" {
+  value = "${aws_elb.metrics_elb.name}"
+}
+

--- a/terraform/cloudfoundry/routers.tf
+++ b/terraform/cloudfoundry/routers.tf
@@ -83,7 +83,6 @@ resource "aws_elb" "ingestor_elb" {
   }
 }
 
-
 resource "aws_elb" "es_master_elb" {
   name = "${var.env}-cf-es-elb"
   subnets = ["${split(",", var.infra_subnet_ids)}"]
@@ -110,4 +109,35 @@ resource "aws_elb" "es_master_elb" {
 }
 
 
+
+resource "aws_elb" "metrics_elb" {
+  name = "${var.env}-metrics-elb"
+  subnets = ["${split(",", var.infra_subnet_ids)}"]
+  idle_timeout = "${var.elb_idle_timeout}"
+  cross_zone_load_balancing = "true"
+  security_groups = [
+    "${aws_security_group.metrics_elb.id}",
+  ]
+
+  health_check {
+    target = "TCP:3000"
+    interval = "${var.health_check_interval}"
+    timeout = "${var.health_check_timeout}"
+    healthy_threshold = "${var.health_check_healthy}"
+    unhealthy_threshold = "${var.health_check_unhealthy}"
+  }
+  listener {
+    instance_port = 3000
+    instance_protocol = "tcp"
+    lb_port = 443
+    lb_protocol = "tcp"
+  }
+
+  listener {
+    instance_port = 3001
+    instance_protocol = "tcp"
+    lb_port = 3001 
+    lb_protocol = "tcp"
+  }
+}
 

--- a/terraform/cloudfoundry/routers.tf
+++ b/terraform/cloudfoundry/routers.tf
@@ -110,6 +110,12 @@ resource "aws_elb" "es_master_elb" {
 
 
 
+resource "aws_iam_server_certificate" "metrics" {
+  name = "${var.env}-metrics"
+  certificate_body = "${file("metrics.crt")}"
+  private_key = "${file("metrics.key")}"
+}
+
 resource "aws_elb" "metrics_elb" {
   name = "${var.env}-metrics-elb"
   subnets = ["${split(",", var.infra_subnet_ids)}"]
@@ -128,16 +134,17 @@ resource "aws_elb" "metrics_elb" {
   }
   listener {
     instance_port = 3000
-    instance_protocol = "tcp"
+    instance_protocol = "http"
     lb_port = 443
-    lb_protocol = "tcp"
+    lb_protocol = "https"
+    ssl_certificate_id = "${aws_iam_server_certificate.metrics.arn}"
   }
 
   listener {
     instance_port = 3001
-    instance_protocol = "tcp"
-    lb_port = 3001 
-    lb_protocol = "tcp"
+    instance_protocol = "http"
+    lb_port = 3001
+    lb_protocol = "https"
+    ssl_certificate_id = "${aws_iam_server_certificate.metrics.arn}"
   }
 }
-

--- a/terraform/cloudfoundry/security-groups.tf
+++ b/terraform/cloudfoundry/security-groups.tf
@@ -153,8 +153,8 @@ resource "aws_security_group" "elastic_master_elb" {
   }
 }
 
-resource "aws_security_group" "grafana_elb" {
-  name = "${var.env}-grafana"
+resource "aws_security_group" "metrics_elb" {
+  name = "${var.env}-metrics"
   description = "Security group for graphite/grafana ELB"
   vpc_id = "${var.vpc_id}"
 
@@ -170,7 +170,7 @@ resource "aws_security_group" "grafana_elb" {
     to_port   = 443
     protocol  = "tcp"
     cidr_blocks = [
-      "${var.vpc_cidr}"
+      "${split(",", var.office_cidrs)}"
     ]
   }
 
@@ -179,12 +179,12 @@ resource "aws_security_group" "grafana_elb" {
     to_port   = 3001
     protocol  = "tcp"
     cidr_blocks = [
-      "${var.vpc_cidr}"
+      "${split(",", var.office_cidrs)}"
     ]
   }
 
   tags {
-    Name = "${var.env}-grafana_elb"
+    Name = "${var.env}-metrics_elb"
   }
 }
 

--- a/terraform/cloudfoundry/security-groups.tf
+++ b/terraform/cloudfoundry/security-groups.tf
@@ -153,3 +153,39 @@ resource "aws_security_group" "elastic_master_elb" {
   }
 }
 
+resource "aws_security_group" "grafana_elb" {
+  name = "${var.env}-grafana"
+  description = "Security group for graphite/grafana ELB"
+  vpc_id = "${var.vpc_id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 443
+    to_port   = 443
+    protocol  = "tcp"
+    cidr_blocks = [
+      "${var.vpc_cidr}"
+    ]
+  }
+
+  ingress {
+    from_port = 3001
+    to_port   = 3001
+    protocol  = "tcp"
+    cidr_blocks = [
+      "${var.vpc_cidr}"
+    ]
+  }
+
+  tags {
+    Name = "${var.env}-grafana_elb"
+  }
+}
+
+


### PR DESCRIPTION

[ELB for access to metrics](https://www.pivotaltracker.com/story/show/115251665)

## What

Currently to access metrics we are using SSH tunnels. We should change this to allow access via ELB over HTTPS and limited to whitelisted IP ranges.

## How to Review This PR

This PR has been written with the following narrative:

* I would like to:
	* I create a new security group for:
     * Grafana and;
     * Graphite
 	* Create a new ELB for 
     * Grafana listening on port 443 and forwarding to port 3000 on all registered grafana nodes;
     * Graphite listening on port 3001 and forwarding to port 3001 on all registered grafana/graphite nodes;
     * Create Terraform outputs for graphana so I can use them in cloud foundry manifests
     * Fix ACL port range on rule 118 to allow ELB's to talk to grafana and graphite node.
     * Create new resources for metrics-certificates and vpc terraform state
			* The metrics-cert is a resource for the metrics certificates
			* The vpc-state is to get the terraform variables for the VPC in order
  to correctly name the certificate
     * Generate and use metrics SSL certificates


## How to test this PR

* Deploy a new environment
* For Grafana:
  * Browse to https://metrics.$DEPLOY_ENV.dev.paas.alphagov.co.uk 
* For Graphite:
  * Browse to https://metrics.$DEPLOY_ENV.dev.paas.alphagov.co.uk:3001 



  
## Who can merge this PR

[Don't cry because this story is over. Smile because it happened.](http://www.brainyquote.com/quotes/authors/d/dr_seuss.html) Though @jimconner, @actionjack and @henrytk aren't allowed to 