### PR TITLE
[#120591859] Upgrade cloudfoundry to 237

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -107,8 +107,8 @@ resources:
   - name: graphite-nozzle
     type: git
     source:
-      uri: https://github.com/alphagov/graphite-nozzle
-      branch: 106191208-deaggregated_names
+      uri: https://github.com/alphagov/paas-graphite-nozzle
+      branch: upgrade_go
 
   - name: vpc-tfstate
     type: s3-iam
@@ -1335,6 +1335,7 @@ jobs:
                     instances: 1
                     no-route: true
                     health-check-type: none
+                    buildpack: go_buildpack
                     env:
                       DOPPLER_ENDPOINT: "${DOPPLER_ENDPOINT}"
                       UAA_ENDPOINT: "${UAA_ENDPOINT}"

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1373,8 +1373,6 @@ jobs:
                 cf set-quota testers test_apps
                 cf create-space healthcheck -o testers
                 cf target -o testers -s healthcheck
-                # FIXME remove this after https://github.com/alphagov/paas-cf/pull/295 is accepted and in prod
-                cf delete healthcheck-app -f -r
 
                 cd paas-cf/tests/example-apps/healthcheck
                 cf push --no-start

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -10,9 +10,9 @@ releases:
     url: https://bosh.io/d/github.com/cloudfoundry/cf-release?v=237
     sha1: 8996122278b03b6ba21ec673812d2075c37f1097
   - name: diego
-    version: 0.1467.0
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/diego-release?v=0.1467.0
-    sha1: 64af2b1b99f0ff771e3e60daacbe5fd3b48d2ddc
+    version: 0.1472.0
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/diego-release?v=0.1472.0
+    sha1: a143e9e850ee794beb27bcd9ee9425406beb2987
   - name: garden-linux
     version: 0.337.0
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/garden-linux-release?v=0.337.0

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -18,9 +18,9 @@ releases:
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/garden-linux-release?v=0.337.0
     sha1: d1d81d56c3c07f6f9f04ebddc68e51b8a3cf541d
   - name: etcd
-    version: 45
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/etcd-release?v=45
-    sha1: c166c0e34fa2ebdc42585075409f9b84aa4d14d8
+    version: 49
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/etcd-release?v=49
+    sha1: 5d145db1ddda984faf4777e022a748b355060478
   - name: paas-haproxy
     version: 0.0.2
 

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -6,9 +6,9 @@ director_uuid: ~
 
 releases:
   - name: cf
-    version: 235
-    url: https://bosh.io/d/github.com/cloudfoundry/cf-release?v=235
-    sha1: a4ab2d7a2912b8c700ef4b8a45e7f688127930b6
+    version: 237
+    url: https://bosh.io/d/github.com/cloudfoundry/cf-release?v=237
+    sha1: 8996122278b03b6ba21ec673812d2075c37f1097
   - name: diego
     version: 0.1467.0
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/diego-release?v=0.1467.0

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -21,6 +21,10 @@ releases:
     version: 49
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/etcd-release?v=49
     sha1: 5d145db1ddda984faf4777e022a748b355060478
+  - name: cflinuxfs2-rootfs
+    version: 1.5.0
+    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-rootfs-release?v=1.5.0
+    sha1: 4ab6166d800668ad3e9c2c10cfd3403a7de5885f
   - name: paas-haproxy
     version: 0.0.2
 

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -170,13 +170,13 @@ meta:
       - name: consul_agent
         release: cf
       - name: stager
-        release: diego
+        release: cf
       - name: nsync
-        release: diego
+        release: cf
       - name: tps
-        release: diego
+        release: cf
       - name: cc_uploader
-        release: diego
+        release: cf
       - name: metron_agent
         release: cf
     route_emitter:
@@ -210,7 +210,7 @@ meta:
       - name: bbs
         release: diego
       - name: cc_uploader
-        release: diego
+        release: cf
       - name: converger
         release: diego
       - name: file_server
@@ -218,15 +218,15 @@ meta:
       - name: metron_agent
         release: cf
       - name: nsync
-        release: diego
+        release: cf
       - name: route_emitter
         release: diego
       - name: ssh_proxy
         release: diego
       - name: stager
-        release: diego
+        release: cf
       - name: tps
-        release: diego
+        release: cf
 
 jobs:
   - name: consul

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -162,8 +162,8 @@ meta:
         release: diego
       - name: garden
         release: garden-linux
-      - name: rootfses
-        release: diego
+      - name: cflinuxfs2-rootfs-setup
+        release: cflinuxfs2-rootfs
       - name: metron_agent
         release: cf
     cc_bridge:

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -167,8 +167,6 @@ properties:
         timeout_in_seconds: ~
       droplet_upload:
         timeout_in_seconds: ~
-      model_deletion:
-        timeout_in_seconds: ~
       generic:
         number_of_workers: ~
 

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -559,6 +559,8 @@ properties:
         client_cert: (( grab secrets.bbs_client_cert ))
         client_key: (( grab secrets.bbs_client_key ))
         require_ssl: true
+      preloaded_rootfses:
+        - "cflinuxfs2:/var/vcap/packages/cflinuxfs2/rootfs"
 
     route_emitter:
       dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
@@ -615,5 +617,5 @@ properties:
         client_key: (( grab secrets.bbs_client_key ))
         require_ssl: true
       traffic_controller_url: (( grab properties.loggregator.traffic_controller_url ))
-    rootfs_cflinuxfs2:
-      trusted_certs: (( grab meta.ca_certs.aws_rds_combined_ca_bundle ))
+  cflinuxfs2-rootfs:
+    trusted_certs: (( grab meta.ca_certs.aws_rds_combined_ca_bundle ))

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -528,29 +528,6 @@ properties:
     file_server:
       dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
 
-    cc_uploader:
-      dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
-      cc:
-        base_url: (( grab properties.cc.srv_api_uri ))
-        basic_auth_password: (( grab properties.cc.internal_api_password ))
-        staging_upload_user: (( grab properties.cc.staging_upload_user ))
-        staging_upload_password: (( grab properties.cc.staging_upload_password ))
-
-    nsync:
-      dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
-      bbs:
-        api_location: bbs.service.cf.internal:8889
-        ca_cert: (( grab meta.secrets.bbs_ca_cert ))
-        client_cert: (( grab secrets.bbs_client_cert  ))
-        client_key: (( grab secrets.bbs_client_key  ))
-        require_ssl: true
-
-      cc:
-        base_url:  (( grab properties.cc.srv_api_uri ))
-        basic_auth_password: (( grab properties.cc.internal_api_password ))
-        staging_upload_user: (( grab properties.cc.staging_upload_user ))
-        staging_upload_password: (( grab properties.cc.staging_upload_password ))
-
     rep:
       dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
       bbs:
@@ -588,6 +565,30 @@ properties:
 
       uaa_secret: (( grab properties.uaa.ssh_proxy_client_secret ))
       uaa_token_url: (( grab properties.uaa.token_url ))
+
+  capi:
+    cc_uploader:
+      dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
+      cc:
+        base_url: (( grab properties.cc.srv_api_uri ))
+        basic_auth_password: (( grab properties.cc.internal_api_password ))
+        staging_upload_user: (( grab properties.cc.staging_upload_user ))
+        staging_upload_password: (( grab properties.cc.staging_upload_password ))
+
+    nsync:
+      dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
+      bbs:
+        api_location: bbs.service.cf.internal:8889
+        ca_cert: (( grab meta.secrets.bbs_ca_cert ))
+        client_cert: (( grab secrets.bbs_client_cert  ))
+        client_key: (( grab secrets.bbs_client_key  ))
+        require_ssl: true
+
+      cc:
+        base_url:  (( grab properties.cc.srv_api_uri ))
+        basic_auth_password: (( grab properties.cc.internal_api_password ))
+        staging_upload_user: (( grab properties.cc.staging_upload_user ))
+        staging_upload_password: (( grab properties.cc.staging_upload_password ))
 
     stager:
       dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))


### PR DESCRIPTION
## What

This upgrades Cloudfoundry to release 237. It also upgrades the related components to the recommended versions for this release:

* diego to 0.1472.0
* etcd to 49

The diego release includes some changes to how the releases are structured:

* the rootfses have been split into a separate release
* the cc-bridge jobs have been extracted into a separate release `capi-release` which is now included as part of the CF release.

See the corresponding commits for more details.

## How to review

This should be tested by deploying both a clean environment, and an upgrade of an existing environment.

## Who can review

Anyone but myself or @Jonty.