### PR TITLE
[#116309951] Setup ProxyProtocol between ELB and HAProxy to support  X-Forwarded headers

### DIFF
--- a/manifests/cf-manifest/deployments/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/deployments/000-base-cf-deployment.yml
@@ -29,7 +29,7 @@ releases:
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/etcd-release?v=38
     sha1: c7d303c1b733e77c5c5f3dedfe4dbf75997f30bc
   - name: paas-haproxy
-    version: 0.0.1
+    version: 0.0.2
 
 compilation:
   workers: 6

--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -801,7 +801,7 @@ properties:
   logger_endpoint: ~
 
   ha_proxy:
-    ssl_pem: (( concat secrets.router_internal_cert secrets.router_internal_key ))
+    enable_proxy_protocol: true
     disable_http: true
     go_router:
       servers: [ "127.0.0.1" ]

--- a/terraform/cloudfoundry/router_elb.tf
+++ b/terraform/cloudfoundry/router_elb.tf
@@ -11,17 +11,22 @@ resource "aws_elb" "cf_router" {
   ]
 
   health_check {
-    target = "TCP:443"
+    target = "TCP:81"
     interval = "${var.health_check_interval}"
     timeout = "${var.health_check_timeout}"
     healthy_threshold = "${var.health_check_healthy}"
     unhealthy_threshold = "${var.health_check_unhealthy}"
   }
   listener {
-    instance_port = 443
-    instance_protocol = "ssl"
+    instance_port = 81
+    instance_protocol = "tcp"
     lb_port = 443
     lb_protocol = "ssl"
     ssl_certificate_id = "${var.apps_domain_cert_arn}"
   }
+}
+
+resource "aws_proxy_protocol_policy" "http_haproxy" {
+  load_balancer = "${aws_elb.cf_router.name}"
+  instance_ports = ["81"]
 }

--- a/tests/acceptance-tests/src/acceptance/http_forwarded_proto_test.go
+++ b/tests/acceptance-tests/src/acceptance/http_forwarded_proto_test.go
@@ -1,0 +1,42 @@
+package acceptance_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+
+	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
+	"github.com/cloudfoundry-incubator/cf-test-helpers/generator"
+	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
+
+	"encoding/json"
+)
+
+var _ = Describe("X-Forwarded headers", func() {
+	var headers struct {
+		X_Forwarded_Proto []string `json:"X-Forwarded-Proto"`
+	}
+
+	var _ = BeforeEach(func() {
+		appName := generator.PrefixedRandomName("CATS-APP-")
+		Expect(cf.Cf(
+			"push", appName,
+			"-b", config.GoBuildpackName,
+			"-p", "../../apps/print_request_headers",
+			"-d", config.AppsDomain,
+			"-c", "./bin/debug_app; sleep 1; echo 'done'",
+		).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+
+		curlArgs := []string{"-f", "-H", "X-Forwarded-Proto: IPoAC"}
+		jsonData := helpers.CurlApp(appName, "/", curlArgs...)
+
+		err := json.Unmarshal([]byte(jsonData), &headers)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should indicate that the user connection was encrypted", func() {
+		Expect(headers.X_Forwarded_Proto).Should(HaveLen(1))
+		Expect(headers.X_Forwarded_Proto[0]).To(Equal("https"))
+	})
+
+})


### PR DESCRIPTION
[#116309951 X-Forwarded headers available to applications](https://www.pivotaltracker.com/n/projects/1275640/stories/116309951)

What
----

As a tenant deploying an application to the PaaS, I want an X-Forwarded-Proto and X-Forwarded-For headers to be available to my application so that the application can determine whether it is being served externally over HTTPS.

In order to implement this, we need to get the client origin IP from the ELB in front of HAProxy, for that we want to use [ProxyProtocols](http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt) in [ELB](http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/enable-proxy-protocol.html).

Prerequisites
-------------

**Note** This PR depends in this other one: https://github.com/alphagov/paas-haproxy-release/pull/2 and they should be tested together. After that PR is merge, you must remove the latest commit in this PR.

Context
-------

In this PR:

 * We use a new version of haproxy release too support proxy protocol and other features related to X-Forwarded headers.
 * We disable the HAProxy SSL endpoint and enable the HTTP+ProxyProtocol one
 * We change the ELB to send the traffic to the new endpoint [with ProxyProtocol enabled.](https://www.terraform.io/docs/providers/aws/r/proxy_protocol_policy.html)
 * We update the related custom acceptance tests for X-Forwarded headers.

How to test this
----------------

In order to test this.

 1. Deploy the environment as usual.
 2. You can check the ELB config and confirm that now sends the traffic to 81 (N.B. Proxy protocol config cannot be check from the console, but you can use this command: `aws elb describe-load-balancers --load-balancer-name hector-cf-router`. More info [here](http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/enable-proxy-protocol.html))
 3. The tests must pass, specially the custom ones

If the test is successful, remember merge the PR https://github.com/alphagov/paas-haproxy-release/pull/2

Who?
---

Anyone but @keymon or @combor