### PR TITLE
Don't output Concourse password to STDERR

### DIFF
--- a/concourse/scripts/environment.sh
+++ b/concourse/scripts/environment.sh
@@ -52,7 +52,3 @@ export LOGSEARCH_URL=https://logsearch.${SYSTEM_DNS_ZONE_NAME}
 export GRAFANA_URL=https://metrics.${SYSTEM_DNS_ZONE_NAME}
 export GRAPHITE_URL=https://metrics.${SYSTEM_DNS_ZONE_NAME}:3001
 EOF
-
-echo "Deploy environment name: $DEPLOY_ENV" 1>&2
-echo "Concourse URL is ${CONCOURSE_URL}" 1>&2
-echo "Concourse auth is ${CONCOURSE_ATC_USER} : ${CONCOURSE_ATC_PASSWORD}" 1>&2


### PR DESCRIPTION
## Notice

No story ID - I'm invoking Tech Lead privilege. This came up in conversation, but I can't remember who or when.

## What

Stop the Concourse password from being written to STDERR each time something
calls `environment.sh`. This mostly happens on a developer's command line
when uploading pipelines, but also gets written into the task output of
Concourse tasks which call back to Concourse (e.g. self updating pipelines
and bosh-cli tests). Concourse has access to the whole environment so we
should be more protective of its password.

You'll still be able to get the password by running `make <env> showenv` and
it will still be output when running `make <env> bootstrap` which happens
less frequently and doesn't get called by Concourse itself.

## How to review

1. `git checkout bugfix/dont_echo_concourse_password`
1. `BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines` and check that it doesn't output the password.
1. Run the `create-bosh-cloudfoundry` pipeline and check that the `init` and `bosh-tests` jobs don't list the password.

## Who can review

Not @dcarley.