### PR TITLE
Clear environment before running PR specs.

### DIFF
--- a/scripts/spec/pull_request_spec.rb
+++ b/scripts/spec/pull_request_spec.rb
@@ -6,6 +6,11 @@ RSpec.describe PullRequest do
   let(:pull_request) { PullRequest.new(1) }
   let(:pr_commit_id) { "12345678901234567890" }
 
+  before :all do
+    # Clear any value set in a user's global environment (eg from .bashrc etc).
+    ENV.delete("GITHUB_API_TOKEN")
+  end
+
   before :each do
     allow_any_instance_of(PullRequest).to receive(:info) # silence logging
 


### PR DESCRIPTION
## What

Without this the tests will fail if you have `GITHUB_API_TOKEN` set in
your environment as the test expectations won't match the requests that
are actually made.

## How to review

Ensure that the Travis build passes.
Set `GITHUB_API_TOKEN` to something in your local environment, and verify that the tests still pass.

## Who can review

Anyone but myself.