### PR TITLE
[#117020631] Reduce default quota to 2GB

### DIFF
--- a/manifests/cf-manifest/deployments/040-cf-properties.yml
+++ b/manifests/cf-manifest/deployments/040-cf-properties.yml
@@ -2,9 +2,9 @@ meta:
   environment: ~
   default_quota_definitions:
     default:
-       memory_limit: 10240
-       total_services: 100
-       non_basic_services_allowed: true
+       memory_limit: 2048
+       total_services: 10
+       non_basic_services_allowed: false
        total_routes: 1000
   secrets:
     consul_ca_cert: (( grab secrets.bosh_ca_cert ))


### PR DESCRIPTION
## What

We only want to allocate 2GB of "Freemium" memory in the default
quota. We also limit usage to 10 basic (free) services.

## How to review

Deploy from scratch (see https://github.com/cloudfoundry/bosh/issues/1201). View quotas (`cf quotas`). Try exceeding it - you should not be able.

## Who can review

not @mtekel