### PR TITLE
[#112234445] Use correct argument for aws_route_table gateway

### DIFF
--- a/terraform/cloudfoundry/nat.tf
+++ b/terraform/cloudfoundry/nat.tf
@@ -14,7 +14,7 @@ resource "aws_route_table" "internet" {
   count = "${var.zone_count}"
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = "${element(aws_nat_gateway.cf.*.id, count.index)}"
+    nat_gateway_id = "${element(aws_nat_gateway.cf.*.id, count.index)}"
   }
 }
 


### PR DESCRIPTION
## What

Change `terraform/cloudfoundry/` to use the `nat_gateway_id` argument
instead of `gateway_id` because we're passing the ID of a NAT Gateway rather
than an Internet Gateway.

When creating or updating a `route_table` resource the AWS API will let you
use either argument interchangeably for either type of gateway. However,
when you read it back, it modifies it to the right argument. This causes
Terraform to think that the resource needs updating on every run.

I've started a discussion with upstream in hashicorp/terraform#6551 about
how this could be handled in a more explicit way.

In the meantime this change will stop Terraform from modifying our route
tables on every run of the `cf-terraform` job:

    aws_route_table.internet.1: Modifying...
      route.28127694.cidr_block:                  "0.0.0.0/0" => ""
      route.28127694.gateway_id:                  "" => ""
      route.28127694.instance_id:                 "" => ""
      route.28127694.nat_gateway_id:              "nat-0435bb1217614301c" => ""
      route.28127694.network_interface_id:        "" => ""
      route.28127694.vpc_peering_connection_id:   "" => ""
      route.3849577180.cidr_block:                "" => "0.0.0.0/0"
      route.3849577180.gateway_id:                "" => "nat-0435bb1217614301c"
      route.3849577180.instance_id:               "" => ""
      route.3849577180.nat_gateway_id:            "" => ""
      route.3849577180.network_interface_id:      "" => ""
      route.3849577180.vpc_peering_connection_id: "" => ""
    aws_route_table.internet.0: Modifying...
      route.1177416365.cidr_block:                "" => "0.0.0.0/0"
      route.1177416365.gateway_id:                "" => "nat-08218b6154223426a"
      route.1177416365.instance_id:               "" => ""
      route.1177416365.nat_gateway_id:            "" => ""
      route.1177416365.network_interface_id:      "" => ""
      route.1177416365.vpc_peering_connection_id: "" => ""
      route.2849130247.cidr_block:                "0.0.0.0/0" => ""
      route.2849130247.gateway_id:                "" => ""
      route.2849130247.instance_id:               "" => ""
      route.2849130247.nat_gateway_id:            "nat-08218b6154223426a" => ""
      route.2849130247.network_interface_id:      "" => ""
      route.2849130247.vpc_peering_connection_id: "" => ""
    aws_route_table.internet.2: Modifying...
      route.2265194627.cidr_block:                "0.0.0.0/0" => ""
      route.2265194627.gateway_id:                "" => ""
      route.2265194627.instance_id:               "" => ""
      route.2265194627.nat_gateway_id:            "nat-07ff5739f2a6fc3f6" => ""
      route.2265194627.network_interface_id:      "" => ""
      route.2265194627.vpc_peering_connection_id: "" => ""
      route.3390338511.cidr_block:                "" => "0.0.0.0/0"
      route.3390338511.gateway_id:                "" => "nat-07ff5739f2a6fc3f6"
      route.3390338511.instance_id:               "" => ""
      route.3390338511.nat_gateway_id:            "" => ""
      route.3390338511.network_interface_id:      "" => ""
      route.3390338511.vpc_peering_connection_id: "" => ""
    aws_route_table.internet.1: Modifications complete
    aws_route_table.internet.0: Modifications complete
    aws_route_table.internet.2: Modifications complete

    Apply complete! Resources: 0 added, 3 changed, 0 destroyed.

## How to review

1. Checkout this branch: `git checkout bugfix/112234445-terraform_route_table_flapping`
1. Upload the pipeline to your environment: `BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines`
1. Run the `create-bosh-cloudfoundry` pipeline.
1. Look in the output of the `terraform-apply` task in the `cf-terraform` job.
1. Confirm that it no longer contains the log lines mentioned about about modifying the `aws_route_table` resource.

## Who can review

Not @dcarley