### PR TITLE
[#116047559] Explicitly define prefix when using mktemp

### DIFF
--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -7,7 +7,7 @@ export TARGET_CONCOURSE=deployer
 $("${SCRIPT_DIR}/environment.sh" "$@")
 
 download_git_id_rsa() {
-  git_id_rsa_file=$(mktemp)
+  git_id_rsa_file=$(mktemp -t id_rsa.XXXXXX)
 
   aws s3 cp "s3://${env}-state/git_id_rsa" "${git_id_rsa_file}"
 
@@ -17,7 +17,7 @@ download_git_id_rsa() {
 }
 
 get_git_concourse_pool_clone_full_url_ssh() {
-  tfstate_file=$(mktemp)
+  tfstate_file=$(mktemp -t tfstate.XXXXXX)
 
   aws s3 cp "s3://${env}-state/concourse.tfstate" "${tfstate_file}"
 


### PR DESCRIPTION
## What

Different operating systems have different implementations of the mktemp command. Some do not allow you to call mktemp without specifying the prefix. We want to explicitly pass the prefix whenever we call mktemp.

## How to review

Run `concourse/scripts/pipelines-bosh-cloudfoundry.sh` and check it works

## Who can review

Anyone but @saliceti or me. Preferably a Mac user.