### PR TITLE
[#116681747] Download fly based on file modified time

### DIFF
--- a/concourse/scripts/fly_sync_and_login.sh
+++ b/concourse/scripts/fly_sync_and_login.sh
@@ -8,19 +8,11 @@ set -euo pipefail
 # FLY_CMD
 # FLY_TARGET
 
-if [ ! -x "$FLY_CMD" ]; then
-  FLY_CMD_URL="${CONCOURSE_URL}/api/v1/cli?arch=amd64&platform=$(uname | tr '[:upper:]' '[:lower:]')"
-  echo "Downloading fly command..."
-  curl "$FLY_CMD_URL" -L -f -k -o "$FLY_CMD" -u "${CONCOURSE_ATC_USER}:${CONCOURSE_ATC_PASSWORD}"
-  chmod +x "$FLY_CMD"
-fi
+FLY_CMD_URL="${CONCOURSE_URL}/api/v1/cli?arch=amd64&platform=$(uname | tr '[:upper:]' '[:lower:]')"
+echo "Downloading fly command..."
+curl "$FLY_CMD_URL" -L -f -k -z "$FLY_CMD" -o "$FLY_CMD" -u "${CONCOURSE_ATC_USER}:${CONCOURSE_ATC_PASSWORD}"
+chmod +x "$FLY_CMD"
 
 echo "Doing fly login"
 echo -e "${CONCOURSE_ATC_USER}\n${CONCOURSE_ATC_PASSWORD}" | \
   $FLY_CMD -t "${FLY_TARGET}" login -k --concourse-url "${CONCOURSE_URL}"
-
-# Sync if the file is older than 1 day (1440 mins)
-if [ -z "$(find "${FLY_CMD}" -mmin -1440)" ]; then
-  echo "Doing fly sync"
-  $FLY_CMD -t "${FLY_TARGET}" sync
-fi


### PR DESCRIPTION
## What

This is a different solution to the problem described and worked around in
bcb785b. We noticed some confusion when upgrading Concourse because the
wrong version of `fly` was used and not replaced because it was <24hrs old.
It's also inconvenient to wait for the file to be re-downloaded each day
when there are no changes.

We can reduce the time that old binaries are used without significantly
increasing the time it takes to run by using HTTP `If-Modified-Since`
headers. I've raised concourse/fly#87 to implement this in `fly` itself, but
in the meantime we can do the same thing using `curl` by passing the `-z`
argument. It will only download the whole file if it either:

1. doesn't exist locally
2. has a later modified time than the file we have locally

I can't see any disadvantage to not using `fly sync` for the moment since we
have to construct the download URL for the first time anyway.

This adds about 300ms to the runtime when you already have `fly`.

Before:

    ➜  paas-cf git:(master) ✗ time ./concourse/scripts/fly_sync_and_login.sh
    Doing fly login
    username: admin
    password:
    target saved
    ./concourse/scripts/fly_sync_and_login.sh  0.03s user 0.02s system 16% cpu 0.339 total

After:

    ➜  paas-cf git:(bugfix/116681747-download_fly_mtime) ✗ time ./concourse/scripts/fly_sync_and_login.sh
    Downloading fly command...
      % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                     Dload  Upload   Total   Spent    Left  Speed
      0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
    Doing fly login
    username: admin
    password:
    target saved
    ./concourse/scripts/fly_sync_and_login.sh  0.06s user 0.03s system 15% cpu 0.608 total

## How to review

1. Checkout this branch: `git checkout bugfix/116681747-download_fly_mtime`
1. Delete your exist binary: `rm bin/fly`
1. Upload your pipelines and watch it download fly: `make dev pipelines`
1. Upload your pipelines again and it shouldn't download fly: `make dev pipelines`
1. Run the pipeline and confirm that `self-update-pipeline` still works.

## Who can review

Not @dcarley