### PR TITLE
Added a full-stop at the end of a sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ logged into the cf environment you want to create users for
 ### Creating Org managers
 
 By default, the script creates an unprivileged users. To create an org manager,
-pass the `-m` option to the script
+pass the `-m` option to the script.
 
 ### Verifying email address
 


### PR DESCRIPTION
## What

Having accidentally pressed the big green merge button in Github's web interface, a small and not particularly important change is required to enable a new merge commit to be properly signed.
There was a missing full-stop at the end of the sentence about creating org managers, so I've added the requisite full-stop with this commit/pr.

## How to review
Check the commit and confrim that the only change is the addition of a full-stop at the end of a sentence.

## Who can review

Anyone on the team.