### PR TITLE
[#115318745] Ability to deploy without environment name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,9 @@ spec:
 lint_yaml:
 	$(YAMLLINT) -c yamllint.yml .
 
-lint_terraform:
+lint_terraform: set_env_class_dev
+	$(eval export TF_VAR_system_dns_zone_name=$SYSTEM_DNS_ZONE_NAME)
+	$(eval export TF_VAR_apps_dns_zone_name=$APPS_DNS_ZONE_NAME)
 	find terraform -mindepth 1 -maxdepth 1 -type d -print0 | xargs -0 -n 1 -t terraform graph > /dev/null
 
 lint_shellcheck:
@@ -64,6 +66,8 @@ prod-bootstrap: check-env-vars set_env_class_prod vagrant-deploy  ## Start Produ
 set_env_class_dev:
 	$(eval export MAKEFILE_ENV_TARGET=dev)
 	$(eval export AWS_ACCOUNT=dev)
+	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
+	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipelineapps.digital)
 
 .PHONY: set_env_class_ci
 set_env_class_ci:
@@ -72,6 +76,8 @@ set_env_class_ci:
 	$(eval export ENABLE_AUTO_DEPLOY=true)
 	$(eval export DISABLE_AUTODELETE=1)
 	$(eval export TAG_PREFIX=stage-)
+	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.ci.cloudpipeline.digital)
+	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.ci.cloudpipelineapps.digital)
 
 .PHONY: set_env_class_stage
 set_env_class_stage:
@@ -81,6 +87,8 @@ set_env_class_stage:
 	$(eval export DISABLE_AUTODELETE=1)
 	$(eval export PAAS_CF_TAG_FILTER=stage-*)
 	$(eval export TAG_PREFIX=prod-)
+	$(eval export SYSTEM_DNS_ZONE_NAME=staging.cloudpipeline.digital)
+	$(eval export APPS_DNS_ZONE_NAME=staging.cloudpipelineapps.digital)
 
 .PHONY: set_env_class_prod
 set_env_class_prod:
@@ -88,6 +96,8 @@ set_env_class_prod:
 	$(eval export AWS_ACCOUNT=prod)
 	$(eval export ENABLE_AUTO_DEPLOY=true)
 	$(eval export PAAS_CF_TAG_FILTER=prod-*)
+	$(eval export SYSTEM_DNS_ZONE_NAME=cloud.service.gov.uk)
+	$(eval export APPS_DNS_ZONE_NAME=cloudapps.digital)
 
 .PHONY: vagrant-deploy
 vagrant-deploy:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test spec lint_yaml lint_terraform lint_shellcheck set_aws_count set_auto_trigger disable_auto_delete check-env-vars
+.PHONY: help test spec lint_yaml lint_terraform lint_shellcheck check-env-vars
 
 .DEFAULT_GOAL := help
 

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -555,6 +555,8 @@ jobs:
             - name: updated-tfstate
           params:
             TF_VAR_env: {{deploy_env}}
+            TF_VAR_system_dns_zone_name: {{system_dns_zone_name}}
+            TF_VAR_apps_dns_zone_name: {{apps_dns_zone_name}}
             AWS_DEFAULT_REGION: {{aws_region}}
           run:
             path: sh

--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -240,7 +240,8 @@ jobs:
         image: docker:///governmentpaas/curl-ssl
         inputs:
         - name: concourse-cert
-        - name: vpc-terraform-outputs
+        params:
+          SYSTEM_DNS_ZONE_NAME: {{system_dns_zone_name}}
         run:
           path: sh
           args:
@@ -253,10 +254,9 @@ jobs:
               cp concourse-cert/concourse-cert.tar.gz .
               exit 0
             fi
-            . vpc-terraform-outputs/tfvars.sh
             openssl req -x509 -newkey rsa:2048 -keyout concourse.key \
               -out concourse.crt -days 365 -nodes -subj \
-              "/C=UK/ST=London/L=London/O=GDS/CN=deployer.{{deploy_env}}.${TF_VAR_system_dns_zone_name}"
+              "/C=UK/ST=London/L=London/O=GDS/CN=deployer.${SYSTEM_DNS_ZONE_NAME}"
             tar czvf concourse-cert.tar.gz concourse.crt concourse.key
 
     - task: terraform-apply
@@ -270,6 +270,7 @@ jobs:
         params:
           VAGRANT_IP: {{vagrant_ip}}
           TF_VAR_env: {{deploy_env}}
+          TF_VAR_system_dns_zone_name: {{system_dns_zone_name}}
           AWS_DEFAULT_REGION: {{aws_region}}
         run:
           path: sh
@@ -515,6 +516,7 @@ jobs:
         - name: concourse-terraform-state
         params:
           TF_VAR_env: {{deploy_env}}
+          TF_VAR_system_dns_zone_name: {{system_dns_zone_name}}
           AWS_DEFAULT_REGION: {{aws_region}}
         run:
           path: sh

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -161,6 +161,8 @@ jobs:
           outputs:
             - name: updated-cf-tfstate
           params:
+            TF_VAR_system_dns_zone_name: {{system_dns_zone_name}}
+            TF_VAR_apps_dns_zone_name: {{apps_dns_zone_name}}
             AWS_DEFAULT_REGION: {{aws_region}}
           run:
             path: sh

--- a/concourse/pipelines/destroy-deployer.yml
+++ b/concourse/pipelines/destroy-deployer.yml
@@ -122,6 +122,7 @@ jobs:
         params:
           AWS_DEFAULT_REGION: {{aws_region}}
           TF_VAR_env: {{deploy_env}}
+          TF_VAR_system_dns_zone_name: {{system_dns_zone_name}}
         run:
           path: sh
           args:

--- a/concourse/scripts/environment.sh
+++ b/concourse/scripts/environment.sh
@@ -9,10 +9,6 @@ hashed_password() {
   echo "$1" | shasum -a 256 | base64 | head -c 32
 }
 
-fetch_system_dns_zone(){
-  awk -F' *= *|"' '$1=="system_dns_zone_name" { print $3}' "${PROJECT_DIR}/terraform/${AWS_ACCOUNT}.tfvars"
-}
-
 DEPLOY_ENV=${1:-${DEPLOY_ENV:-}}
 if [ -z "${DEPLOY_ENV}" ]; then
   echo "Must specify DEPLOY_ENV as \$1 or environment variable" 1>&2
@@ -23,7 +19,7 @@ AWS_ACCOUNT=${AWS_ACCOUNT:-dev}
 
 case $TARGET_CONCOURSE in
   deployer)
-    CONCOURSE_URL="${CONCOURSE_URL:-https://deployer.${DEPLOY_ENV}.$(fetch_system_dns_zone)}"
+    CONCOURSE_URL="${CONCOURSE_URL:-https://deployer.${SYSTEM_DNS_ZONE_NAME}}"
     FLY_TARGET=${FLY_TARGET:-$DEPLOY_ENV}
     FLY_CMD="${PROJECT_DIR}/bin/fly"
     ;;

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -34,6 +34,8 @@ cf_graphite_version: ${cf_graphite_version}
 cf_grafana_version: ${cf_grafana_version}
 paas_cf_tag_filter: ${PAAS_CF_TAG_FILTER:-}
 TAG_PREFIX: ${TAG_PREFIX:-}
+system_dns_zone_name: ${SYSTEM_DNS_ZONE_NAME}
+apps_dns_zone_name: ${APPS_DNS_ZONE_NAME}
 EOF
 }
 

--- a/concourse/scripts/pipelines-deployer.sh
+++ b/concourse/scripts/pipelines-deployer.sh
@@ -23,6 +23,7 @@ aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
 concourse_atc_password: ${CONCOURSE_ATC_PASSWORD}
 log_level: ${LOG_LEVEL:-}
 paas_cf_tag_filter: ${PAAS_CF_TAG_FILTER:-}
+system_dns_zone_name: ${SYSTEM_DNS_ZONE_NAME}
 EOF
 }
 

--- a/manifests/cf-manifest/spec/fixtures/terraform/terraform-outputs.yml
+++ b/manifests/cf-manifest/spec/fixtures/terraform/terraform-outputs.yml
@@ -9,7 +9,6 @@ terraform_outputs:
   router2_subnet_id: subnet-98765432
   cf_root_domain: unit-test.dev.paas.example.com
   cf_apps_domain: unit-test.dev-apps.paas.example.com
-  system_dns_zone_name: dev.paas.example.com
   elb_name: unit-test-cf-router-elb
   environment: unit-test
   region: sealand-1

--- a/terraform/ci.tfvars
+++ b/terraform/ci.tfvars
@@ -1,8 +1,6 @@
 aws_account = "ci"
 system_dns_zone_id = "Z2PF4LCV9VR1MV"
-system_dns_zone_name = "ci.cloudpipeline.digital"
 apps_dns_zone_id = "Z29I9K6RNC6344"
-apps_dns_zone_name = "ci.cloudpipelineapps.digital"
 cf_db_multi_az = "false"
 cf_db_backup_retention_period = "0"
 cf_db_skip_final_snapshot = "true"

--- a/terraform/cloudfoundry/dns-records.tf
+++ b/terraform/cloudfoundry/dns-records.tf
@@ -1,6 +1,6 @@
 resource "aws_route53_record" "system_wildcard" {
   zone_id = "${var.system_dns_zone_id}"
-  name = "*.${var.env}.${var.system_dns_zone_name}."
+  name = "*.${var.system_dns_zone_name}."
   type = "CNAME"
   ttl = "60"
   records = ["${aws_elb.router.dns_name}"]
@@ -8,7 +8,7 @@ resource "aws_route53_record" "system_wildcard" {
 
 resource "aws_route53_record" "sshproxy" {
   zone_id = "${var.system_dns_zone_id}"
-  name = "ssh.${var.env}.${var.system_dns_zone_name}."
+  name = "ssh.${var.system_dns_zone_name}."
   type = "CNAME"
   ttl = "60"
   records = ["${aws_elb.ssh-proxy-router.dns_name}"]
@@ -16,7 +16,7 @@ resource "aws_route53_record" "sshproxy" {
 
 resource "aws_route53_record" "apps_wildcard" {
   zone_id = "${var.apps_dns_zone_id}"
-  name = "*.${var.env}.${var.apps_dns_zone_name}."
+  name = "*.${var.apps_dns_zone_name}"
   type = "CNAME"
   ttl = "60"
   records = ["${aws_elb.router.dns_name}"]

--- a/terraform/cloudfoundry/outputs.tf
+++ b/terraform/cloudfoundry/outputs.tf
@@ -31,11 +31,11 @@ output "ssh_elb_name" {
 }
 
 output "cf_root_domain" {
-  value = "${var.env}.${var.system_dns_zone_name}"
+  value = "${var.system_dns_zone_name}"
 }
 
 output "cf_apps_domain" {
-  value = "${var.env}.${var.apps_dns_zone_name}"
+  value = "${var.apps_dns_zone_name}"
 }
 
 output "elb_name" {

--- a/terraform/cloudfoundry/variables.tf
+++ b/terraform/cloudfoundry/variables.tf
@@ -97,3 +97,19 @@ variable "cf_db_backup_retention_period" {
 variable "cf_db_skip_final_snapshot" {
   descrition = "Whether to skip final RDS snapshot (just before destroy). Differs per environment."
 }
+
+variable "system_dns_zone_id" {
+  description = "Amazon Route53 DNS zone identifier for the system components. Different per account."
+}
+
+variable "system_dns_zone_name" {
+  description = "Amazon Route53 DNS zone name for the provisioned environment."
+}
+
+variable "apps_dns_zone_id" {
+  description = "Amazon Route53 DNS zone identifier for hosted apps. Different per account."
+}
+
+variable "apps_dns_zone_name" {
+  description = "Amazon Route53 DNS zone name for hosted apps. Differs per account."
+}

--- a/terraform/concourse/elb.tf
+++ b/terraform/concourse/elb.tf
@@ -67,7 +67,7 @@ resource "aws_security_group" "concourse-elb" {
 
 resource "aws_route53_record" "deployer-concourse" {
   zone_id = "${var.system_dns_zone_id}"
-  name    = "deployer.${var.env}.${var.system_dns_zone_name}."
+  name    = "deployer.${var.system_dns_zone_name}."
   type    = "CNAME"
   ttl     = "60"
   records = ["${aws_elb.concourse.dns_name}"]

--- a/terraform/concourse/variables.tf
+++ b/terraform/concourse/variables.tf
@@ -1,0 +1,7 @@
+variable "system_dns_zone_id" {
+  description = "Amazon Route53 DNS zone identifier for the system components. Different per account."
+}
+
+variable "system_dns_zone_name" {
+  description = "Amazon Route53 DNS zone name for the provisioned environment."
+}

--- a/terraform/dev.tfvars
+++ b/terraform/dev.tfvars
@@ -1,8 +1,6 @@
 aws_account = "dev"
 system_dns_zone_id = "Z1QGLFML8EG6G7"
-system_dns_zone_name = "dev.cloudpipeline.digital"
 apps_dns_zone_id = "Z3R6XFWUT4YZHB"
-apps_dns_zone_name = "dev.cloudpipelineapps.digital"
 cf_db_multi_az = "false"
 cf_db_backup_retention_period = "0"
 cf_db_skip_final_snapshot = "true"

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -65,22 +65,6 @@ variable "vagrant_cidr" {
   default     = ""
 }
 
-variable "system_dns_zone_id" {
-  description = "Amazon Route53 DNS zone identifier for the system components. Different per account."
-}
-
-variable "system_dns_zone_name" {
-  description = "Amazon Route53 DNS zone name for the system components. Differs per account."
-}
-
-variable "apps_dns_zone_id" {
-  description = "Amazon Route53 DNS zone identifier for hosted apps. Different per account."
-}
-
-variable "apps_dns_zone_name" {
-  description = "Amazon Route53 DNS zone name for hosted apps. Differs per account."
-}
-
 variable "microbosh_static_private_ip" {
   description = "Microbosh internal IP"
   default     = "10.0.0.6"

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -1,8 +1,6 @@
 aws_account = "prod"
 system_dns_zone_id = "Z39UURGVWSYTHL"
-system_dns_zone_name = "cloud.service.gov.uk"
 apps_dns_zone_id = "Z29K8LQNCFDZ1T"
-apps_dns_zone_name = "cloudapps.digital"
 cf_db_multi_az = "true"
 cf_db_backup_retention_period = "35"
 cf_db_skip_final_snapshot = "false"

--- a/terraform/stage.tfvars
+++ b/terraform/stage.tfvars
@@ -1,8 +1,6 @@
 aws_account = "stage"
 system_dns_zone_id = "ZPFAUK62IO6DS"
-system_dns_zone_name = "staging.cloudpipeline.digital"
 apps_dns_zone_id = "Z32JRRSU1CAFE8"
-apps_dns_zone_name = "staging.cloudpipelineapps.digital"
 cf_db_multi_az = "true"
 cf_db_backup_retention_period = "35"
 cf_db_skip_final_snapshot = "false"

--- a/terraform/vpc/outputs.tf
+++ b/terraform/vpc/outputs.tf
@@ -41,7 +41,3 @@ output "key_pair_name" {
 output "infra_subnet_ids" {
   value = "${join(",", aws_subnet.infra.*.id)}"
 }
-
-output "system_dns_zone_name" {
-  value = "${var.system_dns_zone_name}"
-}


### PR DESCRIPTION
## What

[Story link: https://www.pivotaltracker.com/story/show/115318745](https://www.pivotaltracker.com/story/show/115318745)
We want to be able to deploy CF environment without a specific development name.
In staging and production we don't have a need for the "environment name" because there will only be one environment under that "domain name". We need to optionally omit that "thing" from the naming, so that we can create DNS entries such as:
- api.cloud.service.gov.uk
- api.staging.cloudpipeline.digital

And not:
- api.production.cloud.service.gov.uk
- api.staging.staging.cloudpipeline.digital

## How to review

```
BRANCH=no-env-name-115318745 make dev
```
Deploy BOSH and CF (smoke test should pass ) and test destruction as well.
If you are not following master branch closely and your env is pre https://github.com/alphagov/paas-cf/pull/157 you will have to start from scratch and create deployer concourse as well. 
If you are FTA please test stage and prod as well.


## Who can review

Anyone but @combor or @keymon 