### PR TITLE
[#115414833] Ensure orphaned volumes aren't left behind in EC2

### DIFF
--- a/concourse/pipelines/destroy-microbosh.yml
+++ b/concourse/pipelines/destroy-microbosh.yml
@@ -98,6 +98,22 @@ jobs:
           - get: bosh-secrets
           - get: bosh-init-state
           - get: bosh-manifest
+      - task: cleanup-orphaned-disks
+        config:
+          platform: linux
+          image: docker:///governmentpaas/bosh-cli
+          inputs:
+            - name: paas-cf
+            - name: bosh-secrets
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
+
+                bosh cleanup --all
       - task: bosh-init-microbosh
         config:
           platform: linux

--- a/manifests/bosh-manifest/deployments/010-bosh-template.yml
+++ b/manifests/bosh-manifest/deployments/010-bosh-template.yml
@@ -85,6 +85,8 @@ jobs:
       address: 127.0.0.1
       name: my-bosh
       db: (( grab meta.postgres ))
+      disks:
+        max_orphaned_age_in_days: 0
       cpi_job: (( grab cloud_provider.template.name ))
       ignore_missing_gateway: "false"
       user_management:

--- a/manifests/bosh-manifest/reference-bosh-manifest.yml
+++ b/manifests/bosh-manifest/reference-bosh-manifest.yml
@@ -81,6 +81,8 @@ jobs:
         host: 127.0.0.1
         password: BOSH_POSTGRES_PASSWORD
         user: postgres
+      disks:
+        max_orphaned_age_in_days: 0
       ignore_missing_gateway: "false"
       name: my-bosh
       user_management:


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/115414833

## What

Bosh doesn't delete persistent disks imediately when deleting the
corresponding VM, instead there's a scheduled job that deletes them N
days after their VM was deleted (5 days by default).

This PR does 2 things to prevent this.
* It sets the `max_orphaned_age_in_days` parameter to 0, which means bosh will clean them up within 30 mins (the cleanup job runs every 30 mins by default)
* It adds a task to run a `bosh cleanup --all` to the `destroy-microbosh` pipeline to ensure that all orphaned disks are cleaned up before bosh is destroyed.

## How to review

Deploy from this branch. Then delete the CF deployment. Note that there are 14 unused volumes in the EC2 console. Verify that these are automatically removed within 30 mins (the cleanup job runs on the hour and at 30 mins past the hour).

## Who can review

Anyone but myself.