### PR TITLE
[#115870117] BOSH failover to other AZ

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,3 +376,6 @@ pass the `-m` option to the script
 To run the above script, you need to verify your email address with [AWS SES](https://aws.amazon.com/ses/)
 To do this, run `aws ses verify-email-identity --email-address youremail@example.com --region eu-west-1`
 and click on the link in the resulting email
+
+## BOSH failover
+Visit [BOSH failover page](https://github.com/alphagov/paas-cf/doc/bosh_failover.md)

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -303,6 +303,7 @@ jobs:
             MAKEFILE_ENV_TARGET: {{makefile_env_target}}
             SELF_UPDATE_PIPELINE: {{self_update_pipeline}}
             PIPELINES_TO_UPDATE: {{pipeline_name}}
+            BOSH_AZ: {{bosh_az}}
           run:
             path: ./paas-cf/concourse/scripts/self-update-pipeline.sh
 
@@ -515,6 +516,7 @@ jobs:
           params:
             DEPLOY_ENV: {{deploy_env}}
             AWS_DEFAULT_REGION: {{aws_region}}
+            BOSH_AZ: {{bosh_az}}
             TF_VAR_system_dns_zone_name: {{system_dns_zone_name}}
           run:
             path: sh
@@ -525,6 +527,7 @@ jobs:
                 . terraform-variables/vpc.tfvars.sh
                 . terraform-variables/concourse.tfvars.sh
                 . terraform-variables/bosh-secrets.tfvars.sh
+                export TF_VAR_bosh_az="${BOSH_AZ}"
 
                 terraform apply -var env={{deploy_env}} -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
                   -state=bosh-tfstate/bosh.tfstate -state-out=updated-bosh-tfstate/bosh.tfstate paas-cf/terraform/bosh

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -157,7 +157,7 @@ resources:
     source:
       bucket: {{state_bucket}}
       region_name: {{aws_region}}
-      versioned_file: bosh-manifest-state.json
+      versioned_file: {{bosh_manifest_state}}
 
   - name: ssh-private-key
     type: s3-iam
@@ -320,7 +320,7 @@ jobs:
               - -c
               - |
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} bosh.tfstate paas-cf/concourse/init_files/terraform.tfstate.tpl
-                paas-cf/concourse/scripts/s3init.sh {{state_bucket}} bosh-manifest-state.json paas-cf/concourse/init_files/bosh-init-state.json.tpl
+                paas-cf/concourse/scripts/s3init.sh {{state_bucket}} {{bosh_manifest_state}} paas-cf/concourse/init_files/bosh-init-state.json.tpl
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} bosh-secrets.yml paas-cf/concourse/init_files/zero_bytes
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} bosh-CA.tar.gz paas-cf/concourse/init_files/empty.tar.gz
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} cf-secrets.yml paas-cf/concourse/init_files/zero_bytes
@@ -650,6 +650,8 @@ jobs:
             - name: ssh-private-key
           outputs:
             - name: updated-bosh-init-state
+          params:
+            BOSH_MANIFEST_STATE: {{bosh_manifest_state}}
           run:
             path: sh
             args:
@@ -659,13 +661,13 @@ jobs:
                 mkdir -p bosh-manifest/.ssh
                 cp ssh-private-key/id_rsa bosh-manifest/.ssh/id_rsa
                 chmod 400 bosh-manifest/.ssh/id_rsa
-                cp bosh-init-state/bosh-manifest-state.json bosh-manifest/bosh-manifest-state.json
+                cp bosh-init-state/"${BOSH_MANIFEST_STATE}" bosh-manifest/bosh-manifest-state.json
                 bosh-init deploy bosh-manifest/bosh-manifest.yml
-                cp bosh-manifest/bosh-manifest-state.json updated-bosh-init-state/bosh-manifest-state.json
+                cp bosh-manifest/bosh-manifest-state.json updated-bosh-init-state/"${BOSH_MANIFEST_STATE}"
         ensure:
           put: bosh-init-state
           params:
-            file: updated-bosh-init-state/bosh-manifest-state.json
+            file: "updated-bosh-init-state/bosh-manifest-state-*.json"
 
   - name: cf-terraform
     serial_groups: [cf-deploy]

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -13,7 +13,7 @@ groups:
       - smoke-tests
       - acceptance-tests
       - custom-acceptance-tests
-      - bosh-cli-test
+      - bosh-tests
       - performance-tests
       - tag-release
       - pipeline-unlock
@@ -32,7 +32,7 @@ groups:
       - smoke-tests
       - acceptance-tests
       - custom-acceptance-tests
-      - bosh-cli-test
+      - bosh-tests
       - performance-tests
       - tag-release
       - pipeline-unlock
@@ -50,7 +50,7 @@ groups:
       - smoke-tests
       - acceptance-tests
       - custom-acceptance-tests
-      - bosh-cli-test
+      - bosh-tests
       - performance-tests
   - name: health
     jobs:
@@ -1437,7 +1437,7 @@ jobs:
           task: remove-temp-user
           file: paas-cf/concourse/tasks/delete_admin.yml
 
-  - name: bosh-cli-test
+  - name: bosh-tests
     plan:
       - aggregate:
           - get: pipeline-trigger
@@ -1446,7 +1446,7 @@ jobs:
           - get: paas-cf
             passed: ['cf-deploy']
           - get: concourse-manifest
-      - task: connect-to-bosh-cli
+      - task: test-bosh-vms-via-bosh-cli
         config:
           platform: linux
           image: docker:///ruby#2.2-slim
@@ -1465,16 +1465,18 @@ jobs:
               VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
               CONCOURSE_ATC_PASSWORD=$("$VAL_FROM_YAML" jobs.concourse.properties.atc.basic_auth_password concourse-manifest/concourse-manifest.yml)
               export CONCOURSE_ATC_PASSWORD
-              ./paas-cf/concourse/scripts/bosh-cli.sh bosh status
+              echo Looking for non running VMs
+              ./paas-cf/concourse/scripts/bosh-cli.sh bosh vms | tee vms.txt
+              [ $(grep '|' vms.txt | grep -cEv "(\-\-|VM|running)") -eq 0 ]
 
   - name: performance-tests
     plan:
       - aggregate:
           - get: pipeline-trigger
-            passed: ['smoke-tests', 'acceptance-tests', 'custom-acceptance-tests', 'bosh-cli-test']
+            passed: ['smoke-tests', 'acceptance-tests', 'custom-acceptance-tests', 'bosh-tests']
             trigger: true
           - get: paas-cf
-            passed: ['smoke-tests', 'acceptance-tests', 'custom-acceptance-tests', 'bosh-cli-test']
+            passed: ['smoke-tests', 'acceptance-tests', 'custom-acceptance-tests', 'bosh-tests']
           - get: cf-manifest
             passed: ['smoke-tests', 'acceptance-tests', 'custom-acceptance-tests']
           - get: bosh-CA

--- a/concourse/pipelines/destroy-microbosh.yml
+++ b/concourse/pipelines/destroy-microbosh.yml
@@ -26,7 +26,7 @@ resources:
     source:
       bucket: {{state_bucket}}
       region_name: {{aws_region}}
-      versioned_file: bosh-manifest-state.json
+      versioned_file: {{bosh_manifest_state}}
 
   - name: bosh-manifest
     type: s3-iam
@@ -122,6 +122,8 @@ jobs:
             - name: paas-cf
             - name: bosh-manifest
             - name: bosh-init-state
+          params:
+            BOSH_MANIFEST_STATE: {{bosh_manifest_state}}
           outputs:
             - name: updated-bosh-init-state
           run:
@@ -130,18 +132,18 @@ jobs:
               - -e
               - -c
               - |
-                cp bosh-init-state/bosh-manifest-state.json bosh-manifest/bosh-manifest-state.json
+                cp bosh-init-state/"${BOSH_MANIFEST_STATE}" bosh-manifest/bosh-manifest-state.json
                 bosh-init delete bosh-manifest/bosh-manifest.yml
                 # If the delete is successful, the file will be missing
-                if [ -f "bosh-manifest/bosh-manifest-state.json" ] ; then
-                  cp bosh-manifest/bosh-manifest-state.json updated-bosh-init/bosh-manifest-state.json
+                if [ -f bosh-manifest/bosh-manifest-state.json ] ; then
+                  cp bosh-manifest/bosh-manifest-state.json updated-bosh-init/"${BOSH_MANIFEST_STATE}"
                 else
-                  cp paas-cf/concourse/init_files/bosh-init-state.json.tpl updated-bosh-init-state/bosh-manifest-state.json
+                  cp paas-cf/concourse/init_files/bosh-init-state.json.tpl updated-bosh-init-state/"${BOSH_MANIFEST_STATE}"
                 fi
         ensure:
           put: bosh-init-state
           params:
-            file: updated-bosh-init-state/bosh-manifest-state.json
+            file: "updated-bosh-init-state/bosh-manifest-state-*.json"
 
   - name: bosh-terraform-destroy
     serial: true

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -79,6 +79,7 @@ apps_dns_zone_name: ${APPS_DNS_ZONE_NAME}
 git_concourse_pool_clone_full_url_ssh: ${git_concourse_pool_clone_full_url_ssh}
 ALERT_EMAIL_ADDRESS: ${ALERT_EMAIL_ADDRESS:-}
 bosh_az: ${bosh_az}
+bosh_manifest_state: bosh-manifest-state-${bosh_az}.json
 bosh_fqdn: bosh.${SYSTEM_DNS_ZONE_NAME}
 EOF
   echo -e "pipeline_lock_git_private_key: |\n  ${git_id_rsa//$'\n'/$'\n'  }"

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -33,6 +33,7 @@ prepare_environment() {
   export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-eu-west-1}
 
   pipelines_to_update="${PIPELINES_TO_UPDATE:-create-bosh-cloudfoundry destroy-cloudfoundry destroy-microbosh autodelete-cloudfoundry failure-testing}"
+  bosh_az=${BOSH_AZ:-eu-west-1a}
 
   cf_manifest_dir="${SCRIPT_DIR}/../../manifests/cf-manifest/deployments"
   cf_release_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.cf.version "${cf_manifest_dir}/000-base-cf-deployment.yml")
@@ -77,6 +78,7 @@ system_dns_zone_name: ${SYSTEM_DNS_ZONE_NAME}
 apps_dns_zone_name: ${APPS_DNS_ZONE_NAME}
 git_concourse_pool_clone_full_url_ssh: ${git_concourse_pool_clone_full_url_ssh}
 ALERT_EMAIL_ADDRESS: ${ALERT_EMAIL_ADDRESS:-}
+bosh_az: ${bosh_az}
 bosh_fqdn: bosh.${SYSTEM_DNS_ZONE_NAME}
 EOF
   echo -e "pipeline_lock_git_private_key: |\n  ${git_id_rsa//$'\n'/$'\n'  }"

--- a/doc/bosh_failover.md
+++ b/doc/bosh_failover.md
@@ -1,0 +1,33 @@
+# BOSH failover
+
+In case of availability zone failure, BOSH can be recreated in another AZ. The state
+is stored in RDS and S3 so the new BOSH can take over straight away.
+
+## Failover process
+
+There are 3 AZs available:
+
+* eu-west-1a
+* eu-west-1b
+* eu-west-1c
+
+The default one is *eu-west-1a*. To deploy BOSH to another AZ, set the environment
+variable `BOSH_AZ` before uploading the pipelines. Ex:
+
+```
+BOSH_AZ='eu-west-1b' make prod pipelines
+```
+
+Run the `create-bosh-cloudfoundry` pipeline, it should deploy a new BOSH, then run
+`cf-deploy` successfully. Watch for `bosh-tests` that will run basic BOSH validation tests.
+
+## Warning
+
+* You shouldn't run 2 instances of BOSH at the same time as this may cause issues. For
+example the bosh agents may remain connected to the old BOSH and the new BOSH may not
+see what it expects.
+To avoid this issue, kill the first BOSH or make sure it doesn't come back alive.
+
+* Once the AZ has been changed from default, the `BOSH_AZ` environment variable should
+always be set to the new AZ when uploading pipelines manually. Otherwise a new BOSH will
+be recreated in the default AZ.

--- a/terraform/bosh/variables.tf
+++ b/terraform/bosh/variables.tf
@@ -23,7 +23,6 @@ variable "bosh_db_skip_final_snapshot" {
 
 variable "bosh_az" {
   description = "A zone used to provision bosh"
-  default = "eu-west-1a"
 }
 
 variable "system_dns_zone_id" {


### PR DESCRIPTION
## What
Story: [Process for recreating BOSH on AZ Failure](https://www.pivotaltracker.com/story/show/119090295)

We want to be able to recreate BOSH in another AZ in case of AZ failure and test it can still see the VMs as running.

## How to review

* Apply on existing pipeline
* Kill BOSH via AWS console
* Upload pipeline with:

```
BOSH_AZ=eu-west-1b make dev pipelines
```

* This should recreate BOSH and test all VMs are in running state. You can check this by doing:

```
make dev bosh-cli
```

or check the output of bosh-tests job.

## ⚠️  Before merging ⚠️ 

As the BOSH state file name is changed in this PR, when this is applied to CI, Staging, Prod bosh-init would try to recreate BOSH and fail because of IP conflict. To solve this rename BOSH state file in S3 to `bosh-manifest-state-eu-west-1a.json` in each environment.

## Who can review
Anyone but @combor or myself.