### PR TITLE
[#116603765] Enable concourse public read-only access

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,16 +18,19 @@ before_install:
   - mkdir ~/bin
   - export PATH=~/bin:$PATH
   - |
+    echo "Fetching Terraform"
+    set -e
     wget https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip
     unzip -o terraform_${TF_VERSION}_linux_amd64.zip -d ~/bin
     rm terraform_${TF_VERSION}_linux_amd64.zip
   - |
+    echo "Fetching Spruce"
+    set -e
     wget https://github.com/geofffranks/spruce/releases/download/v${SPRUCE_VERSION}/spruce_${SPRUCE_VERSION}_linux_amd64.tar.gz
     tar -xvzf spruce_${SPRUCE_VERSION}_linux_amd64.tar.gz
     mv spruce_${SPRUCE_VERSION}_linux_amd64/spruce ~/bin && chmod +x ~/bin/spruce
     rm -rf spruce_${SPRUCE_VERSION}_linux_amd64.tar.gz spruce_${SPRUCE_VERSION}_linux_amd64
-  - |
-    pip install --user yamllint
+  - pip install --user yamllint
 
 script:
   - make test

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -84,6 +84,7 @@ jobs:
         external_url: (( concat "https://" terraform_outputs.concourse_dns_name ))
         basic_auth_username: admin
         basic_auth_password: (( grab secrets.concourse_atc_password ))
+        publicly_viewable: true
         postgresql:
           address: 127.0.0.1:5432
           role: &atc-role


### PR DESCRIPTION
## What

Enable `publicly_viewable` for the deployer-concourse so that we can put the pipelines on the big screen without having to have it logged in. This concourse is still locked down by IP.

This allows read-only access to the concourse UI, but not to the output
of job runs (unless the job itself is defined as public). See
http://bosh.io/jobs/atc?source=github.com/concourse/concourse&version=0.74.0#p=atc.publicly_viewable
for more details.

This also includes a commit to make the Travis `before_install` tasks fail with better errors. 

## How to review

Run the create-deployer pipeline from this branch. Verify that the deployer-concourse can be accessed in read-only mode without any auth.

## Who can review

Anyone but myself.
