### PR TITLE
[#115845521] Remove $DEPLOY_ENV from bosh-cli execution in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ bootstrap-destroy: ## Destroy bootsrap
 
 .PHONY: bosh-cli
 bosh-cli: ## Create interactive connnection to BOSH container
-	concourse/scripts/bosh-cli.sh $(DEPLOY_ENV)
+	concourse/scripts/bosh-cli.sh
 
 .PHONY: set_env_class_dev
 set_env_class_dev:


### PR DESCRIPTION
## What

As we have changed bosh-cli behaviour in previous PR we need to modify
Makefile to behave accordingly.

## How to review

run `make dev bosh-cli`

## Who can review

not @jimconner or @combor

