### PR TITLE
[#117704989] Disable commit verification in staging and prod.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,8 @@ staging: globals check-env-vars ## Set Environment to Staging
 	$(eval export SYSTEM_DNS_ZONE_NAME=staging.cloudpipeline.digital)
 	$(eval export APPS_DNS_ZONE_NAME=staging.cloudpipelineapps.digital)
 	$(eval export ALERT_EMAIL_ADDRESS=the-multi-cloud-paas-team+staging@digital.cabinet-office.gov.uk)
+	#FIXME: Remove this when tag verification has been fixed
+	$(eval export SKIP_COMMIT_VERIFICATION=true)
 	@true
 
 .PHONY: prod
@@ -93,6 +95,8 @@ prod: globals check-env-vars ## Set Environment to Production
 	$(eval export SYSTEM_DNS_ZONE_NAME=cloud.service.gov.uk)
 	$(eval export APPS_DNS_ZONE_NAME=cloudapps.digital)
 	$(eval export ALERT_EMAIL_ADDRESS=the-multi-cloud-paas-team+prod@digital.cabinet-office.gov.uk)
+	#FIXME: Remove this when tag verification has been fixed
+	$(eval export SKIP_COMMIT_VERIFICATION=true)
 	@true
 
 .PHONY: bootstrap


### PR DESCRIPTION
## What

Commit verification currently doesn't work when combined with a
tag_filter.

This disables commit verification in staging and prod to unblock the
builds while this is fixed. It remains enabled in CI because CI doesn't use a tag_filter.

## How to review

Verify that the changes look sensible.

## Who can review

Anyone but myself.