### PR TITLE
README: Document how to access CloudFoundry

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,19 @@ deployment.
 
 # Additional notes
 
+## Accessing CloudFoundry
+
+To interact with a CloudFoundry environment you will need the following:
+
+- the `cf` command line tool ([installation instructions](https://github.com/cloudfoundry/cli#downloads))
+- `API_ENDPOINT` from `make dev showenv`
+- `uaa_admin_password` from `cf-secrets.yml` in the state bucket
+
+Then you can use `cf login` as [documented here](http://docs.cloudfoundry.org/cf-cli/getting-started.html#login).
+
+You will need to supply the `--skip-ssl-validation` argument if you are
+using a development environment.
+
 ## Running tests locally
 
 You will need to install some dependencies to run the unit tests on your own


### PR DESCRIPTION
## What

As suggested by Toby in #153. I've refactored the instructions so that:

- We link to the downloads section in the README which is a bit simpler than
  the release page (the version probably doesn't matter too much at the
  moment).
- Use the recently added `showenv` make target for getting the URL
- Describe where the admin password can be found
- Link to a page about `cf login` rather than describing everything here

I did experiment with adding a `cf-login` make target and script, which
fetches the password automatically, but I'm not sure whether it's too
opinionated and it's not very easy to test it in the same way we do
`bosh-cli`.

## How to review

Test the instructions in the new section of the README.

## Who can review

Not @dcarley