### PR TITLE
[#116230113] Revert "Workaround terraform codecommit issue"

### DIFF
--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -280,41 +280,6 @@ jobs:
         params:
           file: generated-concourse-cert/concourse-cert.tar.gz
 
-    # Temporary task to retrieve the codecommit default branch if it exists
-    - task: get-codecommit-default-branch
-      config:
-        image: docker:///governmentpaas/awscli
-        inputs:
-        - name: paas-cf
-        outputs:
-        - name: codecommit-default-branch
-        params:
-          DEPLOY_ENV: {{deploy_env}}
-        run:
-          path: sh
-          args:
-          - -c
-          - |
-            aws codecommit get-repository \
-              --region us-east-1 \
-              --repository-name concourse-pool-${DEPLOY_ENV} \
-              --query 'repositoryMetadata.defaultBranch' \
-              --output text > output.txt 2>&1
-            RET=$?
-
-            if [ "$RET" == "0" ]; then
-              if [ "$(cat output.txt)" == "None" ]; then
-                echo "" > codecommit-default-branch/default_branch.txt
-              else
-                cat output.txt > codecommit-default-branch/default_branch.txt
-              fi
-            elif grep -q RepositoryDoesNotExistException output.txt; then
-              echo "" > codecommit-default-branch/default_branch.txt
-            else
-              cat output.txt
-              exit 1
-            fi
-
     - task: terraform-apply
       config:
         image: docker:///governmentpaas/terraform
@@ -324,7 +289,6 @@ jobs:
         - name: concourse-terraform-state
         - name: generated-concourse-cert
         - name: git-ssh-public-key
-        - name: codecommit-default-branch
         params:
           VAGRANT_IP: {{vagrant_ip}}
           TF_VAR_env: {{deploy_env}}
@@ -338,10 +302,7 @@ jobs:
           - |
             tar xzvf generated-concourse-cert/concourse-cert.tar.gz
             . vpc-terraform-outputs/tfvars.sh
-
             export TF_VAR_git_rsa_id_pub=$(cat git-ssh-public-key/git_id_rsa.pub)
-            export TF_VAR_git_default_branch_workaround=$(cat codecommit-default-branch/default_branch.txt)
-
             terraform_params=${VAGRANT_IP:+-var vagrant_cidr=$VAGRANT_IP/32}
             terraform apply ${terraform_params} \
               -var-file=paas-cf/terraform/{{aws_account}}.tfvars \

--- a/terraform/concourse/codecommit.tf
+++ b/terraform/concourse/codecommit.tf
@@ -2,7 +2,7 @@ resource "aws_codecommit_repository" "concourse-pool" {
   provider = "aws.codecommit"
   repository_name = "concourse-pool-${var.env}"
   description = "Git repository to keep concourse pool resource locks"
-  default_branch = "${var.git_default_branch_workaround}"
+  default_branch = "master"
 }
 
 resource "aws_iam_user" "git" {

--- a/terraform/concourse/variables.tf
+++ b/terraform/concourse/variables.tf
@@ -9,8 +9,3 @@ variable "system_dns_zone_name" {
 variable "git_rsa_id_pub" {
   description = "Public SSH key for the git user"
 }
-
-variable "git_default_branch_workaround" {
-  description = "Value of current default branch for codecommit git repo. Temporary workaround."
-  default     = ""
-}


### PR DESCRIPTION
**NOTICE: alphagov/paas-docker-cloudfoundry-tools#49 needs to be merged first**

## What

This reverts commit 15367aeb79f73e5c0b3cc83d81f9787d1ee1ea40.

This has been fixed upstream in Terraform 0.6.15 which we're upgrading to in
the PR: alphagov/paas-docker-cloudfoundry-tools#49

The output file is passed between two tasks, rather than into an s3
resource, so we don't need to do any other cleanup.

## How to review

You need to run the `create-deployer` pipeline twice:

1. first without the codecommit repo (or branch) already there
1. then with the codecommit repo (or branch) already there

I did manage to test this on an existing environment, but it was a lot of hassle because:

- it seems we don't have permissions to delete codecommit repos using our ordinary credentials so you have to hijack an `awscli` container on the Bootstrap Concourse
- Terraform gets upset if you delete the resource it was managing so you have to remove it from the statefile
- it might have been easier to delete the branch from a container on the Deployer, but I'd already got so far..

Frankly it's probably easier if you create a new environment with a different `DEPLOY_ENV`:

1. Checkout this branch: `git checkout feature/116230113-revert_codecommit_workaround`
1. Create a Bootstrap: `BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev bootstrap`
1. Run the `create-deployer` pipeline once and confirm that it completes.
1. Run the `create-deployer` pipeline again  and confirm that it completes.
1. Run the `destroy-deployer` pipeline.
1. Destroy the Boostrap: `make dev bootstrap-destroy`

## Who can review

Not @dcarley