### PR TITLE
[#120368533] Specify a branch for os-conf-release resource

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -102,6 +102,7 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-os-conf-release.git
       tag_filter: {{cf_os_conf_version}}
+      branch: gds_master
 
   - name: graphite-nozzle
     type: git


### PR DESCRIPTION
## What

The `tag_filter` option for the git-resource will by default only look for
tags that resolve to commits on the `master` branch, however the tag that we
were giving it resolves to a commit on the `gds_master` branch of
alphagov/os-conf-release.

This caused Concourse to hang in a rather surprising way. The `cf-deploy`
job wasn't triggered automatically, so at first glance it looked like the
pipeline had run successfully. If you triggered the `cf-deploy` job manually
then it got stuck in a "pending" state with a message:

    waiting for a suitable set of input versions

Tim found that the reporting for this has improved in later versions of
Concourse:

- https://www.pivotaltracker.com/n/projects/1059262/stories/118715899

It's not clear how we missed this in testing. We can look at that after
we've resolved the immediate problem with our CI pipeline.

## How to review

1. Checkout this branch: `git fetch && git co bugfix/120368533-branch_for_os_conf_release`
1. Deploy from this branch, you don't need to specify `BRANCH` because the changes are in the pipeline config itself: `make dev pipelines`
1. Run the `create-bosh-cloudfoundry` pipeline.
1. Double check that the `cf-deploy` job was triggered and completed successfully.

## Who can review

Not @dcarley