### PR TITLE
[#115320097] ELB for access to logs

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -520,7 +520,7 @@ jobs:
                 fi
                 openssl req -x509 -newkey rsa:2048 -keyout metrics.key \
                   -out metrics.crt -days 365 -nodes -subj \
-                  "/C=UK/ST=London/L=London/O=GDS/CN=metrics.{{deploy_env}}.${SYSTEM_DNS_ZONE_NAME}"
+                  "/C=UK/ST=London/L=London/O=GDS/CN=metrics.${SYSTEM_DNS_ZONE_NAME}"
                 tar czvf generated-metrics-cert/metrics-cert.tar.gz metrics.crt metrics.key
         on_success:
           put: metrics-cert

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -107,6 +107,13 @@ resources:
       region_name: {{aws_region}}
       versioned_file: bosh-CA.tar.gz
 
+  - name: logsearch-cert
+    type: s3-iam
+    source:
+      bucket: {{state_bucket}}
+      region_name: {{aws_region}}
+      versioned_file: logsearch-cert.tar.gz
+
   - name: concourse-manifest
     type: s3-iam
     source:
@@ -232,6 +239,7 @@ jobs:
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} bosh-secrets.yml paas-cf/concourse/init_files/zero_bytes
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} bosh-CA.tar.gz paas-cf/concourse/init_files/empty.tar.gz
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} metrics-cert.tar.gz paas-cf/concourse/init_files/empty.tar.gz
+                paas-cf/concourse/scripts/s3init.sh {{state_bucket}} logsearch-cert.tar.gz paas-cf/concourse/init_files/empty.tar.gz
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} cf-secrets.yml paas-cf/concourse/init_files/zero_bytes
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} cf.tfstate paas-cf/concourse/init_files/terraform.tfstate.tpl
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} cf-certs.tar.gz paas-cf/concourse/init_files/empty.tar.gz
@@ -483,6 +491,7 @@ jobs:
             trigger: true
           - get: cf-secrets
           - get: metrics-cert
+          - get: logsearch-cert
           - get: vpc-tfstate
           - get: concourse-tfstate
           - get: bosh-tfstate
@@ -517,6 +526,7 @@ jobs:
           put: metrics-cert
           params:
             file: generated-metrics-cert/metrics-cert.tar.gz
+
       - task: generate-cf-secrets
         config:
           platform: linux
@@ -543,6 +553,38 @@ jobs:
           params:
             file: generated-cf-secrets/cf-secrets.yml
 
+      - task: generate-logsearch-certificates
+        config:
+          platform: linux
+          image: docker:///governmentpaas/curl-ssl
+          inputs:
+            - name: logsearch-cert
+              path: existing-logsearch-cert
+          outputs:
+            - name: generated-logsearch-cert
+          params:
+            SYSTEM_DNS_ZONE_NAME: {{system_dns_zone_name}}
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                tar xzvf existing-logsearch-cert/logsearch-cert.tar.gz
+                if [ -f logsearch.crt ] && [ -f logsearch.key ]; then
+                  echo Certificate and private key already created, nothing to do
+                  cp existing-logsearch-cert/logsearch-cert.tar.gz generated-logsearch-cert/.
+                  exit 0
+                fi
+                openssl req -x509 -newkey rsa:2048 -keyout logsearch.key \
+                  -out logsearch.crt -days 365 -nodes -subj \
+                  "/C=UK/ST=London/L=London/O=GDS/CN=logsearch.${SYSTEM_DNS_ZONE_NAME}"
+                tar czvf generated-logsearch-cert/logsearch-cert.tar.gz logsearch.crt logsearch.key
+        on_success:
+          put: logsearch-cert
+          params:
+            file: generated-logsearch-cert/logsearch-cert.tar.gz
+
   - name: cf-terraform
     serial_groups: [cf-deploy]
     serial: true
@@ -558,6 +600,8 @@ jobs:
           - get: bosh-tfstate
           - get: cf-tfstate
           - get: metrics-cert
+          - get: logsearch-cert
+            passed: ['generate-cf-secrets']
           - get: cf-secrets
             passed: ['generate-cf-secrets']
 
@@ -596,7 +640,7 @@ jobs:
             - name: paas-cf
             - name: cf-tfstate
             - name: metrics-cert
-
+            - name: logsearch-cert
           outputs:
             - name: updated-tfstate
           params:
@@ -615,6 +659,7 @@ jobs:
                 . terraform-variables/bosh.tfvars.sh
                 . terraform-variables/cf-secrets.tfvars.sh
                 tar xzvf metrics-cert/metrics-cert.tar.gz -C .
+                tar xzvf logsearch-cert/logsearch-cert.tar.gz -C .
 
                 terraform apply -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
                   -state=cf-tfstate/cf.tfstate -state-out=updated-tfstate/cf.tfstate paas-cf/terraform/cloudfoundry

--- a/manifests/cf-manifest/deployments/050-logsearch.yml
+++ b/manifests/cf-manifest/deployments/050-logsearch.yml
@@ -67,6 +67,9 @@ resource_pools:
     availability_zone: (( grab meta.zones.z1 ))
     instance_type: (( grab resource_pools.small_z1.cloud_properties.instance_type ))
     ephemeral_disk: (( grab resource_pools.small_z1.cloud_properties.ephemeral_disk ))
+    elbs:
+      - (( grab terraform_outputs.logsearch_elb_name ))
+
 disk_pools:
 - name: elasticsearch_master
   disk_size: 102400

--- a/manifests/cf-manifest/deployments/050-logsearch.yml
+++ b/manifests/cf-manifest/deployments/050-logsearch.yml
@@ -264,6 +264,7 @@ jobs:
   release: logsearch
   templates:
   - {name: kibana, release: logsearch}
+  - {name: haproxy, release: logsearch}
   resource_pool: kibana_z1
   instances: 1
   networks:
@@ -286,6 +287,10 @@ properties:
     cluster_name: logsearch
   kibana:
     elasticsearch: (( concat terraform_outputs.elastic_master_elb_dns_name ":9200" ))
+  haproxy:
+    inbound_port: 5602
+    backend_servers: ["localhost"]
+    backend_port: 5601
   elasticsearch_config:
     elasticsearch:
       host: (( grab terraform_outputs.elastic_master_elb_dns_name ))

--- a/manifests/cf-manifest/deployments/050-logsearch.yml
+++ b/manifests/cf-manifest/deployments/050-logsearch.yml
@@ -59,6 +59,14 @@ resource_pools:
     elbs:
       - (( grab terraform_outputs.ingestor_elb_name ))
 
+- name: kibana_z1
+  network: (( grab resource_pools.small_z1.network ))
+  stemcell: (( grab meta.stemcell ))
+  env: (( grab meta.default_env ))
+  cloud_properties:
+    availability_zone: (( grab meta.zones.z1 ))
+    instance_type: (( grab resource_pools.small_z1.cloud_properties.instance_type ))
+    ephemeral_disk: (( grab resource_pools.small_z1.cloud_properties.ephemeral_disk ))
 disk_pools:
 - name: elasticsearch_master
   disk_size: 102400
@@ -253,7 +261,7 @@ jobs:
   release: logsearch
   templates:
   - {name: kibana, release: logsearch}
-  resource_pool: small_z1
+  resource_pool: kibana_z1
   instances: 1
   networks:
   - name: cf1

--- a/manifests/cf-manifest/spec/fixtures/terraform/terraform-outputs.yml
+++ b/manifests/cf-manifest/spec/fixtures/terraform/terraform-outputs.yml
@@ -26,3 +26,5 @@ terraform_outputs:
   elastic_master_elb_name: elastic_master_elb
   elastic_master_elb_dns_name: elastic_master_elb_dns
   metrics_elb_name: metrics_elb_name
+  logsearch_elb_name: logsearch_elb_name
+

--- a/terraform/cloudfoundry/dns-records.tf
+++ b/terraform/cloudfoundry/dns-records.tf
@@ -29,3 +29,12 @@ resource "aws_route53_record" "metrics" {
   ttl = "60"
   records = ["${aws_elb.metrics_elb.dns_name}"]
 }
+
+resource "aws_route53_record" "logsearch" {
+  zone_id = "${var.system_dns_zone_id}"
+  name = "logsearch.${var.system_dns_zone_name}."
+  type = "CNAME"
+  ttl = "60"
+  records = ["${aws_elb.logsearch_elb.dns_name}"]
+}
+

--- a/terraform/cloudfoundry/outputs.tf
+++ b/terraform/cloudfoundry/outputs.tf
@@ -70,3 +70,7 @@ output "metrics_elb_name" {
   value = "${aws_elb.metrics_elb.name}"
 }
 
+output "logsearch_elb_name" {
+  value = "${aws_elb.logsearch_elb.name}"
+}
+

--- a/terraform/cloudfoundry/routers.tf
+++ b/terraform/cloudfoundry/routers.tf
@@ -124,7 +124,7 @@ resource "aws_elb" "logsearch_elb" {
   ]
 
   health_check {
-    target = "TCP:5601"
+    target = "TCP:5602"
     interval = "${var.health_check_interval}"
     timeout = "${var.health_check_timeout}"
     healthy_threshold = "${var.health_check_healthy}"
@@ -132,7 +132,7 @@ resource "aws_elb" "logsearch_elb" {
   }
 
   listener {
-    instance_port = 5601
+    instance_port = 5602
     instance_protocol = "http"
     lb_port = 443
     lb_protocol = "https"

--- a/terraform/cloudfoundry/security-groups.tf
+++ b/terraform/cloudfoundry/security-groups.tf
@@ -188,4 +188,29 @@ resource "aws_security_group" "metrics_elb" {
   }
 }
 
+resource "aws_security_group" "logsearch_elb" {
+  name = "${var.env}-logsearch"
+  description = "Security group for logsearch ELB"
+  vpc_id = "${var.vpc_id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 443
+    to_port   = 443
+    protocol  = "tcp"
+    cidr_blocks = [
+      "${split(",", var.office_cidrs)}"
+    ]
+  }
+
+  tags {
+    Name = "${var.env}-logsearch_elb"
+  }
+}
 


### PR DESCRIPTION
## What
Story: [ELB for access to logs](https://www.pivotaltracker.com/story/show/115320097)
We want to be able to access Logsearch via its web interface (Kibana), without the need for SSH tunneling. For this we provision an ELB and provide it with a self-signed certificate. 

An extension to the IAM policy allowing the uploading of the certificate has already been merged as a result of PR 25 in the aws-account-wide-terraform repository. 

There is an intermediate HAProxy because there is an intention to set up authentication for access to Kibana. This is already provided in the latest Logsearch releases. 

## How to review

- Deploy CF using branch `115320097-elb-access-to-logs-rebase`. 
- Check you can access Kibana on https://logsearch.[deploy_env].dev.cloudpipeline.digital
- View the certificate and check the Common Name is the same as the URL above. 

## Who can review

Anyone but @saliceti or myself. 
