### PR TITLE
[#117020631] Reduce default quota to 2GB

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1016,6 +1016,34 @@ jobs:
                 echo export "${var_name}"=\"$(eval echo \$${var_name})\"
               done > config/config.sh
 
+              CF_MANIFEST=cf-manifest/cf-manifest.yml $(pwd)/paas-cf/concourse/scripts/extract_quota_settings.rb > config/quota_settings.sh
+
+    - task: update-default-quota
+      config:
+        platform: linux
+        inputs:
+          - name: config
+        params:
+        image: docker:///governmentpaas/cf-cli
+        run:
+          path: sh
+          args:
+            - -e
+            - -c
+            - |
+              . ./config/config.sh
+              cf api --skip-ssl-validation ${API_ENDPOINT}
+              echo | cf login -u ${CF_ADMIN} -p ${CF_PASS}
+
+              . ./config/quota_settings.sh
+              ${QUOTA_non_basic_services_allowed} || prefix="dis"
+
+              cf update-quota "${QUOTA_DEFAULT}" \
+                -m "${QUOTA_memory_limit}"M \
+                -r "${QUOTA_total_routes}" \
+                -s "${QUOTA_total_services}" \
+                --${prefix}allow-paid-service-plans
+
     - task: deploy-healthcheck-app
       config:
         platform: linux

--- a/concourse/scripts/extract_quota_settings.rb
+++ b/concourse/scripts/extract_quota_settings.rb
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+require 'json'
+require 'yaml'
+
+manifest_file = ENV.fetch("CF_MANIFEST")
+manifest = YAML.load_file(manifest_file)
+default = manifest['properties']['cc']['default_quota_definition']
+puts "export QUOTA_DEFAULT=#{default}"
+
+manifest['properties']['cc']['quota_definitions'][default].each { |k,v|
+  puts "export QUOTA_#{k}='#{v}'"
+}

--- a/manifests/cf-manifest/deployments/040-cf-properties.yml
+++ b/manifests/cf-manifest/deployments/040-cf-properties.yml
@@ -2,9 +2,9 @@ meta:
   environment: ~
   default_quota_definitions:
     default:
-       memory_limit: 10240
-       total_services: 100
-       non_basic_services_allowed: true
+       memory_limit: 2048
+       total_services: 10
+       non_basic_services_allowed: false
        total_routes: 1000
   secrets:
     consul_ca_cert: (( grab secrets.bosh_ca_cert ))


### PR DESCRIPTION
## What

We only want to allocate 2GB of "Freemium" memory in the default quota. We also limit usage to 10 basic (free) services. Because BOSH can't update values directly from manifest changes (https://github.com/cloudfoundry/bosh/issues/1201), add a step in post-deploy job to use cf-cli to update quotas. Add a small script to help extract quota settings from manifest.

## How to review

Deploy. View quotas (`cf quotas`) and verify default has been updated to new values. Try exceeding it - you should not be able to.

## Who can review

not @mtekel