### PR TITLE
[#121055399] Remove migrated from

### DIFF
--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -265,9 +265,6 @@ jobs:
     properties:
       metron_agent:
         zone: ""
-    migrated_from:
-      - {name: nats_z1, az: z1}
-      - {name: nats_z2, az: z2}
 
   - name: etcd
     azs: [z1, z2, z3]
@@ -291,10 +288,6 @@ jobs:
         agent:
           services:
             etcd: {}
-    migrated_from:
-      - {name: etcd_z1, az: z1}
-      - {name: etcd_z2, az: z2}
-      - {name: etcd_z3, az: z3}
 
   - name: stats
     azs: [z1]
@@ -307,8 +300,6 @@ jobs:
     properties:
       metron_agent:
         zone: ""
-    migrated_from:
-      - {name: stats_z1, az: z1}
 
 
   - name: uaa
@@ -326,9 +317,6 @@ jobs:
             uaa: {}
       metron_agent:
         zone: ""
-    migrated_from:
-      - {name: uaa_z1, az: z1}
-      - {name: uaa_z2, az: z2}
 
   - name: api
     azs: [z1, z2]
@@ -344,9 +332,6 @@ jobs:
           services: (( grab meta.api_consul_services ))
       metron_agent:
         zone: ""
-    migrated_from:
-      - {name: api_z1, az: z1}
-      - {name: api_z2, az: z2}
 
   - name: clock_global
     azs: [z1]
@@ -359,8 +344,6 @@ jobs:
     properties:
       metron_agent:
         zone: ""
-    migrated_from:
-      - {name: clock_global, az: z1}
 
   - name: api_worker
     azs: [z1, z2]
@@ -373,9 +356,6 @@ jobs:
     properties:
       metron_agent:
         zone: ""
-    migrated_from:
-      - {name: api_worker_z1, az: z1}
-      - {name: api_worker_z2, az: z2}
 
 
   - name: doppler
@@ -391,9 +371,6 @@ jobs:
         zone: ""
       metron_agent:
         zone: ""
-    migrated_from:
-      - {name: doppler_z1, az: z1}
-      - {name: doppler_z2, az: z2}
 
   - name: loggregator_trafficcontroller
     azs: [z1, z2]
@@ -408,9 +385,6 @@ jobs:
         zone: ""
       metron_agent:
         zone: ""
-    migrated_from:
-      - {name: loggregator_trafficcontroller_z1, az: z1}
-      - {name: loggregator_trafficcontroller_z2, az: z2}
 
   - name: router
     azs: [z1, z2]
@@ -427,9 +401,6 @@ jobs:
             gorouter: {}
       metron_agent:
         zone: ""
-    migrated_from:
-      - {name: router_z1, az: z1}
-      - {name: router_z2, az: z2}
 
 # Diego
 
@@ -483,8 +454,6 @@ jobs:
       diego:
         rep:
           zone: z1
-    migrated_from:
-      - {name: cell_z1, az: z1}
 
   - name: colocated_z1
     azs: [z1]
@@ -502,8 +471,6 @@ jobs:
         zone: ""
     update:
       serial: true
-    migrated_from:
-      - {name: colocated_z1, az: z1}
 
   - name: colocated_z2
     azs: [z2]
@@ -519,8 +486,6 @@ jobs:
           zone: z2
       metron_agent:
         zone: ""
-    migrated_from:
-      - {name: colocated_z2, az: z2}
 
   - name: cell_z2
     azs: [z2]
@@ -536,8 +501,6 @@ jobs:
       diego:
         rep:
           zone: z2
-    migrated_from:
-      - {name: cell_z2, az: z2}
 
   - name: database
     azs: [z1, z2]

--- a/manifests/cf-manifest/manifest/030-logsearch.yml
+++ b/manifests/cf-manifest/manifest/030-logsearch.yml
@@ -33,8 +33,6 @@ jobs:
   properties:
     redis:
       host: (( grab jobs.queue.networks.cf.static_ips.[0] ))
-  migrated_from:
-    - {name: ingestor_z1, az: z1}
 
 - name: ingestor_z2
   release: logsearch
@@ -54,8 +52,6 @@ jobs:
   properties:
     redis:
       host: (( grab jobs.queue.networks.cf.static_ips.[1] ))
-  migrated_from:
-    - {name: ingestor_z2, az: z2}
 
 - name: queue
   release: logsearch
@@ -72,9 +68,6 @@ jobs:
       - 10.0.17.13
   disk_type: queue
   update: (( grab meta.update ))
-  migrated_from:
-    - {name: queue_z1, az: z1}
-    - {name: queue_z2, az: z2}
 
 - name: parser_z1
   release: logsearch
@@ -93,8 +86,6 @@ jobs:
     redis:
       host: (( grab jobs.queue.networks.cf.static_ips.[0] ))
     logstash: (( grab properties.parser_logstash ))
-  migrated_from:
-    - {name: parser_z1, az: z1}
 
 - name: parser_z2
   release: logsearch
@@ -113,8 +104,6 @@ jobs:
     redis:
       host: (( grab jobs.queue.networks.cf.static_ips.[1] ))
     logstash: (( grab properties.parser_logstash ))
-  migrated_from:
-    - {name: parser_z2, az: z2}
 
 - name: elasticsearch_master
   release: logsearch
@@ -140,10 +129,6 @@ jobs:
         minimum_master_nodes: 2
       master_hosts: (( grab properties.elasticsearch.master_hosts ))
   update: (( grab meta.update ))
-  migrated_from:
-    - {name: elasticsearch_master_z1, az: z1}
-    - {name: elasticsearch_master_z2, az: z2}
-    - {name: elasticsearch_master_z3, az: z3}
 
 - name: maintenance
   instances: 1
@@ -157,8 +142,6 @@ jobs:
   networks:
   - name: cf
   update: (( grab meta.update ))
-  migrated_from:
-    - {name: maintenance_z1, az: z1}
 
 - name: kibana
   release: logsearch
@@ -172,8 +155,6 @@ jobs:
   networks:
   - name: cf
   update: (( grab meta.update ))
-  migrated_from:
-    - {name: kibana, az: z1}
 
 properties:
   syslog_daemon_config:

--- a/manifests/cf-manifest/manifest/040-graphite.yml
+++ b/manifests/cf-manifest/manifest/040-graphite.yml
@@ -28,8 +28,6 @@ jobs:
     - name: cf
       static_ips:
         - 10.0.16.20
-  migrated_from:
-    - {name: graphite_z1, az: z1}
   properties:
     metron_agent:
       zone: ""

--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -34,8 +34,6 @@ jobs:
       - name: cf
         static_ips:
           - 10.0.16.25
-    migrated_from:
-      - {name: rds_broker_z1, az: z1}
     properties:
       rds-broker:
         aws_access_key_id: ""


### PR DESCRIPTION
## What
[Remove BOSH migrated_from property](https://www.pivotaltracker.com/projects/1275640/stories/121055399)

We have now finished migration to cloud_config. No need to keep `migrated_from` in the manifest any more. Clean up cf-manifest to stop BOSH looking for previous jobs on every deploy.

## How to review

Apply to existing environments. On BOSH deploy, you should see that migrate_from was removed from all jobs that had it. But on actual deployment, there will be no changes applied to CF.

## Who can review

not @mtekel