### PR TITLE
[#119903539] Cleanup temp. admin on failure

### DIFF
--- a/concourse/tasks/create_admin.yml
+++ b/concourse/tasks/create_admin.yml
@@ -29,12 +29,11 @@ run:
       uaac target "${UAA_ENDPOINT}"
       uaac token client get admin -s "${UAA_ADMIN_CLIENT_PASS}"
       uaac user add "${NAME}" -p "${PASSWORD}" --emails ignored
+      echo "${NAME}" >admin-creds/username
+      echo "${PASSWORD}" >admin-creds/password
 
       uaac member add cloud_controller.admin "${NAME}"
       uaac member add uaa.admin "${NAME}"
       uaac member add scim.read "${NAME}"
       uaac member add scim.write "${NAME}"
       uaac member add doppler.firehose "${NAME}"
-
-      echo "${NAME}" >admin-creds/username
-      echo "${PASSWORD}" >admin-creds/password


### PR DESCRIPTION
## What

Store new user credentials in output immediately after user is created, so that if any of the group additions fail, the ensure task would have access to the username in the outputs.

## How to review

Apply. Run your pipeline enough times till you get failure from UAA:
```
error response:
{
  "error_description": "Incorrect result size: expected 1, actual 0",
  "error": "scim",
  "message": "Incorrect result size: expected 1, actual 0"
}
```
Check that the delete temp user task ran successfully (previously this would fail).

## Who can review

not @mtekel