### PR TITLE
Add CONCOURSE_IP to show environment script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,9 @@ pipelines: ## Upload pipelines to Concourse
 .PHONY: showenv
 showenv: ## Display environment information
 	$(eval export TARGET_CONCOURSE=deployer)
+	@echo CONCOURSE_IP=$$(aws ec2 describe-instances \
+		--filters 'Name=tag:Name,Values=concourse/0' "Name=key-name,Values=${DEPLOY_ENV}_key_pair" \
+		--query 'Reservations[].Instances[].PublicIpAddress' --output text)
 	@concourse/scripts/environment.sh
 
 .PHONY: manually_upload_certs

--- a/README.md
+++ b/README.md
@@ -275,9 +275,7 @@ To manually ssh to the *Deployer Concourse*, you will need its IP and `id_rsa` k
 You can get both from command line. You will need [aws-cli](#aws-cli), to do this:
 
 ```
-export CONCOURSE_IP=$(aws ec2 describe-instances \
---filters 'Name=tag:Name,Values=concourse/0' "Name=key-name,Values=${DEPLOY_ENV}_key_pair" \
---query 'Reservations[].Instances[].PublicIpAddress' --output text)
+eval $(make dev showenv | grep CONCOURSE_IP=)
 
 aws s3 cp "s3://${DEPLOY_ENV}-state/id_rsa" . && \
 chmod 400 id_rsa && \


### PR DESCRIPTION
## What

In the recent days I found myself needing to get concourse IP way too often. I have realized that other team members might have to do the same. Enhance environment script to show CONCOURSE_IP as well.

## How to review

run `make <environment> showenv` and check that the output now also contains CONCOURSE_IP

## Who can review

not @mtekel