### PR TITLE
[#116983391] Upgrade CF to v233

### DIFF
--- a/manifests/bosh-manifest/deployments/010-bosh-template.yml
+++ b/manifests/bosh-manifest/deployments/010-bosh-template.yml
@@ -22,8 +22,8 @@ name: bosh
 
 releases:
 - name: bosh
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=253
-  sha1: 940956a23b642af3bb24b3cac37c4da746d6f9a9
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=255.8
+  sha1: 6b12652650b87810dcef1be1f6a6d23f1c0c13a7
 
 
 disk_pools:

--- a/manifests/bosh-manifest/deployments/aws/000-bosh-infrastructure.yml
+++ b/manifests/bosh-manifest/deployments/aws/000-bosh-infrastructure.yml
@@ -3,8 +3,8 @@ resource_pools:
 - name: vms
   network: private
   stemcell:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3197
-    sha1: 89a2210b8caf3884855d7db6d48b8863202c7783
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3215
+    sha1: 84c51fed6342d5eb7cd59728c7d691c75b6c1de8
   cloud_properties:
     instance_type: t2.medium
     ephemeral_disk: {size: 40_000, type: gp2}

--- a/manifests/bosh-manifest/reference-bosh-manifest.yml
+++ b/manifests/bosh-manifest/reference-bosh-manifest.yml
@@ -172,8 +172,8 @@ properties:
       -----END RSA PRIVATE KEY-----
 releases:
 - name: bosh
-  sha1: 940956a23b642af3bb24b3cac37c4da746d6f9a9
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=253
+  sha1: 6b12652650b87810dcef1be1f6a6d23f1c0c13a7
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=255.8
 - name: bosh-aws-cpi
   sha1: a1fe03071e8b9bf1fa97a4022151081bf144c8bc
   url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=44

--- a/manifests/bosh-manifest/reference-bosh-manifest.yml
+++ b/manifests/bosh-manifest/reference-bosh-manifest.yml
@@ -191,5 +191,5 @@ resource_pools:
   name: vms
   network: private
   stemcell:
-    sha1: 89a2210b8caf3884855d7db6d48b8863202c7783
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3197
+    sha1: 84c51fed6342d5eb7cd59728c7d691c75b6c1de8
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3215

--- a/manifests/cf-manifest/deployments/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/deployments/000-base-cf-deployment.yml
@@ -9,25 +9,25 @@ name: (( grab meta.environment ))
 
 releases:
   - name: cf
-    version: 228
-    url: https://bosh.io/d/github.com/cloudfoundry/cf-release?v=228
-    sha1: cc9d5930f67e48c6862b686c628730a0846bd9e3
+    version: 233
+    url: https://bosh.io/d/github.com/cloudfoundry/cf-release?v=233
+    sha1: 611b0e37f5c8a61948e547630f3c218c0c465cc0
   - name: nginx
     version: 2
     url: https://s3.amazonaws.com/nginx-release/nginx-2.tgz
     sha1: 667cc1a0f9117bdb4b217ee2b76dc20e61371c02
   - name: diego
-    version: 0.1450.0
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/diego-release?v=0.1450.0
-    sha1: 351162532cc27424836b9ff3300b39333b584f23
+    version: 0.1460.0
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/diego-release?v=0.1460.0
+    sha1: 2d9a65acc34802ef0deb4446c684d7973c65cc94
   - name: garden-linux
-    version: 0.331.0
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/garden-linux-release?v=0.331.0
-    sha1: b89d7fe2e230bd88f143d5eba1ca1d15570aa146
+    version: 0.334.0
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/garden-linux-release?v=0.334.0
+    sha1: 85170c5089fa4ff317f139c2f1da024860dbea85
   - name: etcd
-    version: 27
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/etcd-release?v=27
-    sha1: 11a64cb5e23cdd1f6c670fad0d776424807f4923
+    version: 38
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/etcd-release?v=38
+    sha1: c7d303c1b733e77c5c5f3dedfe4dbf75997f30bc
 
 compilation:
   workers: 6

--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -570,11 +570,6 @@ jobs:
     properties:
       metron_agent:
         zone: z1
-      consul:
-        agent:
-          services:
-            file_server: {}
-            ssh_proxy: {}
 
   - name: access_z2
     templates: (( grab base_job_templates.access ))
@@ -585,11 +580,6 @@ jobs:
     properties:
       metron_agent:
         zone: z2
-      consul:
-        agent:
-          services:
-            file_server: {}
-            ssh_proxy: {}
 
   - name: brain_z1
     templates: (( grab base_job_templates.brain ))
@@ -598,10 +588,6 @@ jobs:
     networks:
       - name: cf1
     properties:
-      consul:
-        agent:
-          services:
-            auctioneer: {}
       metron_agent:
         zone: z1
 
@@ -612,10 +598,6 @@ jobs:
     networks:
       - name: cf2
     properties:
-      consul:
-        agent:
-          services:
-            auctioneer: {}
       metron_agent:
         zone: z2
 
@@ -628,13 +610,6 @@ jobs:
     properties:
       metron_agent:
         zone: z1
-      consul:
-        agent:
-          services:
-            cc_uploader: {}
-            nsync: {}
-            stager: {}
-            tps: {}
 
   - name: cc_bridge_z2
     templates: (( grab base_job_templates.cc_bridge ))
@@ -645,13 +620,6 @@ jobs:
     properties:
       metron_agent:
         zone: z2
-      consul:
-        agent:
-          services:
-            cc_uploader: {}
-            nsync: {}
-            stager: {}
-            tps: {}
 
   - name: cell_z1
     templates: (( grab base_job_templates.cell ))
@@ -687,17 +655,6 @@ jobs:
     networks:
       - name: cf1
     properties:
-      consul:
-        agent:
-          services:
-            auctioneer: {}
-            bbs: {}
-            cc_uploader: {}
-            file_server: {}
-            nsync: {}
-            ssh_proxy: {}
-            stager: {}
-            tps: {}
       diego:
         rep:
           zone: z1
@@ -712,17 +669,6 @@ jobs:
     networks:
       - name: cf2
     properties:
-      consul:
-        agent:
-          services:
-            auctioneer: {}
-            bbs: {}
-            cc_uploader: {}
-            file_server: {}
-            nsync: {}
-            ssh_proxy: {}
-            stager: {}
-            tps: {}
       diego:
         rep:
           zone: z2
@@ -737,10 +683,6 @@ jobs:
     networks:
       - name: cf1
     properties:
-      consul:
-        agent:
-          services:
-            bbs: {}
       metron_agent:
         zone: z1
 
@@ -752,10 +694,6 @@ jobs:
     networks:
       - name: cf2
     properties:
-      consul:
-        agent:
-          services:
-            bbs: {}
       metron_agent:
         zone: z2
 

--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -39,6 +39,24 @@ meta:
     release: (( grab meta.release.name ))
   - release: "logsearch-shipper"
     name: (( grab meta.logsearch_shipper.release.name ))
+  - name: java-buildpack
+    release: (( grab meta.release.name ))
+  - name: java-offline-buildpack
+    release: (( grab meta.release.name ))
+  - name: go-buildpack
+    release: (( grab meta.release.name ))
+  - name: binary-buildpack
+    release: (( grab meta.release.name ))
+  - name: nodejs-buildpack
+    release: (( grab meta.release.name ))
+  - name: ruby-buildpack
+    release: (( grab meta.release.name ))
+  - name: php-buildpack
+    release: (( grab meta.release.name ))
+  - name: python-buildpack
+    release: (( grab meta.release.name ))
+  - name: staticfile-buildpack
+    release: (( grab meta.release.name ))
 
   api_worker_templates:
   - name: cloud_controller_worker

--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -27,14 +27,14 @@ meta:
     cloud_controller_ng: {}
 
   api_templates:
+  - name: consul_agent
+    release: (( grab meta.consul_templates.consul_agent.release ))
   - name: cloud_controller_ng
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
   - name: statsd-injector
     release: (( grab meta.release.name ))
-  - name: consul_agent
-    release: (( grab meta.consul_templates.consul_agent.release ))
   - name: nfs_mounter
     release: (( grab meta.release.name ))
   - release: "logsearch-shipper"
@@ -59,12 +59,12 @@ meta:
     release: (( grab meta.release.name ))
 
   api_worker_templates:
+  - name: consul_agent
+    release: (( grab meta.consul_templates.consul_agent.release ))
   - name: cloud_controller_worker
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - name: consul_agent
-    release: (( grab meta.consul_templates.consul_agent.release ))
   - name: nfs_mounter
     release: (( grab meta.release.name ))
   - release: "logsearch-shipper"
@@ -87,106 +87,106 @@ meta:
     name: (( grab meta.logsearch_shipper.release.name ))
 
   etcd_templates:
+  - name: consul_agent
+    release: (( grab meta.release.name ))
   - name: etcd
     release: etcd
   - name: etcd_metrics_server
     release: etcd
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - name: consul_agent
-    release: (( grab meta.release.name ))
   - release: "logsearch-shipper"
     name: (( grab meta.logsearch_shipper.release.name ))
 
   ha_proxy_templates:
+  - name: consul_agent
+    release: (( grab meta.consul_templates.consul_agent.release ))
   - name: haproxy
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - name: consul_agent
-    release: (( grab meta.consul_templates.consul_agent.release ))
   - release: "logsearch-shipper"
     name: (( grab meta.logsearch_shipper.release.name ))
 
   loggregator_templates:
+  - name: consul_agent
+    release: (( grab meta.consul_templates.consul_agent.release ))
   - name: doppler
     release: (( grab meta.release.name ))
   - name: syslog_drain_binder
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - name: consul_agent
-    release: (( grab meta.consul_templates.consul_agent.release ))
   - release: "logsearch-shipper"
     name: (( grab meta.logsearch_shipper.release.name ))
 
   loggregator_trafficcontroller_templates:
+  - name: consul_agent
+    release: (( grab meta.consul_templates.consul_agent.release ))
   - name: loggregator_trafficcontroller
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - name: consul_agent
-    release: (( grab meta.consul_templates.consul_agent.release ))
   - release: "logsearch-shipper"
     name: (( grab meta.logsearch_shipper.release.name ))
 
   nats_templates:
+  - name: consul_agent
+    release: (( grab meta.consul_templates.consul_agent.release ))
   - name: nats
     release: (( grab meta.release.name ))
   - name: nats_stream_forwarder
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - name: consul_agent
-    release: (( grab meta.consul_templates.consul_agent.release ))
 
   nfs_templates:
+  - name: consul_agent
+    release: (( grab meta.consul_templates.consul_agent.release ))
   - name: debian_nfs_server
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - name: consul_agent
-    release: (( grab meta.consul_templates.consul_agent.release ))
   - release: "logsearch-shipper"
     name: (( grab meta.logsearch_shipper.release.name ))
 
   postgres_templates:
+  - name: consul_agent
+    release: (( grab meta.consul_templates.consul_agent.release ))
   - name: postgres
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - name: consul_agent
-    release: (( grab meta.consul_templates.consul_agent.release ))
   - release: "logsearch-shipper"
     name: (( grab meta.logsearch_shipper.release.name ))
 
   router_templates:
+  - name: consul_agent
+    release: (( grab meta.consul_templates.consul_agent.release ))
   - name: gorouter
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - name: consul_agent
-    release: (( grab meta.consul_templates.consul_agent.release ))
   - release: "logsearch-shipper"
     name: (( grab meta.logsearch_shipper.release.name ))
 
   stats_templates:
+  - name: consul_agent
+    release: (( grab meta.consul_templates.consul_agent.release ))
   - name: collector
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - name: consul_agent
-    release: (( grab meta.consul_templates.consul_agent.release ))
   - release: "logsearch-shipper"
     name: (( grab meta.logsearch_shipper.release.name ))
 
   uaa_templates:
+  - name: consul_agent
+    release: (( grab meta.consul_templates.consul_agent.release ))
   - name: uaa
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - name: consul_agent
-    release: (( grab meta.consul_templates.consul_agent.release ))
   - name: statsd-injector
     release: (( grab meta.release.name ))
   - release: "logsearch-shipper"

--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -26,6 +26,7 @@ meta:
   api_consul_services:
     cloud_controller_ng: {}
 
+  # FIXME: Remove route_registrar (https://github.com/cloudfoundry/cf-release/issues/950)
   api_templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
@@ -36,6 +37,8 @@ meta:
   - name: statsd-injector
     release: (( grab meta.release.name ))
   - name: nfs_mounter
+    release: (( grab meta.release.name ))
+  - name: route_registrar
     release: (( grab meta.release.name ))
   - release: "logsearch-shipper"
     name: (( grab meta.logsearch_shipper.release.name ))
@@ -120,12 +123,15 @@ meta:
   - release: "logsearch-shipper"
     name: (( grab meta.logsearch_shipper.release.name ))
 
+  # FIXME: Remove route_registrar (https://github.com/cloudfoundry/cf-release/issues/950)
   loggregator_trafficcontroller_templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
   - name: loggregator_trafficcontroller
     release: (( grab meta.release.name ))
   - name: metron_agent
+    release: (( grab meta.release.name ))
+  - name: route_registrar
     release: (( grab meta.release.name ))
   - release: "logsearch-shipper"
     name: (( grab meta.logsearch_shipper.release.name ))
@@ -180,12 +186,15 @@ meta:
   - release: "logsearch-shipper"
     name: (( grab meta.logsearch_shipper.release.name ))
 
+  # FIXME: Remove route_registrar (https://github.com/cloudfoundry/cf-release/issues/950)
   uaa_templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
   - name: uaa
     release: (( grab meta.release.name ))
   - name: metron_agent
+    release: (( grab meta.release.name ))
+  - name: route_registrar
     release: (( grab meta.release.name ))
   - name: statsd-injector
     release: (( grab meta.release.name ))
@@ -364,6 +373,7 @@ jobs:
       metron_agent:
         zone: z1
 
+  # FIXME: Remove route_registrar (https://github.com/cloudfoundry/cf-release/issues/950)
   - name: uaa_z1
     templates: (( grab meta.uaa_templates ))
     instances: 1
@@ -377,6 +387,8 @@ jobs:
             uaa: {}
       metron_agent:
         zone: z1
+      route_registrar:
+        routes: []
 
   - name: uaa_z2
     templates: (( grab meta.uaa_templates ))
@@ -391,6 +403,8 @@ jobs:
             uaa: {}
       metron_agent:
         zone: z2
+      route_registrar:
+        routes: []
 
   - name: api_z1
     templates: (( grab meta.api_templates ))
@@ -405,6 +419,8 @@ jobs:
           services: (( grab meta.api_consul_services ))
       metron_agent:
         zone: z1
+      route_registrar:
+        routes: []
       nfs_server: (( grab meta.nfs_server ))
 
   - name: api_z2
@@ -420,6 +436,8 @@ jobs:
           services: (( grab meta.api_consul_services ))
       metron_agent:
         zone: z2
+      route_registrar:
+        routes: []
       nfs_server: (( grab meta.nfs_server ))
 
   - name: clock_global
@@ -516,6 +534,8 @@ jobs:
         zone: z1
       metron_agent:
         zone: z1
+      route_registrar:
+        routes: []
 
   - name: loggregator_trafficcontroller_z2
     templates: (( grab meta.loggregator_trafficcontroller_templates ))
@@ -528,6 +548,8 @@ jobs:
         zone: z2
       metron_agent:
         zone: z2
+      route_registrar:
+        routes: []
 
   - name: router_z1
     templates: (( grab meta.router_templates ))

--- a/manifests/cf-manifest/deployments/040-cf-properties.yml
+++ b/manifests/cf-manifest/deployments/040-cf-properties.yml
@@ -80,7 +80,7 @@ properties:
     audit_events:
       cutoff_age_in_days: 31
 
-    users_can_select_backend: false
+    users_can_select_backend: true
     default_to_diego_backend: true
     allow_app_ssh_access: true
     default_app_memory: 1024

--- a/manifests/cf-manifest/deployments/040-cf-properties.yml
+++ b/manifests/cf-manifest/deployments/040-cf-properties.yml
@@ -21,7 +21,7 @@ properties:
     dropsonde_incoming_port: 3457
     traffic_controller_url: (( concat "wss://doppler." properties.system_domain ":443" ))
     tls:
-      ca: ~
+      ca_cert: ~
 
   doppler:
     maxRetainedLogMessages: 100
@@ -29,11 +29,11 @@ properties:
     blacklisted_syslog_ranges: ~
     unmarshaller_count: 5
     port: 443
-    enable_tls_transport: ~
-    tls_server:
-      cert: ~
+    tls:
+      enable: ~
+      server_cert: ~
       port: ~
-      key: ~
+      server_key: ~
 
   metron_agent:
     deployment: (( grab meta.environment ))
@@ -41,9 +41,9 @@ properties:
     enable_buffer: ~
     buffer_size: ~
     dropsonde_incoming_port: (( grab properties.loggregator.dropsonde_incoming_port ))
-    tls_client:
-      cert: ~
-      key: ~
+    tls:
+      client_cert: ~
+      client_key: ~
 
   traffic_controller:
     outgoing_port: 8080
@@ -153,21 +153,21 @@ properties:
     system_buildpacks: (( grab properties.cc.default_buildpacks ))
     default_buildpacks:
       - name: staticfile_buildpack
-        package: buildpack_staticfile
+        package: staticfile-buildpack
       - name: java_buildpack
         package: buildpack_java
       - name: ruby_buildpack
-        package: buildpack_ruby
+        package: ruby-buildpack
       - name: nodejs_buildpack
-        package: buildpack_nodejs
+        package: nodejs-buildpack
       - name: go_buildpack
-        package: buildpack_go
+        package: go-buildpack
       - name: python_buildpack
-        package: buildpack_python
+        package: python-buildpack
       - name: php_buildpack
-        package: buildpack_php
+        package: php-buildpack
       - name: binary_buildpack
-        package: buildpack_binary
+        package: binary-buildpack
 
     install_buildpacks: (( grab properties.cc.system_buildpacks properties.cc.user_buildpacks ))
 

--- a/manifests/cf-manifest/deployments/040-cf-properties.yml
+++ b/manifests/cf-manifest/deployments/040-cf-properties.yml
@@ -287,10 +287,10 @@ properties:
         authorities: routing.routes.read
         authorized-grant-types: client_credentials,refresh_token
       tcp_emitter:
-        authorities: routing.routes.write,routing.routes.read
+        authorities: routing.routes.write,routing.routes.read,routing.router_groups.read
         authorized-grant-types: client_credentials,refresh_token
       tcp_router:
-        authorities: routing.routes.read
+        authorities: routing.routes.read,routing.router_groups.read
         authorized-grant-types: client_credentials,refresh_token
       ssh-proxy:
         authorized-grant-types: authorization_code

--- a/manifests/cf-manifest/deployments/040-cf-properties.yml
+++ b/manifests/cf-manifest/deployments/040-cf-properties.yml
@@ -266,7 +266,7 @@ properties:
       cf:
         id: cf
         override: true
-        authorized-grant-types: implicit,password,refresh_token
+        authorized-grant-types: password,refresh_token
         scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read
         authorities: uaa.none
         access-token-validity: 600

--- a/manifests/cf-manifest/deployments/040-cf-properties.yml
+++ b/manifests/cf-manifest/deployments/040-cf-properties.yml
@@ -316,6 +316,7 @@ properties:
   diego:
     ssl:
       skip_cert_verify: true
+      starting_container_weight: 0.25
     auctioneer:
       bbs:
         api_location: bbs.service.cf.internal:8889

--- a/manifests/cf-manifest/deployments/040-cf-properties.yml
+++ b/manifests/cf-manifest/deployments/040-cf-properties.yml
@@ -459,10 +459,10 @@ base_job_templates:
     - name: metron_agent
       release: cf
   cell:
-    - name: rep
-      release: diego
     - name: consul_agent
       release: cf
+    - name: rep
+      release: diego
     - name: garden
       release: garden-linux
     - name: rootfses
@@ -470,6 +470,8 @@ base_job_templates:
     - name: metron_agent
       release: cf
   cc_bridge:
+    - name: consul_agent
+      release: cf
     - name: stager
       release: diego
     - name: nsync
@@ -478,34 +480,34 @@ base_job_templates:
       release: diego
     - name: cc_uploader
       release: diego
-    - name: consul_agent
-      release: cf
     - name: metron_agent
       release: cf
   route_emitter:
-    - name: route_emitter
-      release: diego
     - name: consul_agent
       release: cf
+    - name: route_emitter
+      release: diego
     - name: metron_agent
       release: cf
   access:
-    - name: ssh_proxy
-      release: diego
     - name: consul_agent
       release: cf
+    - name: ssh_proxy
+      release: diego
     - name: metron_agent
       release: cf
     - name: file_server
       release: diego
   database:
-    - name: bbs
-      release: diego
     - name: consul_agent
       release: cf
+    - name: bbs
+      release: diego
     - name: metron_agent
       release: cf
   colocated:
+    - name: consul_agent
+      release: cf
     - name: auctioneer
       release: diego
     - name: bbs
@@ -514,8 +516,6 @@ base_job_templates:
       release: diego
     - name: converger
       release: diego
-    - name: consul_agent
-      release: cf
     - name: file_server
       release: diego
     - name: metron_agent

--- a/manifests/cf-manifest/deployments/900-cf-tests.yml
+++ b/manifests/cf-manifest/deployments/900-cf-tests.yml
@@ -9,7 +9,7 @@ properties:
     backend: "diego"
     client_secret: (( grab secrets.uaa_clients_gorouter_secret ))
     skip_diego_unsupported_tests: true
-    include_tasks: true
+    include_tasks: false
     include_v3: true
     include_security_groups: true
     include_routing: true

--- a/manifests/cf-manifest/deployments/aws/000-cf-infrastructure.yml
+++ b/manifests/cf-manifest/deployments/aws/000-cf-infrastructure.yml
@@ -37,9 +37,6 @@ properties:
     buildpacks:
       fog_connection: (( grab meta.fog_config ))
 
-  uaa:
-    catalina_opts: -Xmx768m -XX:MaxPermSize=256m
-
 compilation:
   cloud_properties:
     instance_type: c3.large

--- a/manifests/cf-manifest/deployments/aws/000-cf-infrastructure.yml
+++ b/manifests/cf-manifest/deployments/aws/000-cf-infrastructure.yml
@@ -13,9 +13,9 @@ meta:
 
   default_stemcell:
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: 3197
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3197
-    sha1: 89a2210b8caf3884855d7db6d48b8863202c7783
+    version: 3215
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3215
+    sha1: 84c51fed6342d5eb7cd59728c7d691c75b6c1de8
 
 properties:
 

--- a/manifests/cf-manifest/spec/jobs_spec.rb
+++ b/manifests/cf-manifest/spec/jobs_spec.rb
@@ -73,3 +73,22 @@ RSpec.describe "the jobs definitions block" do
 
 
 end
+
+RSpec.describe "the job definitions" do
+
+  let(:jobs) { manifest_with_defaults["jobs"] }
+
+  it "should list consul_agent first if present" do
+    jobs_with_consul = jobs.select{ |j|
+      not j["templates"].select{ |t|
+        t["name"] == "consul_agent"
+      }.empty?
+    }
+
+    jobs_with_consul.each{ |j|
+      expect(j["templates"].first["name"]).to eq("consul_agent"),
+        "expected '#{j["name"]}' job to list 'consul_agent' first"
+    }
+  end
+
+end


### PR DESCRIPTION
## What
Story: [Upgrade to CF -N](https://www.pivotaltracker.com/story/show/116983391)

We upgrade CF, diego, stemcell, bosh. This required adjustments to CF configuration and tests properties.

## How to review
### Prerequisite
This version works with cf version 6.16.1. There are containers ready in docker hub. To use them: 
* open `create-bosh-cloudfoundry.yml`
* replace `docker:///governmentpaas/cf-acceptance-tests` with `docker:///governmentpaas/cf-acceptance-tests#116983391_upgrade_cf_to_v233`
* replace `docker:///governmentpaas/cf-cli` with `docker:///governmentpaas/cf-cli#116983391_upgrade_cf_to_v233`

### Test
Run on top of existing deployment or create a new deployment. Everything should succeed.

### Before merging
Merge PRs on `paas-docker-cloudfoundry-tools` to update `cf-cli` and `cf-acceptance-tests` images.

## Who can review
Anyone but @jimconner @HenryTK or myself.