### PR TITLE
[#117704989] Re-enable commit signature verification in staging and prod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,6 @@ staging: globals check-env-vars ## Set Environment to Staging
 	$(eval export SYSTEM_DNS_ZONE_NAME=staging.cloudpipeline.digital)
 	$(eval export APPS_DNS_ZONE_NAME=staging.cloudpipelineapps.digital)
 	$(eval export ALERT_EMAIL_ADDRESS=the-multi-cloud-paas-team+staging@digital.cabinet-office.gov.uk)
-	#FIXME: Remove this when tag verification has been fixed
-	$(eval export SKIP_COMMIT_VERIFICATION=true)
 	@true
 
 .PHONY: prod
@@ -94,8 +92,6 @@ prod: globals check-env-vars ## Set Environment to Production
 	$(eval export SYSTEM_DNS_ZONE_NAME=cloud.service.gov.uk)
 	$(eval export APPS_DNS_ZONE_NAME=cloudapps.digital)
 	$(eval export ALERT_EMAIL_ADDRESS=the-multi-cloud-paas-team+prod@digital.cabinet-office.gov.uk)
-	#FIXME: Remove this when tag verification has been fixed
-	$(eval export SKIP_COMMIT_VERIFICATION=true)
 	@true
 
 .PHONY: bootstrap


### PR DESCRIPTION
> Comes from PR #233 and story [#117704989](https://www.pivotaltracker.com/story/show/117704989)

What
------

Commit verification was not working when combined with a tag_filter.

After merging this https://github.com/alphagov/paas-git-resource/pull/2 we allow
it to start working. The associated container has been built automatically
and all the concourse installation pulled the image automatically.

This re-enables commit verification in staging and prod

How to review
-------------

Verify that the changes look sensible, merge it, wait until it passes staging and prod.

Who can review
--------------

Anyone but myself.