### PR TITLE
var_from_yaml: Test CLI and return non-zero exit code on errors

### DIFF
--- a/concourse/scripts/spec/fixtures/val_from_yaml.yml
+++ b/concourse/scripts/spec/fixtures/val_from_yaml.yml
@@ -1,0 +1,14 @@
+---
+foo:
+ bar:
+  val1: a
+  val2: b
+ array1:
+ - name: item1
+   val: array1_item1_value
+ - name: item2
+   val: array1_item2_value
+ array2:
+ - array2_value1
+ - array2_value2
+ - array2_value3

--- a/concourse/scripts/spec/val_from_yaml_spec.rb
+++ b/concourse/scripts/spec/val_from_yaml_spec.rb
@@ -23,15 +23,15 @@ val2: b
     EOF
   end
 
-  it "returns nil for non existing properties" do
+  it "exits non-zero with no output for non existing properties" do
     run_with_fixture("x.y.z")
-    expect(last_command_started).to have_exit_status(0)
+    expect(last_command_started).to have_exit_status(1)
     expect(last_command_started.output).to be_empty
   end
 
-  it "returns nil when trasversing simple values" do
+  it "exits non-zero with no output when traversing simple values" do
     run_with_fixture("foo.var.val1.nothing_to_see_here")
-    expect(last_command_started).to have_exit_status(0)
+    expect(last_command_started).to have_exit_status(1)
     expect(last_command_started.output).to be_empty
   end
 
@@ -43,15 +43,15 @@ array1_item1_value
     EOF
   end
 
-  it "returns nil for non existing array item indexed by name" do
+  it "exits non-zero with no output for non existing array item indexed by name" do
     run_with_fixture("foo.array1.item3.val")
-    expect(last_command_started).to have_exit_status(0)
+    expect(last_command_started).to have_exit_status(1)
     expect(last_command_started.output).to be_empty
   end
 
-  it "returns nil for non existing key in a array item indexed by name" do
+  it "exits non-zero with no output for non existing key in a array item indexed by name" do
     run_with_fixture("foo.array1.item1.other_val")
-    expect(last_command_started).to have_exit_status(0)
+    expect(last_command_started).to have_exit_status(1)
     expect(last_command_started.output).to be_empty
   end
 

--- a/concourse/scripts/spec/val_from_yaml_spec.rb
+++ b/concourse/scripts/spec/val_from_yaml_spec.rb
@@ -1,52 +1,73 @@
-require File.join(File.dirname(__FILE__), '..', 'val_from_yaml.rb')
+RSpec.describe "val_from_yaml.rb", :type => :aruba do
+  FIXTURE = File.expand_path("../fixtures/val_from_yaml.yml", __FILE__)
 
-RSpec.describe "PropertyTreeHelper" do
-  let(:test_property_tree) {
-    property_yaml = %q{
----
-foo:
- bar:
-  val1: a
-  val2: b
- array1:
- - name: item1
-   val: array1_item1_value
- - name: item2
-   val: array1_item2_value
- array2:
- - array2_value1
- - array2_value2
- - array2_value3
-}
-    PropertyTree.load_yaml(property_yaml)
-  }
+  def run_with_fixture(arg)
+    run("./val_from_yaml.rb #{arg} #{FIXTURE}")
+  end
+
   it "retrieves a simple value" do
-    expect(test_property_tree['foo.bar.val1']).to eq('a')
+    run_with_fixture("foo.bar.val1")
+    expect(last_command_started).to have_exit_status(0)
+    expect(last_command_started.output).to eq <<-EOF
+a
+    EOF
   end
+
   it "retrieves a full data structure" do
-    val = test_property_tree['foo.bar']
-    expect(val).to be_a(Hash)
-    expect(val).to include('val1', 'val2')
+    run_with_fixture("foo.bar")
+    expect(last_command_started).to have_exit_status(0)
+    expect(last_command_started.output).to eq <<-EOF
+---
+val1: a
+val2: b
+    EOF
   end
+
   it "returns nil for non existing properties" do
-    expect(test_property_tree['x.y.z']).to be_nil
+    run_with_fixture("x.y.z")
+    expect(last_command_started).to have_exit_status(0)
+    expect(last_command_started.output).to be_empty
   end
+
   it "returns nil when trasversing simple values" do
-    expect(test_property_tree['foo.var.val1.nothing_to_see_here']).to be_nil
+    run_with_fixture("foo.var.val1.nothing_to_see_here")
+    expect(last_command_started).to have_exit_status(0)
+    expect(last_command_started.output).to be_empty
   end
+
   it "retrieves a value from an array indexed by name" do
-    expect(test_property_tree['foo.array1.item1.val']).to eq('array1_item1_value')
+    run_with_fixture("foo.array1.item1.val")
+    expect(last_command_started).to have_exit_status(0)
+    expect(last_command_started.output).to eq <<-EOF
+array1_item1_value
+    EOF
   end
+
   it "returns nil for non existing array item indexed by name" do
-    expect(test_property_tree['foo.array1.item3.val']).to be_nil
+    run_with_fixture("foo.array1.item3.val")
+    expect(last_command_started).to have_exit_status(0)
+    expect(last_command_started.output).to be_empty
   end
+
   it "returns nil for non existing key in a array item indexed by name" do
-    expect(test_property_tree['foo.array1.item1.other_val']).to be_nil
+    run_with_fixture("foo.array1.item1.other_val")
+    expect(last_command_started).to have_exit_status(0)
+    expect(last_command_started.output).to be_empty
   end
+
   it "retrieves a value from an array indexed by index" do
-    expect(test_property_tree['foo.array2.0']).to eq('array2_value1')
+    run_with_fixture("foo.array2.0")
+    expect(last_command_started).to have_exit_status(0)
+    expect(last_command_started.output).to eq <<-EOF
+array2_value1
+    EOF
   end
+
   it "retrieves a value from an array of hashes indexed by index" do
-    expect(test_property_tree['foo.array1.0.val']).to eq('array1_item1_value')
+    run_with_fixture("foo.array1.0.val")
+    expect(last_command_started).to have_exit_status(0)
+    expect(last_command_started.output).to eq <<-EOF
+array1_item1_value
+    EOF
   end
 end

--- a/concourse/scripts/val_from_yaml.rb
+++ b/concourse/scripts/val_from_yaml.rb
@@ -52,9 +52,11 @@ if __FILE__ == $0 # Only execute if called directly as command
   end
 
   val = property_tree[key]
+  abort if val.nil?
+
   if val.is_a? Array or val.is_a? Hash
     puts YAML.dump(val)
   else
-    puts val unless val.nil?
+    puts val
   end
 end


### PR DESCRIPTION
## What

Refactor the existing tests for `val_from_yaml` to use the command line
interface instead of the underlying Ruby object.

This matches how we use the script in our Concourse pipelines, it exercises
more of the code, and allows us to make assertions about the standard output
and exit codes.

.. then ..

Return a non-zero exit code when the script is unable to find the user
provided key in the YAML document. This decreases the chance of another
script silently using an empty value, such as a password.

## How to review

- Look at the code changes and confirm that they make sense.
- Confirm that the Travis CI build completes successfully.

## Who can review

Not @dcarley