### PR TITLE
[#118552679] bosh renderer can read properties under jobs

### DIFF
--- a/tests/bosh-template-renderer/render.rb
+++ b/tests/bosh-template-renderer/render.rb
@@ -2,10 +2,10 @@
 require 'yaml'
 require File.join(File.dirname(__FILE__), 'render_lib.rb')
 
-template_path, spec_path, manifest_path = ARGV
+template_path, spec_path, manifest_path, job = ARGV
 
 template = File.read(template_path)
 spec = YAML.load_file(spec_path)
 manifest = YAML.load_file(manifest_path)
-puts render_template(template, spec, manifest)
+puts render_template(template, spec, manifest, job)
 

--- a/tests/bosh-template-renderer/render_lib.rb
+++ b/tests/bosh-template-renderer/render_lib.rb
@@ -36,9 +36,19 @@ class Hash
   end
 end
 
-def render_template(template, spec, manifest)
+def render_template(template, spec, manifest, job = nil)
   job_spec = {}
-  job_spec["properties"] = manifest["properties"].clone()
+  job_spec["properties"] = {}
+
+  if manifest["properties"]
+    job_spec["properties"] = manifest["properties"].clone()
+  end
+
+  if job
+    job_properties = manifest["jobs"].select{ |j| j["name"] == job }.first["properties"].clone()
+    job_spec["properties"].merge!(job_properties)
+  end
+
   job_spec.populate_default_properties_from_spec(spec)
 
   # Populate the network

--- a/tests/bosh-template-renderer/spec/render_lib_spec.rb
+++ b/tests/bosh-template-renderer/spec/render_lib_spec.rb
@@ -89,6 +89,12 @@ properties:
   a:
     b:
       c: foo
+  d: x
+jobs:
+- instances: 1
+  name: job1
+  properties:
+    d: y
     }
   }
 
@@ -124,6 +130,12 @@ a.b.c is <%= p('a.b.c') %> and a.b.d is <%= p('a.b.d') %> and the ip is <%= disc
     }
     result = render_template(template, YAML.load(example_spec), YAML.load(example_manifest))
     expect(result).to include("a.b.c is foo and a.b.d is foobar and the ip is 127.0.0.1")
+  end
+
+  it "renders from a template with overriding job properties" do
+    template = "d is <%= p('d') %>"
+    result = render_template(template, YAML.load(example_spec), YAML.load(example_manifest), "job1")
+    expect(result).to eq("d is y")
   end
 end
 


### PR DESCRIPTION
## What
Story: [Make Concourse 1.1 work with bosh-init](https://www.pivotaltracker.com/story/show/118552679)

bosh renderer was only considering global properties. But some
manifests (like our concourse manifest) don't provide global
properties but use properties under the jobs.

This now considers both, with the job ones taking priority.

## How to review
Test with the concourse manifest for example.

* retrieve the concourse manifest from S3
* get https://github.com/alphagov/paas-concourse and checkout our current version (v0.74.0)
* This should render the template:

```
$./render.rb [...]/paas-concourse/jobs/atc/templates/atc_ctl.erb [...]/paas-concourse/jobs/atc/spec concourse-manifest.yml concourse
```
* run the tests with `make test`

## Who can review
Anyone but @HenryTK or myself