### PR TITLE
[#118830743] Command to check our github forks against upstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,3 +142,7 @@ pingdom: ## Use custom Terraform provider to set up Pingdom check
 merge_pr: ## Merge a PR. Must specify number in a PR=<number> form.
 	$(if ${PR},,$(error Must pass PR=<number>))
 	./scripts/merge_pr.rb --pr ${PR}
+
+find_diverged_forks: ## Check all github forks belonging to paas to see if they've diverged upstream
+	$(if ${GITHUB_TOKEN},,$(error Must pass GITHUB_TOKEN=<personal github token>))
+	./scripts/find_diverged_forks.py alphagov --prefix=paas --extra-repo=cf-release --extra-repo=graphite-nozzle --github-token=${GITHUB_TOKEN}

--- a/scripts/find_diverged_forks.py
+++ b/scripts/find_diverged_forks.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+import argparse
+from github import Github
+
+class ForkChecker(object):
+    def __init__(self, github_token):
+        self.github_token = github_token
+
+    def check(self, organization, prefix, extra_repos):
+        g = Github(self.github_token)
+        for repo in g.get_organization(organization).get_repos(type='fork'):
+            if repo.name.startswith(prefix) or repo.name in extra_repos:
+                comparison = repo.compare(repo.owner.login + ':master', repo.parent.owner.login + ':master')
+
+                open_prs = []
+                for pull in repo.parent.get_pulls():
+                    if pull.head.user.login == organization:
+                        open_prs.append(pull)
+
+                if comparison.ahead_by or open_prs:
+                    print "\n%s/%s:" % (organization, repo.name)
+
+                if comparison.ahead_by:
+                    print " * Upstream ahead by %s commits: %s" % (comparison.ahead_by, comparison.html_url)
+
+                for pull in open_prs:
+                    print " * Open pull request: %s" % pull.html_url
+        print
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('organization', help='Organization to search for forks', nargs='+')
+    parser.add_argument('--prefix', help='Repository name prefix to filter on', default='')
+    parser.add_argument('--extra-repo', help='Repository not matching the prefix to be included', action='append', default=[])
+    parser.add_argument('--github-token', help='Github personal API token to increase rate limit')
+    args = parser.parse_args()
+
+    f = ForkChecker(args.github_token)
+    f.check(args.organization[0], args.prefix, args.extra_repo)


### PR DESCRIPTION
## What

We want to keep an eye on the repositories we have forked as they quickly diverge from upstream, this tool allows us to do that in an automated fashion.

## How to review

This requires the python `pygithub` module, which can be installed using `pip install pygithub`.

Running `make find_diverged_forks GITHUB_TOKEN=<personal access token>` will output a list of forks on github belonging to the PaaS team that have diverged from the upstream repository, it will also output any open pull requests belonging to us on those forks.

While the script will run without a personal access token it will quickly run into rate limits due to the size of alphagov and the size of the repositories we have forked, so the makefile makes it mandatory.

You can get a personal access token here:
https://github.com/settings/tokens

The output should look similar to this:
````
$ make find_diverged_forks GITHUB_TOKEN=<REDACTED>
./scripts/find_diverged_forks.py alphagov --prefix=paas --extra-repo=cf-release --extra-repo=graphite-nozzle --github-token=82e9ff45189854f161b4c6c7d8dee8f1d4953058

alphagov/paas-terraform:
 * Upstream ahead by 2791 commits: https://github.com/alphagov/paas-terraform/compare/alphagov:master...hashicorp:master

alphagov/cf-release:
 * Upstream ahead by 1309 commits: https://github.com/alphagov/cf-release/compare/alphagov:master...cloudfoundry:master

alphagov/graphite-nozzle:
 * Upstream ahead by 4 commits: https://github.com/alphagov/graphite-nozzle/compare/alphagov:master...CloudCredo:master

alphagov/paas-graphite-statsd-boshrelease:
 * Open pull request: https://github.com/CloudCredo/graphite-statsd-boshrelease/pull/8

alphagov/paas-s3-resource:
 * Upstream ahead by 26 commits: https://github.com/alphagov/paas-s3-resource/compare/alphagov:master...concourse:master

alphagov/paas-semver-resource:
 * Upstream ahead by 26 commits: https://github.com/alphagov/paas-semver-resource/compare/alphagov:master...concourse:master

alphagov/paas-bosh-aws-cpi-release:
 * Upstream ahead by 141 commits: https://github.com/alphagov/paas-bosh-aws-cpi-release/compare/alphagov:master...cloudfoundry-incubator:master

alphagov/paas-docs-bosh:
 * Upstream ahead by 159 commits: https://github.com/alphagov/paas-docs-bosh/compare/alphagov:master...cloudfoundry:master

alphagov/paas-grafana-boshrelease:
 * Upstream ahead by 9 commits: https://github.com/alphagov/paas-grafana-boshrelease/compare/alphagov:master...vito:master

alphagov/paas-git-resource:
 * Upstream ahead by 13 commits: https://github.com/alphagov/paas-git-resource/compare/alphagov:master...concourse:master
 * Open pull request: https://github.com/concourse/git-resource/pull/58

alphagov/paas-gorouter:
 * Upstream ahead by 44 commits: https://github.com/alphagov/paas-gorouter/compare/alphagov:master...cloudfoundry:master
 * Open pull request: https://github.com/cloudfoundry/gorouter/pull/127

alphagov/paas-terraform-provider-pingdom:
 * Upstream ahead by 2 commits: https://github.com/alphagov/paas-terraform-provider-pingdom/compare/alphagov:master...russellcardullo:master

alphagov/paas-go-pingdom:
 * Upstream ahead by 2 commits: https://github.com/alphagov/paas-go-pingdom/compare/alphagov:master...russellcardullo:master

alphagov/paas-concourse:
 * Upstream ahead by 82 commits: https://github.com/alphagov/paas-concourse/compare/alphagov:master...concourse:master
````

## Who can review

Neither @jonty or @mtekel should lay hands on this PR again.