### PR TITLE
Bump terraform in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
   - 2.2.3
 env:
   global:
-    - TF_VERSION="0.6.10"
+    - TF_VERSION="0.6.12"
     - SPRUCE_VERSION="0.13.0"
 
 addons:


### PR DESCRIPTION
## What

We upgraded terraform in our concourse containers to 0.6.12 a while ago.
We should therefore be using the same version in Travis.

## How to review

Verify that the Travis build downloads 0.6.12, and passes

## Who can review

Anyone but myself.