### PR TITLE
Disable Travis CI email notifications on success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,7 @@ before_install:
 
 script:
   - make test
+
+notifications:
+  email:
+    on_success: never


### PR DESCRIPTION
## What

I get a "build passed" email whenever a tag is created for a PR that I've
merged. These emails are cluttering up my mailbox and aren't terribly
useful, because I don't need to take any action when a build has succeeded.
I only need to know if it has failed.

Prevent this from happening by never sending email notifications for
successful builds. The default for `on_failure` is `always` so the behaviour
of failed builds remains unchanged.

ref: https://docs.travis-ci.com/user/notifications/#Email-notifications

Part of the problem here is that Travis CI doesn't really need to build
tags. But turning that off is currently a hack: travis-ci/travis-ci#1532

## How to review

This isn't very easy to test. I guess you could confirm that the failure path still works, by branching from this PR, pushing a commit which fails the build, and confirming that it still sends you an email.

## Who can review

Not @dcarley