### PR TITLE
Update bosh_cli gem to 1.3232.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem 'aruba'
 gem 'rspec', '~> 3.3'
-gem 'bosh_cli'
+gem 'bosh_cli', '= 1.3232.0'
 gem 'webmock', "~> 1.24"
 gem 'rubocop'
 gem 'mimic'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,17 +14,17 @@ GEM
       jmespath (~> 1.0)
     aws-sdk-resources (2.2.0)
       aws-sdk-core (= 2.2.0)
-    blobstore_client (1.3202.0)
+    blobstore_client (1.3232.0)
       aws-sdk-resources (= 2.2.0)
-      bosh_common (~> 1.3202.0)
+      bosh_common (~> 1.3232.0)
       httpclient (= 2.7.1)
       multi_json (~> 1.1)
-    bosh-template (1.3202.0)
+    bosh-template (1.3232.0)
       semi_semantic (~> 1.1.0)
-    bosh_cli (1.3202.0)
-      blobstore_client (~> 1.3202.0)
-      bosh-template (~> 1.3202.0)
-      bosh_common (~> 1.3202.0)
+    bosh_cli (1.3232.0)
+      blobstore_client (~> 1.3232.0)
+      bosh-template (~> 1.3232.0)
+      bosh_common (~> 1.3232.0)
       cf-uaa-lib (~> 3.2.1)
       highline (~> 1.6.2)
       httpclient (= 2.7.1)
@@ -37,7 +37,7 @@ GEM
       progressbar (~> 0.9.0)
       sshkey (~> 1.7.0)
       terminal-table (~> 1.4.3)
-    bosh_common (1.3202.0)
+    bosh_common (1.3232.0)
       logging (~> 1.8.2)
       semi_semantic (~> 1.1.0)
     builder (3.2.2)
@@ -65,7 +65,8 @@ GEM
     hashdiff (0.3.0)
     highline (1.6.21)
     httpclient (2.7.1)
-    jmespath (1.1.3)
+    jmespath (1.2.4)
+      json_pure (>= 1.8.1)
     json (1.8.3)
     json_pure (1.8.3)
     little-plugger (1.1.4)
@@ -136,11 +137,11 @@ PLATFORMS
 
 DEPENDENCIES
   aruba
-  bosh_cli
+  bosh_cli (= 1.3232.0)
   mimic
   rspec (~> 3.3)
   rubocop
   webmock (~> 1.24)
 
 BUNDLED WITH
-   1.11.2
+   1.12.5


### PR DESCRIPTION
## What
The previous version was causing an error related to Bosh::Cli::Config.
We now pin the version to a known working version.

## How to review
* Run `bundle`
* Run the tests via `make test`
* The bosh_pre_destroy test should pass
* If it fails with an error related to Bosh::Cli::Config, you may have to remove the old bosh_cli gem, or recreate the gemset entirely.

## Who can review
Anyone but me