### PR TITLE
[#115869119] Remove cf-terraform bosh-ftstate dependency

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -658,11 +658,10 @@ jobs:
           - get: paas-cf
             passed: ['generate-secrets']
           - get: pipeline-trigger
-            passed: [ 'generate-secrets' ]
+            passed: ['generate-secrets']
             trigger: true
           - get: vpc-tfstate
           - get: concourse-tfstate
-          - get: bosh-tfstate
           - get: cf-tfstate
           - get: cf-certs-tfstate
           - get: cf-certs
@@ -738,7 +737,6 @@ jobs:
             - name: paas-cf
             - name: vpc-tfstate
             - name: concourse-tfstate
-            - name: bosh-tfstate
             - name: cf-secrets
             - name: cf-certs-tfstate
           outputs:
@@ -753,8 +751,6 @@ jobs:
                 < vpc-tfstate/vpc.tfstate > terraform-variables/vpc.tfvars.sh
                 ruby paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
                 < concourse-tfstate/concourse.tfstate > terraform-variables/concourse.tfvars.sh
-                ruby paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
-                < bosh-tfstate/bosh.tfstate > terraform-variables/bosh.tfvars.sh
                 ruby paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
                 < cf-certs-tfstate/cf-certs.tfstate > terraform-variables/cf-certs.tfvars.sh
                 ruby paas-cf/concourse/scripts/extract_tf_vars_from_yaml.rb \
@@ -784,7 +780,6 @@ jobs:
               - |
                 . terraform-variables/vpc.tfvars.sh
                 . terraform-variables/concourse.tfvars.sh
-                . terraform-variables/bosh.tfvars.sh
                 . terraform-variables/cf-certs.tfvars.sh
                 . terraform-variables/cf-secrets.tfvars.sh
 
@@ -855,6 +850,7 @@ jobs:
           - get: vpc-tfstate
           - get: concourse-tfstate
           - get: bosh-tfstate
+            passed: ['bosh-terraform']
           - get: cf-tfstate
             passed: ['cf-terraform']
       - task: extract-terraform-outputs

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -463,6 +463,7 @@ jobs:
           - get: concourse-tfstate
           - get: bosh-tfstate
           - get: bosh-secrets
+            passed: [ generate-secrets ]
 
       - task: extract-terraform-variables
         config:
@@ -529,6 +530,7 @@ jobs:
           - get: paas-cf
             passed: ['bosh-terraform']
           - get: bosh-secrets
+            passed: ['bosh-terraform']
           - get: bosh-CA
           - get: vpc-tfstate
             passed: ['bosh-terraform']


### PR DESCRIPTION
## What

The cf and bosh terraform jobs have run in parallel since #213 was
merged. This suggests that the cf-terraform job doesn't depend on the
outputs from bosh-terraform. Reading the code confirms this - there are
no variables in the cf-terraform that match the names of outputs in
bosh-terraform. Additionally the cf-terraform destroy job doesn't rely
on the bosh-ftstate file.

This PR therefore removes the bosh tfstate from the cf-terraform job.

In addition, I've also pinned the bosh-secrets used in the bosh-terraform job to the output of generate-secrets to make this dependency clear

## How to review

Run the create pipeline for a new environment and verify that it works.

## Who can review

Anyone but myself.