### PR TITLE
val_from_yaml: STDERR msg when unable to find key

### DIFF
--- a/concourse/scripts/spec/val_from_yaml_spec.rb
+++ b/concourse/scripts/spec/val_from_yaml_spec.rb
@@ -26,13 +26,19 @@ val2: b
   it "exits non-zero with no output for non existing properties" do
     run_with_fixture("x.y.z")
     expect(last_command_started).to have_exit_status(1)
-    expect(last_command_started.output).to be_empty
+    expect(last_command_started.stdout).to be_empty
+    expect(last_command_started.stderr).to eq <<-EOF
+Unable to find key: x.y.z
+    EOF
   end
 
   it "exits non-zero with no output when traversing simple values" do
     run_with_fixture("foo.var.val1.nothing_to_see_here")
     expect(last_command_started).to have_exit_status(1)
-    expect(last_command_started.output).to be_empty
+    expect(last_command_started.stdout).to be_empty
+    expect(last_command_started.stderr).to eq <<-EOF
+Unable to find key: foo.var.val1.nothing_to_see_here
+    EOF
   end
 
   it "retrieves a value from an array indexed by name" do
@@ -46,13 +52,19 @@ array1_item1_value
   it "exits non-zero with no output for non existing array item indexed by name" do
     run_with_fixture("foo.array1.item3.val")
     expect(last_command_started).to have_exit_status(1)
-    expect(last_command_started.output).to be_empty
+    expect(last_command_started.stdout).to be_empty
+    expect(last_command_started.stderr).to eq <<-EOF
+Unable to find key: foo.array1.item3.val
+    EOF
   end
 
   it "exits non-zero with no output for non existing key in a array item indexed by name" do
     run_with_fixture("foo.array1.item1.other_val")
     expect(last_command_started).to have_exit_status(1)
-    expect(last_command_started.output).to be_empty
+    expect(last_command_started.stdout).to be_empty
+    expect(last_command_started.stderr).to eq <<-EOF
+Unable to find key: foo.array1.item1.other_val
+    EOF
   end
 
   it "retrieves a value from an array indexed by index" do

--- a/concourse/scripts/val_from_yaml.rb
+++ b/concourse/scripts/val_from_yaml.rb
@@ -53,7 +53,7 @@ if __FILE__ == $0 # Only execute if called directly as command
   end
 
   val = property_tree[key]
-  abort if val.nil?
+  abort "Unable to find key: #{key}" if val.nil?
 
   if val.is_a? Array or val.is_a? Hash
     puts YAML.dump(val)


### PR DESCRIPTION
## What

Write an error message to STDERR when `val_from_yaml` is unable to find a
key in the YAML document. This will make it easier to diagnose typos when
running from within the pipeline. Previously the non-zero exit code would
make the task fail without any output.

For example, when called as we do in the pipeline:

    ➜  paas-cf git:(master) ✗ TEST=$(./concourse/scripts/val_from_yaml.rb foo manifests/concourse-manifest/concourse-base.yml)
    Unable to find key: foo

## How to review

Confirm that the tests look correct and that they pass in Travis. The changes don't affect the happy path of the code, so it's probably not necessary for you to test the whole thing in a pipeline.

## Who can review

Not @dcarley