### PR TITLE
[#119090295] TF_VAR_bosh_az variable missing in microbosh-destroy pipeline

### DIFF
--- a/concourse/pipelines/destroy-microbosh.yml
+++ b/concourse/pipelines/destroy-microbosh.yml
@@ -195,6 +195,7 @@ jobs:
             DEPLOY_ENV: {{deploy_env}}
             AWS_DEFAULT_REGION: {{aws_region}}
             TF_VAR_system_dns_zone_name: {{system_dns_zone_name}}
+            TF_VAR_bosh_az: {{bosh_az}}
           run:
             path: sh
             args:


### PR DESCRIPTION
## What

It seems that we missed the update for microbosh-destroy pipeline during implementation of deployment to multiple AZs for bosh. This PR fixes this.

## How to review

Run microbosh-destroy and make sure if passes. Especially terraform-destroy task shouldn't throw:

```
Errors:

  * 1 error(s) occurred:

* Required variable not set: bosh_az
```

## Who can review

not @combor