### PR TITLE
[#118837127] Add trade tariff quota

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1063,9 +1063,9 @@ jobs:
                   echo export "${var_name}"=\"$(eval echo \$${var_name})\"
                 done > config/config.sh
 
-                CF_MANIFEST=cf-manifest/cf-manifest.yml $(pwd)/paas-cf/concourse/scripts/extract_quota_settings.rb > config/quota_settings.sh
+                CF_MANIFEST=cf-manifest/cf-manifest.yml $(pwd)/paas-cf/concourse/scripts/extract_quota_settings.rb config
       - aggregate:
-        - task: update-default-quota
+        - task: update-quotas
           config:
             platform: linux
             inputs:
@@ -1078,22 +1078,32 @@ jobs:
               path: sh
               args:
                 - -e
+                - -u
                 - -c
                 - |
                   ./paas-cf/concourse/scripts/import_bosh_ca.sh
-
                   . ./config/config.sh
-                  echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
 
-                  . ./config/quota_settings.sh
-                  ${QUOTA_non_basic_services_allowed} || prefix="dis"
+                  echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}"
 
-                  cf update-quota "${QUOTA_DEFAULT}" \
-                    -m "${QUOTA_memory_limit}"M \
-                    -r "${QUOTA_total_routes}" \
-                    -s "${QUOTA_total_services}" \
-                    --${prefix}allow-paid-service-plans
+                  for quota_file in config/*_quota.sh; do
+                    # Run in a subshell to make sure the variables are not kept
+                    (
+                    . "${quota_file}"
 
+                    if [ "${QUOTA_non_basic_services_allowed}" = "true" ]; then
+                      extra_options="--allow-paid-service-plans"
+                    else
+                      extra_options="--disallow-paid-service-plans"
+                    fi
+
+                    cf update-quota "${QUOTA_name}" \
+                      -m "${QUOTA_memory_limit}"M \
+                      -r "${QUOTA_total_routes}" \
+                      -s "${QUOTA_total_services}" \
+                      ${extra_options}
+                    )
+                  done
         - task: deploy-healthcheck-app
           config:
             platform: linux

--- a/concourse/scripts/extract_quota_settings.rb
+++ b/concourse/scripts/extract_quota_settings.rb
@@ -2,11 +2,25 @@
 require 'json'
 require 'yaml'
 
-manifest_file = ENV.fetch("CF_MANIFEST")
-manifest = YAML.load_file(manifest_file)
-default = manifest['properties']['cc']['default_quota_definition']
-puts "export QUOTA_DEFAULT=#{default}"
+def usage()
+  STDERR.puts "Usage CF_MANIFEST=/path/to/manifest.yml extract_quota_settings.rb /path/to/output_dir"
+  exit 100
+end
 
-manifest['properties']['cc']['quota_definitions'][default].each { |k,v|
-  puts "export QUOTA_#{k}='#{v}'"
-}
+output_dir=ARGV[0]
+usage unless output_dir
+usage unless File.directory? output_dir
+
+manifest_file = ENV.fetch("CF_MANIFEST", "")
+usage if manifest_file.empty?
+
+manifest = YAML.load_file(manifest_file)
+
+quotas = manifest['properties']['cc']['quota_definitions'].keys
+quotas.each do |quota|
+  quotas_string = "export QUOTA_name='#{quota}'\n"
+  manifest['properties']['cc']['quota_definitions'][quota].each { |k,v|
+    quotas_string << "export QUOTA_#{k}='#{v}'\n"
+  }
+  File.write("#{output_dir}/#{quota}_quota.sh", quotas_string)
+end

--- a/concourse/scripts/spec/extract_quota_settings_spec.rb
+++ b/concourse/scripts/spec/extract_quota_settings_spec.rb
@@ -1,0 +1,72 @@
+require 'yaml'
+
+RSpec.describe "extract quota settings", :type => :aruba do
+
+  context("the directory argument is missing") do
+    it "should fail with code 100" do
+      run("./extract_quota_settings.rb")
+      expect(last_command_started).to have_exit_status(100)
+    end
+  end
+
+  context("the directory argument is not a directory") do
+    it "should fail with code 100" do
+      run("./extract_quota_settings.rb abcd")
+      expect(last_command_started).to have_exit_status(100)
+    end
+  end
+
+  context("the CF_MANIFEST variable is missing") do
+    it "should fail with code 100" do
+      run("./extract_quota_settings.rb .")
+      expect(last_command_started).to have_exit_status(100)
+    end
+  end
+
+  context("given a yaml with 2 quota definitions") do
+
+  quotas_yaml = <<EOF
+properties:
+  cc:
+    quota_definitions:
+      default:
+        memory_limit: 2048
+        total_services: 10
+        non_basic_services_allowed: false
+        total_routes: 1000
+      big_mem:
+        memory_limit: 60000
+        total_services: 10
+        non_basic_services_allowed: false
+        total_routes: 1000
+    default_quota_definition: default
+EOF
+
+    it "should create 2 files with environment variables" do
+      write_file 'manifest.yml', quotas_yaml
+      set_environment_variable "CF_MANIFEST", "manifest.yml"
+      run("./extract_quota_settings.rb .")
+      expect("default_quota.sh").to be_an_existing_file
+      default_quota = <<EOF
+export QUOTA_name='default'
+export QUOTA_memory_limit='2048'
+export QUOTA_total_services='10'
+export QUOTA_non_basic_services_allowed='false'
+export QUOTA_total_routes='1000'
+EOF
+      expect("default_quota.sh").to have_file_content default_quota
+
+      expect("big_mem_quota.sh").to be_an_existing_file
+      big_mem_quota = <<EOF
+export QUOTA_name='big_mem'
+export QUOTA_memory_limit='60000'
+export QUOTA_total_services='10'
+export QUOTA_non_basic_services_allowed='false'
+export QUOTA_total_routes='1000'
+EOF
+      expect("big_mem_quota.sh").to have_file_content big_mem_quota
+    end
+
+  end
+
+end

--- a/manifests/cf-manifest/deployments/040-cf-properties.yml
+++ b/manifests/cf-manifest/deployments/040-cf-properties.yml
@@ -134,7 +134,17 @@ properties:
       buildpack_directory_key: (( concat meta.environment "-cf-buildpacks" ))
       fog_connection: ~
       cdn: ~
-    quota_definitions: (( grab meta.default_quota_definitions ))
+    quota_definitions:
+      default:
+        memory_limit: 2048
+        total_services: 10
+        non_basic_services_allowed: false
+        total_routes: 1000
+      trade_tariff:
+        memory_limit: 61440
+        total_services: 10
+        non_basic_services_allowed: false
+        total_routes: 1000
     default_quota_definition: default
 
     user_buildpacks: []
@@ -438,12 +448,6 @@ properties:
 
 meta:
   environment: ~
-  default_quota_definitions:
-    default:
-       memory_limit: 2048
-       total_services: 10
-       non_basic_services_allowed: false
-       total_routes: 1000
   secrets:
     consul_ca_cert: (( grab secrets.bosh_ca_cert ))
     bbs_ca_cert: (( grab secrets.bosh_ca_cert ))


### PR DESCRIPTION
[#118837127 Create trade-tariff organisation and org manager with quota](https://www.pivotaltracker.com/story/show/118837127)

## What

Create the specific quota for Trade Tariff for 3x environments. Their current deployment is 15G, so we will set the quota to 60G.

We will create the quota named `trade_tariff` and in the future we will create more generic quotas (`big_mem`, `medium`...) as soon as we define our quota model.

We also want to make it easy to add define more quotas in the future.

## Context

The quotas are set during deployment, but we have a task in concourse to update them directly from the manifest.yml in consequent deployments. In this PR we:

 * Add the new quota for trade tariff
 * Add logic to allow define and update multiple quotas,

## How to test

 1. Deploy the environment
 2. Run `cf quotas`, it should report this quota:

```
trade_tariff                            60G                  unlimited               1000     10                  disallowed  
```

## Who can review

Anyone but @colin or @keymon