### PR TITLE
[#115869119] Compilation VMs require write access to S3

### DIFF
--- a/manifests/cf-manifest/deployments/aws/000-cf-infrastructure.yml
+++ b/manifests/cf-manifest/deployments/aws/000-cf-infrastructure.yml
@@ -44,6 +44,7 @@ compilation:
   cloud_properties:
     instance_type: c3.large
     availability_zone: (( grab meta.zones.z1 ))
+    iam_instance_profile: bosh-director
 
 disk_pools:
   - name: database_disks


### PR DESCRIPTION
## What

Assign bosh-director IAM profile to compilation VMs so that they can 'put' compiled blobs into the compiled package cache.

Compilation VMs store their compiled blobs directly in S3, rather than
passing them back through the director - These 'put' operations were previously failing
as the iam profile applied to these VMs did not allow for 'put' operations.

The compilation VMs are effectively an extension of the bosh-director
machine to allow for parallel compilation, so applying the same
bosh-director iam profile does not seem an unreasonable approach.
Using the bosh-director iam role will allow them to put objects
into the compiled package cache bucket.

## How to review

Check that the code looks good. 
Deploy a new version of CF, or deploy into an environment where the packages have not already been cached. (This has already been tested by myself and confirmed to fix the issue)

## Who can review

Anyone on the core team except for myself.
