### PR TITLE
[#118389245] Remove logs from alert email

### DIFF
--- a/concourse/scripts/smoke_tests_email.sh
+++ b/concourse/scripts/smoke_tests_email.sh
@@ -8,13 +8,8 @@ ALERT_EMAIL_ADDRESS=$3
 
 TO="${ALERT_EMAIL_ADDRESS}"
 FROM="${ALERT_EMAIL_ADDRESS}"
-SMOKE_TEST_LOG=./smoke-tests-log/smoke-tests.log
-LAST_COMMIT_LOG=./smoke-tests-log/last-commit.log
-
-text_2_html(){
-  TEXT_FILE=$1
-  sed -e 's@$@<br/>@g' "${TEXT_FILE}" | tr -d '\n' | tr -d '"' | tr -d '\015'
-}
+# SMOKE_TEST_LOG=./smoke-tests-log/smoke-tests.log
+# LAST_COMMIT_LOG=./smoke-tests-log/last-commit.log
 
 write_message_json() {
 
@@ -27,9 +22,7 @@ write_message_json() {
     "Html": {
       "Data": "The smoke tests have failed in environment <b>${DEPLOY_ENV}</b>. See \
       <a href='https://deployer.${SYSTEM_DNS_ZONE_NAME}/pipelines/create-bosh-cloudfoundry?groups=health'>Concourse</a> \
-      for details<br/>\
-      <h3>Last commit:</h3><br/>$(text_2_html "${LAST_COMMIT_LOG}")<br/>\
-      <h3>Smoke test log:</h3><br/>$(text_2_html "${SMOKE_TEST_LOG}")"
+      for details<br/>"
     }
   }
 }


### PR DESCRIPTION
## What
Story: [FIX THE BUILD : Staging](https://www.pivotaltracker.com/story/show/118389245)

The continuous smoke tests were failing in staging but we were not notified because of an error in the alert email task. This is a quick fix that removes the smoke test log and commit message from the email so we can at least be notified.

## How to review
Switch on the alert email with `ALERT_EMAIL_ADDRESS` variable, make the smoke test fail and check you receive the email.

## Who can review
Anyone but myself
