### PR TITLE
[#118838943] Fix typo in admin sync logging

### DIFF
--- a/scripts/lib/mail_credentials_helper.rb
+++ b/scripts/lib/mail_credentials_helper.rb
@@ -28,8 +28,8 @@ module EmailCredentialsHelper
     region = opts.fetch(:region, DEFAULT_REGION)
     ses = Aws::SES::Client.new(:region => region)
     mail = Mail.new do
-      from    opts.fetch(:source_address)
-      to      opts.fetch(:email)
+      from    opts.fetch(:from)
+      to      opts.fetch(:to)
       subject opts.fetch(:subject)
 
       text_part do

--- a/scripts/lib/mail_credentials_helper.rb
+++ b/scripts/lib/mail_credentials_helper.rb
@@ -28,21 +28,21 @@ module EmailCredentialsHelper
     region = opts.fetch(:region, DEFAULT_REGION)
     ses = Aws::SES::Client.new(:region => region)
     mail = Mail.new do
-      from    opts[:source_address]
-      to      opts[:email]
-      subject opts[:subject]
+      from    opts.fetch(:source_address)
+      to      opts.fetch(:email)
+      subject opts.fetch(:subject)
 
       text_part do
-        body opts[:message]
+        body opts.fetch(:message)
       end
     end
-    opts[:attachments].each { | name, value |
+    opts.fetch(:attachments, {}).each { | name, value |
       mail.attachments[name] = value
     }
 
     ses.send_raw_email({
-      source: opts[:from],
-      destinations: [opts[:to]],
+      source: opts.fetch(:from),
+      destinations: [opts.fetch(:to)],
       raw_message: {
         data: mail.to_s,
       },
@@ -50,11 +50,11 @@ module EmailCredentialsHelper
   end
 
   def self.send_admin_credentials(api_url, user, source_address)
-    attachment_source = encrypt_message_to(user[:password], user[:gpg_key])
+    attachment_source = encrypt_message_to(user.fetch(:password), user.fetch(:gpg_key))
 
     send_email(
       :from           => source_address,
-      :to             => user[:email],
+      :to             => user.fetch(:email),
       :subject        => "PaaS admin account credentials",
       :message        => %Q{
 Hello,
@@ -62,8 +62,8 @@ Hello,
 A CF admin user has been created for you with the following details:
 
  - API url: #{api_url}
- - Login: #{user[:username]}
- - Password: Attached as a GPG encrypted file with key ID #{user[:gpg_key]}
+ - Login: #{user.fetch(:username)}
+ - Password: Attached as a GPG encrypted file with key ID #{user.fetch(:gpg_key)}
 
 You can decrypt the password attachment using:
 
@@ -71,7 +71,7 @@ You can decrypt the password attachment using:
 
 You can login and change your password by executing:
 
-  cf login -a #{api_url} -u #{user[:username]}
+  cf login -a #{api_url} -u #{user.fetch(:username)}
   cf passwd
 
 Regards,

--- a/scripts/lib/uaa_sync_admin_users.rb
+++ b/scripts/lib/uaa_sync_admin_users.rb
@@ -180,7 +180,7 @@ class UaaSyncAdminUsers
       end
 
       if Time.parse(user_info.fetch("meta").fetch("created")) < (Time.now - HOURS_TO_KEEP_TEST_USERS * 60 * 60)
-        get_logger.info("Deleting admin user #{user_info.fetch("userName")} which is not in the list.")
+        get_logger.info("Deleting admin user #{user_info.fetch("username")} which is not in the list.")
         ua.delete(:user, user_id)
         deleted_users << { username: user_info.fetch("username"), email: user_info.fetch("emails").fetch(0).fetch("value") }
       else

--- a/scripts/lib/uaa_sync_admin_users.rb
+++ b/scripts/lib/uaa_sync_admin_users.rb
@@ -40,7 +40,7 @@ class UaaSyncAdminUsers
     @admin_password = admin_password
     @options = options
 
-    self.admin_groups = DEFAULT_ADMIN_GROUPS + (options[:extra_admin_groups] || [])
+    self.admin_groups = DEFAULT_ADMIN_GROUPS + (options.fetch(:extra_admin_groups, []))
 
     self.token_issuer = CF::UAA::TokenIssuer.new(@target, @admin_client, @admin_password, @options)
     self.token_issuer.logger = self.get_logger()
@@ -51,9 +51,9 @@ class UaaSyncAdminUsers
   def get_logger()
     if @logger.nil?
       if ENV['UAA_LOG_LEVEL']
-        log_level = ENV['UAA_LOG_LEVEL'].strip.downcase.to_sym
+        log_level = ENV.fetch('UAA_LOG_LEVEL').strip.downcase.to_sym
       else
-        log_level = @options[:log_level] || :info
+        log_level = @options.fetch(:log_level, :info)
       end
       @logger = Logger.new($stdout)
       @logger.level = Logger::Severity.const_get(log_level.to_s.upcase)
@@ -67,7 +67,7 @@ class UaaSyncAdminUsers
   end
 
   def auth_header()
-    return "#{self.token['token_type']} #{self.token['access_token']}"
+    return "#{self.token.fetch('token_type')} #{self.token.fetch('access_token')}"
   end
 
   def get_user_by_username(username)
@@ -86,11 +86,11 @@ class UaaSyncAdminUsers
   # params:
   # - user: Hash as {username: ..., password: ..., email:...}
   def create_user(user)
-    self.get_logger.info("Creating user #{user[:username]}")
+    self.get_logger.info("Creating user #{user.fetch(:username)}")
     info = {
-      userName: user[:username],
-      password: user[:password],
-      emails: [{value: user[:email]}],
+      userName: user.fetch(:username),
+      password: user.fetch(:password),
+      emails: [{value: user.fetch(:email)}],
     }
     self.ua.add(:user, info)
   end
@@ -134,28 +134,28 @@ class UaaSyncAdminUsers
     # Get/Create users if required
     users_info = {}
     users.each{ |user|
-      user_info = self.get_user_by_username(user[:username])
+      user_info = self.get_user_by_username(user.fetch(:username))
       if user_info.nil?
         user[:password] ||= SecureRandom.hex
         user_info = self.create_user(user)
         created_users << user
       end
-      users_info[user[:username]] = user_info
+      users_info[user.fetch(:username)] = user_info
     }
 
     # Add users to groups if required
     self.admin_groups.each { |group_name|
       group_info_to_update = nil
       member_set = Set.new
-      groups_info[group_name]["members"].each { |m|
-        member_set << m["value"]
+      groups_info.fetch(group_name).fetch("members").each { |m|
+        member_set << m.fetch("value")
       }
       users.each{ |user|
-        user_info = users_info[user[:username]]
-        if not member_set.include? user_info["id"]
-          get_logger.info("Adding user #{user_info["username"]} to group #{group_name}")
-          member_set << user_info["id"]
-          group_info_to_update ||= groups_info[group_name].clone()
+        user_info = users_info.fetch(user.fetch(:username))
+        if not member_set.include? user_info.fetch("id")
+          get_logger.info("Adding user #{user_info.fetch("username")} to group #{group_name}")
+          member_set << user_info.fetch("id")
+          group_info_to_update ||= groups_info.fetch(group_name).clone()
           group_info_to_update["members"] = member_set.to_a
         end
       }
@@ -166,10 +166,10 @@ class UaaSyncAdminUsers
     }
 
     # Remove users in groups that should not be there
-    allowed_user_ids = users_info.map { |_, v| v["id"] }
+    allowed_user_ids = users_info.map { |_, v| v.fetch("id") }
     existing_user_ids = Set.new
     groups_info.each { |_, group_info|
-      group_info["members"].each{ |m| existing_user_ids << m["value"] }
+      group_info.fetch("members").each{ |m| existing_user_ids << m.fetch("value") }
     }
 
     to_delete_user_ids = existing_user_ids - allowed_user_ids
@@ -179,12 +179,12 @@ class UaaSyncAdminUsers
         raise "User #{user_id} not found"
       end
 
-      if Time.parse(user_info["meta"]["created"]) < (Time.now - HOURS_TO_KEEP_TEST_USERS * 60 * 60)
-        get_logger.info("Deleting admin user #{user_info["userName"]} which is not in the list.")
+      if Time.parse(user_info.fetch("meta").fetch("created")) < (Time.now - HOURS_TO_KEEP_TEST_USERS * 60 * 60)
+        get_logger.info("Deleting admin user #{user_info.fetch("userName")} which is not in the list.")
         ua.delete(:user, user_id)
-        deleted_users << { username: user_info["username"], email: user_info["emails"][0]["value"] }
+        deleted_users << { username: user_info.fetch("username"), email: user_info.fetch("emails").fetch(0).fetch("value") }
       else
-        get_logger.info("Not deleting user #{user_info["username"]} created in the last #{HOURS_TO_KEEP_TEST_USERS} hours.")
+        get_logger.info("Not deleting user #{user_info.fetch("username")} created in the last #{HOURS_TO_KEEP_TEST_USERS} hours.")
       end
     }
 

--- a/scripts/sync-admin-users.rb
+++ b/scripts/sync-admin-users.rb
@@ -18,14 +18,14 @@ def get_uaa_target(api_url)
     raise "Error connecting to API endpoint #{uri}: #{response}"
   end
   api_info = JSON.load(response.body)
-  api_info["token_endpoint"]
+  api_info.fetch("token_endpoint")
 end
 
 def load_admin_user_list(filename)
   users = YAML.load_file(filename)
   users.each_with_index.map { |u, i|
     {
-      username: u["username"] || u["email"],
+      username: u.fetch("username", u.fetch("email")),
       email: u["email"] || raise("User #{i} defined in file #{filename} is missing email"),
       gpg_key: u["gpg_key"] || raise("User #{i} defined in file #{filename} is missing gpg_key"),
     }
@@ -36,7 +36,7 @@ api_url = ARGV[0] || raise("You must pass API endpoint as first argument")
 users_filename = ARGV[1] || raise("You must pass a file of users as second argument")
 source_address = ARGV[2] || raise("You must pass an SES-validated address as third argument")
 
-admin_user = ENV['UAA_CLIENT'] || "admin"
+admin_user = ENV.fetch('UAA_CLIENT', "admin")
 admin_password = ENV['UAA_CLIENT_SECRET'] || raise("Must set $UAA_CLIENT_SECRET env var")
 
 puts "Syncing Admin users in #{api_url}..."
@@ -52,16 +52,16 @@ uaa_sync_admin_users.request_token()
 created_users, deleted_users = uaa_sync_admin_users.update_admin_users(users)
 
 created_users.each { |user|
-  puts "Sending credentials to new user #{user[:username]}"
+  puts "Sending credentials to new user #{user.fetch(:username)}"
   EmailCredentialsHelper.send_admin_credentials(api_url, user, source_address)
 }
 
 puts "Created users: #{created_users.length}"
 created_users.each { |u|
-  puts " - #{u[:username]}"
+  puts " - #{u.fetch(:username)}"
 }
 puts "Deleted users: #{deleted_users.length}"
 deleted_users.each { |u|
-  puts " - #{u[:username]}"
+  puts " - #{u.fetch(:username)}"
 }
 


### PR DESCRIPTION
## What

#### Use Hash#fetch in all admin sync scripts

Make all hash lookups where we're getting (not setting) a value use `#fetch`
instead of `#[]` so that an exception is raised if we mis-type the key name
or the object isn't populated as expected. Previously a `nil` object would
be returned and the scripts could fail in a silent or unclear way.

This change highlights one such case, whereby we're using a key name with
the wrong capitalisation, which I'll fix in a following commit. We don't
explicitly test the log function where it occurs, but it now makes the tests
fail because we exercise the code path and get an exception:

     Failure/Error: get_logger.info("Deleting admin user #{user_info.fetch("userName")} which is not in the list.")

     KeyError:
       key not found: "userName"

I haven't changed the `self.ua.all_pages` calls which return the first item
because it seems that it's expected for them to return `nil` if there are no
results.

#### Fix typo in admin sync logging

When `sync-admin-users` was first run in the staging and prod environments
it deleted a lot of old test users but the logs didn't indicate what their
usernames were:

    I, [2016-05-31T09:26:48.723823 #15203]  INFO -- : Deleting admin user  which is not in the list.
    I, [2016-05-31T09:26:48.840621 #15203]  INFO -- : Deleting admin user  which is not in the list.
    I, [2016-05-31T09:26:48.986202 #15203]  INFO -- : Deleting admin user  which is not in the list.
    I, [2016-05-31T09:26:49.097718 #15203]  INFO -- : Deleting admin user  which is not in the list.
    I, [2016-05-31T09:26:49.219233 #15203]  INFO -- : Deleting admin user  which is not in the list.
    …

This is because it was using a hash key with the incorrect capitalisation;
`userName` instead of `username`. This resulted in a `nil` object which is
cast to an empty string.

This makes the tests pass after the preceding commit to use `Hash#fetch`
made them fail and should prevent this from happening again in the future.

## How to review

Sorry, this is a bit involved..

To test deleting users you'll need to create one:

1. Use a Bundler setup with UAAC:

    ```
cd scripts/
```
1. Install the dependencies:

    ```
bundle install
```
1. Target your environment:

    ```
bundle exec uaac target https://uaa.${DEPLOY_ENV}.dev.cloudpipeline.digital
```
1. Login using the password from the state bucket:

    ```
bundle exec uaac token client get admin -s $(aws s3 cp s3://${DEPLOY_ENV}-state/cf-secrets.yml - | awk '/uaa_admin_client_secret/ {print $2}')
```
1. Add a user:

    ```
bundle exec uaac user add this-should-be-deleted -p "$(pwgen 16 1)" --emails ignored
```
1. Add them to the admin group:

    ```
bundle exec uaac member add uaa.admin this-should-be-deleted
```

To run this on your development environment you'll need to make some further changes:

1. Edit `config/admin_users.yml` and remove all users but yourself.
2. Apply the following patch to delete unmanaged users sooner:

    ```
diff --git a/scripts/lib/uaa_sync_admin_users.rb b/scripts/lib/uaa_sync_admin_users.rb
index f871701..9675837 100644
--- a/scripts/lib/uaa_sync_admin_users.rb
+++ b/scripts/lib/uaa_sync_admin_users.rb
@@ -21,7 +21,7 @@ class UaaSyncAdminUsers
     "doppler.firehose"
   ]

-  HOURS_TO_KEEP_TEST_USERS = 2
+  MINS_TO_KEEP_TEST_USERS = 2

   # Initialise the class with to the given UAA target with the given
   # credentials.
@@ -179,7 +179,7 @@ class UaaSyncAdminUsers
         raise "User #{user_id} not found"
       end

-      if Time.parse(user_info.fetch("meta").fetch("created")) < (Time.now - HOURS_TO_KEEP_TEST_USERS * 60 * 60)
+      if Time.parse(user_info.fetch("meta").fetch("created")) < (Time.now - MINS_TO_KEEP_TEST_USERS * 60)
         get_logger.info("Deleting admin user #{user_info.fetch("username")} which is not in the list.")
         ua.delete(:user, user_id)
         deleted_users << { username: user_info.fetch("username"), email: user_info.fetch("emails").fetch(0).fetch("value") }
```
1. Wait for 2 minutes to have passed since you added the temporary user.
1. Commit and push those changes to a temporary branch e.g. `wip/<yourname>`
1. Deploy that branch and enable account creation (normally disabled in dev):

    ```
NEW_ACCOUNT_EMAIL_ADDRESS=the-multi-cloud-paas-team@digital.cabinet-office.gov.uk BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines
```
1. Run `create-bosh-cloudfoundry` pipeline and check in the `cf-deploy` job that it has:
  1. Created yourself a user.
  1. Deleted the temporary user.

## Who can review

Not @dcarley