### PR TITLE
[#117705909] Upgrade cf-test-helpers for password redaction 

### DIFF
--- a/tests/acceptance-tests/src/acceptance/Godeps/Godeps.json
+++ b/tests/acceptance-tests/src/acceptance/Godeps/Godeps.json
@@ -7,19 +7,19 @@
 	"Deps": [
 		{
 			"ImportPath": "github.com/cloudfoundry-incubator/cf-test-helpers/cf",
-			"Rev": "28076d2e08da4cfeed911136cf5bdc0175b34b33"
+			"Rev": "41e1e261d084de8b61dd52482fce9ea1049fe82b"
 		},
 		{
 			"ImportPath": "github.com/cloudfoundry-incubator/cf-test-helpers/generator",
-			"Rev": "28076d2e08da4cfeed911136cf5bdc0175b34b33"
+			"Rev": "41e1e261d084de8b61dd52482fce9ea1049fe82b"
 		},
 		{
 			"ImportPath": "github.com/cloudfoundry-incubator/cf-test-helpers/helpers",
-			"Rev": "28076d2e08da4cfeed911136cf5bdc0175b34b33"
+			"Rev": "41e1e261d084de8b61dd52482fce9ea1049fe82b"
 		},
 		{
 			"ImportPath": "github.com/cloudfoundry-incubator/cf-test-helpers/runner",
-			"Rev": "28076d2e08da4cfeed911136cf5bdc0175b34b33"
+			"Rev": "41e1e261d084de8b61dd52482fce9ea1049fe82b"
 		},
 		{
 			"ImportPath": "github.com/nu7hatch/gouuid",

--- a/tests/acceptance-tests/src/acceptance/http_closed_test.go
+++ b/tests/acceptance-tests/src/acceptance/http_closed_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cloudfoundry-incubator/cf-test-helpers/generator"
 
 	"net"
+	"net/url"
 	"time"
 )
 
@@ -36,11 +37,13 @@ var _ = Describe("Http client", func() {
 	})
 
 	It("that tries to connect to api", func() {
-		uri := "api." + config.SystemDomain + ":80"
-		_, err := net.DialTimeout("tcp", uri, CONNECTION_TIMEOUT)
+		apiURL, err := url.Parse(config.ApiEndpoint)
+		Expect(err).To(BeNil(), "unable to parse API endpoint URL")
+
+		uri := apiURL.Host + ":80"
+		_, err = net.DialTimeout("tcp", uri, CONNECTION_TIMEOUT)
 		Expect(err).ToNot(BeNil(), "should not connect")
 		Expect(err.(net.Error).Timeout()).To(BeTrue(), "should timeout")
-
 	})
 
 })

--- a/tests/performance-tests/src/performance/Godeps/Godeps.json
+++ b/tests/performance-tests/src/performance/Godeps/Godeps.json
@@ -8,19 +8,19 @@
 	"Deps": [
 		{
 			"ImportPath": "github.com/cloudfoundry-incubator/cf-test-helpers/cf",
-			"Rev": "28076d2e08da4cfeed911136cf5bdc0175b34b33"
+			"Rev": "41e1e261d084de8b61dd52482fce9ea1049fe82b"
 		},
 		{
 			"ImportPath": "github.com/cloudfoundry-incubator/cf-test-helpers/generator",
-			"Rev": "28076d2e08da4cfeed911136cf5bdc0175b34b33"
+			"Rev": "41e1e261d084de8b61dd52482fce9ea1049fe82b"
 		},
 		{
 			"ImportPath": "github.com/cloudfoundry-incubator/cf-test-helpers/helpers",
-			"Rev": "28076d2e08da4cfeed911136cf5bdc0175b34b33"
+			"Rev": "41e1e261d084de8b61dd52482fce9ea1049fe82b"
 		},
 		{
 			"ImportPath": "github.com/cloudfoundry-incubator/cf-test-helpers/runner",
-			"Rev": "28076d2e08da4cfeed911136cf5bdc0175b34b33"
+			"Rev": "41e1e261d084de8b61dd52482fce9ea1049fe82b"
 		},
 		{
 			"ImportPath": "github.com/nu7hatch/gouuid",


### PR DESCRIPTION
## What

Our custom acceptance and performance tests currently expose the (now
temporary) admin password in the output on every run.

More recent versions of cf-test-helpers, as used by cf-acceptance-tests and
cf-smoke-tests, now redact the password. By upgrading our test suites we can
benefit from the same thing.

The output now looks like:

    [2016-05-06 14:05:36.20 (UTC)]> cf auth admin [REDACTED]
    API endpoint: https://api.dcarley.dev.cloudpipeline.digital
    Authenticating...
    OK
    Use 'cf target' to view or set your target org and space

I've taken current HEAD of cf-test-helpers as used by cf-acceptance-tests
(not related to any particular cf-release version):

- cloudfoundry/cf-acceptance-tests@3582729

The complete diff from the previous version is as follows:

- cloudfoundry-incubator/cf-test-helpers@28076d2...41e1e26

The commits relevant to password output are:

- cloudfoundry-incubator/cf-test-helpers@7df92b1
- cloudfoundry-incubator/cf-test-helpers@f4821ac

I think there's still an outstanding issue with our tests producing more
output than you'd normally expect. cf-acceptance-tests don't log `cf auth`
under normal circumstances (though they might during failure - which is why
we still need the temporary user).

## How to review

1. Deploy the pipeline from this branch.
1. Run the pipeline.
1. Check that all the tests pass.
1. Check that the password does not appear in the test output.

## Who can review

Not @dcarley