### PR TITLE
[#119818859] Manifest cleanup (part 2)

### DIFF
--- a/manifests/cf-manifest/deployments/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/deployments/000-base-cf-deployment.yml
@@ -9,10 +9,6 @@ releases:
     version: 235
     url: https://bosh.io/d/github.com/cloudfoundry/cf-release?v=235
     sha1: a4ab2d7a2912b8c700ef4b8a45e7f688127930b6
-  - name: nginx
-    version: 2
-    url: https://s3.amazonaws.com/nginx-release/nginx-2.tgz
-    sha1: 667cc1a0f9117bdb4b217ee2b76dc20e61371c02
   - name: diego
     version: 0.1467.0
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/diego-release?v=0.1467.0

--- a/manifests/cf-manifest/deployments/020-cf-resource-pools.yml
+++ b/manifests/cf-manifest/deployments/020-cf-resource-pools.yml
@@ -81,28 +81,6 @@ resource_pools:
         type: gp2
       availability_zone: (( grab meta.zones.z3 ))
 
-  - name: large_z1
-    network: cf1
-    stemcell: (( grab meta.stemcell ))
-    env: (( grab meta.default_env ))
-    cloud_properties:
-      instance_type: m3.medium
-      ephemeral_disk:
-        size: 65536
-        type: gp2
-      availability_zone: (( grab meta.zones.z1 ))
-
-  - name: large_z2
-    network: cf2
-    stemcell: (( grab meta.stemcell ))
-    env: (( grab meta.default_env ))
-    cloud_properties:
-      instance_type: m3.medium
-      ephemeral_disk:
-        size: 65536
-        type: gp2
-      availability_zone: (( grab meta.zones.z2 ))
-
   - name: api_z1
     network: cf1
     stemcell: (( grab meta.stemcell ))
@@ -266,25 +244,6 @@ resource_pools:
       availability_zone: (( grab meta.zones.z2 ))
       elbs:
         - (( grab terraform_outputs.cf_router_elb_name ))
-
-  - name: small_errand
-    network: cf1
-    stemcell: (( grab meta.stemcell ))
-    env: (( grab meta.default_env ))
-    cloud_properties:
-      instance_type: m3.medium
-      ephemeral_disk:
-        size: 10240
-        type: gp2
-      availability_zone: (( grab meta.zones.z1 ))
-
-  - name: xlarge_errand
-    network: cf1
-    stemcell: (( grab meta.stemcell ))
-    env: (( grab meta.default_env ))
-    cloud_properties:
-      instance_type: c3.xlarge
-      availability_zone: (( grab meta.zones.z1 ))
 
 # Diego below
   - name: access_z1

--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -11,7 +11,6 @@ meta:
   api_consul_services:
     cloud_controller_ng: {}
 
-  # FIXME: Remove route_registrar (https://github.com/cloudfoundry/cf-release/issues/950)
   api_templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
@@ -20,8 +19,6 @@ meta:
   - name: metron_agent
     release: (( grab meta.release.name ))
   - name: statsd-injector
-    release: (( grab meta.release.name ))
-  - name: route_registrar
     release: (( grab meta.release.name ))
   - name: logsearch-shipper
     release: (( grab meta.logsearch_shipper.release.name ))
@@ -94,15 +91,12 @@ meta:
   - name: logsearch-shipper
     release: (( grab meta.logsearch_shipper.release.name ))
 
-  # FIXME: Remove route_registrar (https://github.com/cloudfoundry/cf-release/issues/950)
   loggregator_trafficcontroller_templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
   - name: loggregator_trafficcontroller
     release: (( grab meta.release.name ))
   - name: metron_agent
-    release: (( grab meta.release.name ))
-  - name: route_registrar
     release: (( grab meta.release.name ))
   - name: logsearch-shipper
     release: (( grab meta.logsearch_shipper.release.name ))
@@ -139,15 +133,12 @@ meta:
   - name: logsearch-shipper
     release: (( grab meta.logsearch_shipper.release.name ))
 
-  # FIXME: Remove route_registrar (https://github.com/cloudfoundry/cf-release/issues/950)
   uaa_templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
   - name: uaa
     release: (( grab meta.release.name ))
   - name: metron_agent
-    release: (( grab meta.release.name ))
-  - name: route_registrar
     release: (( grab meta.release.name ))
   - name: statsd-injector
     release: (( grab meta.release.name ))
@@ -373,7 +364,6 @@ jobs:
       metron_agent:
         zone: ""
 
-  # FIXME: Remove route_registrar (https://github.com/cloudfoundry/cf-release/issues/950)
   - name: uaa_z1
     templates: (( grab meta.uaa_templates ))
     instances: 1
@@ -387,8 +377,6 @@ jobs:
             uaa: {}
       metron_agent:
         zone: ""
-      route_registrar:
-        routes: []
 
   - name: uaa_z2
     templates: (( grab meta.uaa_templates ))
@@ -403,8 +391,6 @@ jobs:
             uaa: {}
       metron_agent:
         zone: ""
-      route_registrar:
-        routes: []
 
   - name: api_z1
     templates: (( grab meta.api_templates ))
@@ -419,8 +405,6 @@ jobs:
           services: (( grab meta.api_consul_services ))
       metron_agent:
         zone: ""
-      route_registrar:
-        routes: []
 
   - name: api_z2
     templates: (( grab meta.api_templates ))
@@ -435,8 +419,6 @@ jobs:
           services: (( grab meta.api_consul_services ))
       metron_agent:
         zone: ""
-      route_registrar:
-        routes: []
 
   - name: clock_global
     templates: (( grab meta.clock_templates ))
@@ -506,8 +488,6 @@ jobs:
         zone: z1
       metron_agent:
         zone: ""
-      route_registrar:
-        routes: []
 
   - name: loggregator_trafficcontroller_z2
     templates: (( grab meta.loggregator_trafficcontroller_templates ))
@@ -520,8 +500,6 @@ jobs:
         zone: z2
       metron_agent:
         zone: ""
-      route_registrar:
-        routes: []
 
   - name: router_z1
     templates: (( grab meta.router_templates ))

--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -82,16 +82,6 @@ meta:
   - name: logsearch-shipper
     release: (( grab meta.logsearch_shipper.release.name ))
 
-  ha_proxy_templates:
-  - name: consul_agent
-    release: (( grab meta.consul_templates.consul_agent.release ))
-  - name: haproxy
-    release: (( grab meta.release.name ))
-  - name: metron_agent
-    release: (( grab meta.release.name ))
-  - name: logsearch-shipper
-    release: (( grab meta.logsearch_shipper.release.name ))
-
   loggregator_templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
@@ -126,16 +116,6 @@ meta:
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
-
-  postgres_templates:
-  - name: consul_agent
-    release: (( grab meta.consul_templates.consul_agent.release ))
-  - name: postgres
-    release: (( grab meta.release.name ))
-  - name: metron_agent
-    release: (( grab meta.release.name ))
-  - name: logsearch-shipper
-    release: (( grab meta.logsearch_shipper.release.name ))
 
   router_templates:
   - name: consul_agent
@@ -383,40 +363,12 @@ jobs:
           services:
             etcd: {}
 
-  - name: ha_proxy_z1
-    templates: (( grab meta.ha_proxy_templates ))
-    instances: 0
-    resource_pool: router_z1
-    networks:
-      - name: cf1
-        static_ips: ~
-    properties:
-      ha_proxy:
-      router:
-        servers:
-          z1: (( grab jobs.router_z1.networks.router1.static_ips ))
-          z2: (( grab jobs.router_z2.networks.router2.static_ips ))
-      metron_agent:
-        zone: ""
-
   - name: stats_z1
     templates: (( grab meta.stats_templates ))
     instances: 1
     resource_pool: small_z1
     networks:
       - name: cf1
-    properties:
-      metron_agent:
-        zone: ""
-
-  - name: postgres_z1
-    templates: (( grab meta.postgres_templates ))
-    instances: 0
-    resource_pool: medium_z1
-    persistent_disk: 4096
-    networks:
-      - name: cf1
-        static_ips: (( static_ips(7) ))
     properties:
       metron_agent:
         zone: ""
@@ -516,30 +468,6 @@ jobs:
     networks:
       - name: cf2
     properties:
-      metron_agent:
-        zone: ""
-
-  - name: loggregator_z1
-    templates: (( grab meta.loggregator_templates ))
-    instances: 0
-    resource_pool: medium_z1
-    networks:
-      - name: cf1
-    properties:
-      doppler:
-        zone: z1
-      metron_agent:
-        zone: ""
-
-  - name: loggregator_z2
-    templates: (( grab meta.loggregator_templates ))
-    instances: 0
-    resource_pool: medium_z2
-    networks:
-      - name: cf2
-    properties:
-      doppler:
-        zone: z2
       metron_agent:
         zone: ""
 

--- a/manifests/cf-manifest/deployments/030-cf-jobs.yml
+++ b/manifests/cf-manifest/deployments/030-cf-jobs.yml
@@ -8,15 +8,6 @@ meta:
     release:
       name: "logsearch-shipper"
 
-  nfs_client_ranges:
-    - (( grab networks.cf1.subnets.[0].range || nil ))
-    - (( grab networks.cf2.subnets.[0].range || nil ))
-
-  nfs_server:
-    address: (( grab jobs.nfs_z1.networks.cf1.static_ips.[0] || nil ))
-    allow_from_entries: (( grab meta.nfs_client_ranges ))
-    share: ~
-
   api_consul_services:
     cloud_controller_ng: {}
 
@@ -29,8 +20,6 @@ meta:
   - name: metron_agent
     release: (( grab meta.release.name ))
   - name: statsd-injector
-    release: (( grab meta.release.name ))
-  - name: nfs_mounter
     release: (( grab meta.release.name ))
   - name: route_registrar
     release: (( grab meta.release.name ))
@@ -61,8 +50,6 @@ meta:
   - name: cloud_controller_worker
     release: (( grab meta.release.name ))
   - name: metron_agent
-    release: (( grab meta.release.name ))
-  - name: nfs_mounter
     release: (( grab meta.release.name ))
   - name: logsearch-shipper
     release: (( grab meta.logsearch_shipper.release.name ))
@@ -139,16 +126,6 @@ meta:
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
-
-  nfs_templates:
-  - name: consul_agent
-    release: (( grab meta.consul_templates.consul_agent.release ))
-  - name: debian_nfs_server
-    release: (( grab meta.release.name ))
-  - name: metron_agent
-    release: (( grab meta.release.name ))
-  - name: logsearch-shipper
-    release: (( grab meta.logsearch_shipper.release.name ))
 
   postgres_templates:
   - name: consul_agent
@@ -432,18 +409,6 @@ jobs:
       metron_agent:
         zone: ""
 
-  - name: nfs_z1
-    templates: (( grab meta.nfs_templates ))
-    instances: 0
-    resource_pool: medium_z1
-    persistent_disk: 102400
-    networks:
-      - name: cf1
-        static_ips: ~
-    properties:
-      metron_agent:
-        zone: ""
-
   - name: postgres_z1
     templates: (( grab meta.postgres_templates ))
     instances: 0
@@ -504,7 +469,6 @@ jobs:
         zone: ""
       route_registrar:
         routes: []
-      nfs_server: (( grab meta.nfs_server ))
 
   - name: api_z2
     templates: (( grab meta.api_templates ))
@@ -521,7 +485,6 @@ jobs:
         zone: ""
       route_registrar:
         routes: []
-      nfs_server: (( grab meta.nfs_server ))
 
   - name: clock_global
     templates: (( grab meta.clock_templates ))
@@ -544,7 +507,6 @@ jobs:
     properties:
       metron_agent:
         zone: ""
-      nfs_server: (( grab meta.nfs_server ))
 
   - name: api_worker_z2
     templates: (( grab meta.api_worker_templates ))
@@ -556,7 +518,6 @@ jobs:
     properties:
       metron_agent:
         zone: ""
-      nfs_server: (( grab meta.nfs_server ))
 
   - name: loggregator_z1
     templates: (( grab meta.loggregator_templates ))

--- a/manifests/cf-manifest/deployments/040-cf-properties.yml
+++ b/manifests/cf-manifest/deployments/040-cf-properties.yml
@@ -89,8 +89,6 @@ properties:
     port: 443
   syslog_daemon_config: ~
 
-  nfs_server: (( grab meta.nfs_server ))
-
   collector:
 
   doppler:

--- a/manifests/cf-manifest/spec/resource_pools_spec.rb
+++ b/manifests/cf-manifest/spec/resource_pools_spec.rb
@@ -5,13 +5,8 @@ RSpec.describe "resource_pools" do
   POOL_BASE_NAMES = %w(
     small
     medium
-    large
     api
     router
-  )
-  ERRAND_POOL_NAMES = %w(
-    small_errand
-    xlarge_errand
   )
   ZONE_KEYS = {
     "z1" => :zone0,
@@ -26,16 +21,6 @@ RSpec.describe "resource_pools" do
         it "should specify the correct AWS AZ" do
           expect(pool["cloud_properties"]["availability_zone"]).to eq(terraform_fixture(ZONE_KEYS[zone_suffix]))
         end
-      end
-    end
-  end
-
-  ERRAND_POOL_NAMES.each do |pool_name|
-    describe pool_name do
-      let(:pool) { resource_pools.find {|p| p["name"] == pool_name } }
-
-      it "should specify the correct AWS AZ" do
-        expect(pool["cloud_properties"]["availability_zone"]).to eq(terraform_fixture(:zone0))
       end
     end
   end


### PR DESCRIPTION
## What

In order to make the upcoming transition to cloud-config and the Bosh zones features easier we want to remove things from the manifests that aren't used. This therefore makes the following changes:

* Remove NFS job definitions and related properties
* Removed unused ha-proxy and Postgres job definitions
* Remove route_registrar FIXMEs
* Remove unused nginx release
* Remove some unused resource_pools.

See the individual commits for more details.

Note: this doesn't remove the unused Diego job definitions as we're likely to use them instead of the colocated VMs at some point.

## How to review

Deploy this branch. Due to the way Bosh handles jobs being removed from VMs, it's probably necessary to test both a clean deployment, and an update to an existing deployment.

## Who can review

Anyone but myself.