### PR TITLE
[#117909253] Add shellcheck binary to the repo.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,18 @@ env:
 addons:
   apt:
     sources:
-      - debian-sid
       - git-core
     packages:
-      - shellcheck
       - git
 
 before_install:
-  - mkdir ~/bin
-  - export PATH=~/bin:$PATH
+  - |
+    mkdir ~/bin
+    export PATH=~/bin:$PATH
+  - |
+    echo "Fetching shellcheck"
+    wget -O ~/bin/shellcheck https://github.com/alphagov/paas-cf/releases/download/shellcheck_binary_0.3.7/shellcheck_linux_amd64
+    chmod +x ~/bin/shellcheck
   - |
     echo "Fetching Terraform"
     set -e


### PR DESCRIPTION
## What

Installing shellcheck from debian sid is no longer working, and
resulting in dependency errors (eg https://travis-ci.org/alphagov/paas-cf/builds/124150110).

This adds a shellcheck linux binary to the repo, and updates Travis to
use it. This binary is extracted from the ubuntu wily package version 0.3.7-1.

## How to review

Verify that the Travis build now passes

## Who can review

Anyone but myself.