### PR TITLE
[#117705909] Fix concourse `do` blocks in pipecleaner lint

### DIFF
--- a/concourse/scripts/pipecleaner.py
+++ b/concourse/scripts/pipecleaner.py
@@ -62,15 +62,23 @@ class Pipecleaner(object):
 
             while plan:
                 item = plan.pop(0)
-                # Flatten aggregate blocks as we don't care
-                if 'aggregate' in item:
-                    plan = item['aggregate'] + plan
-                    continue
+                discovered_blocks = []
 
-                # Flatten blocks we don't care about
+                # Flatten array blocks as we don't care
+                for block_type in ('aggregate', 'do'):
+                    if block_type in item:
+                        discovered_blocks.extend(item[block_type])
+                        del item[block_type]
+
+                # Flatten single blocks we don't care about
                 for block_type in ('on_success', 'on_failure', 'ensure'):
                     if block_type in item:
-                        plan = [item[block_type]] + plan
+                        discovered_blocks.append(item[block_type])
+                        del item[block_type]
+
+                if discovered_blocks:
+                    plan = [item] + discovered_blocks + plan
+                    continue
 
                 if 'get' in item:
                     get_resources.add(item['get'])


### PR DESCRIPTION
117705909-ensure-temp-admin-deletion introduces `do` blocks into our pipelines, which causes ordering issues in pipecleaners dependency resolution and spurious fatal errors to be reported.

Until this fix is merged branches with `do` blocks cannot be merged. https://travis-ci.org/alphagov/paas-cf/builds/128887561