### PR TITLE
Use per-account email addresses for acc creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,6 @@ dev: globals check-env-vars ## Set Environment to DEV
 	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipelineapps.digital)
 	$(eval export SKIP_COMMIT_VERIFICATION=true)
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-default.yml)
-	$(eval export DISABLE_USER_CREATION=true)
 	@true
 
 .PHONY: ci
@@ -73,6 +72,7 @@ ci: globals check-env-vars ## Set Environment to CI
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.ci.cloudpipeline.digital)
 	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.ci.cloudpipelineapps.digital)
 	$(eval export ALERT_EMAIL_ADDRESS=the-multi-cloud-paas-team+ci@digital.cabinet-office.gov.uk)
+	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS=${ALERT_EMAIL_ADDRESS})
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-default.yml)
 	@true
 
@@ -87,6 +87,7 @@ staging: globals check-env-vars ## Set Environment to Staging
 	$(eval export SYSTEM_DNS_ZONE_NAME=staging.cloudpipeline.digital)
 	$(eval export APPS_DNS_ZONE_NAME=staging.cloudpipelineapps.digital)
 	$(eval export ALERT_EMAIL_ADDRESS=the-multi-cloud-paas-team+staging@digital.cabinet-office.gov.uk)
+	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS=${ALERT_EMAIL_ADDRESS})
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-default.yml)
 	@true
 
@@ -100,6 +101,7 @@ prod: globals check-env-vars ## Set Environment to Production
 	$(eval export SYSTEM_DNS_ZONE_NAME=cloud.service.gov.uk)
 	$(eval export APPS_DNS_ZONE_NAME=cloudapps.digital)
 	$(eval export ALERT_EMAIL_ADDRESS=the-multi-cloud-paas-team+prod@digital.cabinet-office.gov.uk)
+	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS=${ALERT_EMAIL_ADDRESS})
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-prod.yml)
 	@true
 

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1144,7 +1144,7 @@ jobs:
                   export UAA_CLIENT_SECRET=$($VAL_FROM_YAML secrets.uaa_admin_client_secret cf-secrets/cf-secrets.yml)
                   cd paas-cf/scripts
                   bundle
-                  bundle exec sync-admin-users.rb ${API_ENDPOINT} ../config/admin_users.yml
+                  bundle exec sync-admin-users.rb ${API_ENDPOINT} ../config/admin_users.yml "{{NEW_ACCOUNT_EMAIL_ADDRESS}}"
 
         - task: register-rds-broker
           config:

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -78,6 +78,7 @@ system_dns_zone_name: ${SYSTEM_DNS_ZONE_NAME}
 apps_dns_zone_name: ${APPS_DNS_ZONE_NAME}
 git_concourse_pool_clone_full_url_ssh: ${git_concourse_pool_clone_full_url_ssh}
 ALERT_EMAIL_ADDRESS: ${ALERT_EMAIL_ADDRESS:-}
+NEW_ACCOUNT_EMAIL_ADDRESS: ${NEW_ACCOUNT_EMAIL_ADDRESS:-}
 bosh_az: ${bosh_az}
 bosh_manifest_state: bosh-manifest-state-${bosh_az}.json
 bosh_fqdn: bosh.${SYSTEM_DNS_ZONE_NAME}
@@ -89,7 +90,7 @@ generate_manifest_file() {
   # This exists because concourse does not support boolean value interpolation by design
   enable_auto_deploy=$([ "${ENABLE_AUTO_DEPLOY:-}" ] && echo "true" || echo "false")
   continuous_smoke_tests_trigger=$([ "${ALERT_EMAIL_ADDRESS:-}" ] && echo "true" || echo "false")
-  disable_user_creation=$([ "${DISABLE_USER_CREATION:-}" ] && echo "true" || echo "false")
+  disable_user_creation=$([ "${NEW_ACCOUNT_EMAIL_ADDRESS:-}" ] && echo "false" || echo "true")
   sed -e "s/{{auto_deploy}}/${enable_auto_deploy}/" \
       -e "s/{{continuous_smoke_tests_trigger}}/${continuous_smoke_tests_trigger}/" \
       -e "s/{{gpg_ids}}/${gpg_ids}/" \

--- a/scripts/lib/mail_credentials_helper.rb
+++ b/scripts/lib/mail_credentials_helper.rb
@@ -8,7 +8,6 @@ require 'gpgme'
 
 module EmailCredentialsHelper
 
-  DEFAULT_SOURCE_ADDRESS = "the-multi-cloud-paas-team@digital.cabinet-office.gov.uk"
   DEFAULT_REGION = "eu-west-1"
 
   def self.encrypt_message_to(message, key)
@@ -50,9 +49,7 @@ module EmailCredentialsHelper
     })
   end
 
-  def self.send_admin_credentials(api_url, user, source_address=nil)
-    source_address ||= DEFAULT_SOURCE_ADDRESS
-
+  def self.send_admin_credentials(api_url, user, source_address)
     attachment_source = encrypt_message_to(user[:password], user[:gpg_key])
 
     send_email(

--- a/scripts/sync-admin-users.rb
+++ b/scripts/sync-admin-users.rb
@@ -34,6 +34,7 @@ end
 
 api_url = ARGV[0] || raise("You must pass API endpoint as first argument")
 users_filename = ARGV[1] || raise("You must pass a file of users as second argument")
+source_address = ARGV[2] || raise("You must pass an SES-validated address as third argument")
 
 admin_user = ENV['UAA_CLIENT'] || "admin"
 admin_password = ENV['UAA_CLIENT_SECRET'] || raise("Must set $UAA_CLIENT_SECRET env var")
@@ -52,7 +53,7 @@ created_users, deleted_users = uaa_sync_admin_users.update_admin_users(users)
 
 created_users.each { |user|
   puts "Sending credentials to new user #{user[:username]}"
-  EmailCredentialsHelper.send_admin_credentials(api_url, user)
+  EmailCredentialsHelper.send_admin_credentials(api_url, user, source_address)
 }
 
 puts "Created users: #{created_users.length}"


### PR DESCRIPTION
## Wat
We do not have the same email addresses SES-validated in all environments, preferring addresses that are +tagged with the environment name so they can be easily filtered.

This also removes the default source email address for the mail helper so specifying one is mandatory. It also removes DISABLE_USER_CREATION and uses the presence of an email address in the env var to enable/disable the account creation, matching the behaviour of ALERT_EMAIL_ADDRESS.

## How to test
Because this is disabled in dev and we'd rather you didn't email all team members this is slightly more manual than usual.

1) Fork this branch.
2) Remove all users except yourself from `config/admin_users.yml` & commit/push the resulting branch.
3) `export NEW_ACCOUNT_EMAIL_ADDRESS=the-multi-cloud-paas-team@digital.cabinet-office.gov.uk`
4) Update your pipelines using the `Makefile` and redeploy.

You should get an email from the environment telling you your password.

## Who can review
Not @jonty