### PR TITLE
[#113428783] Docs refer production DEPLOY_ENV as 'prod'

### DIFF
--- a/doc/non_dev_deployments.md
+++ b/doc/non_dev_deployments.md
@@ -33,7 +33,7 @@ bucket names have to be gloablly unique)
 
 For staging and production a `DEPLOY_ENV` is required even though it's not used
 in domain names. Staging should use a `DEPLOY_ENV` of "staging", and production
-should use "production".
+should use "prod".
 
 ## Deployment process
 


### PR DESCRIPTION
What?
----

We decided to name the production DEPLOY_ENV variable as 'prod',
instead of 'production', to keep consistency.

Who?
---

Anyone but @keymon