### PR TITLE
[#116104189] Renamed Pingdom Terraform state file and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,3 +339,5 @@ deployed as part of the pipeline. This requires paas-pass to be setup, and
 installation of an additional terraform provider - instructions for this are
 documented when running the make target for the first time.
 
+Make sure you are using the correct AWS credentials for the environment you are setting up checks for. For those developers with AWS CLI config files, the [AWS CLI Documentation](http://docs.aws.amazon.com/cli/latest/topic/config-vars.html#id1) states environment variables have the highest precedence.
+

--- a/terraform/scripts/set-up-pingdom.sh
+++ b/terraform/scripts/set-up-pingdom.sh
@@ -33,7 +33,7 @@ PINGDOM_ACCOUNT_EMAIL=$(pass pingdom.com/account_email)
 
 # Check bucket for Terraform state file
 cd terraform/pingdom
-declare -r STATEFILE=${MAKEFILE_ENV_TARGET}.tfstate
+declare -r STATEFILE=pingdom-${MAKEFILE_ENV_TARGET}.tfstate
 if ! aws s3 ls "s3://${DEPLOY_ENV}-state/${STATEFILE}" --summarize | grep -q "Total Objects: 0";
 	then aws s3 cp "s3://${DEPLOY_ENV}-state/${STATEFILE}" "${STATEFILE}"
 else


### PR DESCRIPTION
## What

We want Terraform state files for Pingdom to have a descriptive name so it is clear in AWS Console S3 bucket what the file is for. The previous file name would have just been ${MAKEFILE_ENV_TARGET}.tfstate, so `pingdom-` has been added to the start.

Also, we want to make sure developers have the correct AWS credentials when running the script, so the README has been updated.

## How to review

* Run shellcheck on `terraform/scripts/set-up-pingdom.sh`.
* Run `make dev pingdom` and make sure the script runs successfully and Terraform / AWS CLI does not complain.
* Run the script again and it should say nothing has been updated.


## Who can review

Anybody except @henrytk @timmow or @jimconner 

