### PR TITLE
[#113528323] destroy-microbosh: Abort if any deployments exist

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gem 'rspec', '~> 3.3'
 gem 'bosh_cli'
 gem 'webmock', "~> 1.24"
 gem 'rubocop'
+gem 'mimic'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,11 +66,17 @@ GEM
     highline (1.6.21)
     httpclient (2.7.1)
     jmespath (1.1.3)
+    json (1.8.3)
     json_pure (1.8.3)
     little-plugger (1.1.4)
     logging (1.8.2)
       little-plugger (>= 1.1.3)
       multi_json (>= 1.8.4)
+    mimic (0.4.3)
+      json
+      plist
+      rack
+      sinatra
     minitar (0.5.4)
     multi_json (1.11.2)
     multi_test (0.1.2)
@@ -82,8 +88,12 @@ GEM
     netaddr (1.5.1)
     parser (2.3.0.7)
       ast (~> 2.2)
+    plist (3.2.0)
     powerpack (0.1.1)
     progressbar (0.9.2)
+    rack (1.6.4)
+    rack-protection (1.5.3)
+      rack
     rainbow (2.1.0)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
@@ -107,9 +117,14 @@ GEM
     ruby-progressbar (1.7.5)
     safe_yaml (1.0.4)
     semi_semantic (1.1.0)
+    sinatra (1.4.7)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
     sshkey (1.7.0)
     terminal-table (1.4.5)
     thor (0.19.1)
+    tilt (2.0.4)
     unicode-display_width (1.0.3)
     webmock (1.24.5)
       addressable (>= 2.3.6)
@@ -122,6 +137,7 @@ PLATFORMS
 DEPENDENCIES
   aruba
   bosh_cli
+  mimic
   rspec (~> 3.3)
   rubocop
   webmock (~> 1.24)

--- a/concourse/pipelines/destroy-microbosh.yml
+++ b/concourse/pipelines/destroy-microbosh.yml
@@ -98,6 +98,22 @@ jobs:
           - get: bosh-secrets
           - get: bosh-init-state
           - get: bosh-manifest
+      - task: check-existing-deployments
+        config:
+          platform: linux
+          image: docker:///governmentpaas/bosh-cli
+          inputs:
+            - name: paas-cf
+            - name: bosh-secrets
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                ./paas-cf/concourse/scripts/bosh_login.sh {{bosh_fqdn}} bosh-secrets/bosh-secrets.yml
+
+                ./paas-cf/concourse/scripts/bosh_pre_destroy.rb
       - task: cleanup-orphaned-disks
         config:
           platform: linux

--- a/concourse/scripts/bosh_pre_destroy.rb
+++ b/concourse/scripts/bosh_pre_destroy.rb
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+require 'cli'
+
+bosh_cli = Bosh::Cli::Command::Base.new.director
+deployments = bosh_cli.list_deployments
+
+unless deployments.empty?
+  warn("The following deployments must be deleted before destroying BOSH:")
+  warn(deployments.map { |d| "- " + d.fetch('name') })
+  abort
+end

--- a/concourse/scripts/spec/bosh_pre_destroy_spec.rb
+++ b/concourse/scripts/spec/bosh_pre_destroy_spec.rb
@@ -1,0 +1,52 @@
+require 'yaml'
+require 'mimic'
+
+RSpec.describe "bosh_pre_destroy.rb", :type => :aruba do
+  before(:each) do
+    bosh_port = 25555
+
+    @fake_bosh = Mimic.mimic(:port => bosh_port) do
+      get("/info").returning('{}', 200)
+    end
+
+    bosh_config = {'target' => "http://localhost:#{bosh_port}"}
+    bosh_config_file = Tempfile.new('bosh_config')
+    bosh_config_file.write(bosh_config.to_yaml)
+    bosh_config_file.close
+    set_environment_variable('BOSH_CONFIG', bosh_config_file.path)
+  end
+
+  after(:each) do
+    Mimic.cleanup!
+  end
+
+  context("no deployments") do
+    before(:each) do
+      @fake_bosh.get("/deployments").returning('{}', 200)
+    end
+
+    it "it should return a zero exit code and no output" do
+      run("./bosh_pre_destroy.rb")
+      expect(last_command_started).to have_exit_status(0)
+      expect(last_command_started.stdout).to be_empty
+      expect(last_command_started.stderr).to be_empty
+    end
+  end
+
+  context("two deployments") do
+    before(:each) do
+      @fake_bosh.get("/deployments").returning('[{"name": "one"}, {"name": "two"}]', 200)
+    end
+
+    it "it should return a non-zero exit code and list of deployments" do
+      run("./bosh_pre_destroy.rb")
+      expect(last_command_started).to have_exit_status(1)
+      expect(last_command_started.stdout).to be_empty
+      expect(last_command_started.stderr).to eq <<-EOF
+The following deployments must be deleted before destroying BOSH:
+- one
+- two
+      EOF
+    end
+  end
+end


### PR DESCRIPTION
## What




It's possible to run the `destroy-microbosh` pipeline before the
`destroy-cloudfoundry` pipeline. When this happens, all of the Cloud Foundry
VMs and their related EBS volumes are left "orphaned". You have to cleanup
manually using the AWS console, which is tiresome and prone to error.

Prevent this from happening by aborting the `destroy-microbosh` pipeline
before it calls `bosh-init delete` if there are any existing deployments.
The script lists the deployments that you need to delete.

To test this I've used a library called `mimic` to mock the minimal API
responses from BOSH and overridden `BOSH_CONFIG` to point `bosh_cli` at that
fake BOSH.

I looked at using `webmock` as we've used elsewhere, but it only works for
HTTP calls within the same Ruby interpreter and I want to test the script in
a different process using Aruba so that we can assert on the exit code and
STDERR. I looked at the library `webmock-server`, which allows you to
configure a daemon using normal webmock stubs, but it looked more
complicated and could have affected other tests in this suite.

## How to review

1. Checkout the branch and deploy:

  ```
git checkout feature/113528323-dont_destroy_if_deployments
BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines
```
1. Run the `create-bosh-cloudfoundry` pipeline to get a CF environment
1. Run the `destroy-microbosh` pipeline and see it fail with a message
1. If you wish, run `destroy-cloudfoundry` and then `destroy-microbosh`, see it pass.

## Who can review

Not @dcarley