### PR TITLE
[#115845521] Move bosh-cli to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,28 +39,28 @@ lint_shellcheck:
 	find . -name '*.sh' -print0 | xargs -0 $(SHELLCHECK)
 
 .PHONY: dev
-dev: check-env-vars set_env_class_dev deploy_pipelines ## Deploy Pipelines to Dev Environment
-
-.PHONY: dev-bootstrap
-dev-bootstrap: check-env-vars set_env_class_dev vagrant-deploy ## Start DEV bootsrap
+dev: check-env-vars set_env_class_dev ## Set environment to DEV
 
 .PHONY: ci
-ci: check-env-vars set_env_class_ci deploy_pipelines  ## Deploy Pipelines to CI Environment
-
-.PHONY: ci-bootstrap
-ci-bootstrap: check-env-vars set_env_class_ci vagrant-deploy  ## Start CI bootsrap
+ci: check-env-vars set_env_class_ci ## Set environment to CI
 
 .PHONY: stage
-stage: check-env-vars set_env_class_stage deploy_pipelines  ## Deploy Pipelines to Staging Environment
-
-.PHONY: stage-bootstrap
-stage-bootstrap: check-env-vars set_env_class_stage vagrant-deploy  ## Start Staging bootsrap
+stage: check-env-vars set_env_class_stage  ## Set Envirnoment to Staging
 
 .PHONY: prod
-prod: check-env-vars set_env_class_prod deploy_pipelines  ## Deploy Pipelines to Production Environment
+prod: check-env-vars set_env_class_prod ## Set Envirnoment to Production 
 
-.PHONY: prod-bootstrap
-prod-bootstrap: check-env-vars set_env_class_prod vagrant-deploy  ## Start Production bootsrap
+.PHONY: bootstrap
+bootstrap: ## Start bootsrap 
+	vagrant/deploy.sh
+
+.PHONY: bootstrap-destroy
+bootstrap-destroy: ## Destroy bootsrap 
+	./vagrant/destroy.sh
+
+.PHONY: bosh-cli
+bosh-cli: ## Create interactive connnection to BOSH container
+	concourse/scripts/bosh-cli.sh $(DEPLOY_ENV)
 
 .PHONY: set_env_class_dev
 set_env_class_dev:
@@ -97,10 +97,6 @@ set_env_class_prod:
 	$(eval export SYSTEM_DNS_ZONE_NAME=cloud.service.gov.uk)
 	$(eval export APPS_DNS_ZONE_NAME=cloudapps.digital)
 
-.PHONY: vagrant-deploy
-vagrant-deploy:
-	vagrant/deploy.sh
-
-.PHONY: deploy_pipelines
-deploy_pipelines:
+.PHONY: pipelines
+pipelines: ## Upload pipelines to Concourse
 	concourse/scripts/pipelines-bosh-cloudfoundry.sh

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $ export DEPLOY_ENV=environment-name
 Create the bootstrap Concourse with `make`. Select the target based on which AWS account you want to work with. For instance for a DEV bootstrap:
 
 ```
-make dev-bootstrap
+make dev bootstrap
 ```
 `make help` will show all available options.
 
@@ -89,7 +89,7 @@ use to login.
 Run the following script:
 
 ```
-./vagrant/destroy.sh
+make dev bootstrap-destroy
 ```
 
 ## Deployer Concourse
@@ -110,7 +110,9 @@ Run the `create-deployer` pipeline from your *Bootstrap Concourse*.
 When complete you can access the UI from a browser with the same credentials as
 your *Bootstrap Concourse* on the following URL:
 
-`https://deployer.${DEPLOY_ENV}.dev.cloudpipeline.digital/`
+```
+https://deployer.${DEPLOY_ENV}.dev.cloudpipeline.digital/
+```
 
 ### Destroy
 
@@ -127,7 +129,7 @@ You will need a working [Deployer Concourse](#deployer-concourse).
 
 Deploy the pipeline configurations with `make`. Select the target based on which AWS accout you want to work with. For instance, execute: 
 ```
-make dev
+make dev pipelines
 ```
 if you want to deploy to DEV account.
 
@@ -163,7 +165,7 @@ All of the pipeline scripts (including `vagrant/deploy.sh`) honour a
 used within the pipeline. This is useful for development and code review:
 
 ```
-BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev
+BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines
 ```
 
 ## Optionally deploy to a different AWS account
@@ -199,12 +201,14 @@ ssh ubuntu@<bootstrap_concourse_ip> -L 8080:127.0.0.1:8080 -fN
 
 ## Using the bosh cli and `bosh ssh`
 
-There's a script that starts an interactive session on the deployer concourse
+There's a Makefile target that starts an interactive session on the deployer concourse
 to allow running bosh CLI commands targeting MicroBOSH:
 
 ```
-./concourse/scripts/bosh-cli.sh
+make dev bosh-cli
 ```
+
+You can use any environment supported by Makefile.
 
 This connects you to a one-off task in concourse that's already logged into
 bosh and has the deployment set using the CF manifest.

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -13,6 +13,7 @@ groups:
       - smoke-tests
       - acceptance-tests
       - custom-acceptance-tests
+      - bosh-cli-test
       - tag-release
   - name: bosh
     jobs:
@@ -30,6 +31,7 @@ groups:
       - smoke-tests
       - acceptance-tests
       - custom-acceptance-tests
+      - bosh-cli-test
       - tag-release
   - name: release
     jobs:
@@ -38,6 +40,12 @@ groups:
       - bump-minor-version
       - bump-major-version
       - bump-patch-version
+  - name: tests
+    jobs: 
+      - smoke-tests
+      - acceptance-tests
+      - custom-acceptance-tests
+      - bosh-cli-test
 
 resources:
   - name: pipeline-trigger
@@ -1189,14 +1197,45 @@ jobs:
                 export CONFIG="$(pwd)/test-config/config.json"
                 ./paas-cf/tests/acceptance-tests/run_tests.sh
 
+  - name: bosh-cli-test
+    plan:
+      - aggregate:
+          - get: pipeline-trigger
+            passed: ['cf-deploy']
+            trigger: true
+          - get: paas-cf
+            passed: ['cf-deploy']
+          - get: concourse-manifest
+      - task: connect-to-bosh-cli
+        config:
+          platform: linux
+          image: docker:///ruby#2.2-slim
+          params:
+            SYSTEM_DNS_ZONE_NAME: {{system_dns_zone_name}}
+            DEPLOY_ENV: {{deploy_env}}
+          inputs:
+          - name: paas-cf
+          - name: concourse-manifest
+          run:
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
+              CONCOURSE_ATC_PASSWORD=$("$VAL_FROM_YAML" jobs.concourse.properties.atc.basic_auth_password concourse-manifest/concourse-manifest.yml)
+              export CONCOURSE_ATC_PASSWORD
+              ./paas-cf/concourse/scripts/bosh-cli.sh bosh status
+
+
   - name: tag-release
     plan:
       - aggregate:
           - get: pipeline-trigger
-            passed: ['post-deploy', 'smoke-tests', 'acceptance-tests', 'custom-acceptance-tests']
+            passed: ['post-deploy', 'smoke-tests', 'acceptance-tests', 'custom-acceptance-tests', 'bosh-cli-test']
             trigger: true
           - get: paas-cf
-            passed: ['post-deploy', 'smoke-tests', 'acceptance-tests', 'custom-acceptance-tests']
+            passed: ['post-deploy', 'smoke-tests', 'acceptance-tests', 'custom-acceptance-tests', 'bosh-cli-test']
           - get: git-keys
 
       - put: release-version

--- a/concourse/scripts/bosh-cli.sh
+++ b/concourse/scripts/bosh-cli.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
 export TARGET_CONCOURSE=deployer
 # shellcheck disable=SC2091
-$("${SCRIPT_DIR}/environment.sh" "$@")
+$("${SCRIPT_DIR}/environment.sh")
 "${SCRIPT_DIR}/fly_sync_and_login.sh"
 
 OUTPUT_FILE=$(mktemp -t bosh-cli.XXXXXX)
@@ -25,4 +25,4 @@ $FLY_CMD -t "${FLY_TARGET}" \
   intercept \
   --build="${BUILD_NUMBER}"\
   --step=one-off \
-  sh
+  "${@:-sh}"


### PR DESCRIPTION
## What

This is a fix for `bosh-cli.sh` as https://github.com/alphagov/paas-cf/pull/159 introduced SYSTEM_DNS_ZONE_NAME variable. This var is set only by running `make` so we had to move bosh-cli.sh execution to Makefile. Additionally we re-arranged all targets so it's now possible to execute `make $ENV bootstrap`.  Read the updated README if you want more details. 

## How to review

Check if `make dev bosh-cli` works properly and connects to Concourse container. Also, run create-bosh-cloudfoundry pipeline and make sure that test-bosh-cli job succeeds .

## Who can review

Not @jimconner or @combor
