### PR TITLE
[#118484173] RDS broker cleanup

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1171,10 +1171,16 @@ jobs:
                   ./paas-cf/concourse/scripts/import_bosh_ca.sh
                   . ./config/config.sh
                   echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
+
+                  # FIXME: Remove this once it's been renamed everywhere.
                   if cf service-brokers | grep "postgres\s*http://$RDS_BROKER_SERVER"; then
-                    cf update-service-broker postgres rds-broker $RDS_BROKER_PASS http://$RDS_BROKER_SERVER
+                    cf rename-service-broker postgres rds-broker
+                  fi
+
+                  if cf service-brokers | grep "rds-broker\s*http://$RDS_BROKER_SERVER"; then
+                    cf update-service-broker rds-broker rds-broker $RDS_BROKER_PASS http://$RDS_BROKER_SERVER
                   else
-                    cf create-service-broker postgres rds-broker $RDS_BROKER_PASS http://$RDS_BROKER_SERVER
+                    cf create-service-broker rds-broker rds-broker $RDS_BROKER_PASS http://$RDS_BROKER_SERVER
                   fi
                   cf enable-service-access postgres
 

--- a/manifests/cf-manifest/deployments/060-aws-broker.yml
+++ b/manifests/cf-manifest/deployments/060-aws-broker.yml
@@ -1,6 +1,6 @@
 releases:
   - name: aws-broker
-    version: 0.0.2
+    version: 0.0.3
 
 jobs:
   - name: rds_broker_z1

--- a/tests/src/acceptance/rds_broker_test.go
+++ b/tests/src/acceptance/rds_broker_test.go
@@ -17,14 +17,14 @@ import (
 
 var _ = Describe("RDS broker", func() {
 	const (
-		brokerName   = "postgres"
+		serviceName  = "postgres"
 		testPlanName = "temporary-test-plan"
 	)
 
 	It("should be registered", func() {
 		plans := cf.Cf("marketplace").Wait(DEFAULT_TIMEOUT)
 		Expect(plans).To(Exit(0))
-		Expect(plans).To(Say(brokerName))
+		Expect(plans).To(Say(serviceName))
 	})
 
 	Context("creating a database instance", func() {
@@ -42,7 +42,7 @@ var _ = Describe("RDS broker", func() {
 		BeforeEach(func() {
 			appName = generator.PrefixedRandomName("CATS-APP-")
 			dbInstanceName = generator.PrefixedRandomName("test-db-")
-			Expect(cf.Cf("create-service", brokerName, testPlanName, dbInstanceName).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
+			Expect(cf.Cf("create-service", serviceName, testPlanName, dbInstanceName).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
 
 			fmt.Fprint(GinkgoWriter, "Polling for RDS creation to complete")
 			Eventually(func() *Buffer {


### PR DESCRIPTION
## What

This includes a number of changes to clean up the RDS broker and deployment:

* Removed support for AWS Aurora (alphagov/paas-rds-broker#5)
* Removed some unused jobs from the bosh release (alphagov/paas-aws-broker-boshrelease#6)
* Clarify the broker name. 

On the last point - the broker had been given the same name as the service it provided, which had led to some confusion (especially if we were to enable the mysql services). See the commit for more details

## How to review

Deploy from this branch and verify that everything works (the custom-acceptance tests pass etc).

## Who can review

Anyone but @HenryTK or myself.