### PR TITLE
[#115251811] Display system URLs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,15 +40,19 @@ lint_shellcheck:
 
 .PHONY: dev
 dev: check-env-vars set_env_class_dev ## Set environment to DEV
+	@true
 
 .PHONY: ci
 ci: check-env-vars set_env_class_ci ## Set environment to CI
+	@true
 
 .PHONY: stage
 stage: check-env-vars set_env_class_stage  ## Set Envirnoment to Staging
+	@true
 
 .PHONY: prod
 prod: check-env-vars set_env_class_prod ## Set Envirnoment to Production 
+	@true
 
 .PHONY: bootstrap
 bootstrap: ## Start bootsrap 

--- a/Makefile
+++ b/Makefile
@@ -101,3 +101,8 @@ set_env_class_prod:
 .PHONY: pipelines
 pipelines: ## Upload pipelines to Concourse
 	concourse/scripts/pipelines-bosh-cloudfoundry.sh
+
+.PHONY: showenv
+showenv: ## Display environment information
+	$(eval export TARGET_CONCOURSE=deployer)
+	@concourse/scripts/environment.sh

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ if you want to deploy to DEV account.
 
 Run the `create-bosh-cloudfoundry` pipeline. This will deploy MicroBOSH, and CloudFoundry.
 
+Run `make dev showenv` to show environment information such as system URLs and Concourse password.
+
 NB: The CloudFoundry deployment (but not the supporting infrastructure) will [auto-delete
 overnight](#overnight-deletion-of-environments) by default.
 

--- a/concourse/scripts/environment.sh
+++ b/concourse/scripts/environment.sh
@@ -47,6 +47,10 @@ export CONCOURSE_ATC_PASSWORD=${CONCOURSE_ATC_PASSWORD}
 export CONCOURSE_URL=${CONCOURSE_URL}
 export FLY_CMD=${FLY_CMD}
 export FLY_TARGET=${FLY_TARGET}
+export API_ENDPOINT=https://api.${SYSTEM_DNS_ZONE_NAME}
+export LOGSEARCH_URL=https://logsearch.${SYSTEM_DNS_ZONE_NAME}
+export GRAFANA_URL=https://metrics.${SYSTEM_DNS_ZONE_NAME}
+export GRAPHITE_URL=https://metrics.${SYSTEM_DNS_ZONE_NAME}:3001
 EOF
 
 echo "Deploy environment name: $DEPLOY_ENV" 1>&2


### PR DESCRIPTION
## What
Story: [Basic Information listing URLs for Metrics and Visualisations](https://www.pivotaltracker.com/story/show/115251811)

Display system URLs to simplify use of each environment. It works by adding variables to `environment.sh` and create a make target to call it.

## How to review

* Run `make dev env`
* Check the new URLs

## Who can review

Anyone but @HenryTK or myself