### PR TITLE
[#113528323] Force IPv4 loopback for bosh_pre_destroy test

### DIFF
--- a/concourse/scripts/spec/bosh_pre_destroy_spec.rb
+++ b/concourse/scripts/spec/bosh_pre_destroy_spec.rb
@@ -3,13 +3,14 @@ require 'mimic'
 
 RSpec.describe "bosh_pre_destroy.rb", :type => :aruba do
   before(:each) do
+    bosh_host = "127.0.0.1"
     bosh_port = 25555
 
-    @fake_bosh = Mimic.mimic(:port => bosh_port) do
+    @fake_bosh = Mimic.mimic(:hostname => bosh_host, :port => bosh_port) do
       get("/info").returning('{}', 200)
     end
 
-    bosh_config = {'target' => "http://localhost:#{bosh_port}"}
+    bosh_config = {'target' => "http://#{bosh_host}:#{bosh_port}"}
     bosh_config_file = Tempfile.new('bosh_config')
     bosh_config_file.write(bosh_config.to_yaml)
     bosh_config_file.close


### PR DESCRIPTION
## What

We've seen an intermittent problem with the `bosh_pre_destroy.rb` tests
running in Travis CI whereby BOSH is unable to connect to the fake BOSH
server that's provided by Mimic.

The error is truncated in the test output because Aruba's command timeout kicks
in before BOSH has retried 4 times and printed the traceback. But you can see
it by setting `aruba_config.exit_timeout=60` in `support/configure_aruba.rb`:

     1.2) Failure/Error: raise Exception.new("Last command output: " + last_command_started.output)

          Exception:
            Last command output: [WARNING] cannot access director, trying 4 more times...
            [WARNING] cannot access director, trying 3 more times...
            [WARNING] cannot access director, trying 2 more times...
            [WARNING] cannot access director, trying 1 more times...
            /home/travis/build/alphagov/paas-cf/vendor/bundle/ruby/2.2.0/gems/bosh_cli-1.3202.0/lib/cli/client/director.rb:856:in `rescue in perform_http_request': cannot access director (Connection refused - connect(2) for "::1" port 25555 (::1:25555)) (Bosh::Cli::DirectorInaccessible)
            …

Each time it fails it can be seen trying to connect to the IPv6 loopback
address. When logging is added it can be seen that all of the successful
runs use IPv4 loopback instead.

It seems that IPv6 is disabled in Travis' container based infrastructure
(which is where our tests are running):
https://docs.travis-ci.com/user/ci-environment/#Networking

> The virtual machines in the Legacy environment running the tests have IPv6
> enabled. They do not have any external IPv4 address but are fully able to
> communicate with any external IPv4 service. The container-based, OSX, and
> Trusty builds do not currently have IPv6 connectivity.

So Mimic won't be binding dual-stack to `::1`. travis-ci/travis-ci#4978
describes that there are incorrect `hosts(5)` entries for IPv6. Though it's
not clear why BOSH sometimes resolves `localhost` to IPv4 and sometimes to
IPv6.

## How to review

To confirm that this fixes the original problem you'll probably need to restart the Travis build several times. I've done this quite a lot myself though, so I think it'd be sufficient to review the code alone.

## Who can review

Not @dcarley