### PR TITLE
WIP: [#118479861] Configure prefix master password generation with a seed

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1246,6 +1246,27 @@ jobs:
 
                   cf push
 
+      # FIXME: Delete this once https://github.com/alphagov/paas-cf/pull/314 is
+      # deployed in prod
+      - task: temp-update-rds-broker-master-password
+        config:
+          platform: linux
+          image: docker:///governmentpaas/awscli
+          inputs:
+            - name: paas-cf
+            - name: cf-secrets
+          params:
+            AWS_DEFAULT_REGION: {{aws_region}}
+            DEPLOY_ENV: {{deploy_env}}
+          run:
+            path: sh
+            args:
+              - -e
+              - -u
+              - -c
+              - |
+                ./paas-cf/scripts/update-rds-broker-passwords.sh
+
       - task: deploy-healthcheck
         config:
           platform: linux

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -95,7 +95,8 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-aws-broker-boshrelease.git
-      tag_filter: {{cf_aws_broker_version}}
+      branch: seed_master_passwords_118479861
+      #tag_filter: {{cf_aws_broker_version}}
 
   - name: os-conf-boshrelease
     type: git

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -40,7 +40,8 @@ prepare_environment() {
   cf_paas_haproxy_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.paas-haproxy.version "${cf_manifest_dir}/000-base-cf-deployment.yml")
   cf_graphite_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.graphite.version "${cf_manifest_dir}/055-graphite.yml")
   cf_grafana_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.grafana.version "${cf_manifest_dir}/055-graphite.yml")
-  cf_aws_broker_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.aws-broker.version "${cf_manifest_dir}/060-rds-broker.yml")
+  #cf_aws_broker_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.aws-broker.version "${cf_manifest_dir}/060-rds-broker.yml")
+  cf_aws_broker_version="0.0.$(date +%s)"
   cf_os_conf_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.os-conf.version "${cf_manifest_dir}/runtime/runtime.yml")
 
   if [ -z "${SKIP_COMMIT_VERIFICATION:-}" ] ; then

--- a/manifests/cf-manifest/deployments/060-rds-broker.yml
+++ b/manifests/cf-manifest/deployments/060-rds-broker.yml
@@ -19,7 +19,7 @@ meta:
 
 releases:
   - name: aws-broker
-    version: 0.0.3
+    version: 0.0.4
 
 resource_pools:
   - name: rds_broker_z1

--- a/manifests/cf-manifest/deployments/060-rds-broker.yml
+++ b/manifests/cf-manifest/deployments/060-rds-broker.yml
@@ -54,6 +54,7 @@ jobs:
         aws_region: "eu-west-1"
         password: (( grab secrets.rds_broker_admin_password ))
         db_prefix: "rdsbroker"
+        master_password_seed: (( grab secrets.rds_broker_master_password_seed ))
         catalog:
           services:
             - id: "ce71b484-d542-40f7-9dd4-5526e38c81ba"

--- a/manifests/cf-manifest/deployments/060-rds-broker.yml
+++ b/manifests/cf-manifest/deployments/060-rds-broker.yml
@@ -19,7 +19,7 @@ meta:
 
 releases:
   - name: aws-broker
-    version: 0.0.4
+    version: latest
 
 resource_pools:
   - name: rds_broker_z1

--- a/manifests/cf-manifest/scripts/generate-cf-secrets.rb
+++ b/manifests/cf-manifest/scripts/generate-cf-secrets.rb
@@ -31,6 +31,7 @@ generator = SecretGenerator.new({
   "consul_encrypt_keys" => :simple_in_array,
   "grafana_admin_password" => :simple,
   "rds_broker_admin_password" => :simple,
+  "rds_broker_master_password_seed" => :simple,
 })
 
 OptionParser.new do |opts|

--- a/manifests/cf-manifest/spec/fixtures/cf-secrets.yml
+++ b/manifests/cf-manifest/spec/fixtures/cf-secrets.yml
@@ -50,6 +50,9 @@ secrets:
   # rds broker creds
   rds_broker_admin_password: RDS_BROKER_ADMIN_PASSWORD
 
+  # rds broker creds
+  rds_broker_master_password_seed: RDS_BROKER_MASTER_PASSWORD_SEED
+
   # consul keys and secrets
   # generated according to https://docs.cloudfoundry.org/deploying/common/consul-security.html
   consul_encrypt_keys:

--- a/scripts/update-rds-broker-passwords.sh
+++ b/scripts/update-rds-broker-passwords.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+export AWS_DEFAULT_REGION=eu-west-1
+
+DB_INSTANCES=$(
+  aws rds describe-db-instances --output text \
+  --query "DBInstances[?starts_with(DBInstanceIdentifier, 'rdsbroker-') && ends_with(DBParameterGroups[0].DBParameterGroupName, '${DEPLOY_ENV}') ] | [*].DBInstanceIdentifier"
+)
+
+secret=$(awk '/rds_broker_master_password_seed/ { print $2 }' cf-secrets/cf-secrets.yml)
+
+for instance in $DB_INSTANCES; do
+  guuid=${instance##rdsbroker-}
+  new_password=$(printf "%s" "${secret}${guuid}" | openssl dgst -md5 -binary | openssl enc -base64 | tr '+/' '-_')
+  aws rds modify-db-instance --db-instance-identifier "${instance}" --master-user-password "${new_password}"
+done


### PR DESCRIPTION
What
----

In a previous version of rds-broker, if you know the service GUID for a database instance, you can  determine the master password. This should not be possible as this password is supposed to be secret.

In https://github.com/alphagov/paas-rds-broker/pull/7 we added a configuration variable master_password_seed which is added to the service GUID before hashing. This means that it's no longer possible to determine the master password from the instance_id alone.

This PR we point to the new version of aws-broker-boshrelease which supports this.


Dependency
----------

We must merge first:
 - https://github.com/alphagov/paas-rds-broker/pull/7
 - https://github.com/alphagov/paas-aws-broker-boshrelease/pull/7

But you can test this PR now before merging.

After merge that PR, you must tag https://github.com/alphagov/paas-aws-broker-boshrelease to 0.0.4 and remove the latest commit of this PR.

Considerations
-------------------

As we changed the method to generate the master password, we need to update it for the existing DBs. We solved by using the script `scripts/update-rds-broker-passwords.sh` that runs after CF deploy. 

We must revert the latest commit once it has been deployed in all the environments.

How to test
-----------

Deploy CF and run the custom acceptance tests.

You can also check that the exiting DBs have their master password updated, by binding an existing instance (e.g. `healthcheck_db`) to other app:

```
cd tests/example-apps/static-app
cf org testers && cf space healthcheck
cf push my-static-app
cf bind-service my-static-app healthcheck-db # It should work

cf delete my-static-app
```

Who?
----

Anyone but @keymon or @alext