### PR TITLE
[#118089721] Hardcode PASSWORD_STORE_DIR for Terraform scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,16 +123,11 @@ showenv: ## Display environment information
 	@concourse/scripts/environment.sh
 
 .PHONY: manually_upload_certs
-CERT_PASSWORD_STORE_DIR?=~/.paas-pass-high
 manually_upload_certs: ## Manually upload to AWS the SSL certificates for public facing endpoints
-	# check password store and if varables are accesible
-	$(if ${CERT_PASSWORD_STORE_DIR},,$(error Must pass CERT_PASSWORD_STORE_DIR=<path_to_password_store>))
-	$(if $(wildcard ${CERT_PASSWORD_STORE_DIR}),,$(error Password store ${CERT_PASSWORD_STORE_DIR} does not exist))
 	@terraform/scripts/manually-upload-certs.sh
 
 .PHONY: pingdom
 pingdom: ## Use custom Terraform provider to set up Pingdom check
-	$(eval export PASSWORD_STORE_DIR?=~/.paas-pass)
 	@terraform/scripts/set-up-pingdom.sh
 
 merge_pr:

--- a/doc/non_dev_deployments.md
+++ b/doc/non_dev_deployments.md
@@ -50,11 +50,9 @@ In that case, the operator must manually upload the certificates:
 [credentials-high]: https://github.gds/government-paas/credentials-high
 
  2. After deploying the deployer with `create-deployer`, execute the make task
-    `manually_upload_certs`. You indicate the
-    [password store](https://www.passwordstore.org/) directory to read
-    the certificates from by passing the variable `CERT_PASSWORD_STORE_DIR`
+    `manually_upload_certs`.
 
-    For example: `make prod manually_upload_certs CERT_PASSWORD_STORE_DIR=~/.paas-pass`
+    For example: `make prod manually_upload_certs`
 
     This will upload the certificates and update the `cf-certs.tfstate` with
     the information of the aws server certificates.

--- a/terraform/scripts/manually-upload-certs.sh
+++ b/terraform/scripts/manually-upload-certs.sh
@@ -2,8 +2,8 @@
 
 set -eu
 
-export PASSWORD_STORE_DIR=${CERT_PASSWORD_STORE_DIR}
-
+export PASSWORD_STORE_DIR=~/.paas-pass-high
+echo "Using password store: ${PASSWORD_STORE_DIR}"
 pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain.crt" > /dev/null
 pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain.key" > /dev/null
 pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain_intermediate.crt" > /dev/null

--- a/terraform/scripts/set-up-pingdom.sh
+++ b/terraform/scripts/set-up-pingdom.sh
@@ -26,6 +26,7 @@ fi
 
 # Get Pingdom credentials
 export PASSWORD_STORE_DIR=~/.paas-pass
+echo "Using password store: ${PASSWORD_STORE_DIR}"
 PINGDOM_USER=$(pass pingdom.com/username)
 PINGDOM_PASSWORD=$(pass pingdom.com/password)
 PINGDOM_API_KEY=$(pass pingdom.com/api_key)


### PR DESCRIPTION
## What

These weren't working quite as desired due to a combination of GNU Make
oddities and refactoring. I noticed while reviewing #236, but I've only just
got round to looking at it.

#### manually_upload_certs

Expansion of `~/` in `CERT_PASSWORD_STORE_DIR` worked when specifying it as
an environment variable:

    ➜  paas-cf git:(master) ✗ CERT_PASSWORD_STORE_DIR=~/.paas-pass-high make staging manually_upload_certs
    …

But not when passed as an "argument" (I'm not sure what the right is -
variable?) to `make`, as described in our documentation:

    ➜  paas-cf git:(master) ✗ make staging manually_upload_certs CERT_PASSWORD_STORE_DIR=~/.paas-pass-high
    #FIXME: Remove this when tag verification has been fixed
    # check password store and if varables are accesible
    Error: certs/staging/staging/system_domain.crt is not in the password store.
    make: *** [manually_upload_certs] Error 1

It also seems that the default had no effect after the refactoring to move
it to a separate shell script in 0262322:

    ➜  paas-cf git:(master) ✗ make staging manually_upload_certs
    #FIXME: Remove this when tag verification has been fixed
    # check password store and if varables are accesible
    terraform/scripts/manually-upload-certs.sh: line 5: CERT_PASSWORD_STORE_DIR: unbound variable
    make: *** [manually_upload_certs] Error 1

#### pingdom

The `eval export PASSWORD_STORE_DIR` in the `Makefile` had no effect because
`PASSWORD_STORE_DIR` was being explicitly exported within the shell script.

Even if the explicit export is removed, it still doesn't work as I would
have expected, because it also suffers from the same problem with `~/` not
being expanded.

#### Solution

Hardcode both of these paths within the scripts that use them to
standardised paths. This means that you can no longer have your password
store in a different path, but I think that's OK.

I think there might have been some rationale in having
`CERT_PASSWORD_STORE_DIR` be a different variable name from
`PASSWORD_STORE_DIR` which `pass` uses. But since we're no longer passing
anything in, I think that's also OK.

I have also omitted the check in the `Makefile` and instead put an `echo`
statement in both scripts that states where it's using the password store
from. This, combined with the `is not in the password store` error message,
should help you figure out what is wrong if you don't have the password
store cloned in the right place.

## How to review

1. Look at the code changes and see if they make sense.
1. Apply the following patch to prevent it modifying resource or state:

    ```patch
diff --git a/terraform/scripts/manually-upload-certs.sh b/terraform/scripts/manually-upload-certs.sh
index 8f4efc2..5507632 100755
--- a/terraform/scripts/manually-upload-certs.sh
+++ b/terraform/scripts/manually-upload-certs.sh
@@ -21,7 +21,7 @@ else
 fi

 set +e
-terraform apply -var env="${DEPLOY_ENV}" \
+terraform plan -var env="${DEPLOY_ENV}" \
   -var-file="terraform/${AWS_ACCOUNT}.tfvars" \
   -state="${WORKING_DIR}/cf-certs.tfstate" \
   -var system_domain_crt="$(pass "certs/${AWS_ACCOUNT}/${DEPLOY_ENV}/system_domain.crt")" \
@@ -34,6 +34,4 @@ terraform apply -var env="${DEPLOY_ENV}" \
 exit_status=$?
 set -e

-aws s3 cp "${WORKING_DIR}/cf-certs.tfstate" "s3://${DEPLOY_ENV}-state/cf-certs.tfstate"
-
 exit $exit_status
diff --git a/terraform/scripts/set-up-pingdom.sh b/terraform/scripts/set-up-pingdom.sh
index 950256e..d9aa5e1 100755
--- a/terraform/scripts/set-up-pingdom.sh
+++ b/terraform/scripts/set-up-pingdom.sh
@@ -43,7 +43,7 @@ fi

 # Run Terraform Pingdom Provider
 set +e
-terraform apply -state="${STATEFILE}" \
+terraform plan -state="${STATEFILE}" \
        -var "env=${MAKEFILE_ENV_TARGET}" \
        -var "pingdom_user=${PINGDOM_USER}" \
        -var "pingdom_password=${PINGDOM_PASSWORD}" \
@@ -54,6 +54,5 @@ if [ "$?" -ne 0 ]; then help; fi
 set -e

 # Copy statefile back to bucket and remove local copy
-aws s3 cp "${STATEFILE}" "s3://${DEPLOY_ENV}-state/${STATEFILE}"
 rm -f "${STATEFILE}"
 rm -f "${STATEFILE}".backup
```
1. Run `DEPLOY_ENV=staging make staging pingdom` and confirm that it doesn't make any changes.
1. Run `DEPLOY_ENV=staging make staging manually_upload_certs` and confirm that it doesn't make any changes (if you're a Civil Servant and have access to the "high" password store).

## Who can review

Not @dcarley. Ideally a Civil Servant, but it's probably OK if you're not.