### PR TITLE
Disable verbose output for platform tests

### DIFF
--- a/tests/performance-tests/src/performance/load_test.go
+++ b/tests/performance-tests/src/performance/load_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Load performance", func() {
 		It("has a response latency within our threshold", func() {
 			metrics, latency := loadTest(appName, loadTestRate, loadTestDuration, false)
 			generateJsonReport(metrics, "load-test-no-keep-alive.json")
-			vegeta.NewTextReporter(metrics).Report(GinkgoWriter)
+			vegeta.NewTextReporter(metrics).Report(os.Stdout)
 			Expect(time.Duration.Nanoseconds(latency)).To(BeNumerically("<", loadTestLatency))
 
 		})
@@ -82,7 +82,7 @@ var _ = Describe("Load performance", func() {
 		It("has a response latency within our threshold", func() {
 			metrics, latency := loadTest(appName, loadTestRate, loadTestDuration, true)
 			generateJsonReport(metrics, "load-test-keep-alive.json")
-			vegeta.NewTextReporter(metrics).Report(GinkgoWriter)
+			vegeta.NewTextReporter(metrics).Report(os.Stdout)
 			Expect(time.Duration.Nanoseconds(latency)).To(BeNumerically("<", loadTestLatency))
 
 		})

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -9,4 +9,4 @@ cd "${TESTS_DIR}"
 export GOPATH
 GOPATH="${GOPATH}:$(pwd)}"
 godep restore
-go test -ginkgo.v
+go test

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -7,6 +7,6 @@ TESTS_DIR="${1}"
 
 cd "${TESTS_DIR}"
 export GOPATH
-GOPATH="${GOPATH}:$(pwd)}"
+GOPATH="${GOPATH}:$(pwd)"
 godep restore
 go test


### PR DESCRIPTION
## What

There are three related changes:

- Disable verbose mode for our own tests suites so that the output is easier to read
- Ensure that the Vegeta report is still written to the output
- Fix a typo in the `run_tests.sh` script

More detail can be found in the individual commit messages.

## How to review

1. Deploy the pipelines from this branch
1. Run the `create-bosh-cloudfoundry` pipeline
1. Confirm that all of the test jobs pass
1. Confirm that the custom acceptance and performance tests don't output verbose information
1. Confirm that the Vegeta report is still visible in the performance test job

## Who can review

Not @dcarley. @combor should have a look, because he has some context about the Vegeta output.