### PR TITLE
[#115709073] close port 80

### DIFF
--- a/manifests/cf-manifest/deployments/900-cf-tests.yml
+++ b/manifests/cf-manifest/deployments/900-cf-tests.yml
@@ -1,6 +1,6 @@
 properties:
   acceptance_tests:
-    api: (( grab meta.api_domain ))
+    api: (( concat "https://" meta.api_domain ))
     apps_domain: (( grab properties.app_domains[0] ))
     system_domain: (( grab properties.system_domain ))
     admin_user: "admin"

--- a/terraform/cloudfoundry/routers.tf
+++ b/terraform/cloudfoundry/routers.tf
@@ -15,12 +15,6 @@ resource "aws_elb" "router" {
     unhealthy_threshold = "${var.health_check_unhealthy}"
   }
   listener {
-    instance_port = 80
-    instance_protocol = "http"
-    lb_port = 80
-    lb_protocol = "http"
-  }
-  listener {
     instance_port = 443
     instance_protocol = "tcp"
     lb_port = 443

--- a/terraform/cloudfoundry/security-groups.tf
+++ b/terraform/cloudfoundry/security-groups.tf
@@ -13,27 +13,6 @@ resource "aws_security_group" "web" {
   /* FIXME: Merge these two ingress block back together once */
   /* https://github.com/hashicorp/terraform/issues/5301 is resolved. */
   ingress {
-    from_port = 80
-    to_port   = 80
-    protocol  = "tcp"
-    cidr_blocks = [
-      "${split(",", var.web_access_cidrs)}",
-      "${var.concourse_elastic_ip}/32",
-    ]
-  }
-
-  ingress {
-    from_port = 80
-    to_port   = 80
-    protocol  = "tcp"
-    cidr_blocks = [
-      "${formatlist("%s/32", aws_eip.cf.*.public_ip)}",
-    ]
-  }
-
-  /* FIXME: Merge these two ingress block back together once */
-  /* https://github.com/hashicorp/terraform/issues/5301 is resolved. */
-  ingress {
     from_port = 443
     to_port   = 443
     protocol  = "tcp"

--- a/tests/acceptance-tests/generate_test_config.rb
+++ b/tests/acceptance-tests/generate_test_config.rb
@@ -9,12 +9,14 @@ manifest = YAML.load_file(manifest_file)
 admin_password = manifest.fetch("properties").fetch("acceptance_tests").fetch("admin_password")
 api_url = manifest.fetch("properties").fetch("cc").fetch("srv_api_uri")
 apps_domain = manifest.fetch("properties").fetch("app_domains").first
+system_domain = manifest.fetch("properties").fetch("system_domain")
 
 config = {
   "api" => api_url,
   "admin_user" => "admin",
   "admin_password" => admin_password,
   "apps_domain" => apps_domain,
+  "system_domain" => system_domain,
   "use_http" => false,
 }
 puts config.to_json

--- a/tests/acceptance-tests/src/acceptance/http_closed_test.go
+++ b/tests/acceptance-tests/src/acceptance/http_closed_test.go
@@ -1,0 +1,44 @@
+package acceptance_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+
+	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
+	"github.com/cloudfoundry-incubator/cf-test-helpers/generator"
+
+	"net"
+	"time"
+)
+
+var _ = Describe("Http is closed", func() {
+
+	var (
+		CONNECTION_TIMEOUT = 11 * time.Second
+	)
+
+	It("for apps", func() {
+		appName := generator.PrefixedRandomName("CATS-APP-")
+		Expect(cf.Cf(
+			"push", appName,
+			"--no-start",
+			"-b", config.StaticFileBuildpackName,
+			"-p", "../../example_apps/static_app",
+			"-d", config.AppsDomain,
+		).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+		Expect(cf.Cf("start", appName).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
+
+		uri := appName + "." + config.AppsDomain + ":80"
+		_, err := net.DialTimeout("tcp", uri, CONNECTION_TIMEOUT)
+		Expect(err.(net.Error).Timeout()).To(BeTrue())
+	})
+
+	It("for api", func() {
+		uri := "api." + config.SystemDomain + ":80"
+		_, err := net.DialTimeout("tcp", uri, CONNECTION_TIMEOUT)
+		Expect(err.(net.Error).Timeout()).To(BeTrue())
+
+	})
+
+})


### PR DESCRIPTION
## What

[Move public facing TLS terminations to ELBs](https://www.pivotaltracker.com/n/projects/1275640/stories/115709073)

Close port 80 as a part of leaving only secure endpoints open. This is 1st PR for the story.

## How to review

Apply to existing environment or build new. All tests should pass. You should not be able to connect to port 80 on any CF or app interfaces.

## Who can review

not @mtekel