### PR TITLE
[#118837127] - Fixed errors in documentation for creating users

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,14 +353,14 @@ Make sure you are using the correct AWS credentials for the environment you are 
 ## Creating Users
 
 Once you got the OK from the Product and Delivery managers to create
-an organisations with a user, you can use the script `./scripts/create-tenant.sh`
+an organisations with a user, you can use the script `./scripts/create-user.sh`
 to automatically create them:
 
 ```
-./scripts/create-tenant.sh -o orgname -e email@example.com
+./scripts/create-user.sh -o orgname -e email@example.com
 ```
 
-Run `./scripts/create-tenant.sh` for detailed help.
+Run `./scripts/create-user.sh` for detailed help.
 
 The script will create the organisation if it doesnt exist, create the user and
 email them the password. You must have the aws cli and cf cli installed, and be

--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -21,7 +21,7 @@ Your organisation is \"${ORG}\" and your login and password:
 To begin using the PaaS you will need to install the cf command line client
 and execute the following commands.
 
-cf target https://api.cloud.service.gov.uk
+cf api https://api.cloud.service.gov.uk
 cf login
 
 Further documentation on the cf command line client is available from


### PR DESCRIPTION
## What

[#118837127 - Create trade-tariff organisation and org manager with quota](https://www.pivotaltracker.com/n/projects/1275640/stories/118837127)

We want to be able to provide documentation for operations staff and users for the CF CLI. This pull request fixes two errors which may cause confusion.

## How to review

Read the 'Creating Users' section of the README, make sure it still makes sense. Try the commands given to the user in the `scripts/create-user.sh` email and make sure they work.

## Who can review

Anyone but me @saliceti or @keymon 