### PR TITLE
WIP: [#119516287] Add tests for network MTU

### DIFF
--- a/tests/src/run_from_vm/Godeps/Godeps.json
+++ b/tests/src/run_from_vm/Godeps/Godeps.json
@@ -1,0 +1,141 @@
+{
+	"ImportPath": "run_from_vm",
+	"GoVersion": "go1.6",
+	"Deps": [
+		{
+			"ImportPath": "github.com/onsi/ginkgo",
+			"Comment": "v1.2.0-42-g07d85e6",
+			"Rev": "07d85e6b10c4289c7d612f9b13f45ba36f66d55b"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/config",
+			"Comment": "v1.2.0-42-g07d85e6",
+			"Rev": "07d85e6b10c4289c7d612f9b13f45ba36f66d55b"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/internal/codelocation",
+			"Comment": "v1.2.0-42-g07d85e6",
+			"Rev": "07d85e6b10c4289c7d612f9b13f45ba36f66d55b"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/internal/containernode",
+			"Comment": "v1.2.0-42-g07d85e6",
+			"Rev": "07d85e6b10c4289c7d612f9b13f45ba36f66d55b"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/internal/failer",
+			"Comment": "v1.2.0-42-g07d85e6",
+			"Rev": "07d85e6b10c4289c7d612f9b13f45ba36f66d55b"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/internal/leafnodes",
+			"Comment": "v1.2.0-42-g07d85e6",
+			"Rev": "07d85e6b10c4289c7d612f9b13f45ba36f66d55b"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/internal/remote",
+			"Comment": "v1.2.0-42-g07d85e6",
+			"Rev": "07d85e6b10c4289c7d612f9b13f45ba36f66d55b"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/internal/spec",
+			"Comment": "v1.2.0-42-g07d85e6",
+			"Rev": "07d85e6b10c4289c7d612f9b13f45ba36f66d55b"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/internal/specrunner",
+			"Comment": "v1.2.0-42-g07d85e6",
+			"Rev": "07d85e6b10c4289c7d612f9b13f45ba36f66d55b"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/internal/suite",
+			"Comment": "v1.2.0-42-g07d85e6",
+			"Rev": "07d85e6b10c4289c7d612f9b13f45ba36f66d55b"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/internal/testingtproxy",
+			"Comment": "v1.2.0-42-g07d85e6",
+			"Rev": "07d85e6b10c4289c7d612f9b13f45ba36f66d55b"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/internal/writer",
+			"Comment": "v1.2.0-42-g07d85e6",
+			"Rev": "07d85e6b10c4289c7d612f9b13f45ba36f66d55b"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/reporters",
+			"Comment": "v1.2.0-42-g07d85e6",
+			"Rev": "07d85e6b10c4289c7d612f9b13f45ba36f66d55b"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/reporters/stenographer",
+			"Comment": "v1.2.0-42-g07d85e6",
+			"Rev": "07d85e6b10c4289c7d612f9b13f45ba36f66d55b"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/types",
+			"Comment": "v1.2.0-42-g07d85e6",
+			"Rev": "07d85e6b10c4289c7d612f9b13f45ba36f66d55b"
+		},
+		{
+			"ImportPath": "github.com/onsi/gomega",
+			"Comment": "v1.0-83-gc72df92",
+			"Rev": "c72df929b80ef4930aaa75d5e486887ff2f3e06a"
+		},
+		{
+			"ImportPath": "github.com/onsi/gomega/format",
+			"Comment": "v1.0-83-gc72df92",
+			"Rev": "c72df929b80ef4930aaa75d5e486887ff2f3e06a"
+		},
+		{
+			"ImportPath": "github.com/onsi/gomega/internal/assertion",
+			"Comment": "v1.0-83-gc72df92",
+			"Rev": "c72df929b80ef4930aaa75d5e486887ff2f3e06a"
+		},
+		{
+			"ImportPath": "github.com/onsi/gomega/internal/asyncassertion",
+			"Comment": "v1.0-83-gc72df92",
+			"Rev": "c72df929b80ef4930aaa75d5e486887ff2f3e06a"
+		},
+		{
+			"ImportPath": "github.com/onsi/gomega/internal/oraclematcher",
+			"Comment": "v1.0-83-gc72df92",
+			"Rev": "c72df929b80ef4930aaa75d5e486887ff2f3e06a"
+		},
+		{
+			"ImportPath": "github.com/onsi/gomega/internal/testingtsupport",
+			"Comment": "v1.0-83-gc72df92",
+			"Rev": "c72df929b80ef4930aaa75d5e486887ff2f3e06a"
+		},
+		{
+			"ImportPath": "github.com/onsi/gomega/matchers",
+			"Comment": "v1.0-83-gc72df92",
+			"Rev": "c72df929b80ef4930aaa75d5e486887ff2f3e06a"
+		},
+		{
+			"ImportPath": "github.com/onsi/gomega/matchers/support/goraph/bipartitegraph",
+			"Comment": "v1.0-83-gc72df92",
+			"Rev": "c72df929b80ef4930aaa75d5e486887ff2f3e06a"
+		},
+		{
+			"ImportPath": "github.com/onsi/gomega/matchers/support/goraph/edge",
+			"Comment": "v1.0-83-gc72df92",
+			"Rev": "c72df929b80ef4930aaa75d5e486887ff2f3e06a"
+		},
+		{
+			"ImportPath": "github.com/onsi/gomega/matchers/support/goraph/node",
+			"Comment": "v1.0-83-gc72df92",
+			"Rev": "c72df929b80ef4930aaa75d5e486887ff2f3e06a"
+		},
+		{
+			"ImportPath": "github.com/onsi/gomega/matchers/support/goraph/util",
+			"Comment": "v1.0-83-gc72df92",
+			"Rev": "c72df929b80ef4930aaa75d5e486887ff2f3e06a"
+		},
+		{
+			"ImportPath": "github.com/onsi/gomega/types",
+			"Comment": "v1.0-83-gc72df92",
+			"Rev": "c72df929b80ef4930aaa75d5e486887ff2f3e06a"
+		}
+	]
+}

--- a/tests/src/run_from_vm/Godeps/Readme
+++ b/tests/src/run_from_vm/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.

--- a/tests/src/run_from_vm/mtu_test.go
+++ b/tests/src/run_from_vm/mtu_test.go
@@ -1,13 +1,26 @@
 package run_from_vm_test
 
 import (
+	"bytes"
+	"fmt"
+	"net/http"
 	"os"
+	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("MTU", func() {
+	const (
+		DefaultTimeout = time.Second
+		HeaderName     = "Authorization"
+		HeaderBase     = "bearer ="
+		ReqSizeMin     = 1300
+		ReqSizeMax     = 1500
+	)
+
 	var (
 		EndpointURL string
 	)
@@ -15,5 +28,30 @@ var _ = Describe("MTU", func() {
 	BeforeEach(func() {
 		EndpointURL = os.Getenv("API_ENDPOINT")
 		Expect(EndpointURL).ToNot(BeEmpty(), "API_ENDPOINT environment variable must be set")
+	})
+
+	It("can access the endpoint with a variety of request sizes", func() {
+		req, err := http.NewRequest("GET", EndpointURL, nil)
+		Expect(err).To(BeNil())
+
+		var buf bytes.Buffer
+		req.Header.Set(HeaderName, HeaderBase)
+		req.Write(&buf)
+		baseSize := buf.Len()
+
+		client := &http.Client{Timeout: DefaultTimeout}
+		var padding string
+		for reqSize := ReqSizeMin; reqSize <= ReqSizeMax; reqSize++ {
+			By(fmt.Sprintf("using request size of %d bytes", reqSize))
+			padding = strings.Repeat("=", reqSize-baseSize)
+			req.Header.Set(HeaderName, HeaderBase+padding)
+
+			buf.Reset()
+			req.Write(&buf)
+			Expect(buf.Len()).To(Equal(reqSize))
+
+			_, err := client.Do(req)
+			Expect(err).To(BeNil(), "request failed with size of %d bytes", reqSize)
+		}
 	})
 })

--- a/tests/src/run_from_vm/mtu_test.go
+++ b/tests/src/run_from_vm/mtu_test.go
@@ -1,0 +1,19 @@
+package run_from_vm_test
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("MTU", func() {
+	var (
+		EndpointURL string
+	)
+
+	BeforeEach(func() {
+		EndpointURL = os.Getenv("API_ENDPOINT")
+		Expect(EndpointURL).ToNot(BeEmpty(), "API_ENDPOINT environment variable must be set")
+	})
+})

--- a/tests/src/run_from_vm/mtu_test.go
+++ b/tests/src/run_from_vm/mtu_test.go
@@ -2,8 +2,11 @@ package run_from_vm_test
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -17,6 +20,7 @@ var _ = Describe("MTU", func() {
 		DefaultTimeout = time.Second
 		HeaderName     = "Authorization"
 		HeaderBase     = "bearer ="
+		JumboMTU       = 9000
 		ReqSizeMin     = 1300
 		ReqSizeMax     = 1500
 	)
@@ -28,6 +32,19 @@ var _ = Describe("MTU", func() {
 	BeforeEach(func() {
 		EndpointURL = os.Getenv("API_ENDPOINT")
 		Expect(EndpointURL).ToNot(BeEmpty(), "API_ENDPOINT environment variable must be set")
+	})
+
+	It("is running from a host configured to use jumbo frames", func() {
+		egressAddr, err := EgressAddr(EndpointURL, DefaultTimeout)
+		Expect(err).To(BeNil())
+
+		egressIP, _, err := net.SplitHostPort(egressAddr.String())
+		Expect(err).To(BeNil())
+
+		iface, err := InterfaceByAddr(egressIP)
+		Expect(err).To(BeNil())
+
+		Expect(iface.MTU).To(BeNumerically("~", JumboMTU, 10))
 	})
 
 	It("can access the endpoint with a variety of request sizes", func() {
@@ -55,3 +72,71 @@ var _ = Describe("MTU", func() {
 		}
 	})
 })
+
+// EgressAddr returns the address (host:port) of the network interface used
+// to connect to `endpointURL`.
+func EgressAddr(endpointURL string, timeout time.Duration) (net.Addr, error) {
+	var (
+		egressAddr   net.Addr
+		errConnAbort error = errors.New("connection aborted because we only wanted the local addr")
+	)
+
+	dialHijack := func(network, addr string) (net.Conn, error) {
+		conn, err := net.DialTimeout(network, addr, timeout)
+		if err != nil {
+			return conn, err
+		}
+
+		defer conn.Close()
+		egressAddr = conn.LocalAddr()
+
+		return nil, errConnAbort
+	}
+
+	client := &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			Dial:    dialHijack,
+			DialTLS: dialHijack,
+		},
+	}
+
+	req, err := http.NewRequest("GET", endpointURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = client.Do(req)
+	if err != nil {
+		if urlErr, ok := err.(*url.Error); !(ok && urlErr.Err == errConnAbort) {
+			return nil, err
+		}
+	}
+
+	return egressAddr, nil
+}
+
+// InterfaceByAddr returns the network interface that has the IP address
+// `ipAddr`
+func InterfaceByAddr(ipAddr string) (net.Interface, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return net.Interface{}, err
+	}
+
+	for _, iface := range ifaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+
+		for _, addr := range addrs {
+			ip, _, err := net.ParseCIDR(addr.String())
+			if err == nil && ip.String() == ipAddr {
+				return iface, nil
+			}
+		}
+	}
+
+	return net.Interface{}, fmt.Errorf("unable to find interface for IP %s", ipAddr)
+}

--- a/tests/src/run_from_vm/run_from_vm_suite_test.go
+++ b/tests/src/run_from_vm/run_from_vm_suite_test.go
@@ -1,0 +1,13 @@
+package run_from_vm_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestRunFromVm(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "RunFromVm Suite")
+}


### PR DESCRIPTION
## Notice

Please don't merge straight away. I'd like to get a few opinions from the team about the code and whether we think:

- this is something worth testing for future regressions
- is it possible to automate this in the pipeline?
  - would we build and transfer the binary? how?
  - would we use an errand on a job that has Golang available?
  - how would we choose the VM it runs on?
- is this worth merging before we have it automated in the pipeline?

## What

Here's an overview. Please see the commits for more details:

### Ginkgo suite for "run_from_vm"

Add a new test suite that will need to be run from a BOSH VM rather than a
Concourse or Diego container.

### tests/run_from_vm: Requests of different sizes

We experienced a bug in CF on AWS whereby TPS was unable to query Doppler
with an `Authorization` header that contained a username of a specific
length.

This test reproduces the same behaviour by making HTTP or HTTPS requests
with increasingly large packet sizes near to the standard network MTU of
1500 bytes. It should prevent the same from happening again in the future
without us needing to debug the internal CF calls.

### tests/run_from_vm: Check MTU of host

Test that the suite is being run from a host with a network interface
configured with an MTU of 9000~, because that is needed to exercise the bug
found by the other test in this suite.

## How to review

1. You'll need Go, Godep, and Ginkgo installed locally.
1. Run the following to build the test binary:

    ```
➜  paas-cf git:(feature/119516287-mtu_test) ✗ export GOPATH=${GOPATH}:$(pwd)/tests
➜  paas-cf git:(feature/119516287-mtu_test) ✗ cd tests/src/run_from_vm
➜  run_from_vm git:(feature/119516287-mtu_test) ✗ godep restore
➜  run_from_vm git:(feature/119516287-mtu_test) ✗ ginkgo build
Compiling run_from_vm...
    compiled run_from_vm.test
```
1. Transfer the binary to a VM such as `colocated_z1`. You might be to be creative about how you do this - I `scp`ed it to a personal VM and `wget`ed it back, but you could use SSH tunnels or S3.
1. Run the binary.
1. Confirm the host "MTU test" passes and the "request size" test fails.

## Who can review

Not @dcarley