### PR TITLE
[#116230113] Travis: Upgrade to Terraform 0.6.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
   - 2.2.3
 env:
   global:
-    - TF_VERSION="0.6.12"
+    - TF_VERSION="0.6.15"
     - SPRUCE_VERSION="0.13.0"
     - DEPLOY_ENV="travis"
 


### PR DESCRIPTION
## What

Upgrade to Terraform 0.6.15 in order to match alphagov/paas-docker-cloudfoundry-tools#49

## How to review

Check that the Travis build passes for this PR. This can be merged before the referenced PR.

## Who can review

Not @dcarley.