### PR TITLE
[#119382595] Reduce the length of the temp user for smoketests

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1665,7 +1665,7 @@ jobs:
           file: paas-cf/concourse/tasks/create_admin.yml
           config:
             params:
-              PREFIX: continuous-smoketest-user
+              PREFIX: cont-smoketest-user
 
         - task: smoke-tests-config
           file: paas-cf/concourse/tasks/smoke-tests-config.yml


### PR DESCRIPTION
What
----

In the continous smoke tests we were creating a user called
`continuous-smoketest-user`. With the random suffix that makes
a user name of 36 chars.

But it turns out that the deployment of applications fails when
using a user with 36, 35 or 34 characters in the name only in prod,
but works on staging and ci.

Longer names seem to work. We still need to investigate the root case
in a different story.

In order to allow the continuous smoke test work on prod, we change
the username to a shorter one.

How to test it
--------------

It has been already applied and tested in prod, [builds ~10246](https://deployer.cloud.service.gov.uk/pipelines/create-bosh-cloudfoundry/jobs/continuous-smoke-tests/builds/10246

Does not require too much testing, just check that makes sense.

Who?
----

Anyone but @jimconner or @keymon