### PR TITLE
Add chrome plugin used on concourse monitors

### DIFF
--- a/concourse/chrome_plugin/README.md
+++ b/concourse/chrome_plugin/README.md
@@ -1,0 +1,21 @@
+What
+====
+
+This is a small chrome plugin that strips away some of the cruft from the concourse pipeline view when showing it on monitoring screens.
+
+It removes:
+* The legend from the bottom left
+* The download links from the bottom right
+* The top menu bar & shortcuts
+
+It adds:
+* The hostname of the concourse instance to the top left, stripped of "deployer." and ".cloudpipeline.digital"
+
+Installing
+==========
+
+1. Download this directory onto the machine running the monitors
+2. Open [chrome://extensions](chrome://extensions)
+3. Tick the "Developer mode" checkbox in the top right
+4. Click "Load unpacked extention..." and select this directory
+5. Refresh your concourse tabs, and they shall lack cruft.

--- a/concourse/chrome_plugin/manifest.json
+++ b/concourse/chrome_plugin/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "Concourse monitor mode",
+  "version": "0.0.1",
+  "manifest_version": 2,
+  "permissions": [
+    "https://*.cloudpipeline.digital/*",
+    "https://deployer.cloud.service.gov.uk/*"
+  ],
+  "content_scripts": [
+    {
+      "matches": [
+        "https://*.cloudpipeline.digital/*",
+        "https://deployer.cloud.service.gov.uk/*"
+      ],
+      "js": [
+        "src/inject/inject.js"
+      ],
+      "all_frames": true
+    }
+  ]
+}

--- a/concourse/chrome_plugin/src/inject/inject.js
+++ b/concourse/chrome_plugin/src/inject/inject.js
@@ -1,0 +1,19 @@
+chrome.extension.sendMessage({}, function(response) {
+    var readyStateCheckInterval = setInterval(function() {
+        if (document.readyState === "complete") {
+            clearInterval(readyStateCheckInterval);
+
+            console.log("Monitor mode is go");
+            var element = document.getElementsByClassName("legend")[0];
+            element.parentNode.removeChild(element);
+
+            var element = document.getElementById("cli-downloads");
+            element.parentNode.removeChild(element);
+
+            var hostname = location.hostname.replace("deployer.", "").replace(".cloudpipeline.digital","")
+
+            var element = document.getElementsByTagName("nav")[0];
+            element.innerHTML = "&nbsp;<font size=5>" + hostname + "</font>";
+        }
+    }, 10);
+});


### PR DESCRIPTION
## What

This is the terrible chrome plugin we've got deployed on the concourse monitoring screens to remove all the non-essential information.

## How to review

1. Install the plugin in chrome, then load a concourse web interface.
2. Observe that there is less concourse interface.
3. Uninstall the chrome plugin.

## Who can review

Not @jonty.