### PR TITLE
Fix missing git_rsa_id_pub in destroy-deployer pipeline

### DIFF
--- a/concourse/pipelines/destroy-deployer.yml
+++ b/concourse/pipelines/destroy-deployer.yml
@@ -123,6 +123,7 @@ jobs:
           AWS_DEFAULT_REGION: {{aws_region}}
           TF_VAR_env: {{deploy_env}}
           TF_VAR_system_dns_zone_name: {{system_dns_zone_name}}
+          TF_VAR_git_rsa_id_pub: anything
         run:
           path: sh
           args:


### PR DESCRIPTION
## What

The concourse terraform destroy was failing because it requires the
git_rsa_id_pub variable to be set. It doesn't actually matter what this
is set to because we're destroying.

## How to review

Run the destroy-deployer pipeline and verify that it doesn't error with "Required variable not set: git_rsa_id_pub".  It may error with another error about IAM permissions that needs to be fixed in the IAM policies.

## Who can review

Anyone but myself.