### PR TITLE
README: Fix CF link in overview section

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ destroyed in reverse order so as not to leave any orphaned resources:
 
 1. [Bootstrap Concourse](#bootstrap-concourse)
 1. [Deployer Concourse](#deployer-concourse)
-1. [MicroBOSH](#microbosh-and-cloudfoundry)
-1. [CloudFoundry](#cloudfoundry)
+1. [MicroBOSH and CloudFoundry](#microbosh-and-cloudfoundry)
 
 The word *environment* is used herein to describe a single Cloud Foundry
 installation and its supporting infrastructure.


### PR DESCRIPTION
## What

This was broken when we combined the BOSH and CloudFoundry pipelines. I
don't think it's worth listing them as separate bullet points when they
point to the same section.

## How to review

View the rendered page and see if it makes sense.

## Who can review

Not @dcarley