### PR TITLE
[#108444338] Disable custom buildpacks

### DIFF
--- a/manifests/cf-manifest/deployments/040-cf-properties.yml
+++ b/manifests/cf-manifest/deployments/040-cf-properties.yml
@@ -106,7 +106,7 @@ properties:
 
     directories: ~
 
-    disable_custom_buildpacks: false
+    disable_custom_buildpacks: true
 
     broker_client_timeout_seconds: 70
     broker_client_default_async_poll_interval_seconds: ~

--- a/manifests/cf-manifest/deployments/900-cf-tests.yml
+++ b/manifests/cf-manifest/deployments/900-cf-tests.yml
@@ -13,7 +13,7 @@ properties:
     include_v3: true
     include_security_groups: true
     include_routing: true
-    skip_regex: 'routing.API|allows\spreviously-blocked\sip|Adding\sa\swildcard\sroute\sto\sa\sdomain|forwards\sapp\smessages\sto\sregistered\ssyslog\sdrains'
+    skip_regex: 'routing.API|allows\spreviously-blocked\sip|Adding\sa\swildcard\sroute\sto\sa\sdomain|forwards\sapp\smessages\sto\sregistered\ssyslog\sdrains|uses\sa\sbuildpack\sfrom\sa\sgit\surl'
     include_internet_dependent: true
     include_logging: true
     include_operator: true

--- a/tests/acceptance-tests/src/acceptance/custom_buildpacks_test.go
+++ b/tests/acceptance-tests/src/acceptance/custom_buildpacks_test.go
@@ -1,0 +1,30 @@
+package acceptance_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+
+	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
+	"github.com/cloudfoundry-incubator/cf-test-helpers/generator"
+)
+
+var _ = Describe("CustomBuildpacks", func() {
+	var (
+		appName string
+	)
+
+	It("should fail when using a buildpack from a git url", func() {
+		appName = generator.PrefixedRandomName("CATS-APP-")
+		session := cf.Cf(
+			"push", appName, "--no-start",
+			"-m", DEFAULT_MEMORY_LIMIT,
+			"-p", "../../example-apps/static-app",
+			"-b", "https://github.com/cloudfoundry/staticfile-buildpack.git",
+			"-d", config.AppsDomain,
+		).Wait(DEFAULT_TIMEOUT)
+		Expect(session).To(Exit(1))
+		Expect(session.Out.Contents()).To(ContainSubstring("custom buildpacks are disabled"))
+	})
+
+})


### PR DESCRIPTION
## What

As a PaaS Ops Engineer responsible for the security and supportability of the platform, I want to ensure we are dealing with a known set of buildpacks, in order to reduce the complexity of supporting the platform.

## Context

This feature is disabled by changing  the manifest property of CF Cloud Controller    [`cc.disable_custom_buildpacks`]( https://bosh.io/jobs/cloud_controller_worker?source=github.com/cloudfoundry/cf-release&version=228#p=cc.disable_custom_buildpacks) to `true`.

It will prevent users uploading  their own buildpacks so they only use the trusted provided ones. The cf cli will report an error to the user:

```
$ cf push my-new-app -b https://github.com/keymon/ruby-buildpack
Updating app my-new-app in org admin / space admin as admin...
FAILED
Server error, status code: 400, error code: 100001, message: The app is invalid: buildpack custom buildpacks are disabled
```

As we disable this feature, we had to disable the [test in acceptance test which tests it](https://github.com/cloudfoundry/cf-acceptance-tests/blob/f39ba990159dee932e99a6ca829df79a42746822/internet_dependent/git_buildpack_test.go#L20)

Finally, we add a custom test that checks that the feature is indeed disabled.

## How to test it

 1. Deploy all the environment. The tests should finish. Check that `custom_accceptance_tests` run the test: `should fail when using a buildpack from a git url`
 2. Try to push from cf cli: `mkdir my-app && cf push my-app -p my-app -b https://github.com/cloudfoundry/staticfile-buildpack.git`, it shall fail.

## Who?

Anyone but  @HenryTK or @keymon
