### PR TITLE
[#117515045] Use points-at to find tags pointing to HEAD

### DIFF
--- a/concourse/scripts/tag-release.sh
+++ b/concourse/scripts/tag-release.sh
@@ -25,7 +25,7 @@ EOF
 
 check_already_tagged() {
   tag_prefix="${1}"
-  previous_tags="$(git tag -l --contains HEAD "${tag_prefix}*")"
+  previous_tags="$(git tag -l --points-at HEAD "${tag_prefix}*")"
   if [ -n "${previous_tags}" ] ; then
     echo "WARNING: already tagged to current commit for environment ${DEPLOY_ENV}. Skipping."
     echo "Tags: ${previous_tags}"

--- a/concourse/scripts/tag-release.sh
+++ b/concourse/scripts/tag-release.sh
@@ -35,7 +35,7 @@ check_already_tagged() {
 
 get_tag(){
   tag_filter="${1}"
-  git tag -l --contains HEAD --sort=version:refname "${tag_filter}" | tail -n 1
+  git tag -l --points-at HEAD --sort=version:refname "${tag_filter}" | tail -n 1
 }
 
 promote_existing_tag(){


### PR DESCRIPTION
[#117515045 Fix the Build : Tags](https://www.pivotaltracker.com/story/show/117515045)

What
---

We found the following problem in tag-release:

 1. The git resource ALWAYS clone the full repo, downloading all latest tags
 2. Then it checks-out the required ref, tag or commit
 4. But when promoting a tag, tag-release.sh queries for all the tags that
    **CONTAIN** the current HEAD, so any new tag in new commits in master
    will match and their version promoted.

The solution is simply query for the tags to point-at the current HEAD

Note that we were checking if the current commit was already included in any other previous tag with the destination prefix to avoid tagging twice. In this check we also use `--contains`, but it should be `--points-at`.

Note we are not checking if the destination tag already exists, it just fails on creation..

Detailed issue
----------------

In more detail, in our case the error was the following race condition.
 * Tag `staging-0.0.30` was created after a successful deployment of CI
 * Staging started working with tag `staging-0.0.30`
 * CI got immediatelly triggered due other new commits.
 * CI finished before staging did, creating a tag called `staging-0.0.31`
 * Staging, which was triggered with tag `staging-0.0.030`
   finished the tests just after, but the "tag_release" job
   queried all the tags containing the HEAD commit it took the
   latest: `staging-0.0.31`, creating the tag `prod-0.0.31`
 * Staging was triggered again, this time for the tag `staging-0.0.31`
 * When staging finished, it tried to do another tag-release for prod,
   based on the current tag in staging, so `prod-0.0.31`. But it failed
   because the tag was already there.


How to test it
-------------

I provided this Docker file to test the case:

```
cat <<"EOF"
FROM governmentpaas/git-ssh

WORKDIR /tmp
ENV GIT_PUSH=false


RUN mkdir -p /tmp/git-keys && cd  /tmp/git-keys  && \
    ssh-keygen -f git-key -N '' && \
    tar -cvzf git-keys.tar.gz git-key git-key.pub

ADD ./concourse/scripts/tag-release.sh /tmp/


RUN echo "When working on a git repo with two tags in one commit" && \
    mkdir -p /tmp/paas-cf && \
    cd /tmp/paas-cf && \
    git init && \
    git commit --allow-empty -m "First commit" && \
    git tag previous-0.0.1 && \
    git tag previous-0.0.2 && \
    echo "When and other tag in a later commit" && \
    git commit --allow-empty -m "Second commit" && \
    git tag previous-0.0.3

RUN echo "When I checkout the version previous-0.0.2" && \
    cd /tmp/paas-cf && \
    git checkout HEAD^1 && \
    echo "And tag the next-* release" && \
    cd /tmp && \
    /tmp/tag-release.sh next- testaccount testenv 'previous-*' && \
    echo "It tags with next-0.0.2" && \
    cd /tmp/paas-cf && \
    LATEST_NEXT_TAG=$(git tag -l next-* --sort version:refname | tail -n1) && \
    echo "LATEST_NEXT_TAG=$LATEST_NEXT_TAG" && \
    test "$LATEST_NEXT_TAG" == "next-0.0.2"

RUN echo "When I retry to tag again and it is already tagged" && \
    echo "It does not fail" && \
    cd /tmp && \
    /tmp/tag-release.sh next- testaccount testenv 'previous-*' && \
    echo "and keeps the old tag next-0.0.2" && \
    cd /tmp/paas-cf && \
    LATEST_NEXT_TAG=$(git tag -l next-* --sort version:refname | tail -n1) && \
    echo "LATEST_NEXT_TAG=$LATEST_NEXT_TAG" && \
    test $LATEST_NEXT_TAG == next-0.0.2
EOF
```

Run `docker build --force-rm=true --no-cache=true .` to run the tests. It should complete with the current commit.

To test the fail scenario, simply checkout master and run again

Who?
---

Anyone but @keymon