### PR TITLE
[#115845521] Add target pipelines to self-update-pipelines.sh

### DIFF
--- a/concourse/scripts/self-update-pipeline.sh
+++ b/concourse/scripts/self-update-pipeline.sh
@@ -26,5 +26,5 @@ else
   CONCOURSE_ATC_PASSWORD=$("$VAL_FROM_YAML" jobs.concourse.properties.atc.basic_auth_password concourse-manifest/concourse-manifest.yml)
   export CONCOURSE_ATC_PASSWORD
 
-  make -C ./paas-cf "${MAKEFILE_ENV_TARGET}"
+  make -C ./paas-cf "${MAKEFILE_ENV_TARGET}" pipelines
 fi


### PR DESCRIPTION
What?
-----

After #165 you must pass the target `pipelines` to update the pipelines,
but the `self-update-pipeline.sh` script was not updated.

Scope
-----

Just add the right target to the script

How to test?
------------

Self update should work as described in #156. See that PR for instructions
to test this.

Who?
----

Anyone but @keymon