### PR TITLE
[#115624569] Workaround terraform codecommit issue with default_branch property

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -312,8 +312,6 @@ jobs:
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} cf.tfstate paas-cf/concourse/init_files/terraform.tfstate.tpl
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} cf-certs.tar.gz paas-cf/concourse/init_files/empty.tar.gz
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} git-keys.tar.gz paas-cf/concourse/init_files/empty.tar.gz
-      - put: pipeline-trigger
-        params: {bump: patch}
 
   - name: bosh-terraform
     serial_groups: [bosh-deploy]

--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -270,6 +270,41 @@ jobs:
               "/C=UK/ST=London/L=London/O=GDS/CN=deployer.${SYSTEM_DNS_ZONE_NAME}"
             tar czvf concourse-cert.tar.gz concourse.crt concourse.key
 
+    # Temporary task to retrieve the codecommit default branch if it exists
+    - task: get-codecommit-default-branch
+      config:
+        image: docker:///governmentpaas/awscli
+        inputs:
+        - name: paas-cf
+        outputs:
+        - name: codecommit-default-branch
+        params:
+          DEPLOY_ENV: {{deploy_env}}
+        run:
+          path: sh
+          args:
+          - -c
+          - |
+            aws codecommit get-repository \
+              --region us-east-1 \
+              --repository-name concourse-pool-${DEPLOY_ENV} \
+              --query 'repositoryMetadata.defaultBranch' \
+              --output text > output.txt 2>&1
+            RET=$?
+
+            if [ "$RET" == "0" ]; then
+              if [ "$(cat output.txt)" == "None" ]; then
+                echo "" > codecommit-default-branch/default_branch.txt
+              else
+                cat output.txt > codecommit-default-branch/default_branch.txt
+              fi
+            elif grep -q RepositoryDoesNotExistException output.txt; then
+              echo "" > codecommit-default-branch/default_branch.txt
+            else
+              cat output.txt
+              exit 1
+            fi
+
     - task: terraform-apply
       config:
         image: docker:///governmentpaas/terraform
@@ -279,6 +314,7 @@ jobs:
         - name: concourse-terraform-state
         - name: generate-concourse-cert
         - name: git-ssh-public-key
+        - name: codecommit-default-branch
         params:
           VAGRANT_IP: {{vagrant_ip}}
           TF_VAR_env: {{deploy_env}}
@@ -292,7 +328,10 @@ jobs:
           - |
             cp generate-concourse-cert/concourse.crt generate-concourse-cert/concourse.key .
             . vpc-terraform-outputs/tfvars.sh
+
             export TF_VAR_git_rsa_id_pub=$(cat git-ssh-public-key/git_id_rsa.pub)
+            export TF_VAR_git_default_branch_workaround=$(cat codecommit-default-branch/default_branch.txt)
+
             terraform_params=${VAGRANT_IP:+-var vagrant_cidr=$VAGRANT_IP/32}
             terraform apply ${terraform_params} \
               -var-file=paas-cf/terraform/{{aws_account}}.tfvars \

--- a/terraform/concourse/codecommit.tf
+++ b/terraform/concourse/codecommit.tf
@@ -2,7 +2,7 @@ resource "aws_codecommit_repository" "concourse-pool" {
   provider = "aws.codecommit"
   repository_name = "concourse-pool-${var.env}"
   description = "Git repository to keep concourse pool resource locks"
-  default_branch = "master"
+  default_branch = "${var.git_default_branch_workaround}"
 }
 
 resource "aws_iam_user" "git" {

--- a/terraform/concourse/variables.tf
+++ b/terraform/concourse/variables.tf
@@ -9,3 +9,8 @@ variable "system_dns_zone_name" {
 variable "git_rsa_id_pub" {
   description = "Public SSH key for the git user"
 }
+
+variable "git_default_branch_workaround" {
+  description = "Value of current default branch for codecommit git repo. Temporary workaround."
+  default     = ""
+}


### PR DESCRIPTION
[#115624569 Implement locking for pipelines](https://www.pivotaltracker.com/story/show/115624569)

What?
----

We did not catch this issue in the PR #173.

Terraform codecommit resource[1] has a bug managing the default_branch
property: https://github.com/hashicorp/terraform/issues/5641

Although this property is optional, terraform will try to manage it.

If defined, codecommit will fail during creation:

```
BranchDoesNotExistException: refs/heads/master does not exist
```

Meanwhile if default_branch is defined, codecommit it will fail as soon
as a branch is pushed to the repository. The reason is that AWS enforces
having at least one branch as default branch, failing when terraform is
trying to set it empty:

```
  * aws_codecommit_repository.concourse-pool: Error Updating Default
  * Branch for CodeCommit Repository: InvalidParameter: 1 validation
    * errors:
     - field too short, minimum length 1: DefaultBranchName
```

Scope
----

This issue will be reported upstream, but meanwhile we will workaround it by
passing the default branch as a variable, and quering it using awscli.
If the respository does not exist or does not have default branch, the
variable will be set to empty string "".

We additionally remove the bump of the `pipeline-trigger` in the init job, which is not required anymore.

How to test
----------

Running from a environment without an associated codecommit git pool-resource
respository:

 1. Run the bootstrap process `SELF_UPDATE_PIPELINE=false BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev bootstrap DEPLOY_ENV=...`
 2. Run the jobs up to `concourse-terraform` (the rest are not relevant)
  * `concourse-terraform` should finnish OK
  * the `terraform apply` output for the resource `aws_codecommit_repository.concourse-pool` should not refer to any `default_branch`
 3. Rerun `concourse-terraform` it should end OK.
 4. Run the `lock-pipeline` job in `create-bosh-cloudfoundry`
    a. Upload the pipelines: `SELF_UPDATE_PIPELINE=false BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines DEPLOY_ENV=...`
    b. This will create a initial branch in the codecommit repo.
 5. Back in the bootstrap concourse (http://localhost:8080), rerun `concourse-terraform`
   * It should finish OK
   * terraform output should not report any change

Who?
---

Anyone but @keymon