### PR TITLE
[#118089721] Split apps and system domain external certs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,8 +121,10 @@ manually_upload_certs: ## Manually upload to AWS the SSL certificates for public
 	# check password store and if varables are accesible
 	$(if ${CERT_PASSWORD_STORE_DIR},,$(error Must pass CERT_PASSWORD_STORE_DIR=<path_to_password_store>))
 	$(if $(wildcard ${CERT_PASSWORD_STORE_DIR}),,$(error Password store ${CERT_PASSWORD_STORE_DIR} does not exist))
-	@PASSWORD_STORE_DIR=${CERT_PASSWORD_STORE_DIR} pass certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/router_external.crt > /dev/null
-	@PASSWORD_STORE_DIR=${CERT_PASSWORD_STORE_DIR} pass certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/router_external.key > /dev/null
+	@PASSWORD_STORE_DIR=${CERT_PASSWORD_STORE_DIR} pass certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain.crt > /dev/null
+	@PASSWORD_STORE_DIR=${CERT_PASSWORD_STORE_DIR} pass certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain.key > /dev/null
+	@PASSWORD_STORE_DIR=${CERT_PASSWORD_STORE_DIR} pass certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/apps_domain.crt > /dev/null
+	@PASSWORD_STORE_DIR=${CERT_PASSWORD_STORE_DIR} pass certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/apps_domain.key > /dev/null
 
 	@if ! aws s3 ls s3://${DEPLOY_ENV}-state/cf-certs.tfstate --summarize | grep -q "Total Objects: 0"; then \
 		aws s3 cp s3://${DEPLOY_ENV}-state/cf-certs.tfstate cf-certs.tfstate; \
@@ -133,8 +135,10 @@ manually_upload_certs: ## Manually upload to AWS the SSL certificates for public
 	@terraform apply -var env=${DEPLOY_ENV} \
 		-var-file=terraform/${AWS_ACCOUNT}.tfvars \
 		-state=cf-certs.tfstate \
-		-var router_external_crt="$$(PASSWORD_STORE_DIR=${CERT_PASSWORD_STORE_DIR} pass certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/router_external.crt)" \
-		-var router_external_key="$$(PASSWORD_STORE_DIR=${CERT_PASSWORD_STORE_DIR} pass certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/router_external.key)" \
+		-var system_domain_crt="$$(PASSWORD_STORE_DIR=${CERT_PASSWORD_STORE_DIR} pass certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain.crt)" \
+		-var system_domain_key="$$(PASSWORD_STORE_DIR=${CERT_PASSWORD_STORE_DIR} pass certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain.key)" \
+		-var apps_domain_crt="$$(PASSWORD_STORE_DIR=${CERT_PASSWORD_STORE_DIR} pass certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/apps_domain.crt)" \
+		-var apps_domain_key="$$(PASSWORD_STORE_DIR=${CERT_PASSWORD_STORE_DIR} pass certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/apps_domain.key)" \
 		terraform/cf-certs
 
 	@aws s3 cp cf-certs.tfstate s3://${DEPLOY_ENV}-state/cf-certs.tfstate

--- a/Makefile
+++ b/Makefile
@@ -121,28 +121,7 @@ manually_upload_certs: ## Manually upload to AWS the SSL certificates for public
 	# check password store and if varables are accesible
 	$(if ${CERT_PASSWORD_STORE_DIR},,$(error Must pass CERT_PASSWORD_STORE_DIR=<path_to_password_store>))
 	$(if $(wildcard ${CERT_PASSWORD_STORE_DIR}),,$(error Password store ${CERT_PASSWORD_STORE_DIR} does not exist))
-	@PASSWORD_STORE_DIR=${CERT_PASSWORD_STORE_DIR} pass certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain.crt > /dev/null
-	@PASSWORD_STORE_DIR=${CERT_PASSWORD_STORE_DIR} pass certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain.key > /dev/null
-	@PASSWORD_STORE_DIR=${CERT_PASSWORD_STORE_DIR} pass certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/apps_domain.crt > /dev/null
-	@PASSWORD_STORE_DIR=${CERT_PASSWORD_STORE_DIR} pass certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/apps_domain.key > /dev/null
-
-	@if ! aws s3 ls s3://${DEPLOY_ENV}-state/cf-certs.tfstate --summarize | grep -q "Total Objects: 0"; then \
-		aws s3 cp s3://${DEPLOY_ENV}-state/cf-certs.tfstate cf-certs.tfstate; \
-	else \
-		echo "No previous cf-certs.tfstate file found in s3://${DEPLOY_ENV}-state/. Assuming first run."; \
-	fi
-
-	@terraform apply -var env=${DEPLOY_ENV} \
-		-var-file=terraform/${AWS_ACCOUNT}.tfvars \
-		-state=cf-certs.tfstate \
-		-var system_domain_crt="$$(PASSWORD_STORE_DIR=${CERT_PASSWORD_STORE_DIR} pass certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain.crt)" \
-		-var system_domain_key="$$(PASSWORD_STORE_DIR=${CERT_PASSWORD_STORE_DIR} pass certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain.key)" \
-		-var apps_domain_crt="$$(PASSWORD_STORE_DIR=${CERT_PASSWORD_STORE_DIR} pass certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/apps_domain.crt)" \
-		-var apps_domain_key="$$(PASSWORD_STORE_DIR=${CERT_PASSWORD_STORE_DIR} pass certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/apps_domain.key)" \
-		terraform/cf-certs
-
-	@aws s3 cp cf-certs.tfstate s3://${DEPLOY_ENV}-state/cf-certs.tfstate
-	@rm -f cf-certs.tfstate
+	@terraform/scripts/manually-upload-certs.sh
 
 .PHONY: pingdom
 pingdom: ## Use custom Terraform provider to set up Pingdom check

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -674,6 +674,8 @@ jobs:
           - get: concourse-tfstate
           - get: cf-tfstate
           - get: cf-certs-tfstate
+          - get: bosh-CA
+            passed: ['generate-secrets']
           - get: cf-certs
             passed: ['generate-secrets']
           - get: cf-secrets
@@ -686,6 +688,7 @@ jobs:
           inputs:
             - name: paas-cf
             - name: cf-certs-tfstate
+            - name: bosh-CA
             - name: cf-certs
           outputs:
             - name: updated-tfstate
@@ -704,12 +707,15 @@ jobs:
                 else
                   mkdir generated-certificates
                   tar xzf cf-certs/cf-certs.tar.gz -C generated-certificates
+                  tar xzf bosh-CA/bosh-CA.tar.gz
 
                   terraform apply -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
                     -var system_domain_crt="$(cat generated-certificates/system_domain.crt)" \
                     -var system_domain_key="$(cat generated-certificates/system_domain.key)" \
+                    -var system_domain_intermediate_crt="$(cat bosh-CA.crt)" \
                     -var apps_domain_crt="$(cat generated-certificates/apps_domain.crt)" \
                     -var apps_domain_key="$(cat generated-certificates/apps_domain.key)" \
+                    -var apps_domain_intermediate_crt="$(cat bosh-CA.crt)" \
                     -state=cf-certs-tfstate/cf-certs.tfstate \
                     -state-out=updated-tfstate/cf-certs.tfstate \
                     paas-cf/terraform/cf-certs

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -706,8 +706,10 @@ jobs:
                   tar xzf cf-certs/cf-certs.tar.gz -C generated-certificates
 
                   terraform apply -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
-                    -var router_external_crt="$(cat generated-certificates/router_external.crt)" \
-                    -var router_external_key="$(cat generated-certificates/router_external.key)" \
+                    -var system_domain_crt="$(cat generated-certificates/system_domain.crt)" \
+                    -var system_domain_key="$(cat generated-certificates/system_domain.key)" \
+                    -var apps_domain_crt="$(cat generated-certificates/apps_domain.crt)" \
+                    -var apps_domain_key="$(cat generated-certificates/apps_domain.key)" \
                     -state=cf-certs-tfstate/cf-certs.tfstate \
                     -state-out=updated-tfstate/cf-certs.tfstate \
                     paas-cf/terraform/cf-certs

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -227,8 +227,10 @@ jobs:
               - -c
               - |
                 terraform destroy -force -var env={{deploy_env}} -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
-                  -var router_external_crt="irrelevant" \
-                  -var router_external_key="irrelevant" \
+                  -var system_domain_crt="irrelevant" \
+                  -var system_domain_key="irrelevant" \
+                  -var apps_domain_crt="irrelevant" \
+                  -var apps_domain_key="irrelevant" \
                   -state=cf-certs-tfstate/cf-certs.tfstate \
                   -state-out=updated-tfstate/cf-certs.tfstate \
                   paas-cf/terraform/cf-certs

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -229,8 +229,10 @@ jobs:
                 terraform destroy -force -var env={{deploy_env}} -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
                   -var system_domain_crt="irrelevant" \
                   -var system_domain_key="irrelevant" \
+                  -var system_domain_intermediate_crt="irrelevant" \
                   -var apps_domain_crt="irrelevant" \
                   -var apps_domain_key="irrelevant" \
+                  -var apps_domain_intermediate_crt="irrelevant" \
                   -state=cf-certs-tfstate/cf-certs.tfstate \
                   -state-out=updated-tfstate/cf-certs.tfstate \
                   paas-cf/terraform/cf-certs

--- a/manifests/cf-manifest/scripts/generate-cf-certs.sh
+++ b/manifests/cf-manifest/scripts/generate-cf-certs.sh
@@ -19,8 +19,6 @@ router_internal,${APPS_DOMAINS}
 uaa_jwt_signing,
 consul_server,server.dc1.cf.internal,server.dc2.cf.internal
 consul_agent,
-logsearch,logsearch.${SYSTEM_DNS_ZONE_NAME}
-metrics,metrics.${SYSTEM_DNS_ZONE_NAME}
 apps_domain,${APPS_DOMAINS}
 system_domain,${SYSTEM_DOMAINS}
 "
@@ -53,6 +51,8 @@ done
 # FIXME: Remove this section once it's been cleaned up everywhere.
 CERTS_TO_CLEANUP="
 router_external
+logsearch
+metrics
 "
 
 for cert_name in ${CERTS_TO_CLEANUP}; do

--- a/manifests/cf-manifest/scripts/generate-cf-certs.sh
+++ b/manifests/cf-manifest/scripts/generate-cf-certs.sh
@@ -9,18 +9,20 @@ CA_NAME="bosh-CA"
 
 # shellcheck disable=SC2154
 # Allow referencing unassigned variables (set -u catches problems)
-ROUTER_DOMAINS="*.${APPS_DNS_ZONE_NAME},*.${SYSTEM_DNS_ZONE_NAME}"
+APPS_DOMAINS="*.${APPS_DNS_ZONE_NAME},${APPS_DNS_ZONE_NAME}"
+SYSTEM_DOMAINS="*.${SYSTEM_DNS_ZONE_NAME},${SYSTEM_DNS_ZONE_NAME}"
 
 CERTS_TO_GENERATE="
 bbs_server,bbs.service.cf.internal
 bbs_client,
-router_internal,${ROUTER_DOMAINS}
+router_internal,${APPS_DOMAINS}
 uaa_jwt_signing,
 consul_server,server.dc1.cf.internal,server.dc2.cf.internal
 consul_agent,
 logsearch,logsearch.${SYSTEM_DNS_ZONE_NAME}
 metrics,metrics.${SYSTEM_DNS_ZONE_NAME}
-router_external,${ROUTER_DOMAINS}
+apps_domain,${APPS_DOMAINS}
+system_domain,${SYSTEM_DOMAINS}
 "
 
 WORKING_DIR="$(mktemp -dt generate-cf-certs.XXXXXX)"
@@ -46,4 +48,17 @@ for cert_entry in ${CERTS_TO_GENERATE}; do
     mv "out/${cn}.csr" "${CERTS_DIR}/"
     mv "out/${cn}.crt" "${CERTS_DIR}/"
   fi
+done
+
+# FIXME: Remove this section once it's been cleaned up everywhere.
+CERTS_TO_CLEANUP="
+router_external
+"
+
+for cert_name in ${CERTS_TO_CLEANUP}; do
+  for ext in csr crt key; do
+    if [ -f "${CERTS_DIR}/${cert_name}.${ext}" ]; then
+      rm "${CERTS_DIR}/${cert_name}.${ext}"
+    fi
+  done
 done

--- a/terraform/cf-certs/outputs.tf
+++ b/terraform/cf-certs/outputs.tf
@@ -1,3 +1,7 @@
-output "router_external_cert_arn" {
-  value = "${aws_iam_server_certificate.router.arn}"
+output "system_domain_cert_arn" {
+  value = "${aws_iam_server_certificate.system.arn}"
+}
+
+output "apps_domain_cert_arn" {
+  value = "${aws_iam_server_certificate.apps.arn}"
 }

--- a/terraform/cf-certs/upload.tf
+++ b/terraform/cf-certs/upload.tf
@@ -2,10 +2,19 @@ provider "aws" {
   region = "${var.region}"
 }
 
-resource "aws_iam_server_certificate" "router" {
-  name_prefix = "${var.env}-router-"
-  certificate_body = "${var.router_external_crt}"
-  private_key = "${var.router_external_key}"
+resource "aws_iam_server_certificate" "system" {
+  name_prefix = "${var.env}-system-domain-"
+  certificate_body = "${var.system_domain_crt}"
+  private_key = "${var.system_domain_key}"
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_iam_server_certificate" "apps" {
+  name_prefix = "${var.env}-apps-domain-"
+  certificate_body = "${var.apps_domain_crt}"
+  private_key = "${var.apps_domain_key}"
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/cf-certs/upload.tf
+++ b/terraform/cf-certs/upload.tf
@@ -6,6 +6,7 @@ resource "aws_iam_server_certificate" "system" {
   name_prefix = "${var.env}-system-domain-"
   certificate_body = "${var.system_domain_crt}"
   private_key = "${var.system_domain_key}"
+  certificate_chain = "${var.system_domain_intermediate_crt}"
   lifecycle {
     create_before_destroy = true
   }
@@ -15,6 +16,7 @@ resource "aws_iam_server_certificate" "apps" {
   name_prefix = "${var.env}-apps-domain-"
   certificate_body = "${var.apps_domain_crt}"
   private_key = "${var.apps_domain_key}"
+  certificate_chain = "${var.apps_domain_intermediate_crt}"
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/cf-certs/variables.tf
+++ b/terraform/cf-certs/variables.tf
@@ -1,7 +1,15 @@
-variable "router_external_crt" {
-  description = "Public facing router certificate"
+variable "system_domain_crt" {
+  description = "Public facing system components certificate"
 }
 
-variable "router_external_key" {
-  description = "Private key of the public facing router certificate"
+variable "system_domain_key" {
+  description = "Private key of the public facing system components certificate"
+}
+
+variable "apps_domain_crt" {
+  description = "Public facing apps certificate"
+}
+
+variable "apps_domain_key" {
+  description = "Private key of the public facing apps certificate"
 }

--- a/terraform/cf-certs/variables.tf
+++ b/terraform/cf-certs/variables.tf
@@ -6,10 +6,18 @@ variable "system_domain_key" {
   description = "Private key of the public facing system components certificate"
 }
 
+variable "system_domain_intermediate_crt" {
+  description = "Intermediate cert bundle for the system domain"
+}
+
 variable "apps_domain_crt" {
   description = "Public facing apps certificate"
 }
 
 variable "apps_domain_key" {
   description = "Private key of the public facing apps certificate"
+}
+
+variable "apps_domain_intermediate_crt" {
+  description = "Intermediate cert bundle for the apps domain"
 }

--- a/terraform/cloudfoundry/cf_api_elb.tf
+++ b/terraform/cloudfoundry/cf_api_elb.tf
@@ -19,7 +19,7 @@ resource "aws_elb" "cf_cc" {
     instance_protocol = "http"
     lb_port = 443
     lb_protocol = "https"
-    ssl_certificate_id = "${var.router_external_cert_arn}"
+    ssl_certificate_id = "${var.system_domain_cert_arn}"
   }
 }
 
@@ -44,7 +44,7 @@ resource "aws_elb" "cf_uaa" {
     instance_protocol = "http"
     lb_port = 443
     lb_protocol = "https"
-    ssl_certificate_id = "${var.router_external_cert_arn}"
+    ssl_certificate_id = "${var.system_domain_cert_arn}"
   }
 }
 
@@ -69,7 +69,7 @@ resource "aws_elb" "cf_loggregator" {
     instance_protocol = "tcp"
     lb_port = 443
     lb_protocol = "ssl"
-    ssl_certificate_id = "${var.router_external_cert_arn}"
+    ssl_certificate_id = "${var.system_domain_cert_arn}"
   }
 }
 
@@ -94,6 +94,6 @@ resource "aws_elb" "cf_doppler" {
     instance_protocol = "tcp"
     lb_port = 443
     lb_protocol = "ssl"
-    ssl_certificate_id = "${var.router_external_cert_arn}"
+    ssl_certificate_id = "${var.system_domain_cert_arn}"
   }
 }

--- a/terraform/cloudfoundry/logsearch_elb.tf
+++ b/terraform/cloudfoundry/logsearch_elb.tf
@@ -54,15 +54,6 @@ resource "aws_elb" "logsearch_es_master" {
   }
 }
 
-resource "aws_iam_server_certificate" "logsearch" {
-  name_prefix = "${var.env}-logsearch-"
-  certificate_body = "${file("generated-certificates/logsearch.crt")}"
-  private_key = "${file("generated-certificates/logsearch.key")}"
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
 resource "aws_elb" "logsearch_kibana" {
   name = "${var.env}-logsearch-kibana"
   subnets = ["${split(",", var.infra_subnet_ids)}"]
@@ -85,6 +76,6 @@ resource "aws_elb" "logsearch_kibana" {
     instance_protocol = "tcp"
     lb_port = 443
     lb_protocol = "ssl"
-    ssl_certificate_id = "${aws_iam_server_certificate.logsearch.arn}"
+    ssl_certificate_id = "${var.system_domain_cert_arn}"
   }
 }

--- a/terraform/cloudfoundry/metrics_elb.tf
+++ b/terraform/cloudfoundry/metrics_elb.tf
@@ -1,12 +1,3 @@
-resource "aws_iam_server_certificate" "metrics" {
-  name_prefix = "${var.env}-metrics-"
-  certificate_body = "${file("generated-certificates/metrics.crt")}"
-  private_key = "${file("generated-certificates/metrics.key")}"
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
 resource "aws_elb" "metrics" {
   name = "${var.env}-metrics"
   subnets = ["${split(",", var.infra_subnet_ids)}"]
@@ -28,7 +19,7 @@ resource "aws_elb" "metrics" {
     instance_protocol = "tcp"
     lb_port = 443
     lb_protocol = "ssl"
-    ssl_certificate_id = "${aws_iam_server_certificate.metrics.arn}"
+    ssl_certificate_id = "${var.system_domain_cert_arn}"
   }
 
   listener {
@@ -36,6 +27,6 @@ resource "aws_elb" "metrics" {
     instance_protocol = "tcp"
     lb_port = 3001
     lb_protocol = "ssl"
-    ssl_certificate_id = "${aws_iam_server_certificate.metrics.arn}"
+    ssl_certificate_id = "${var.system_domain_cert_arn}"
   }
 }

--- a/terraform/cloudfoundry/router_elb.tf
+++ b/terraform/cloudfoundry/router_elb.tf
@@ -22,6 +22,6 @@ resource "aws_elb" "cf_router" {
     instance_protocol = "ssl"
     lb_port = 443
     lb_protocol = "ssl"
-    ssl_certificate_id = "${var.router_external_cert_arn}"
+    ssl_certificate_id = "${var.apps_domain_cert_arn}"
   }
 }

--- a/terraform/cloudfoundry/variables.tf
+++ b/terraform/cloudfoundry/variables.tf
@@ -114,6 +114,10 @@ variable "apps_dns_zone_name" {
   description = "Amazon Route53 DNS zone name for hosted apps. Differs per account."
 }
 
-variable "router_external_cert_arn" {
-  description = "Amazon ARN for the public facing certificate to be used on the router"
+variable "system_domain_cert_arn" {
+  description = "Amazon ARN for the public facing certificate to be used for the system components"
+}
+
+variable "apps_domain_cert_arn" {
+  description = "Amazon ARN for the public facing certificate to be used for apps"
 }

--- a/terraform/scripts/manually-upload-certs.sh
+++ b/terraform/scripts/manually-upload-certs.sh
@@ -9,20 +9,22 @@ pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain.key" > /dev/null
 pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/apps_domain.crt" > /dev/null
 pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/apps_domain.key" > /dev/null
 
+WORKING_DIR=$(mktemp -d cf-certs.XXXXXX)
+
 if ! aws s3 ls "s3://${DEPLOY_ENV}-state/cf-certs.tfstate" --summarize | grep -q "Total Objects: 0"; then
-  aws s3 cp "s3://${DEPLOY_ENV}-state/cf-certs.tfstate" cf-certs.tfstate
+  aws s3 cp "s3://${DEPLOY_ENV}-state/cf-certs.tfstate" "${WORKING_DIR}/cf-certs.tfstate"
 else
   echo "No previous cf-certs.tfstate file found in s3://${DEPLOY_ENV}-state/. Assuming first run."
 fi
 
 terraform apply -var env="${DEPLOY_ENV}" \
   -var-file="terraform/${AWS_ACCOUNT}.tfvars" \
-  -state=cf-certs.tfstate \
+  -state="${WORKING_DIR}/cf-certs.tfstate" \
   -var system_domain_crt="$(pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain.crt")" \
   -var system_domain_key="$(pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain.key")" \
   -var apps_domain_crt="$(pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/apps_domain.crt")" \
   -var apps_domain_key="$(pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/apps_domain.key")" \
   terraform/cf-certs
 
-aws s3 cp cf-certs.tfstate "s3://${DEPLOY_ENV}-state/cf-certs.tfstate"
-rm -f cf-certs.tfstate
+aws s3 cp "${WORKING_DIR}/cf-certs.tfstate" "s3://${DEPLOY_ENV}-state/cf-certs.tfstate"
+rm -r "${WORKING_DIR}"

--- a/terraform/scripts/manually-upload-certs.sh
+++ b/terraform/scripts/manually-upload-certs.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -eu
+
+export PASSWORD_STORE_DIR=${CERT_PASSWORD_STORE_DIR}
+
+pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain.crt" > /dev/null
+pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain.key" > /dev/null
+pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/apps_domain.crt" > /dev/null
+pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/apps_domain.key" > /dev/null
+
+if ! aws s3 ls "s3://${DEPLOY_ENV}-state/cf-certs.tfstate" --summarize | grep -q "Total Objects: 0"; then
+  aws s3 cp "s3://${DEPLOY_ENV}-state/cf-certs.tfstate" cf-certs.tfstate
+else
+  echo "No previous cf-certs.tfstate file found in s3://${DEPLOY_ENV}-state/. Assuming first run."
+fi
+
+terraform apply -var env="${DEPLOY_ENV}" \
+  -var-file="terraform/${AWS_ACCOUNT}.tfvars" \
+  -state=cf-certs.tfstate \
+  -var system_domain_crt="$(pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain.crt")" \
+  -var system_domain_key="$(pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain.key")" \
+  -var apps_domain_crt="$(pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/apps_domain.crt")" \
+  -var apps_domain_key="$(pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/apps_domain.key")" \
+  terraform/cf-certs
+
+aws s3 cp cf-certs.tfstate "s3://${DEPLOY_ENV}-state/cf-certs.tfstate"
+rm -f cf-certs.tfstate

--- a/terraform/scripts/manually-upload-certs.sh
+++ b/terraform/scripts/manually-upload-certs.sh
@@ -6,8 +6,10 @@ export PASSWORD_STORE_DIR=${CERT_PASSWORD_STORE_DIR}
 
 pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain.crt" > /dev/null
 pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain.key" > /dev/null
+pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain_intermediate_crt" > /dev/null
 pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/apps_domain.crt" > /dev/null
 pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/apps_domain.key" > /dev/null
+pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/apps_domain_intermediate_crt" > /dev/null
 
 WORKING_DIR=$(mktemp -d cf-certs.XXXXXX)
 trap 'rm -r "${WORKING_DIR}"' EXIT
@@ -24,8 +26,10 @@ terraform apply -var env="${DEPLOY_ENV}" \
   -state="${WORKING_DIR}/cf-certs.tfstate" \
   -var system_domain_crt="$(pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain.crt")" \
   -var system_domain_key="$(pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain.key")" \
+  -var system_domain_intermediate_crt="$(pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain_intermediate.crt")" \
   -var apps_domain_crt="$(pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/apps_domain.crt")" \
   -var apps_domain_key="$(pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/apps_domain.key")" \
+  -var apps_domain_intermediate_crt="$(pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/apps_domain_intermediate.crt")" \
   terraform/cf-certs
 exit_status=$?
 set -e


### PR DESCRIPTION
**🚨 For review only.  DO NOT MERGE YET.** Please review and indicate in the comments whether it's good to merge.  I'll then merge and deploy myself.

## What

When we came to buy real certs for production and staging, it wasn't
feasible to get a single cert that covered multiple wildcard domains.
We've therefore had to get separate certs for the system and apps
domains.

This updates the pipelines to use separate certs for the system and apps domains. It also updates the dev/ci cert generation to generate separate certs for these.

This PR also updates the metrics ELB to use the system domain cert, instead of a separately generated one.

## How to review

Note: Due to the certs and ELBs being managed in separate terraform runs, it's not possible for this to apply cleanly to an existing environment, so it has to be applied as follows:

When it comes to applying to environments beyond dev, It may be best for me to handle the deployment as I have the context around it.

### dev/ci

* Run the pipeline, the `upload-certs-to-aws` task in the `cf-terraform` job will error
* Log onto the AWS console, and update the following ELBs to use a different cert (it doesn't matter which): `cf-cc`, `cf-doppler`, `cf-loggregator`, `cf-router`, `cf-uaa`.
* Re-run the cf-terraform job, it should run to completion.

### staging/prod

These deployments depend on https://github.gds/government-paas/credentials-high/pull/9

* Run the `manually_upload_certs` make target. It will partially complete, and then error
* Run the pipeline, which should run successfully.
* Re-run the `manually_upload_certs` make task, and it should complete successfully this time.

## Who can review

Anyone but myself.
