### PR TITLE
[#120118561] Upgrade concourse stemcell to 3232.4

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -19,8 +19,8 @@ resource_pools:
   - name: concourse
     network: concourse
     stemcell:
-      url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3200
-      sha1: 9ec6f6affe369f3364eb0db55266a513d3298080
+      url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3232.4
+      sha1: ac920cae17c7159dee3bf1ebac727ce2d01564e9
     cloud_properties:
       instance_type: t2.medium
       availability_zone: (( grab terraform_outputs.zone0 ))


### PR DESCRIPTION
## What

Upgrade the deployer-concourse stemcell to 3232.4. Version 3200 has known vulnerabilities, so we should upgrade.

## How to review

Run the create-deployer pipeline (in a bootstrap-concourse instance). Verify that the deployer concourse continues to work (probably easiest to run the create-bosh-cloudfoundry pipeline).

## Who can review

Anyone but myself.
