### PR TITLE
Add Rubocop lint checks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gem 'aruba'
 gem 'rspec', '~> 3.3'
 gem 'bosh_cli'
 gem 'webmock', "~> 1.24"
+gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ GEM
       ffi (~> 1.9.10)
       rspec-expectations (>= 2.99)
       thor (~> 0.19)
+    ast (2.2.0)
     aws-sdk-core (2.2.0)
       jmespath (~> 1.0)
     aws-sdk-resources (2.2.0)
@@ -79,7 +80,11 @@ GEM
     net-ssh-gateway (1.2.0)
       net-ssh (>= 2.6.5)
     netaddr (1.5.1)
+    parser (2.3.0.7)
+      ast (~> 2.2)
+    powerpack (0.1.1)
     progressbar (0.9.2)
+    rainbow (2.1.0)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -93,11 +98,19 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
+    rubocop (0.39.0)
+      parser (>= 2.3.0.7, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.7.5)
     safe_yaml (1.0.4)
     semi_semantic (1.1.0)
     sshkey (1.7.0)
     terminal-table (1.4.5)
     thor (0.19.1)
+    unicode-display_width (1.0.3)
     webmock (1.24.5)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -110,6 +123,7 @@ DEPENDENCIES
   aruba
   bosh_cli
   rspec (~> 3.3)
+  rubocop
   webmock (~> 1.24)
 
 BUNDLED WITH

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ YAMLLINT=yamllint
 check-env-vars:
 	$(if ${DEPLOY_ENV},,$(error Must pass DEPLOY_ENV=<name>))
 
-test: spec lint_yaml lint_terraform lint_shellcheck lint_concourse ## Run linting tests
+test: spec lint_yaml lint_terraform lint_shellcheck lint_concourse lint_ruby ## Run linting tests
 
 spec:
 	cd scripts &&\
@@ -42,6 +42,10 @@ lint_shellcheck:
 
 lint_concourse:
 	cd .. && python paas-cf/concourse/scripts/pipecleaner.py paas-cf/concourse/pipelines/*.yml
+
+.PHONY: lint_ruby
+lint_ruby:
+	bundle exec rubocop -l
 
 .PHONY: globals
 globals:

--- a/concourse/scripts/spec/support/script_testing_helpers.rb
+++ b/concourse/scripts/spec/support/script_testing_helpers.rb
@@ -4,7 +4,7 @@ require "tempfile"
 # Find the directory of the current git repo
 def find_git_repository_path()
   path = `git rev-parse --show-toplevel`.strip
-  if not File.exists?(path)
+  if not File.exist?(path)
     raise "Cannot find a git repository parent of #{File.dirname(__FILE__)}"
   end
   return path

--- a/concourse/scripts/val_from_yaml.rb
+++ b/concourse/scripts/val_from_yaml.rb
@@ -10,31 +10,32 @@ class PropertyTree
     PropertyTree.new(YAML.load(yaml_string))
   end
 
-  def get(key)
-    def self.recursive_get(tree, key_array)
-      return tree if key_array.empty?
-      current_key, *next_keys = key_array
+  def recursive_get(tree, key_array)
+    return tree if key_array.empty?
+    current_key, *next_keys = key_array
 
-      case tree
-      when Hash
-        next_level = tree[current_key]
-      when Array
-        if /\A[-+]?\d+\z/ === current_key # If the key is an int, access by index
-          next_level = tree[current_key.to_i]
-        else # if not, search for a element with `name: current_key`
-          next_level = tree.select {|x| x.is_a? Hash and x['name'] == current_key}.first
-        end
-      else
-        next_level = nil
+    case tree
+    when Hash
+      next_level = tree[current_key]
+    when Array
+      if /\A[-+]?\d+\z/ === current_key # If the key is an int, access by index
+        next_level = tree[current_key.to_i]
+      else # if not, search for a element with `name: current_key`
+        next_level = tree.select {|x| x.is_a? Hash and x['name'] == current_key}.first
       end
-      if not next_level.nil?
-        recursive_get(next_level, next_keys)
-      else
-        nil
-      end
+    else
+      next_level = nil
     end
+    if not next_level.nil?
+      recursive_get(next_level, next_keys)
+    else
+      nil
+    end
+  end
+
+  def get(key)
     key_array = key.split('.')
-    val = recursive_get(@tree, key_array)
+    self.recursive_get(@tree, key_array)
   end
 
   def [](key)

--- a/manifests/bosh-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/bosh-manifest/spec/support/manifest_helpers.rb
@@ -28,7 +28,7 @@ module ManifestHelpers
   def deep_freeze(object)
     case object
     when Hash
-      object.each { |k,v| deep_freeze(v) }
+      object.each { |_k,v| deep_freeze(v) }
     when Array
       object.each { |v| deep_freeze(v) }
     end

--- a/manifests/cf-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/cf-manifest/spec/support/manifest_helpers.rb
@@ -38,7 +38,7 @@ module ManifestHelpers
   def deep_freeze(object)
     case object
     when Hash
-      object.each { |k,v| deep_freeze(v) }
+      object.each { |_k,v| deep_freeze(v) }
     when Array
       object.each { |v| deep_freeze(v) }
     end

--- a/manifests/concourse-manifest/spec/reference_comparison_spec.rb
+++ b/manifests/concourse-manifest/spec/reference_comparison_spec.rb
@@ -4,7 +4,7 @@ def merge_fixtures(fixtures)
   final = {}
   fixtures.each do |fixture|
     new_fixture = YAML.load_file(File.expand_path(fixture, __FILE__))
-    final.merge!(new_fixture) { |key, a_val, b_val| a_val.merge b_val }
+    final.merge!(new_fixture) { |_key, a_val, b_val| a_val.merge b_val }
   end
   final
 end

--- a/manifests/concourse-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/concourse-manifest/spec/support/manifest_helpers.rb
@@ -28,7 +28,7 @@ module ManifestHelpers
   def deep_freeze(object)
     case object
     when Hash
-      object.each { |k,v| deep_freeze(v) }
+      object.each { |_k,v| deep_freeze(v) }
     when Array
       object.each { |v| deep_freeze(v) }
     end

--- a/scripts/merge_pr.rb
+++ b/scripts/merge_pr.rb
@@ -12,4 +12,4 @@ end.parse!
 
 abort "Must specify PR number" unless pr_number > 0
 
-pull_request = PullRequest.new(pr_number).merge!
+PullRequest.new(pr_number).merge!

--- a/tests/bosh-template-renderer/spec/render_lib_spec.rb
+++ b/tests/bosh-template-renderer/spec/render_lib_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "Hash" do
 end
 
 RSpec.describe "render_template" do
-  let (:example_spec) {
+  let(:example_spec) {
     %Q{
 ---
 properties:
@@ -82,7 +82,7 @@ properties:
     }
   }
 
-  let (:example_manifest) {
+  let(:example_manifest) {
     %Q{
 ---
 properties:


### PR DESCRIPTION
There's no story ID, but I looked at this while originally reviewing #202.

## What

Rubocop is a static code analysis tool for Ruby. It comes with a bunch of
checks, called "cops". Some of them, such as the "style" cop, are very
opinionated and have limited value.

However I've found the "lint" cop very useful for catching unintended
behaviour in previous projects. It is described as:

> Lint cops check for possible errors and very bad practices in your code.
> RuboCop implements in a portable way all built-in MRI lint checks (ruby
> -wc) and adds a lot of extra lint checks of its own.

We now have enough Ruby code, by way of scripts or tests, that this is worth
adding. By adding it to the `test` make target it will be run by Travis CI
(and locally) alongside our other tests.

See the individual commits for fixes to existing warnings.

## How to review

1. Review the code changes.
1. Confirm that the Travis build has passed.

## Who can review

Not @dcarley.