### PR TITLE
[#115624569] Implement locking for pipelines with pool resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,27 +39,27 @@ lint_shellcheck:
 	find . -name '*.sh' -print0 | xargs -0 $(SHELLCHECK)
 
 .PHONY: dev
-dev: check-env-vars set_env_class_dev ## Set environment to DEV
+dev: check-env-vars set_env_class_dev ## Set Environment to DEV
 	@true
 
 .PHONY: ci
-ci: check-env-vars set_env_class_ci ## Set environment to CI
+ci: check-env-vars set_env_class_ci ## Set Environment to CI
 	@true
 
 .PHONY: stage
-stage: check-env-vars set_env_class_stage  ## Set Envirnoment to Staging
+stage: check-env-vars set_env_class_stage  ## Set Environment to Staging
 	@true
 
 .PHONY: prod
-prod: check-env-vars set_env_class_prod ## Set Envirnoment to Production 
+prod: check-env-vars set_env_class_prod ## Set Environment to Production
 	@true
 
 .PHONY: bootstrap
-bootstrap: ## Start bootsrap 
+bootstrap: ## Start bootstrap
 	vagrant/deploy.sh
 
 .PHONY: bootstrap-destroy
-bootstrap-destroy: ## Destroy bootsrap 
+bootstrap-destroy: ## Destroy bootstrap
 	./vagrant/destroy.sh
 
 .PHONY: bosh-cli

--- a/README.md
+++ b/README.md
@@ -33,7 +33,13 @@ or destroyed.
 
 ### Prerequisites
 
-* You will need a recent version of [Vagrant installed][]. The exact version
+In order to use this repository you will need:
+
+* [AWS Command Line tool (`awscli`)](https://aws.amazon.com/cli/). You can
+install it using [any of the official methods](http://docs.aws.amazon.com/cli/latest/userguide/installing.html)
+or by using [`virtualenv`](https://virtualenv.pypa.io/en/latest/) and pip `pip install -r requirements.txt`
+
+* a recent version of [Vagrant installed][]. The exact version
 requirements are listed in the [`Vagrantfile`](vagrant/Vagrantfile).
 
 [Vagrant installed]: https://docs.vagrantup.com/v2/installation/index.html
@@ -44,7 +50,7 @@ Install the AWS plugin for Vagrant:
 vagrant plugin install vagrant-aws
 ```
 
-* You must provide AWS access keys as environment variables:
+* provide AWS access keys as environment variables:
 
 ```
 export AWS_ACCESS_KEY_ID=XXXXXXXXXX
@@ -127,7 +133,7 @@ supporting services for the platform.
 
 You will need a working [Deployer Concourse](#deployer-concourse).
 
-Deploy the pipeline configurations with `make`. Select the target based on which AWS accout you want to work with. For instance, execute: 
+Deploy the pipeline configurations with `make`. Select the target based on which AWS accout you want to work with. For instance, execute:
 ```
 make dev pipelines
 ```

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ supporting services for the platform.
 
 You will need a working [Deployer Concourse](#deployer-concourse).
 
-Deploy the pipeline configurations with `make`. Select the target based on which AWS accout you want to work with. For instance, execute:
+Deploy the pipeline configurations with `make`. Select the target based on which AWS account you want to work with. For instance, execute:
 ```
 make dev pipelines
 ```
@@ -144,6 +144,10 @@ if you want to deploy to DEV account.
 Run the `create-bosh-cloudfoundry` pipeline. This will deploy MicroBOSH, and CloudFoundry.
 
 Run `make dev showenv` to show environment information such as system URLs and Concourse password.
+
+This pipeline implements locking, to prevent two executions of the
+same pipelines to happen at the same time. More details
+in [Additional Notes](#check-and-release-pipeline-locking).
 
 NB: The CloudFoundry deployment (but not the supporting infrastructure) will [auto-delete
 overnight](#overnight-deletion-of-environments) by default.
@@ -165,6 +169,19 @@ deployment.
 You will need to install some dependencies to run the unit tests on your own
 machine. The most up-to-date reference for these is the Travis CI
 configuration in [`.travis.yml`](.travis.yml).
+
+## Check and release pipeline locking
+
+the `create-bosh-cloudfoundry` pipeline implements pipeline locking using
+[the concourse pool resource](https://github.com/concourse/pool-resource).
+
+This lock is acquired at the beginning and released the end of all the
+pipeline if it finishes successfully.
+
+In occasions it might be required to check the state or force the release
+of the lock. For that you can manually trigger the jobs `pipeline-check-lock`
+and `pipeline-release-lock` in the job group `Operator`.
+
 
 ## Optionally override the branch used by pipelines
 

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1,6 +1,7 @@
 groups:
   - name: all
     jobs:
+      - pipeline-lock
       - init
       - bosh-terraform
       - generate-bosh-config
@@ -15,6 +16,7 @@ groups:
       - custom-acceptance-tests
       - bosh-cli-test
       - tag-release
+      - pipeline-unlock
   - name: bosh
     jobs:
       - init
@@ -33,6 +35,7 @@ groups:
       - custom-acceptance-tests
       - bosh-cli-test
       - tag-release
+      - pipeline-unlock
   - name: release
     jobs:
       - generate-git-keys
@@ -215,12 +218,24 @@ resources:
       private_key: {{pipeline_lock_git_private_key}}
 
 jobs:
+  - name: pipeline-lock
+    serial: true
+    plan:
+      - put: pipeline-pool
+        params:
+          claim: lock
+      - put: pipeline-trigger
+        params: {bump: patch}
+
   - name: init
     serial_groups: [bosh-deploy]
     serial: true
     plan:
+      - get: pipeline-trigger
+        trigger: true
+        passed: [pipeline-lock]
       - get: paas-cf
-        trigger: {{auto_deploy}}
+        passed: [pipeline-lock]
       - get: concourse-manifest
       - task: self-update-pipeline
         config:
@@ -1274,6 +1289,17 @@ jobs:
               fi
               paas-cf/concourse/scripts/tag-release.sh \
                 ${TAG_PREFIX} ${aws_account} ${deploy_env} ${TAG_FILTER}
+
+  - name: pipeline-unlock
+    serial: true
+    plan:
+      - get: pipeline-trigger
+        passed: ['tag-release']
+        trigger: true
+      - get: pipeline-pool
+      - put: pipeline-pool
+        params:
+          release: pipeline-pool
 
   - name: generate-git-keys
     plan:

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -41,7 +41,7 @@ groups:
       - bump-major-version
       - bump-patch-version
   - name: tests
-    jobs: 
+    jobs:
       - smoke-tests
       - acceptance-tests
       - custom-acceptance-tests
@@ -205,6 +205,14 @@ resources:
       region_name: {{aws_region}}
       key: release-version
       initial_version: 0.0.0
+
+  - name: pipeline-pool
+    type: pool
+    source:
+      uri: {{git_concourse_pool_clone_full_url_ssh}}
+      branch: master
+      pool: {{pipeline_name}}
+      private_key: {{pipeline_lock_git_private_key}}
 
 jobs:
   - name: init

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -36,13 +36,15 @@ groups:
       - bosh-cli-test
       - tag-release
       - pipeline-unlock
-  - name: release
+  - name: operator
     jobs:
       - generate-git-keys
       - show-release-version
       - bump-minor-version
       - bump-major-version
       - bump-patch-version
+      - pipeline-check-lock
+      - pipeline-release-lock
   - name: tests
     jobs:
       - smoke-tests
@@ -1331,6 +1333,47 @@ jobs:
       - get: pipeline-trigger
         passed: ['tag-release']
         trigger: true
+      - get: pipeline-pool
+      - put: pipeline-pool
+        params:
+          release: pipeline-pool
+
+  - name: pipeline-check-lock
+    plan:
+      - get: pipeline-pool
+      - task: print-pipeline-lock-state
+        config:
+          image: docker:///governmentpaas/git-ssh
+          platform: linux
+          inputs:
+          - name: pipeline-pool
+          run:
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              if [ -f pipeline-pool/{{pipeline_name}}/claimed/lock ]; then
+                current_status_message="LOCKED"
+              elif [ -f pipeline-pool/{{pipeline_name}}/unclaimed/lock ]; then
+                current_status_message="UNLOCKED"
+              else
+                echo "Error: Cannot find lock in pool: pipeline-pool/{{pipeline_name}}/{un,}claimed/lock"
+                exit 1
+              fi
+
+              cd pipeline-pool
+              export GIT_PAGER="cat"
+              git log -1 --pretty=format:"
+              Lock status is: ${current_status_message}
+
+              Last commit change:
+               - %cr at %ci
+               - %s
+              "
+
+  - name: pipeline-release-lock
+    plan:
       - get: pipeline-pool
       - put: pipeline-pool
         params:

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -160,6 +160,13 @@ resources:
       versioned_file: id_rsa
       region_name: {{aws_region}}
 
+  - name: git-ssh-private-key
+    type: s3-iam
+    source:
+      bucket: {{state_bucket}}
+      versioned_file: git_id_rsa
+      region_name: {{aws_region}}
+
   - name: cf-tfstate
     type: s3-iam
     source:
@@ -221,6 +228,34 @@ jobs:
   - name: pipeline-lock
     serial: true
     plan:
+      - get: paas-cf
+        trigger: {{auto_deploy}}
+      - get: git-ssh-private-key
+      - task: init-pipeline-pool
+        config:
+          platform: linux
+          image: docker:///governmentpaas/git-ssh
+          inputs:
+            - name: paas-cf
+            - name: git-ssh-private-key
+          params:
+            DEPLOY_ENV: {{deploy_env}}
+            AWS_ACCOUNT: {{aws_account}}
+          run:
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              chmod 600 git-ssh-private-key/git_id_rsa
+              git config --global push.default simple
+              git config --global user.email "concourse@${DEPLOY_ENV}.${AWS_ACCOUNT}"
+              git config --global user.name "Concourse server ${DEPLOY_ENV} in ${AWS_ACCOUNT}"
+
+              ./paas-cf/concourse/scripts/create_pool_lock.sh \
+                {{git_concourse_pool_clone_full_url_ssh}} \
+                $(pwd)/git-ssh-private-key/git_id_rsa \
+                {{pipeline_name}} lock
       - put: pipeline-pool
         params:
           claim: lock

--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -66,6 +66,13 @@ resources:
       versioned_file: id_rsa
       region_name: {{aws_region}}
 
+  - name: git-ssh-public-key
+    type: s3-iam
+    source:
+      bucket: {{state_bucket}}
+      versioned_file: git_id_rsa.pub
+      region_name: {{aws_region}}
+
   - name: concourse-cert
     type: s3-iam
     source:
@@ -217,6 +224,7 @@ jobs:
       passed: [vpc]
     - get: concourse-terraform-state
     - get: concourse-cert
+    - get: git-ssh-public-key
 
     - task: vpc-terraform-outputs-to-sh
       config:
@@ -270,6 +278,7 @@ jobs:
         - name: vpc-terraform-outputs
         - name: concourse-terraform-state
         - name: generate-concourse-cert
+        - name: git-ssh-public-key
         params:
           VAGRANT_IP: {{vagrant_ip}}
           TF_VAR_env: {{deploy_env}}
@@ -283,6 +292,7 @@ jobs:
           - |
             cp generate-concourse-cert/concourse.crt generate-concourse-cert/concourse.key .
             . vpc-terraform-outputs/tfvars.sh
+            export TF_VAR_git_rsa_id_pub=$(cat git-ssh-public-key/git_id_rsa.pub)
             terraform_params=${VAGRANT_IP:+-var vagrant_cidr=$VAGRANT_IP/32}
             terraform apply ${terraform_params} \
               -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
@@ -478,6 +488,8 @@ jobs:
       passed: [vpc]
     - get: concourse-terraform-state
       passed: [concourse-terraform]
+    - get: git-ssh-public-key
+      passed: [concourse-terraform]
 
     - task: vpc-terraform-outputs-to-sh
       config:
@@ -533,6 +545,7 @@ jobs:
         - name: paas-cf
         - name: vpc-terraform-outputs
         - name: concourse-terraform-state
+        - name: git-ssh-public-key
         params:
           TF_VAR_env: {{deploy_env}}
           TF_VAR_system_dns_zone_name: {{system_dns_zone_name}}
@@ -544,6 +557,7 @@ jobs:
           - -c
           - |
             . vpc-terraform-outputs/tfvars.sh
+            export TF_VAR_git_rsa_id_pub=$(cat git-ssh-public-key/git_id_rsa.pub)
             terraform apply -target=aws_security_group.concourse \
               -state=concourse-terraform-state/concourse.tfstate -state-out=concourse.tfstate \
               -var-file=paas-cf/terraform/{{aws_account}}.tfvars paas-cf/terraform/concourse

--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -291,6 +291,22 @@ jobs:
         params:
           file: terraform-apply/concourse.tfstate
 
+    # Temporary task to add the git-${DEPLOY_ENV} user to git group
+    - task: add-git-user-to-group
+      config:
+        image: docker:///governmentpaas/awscli
+        inputs:
+        - name: paas-cf
+        params:
+          DEPLOY_ENV: {{deploy_env}}
+        run:
+          path: sh
+          args:
+          - -e
+          - -c
+          - |
+            aws iam add-user-to-group --user-name git-${DEPLOY_ENV} --group-name concourse-pool-git-rw
+
     - put: concourse-cert
       params:
         file: generate-concourse-cert/concourse-cert.tar.gz

--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -174,6 +174,9 @@ jobs:
             ssh-keygen -t rsa -b 4096 -f generated_id_rsa -N ''
             ./paas-cf/concourse/scripts/s3init.sh {{state_bucket}} id_rsa generated_id_rsa
             ./paas-cf/concourse/scripts/s3init.sh {{state_bucket}} id_rsa.pub generated_id_rsa.pub
+            ssh-keygen -t rsa -b 4096 -f generated_git_id_rsa -N ''
+            ./paas-cf/concourse/scripts/s3init.sh {{state_bucket}} git_id_rsa generated_git_id_rsa
+            ./paas-cf/concourse/scripts/s3init.sh {{state_bucket}} git_id_rsa.pub generated_git_id_rsa.pub
 
     - task: deploy-vpc
       config:

--- a/concourse/scripts/create_pool_lock.sh
+++ b/concourse/scripts/create_pool_lock.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+set -u
+set -e
+
+# Params: GITREPO, SSHKEY, POOLNAME, LOCKNAME
+# Call example: ./create_pool_lock.sh git@github.com:govuk/locks.git ./id_rsa example_pool example_lock
+
+git_repo=$1
+ssh_key=$2
+pool_name=$3
+lock_name=$4
+local_dir="pool_lock_repo"
+
+if [ ! -s "$ssh_key" ]; then
+    echo "ERROR: SSH key '${ssh_key}' not found"
+    exit 1
+fi
+
+export GIT_SSH_COMMAND="ssh -i '$ssh_key' -F /dev/null -o StrictHostKeyChecking=no"
+if [ ! -d "$local_dir" ]; then
+    git clone -q --single-branch "$git_repo" "$local_dir"
+fi
+
+cd "$local_dir"
+
+# Pull latest changes only if the repo is not empty (HEAD exists)
+if git rev-parse HEAD > /dev/null 2>&1; then
+    git pull -q
+fi
+
+if [ ! -d "${pool_name}" ]; then
+    echo "No '${pool_name}' pool found, creating..."
+    mkdir -p "${pool_name}"
+    for lock_status in claimed unclaimed; do
+        mkdir -p "${pool_name}/${lock_status}"
+        touch "${pool_name}/${lock_status}/.gitkeep"
+    done
+fi
+
+if [ ! -f "${pool_name}/claimed/${lock_name}" ] && ! [ -f "${pool_name}/unclaimed/${lock_name}" ]; then
+    echo "No '${lock_name}' lock found in pool '${pool_name}', creating..."
+    touch "${pool_name}/unclaimed/${lock_name}"
+    git add .
+    git commit -q -m "Add unclaimed '${lock_name}' lock."
+    git push -q
+fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+awscli>=1.10.16
+yamllint>=1.0.0

--- a/terraform/concourse/codecommit.tf
+++ b/terraform/concourse/codecommit.tf
@@ -1,0 +1,6 @@
+resource "aws_codecommit_repository" "concourse-pool" {
+  provider = "aws.codecommit"
+  repository_name = "concourse-pool-${var.env}"
+  description = "Git repository to keep concourse pool resource locks"
+  default_branch = "master"
+}

--- a/terraform/concourse/codecommit.tf
+++ b/terraform/concourse/codecommit.tf
@@ -31,3 +31,9 @@ resource "aws_iam_user" "git" {
 #    ]
 #    append = true
 #}
+
+resource "aws_iam_user_ssh_key" "git" {
+  username = "${aws_iam_user.git.name}"
+  encoding = "PEM"
+  public_key = "${var.git_rsa_id_pub}"
+}

--- a/terraform/concourse/codecommit.tf
+++ b/terraform/concourse/codecommit.tf
@@ -4,3 +4,30 @@ resource "aws_codecommit_repository" "concourse-pool" {
   description = "Git repository to keep concourse pool resource locks"
   default_branch = "master"
 }
+
+resource "aws_iam_user" "git" {
+  name = "git-${var.env}"
+}
+
+# Until this feature request is not solved https://github.com/hashicorp/terraform/issues/5778,
+# `aws_iam_group_membership` will wipe all the other members from the
+# shared group.
+#
+# The workaround is use aws cli:
+#
+#   aws iam add-user-to-group --user-name git-${DEPLOY_ENV} --group-name concourse-pool-git-rw
+#
+# We could do it using terraform provisioner local-exec calling out awscli
+# but we want to avoid this pattern so we will do it in a script in
+# the next step.
+#
+# Once they fix it upstream, we can replace it with this code:
+#
+# resource "aws_iam_group_membership" "concourse-pool-git-rw" {
+#    name = "concourse-pool-git-rw"
+#    group = "concourse-pool-git-rw"
+#    users = [
+#        "${aws_iam_user.git.name}",
+#    ]
+#    append = true
+#}

--- a/terraform/concourse/git_ssh_key_id
+++ b/terraform/concourse/git_ssh_key_id
@@ -1,0 +1,1 @@
+Empty file git_ssh_key_id to avoid terraform fail during the first run.

--- a/terraform/concourse/outputs.tf
+++ b/terraform/concourse/outputs.tf
@@ -17,3 +17,8 @@ output "concourse_elb_name" {
 output "concourse_dns_name" {
   value = "${aws_route53_record.deployer-concourse.fqdn}"
 }
+
+output "git_concourse_pool_clone_full_url_ssh" {
+  # convert the ssh:// url to a scp like connect string and add the git user
+  value = "ssh://${aws_iam_user_ssh_key.git.ssh_public_key_id}@${replace(aws_codecommit_repository.concourse-pool.clone_url_ssh, "/^ssh://([^/]+)//", "$1/")}"
+}

--- a/terraform/concourse/provider.tf
+++ b/terraform/concourse/provider.tf
@@ -1,3 +1,7 @@
 provider "aws" {
   region = "${var.region}"
 }
+provider "aws" {
+  alias = "codecommit"
+  region = "us-east-1"
+}

--- a/terraform/concourse/variables.tf
+++ b/terraform/concourse/variables.tf
@@ -5,3 +5,7 @@ variable "system_dns_zone_id" {
 variable "system_dns_zone_name" {
   description = "Amazon Route53 DNS zone name for the provisioned environment."
 }
+
+variable "git_rsa_id_pub" {
+  description = "Public SSH key for the git user"
+}


### PR DESCRIPTION
[#115624569 Implement locking for pipelines](https://www.pivotaltracker.com/story/show/115624569)

What?
----

We want to implement logic to lock the pipeline to prevent double executions in our deployments.

We decided
 * to use [the existing pool resource](https://github.com/concourse/pool-resource) which
uses git as a backend.
 * Use codecommit to create one git repo per user
 * Create one IAM git user to access that repo and upload one generated SSH key.
 * use IAM groups to grant access to the codecommit repository


Dependencies
--------

This PR depends in these other PR and changes:
 * `aws-account-wide-terraform/26` (already merged and applied to dev account)
 * https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/42 needs be merged and the container generated. After that, update the reference in this repo to the custom container.


Context
------

In this PR will cover the following context:

 * I want to create a codecommit repository
 * I want to create a IAM user
 * I want to generate a new SSH key for git access
 * I want to upload a SSH key to that IAM user
 * I want to setup a pool resource, which uses the created codecommit git resource via the created user with the generated SSH key.
 * I want to implement locking around all the pipeline.
 * I want to allow easily unlock the lock if it is required.

Notes
-----

We decided rename the job group "Release" to "Operator", as it groups different
operator level tasks.

How to review / test this?
-------------------------

You must re-run the bootstrap in order to create the git repository and user.

```
BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev bootstrap DEPLOY_ENV=__yourenvname__
```

Follow the README instructions. Once that is finished, upload the pipelines:

```
BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines DEPLOY_ENV=__yourenvname__
```

And trigger the job `pipeline-lock` from in `create-bosh-cloudfoundry`. You can
see a message saying that the lock is adquired.

Meanwhile the pipeline is running, try to rerun `pipeline-lock`. It should stop
trying to adquire the lock and print a bunch of dots `....`.

Now you can either:
 * let the pipeline finish and see that once `pipeline-unlock` runs, the other job is released.
 * or go to the job group "Operator" and trigger `pipeline-release-unlock`. You can see that
   the pipeline is released again.

who?
----

Anyone but @keymon or @mtekel or @Jonty