### PR TITLE
[#117131037] Fixing the build: Double tags in stage

### DIFF
--- a/concourse/scripts/tag-release.sh
+++ b/concourse/scripts/tag-release.sh
@@ -22,8 +22,8 @@ Host github.com
 EOF
 
 get_tag(){
-  tag_filter=${1}
-  git tag -l --contains HEAD | grep "${tag_filter}"
+  tag_filter="${1}"
+  git tag -l --contains HEAD --sort=version:refname "${tag_filter}" | tail -n 1
 }
 
 promote_existing_tag(){
@@ -44,7 +44,7 @@ git remote add ssh "${GIT_REPO_URL}"
 
 if [ -n "${TAG_FILTER}" ]
 then
-  latest_tag=$(get_tag "${TAG_FILTER%?}")
+  latest_tag=$(get_tag "${TAG_FILTER}")
   tag=$(promote_existing_tag "${latest_tag}")
   echo "Promote ${latest_tag} to ${tag}"
 else

--- a/concourse/scripts/tag-release.sh
+++ b/concourse/scripts/tag-release.sh
@@ -7,6 +7,8 @@ AWS_ACCOUNT="${2}"
 DEPLOY_ENV="${3}"
 TAG_FILTER="${4:-""}"
 
+GIT_PUSH="${GIT_PUSH:-true}" # Push the repo at the end or not
+
 GIT_EMAIL="the-multi-cloud-paas-team+deployer-ci@digital.cabinet-office.gov.uk"
 GIT_USER="gov-paas-${AWS_ACCOUNT}"
 GIT_REPO_URL="git@github.com:alphagov/paas-cf.git"
@@ -67,5 +69,7 @@ fi
 git tag -a "${tag}" -m "Tag ${tag} passed ${AWS_ACCOUNT} \
 in environment ${DEPLOY_ENV}"
 
-echo "Push tag ${tag}"
-git push ssh "${tag}"
+if [ "${GIT_PUSH}" = "true" ]; then
+  echo "Push tag ${tag}"
+  git push ssh "${tag}"
+fi

--- a/concourse/scripts/tag-release.sh
+++ b/concourse/scripts/tag-release.sh
@@ -21,6 +21,16 @@ Host github.com
   IdentityFile $(pwd)/git-key
 EOF
 
+check_already_tagged() {
+  tag_prefix="${1}"
+  previous_tags="$(git tag -l --contains HEAD "${tag_prefix}*")"
+  if [ -n "${previous_tags}" ] ; then
+    echo "WARNING: already tagged to current commit for environment ${DEPLOY_ENV}. Skipping."
+    echo "Tags: ${previous_tags}"
+    exit 0
+  fi
+}
+
 get_tag(){
   tag_filter="${1}"
   git tag -l --contains HEAD --sort=version:refname "${tag_filter}" | tail -n 1
@@ -37,6 +47,8 @@ create_new_tag(){
 }
 
 cd paas-cf
+check_already_tagged "${TAG_PREFIX}"
+
 echo Configure Git
 git config --global user.email "${GIT_EMAIL}"
 git config --global user.name "${GIT_USER}"


### PR DESCRIPTION
[#117131037 Fixing the build: Double tags in stage](https://www.pivotaltracker.com/story/show/117131037)

What
----

It seems that CI run twice and created a double tag of stage. Then staging tag-release failed because the script does not handle well two tags.

Scope
-----

In this PR we add code so that

 - Not fail if there are two tags poiting to HEAD
 - Do not allow double tagging

Additionally, to help testing I added code to optionally disable git push

How to test
-----------

As we lack of a proper unit testing for this script, you can use this
minimum Dockerfile.


```
cat <<EOF > Dockerfile
FROM governmentpaas/git-ssh

WORKDIR /tmp
RUN mkdir -p /tmp/paas-cf
RUN cd /tmp/paas-cf && \
    git init && \
    git commit --allow-empty -m "First commit" && \
    git tag previous-0.0.1 && \
    git tag previous-0.0.2

RUN mkdir -p /tmp/git-keys && cd  /tmp/git-keys  && \
    ssh-keygen -f git-key -N '' && \
    tar -cvzf git-keys.tar.gz git-key git-key.pub

ENV GIT_PUSH=false

ADD ./concourse/scripts/tag-release.sh /tmp/

RUN cd /tmp && /tmp/tag-release.sh next- testaccount testenv 'previous-*' && \
    cd /tmp/paas-cf && git tag && \
    cd /tmp/paas-cf && git remote remove ssh && \
    cd /tmp && /tmp/tag-release.sh next- testaccount testenv 'previous-*' && \
    cd /tmp/paas-cf && git tag
EOF
```

Run it as: `docker build --force-rm=true --no-cache=true .` in the repo directory

Who?
----

Anyone but @keymon