### PR TITLE
[#120763743] Fix the tag already exist problem

### DIFF
--- a/concourse/scripts/tag-release.sh
+++ b/concourse/scripts/tag-release.sh
@@ -50,6 +50,7 @@ create_new_tag(){
 }
 
 cd paas-cf
+git fetch --tags
 check_already_tagged "${TAG_PREFIX}"
 
 echo Configure Git


### PR DESCRIPTION
## What

Story: https://www.pivotaltracker.com/story/show/120763743

Our pipeline fails if Concourse uses cached git resources that that are not in sync with origin repo. It may happen that previous run of the pipeline created a tag already so we want to detect this and skip tag promotion.

Error message from staging pipeline:

```
To git@github.com:alphagov/paas-cf.git
 ! [rejected]        prod-0.0.101 -> prod-0.0.101 (already exists)
  error: failed to push some refs to
  'git@github.com:alphagov/paas-cf.git'
  hint: Updates were rejected because the tag already exists in the
  remote.
```

## How to review

run `make test` and check if it passes. 

## Who can review

not @keymon or @combor
