### PR TITLE
Ensure etcd cluster is updated serially

### DIFF
--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -247,6 +247,24 @@ jobs:
           services:
             etcd: {}
 
+  - name: etcd_z2
+    templates: (( grab meta.etcd_templates ))
+    instances: 1
+    persistent_disk: 10024
+    resource_pool: medium_z2
+    networks:
+      - name: cf2
+        static_ips:
+    update:
+      serial: true
+    properties:
+      metron_agent:
+        zone: z2
+      consul:
+        agent:
+          services:
+            etcd: {}
+
   - name: consul_z3
     templates: (( grab meta.consul_templates ))
     instances: 1
@@ -261,22 +279,6 @@ jobs:
           mode: server
       metron_agent:
         zone: z3
-
-  - name: etcd_z2
-    templates: (( grab meta.etcd_templates ))
-    instances: 1
-    persistent_disk: 10024
-    resource_pool: medium_z2
-    networks:
-      - name: cf2
-        static_ips:
-    properties:
-      metron_agent:
-        zone: z2
-      consul:
-        agent:
-          services:
-            etcd: {}
 
   - name: etcd_z3
     templates: (( grab meta.etcd_templates ))

--- a/manifests/cf-manifest/spec/jobs_spec.rb
+++ b/manifests/cf-manifest/spec/jobs_spec.rb
@@ -43,17 +43,21 @@ RSpec.describe "the jobs definitions block" do
     end
   end
 
-  describe "in order to start one etcd master for consensus" do
+  describe "in order to start/upgrade etcd cluster while maintaining consensus" do
     it "has etcd_z1 serial" do
       expect(is_serial("etcd_z1")).to be true
+    end
+
+    it "has etcd_z2 serial" do
+      expect(is_serial("etcd_z2")).to be true
     end
 
     it "has etcd_z1 before etcd_z2" do
       expect(ordered("etcd_z1", "etcd_z2")).to be true
     end
 
-    it "has etcd_z1 before etcd_z3" do
-      expect(ordered("etcd_z1", "etcd_z3")).to be true
+    it "has etcd_z2 before etcd_z3" do
+      expect(ordered("etcd_z2", "etcd_z3")).to be true
     end
   end
 


### PR DESCRIPTION
## What

Ensure that the etcd cluster is upgraded in a way that maintains the cluster health. This problem was discovered while reviewing #207.

Without this, when upgrading the cluster (eg for a stemcell version
change), the first node will be upgraded, then the other 2 will be
upgraded in parallel, resulting in the cluster losing quorum. This then
requires manual intervention to recover from.

## How to review

Deploy a change that will cause all 3 etcd machines to be re-created (eg a stemcell version bump). Verify that they update cleanly, and that the cluster is healthy afterwards (run `/var/vcap/packages/etcd/etcdctl cluster-health` on one of the nodes).

## Who can review

Anyone but myself.