### PR TITLE
[#113266439] Updates to allow staging deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,6 @@ set_env_class_stage:
 	$(eval export AWS_ACCOUNT=stage)
 	$(eval export ENABLE_AUTO_DEPLOY=true)
 	$(eval export PAAS_CF_TAG_FILTER=stage-*)
-	$(eval export TAG_PREFIX=prod-)
 	$(eval export SYSTEM_DNS_ZONE_NAME=staging.cloudpipeline.digital)
 	$(eval export APPS_DNS_ZONE_NAME=staging.cloudpipelineapps.digital)
 

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ prod-bootstrap: check-env-vars set_env_class_prod vagrant-deploy  ## Start Produ
 set_env_class_dev:
 	$(eval export MAKEFILE_ENV_TARGET=dev)
 	$(eval export AWS_ACCOUNT=dev)
+	$(eval export ENABLE_AUTODELETE=true)
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
 	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipelineapps.digital)
 
@@ -74,7 +75,6 @@ set_env_class_ci:
 	$(eval export MAKEFILE_ENV_TARGET=ci)
 	$(eval export AWS_ACCOUNT=ci)
 	$(eval export ENABLE_AUTO_DEPLOY=true)
-	$(eval export DISABLE_AUTODELETE=1)
 	$(eval export TAG_PREFIX=stage-)
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.ci.cloudpipeline.digital)
 	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.ci.cloudpipelineapps.digital)
@@ -84,7 +84,6 @@ set_env_class_stage:
 	$(eval export MAKEFILE_ENV_TARGET=stage)
 	$(eval export AWS_ACCOUNT=stage)
 	$(eval export ENABLE_AUTO_DEPLOY=true)
-	$(eval export DISABLE_AUTODELETE=1)
 	$(eval export PAAS_CF_TAG_FILTER=stage-*)
 	$(eval export TAG_PREFIX=prod-)
 	$(eval export SYSTEM_DNS_ZONE_NAME=staging.cloudpipeline.digital)

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -57,7 +57,7 @@ update_pipeline() {
         <(generate_vars_file)
     ;;
     autodelete-cloudfoundry)
-      if [ ! "${DISABLE_AUTODELETE:-}" ]; then
+      if [ -n "${ENABLE_AUTODELETE:-}" ]; then
         bash "${SCRIPT_DIR}/deploy-pipeline.sh" \
           "${env}" "${pipeline_name}" \
           "${SCRIPT_DIR}/../pipelines/${pipeline_name}.yml" \
@@ -65,12 +65,13 @@ update_pipeline() {
 
         echo
         echo "WARNING: Pipeline to autodelete Cloud Foundry has been setup and enabled."
-        echo "         To disable it, set DISABLE_AUTODELETE=1 or pause the pipeline."
+        echo "         To disable it, unset ENABLE_AUTODELETE or pause the pipeline."
       else
         yes y | ${FLY_CMD} -t "${FLY_TARGET}" destroy-pipeline --pipeline "${pipeline_name}" || true
 
         echo
         echo "WARNING: Pipeline to autodelete Cloud Foundry has NOT been setup"
+        echo "         To enable it, set ENABLE_AUTODELETE=true"
       fi
     ;;
     *)

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -13,6 +13,14 @@ AWS_ACCOUNT_DATA = {
     :subnet_id => "subnet-68bb7e30", # us-east-1a in default VPC, 172.31.16.0/20 range
     :security_group => "sg-23e1c15a", # "Bootstrap Concourse" security group
   },
+  "stage" => {
+    :subnet_id => "subnet-9034fbc8", # us-east-1c in default VPC, 172.31.16.0/20 range
+    :security_group => "sg-87e1c1fe", # "Bootstrap Concourse" security group
+  },
+  "prod" => {
+    :subnet_id => "subnet-bc34fbe4", # us-east-1a in default VPC, 172.31.16.0/20 range
+    :security_group => "sg-14e2c26d", # "Bootstrap Concourse" security group
+  },
 }
 AWS_ACCOUNT_VARIABLES = AWS_ACCOUNT_DATA.fetch(AWS_ACCOUNT)
 


### PR DESCRIPTION
## What

There were a few small changes necessary to allow deploying to staging:

* We needed to populate the subnet and security group for the bootstrap concourse in the `Vagrantfile`
* We needed to disable the creation of the prod tags - we're not ready for this yet, there are stories to implement this in the backlog.

While doing this, I noticed that `DISABLE_AUTODELETE` had not been enabled for production. I've therefore updated this flag so that autodelete defaults to disabled unless explicitly enabled, and updated the Makefile so that it's enabled for dev. This felt safer, and less likely that autodelete would accidentally be enabled in a production environment.

## How to review

There's not much review that can be done here beyond verifying that the changes look good, and that the pipeline scripts still setup the autodelete pipeline correctly.

## Who can review

Anyone but myself.