### PR TITLE
[#118089721] Fix typo in manually-upload-certs.sh

### DIFF
--- a/terraform/scripts/manually-upload-certs.sh
+++ b/terraform/scripts/manually-upload-certs.sh
@@ -6,10 +6,10 @@ export PASSWORD_STORE_DIR=${CERT_PASSWORD_STORE_DIR}
 
 pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain.crt" > /dev/null
 pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain.key" > /dev/null
-pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain_intermediate_crt" > /dev/null
+pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain_intermediate.crt" > /dev/null
 pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/apps_domain.crt" > /dev/null
 pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/apps_domain.key" > /dev/null
-pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/apps_domain_intermediate_crt" > /dev/null
+pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/apps_domain_intermediate.crt" > /dev/null
 
 WORKING_DIR=$(mktemp -d cf-certs.XXXXXX)
 trap 'rm -r "${WORKING_DIR}"' EXIT


### PR DESCRIPTION
## What

Fixed a typo in manually-upload-certs.sh. The file in the cred store has a `.` not an `_` in it.

## How to review

Modify the `manually-upload-certs.sh` script as follows:

* Change the `terraform apply` to `terraform plan`.
* Comment out the `aws s3` upload on line 37.

Run the script against staging (setup AWS creds, set DEPLOY_ENV to staging, and run `CERT_PASSWORD_STORE_DIR=/path/to/credentials-high make staging manually_upload_certs`), and verify that it works.

## Who can review

Anyone with access to credentials-high but myself.