### PR TITLE
Set support_address to our developer docs

### DIFF
--- a/manifests/cf-manifest/deployments/040-cf-properties.yml
+++ b/manifests/cf-manifest/deployments/040-cf-properties.yml
@@ -21,7 +21,7 @@ properties:
 
   app_ssh: ~
 
-  support_address: "http://support.cloudfoundry.com"
+  support_address: "https://government-paas-developer-docs.readthedocs.io/"
   description: null
   ssl:
     skip_cert_verify: false


### PR DESCRIPTION
## Notice

No story ID - I'm invoking Tech Lead privilege. This was noted in [#119983605](https://www.pivotaltracker.com/story/show/119983605) and [PaaS Improvements](https://docs.google.com/spreadsheets/d/1034dgtWbchumi-xJuTP2n4Iq8KpxF20Vrwgy3txmeBg/edit#gid=520176062).

## What

The default address of "support.cloudfoundry.com" redirects to
"support.run.pivotal.io/home" which is the support portal for Pivotal Web
Services (commercial hosted offering).

Change it to point to our new developer documentation site instead which has
information about how to use our Cloud Foundry service and the email address
for our support ticketing system. I've dropped `/en/latest` of the URL
because it'll redirect automatically and may do some locale magic.

From looking at cf-release and capi-release it seems that this is only used
by cloud_controller's `/info` endpoint. So it's unlikely that many people
will see it, but it still shouldn't be misleading.

Now looks like this:

    ➜  paas-cf git:(bugfix/support_address) ✗ cf curl /info | jq .support
    "https://government-paas-developer-docs.readthedocs.io/"

## How to review

Foremost check that the URL is correct and appropriate.

You can deploy it and confirm using the `cf curl` command above. But it's probably not necessary.

## Who can review

Ideally @Rory80Hz, but anyone can.