### PR TITLE
[#117705909] Make really sure temp. admin gets removed

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1219,17 +1219,19 @@ jobs:
           - get: cf-secrets
             passed: ['cf-deploy']
 
-      - task: create-temp-user
-        file: paas-cf/concourse/tasks/create_admin.yml
-        config:
-          params:
-            PREFIX: smoketest-user
+      - do:
+        - task: create-temp-user
+          file: paas-cf/concourse/tasks/create_admin.yml
+          config:
+            params:
+              PREFIX: smoketest-user
 
-      - task: smoke-tests-config
-        file: paas-cf/concourse/tasks/smoke-tests-config.yml
+        - task: smoke-tests-config
+          file: paas-cf/concourse/tasks/smoke-tests-config.yml
 
-      - task: smoke-tests-run
-        file: paas-cf/concourse/tasks/smoke-tests-run.yml
+        - task: smoke-tests-run
+          file: paas-cf/concourse/tasks/smoke-tests-run.yml
+
         ensure:
           task: remove-temp-user
           file: paas-cf/concourse/tasks/delete_admin.yml
@@ -1252,77 +1254,79 @@ jobs:
           - get: cf-secrets
             passed: ['cf-deploy']
 
-      - task: create-temp-user
-        file: paas-cf/concourse/tasks/create_admin.yml
-        config:
-          params:
-            PREFIX: acceptance-test-user
+      - do:
+        - task: create-temp-user
+          file: paas-cf/concourse/tasks/create_admin.yml
+          config:
+            params:
+              PREFIX: acceptance-test-user
 
-      - task: generate-test-config
-        config:
-          platform: linux
-          image: docker:///governmentpaas/bosh-cli
-          inputs:
-            - name: cf-release
-            - name: paas-cf
-            - name: cf-manifest
-            - name: admin-creds
-          outputs:
-            - name: test-config
-          run:
-            path: sh
-            args:
-              - -e
-              - -c
-              - |
-                ruby -e "require 'yaml'
+        - task: generate-test-config
+          config:
+            platform: linux
+            image: docker:///governmentpaas/bosh-cli
+            inputs:
+              - name: cf-release
+              - name: paas-cf
+              - name: cf-manifest
+              - name: admin-creds
+            outputs:
+              - name: test-config
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  ruby -e "require 'yaml'
 
-                my = {'properties' => {'acceptance_tests' => YAML.load_file('cf-manifest/cf-manifest.yml')['properties']['acceptance_tests']}}
-                my['properties']['acceptance_tests']['user'] = File.read('admin-creds/username').strip()
-                my['properties']['acceptance_tests']['password'] = File.read('admin-creds/password').strip()
+                  my = {'properties' => {'acceptance_tests' => YAML.load_file('cf-manifest/cf-manifest.yml')['properties']['acceptance_tests']}}
+                  my['properties']['acceptance_tests']['user'] = File.read('admin-creds/username').strip()
+                  my['properties']['acceptance_tests']['password'] = File.read('admin-creds/password').strip()
 
-                puts YAML.dump(my)" > acceptance_test_properties.yml
-                cat acceptance_test_properties.yml
+                  puts YAML.dump(my)" > acceptance_test_properties.yml
+                  cat acceptance_test_properties.yml
 
-                ./paas-cf/tests/bosh-template-renderer/render.rb \
-                  ./cf-release/jobs/acceptance-tests/templates/run.erb \
-                  ./cf-release/jobs/acceptance-tests/spec \
-                  acceptance_test_properties.yml \
-                    > ./test-config/run
+                  ./paas-cf/tests/bosh-template-renderer/render.rb \
+                    ./cf-release/jobs/acceptance-tests/templates/run.erb \
+                    ./cf-release/jobs/acceptance-tests/spec \
+                    acceptance_test_properties.yml \
+                      > ./test-config/run
 
-                chmod +x ./test-config/run
+                  chmod +x ./test-config/run
 
-                ./paas-cf/tests/bosh-template-renderer/render.rb \
-                  ./cf-release/jobs/acceptance-tests/templates/config.json.erb \
-                  ./cf-release/jobs/acceptance-tests/spec \
-                  acceptance_test_properties.yml \
-                    > ./test-config/config.json
+                  ./paas-cf/tests/bosh-template-renderer/render.rb \
+                    ./cf-release/jobs/acceptance-tests/templates/config.json.erb \
+                    ./cf-release/jobs/acceptance-tests/spec \
+                    acceptance_test_properties.yml \
+                      > ./test-config/config.json
 
-      - task: run-tests
-        config:
-          platform: linux
-          image: docker:///governmentpaas/cf-acceptance-tests
-          inputs:
-            - name: paas-cf
-            - name: cf-release
-            - name: cf-manifest
-            - name: test-config
-            - name: bosh-CA
-          run:
-            path: sh
-            args:
-              - -e
-              - -c
-              - |
-                ./paas-cf/concourse/scripts/import_bosh_ca.sh
+        - task: run-tests
+          config:
+            platform: linux
+            image: docker:///governmentpaas/cf-acceptance-tests
+            inputs:
+              - name: paas-cf
+              - name: cf-release
+              - name: cf-manifest
+              - name: test-config
+              - name: bosh-CA
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  ./paas-cf/concourse/scripts/import_bosh_ca.sh
 
-                mkdir -p /var/vcap/jobs/acceptance-tests/bin/ /var/vcap/packages/acceptance-tests/src/github.com/cloudfoundry
-                ln -snf $(pwd)/test-config/config.json /var/vcap/jobs/acceptance-tests/bin/config.json
-                ln -snf $(pwd)/test-config/run /var/vcap/jobs/acceptance-tests/bin/run
-                ln -snf /usr/local/go /var/vcap/packages/golang1.4
-                sed -i 's/bits=@"%s"/bits=@%s/' cf-release/src/github.com/cloudfoundry/cf-acceptance-tests/helpers/v3_helpers/v3.go
-                ln -snf $(pwd)/cf-release/src/github.com/cloudfoundry/cf-acceptance-tests /var/vcap/packages/acceptance-tests/src/github.com/cloudfoundry/
-                /var/vcap/jobs/acceptance-tests/bin/run
+                  mkdir -p /var/vcap/jobs/acceptance-tests/bin/ /var/vcap/packages/acceptance-tests/src/github.com/cloudfoundry
+                  ln -snf $(pwd)/test-config/config.json /var/vcap/jobs/acceptance-tests/bin/config.json
+                  ln -snf $(pwd)/test-config/run /var/vcap/jobs/acceptance-tests/bin/run
+                  ln -snf /usr/local/go /var/vcap/packages/golang1.4
+                  sed -i 's/bits=@"%s"/bits=@%s/' cf-release/src/github.com/cloudfoundry/cf-acceptance-tests/helpers/v3_helpers/v3.go
+                  ln -snf $(pwd)/cf-release/src/github.com/cloudfoundry/cf-acceptance-tests /var/vcap/packages/acceptance-tests/src/github.com/cloudfoundry/
+                  /var/vcap/jobs/acceptance-tests/bin/run
+
         ensure:
           task: remove-temp-user
           file: paas-cf/concourse/tasks/delete_admin.yml
@@ -1341,51 +1345,53 @@ jobs:
           - get: cf-secrets
             passed: ['cf-deploy']
 
-      - task: create-temp-user
-        file: paas-cf/concourse/tasks/create_admin.yml
-        config:
-          params:
-            PREFIX: custom-acceptance-test-user
+      - do:
+        - task: create-temp-user
+          file: paas-cf/concourse/tasks/create_admin.yml
+          config:
+            params:
+              PREFIX: custom-acceptance-test-user
 
-      - task: generate-test-config
-        config:
-          platform: linux
-          image: docker:///ruby#2.2-slim
-          inputs:
-            - name: paas-cf
-            - name: cf-manifest
-            - name: admin-creds
-          outputs:
-            - name: test-config
-          run:
-            path: sh
-            args:
-              - -e
-              - -c
-              - |
-                export CF_MANIFEST=cf-manifest/cf-manifest.yml
-                ./paas-cf/tests/generate_test_config.rb \
-                  > test-config/config.json
+        - task: generate-test-config
+          config:
+            platform: linux
+            image: docker:///ruby#2.2-slim
+            inputs:
+              - name: paas-cf
+              - name: cf-manifest
+              - name: admin-creds
+            outputs:
+              - name: test-config
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  export CF_MANIFEST=cf-manifest/cf-manifest.yml
+                  ./paas-cf/tests/generate_test_config.rb \
+                    > test-config/config.json
 
-      - task: run-tests
-        config:
-          platform: linux
-          image: docker:///governmentpaas/cf-acceptance-tests
-          inputs:
-            - name: paas-cf
-            - name: test-config
-            - name: bosh-CA
-          run:
-            path: sh
-            args:
-              - -e
-              - -c
-              - |
-                ./paas-cf/concourse/scripts/import_bosh_ca.sh
+        - task: run-tests
+          config:
+            platform: linux
+            image: docker:///governmentpaas/cf-acceptance-tests
+            inputs:
+              - name: paas-cf
+              - name: test-config
+              - name: bosh-CA
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  ./paas-cf/concourse/scripts/import_bosh_ca.sh
 
-                echo "Running tests"
-                export CONFIG="$(pwd)/test-config/config.json"
-                ./paas-cf/tests/run_tests.sh ./paas-cf/tests/acceptance-tests/src/acceptance/
+                  echo "Running tests"
+                  export CONFIG="$(pwd)/test-config/config.json"
+                  ./paas-cf/tests/run_tests.sh ./paas-cf/tests/acceptance-tests/src/acceptance/
+
         ensure:
           task: remove-temp-user
           file: paas-cf/concourse/tasks/delete_admin.yml
@@ -1434,51 +1440,53 @@ jobs:
           - get: cf-secrets
             passed: ['cf-deploy']
 
-      - task: create-temp-user
-        file: paas-cf/concourse/tasks/create_admin.yml
-        config:
-          params:
-            PREFIX: performance-tests-user
+      - do:
+        - task: create-temp-user
+          file: paas-cf/concourse/tasks/create_admin.yml
+          config:
+            params:
+              PREFIX: performance-tests-user
 
-      - task: generate-test-config
-        config:
-          platform: linux
-          image: docker:///ruby#2.2-slim
-          inputs:
-            - name: paas-cf
-            - name: cf-manifest
-            - name: admin-creds
-          outputs:
-            - name: test-config
-          run:
-            path: sh
-            args:
-              - -e
-              - -c
-              - |
-                export CF_MANIFEST=cf-manifest/cf-manifest.yml
-                ./paas-cf/tests/generate_test_config.rb \
-                  > test-config/config.json
+        - task: generate-test-config
+          config:
+            platform: linux
+            image: docker:///ruby#2.2-slim
+            inputs:
+              - name: paas-cf
+              - name: cf-manifest
+              - name: admin-creds
+            outputs:
+              - name: test-config
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  export CF_MANIFEST=cf-manifest/cf-manifest.yml
+                  ./paas-cf/tests/generate_test_config.rb \
+                    > test-config/config.json
 
-      - task: run-tests
-        config:
-          platform: linux
-          image: docker:///governmentpaas/cf-acceptance-tests
-          inputs:
-            - name: paas-cf
-            - name: test-config
-            - name: bosh-CA
-          run:
-            path: sh
-            args:
-              - -e
-              - -c
-              - |
-                ./paas-cf/concourse/scripts/import_bosh_ca.sh
+        - task: run-tests
+          config:
+            platform: linux
+            image: docker:///governmentpaas/cf-acceptance-tests
+            inputs:
+              - name: paas-cf
+              - name: test-config
+              - name: bosh-CA
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  ./paas-cf/concourse/scripts/import_bosh_ca.sh
 
-                echo "Running tests"
-                export CONFIG="$(pwd)/test-config/config.json"
-                ./paas-cf/tests/run_tests.sh ./paas-cf/tests/performance-tests/src/performance/
+                  echo "Running tests"
+                  export CONFIG="$(pwd)/test-config/config.json"
+                  ./paas-cf/tests/run_tests.sh ./paas-cf/tests/performance-tests/src/performance/
+
         ensure:
           task: remove-temp-user
           file: paas-cf/concourse/tasks/delete_admin.yml
@@ -1642,38 +1650,40 @@ jobs:
       - get: cf-secrets
         passed: ['cf-deploy']
 
-      - task: create-temp-user
-        file: paas-cf/concourse/tasks/create_admin.yml
-        config:
-          params:
-            PREFIX: continuous-smoketest-user
-
-      - task: smoke-tests-config
-        file: paas-cf/concourse/tasks/smoke-tests-config.yml
-
-      - task: smoke-tests-run
-        file: paas-cf/concourse/tasks/smoke-tests-run.yml
-        on_failure:
-          task: alert
+      - do:
+        - task: create-temp-user
+          file: paas-cf/concourse/tasks/create_admin.yml
           config:
-            platform: linux
-            image: docker:///governmentpaas/awscli
             params:
-              AWS_DEFAULT_REGION: {{aws_region}}
-              DEPLOY_ENV: {{deploy_env}}
-              SYSTEM_DNS_ZONE_NAME: {{system_dns_zone_name}}
-              ALERT_EMAIL_ADDRESS: {{ALERT_EMAIL_ADDRESS}}
-            inputs:
-              - name: paas-cf
-              - name: smoke-tests-log
-            run:
-              path: sh
-              args:
-              - -e
-              - -c
-              - |
-                paas-cf/concourse/scripts/smoke_tests_email.sh \
-                  ${DEPLOY_ENV} ${SYSTEM_DNS_ZONE_NAME} ${ALERT_EMAIL_ADDRESS}
+              PREFIX: continuous-smoketest-user
+
+        - task: smoke-tests-config
+          file: paas-cf/concourse/tasks/smoke-tests-config.yml
+
+        - task: smoke-tests-run
+          file: paas-cf/concourse/tasks/smoke-tests-run.yml
+          on_failure:
+            task: alert
+            config:
+              platform: linux
+              image: docker:///governmentpaas/awscli
+              params:
+                AWS_DEFAULT_REGION: {{aws_region}}
+                DEPLOY_ENV: {{deploy_env}}
+                SYSTEM_DNS_ZONE_NAME: {{system_dns_zone_name}}
+                ALERT_EMAIL_ADDRESS: {{ALERT_EMAIL_ADDRESS}}
+              inputs:
+                - name: paas-cf
+                - name: smoke-tests-log
+              run:
+                path: sh
+                args:
+                - -e
+                - -c
+                - |
+                  paas-cf/concourse/scripts/smoke_tests_email.sh \
+                    ${DEPLOY_ENV} ${SYSTEM_DNS_ZONE_NAME} ${ALERT_EMAIL_ADDRESS}
+
         ensure:
           task: remove-temp-user
           file: paas-cf/concourse/tasks/delete_admin.yml

--- a/concourse/pipelines/failure-testing.yml
+++ b/concourse/pipelines/failure-testing.yml
@@ -104,15 +104,16 @@ jobs:
             BOSH_FQDN: {{bosh_fqdn}}
       - task: kill-instance
         file: paas-cf/concourse/tasks/kill-instance.yml
-      - task: create-temp-user
-        file: paas-cf/concourse/tasks/create_admin.yml
-        config:
-          params:
-            PREFIX: controller-smoketest-user
-      - task: generate-test-config
-        file: paas-cf/concourse/tasks/smoke-tests-config.yml
-      - task: run-tests
-        file: paas-cf/concourse/tasks/smoke-tests-run.yml
+      - do:
+        - task: create-temp-user
+          file: paas-cf/concourse/tasks/create_admin.yml
+          config:
+            params:
+              PREFIX: controller-smoketest-user
+        - task: generate-test-config
+          file: paas-cf/concourse/tasks/smoke-tests-config.yml
+        - task: run-tests
+          file: paas-cf/concourse/tasks/smoke-tests-run.yml
         ensure:
           aggregate:
             - task: recover
@@ -148,15 +149,16 @@ jobs:
             BOSH_FQDN: {{bosh_fqdn}}
       - task: kill-instance
         file: paas-cf/concourse/tasks/kill-instance.yml
-      - task: create-temp-user
-        file: paas-cf/concourse/tasks/create_admin.yml
-        config:
-          params:
-            PREFIX: colocated-smoketest-user
-      - task: generate-test-config
-        file: paas-cf/concourse/tasks/smoke-tests-config.yml
-      - task: run-tests
-        file: paas-cf/concourse/tasks/smoke-tests-run.yml
+      - do:
+        - task: create-temp-user
+          file: paas-cf/concourse/tasks/create_admin.yml
+          config:
+            params:
+              PREFIX: colocated-smoketest-user
+        - task: generate-test-config
+          file: paas-cf/concourse/tasks/smoke-tests-config.yml
+        - task: run-tests
+          file: paas-cf/concourse/tasks/smoke-tests-run.yml
         ensure:
           aggregate:
             - task: recover
@@ -192,15 +194,16 @@ jobs:
             BOSH_FQDN: {{bosh_fqdn}}
       - task: kill-instance
         file: paas-cf/concourse/tasks/kill-instance.yml
-      - task: create-temp-user
-        file: paas-cf/concourse/tasks/create_admin.yml
-        config:
-          params:
-            PREFIX: nats-smoketest-user
-      - task: generate-test-config
-        file: paas-cf/concourse/tasks/smoke-tests-config.yml
-      - task: run-tests
-        file: paas-cf/concourse/tasks/smoke-tests-run.yml
+      - do:
+        - task: create-temp-user
+          file: paas-cf/concourse/tasks/create_admin.yml
+          config:
+            params:
+              PREFIX: nats-smoketest-user
+        - task: generate-test-config
+          file: paas-cf/concourse/tasks/smoke-tests-config.yml
+        - task: run-tests
+          file: paas-cf/concourse/tasks/smoke-tests-run.yml
         ensure:
           aggregate:
             - task: recover
@@ -236,15 +239,16 @@ jobs:
             BOSH_FQDN: {{bosh_fqdn}}
       - task: kill-instance
         file: paas-cf/concourse/tasks/kill-instance.yml
-      - task: create-temp-user
-        file: paas-cf/concourse/tasks/create_admin.yml
-        config:
-          params:
-            PREFIX: router-smoketest-user
-      - task: generate-test-config
-        file: paas-cf/concourse/tasks/smoke-tests-config.yml
-      - task: run-tests
-        file: paas-cf/concourse/tasks/smoke-tests-run.yml
+      - do:
+        - task: create-temp-user
+          file: paas-cf/concourse/tasks/create_admin.yml
+          config:
+            params:
+              PREFIX: router-smoketest-user
+        - task: generate-test-config
+          file: paas-cf/concourse/tasks/smoke-tests-config.yml
+        - task: run-tests
+          file: paas-cf/concourse/tasks/smoke-tests-run.yml
         ensure:
           aggregate:
             - task: recover
@@ -280,15 +284,16 @@ jobs:
             BOSH_FQDN: {{bosh_fqdn}}
       - task: kill-instance
         file: paas-cf/concourse/tasks/kill-instance.yml
-      - task: create-temp-user
-        file: paas-cf/concourse/tasks/create_admin.yml
-        config:
-          params:
-            PREFIX: etcd-smoketest-user
-      - task: generate-test-config
-        file: paas-cf/concourse/tasks/smoke-tests-config.yml
-      - task: run-tests
-        file: paas-cf/concourse/tasks/smoke-tests-run.yml
+      - do:
+        - task: create-temp-user
+          file: paas-cf/concourse/tasks/create_admin.yml
+          config:
+            params:
+              PREFIX: etcd-smoketest-user
+        - task: generate-test-config
+          file: paas-cf/concourse/tasks/smoke-tests-config.yml
+        - task: run-tests
+          file: paas-cf/concourse/tasks/smoke-tests-run.yml
         ensure:
           aggregate:
             - task: recover
@@ -324,15 +329,16 @@ jobs:
             BOSH_FQDN: {{bosh_fqdn}}
       - task: kill-instance
         file: paas-cf/concourse/tasks/kill-instance.yml
-      - task: create-temp-user
-        file: paas-cf/concourse/tasks/create_admin.yml
-        config:
-          params:
-            PREFIX: consul-smoketest-user
-      - task: generate-test-config
-        file: paas-cf/concourse/tasks/smoke-tests-config.yml
-      - task: run-tests
-        file: paas-cf/concourse/tasks/smoke-tests-run.yml
+      - do:
+        - task: create-temp-user
+          file: paas-cf/concourse/tasks/create_admin.yml
+          config:
+            params:
+              PREFIX: consul-smoketest-user
+        - task: generate-test-config
+          file: paas-cf/concourse/tasks/smoke-tests-config.yml
+        - task: run-tests
+          file: paas-cf/concourse/tasks/smoke-tests-run.yml
         ensure:
           aggregate:
             - task: recover
@@ -368,15 +374,16 @@ jobs:
             BOSH_FQDN: {{bosh_fqdn}}
       - task: kill-instance
         file: paas-cf/concourse/tasks/kill-instance.yml
-      - task: create-temp-user
-        file: paas-cf/concourse/tasks/create_admin.yml
-        config:
-          params:
-            PREFIX: cell-smoketest-user
-      - task: generate-test-config
-        file: paas-cf/concourse/tasks/smoke-tests-config.yml
-      - task: run-tests
-        file: paas-cf/concourse/tasks/smoke-tests-run.yml
+      - do:
+        - task: create-temp-user
+          file: paas-cf/concourse/tasks/create_admin.yml
+          config:
+            params:
+              PREFIX: cell-smoketest-user
+        - task: generate-test-config
+          file: paas-cf/concourse/tasks/smoke-tests-config.yml
+        - task: run-tests
+          file: paas-cf/concourse/tasks/smoke-tests-run.yml
         ensure:
           aggregate:
             - task: recover


### PR DESCRIPTION
## What

Wrap all the tasks including temp. admin creation into a `do` block
to which we assign ensure step which removes the temp. admin. Previously
only last task had ensure step and if there were any issues in any tasks
before the last one (including the admin creation task), the admin user
would not be deleted.

Note that this is not displayed correctly in concourse, see https://github.com/concourse/concourse/issues/434

## How to review

Apply. You can try canceling jobs as soon as create-temp-user task starts. Ensure task should run even when the job is cancelled by user.

## Who can review
not @mtekel