### PR TITLE
Fix bosh_login.sh when password starts with '-'

### DIFF
--- a/concourse/scripts/bosh_login.sh
+++ b/concourse/scripts/bosh_login.sh
@@ -5,6 +5,6 @@ set -eu
 bosh_host=$1
 bosh_secrets_file=$2
 
-bosh_password=$(awk '/bosh_admin_password/ { print $2 }' "${bosh_secrets_file}")
-bosh -t "${bosh_host}" login admin "${bosh_password}"
+bosh_password=$(awk '/bosh_admin_password/ { print $2 }' "${bosh_secrets_file}" | tr -d '"')
+bosh -t "${bosh_host}" login admin -- "${bosh_password}"
 bosh target "${bosh_host}"

--- a/concourse/scripts/bosh_login.sh
+++ b/concourse/scripts/bosh_login.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
-
 set -eu
 
 bosh_host=$1
 bosh_secrets_file=$2
 
-bosh_password=$(awk '/bosh_admin_password/ { print $2 }' "${bosh_secrets_file}" | tr -d '"')
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+bosh_password=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.bosh_admin_password "${bosh_secrets_file}")
+
 bosh -t "${bosh_host}" login admin -- "${bosh_password}"
 bosh target "${bosh_host}"


### PR DESCRIPTION
What
----

If the random generated password for the bosh admin starts with '-', the
`bosh_login.sh` won't work because it recognises the password with an
option.

Context
-------
To avoid that we add '--' to tell bosh that the following parameters are not options.
    
Additionally, if the string starts with '-', ruby yaml will quote the string in the cf-secrets.yml with `"`. We need to remote these quotes before passing the password as argument.



How to test
-----------

Check that works by running rerunning the pipeline with cf-deploy, which
executes the `bosh_login.sh`.

I don't think it is necessary test when the password has a `-`

Who?
----

Anyone but @keymon