### PR TITLE
Make merge_pr visible in make help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,6 @@ pingdom: ## Use custom Terraform provider to set up Pingdom check
 	$(eval export PASSWORD_STORE_DIR?=~/.paas-pass)
 	@terraform/scripts/set-up-pingdom.sh
 
-merge_pr:
+merge_pr: ## Merge a PR. Must specify number in a PR=<number> form.
 	$(if ${PR},,$(error Must pass PR=<number>))
 	./scripts/merge_pr.rb --pr ${PR}


### PR DESCRIPTION
## What

Add description to merge_pr target so that it becomes visible in make
help (when you do just `make` or `make help`).

## How to review

type `make` or `make help`. Check that it displays merge_pr target with the description added in this PR.

## Who can review

not @mtekel