### PR TITLE
[#117512347] Pull master from aws-broker-boshrelease

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -92,7 +92,6 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-aws-broker-boshrelease.git
-      branch: 117512347_rds_service_broker
       tag_filter: {{cf_aws_broker_version}}
 
   - name: graphite-nozzle


### PR DESCRIPTION
Remove the branch config because it has been merged in
paas-aws-broker-boshrelease.

We missed this step in previous PR #224