### PR TITLE
[#118830743] Don't crash when master is not the default branch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 awscli>=1.10.16
 yamllint>=1.0.0
+PyGithub>=1.26.0

--- a/scripts/find_diverged_forks.py
+++ b/scripts/find_diverged_forks.py
@@ -2,6 +2,9 @@
 import argparse
 from github import Github
 
+BOLD = '\033[1m'
+ENDC = '\033[0m'
+
 class ForkChecker(object):
     def __init__(self, github_token):
         self.github_token = github_token
@@ -10,7 +13,10 @@ class ForkChecker(object):
         g = Github(self.github_token)
         for repo in g.get_organization(organization).get_repos(type='fork'):
             if repo.name.startswith(prefix) or repo.name in extra_repos:
-                comparison = repo.compare(repo.owner.login + ':master', repo.parent.owner.login + ':master')
+                comparison = repo.compare(
+                    repo.owner.login + ':' + repo.default_branch,
+                    repo.parent.owner.login + ':' + repo.parent.default_branch
+                )
 
                 open_prs = []
                 for pull in repo.parent.get_pulls():
@@ -18,13 +24,13 @@ class ForkChecker(object):
                         open_prs.append(pull)
 
                 if comparison.ahead_by or open_prs:
-                    print "\n%s/%s:" % (organization, repo.name)
+                    print (BOLD + "\n== %s/%s ==" + ENDC) % (organization, repo.name)
 
                 if comparison.ahead_by:
-                    print " * Upstream ahead by %s commits: %s" % (comparison.ahead_by, comparison.html_url)
+                    print "\033[91m * " + ENDC + "Upstream ahead by %s commits: %s" % (comparison.ahead_by, comparison.html_url)
 
                 for pull in open_prs:
-                    print " * Open pull request: %s" % pull.html_url
+                    print "\033[93m * " + ENDC + "Open pull request: %s" % pull.html_url
         print
 
 


### PR DESCRIPTION
Related: [#118830743 SPIKE: Investigate if forked code requires updating](https://www.pivotaltracker.com/n/projects/1275640/stories/118830743)

## What

In #268 we added a script `find_diverged_forks.py` to check our forked repositories to their upstream

This script, in cases where the default branch (of either our fork or the origin) is not `master`, will crash as the comparison is invalid. we must use the current default branch to allow tracking of branch renames and reconfigurations.

This also includes some slightly improved formatting, and a requirements.txt addition to simplify installation.

## How to review

1) Get a personal access token from https://github.com/settings/tokens
2) Run `./scripts/find_diverged_forks.py alphagov --github-token=<YOUR_TOKEN>` - this will check _every_ GDS fork
3) Wait for a really long time
4) Observe that it doesn't crash

## Who can review
Not @jonty
