### PR TITLE
Remove unnecessary set_env_class_* Makefile targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
   global:
     - TF_VERSION="0.6.12"
     - SPRUCE_VERSION="0.13.0"
+    - DEPLOY_ENV="travis"
 
 addons:
   apt:

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ spec:
 lint_yaml:
 	$(YAMLLINT) -c yamllint.yml .
 
-lint_terraform: set_env_class_dev
+lint_terraform: dev
 	$(eval export TF_VAR_system_dns_zone_name=$SYSTEM_DNS_ZONE_NAME)
 	$(eval export TF_VAR_apps_dns_zone_name=$APPS_DNS_ZONE_NAME)
 	find terraform -mindepth 1 -maxdepth 1 -type d -print0 | xargs -0 -n 1 -t terraform graph > /dev/null
@@ -39,19 +39,43 @@ lint_shellcheck:
 	find . -name '*.sh' -print0 | xargs -0 $(SHELLCHECK)
 
 .PHONY: dev
-dev: check-env-vars set_env_class_dev ## Set Environment to DEV
+dev: check-env-vars ## Set Environment to DEV
+	$(eval export MAKEFILE_ENV_TARGET=dev)
+	$(eval export AWS_ACCOUNT=dev)
+	$(eval export ENABLE_AUTODELETE=true)
+	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
+	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipelineapps.digital)
 	@true
 
 .PHONY: ci
-ci: check-env-vars set_env_class_ci ## Set Environment to CI
+ci: check-env-vars ## Set Environment to CI
+	$(eval export MAKEFILE_ENV_TARGET=ci)
+	$(eval export AWS_ACCOUNT=ci)
+	$(eval export ENABLE_AUTO_DEPLOY=true)
+	$(eval export TAG_PREFIX=stage-)
+	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.ci.cloudpipeline.digital)
+	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.ci.cloudpipelineapps.digital)
 	@true
 
 .PHONY: stage
-stage: check-env-vars set_env_class_stage  ## Set Environment to Staging
+stage: check-env-vars ## Set Environment to Staging
+	$(eval export MAKEFILE_ENV_TARGET=stage)
+	$(eval export AWS_ACCOUNT=stage)
+	$(eval export ENABLE_AUTO_DEPLOY=true)
+	$(eval export TAG_PREFIX=prod-)
+	$(eval export PAAS_CF_TAG_FILTER=stage-*)
+	$(eval export SYSTEM_DNS_ZONE_NAME=staging.cloudpipeline.digital)
+	$(eval export APPS_DNS_ZONE_NAME=staging.cloudpipelineapps.digital)
 	@true
 
 .PHONY: prod
-prod: check-env-vars set_env_class_prod ## Set Environment to Production
+prod: check-env-vars ## Set Environment to Production
+	$(eval export MAKEFILE_ENV_TARGET=prod)
+	$(eval export AWS_ACCOUNT=prod)
+	$(eval export ENABLE_AUTO_DEPLOY=true)
+	$(eval export PAAS_CF_TAG_FILTER=prod-*)
+	$(eval export SYSTEM_DNS_ZONE_NAME=cloud.service.gov.uk)
+	$(eval export APPS_DNS_ZONE_NAME=cloudapps.digital)
 	@true
 
 .PHONY: bootstrap
@@ -65,42 +89,6 @@ bootstrap-destroy: ## Destroy bootstrap
 .PHONY: bosh-cli
 bosh-cli: ## Create interactive connnection to BOSH container
 	concourse/scripts/bosh-cli.sh
-
-.PHONY: set_env_class_dev
-set_env_class_dev:
-	$(eval export MAKEFILE_ENV_TARGET=dev)
-	$(eval export AWS_ACCOUNT=dev)
-	$(eval export ENABLE_AUTODELETE=true)
-	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
-	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipelineapps.digital)
-
-.PHONY: set_env_class_ci
-set_env_class_ci:
-	$(eval export MAKEFILE_ENV_TARGET=ci)
-	$(eval export AWS_ACCOUNT=ci)
-	$(eval export ENABLE_AUTO_DEPLOY=true)
-	$(eval export TAG_PREFIX=stage-)
-	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.ci.cloudpipeline.digital)
-	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.ci.cloudpipelineapps.digital)
-
-.PHONY: set_env_class_stage
-set_env_class_stage:
-	$(eval export MAKEFILE_ENV_TARGET=stage)
-	$(eval export AWS_ACCOUNT=stage)
-	$(eval export ENABLE_AUTO_DEPLOY=true)
-	$(eval export TAG_PREFIX=prod-)
-	$(eval export PAAS_CF_TAG_FILTER=stage-*)
-	$(eval export SYSTEM_DNS_ZONE_NAME=staging.cloudpipeline.digital)
-	$(eval export APPS_DNS_ZONE_NAME=staging.cloudpipelineapps.digital)
-
-.PHONY: set_env_class_prod
-set_env_class_prod:
-	$(eval export MAKEFILE_ENV_TARGET=prod)
-	$(eval export AWS_ACCOUNT=prod)
-	$(eval export ENABLE_AUTO_DEPLOY=true)
-	$(eval export PAAS_CF_TAG_FILTER=prod-*)
-	$(eval export SYSTEM_DNS_ZONE_NAME=cloud.service.gov.uk)
-	$(eval export APPS_DNS_ZONE_NAME=cloudapps.digital)
 
 .PHONY: pipelines
 pipelines: ## Upload pipelines to Concourse


### PR DESCRIPTION
## What

Now that the makefile is structured so that we always do `make <env> <action>`, there's no need for the environment setup to be in separate targets, it can be in the env targets themselves.

## How to review

Verify that the makefile still works (eg verify that `make <env> showenv` outputs the expected values etc).

## Who can review

Anyone but myself.
