### PR TITLE
Prune base_job_templates from cf manifest

### DIFF
--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -586,7 +586,7 @@ jobs:
 # Diego
 
   - name: access_z1
-    templates: (( grab base_job_templates.access ))
+    templates: (( grab meta.diego_job_templates.access ))
     instances: 0
     resource_pool: access_z1
     networks:
@@ -596,7 +596,7 @@ jobs:
         zone: z1
 
   - name: access_z2
-    templates: (( grab base_job_templates.access ))
+    templates: (( grab meta.diego_job_templates.access ))
     instances: 0
     resource_pool: access_z2
     networks:
@@ -606,7 +606,7 @@ jobs:
         zone: z2
 
   - name: brain_z1
-    templates: (( grab base_job_templates.brain ))
+    templates: (( grab meta.diego_job_templates.brain ))
     instances: 0
     resource_pool: brain_z1
     networks:
@@ -616,7 +616,7 @@ jobs:
         zone: z1
 
   - name: brain_z2
-    templates: (( grab base_job_templates.brain ))
+    templates: (( grab meta.diego_job_templates.brain ))
     instances: 0
     resource_pool: brain_z2
     networks:
@@ -626,7 +626,7 @@ jobs:
         zone: z2
 
   - name: cc_bridge_z1
-    templates: (( grab base_job_templates.cc_bridge ))
+    templates: (( grab meta.diego_job_templates.cc_bridge ))
     instances: 0
     resource_pool: cc_bridge_z1
     networks:
@@ -636,7 +636,7 @@ jobs:
         zone: z1
 
   - name: cc_bridge_z2
-    templates: (( grab base_job_templates.cc_bridge ))
+    templates: (( grab meta.diego_job_templates.cc_bridge ))
     instances: 0
     resource_pool: cc_bridge_z2
     networks:
@@ -646,7 +646,7 @@ jobs:
         zone: z2
 
   - name: cell_z1
-    templates: (( grab base_job_templates.cell ))
+    templates: (( grab meta.diego_job_templates.cell ))
     instances: 1
     resource_pool: cell_z1
     networks:
@@ -659,7 +659,7 @@ jobs:
           zone: z1
 
   - name: cell_z2
-    templates: (( grab base_job_templates.cell ))
+    templates: (( grab meta.diego_job_templates.cell ))
     instances: 1
     resource_pool: cell_z2
     networks:
@@ -672,7 +672,7 @@ jobs:
           zone: z2
 
   - name: colocated_z1
-    templates: (( grab base_job_templates.colocated ))
+    templates: (( grab meta.diego_job_templates.colocated ))
     instances: 1
     persistent_disk_pool: database_disks
     resource_pool: colocated_z1
@@ -686,7 +686,7 @@ jobs:
         zone: z1
 
   - name: colocated_z2
-    templates: (( grab base_job_templates.colocated ))
+    templates: (( grab meta.diego_job_templates.colocated ))
     instances: 1
     persistent_disk_pool: database_disks
     resource_pool: colocated_z2
@@ -700,7 +700,7 @@ jobs:
         zone: z2
 
   - name: database_z1
-    templates: (( grab base_job_templates.database ))
+    templates: (( grab meta.diego_job_templates.database ))
     instances: 0
     persistent_disk_pool: database_disks
     resource_pool: database_z1
@@ -711,7 +711,7 @@ jobs:
         zone: z1
 
   - name: database_z2
-    templates: (( grab base_job_templates.database ))
+    templates: (( grab meta.diego_job_templates.database ))
     instances: 0
     persistent_disk_pool: database_disks
     resource_pool: database_z2
@@ -722,7 +722,7 @@ jobs:
         zone: z2
 
   - name: route_emitter_z1
-    templates: (( grab  base_job_templates.route_emitter ))
+    templates: (( grab meta.diego_job_templates.route_emitter ))
     instances: 0
     resource_pool: route_emitter_z1
     networks:
@@ -732,7 +732,7 @@ jobs:
         zone: z1
 
   - name: route_emitter_z2
-    templates: (( grab base_job_templates.route_emitter ))
+    templates: (( grab meta.diego_job_templates.route_emitter ))
     instances: 0
     resource_pool: route_emitter_z2
     networks:

--- a/manifests/cf-manifest/deployments/040-cf-properties.yml
+++ b/manifests/cf-manifest/deployments/040-cf-properties.yml
@@ -1,15 +1,3 @@
-meta:
-  environment: ~
-  default_quota_definitions:
-    default:
-       memory_limit: 2048
-       total_services: 10
-       non_basic_services_allowed: false
-       total_routes: 1000
-  secrets:
-    consul_ca_cert: (( grab secrets.bosh_ca_cert ))
-    bbs_ca_cert: (( grab secrets.bosh_ca_cert ))
-
 properties:
   app_ssh: ~
 
@@ -448,85 +436,96 @@ properties:
       watcher:
         debug_addr: 0.0.0.0:17015
 
-base_job_templates:
-  brain:
-    - name: consul_agent
-      release: cf
-    - name: auctioneer
-      release: diego
-    - name: converger
-      release: diego
-    - name: metron_agent
-      release: cf
-  cell:
-    - name: consul_agent
-      release: cf
-    - name: rep
-      release: diego
-    - name: garden
-      release: garden-linux
-    - name: rootfses
-      release: diego
-    - name: metron_agent
-      release: cf
-  cc_bridge:
-    - name: consul_agent
-      release: cf
-    - name: stager
-      release: diego
-    - name: nsync
-      release: diego
-    - name: tps
-      release: diego
-    - name: cc_uploader
-      release: diego
-    - name: metron_agent
-      release: cf
-  route_emitter:
-    - name: consul_agent
-      release: cf
-    - name: route_emitter
-      release: diego
-    - name: metron_agent
-      release: cf
-  access:
-    - name: consul_agent
-      release: cf
-    - name: ssh_proxy
-      release: diego
-    - name: metron_agent
-      release: cf
-    - name: file_server
-      release: diego
-  database:
-    - name: consul_agent
-      release: cf
-    - name: bbs
-      release: diego
-    - name: metron_agent
-      release: cf
-  colocated:
-    - name: consul_agent
-      release: cf
-    - name: auctioneer
-      release: diego
-    - name: bbs
-      release: diego
-    - name: cc_uploader
-      release: diego
-    - name: converger
-      release: diego
-    - name: file_server
-      release: diego
-    - name: metron_agent
-      release: cf
-    - name: nsync
-      release: diego
-    - name: route_emitter
-      release: diego
-    - name: ssh_proxy
-      release: diego
-    - name: stager
-      release: diego
-    - name: tps
-      release: diego
+meta:
+  environment: ~
+  default_quota_definitions:
+    default:
+       memory_limit: 2048
+       total_services: 10
+       non_basic_services_allowed: false
+       total_routes: 1000
+  secrets:
+    consul_ca_cert: (( grab secrets.bosh_ca_cert ))
+    bbs_ca_cert: (( grab secrets.bosh_ca_cert ))
+  diego_job_templates:
+    brain:
+      - name: consul_agent
+        release: cf
+      - name: auctioneer
+        release: diego
+      - name: converger
+        release: diego
+      - name: metron_agent
+        release: cf
+    cell:
+      - name: consul_agent
+        release: cf
+      - name: rep
+        release: diego
+      - name: garden
+        release: garden-linux
+      - name: rootfses
+        release: diego
+      - name: metron_agent
+        release: cf
+    cc_bridge:
+      - name: consul_agent
+        release: cf
+      - name: stager
+        release: diego
+      - name: nsync
+        release: diego
+      - name: tps
+        release: diego
+      - name: cc_uploader
+        release: diego
+      - name: metron_agent
+        release: cf
+    route_emitter:
+      - name: consul_agent
+        release: cf
+      - name: route_emitter
+        release: diego
+      - name: metron_agent
+        release: cf
+    access:
+      - name: consul_agent
+        release: cf
+      - name: ssh_proxy
+        release: diego
+      - name: metron_agent
+        release: cf
+      - name: file_server
+        release: diego
+    database:
+      - name: consul_agent
+        release: cf
+      - name: bbs
+        release: diego
+      - name: metron_agent
+        release: cf
+    colocated:
+      - name: consul_agent
+        release: cf
+      - name: auctioneer
+        release: diego
+      - name: bbs
+        release: diego
+      - name: cc_uploader
+        release: diego
+      - name: converger
+        release: diego
+      - name: file_server
+        release: diego
+      - name: metron_agent
+        release: cf
+      - name: nsync
+        release: diego
+      - name: route_emitter
+        release: diego
+      - name: ssh_proxy
+        release: diego
+      - name: stager
+        release: diego
+      - name: tps
+        release: diego


### PR DESCRIPTION
## What

base_job_templates meta is used to define templates for diego jobs.
After rendering, these templates are present in the diego jobs. The
base_job_templates tree (which is on top level with properties,
compilation, releases etc.) has no purpose anymore and is essentially
"dead yaml". Prune it like we prune other scaffolding.

## How to review

Apply against existing environment. Check that there are no changes in the deploy job.

## Who can review

not @mtekel

