### PR TITLE
Fix http is closed tests

### DIFF
--- a/tests/acceptance-tests/src/acceptance/http_closed_test.go
+++ b/tests/acceptance-tests/src/acceptance/http_closed_test.go
@@ -12,13 +12,13 @@ import (
 	"time"
 )
 
-var _ = Describe("Http is closed", func() {
+var _ = Describe("Http client", func() {
 
 	var (
 		CONNECTION_TIMEOUT = 11 * time.Second
 	)
 
-	It("for apps", func() {
+	It("that tries to connect to apps", func() {
 		appName := generator.PrefixedRandomName("CATS-APP-")
 		Expect(cf.Cf(
 			"push", appName,
@@ -31,13 +31,15 @@ var _ = Describe("Http is closed", func() {
 
 		uri := appName + "." + config.AppsDomain + ":80"
 		_, err := net.DialTimeout("tcp", uri, CONNECTION_TIMEOUT)
-		Expect(err.(net.Error).Timeout()).To(BeTrue())
+		Expect(err).ToNot(BeNil(), "should not connect")
+		Expect(err.(net.Error).Timeout()).To(BeTrue(), "should timeout")
 	})
 
-	It("for api", func() {
+	It("that tries to connect to api", func() {
 		uri := "api." + config.SystemDomain + ":80"
 		_, err := net.DialTimeout("tcp", uri, CONNECTION_TIMEOUT)
-		Expect(err.(net.Error).Timeout()).To(BeTrue())
+		Expect(err).ToNot(BeNil(), "should not connect")
+		Expect(err.(net.Error).Timeout()).To(BeTrue(), "should timeout")
 
 	})
 


### PR DESCRIPTION
## What

The test that checks whether TCP connection to http port is possible panics if connection succeeds:

```  
•! Panic [18.896 seconds]
Http is closed
/Users/piotrkomborski/go/src/github.com/alphagov/paas-cf/tests/acceptance-tests/src/acceptance/http_closed_test.go:44
  for apps [It]
  /Users/piotrkomborski/go/src/github.com/alphagov/paas-cf/tests/acceptance-tests/src/acceptance/http_closed_test.go:35

  Test Panicked
  interface conversion: interface is nil, not net.Error
  /usr/local/Cellar/go/1.6.2/libexec/src/runtime/panic.go:443

  Full Stack Trace
        /usr/local/Cellar/go/1.6.2/libexec/src/runtime/panic.go:443 +0x4e9
  github.com/alphagov/paas-cf/tests/acceptance-tests/src/acceptance_test.glob.func2.1()
        /Users/piotrkomborski/go/src/github.com/alphagov/paas-cf/tests/acceptance-tests/src/acceptance/http_closed_test.go:34 +0x6f3
  github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync(0xc820016720, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /Users/piotrkomborski/go/src/github.com/alphagov/paas-cf/tests/acceptance-tests/src/acceptance/init_test.go:50 +0x30f
  testing.tRunner(0xc820080c60, 0x6cb340)
        /usr/local/Cellar/go/1.6.2/libexec/src/testing/testing.go:473 +0x98
  created by testing.RunTests
        /usr/local/Cellar/go/1.6.2/libexec/src/testing/testing.go:582 +0x892
```

This was discovered while running acceptance tests locally. It seems that ELB behaves differently for connections from internet. TCP connection is established and is dropped later:

```
*$ curl -vvvv http://api.piotr-dev.dev.cloudpipeline.digital
* Rebuilt URL to: http://api.piotr-dev.dev.cloudpipeline.digital/
*   Trying 52.16.220.225...
* Connected to api.piotr-dev.dev.cloudpipeline.digital (52.16.220.225) port 80 (#0)
> GET / HTTP/1.1
> Host: api.piotr-dev.dev.cloudpipeline.digital
> User-Agent: curl/7.43.0
> Accept: */*
>
* Recv failure: Connection reset by peer
* Closing connection 0
curl: (56) Recv failure: Connection reset by peer
```


## How to review

On your local PC, inside tests directory:
```
aws s3 cp s3://${state-bucket-name}/cf-manifest.yml .
CF_MANIFEST=$(pwd)/cf-manifest.yml ./generate_test_config.rb | python -m json.tool  > config.json
```
add `"skip_ssl_validation": true` to `config.json` and:

```
CONFIG=$(pwd)/config.json ./run_tests.sh acceptance-tests/src/acceptance/
```

The test should fail with:

```
• Failure [19.712 seconds]
Http is closed
/Users/piotrkomborski/go/src/github.com/alphagov/paas-cf/tests/acceptance-tests/src/acceptance/http_closed_test.go:44
  for apps [It]
  /Users/piotrkomborski/go/src/github.com/alphagov/paas-cf/tests/acceptance-tests/src/acceptance/http_closed_test.go:35

  Expected an error to have occurred.  Got:
      <nil>: nil
```

## Who can review

Not me