### PR TITLE
[#115869215] Create tags for production. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ set_env_class_stage:
 	$(eval export MAKEFILE_ENV_TARGET=stage)
 	$(eval export AWS_ACCOUNT=stage)
 	$(eval export ENABLE_AUTO_DEPLOY=true)
+	$(eval export TAG_PREFIX=prod-)
 	$(eval export PAAS_CF_TAG_FILTER=stage-*)
 	$(eval export SYSTEM_DNS_ZONE_NAME=staging.cloudpipeline.digital)
 	$(eval export APPS_DNS_ZONE_NAME=staging.cloudpipelineapps.digital)

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1249,6 +1249,7 @@ jobs:
             aws_account: {{aws_account}}
             deploy_env: {{deploy_env}}
             TAG_PREFIX: {{TAG_PREFIX}}
+            TAG_FILTER: {{paas_cf_tag_filter}}
           inputs:
           - name: paas-cf
           - name: release-version
@@ -1264,7 +1265,7 @@ jobs:
                 exit 0
               fi
               paas-cf/concourse/scripts/tag-release.sh \
-                ${TAG_PREFIX} ${aws_account} ${deploy_env}
+                ${TAG_PREFIX} ${aws_account} ${deploy_env} ${TAG_FILTER}
 
   - name: generate-git-keys
     plan:

--- a/concourse/scripts/tag-release.sh
+++ b/concourse/scripts/tag-release.sh
@@ -2,9 +2,10 @@
 
 set -eu -o pipefail
 
-TAG_PREFIX=$1
-AWS_ACCOUNT=$2
-DEPLOY_ENV=$3
+TAG_PREFIX="${1}"
+AWS_ACCOUNT="${2}"
+DEPLOY_ENV="${3}"
+TAG_FILTER="${4:-""}"
 
 GIT_EMAIL="the-multi-cloud-paas-team+deployer-ci@digital.cabinet-office.gov.uk"
 GIT_USER="gov-paas-${AWS_ACCOUNT}"
@@ -20,21 +21,37 @@ Host github.com
   IdentityFile $(pwd)/git-key
 EOF
 
-cd paas-cf
-if [ -n "${PAAS_CF_TAG_FILTER}" ]
-then 
-  tag="$(git tag -l --contains HEAD | grep "${PAAS_CF_TAG_FILTER}" | sed s/"${PAAS_CF_TAG_FILTER%?}"/"${TAG_PREFIX}"/)"
-else
-  version=$(cat ../release-version/number)
-  tag="${TAG_PREFIX}${version}"
-fi
+get_tag(){
+  tag_filter=${1}
+  git tag -l --contains HEAD | grep "${tag_filter}"
+}
 
+promote_existing_tag(){
+  existing_tag=${1}
+  echo "${existing_tag}" | sed s/"${TAG_FILTER%?}"/"${TAG_PREFIX}"/
+}
+
+create_new_tag(){
+  version=$(cat ../release-version/number)
+  echo "${TAG_PREFIX}${version}"
+}
+
+cd paas-cf
 echo Configure Git
 git config --global user.email "${GIT_EMAIL}"
 git config --global user.name "${GIT_USER}"
 git remote add ssh "${GIT_REPO_URL}"
 
-echo "Create tag ${tag}"
+if [ -n "${TAG_FILTER}" ]
+then
+  latest_tag=$(get_tag "${TAG_FILTER%?}")
+  tag=$(promote_existing_tag "${latest_tag}")
+  echo "Promote ${latest_tag} to ${tag}"
+else
+  tag=$(create_new_tag)
+  echo "Create new tag ${tag}"
+fi
+
 git tag -a "${tag}" -m "Tag ${tag} passed ${AWS_ACCOUNT} \
 in environment ${DEPLOY_ENV}"
 


### PR DESCRIPTION
## What

When the staging environment completes deployment and all acceptance tests correctly, we want to tag that build with a prod-x.x.x tag, where x.x.x matches the version number of the stage-x.x.x tag which triggered the build in the staging environment.

## How to review this PR.

* Because this uses the AWS_ACCOUNT environment variable to ensure that the tag bumping only happens when running on the stage platform, it is necessary to test on the staging platform (or tweak your own environment so that it pretends that AWS_ACCOUNT is set to staging)
* Modify your Makefile and set SELF_UPDATE_PIPELINE=false in the set_env_class_prod section
* Optionally (if you're impatient) modify the acceptance tests job to perform a quick operation such as `/bin/true` before you push the pipelines.
* Destroy existing staging pipeline.
* Deploy the pipelines from this branch to staging.
* Kick off a deployment from Concourse by running the 'init' job.
* Make coffee
* Wait for acceptance tests to complete.
* Drink the coffe you made - Additional cups of coffee may be required depending upon deployment speed.
* Watch the tag-release box turn green in Concourse
* Check the git tags in github to see the new prod-x.x.x tag that was just created.

## Notes
After testing is complete, do not forget to destroy and re-push the pipelines into staging from the Master branch

## Who can review this PR.
Anyone on the team with the exception of @combor and @jimconner
