### PR TITLE
Enable SSL validation for `cf login`

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -983,6 +983,7 @@ jobs:
           passed: ['generate-cf-config']
         - get: cf-manifest
           passed: ['cf-deploy']
+        - get: bosh-CA
         - get: graphite-nozzle
     - task: retrieve-config
       config:
@@ -1022,7 +1023,9 @@ jobs:
       config:
         platform: linux
         inputs:
+          - name: paas-cf
           - name: config
+          - name: bosh-CA
         params:
         image: docker:///governmentpaas/cf-cli
         run:
@@ -1031,9 +1034,10 @@ jobs:
             - -e
             - -c
             - |
+              ./paas-cf/concourse/scripts/import_bosh_ca.sh
+
               . ./config/config.sh
-              cf api --skip-ssl-validation ${API_ENDPOINT}
-              echo | cf login -u ${CF_ADMIN} -p ${CF_PASS}
+              echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
 
               . ./config/quota_settings.sh
               ${QUOTA_non_basic_services_allowed} || prefix="dis"
@@ -1051,15 +1055,17 @@ jobs:
         inputs:
           - name: paas-cf
           - name: config
+          - name: bosh-CA
         run:
           path: sh
           args:
             - -e
             - -c
             - |
+              ./paas-cf/concourse/scripts/import_bosh_ca.sh
+
               . ./config/config.sh
-              cf api --skip-ssl-validation ${API_ENDPOINT}
-              echo | cf login -u ${CF_ADMIN} -p ${CF_PASS}
+              echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
               echo | cf create-org testers
               cf create-space healthcheck -o testers
               cf target -o testers -s healthcheck
@@ -1072,8 +1078,10 @@ jobs:
       config:
         platform: linux
         inputs:
+          - name: paas-cf
           - name: graphite-nozzle
           - name: config
+          - name: bosh-CA
         params:
         image: docker:///governmentpaas/cf-cli
         run:
@@ -1082,10 +1090,10 @@ jobs:
             - -e
             - -c
             - |
-              . ./config/config.sh
+              ./paas-cf/concourse/scripts/import_bosh_ca.sh
 
-              cf api --skip-ssl-validation ${API_ENDPOINT}
-              echo | cf login -u ${CF_ADMIN} -p ${CF_PASS}
+              . ./config/config.sh
+              echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
               echo | cf create-org admin
               cf create-space admin -o admin
               cf target -o admin -s admin

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1209,9 +1209,8 @@ jobs:
               - -e
               - -c
               - |
-                echo "Adding bosh-CA to root certificates"
-                tar -xf bosh-CA/bosh-CA.tar.gz -C /usr/local/share/ca-certificates bosh-CA.crt
-                update-ca-certificates
+                ./paas-cf/concourse/scripts/import_bosh_ca.sh
+
                 mkdir -p /var/vcap/jobs/acceptance-tests/bin/ /var/vcap/packages/acceptance-tests/src/github.com/cloudfoundry
                 ln -snf $(pwd)/test-config/config.json /var/vcap/jobs/acceptance-tests/bin/config.json
                 ln -snf $(pwd)/test-config/run /var/vcap/jobs/acceptance-tests/bin/run
@@ -1263,9 +1262,7 @@ jobs:
               - -e
               - -c
               - |
-                echo "Adding bosh-CA to root certificates"
-                tar -xf bosh-CA/bosh-CA.tar.gz -C /usr/local/share/ca-certificates bosh-CA.crt
-                update-ca-certificates
+                ./paas-cf/concourse/scripts/import_bosh_ca.sh
 
                 echo "Running tests"
                 export CONFIG="$(pwd)/test-config/config.json"
@@ -1347,9 +1344,7 @@ jobs:
               - -e
               - -c
               - |
-                echo "Adding bosh-CA to root certificates"
-                tar -xf bosh-CA/bosh-CA.tar.gz -C /usr/local/share/ca-certificates bosh-CA.crt
-                update-ca-certificates
+                ./paas-cf/concourse/scripts/import_bosh_ca.sh
 
                 echo "Running tests"
                 export CONFIG="$(pwd)/test-config/config.json"

--- a/concourse/pipelines/tasks/smoke-tests-run.yml
+++ b/concourse/pipelines/tasks/smoke-tests-run.yml
@@ -15,9 +15,8 @@ run:
     - -e
     - -c
     - |
-      echo "Adding bosh-CA to root certificates"
-      tar -xf bosh-CA/bosh-CA.tar.gz -C /usr/local/share/ca-certificates bosh-CA.crt
-      update-ca-certificates
+      ./paas-cf/concourse/scripts/import_bosh_ca.sh
+
       mkdir -p /var/vcap/jobs/smoke-tests/bin/ /var/vcap/packages/smoke-tests/src/github.com/cloudfoundry
       ln -snf $(pwd)/test-config/config.json /var/vcap/jobs/smoke-tests/bin/config.json
       ln -snf $(pwd)/test-config/run /var/vcap/jobs/smoke-tests/bin/run

--- a/concourse/scripts/import_bosh_ca.sh
+++ b/concourse/scripts/import_bosh_ca.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+echo "Adding bosh-CA to root certificates"
+tar -xf bosh-CA/bosh-CA.tar.gz -C /usr/local/share/ca-certificates bosh-CA.crt
+update-ca-certificates

--- a/concourse/tasks/run-tests.yml
+++ b/concourse/tasks/run-tests.yml
@@ -13,9 +13,8 @@ run:
     - -e
     - -c
     - |
-      echo "Adding bosh-CA to root certificates"
-      tar -xf bosh-CA/bosh-CA.tar.gz -C /usr/local/share/ca-certificates bosh-CA.crt
-      update-ca-certificates
+      ./paas-cf/concourse/scripts/import_bosh_ca.sh
+
       mkdir -p /var/vcap/jobs/smoke-tests/bin/ /var/vcap/packages/smoke-tests/src/github.com/cloudfoundry
       ln -snf $(pwd)/test-config/config.json /var/vcap/jobs/smoke-tests/bin/config.json
       ln -snf $(pwd)/test-config/run /var/vcap/jobs/smoke-tests/bin/run


### PR DESCRIPTION
## What

Enable SSL validation for all `cf login` commands in the pipeline. Also includes some refactoring to make the installation of the BOSH CA easier. More detail in the commits.

## How to review

1. Checkout the branch: `git co cf_login_ssl_validation`
1. Deploy the pipelines from the branch: `BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines`
1. Run the whole CF pipeline and confirm that it completes green.

## Who can review

Not @dcarley.

No story ID. I'm invoking Tech Lead gardening privileges.