### PR TITLE
[#118479861] Use new, password generating RDS broker

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1107,6 +1107,25 @@ jobs:
                 - |
                   ./paas-cf/concourse/scripts/bosh_login.sh {{bosh_fqdn}} bosh-secrets/bosh-secrets.yml
                   bosh update cloud-config cloud-config/cloud-config.yml
+        # FIXME: Remove after https://github.com/alphagov/paas-cf/pull/314 deployed in prod
+        - task: add-tags-to-RDS-instances
+          config:
+            platform: linux
+            image: docker:///governmentpaas/awscli
+            inputs:
+              - name: paas-cf
+              - name: cf-secrets
+            params:
+              AWS_DEFAULT_REGION: {{aws_region}}
+              DEPLOY_ENV: {{deploy_env}}
+            run:
+              path: sh
+              args:
+                - -e
+                - -u
+                - -c
+                - |
+                  ./paas-cf/scripts/tag-rds-instances.sh
 
       - task: cf-deploy
         config:

--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -19,7 +19,7 @@ meta:
 
 releases:
   - name: aws-broker
-    version: 0.0.3
+    version: 0.0.4
 
 jobs:
   - name: rds_broker

--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -41,6 +41,7 @@ jobs:
         aws_region: "eu-west-1"
         password: (( grab secrets.rds_broker_admin_password ))
         db_prefix: "rdsbroker"
+        master_password_seed: (( grab secrets.rds_broker_master_password_seed ))
         catalog:
           services:
             - id: "ce71b484-d542-40f7-9dd4-5526e38c81ba"

--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -42,6 +42,7 @@ jobs:
         password: (( grab secrets.rds_broker_admin_password ))
         db_prefix: "rdsbroker"
         master_password_seed: (( grab secrets.rds_broker_master_password_seed ))
+        broker_name: "(( grab terraform_outputs.environment ))"
         catalog:
           services:
             - id: "ce71b484-d542-40f7-9dd4-5526e38c81ba"

--- a/manifests/cf-manifest/scripts/generate-cf-secrets.rb
+++ b/manifests/cf-manifest/scripts/generate-cf-secrets.rb
@@ -31,6 +31,7 @@ generator = SecretGenerator.new({
   "consul_encrypt_keys" => :simple_in_array,
   "grafana_admin_password" => :simple,
   "rds_broker_admin_password" => :simple,
+  "rds_broker_master_password_seed" => :simple,
 })
 
 OptionParser.new do |opts|

--- a/manifests/shared/spec/fixtures/cf-secrets.yml
+++ b/manifests/shared/spec/fixtures/cf-secrets.yml
@@ -50,6 +50,9 @@ secrets:
   # rds broker creds
   rds_broker_admin_password: RDS_BROKER_ADMIN_PASSWORD
 
+  # rds broker creds
+  rds_broker_master_password_seed: RDS_BROKER_MASTER_PASSWORD_SEED
+
   # consul keys and secrets
   # generated according to https://docs.cloudfoundry.org/deploying/common/consul-security.html
   consul_encrypt_keys:

--- a/scripts/tag-rds-instances.sh
+++ b/scripts/tag-rds-instances.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+account=$(aws sts get-caller-identity --query Account | tr -d \")
+
+DB_INSTANCES=$(
+  aws rds describe-db-instances --output text \
+  --query "DBInstances[?starts_with(DBInstanceIdentifier, 'rdsbroker-') && ends_with(DBParameterGroups[0].DBParameterGroupName, '${DEPLOY_ENV}') ] | [*].DBInstanceIdentifier"
+)
+
+for instance in $DB_INSTANCES; do
+  # shellcheck disable=SC2140
+  aws --region "${AWS_DEFAULT_REGION}" rds add-tags-to-resource --resource-name arn:aws:rds:"${AWS_DEFAULT_REGION}":"${account}":db:"${instance}" --tags "Key=Broker Name,Value=${DEPLOY_ENV}"
+  echo "Tagged $instance with 'Broker Name=${DEPLOY_ENV}' tag."
+done


### PR DESCRIPTION
## What

[Generating secure master password for Postgres Instances](https://www.pivotaltracker.com/n/projects/1275640/stories/118479861)

## How to review

Deploy against new or existing deployment. In the existing deployment, you can observe in the RDS broker logs that it fails to 'ping' instances with old password and that it does PW update. All tests should pass.

## Merging

This PR depends on 2 other PRs. It contains temporary commits to use them from branch (before they are merged) so that you can test. Once these PRs are merged, remove these respective temporary commits:

- [x] https://github.com/alphagov/paas-aws-broker-boshrelease/pull/8 https://github.com/alphagov/paas-cf/commit/25aabbad4b3fedefe873402504d5d56459d888c4
- [x] https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/55 https://github.com/alphagov/paas-cf/commit/3c563fe19538fd5c33d01dcd5dc8b9d8a65cc76d

Merge only after above PRs have been merged and temp commits removed. To be really sure, you can test again after removing the temp commits...

## Who can review
not @saliceti or @mtekel or @keymon 