### PR TITLE
[#115403965] Disable debug logging for Cloud Controller 

### DIFF
--- a/manifests/cf-manifest/deployments/040-cf-properties.yml
+++ b/manifests/cf-manifest/deployments/040-cf-properties.yml
@@ -101,8 +101,8 @@ properties:
     internal_api_user: "internal_user"
     internal_api_password: (( grab properties.cc.bulk_api_password ))
 
-    logging_level: debug2
-    db_logging_level: debug2
+    logging_level: info
+    db_logging_level: debug
 
     directories: ~
 


### PR DESCRIPTION
## What

The logs from cloud_controller_ng are nedlessly verbose as they contain every single SQL query performed against the ccdb - We wish to make the logs less verbose as they are currently very difficult to search through when necessary.

There are two parameters within the manifest which control logging from the cloud_controller - `db_logging_level` sets the logging level at which all db query messages will be regsitered, whereas `logging_level` defines the level at which logs will be emitted from cloud_controller_ng and fed into syslog. The distinction between these two logging values is poorly documented, but important to understand - If `db_logging_level` is set to a value of `error` then the totallity of the SQL query logs will be emitted when logging_level is set to a value equal or higher than `error` (e.g. `error`, `warn`, `info`, `debug` etc).   

The different logging levels available are described in https://github.com/cloudfoundry/steno#log-levels


## How to review this PR.

* Deploy as per the instructions in the README.md
* After deployment has completed, `bosh ssh` onto the api_z(n) nodes and check the cloud_controller_ng config file in `/var/vcap/jobs/cloud_controller_ng/config/cloud_controller_ng.yml` - observe that `logging.level` is set to `info` and that `db.log_level` is set to `debug`
* Examine `/var/vcap/sys/log/cloud_controller_ng/cloud_controller_ng.log logfile` - You should note that log messages are now emitted with a logging_level of `info`, and that the SQL debug logs are no longer no longer included by default.

## Who can review this PR.
Anyone on the team with the exception of @combor and @jimconner
