### PR TITLE
[#115931361] Add haproxy in front of gorouter to add HSTS headers (and SSL termination)

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -72,6 +72,14 @@ resources:
       branch: {{branch_name}}
       tag_filter: {{paas_cf_tag_filter}}
 
+  - name: paas-haproxy-release
+    type: git
+    source:
+      uri: https://github.com/alphagov/paas-haproxy-release.git
+      branch: 115931361-extend-haproxy-release
+      # TODO: Un-comment tag_filter and remove branch once release is tagged
+      # tag_filter: {{cf-paas-haproxy-release-version}}
+
   - name: graphite-statsd-boshrelease
     type: git
     source:
@@ -944,6 +952,7 @@ jobs:
           - get: bosh-secrets
           - get: graphite-statsd-boshrelease
           - get: grafana-boshrelease
+          - get: paas-haproxy-release
       - task: upload-releases
         config:
           platform: linux
@@ -953,6 +962,7 @@ jobs:
             - name: bosh-secrets
             - name: graphite-statsd-boshrelease
             - name: grafana-boshrelease
+            - name: paas-haproxy-release
           run:
             path: sh
             args:
@@ -966,6 +976,9 @@ jobs:
 
                 paas-cf/concourse/scripts/bosh_create_and_upload_release.rb grafana \
                   {{cf_grafana_version}} grafana-boshrelease
+
+                paas-cf/concourse/scripts/bosh_create_and_upload_release.rb paas-haproxy \
+                  {{cf-paas-haproxy-release-version}} paas-haproxy-release
 
       - task: cf-deploy
         config:

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -76,9 +76,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-haproxy-release.git
-      branch: 115931361-extend-haproxy-release
-      # TODO: Un-comment tag_filter and remove branch once release is tagged
-      # tag_filter: {{cf-paas-haproxy-release-version}}
+      tag_filter: {{cf-paas-haproxy-release-version}}
 
   - name: graphite-statsd-boshrelease
     type: git

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -36,6 +36,7 @@ prepare_environment() {
 
   cf_manifest_dir="${SCRIPT_DIR}/../../manifests/cf-manifest/deployments"
   cf_release_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.cf.version "${cf_manifest_dir}/000-base-cf-deployment.yml")
+  cf_paas_haproxy_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.paas-haproxy.version "${cf_manifest_dir}/000-base-cf-deployment.yml")
   cf_graphite_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.graphite.version "${cf_manifest_dir}/055-graphite.yml")
   cf_grafana_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.grafana.version "${cf_manifest_dir}/055-graphite.yml")
 
@@ -58,6 +59,7 @@ branch_name: ${BRANCH:-master}
 aws_region: ${AWS_DEFAULT_REGION}
 debug: ${DEBUG:-}
 cf-release-version: v${cf_release_version}
+cf-paas-haproxy-release-version: ${cf_paas_haproxy_version}
 cf_graphite_version: ${cf_graphite_version}
 cf_grafana_version: ${cf_grafana_version}
 paas_cf_tag_filter: ${PAAS_CF_TAG_FILTER:-}

--- a/manifests/cf-manifest/deployments/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/deployments/000-base-cf-deployment.yml
@@ -29,7 +29,7 @@ releases:
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/etcd-release?v=38
     sha1: c7d303c1b733e77c5c5f3dedfe4dbf75997f30bc
   - name: paas-haproxy
-    version: v1
+    version: 0.0.1
 
 compilation:
   workers: 6

--- a/manifests/cf-manifest/deployments/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/deployments/000-base-cf-deployment.yml
@@ -28,6 +28,8 @@ releases:
     version: 38
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/etcd-release?v=38
     sha1: c7d303c1b733e77c5c5f3dedfe4dbf75997f30bc
+  - name: paas-haproxy
+    version: v1
 
 compilation:
   workers: 6

--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -175,6 +175,8 @@ meta:
     release: (( grab meta.release.name ))
   - release: "logsearch-shipper"
     name: (( grab meta.logsearch_shipper.release.name ))
+  - name: haproxy
+    release: paas-haproxy
 
   stats_templates:
   - name: consul_agent
@@ -799,15 +801,16 @@ properties:
   logger_endpoint: ~
 
   ha_proxy:
+    ssl_pem: (( concat secrets.router_internal_cert secrets.router_internal_key ))
+    disable_http: true
+    go_router:
+      servers: [ "127.0.0.1" ]
+      port: 80
 
   router:
-    enable_ssl: true
-    ssl_cert: (( grab secrets.router_internal_cert ))
-    ssl_key: (( grab secrets.router_internal_key ))
-    cipher_suites: TLS_RSA_WITH_AES_128_CBC_SHA:TLS_RSA_WITH_AES_256_CBC_SHA
+    enable_ssl: false
     requested_route_registration_interval_in_seconds:
     ssl_skip_validation:
-    port:
     status:
       port:
     secure_cookies:

--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -806,6 +806,9 @@ properties:
     go_router:
       servers: [ "127.0.0.1" ]
       port: 80
+    additional_frontend_config: |
+      capture response header strict-transport-security len 128
+      http-response add-header Strict-Transport-Security max-age=31536000 unless { capture.res.hdr(0) -m found }
 
   router:
     enable_ssl: false

--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -40,8 +40,8 @@ meta:
     release: (( grab meta.release.name ))
   - name: route_registrar
     release: (( grab meta.release.name ))
-  - release: "logsearch-shipper"
-    name: (( grab meta.logsearch_shipper.release.name ))
+  - name: logsearch-shipper
+    release: (( grab meta.logsearch_shipper.release.name ))
   - name: java-buildpack
     release: (( grab meta.release.name ))
   - name: java-offline-buildpack
@@ -70,24 +70,24 @@ meta:
     release: (( grab meta.release.name ))
   - name: nfs_mounter
     release: (( grab meta.release.name ))
-  - release: "logsearch-shipper"
-    name: (( grab meta.logsearch_shipper.release.name ))
+  - name: logsearch-shipper
+    release: (( grab meta.logsearch_shipper.release.name ))
 
   clock_templates:
   - name: cloud_controller_clock
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - release: "logsearch-shipper"
-    name: (( grab meta.logsearch_shipper.release.name ))
+  - name: logsearch-shipper
+    release: (( grab meta.logsearch_shipper.release.name ))
 
   consul_templates:
   - name: consul_agent
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - release: "logsearch-shipper"
-    name: (( grab meta.logsearch_shipper.release.name ))
+  - name: logsearch-shipper
+    release: (( grab meta.logsearch_shipper.release.name ))
 
   etcd_templates:
   - name: consul_agent
@@ -98,8 +98,8 @@ meta:
     release: etcd
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - release: "logsearch-shipper"
-    name: (( grab meta.logsearch_shipper.release.name ))
+  - name: logsearch-shipper
+    release: (( grab meta.logsearch_shipper.release.name ))
 
   ha_proxy_templates:
   - name: consul_agent
@@ -108,8 +108,8 @@ meta:
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - release: "logsearch-shipper"
-    name: (( grab meta.logsearch_shipper.release.name ))
+  - name: logsearch-shipper
+    release: (( grab meta.logsearch_shipper.release.name ))
 
   loggregator_templates:
   - name: consul_agent
@@ -120,8 +120,8 @@ meta:
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - release: "logsearch-shipper"
-    name: (( grab meta.logsearch_shipper.release.name ))
+  - name: logsearch-shipper
+    release: (( grab meta.logsearch_shipper.release.name ))
 
   # FIXME: Remove route_registrar (https://github.com/cloudfoundry/cf-release/issues/950)
   loggregator_trafficcontroller_templates:
@@ -133,8 +133,8 @@ meta:
     release: (( grab meta.release.name ))
   - name: route_registrar
     release: (( grab meta.release.name ))
-  - release: "logsearch-shipper"
-    name: (( grab meta.logsearch_shipper.release.name ))
+  - name: logsearch-shipper
+    release: (( grab meta.logsearch_shipper.release.name ))
 
   nats_templates:
   - name: consul_agent
@@ -153,8 +153,8 @@ meta:
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - release: "logsearch-shipper"
-    name: (( grab meta.logsearch_shipper.release.name ))
+  - name: logsearch-shipper
+    release: (( grab meta.logsearch_shipper.release.name ))
 
   postgres_templates:
   - name: consul_agent
@@ -163,8 +163,8 @@ meta:
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - release: "logsearch-shipper"
-    name: (( grab meta.logsearch_shipper.release.name ))
+  - name: logsearch-shipper
+    release: (( grab meta.logsearch_shipper.release.name ))
 
   router_templates:
   - name: consul_agent
@@ -173,8 +173,8 @@ meta:
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - release: "logsearch-shipper"
-    name: (( grab meta.logsearch_shipper.release.name ))
+  - name: logsearch-shipper
+    release: (( grab meta.logsearch_shipper.release.name ))
   - name: haproxy
     release: paas-haproxy
 
@@ -185,8 +185,8 @@ meta:
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - release: "logsearch-shipper"
-    name: (( grab meta.logsearch_shipper.release.name ))
+  - name: logsearch-shipper
+    release: (( grab meta.logsearch_shipper.release.name ))
 
   # FIXME: Remove route_registrar (https://github.com/cloudfoundry/cf-release/issues/950)
   uaa_templates:
@@ -200,8 +200,8 @@ meta:
     release: (( grab meta.release.name ))
   - name: statsd-injector
     release: (( grab meta.release.name ))
-  - release: "logsearch-shipper"
-    name: (( grab meta.logsearch_shipper.release.name ))
+  - name: logsearch-shipper
+    release: (( grab meta.logsearch_shipper.release.name ))
 
 jobs:
   - name: consul_z1

--- a/tests/acceptance-tests/src/acceptance/http_strict_transport_security_test.go
+++ b/tests/acceptance-tests/src/acceptance/http_strict_transport_security_test.go
@@ -1,0 +1,68 @@
+package acceptance_test
+
+import (
+	"bufio"
+	"bytes"
+	"net/textproto"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+
+	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
+	"github.com/cloudfoundry-incubator/cf-test-helpers/generator"
+	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
+)
+
+var _ = Describe("Strict-Transport-Security headers", func() {
+
+	It("should add the header if it is not present", func() {
+
+		appName := generator.PrefixedRandomName("CATS-APP-")
+		Expect(cf.Cf(
+			"push", appName,
+			"-b", config.StaticFileBuildpackName,
+			"-p", "../../../example-apps/static-app",
+			"-d", config.AppsDomain,
+			"-i", "1",
+			"-m", "64M",
+		).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+
+		headers := curlAppHeaders(appName, "/")
+
+		Expect(headers["Strict-Transport-Security"]).Should(HaveLen(1))
+		Expect(headers["Strict-Transport-Security"][0]).To(Equal("max-age=31536000"))
+	})
+
+	It("should not override the header if set by an app", func() {
+
+		appName := generator.PrefixedRandomName("CATS-APP-")
+		Expect(cf.Cf(
+			"push", appName,
+			"-b", config.PhpBuildpackName,
+			"-p", "../../../example-apps/strict-transport-security-app",
+			"-d", config.AppsDomain,
+			"-i", "1",
+			"-m", "128M",
+		).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+
+		headers := curlAppHeaders(appName, "/")
+
+		Expect(headers["Strict-Transport-Security"]).Should(HaveLen(1))
+		Expect(headers["Strict-Transport-Security"][0]).To(Equal("max-age=24"))
+
+	})
+
+})
+
+func curlAppHeaders(appName, path string, args ...string) textproto.MIMEHeader {
+	curlResponse := helpers.CurlApp(appName, path, append(args, "-I")...)
+
+	reader := textproto.NewReader(bufio.NewReader(bytes.NewBufferString(curlResponse)))
+	reader.ReadLine()
+
+	m, err := reader.ReadMIMEHeader()
+	Expect(err).ShouldNot(HaveOccurred())
+
+	return m
+}

--- a/tests/example-apps/strict-transport-security-app/index.php
+++ b/tests/example-apps/strict-transport-security-app/index.php
@@ -1,0 +1,17 @@
+<?php
+header('Cache-Control: max-age=0,no-store,no-cache');
+header('Strict-Transport-Security: max-age=24');
+?>
+<!DOCTYPE html PUBLIC "-//IETF//DTD HTML 2.0//EN">
+<HTML>
+  <HEAD>
+    <meta http-equiv="Cache-Control" content="no-store" />
+    <TITLE>
+      Strict Transport Security
+    </TITLE>
+  </HEAD>
+  <BODY>
+    <H1>Hi</H1>
+    <P>This app exists to test whether we are allowing apps to set their own Strict-Transport-Security header</P>
+  </BODY>
+</HTML>


### PR DESCRIPTION
[#115931361 Ensure correct HSTS headers are being served](https://www.pivotaltracker.com/story/show/115931361)

What?
----

We want to serve [HSTS headers](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) for all HTTPS requests to the apps domains, but it will safeguard existing users from being MITMed over insecure connections and it will improve the user experience when they click on a hostname that doesn't have a protocol.

We want to leave open the option of able to override these headers from the tenant application if they wish.


We decided to use haproxy in front of the gorouter to do the job for the time being, using a custom release as the [current haproxy job from `cf-release`](https://github.com/cloudfoundry/cf-release/tree/master/jobs/haproxy/) does not support adding custom config.

Dependencies
----------------

This should be reviewed with https://github.com/alphagov/paas-haproxy-release/pull/1, which should be merged first and this branch updated to point to the tag.

Context
-------

 * We upload and configure the new haproxy release
 * We inject config in the HAProxy frontends to add the Strict-Transport-Security
   header if it is missing.
 * We add acceptance tests to check the desired behaviour.

Additionally, following the [Boy Scout Rule](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule) we fix some typo defining the logsearch-shipper job template.

How to test this?
-----------------

Deploy all the platform. All test should pass.

You can check the headers of any app to confirm that the new header is there.

You can also curl any url in the platform:

```
$ curl -Ik https://test.hector.dev.cloudpipelineapps.digital/
HTTP/1.1 404 Not Found
Content-Type: text/plain; charset=utf-8
X-Cf-Routererror: unknown_route
X-Content-Type-Options: nosniff
X-Vcap-Request-Id: 1c3f05f0-72b3-4c35-7498-6c4a8d9544c8
Date: Fri, 22 Apr 2016 17:09:27 GMT
Content-Length: 93
Strict-Transport-Security: max-age=31536000
```

Who?
----

Anyone but @keymon or @HenryTK