### PR TITLE
[#122117381] Use gp2 storage for Bosh RDS instance.

### DIFF
--- a/terraform/bosh/rds.tf
+++ b/terraform/bosh/rds.tf
@@ -45,7 +45,7 @@ resource "aws_db_instance" "bosh" {
   password = "${var.secrets_bosh_postgres_password}"
   db_subnet_group_name = "${aws_db_subnet_group.bosh_rds.name}"
   parameter_group_name = "${aws_db_parameter_group.default.id}"
-
+  maintenance_window = "Thu:03:00-Thu:04:00"
   multi_az = "${var.bosh_db_multi_az}"
   backup_retention_period = "${var.bosh_db_backup_retention_period}"
   final_snapshot_identifier = "${var.env}-bosh-rds-final-snapshot"

--- a/terraform/bosh/rds.tf
+++ b/terraform/bosh/rds.tf
@@ -38,6 +38,7 @@ resource "aws_db_instance" "bosh" {
   identifier = "${var.env}-bosh"
   name = "bosh"
   allocated_storage = 5
+  storage_type = "gp2"
   engine = "postgres"
   engine_version = "9.4.5"
   instance_class = "db.t2.medium"


### PR DESCRIPTION
## What

This has better performance than the default (magnetic) storage that
it's currently provisioned with.

This modification will not apply immediately; it will apply during the
configured maintenance window. During this time there will be a few
minutes of downtime. In my dev environment, bosh was unavailable
for 3 minutes while the RDS instance restarter. After that, all was well.

## How to review

* Deploy from this branch.
* Using the RDS console to change the maintenance window of your bosh RDS instance to happen in a few minutes time (note: the window is specified in UTC).
* Watch while the change is applied during the maintenance window. Verify that everything is working correctly after the change has completely applied.

Run another deploy to set the maintenance window back to the correct value.

## Who can review

Anyone but myself.