### PR TITLE
[#121215337] Change UAA logging level from DEBUG to INFO

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -373,6 +373,8 @@ properties:
     no_ssl: ~
     require_https: false
 
+    logging_level: INFO
+
     scim:
       userids_enabled: true
       external_groups: ~


### PR DESCRIPTION
## What

Reduce UAA's logging level from the spec default of `DEBUG` to `INFO`. This
will make the logs easier to read and identify errors, as well as reducing
the amount of logs that Logsearch has to parse and store.

There doesn't seem to be much order to the `uaa` property keys. So I've
added the new property to what I think is a vaguely sensible place.

We did the same for CC in 62c0882. UAA is the last component to still log at
debug level, according to the following Logsearch query:

    debug AND NOT syslog_sd_params.bosh_template:uaa AND NOT syslog_program:vcap.uaa_ctl*

I've raised an upstream PR to change the default in future:

- cloudfoundry/uaa-release#20

## How to review

1. Go to logsearch for your environment (URL in `make dev showenv`).
1. Search for `debug` and confirm that UAA is outputting debug logs.
1. Deploy changes from this branch:

    ```
git fetch
git checkout feature/121215337-reduce_uaa_log_level
BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines
```
1. Run the `create-bosh-cloudfoundry` pipeline and wait for `cf-deploy` to finish.
1. Query logsearch for `debug` again and confirm that there are no recent logs.

I'd be interested in an opinion from @HenryTK @timmow @combor about whether the debug logging helped you in anyway when investigating [#121039143](https://www.pivotaltracker.com/story/show/121039143)?

## Who can review

Not @dcarley