### PR TITLE
[#118272895] - Upgrade CF, stemcells and BOSH

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1333,7 +1333,7 @@ jobs:
                   mkdir -p /var/vcap/jobs/acceptance-tests/bin/ /var/vcap/packages/acceptance-tests/src/github.com/cloudfoundry
                   ln -snf $(pwd)/test-config/config.json /var/vcap/jobs/acceptance-tests/bin/config.json
                   ln -snf $(pwd)/test-config/run /var/vcap/jobs/acceptance-tests/bin/run
-                  ln -snf /usr/local/go /var/vcap/packages/golang1.4
+                  ln -snf /usr/local/go /var/vcap/packages/golang1.6
                   sed -i 's/bits=@"%s"/bits=@%s/' cf-release/src/github.com/cloudfoundry/cf-acceptance-tests/helpers/v3_helpers/v3.go
                   ln -snf $(pwd)/cf-release/src/github.com/cloudfoundry/cf-acceptance-tests /var/vcap/packages/acceptance-tests/src/github.com/cloudfoundry/
                   /var/vcap/jobs/acceptance-tests/bin/run

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1334,7 +1334,6 @@ jobs:
                   ln -snf $(pwd)/test-config/config.json /var/vcap/jobs/acceptance-tests/bin/config.json
                   ln -snf $(pwd)/test-config/run /var/vcap/jobs/acceptance-tests/bin/run
                   ln -snf /usr/local/go /var/vcap/packages/golang1.6
-                  sed -i 's/bits=@"%s"/bits=@%s/' cf-release/src/github.com/cloudfoundry/cf-acceptance-tests/helpers/v3_helpers/v3.go
                   ln -snf $(pwd)/cf-release/src/github.com/cloudfoundry/cf-acceptance-tests /var/vcap/packages/acceptance-tests/src/github.com/cloudfoundry/
                   /var/vcap/jobs/acceptance-tests/bin/run
 

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -83,6 +83,7 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-graphite-statsd-boshrelease.git
       tag_filter: {{cf_graphite_version}}
+      branch: gds_master
 
   - name: grafana-boshrelease
     type: git

--- a/concourse/tasks/smoke-tests-run.yml
+++ b/concourse/tasks/smoke-tests-run.yml
@@ -19,7 +19,7 @@ run:
       mkdir -p /var/vcap/jobs/smoke-tests/bin/ /var/vcap/packages/smoke-tests/src/github.com/cloudfoundry
       ln -snf $(pwd)/test-config/config.json /var/vcap/jobs/smoke-tests/bin/config.json
       ln -snf $(pwd)/test-config/run /var/vcap/jobs/smoke-tests/bin/run
-      ln -snf /usr/local/go /var/vcap/packages/golang1.4
+      ln -snf /usr/local/go /var/vcap/packages/golang1.6
       ln -snf $(pwd)/cf-release/src/smoke-tests /var/vcap/packages/smoke-tests/src/github.com/cloudfoundry/cf-smoke-tests
       set -o pipefail
       git --git-dir paas-cf/.git log -1 > smoke-tests-log/last-commit.log

--- a/manifests/cf-manifest/deployments/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/deployments/000-base-cf-deployment.yml
@@ -9,25 +9,25 @@ name: (( grab meta.environment ))
 
 releases:
   - name: cf
-    version: 233
-    url: https://bosh.io/d/github.com/cloudfoundry/cf-release?v=233
-    sha1: 611b0e37f5c8a61948e547630f3c218c0c465cc0
+    version: 235
+    url: https://bosh.io/d/github.com/cloudfoundry/cf-release?v=235
+    sha1: a4ab2d7a2912b8c700ef4b8a45e7f688127930b6
   - name: nginx
     version: 2
     url: https://s3.amazonaws.com/nginx-release/nginx-2.tgz
     sha1: 667cc1a0f9117bdb4b217ee2b76dc20e61371c02
   - name: diego
-    version: 0.1460.0
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/diego-release?v=0.1460.0
-    sha1: 2d9a65acc34802ef0deb4446c684d7973c65cc94
+    version: 0.1467.0
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/diego-release?v=0.1467.0
+    sha1: 64af2b1b99f0ff771e3e60daacbe5fd3b48d2ddc
   - name: garden-linux
-    version: 0.334.0
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/garden-linux-release?v=0.334.0
-    sha1: 85170c5089fa4ff317f139c2f1da024860dbea85
+    version: 0.337.0
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/garden-linux-release?v=0.337.0
+    sha1: d1d81d56c3c07f6f9f04ebddc68e51b8a3cf541d
   - name: etcd
-    version: 38
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/etcd-release?v=38
-    sha1: c7d303c1b733e77c5c5f3dedfe4dbf75997f30bc
+    version: 45
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/etcd-release?v=45
+    sha1: c166c0e34fa2ebdc42585075409f9b84aa4d14d8
   - name: paas-haproxy
     version: 0.0.2
 

--- a/manifests/cf-manifest/deployments/040-cf-properties.yml
+++ b/manifests/cf-manifest/deployments/040-cf-properties.yml
@@ -442,9 +442,6 @@ properties:
         client_key: (( grab secrets.bbs_client_key ))
         require_ssl: true
       traffic_controller_url: (( grab properties.loggregator.traffic_controller_url ))
-      # Override because this is wrong in diego version 0.1441.0
-      watcher:
-        debug_addr: 0.0.0.0:17015
 
 meta:
   environment: ~

--- a/manifests/cf-manifest/deployments/055-graphite.yml
+++ b/manifests/cf-manifest/deployments/055-graphite.yml
@@ -13,7 +13,7 @@ meta:
 
 releases:
 - name: graphite
-  version: commit-db49809b0f339a45ae377fc162f01b0ec49c87dc
+  version: commit-ccc206f3ba21fe5ba4f3e617bb7dca3e66a652ad
 - name: grafana
   version: commit-44564533c9d4d656bdcd5633b808f0bf6fb177ae
 

--- a/manifests/cf-manifest/deployments/900-cf-tests.yml
+++ b/manifests/cf-manifest/deployments/900-cf-tests.yml
@@ -1,6 +1,6 @@
 properties:
   acceptance_tests:
-    api: (( concat "https://" meta.api_domain ))
+    api: (( grab meta.api_domain ))
     apps_domain: (( grab properties.app_domains[0] ))
     system_domain: (( grab properties.system_domain ))
     admin_user: "admin"

--- a/manifests/cf-manifest/deployments/aws/999-cf-stub.yml
+++ b/manifests/cf-manifest/deployments/aws/999-cf-stub.yml
@@ -179,6 +179,8 @@ properties:
     server_key: (( grab secrets.consul_server_key ))
     agent_cert: (( grab secrets.consul_agent_cert ))
     agent_key: (( grab secrets.consul_agent_key ))
+    agent:
+      domain: cf.internal
   loggregator_endpoint:
     shared_secret: (( grab secrets.loggregator_endpoint_shared_secret ))
   nats:

--- a/tests/acceptance-tests/apps/print_request_headers/Godeps/Godeps.json
+++ b/tests/acceptance-tests/apps/print_request_headers/Godeps/Godeps.json
@@ -1,5 +1,5 @@
 {
 	"ImportPath": "debug_app",
-	"GoVersion": "go1.5.2",
+	"GoVersion": "go1.6",
 	"Deps": []
 }


### PR DESCRIPTION
## What

[Story](https://www.pivotaltracker.com/projects/1275640/stories/118272895)

We upgraded:

- ~~BOSH from 255.8 to 256.2~~ Cancelled because of [this issue](https://github.com/cloudfoundry/bosh/issues/1263).  This will be done separately.
- CF from 233 to 235 and its recommended versions of diego, garden, etcd
- ~~Stemcells from 3215 to 3232.2 to get the latest security fixes~~ Cancelled because of time out issues. This will be done separately.

Changes:

- [graphite BOSH release
  changes](https://github.com/alphagov/paas-graphite-statsd-boshrelease/pull/5)
  were needed to work with the new BOSH
- cf-acceptance, smoke tests and app that our custom acceptance tests use to
  print headers all switched to go 1.6
- ~~the new BOSH doesn't use redis~~
- We turned off the V3 suite in cf-acceptance-tests as they break when presented with HTTPS endpoints and we don't currently use the [not yet stable v3 API](http://v3-apidocs.cloudfoundry.org/version/release-candidate/)

## How to review

- Switch your environment to the branch and run the pipeline.
- Review the changes
- First merge the [PR against graphite BOSH release](https://github.com/alphagov/paas-graphite-statsd-boshrelease/pull/5) and create a new tag.
- Amend the manifests in this branch to use the new tag in the graphite BOSH  release.
- Merge this PR.

## Who can review

Anyone but @saliceti @bleach @jimconner