### PR TITLE
[#120654489] Start from specific job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,3 +150,8 @@ merge_pr: ## Merge a PR. Must specify number in a PR=<number> form.
 find_diverged_forks: ## Check all github forks belonging to paas to see if they've diverged upstream
 	$(if ${GITHUB_TOKEN},,$(error Must pass GITHUB_TOKEN=<personal github token>))
 	./scripts/find_diverged_forks.py alphagov --prefix=paas --extra-repo=cf-release --extra-repo=graphite-nozzle --github-token=${GITHUB_TOKEN}
+
+.PHONY: run_job
+run_job: check-env-vars ##  Unbind paas-cf of $JOB in create-bosh-cloudfoundry pipeline and then trigger it
+	$(if ${JOB},,$(error Must pass JOB=<name>))
+	./concourse/scripts/run_job.sh ${JOB}

--- a/README.md
+++ b/README.md
@@ -381,4 +381,4 @@ To do this, run `aws ses verify-email-identity --email-address youremail@example
 and click on the link in the resulting email
 
 ## BOSH failover
-Visit [BOSH failover page](https://github.com/alphagov/paas-cf/doc/bosh_failover.md)
+Visit [BOSH failover page](https://github.com/alphagov/paas-cf/blob/master/doc/bosh_failover.md)

--- a/README.md
+++ b/README.md
@@ -217,6 +217,21 @@ can use SELF_UPDATE_PIPELINE environment variable, set to false (true is default
 
 See [doc/non_dev_deployments.md](doc/non_dev_deployments.md).
 
+## Optionally run specific job in the create-bosh-cloudfoundry pipeline
+
+`create-bosh-cloudfoundry` is our main pipeline. When we are making changes or
+adding new features to our deployment we many times wish to test only the
+specific changes we have just made. To do that, it's many times enough to run
+only the job that is applying the change. In order to do that, you can use
+`run_job` makefile target. Specify the job name you want to execute by setting
+the `JOB` variable. You also have to specify your environment type, e.g.
+`JOB=performance-tests make dev run_job`.
+
+This will not only tigger the job, but before that it will modify the pipeline
+to remove `passed` dependencies for `paas-cf` in the specified job. This means
+that your job will pick the latest changes to `paas-cf` directly, without the
+need to run the pipeline from start in order to bring the changes forward.
+
 ## Sharing your Bootstrap Concourse
 
 If you need to share access to your *Bootstrap Concourse* with a colleague

--- a/concourse/scripts/run_job.sh
+++ b/concourse/scripts/run_job.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -eu
+set -o pipefail
+
+JOB=$1
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+PIPE='create-bosh-cloudfoundry'
+TEMP="/tmp/concourse-run-job.${RANDOM}"
+trap 'rm -f $TEMP' ERR
+
+export TARGET_CONCOURSE=deployer
+# shellcheck disable=SC2091
+$("${SCRIPT_DIR}/environment.sh")
+"${SCRIPT_DIR}/fly_sync_and_login.sh"
+FLY="$FLY_CMD -t ${FLY_TARGET}"
+
+# 2 steps prevent fly reading empty input in case step 1 fails
+${FLY} get-pipeline -p ${PIPE} | "${SCRIPT_DIR}"/unbind_job.rb "${JOB}" >$TEMP
+${FLY} set-pipeline -p ${PIPE} -c=$TEMP -n
+
+curl -k -u "${CONCOURSE_ATC_USER}:${CONCOURSE_ATC_PASSWORD}" "${CONCOURSE_URL}/api/v1/pipelines/${PIPE}/jobs/${JOB}/builds" -d ''
+rm -f $TEMP

--- a/concourse/scripts/spec/unbind_job_spec.rb
+++ b/concourse/scripts/spec/unbind_job_spec.rb
@@ -1,0 +1,139 @@
+require 'securerandom'
+
+RSpec.describe "unbind_job.rb", :type => :aruba do
+  def unbind(yml, job)
+    run("./unbind_job.rb #{job}")
+    last_command_started.write(yml)
+    close_input
+  end
+
+  it "exits on empty YAML" do
+    unbind("", "")
+    expect(last_command_started).to have_exit_status(1)
+    expect(last_command_started.stderr).to eq "Unable to parse YAML hash from the input\n"
+  end
+
+  it "exits on broken YAML" do
+    unbind("? :", "")
+    expect(last_command_started).to have_exit_status(1)
+    expect(last_command_started.stderr).to match "psych.rb"
+  end
+
+  it "exits on missing jobs in YAML" do
+    unbind("a: b", "")
+    expect(last_command_started).to have_exit_status(1)
+    expect(last_command_started.stderr).to eq "Can't find job definitions in the input\n"
+  end
+
+  it "exits on jobs not being an array" do
+    unbind("jobs: b", "")
+    expect(last_command_started).to have_exit_status(1)
+    expect(last_command_started.stderr).to eq "Jobs definition not an array\n"
+  end
+
+  it "exits on job not found" do
+    myjob=SecureRandom.hex
+    unbind("jobs:\n  - name: a", myjob)
+    expect(last_command_started).to have_exit_status(1)
+    expect(last_command_started.stderr).to eq "Job #{myjob} not found in the pipeline\n"
+  end
+
+  it "removes passed from paas-cf in plan" do
+    unbind("---
+jobs:
+- name: myjob
+  plan:
+  - get: paas-cf
+    passed: ['some_previous_job']", "myjob")
+    expect(last_command_started).to have_exit_status(0)
+    expect(last_command_started.stdout).to eq "---
+jobs:
+- name: myjob
+  plan:
+  - get: paas-cf
+"
+  end
+
+  it "removes passed from paas-cf in do in plan" do
+    unbind("---
+jobs:
+- name: myjob
+  plan:
+  - do:
+    - get: paas-cf
+      passed: ['some_previous_job']", "myjob")
+    expect(last_command_started).to have_exit_status(0)
+    expect(last_command_started.stdout).to eq "---
+jobs:
+- name: myjob
+  plan:
+  - do:
+    - get: paas-cf
+"
+  end
+
+  it "removes passed from paas-cf in aggregate in plan" do
+    unbind("---
+jobs:
+- name: myjob
+  plan:
+  - aggregate:
+    - get: paas-cf
+      passed: ['some_previous_job']", "myjob")
+    expect(last_command_started).to have_exit_status(0)
+    expect(last_command_started.stdout).to eq "---
+jobs:
+- name: myjob
+  plan:
+  - aggregate:
+    - get: paas-cf
+"
+  end
+
+  it "removes passed from paas-cf in do in aggregate in plan" do
+    unbind("---
+jobs:
+- name: myjob
+  plan:
+  - aggregate:
+    - do:
+      - get: paas-cf
+        passed: ['some_previous_job']", "myjob")
+    expect(last_command_started).to have_exit_status(0)
+    expect(last_command_started.stdout).to eq "---
+jobs:
+- name: myjob
+  plan:
+  - aggregate:
+    - do:
+      - get: paas-cf
+"
+  end
+
+  it "removes all occurences of passed from paas-cf nested anywhere in plan" do
+    unbind("---
+jobs:
+- name: myjob
+  plan:
+  - get: paas-cf
+    passed: 'some_job'
+  - aggregate:
+    - get: paas-cf
+      passed: ['some', 'jobs']
+    - do:
+      - get: paas-cf
+        passed: ['some_previous_job']", "myjob")
+    expect(last_command_started).to have_exit_status(0)
+    expect(last_command_started.stdout).to eq "---
+jobs:
+- name: myjob
+  plan:
+  - get: paas-cf
+  - aggregate:
+    - get: paas-cf
+    - do:
+      - get: paas-cf
+"
+  end
+
+end

--- a/concourse/scripts/unbind_job.rb
+++ b/concourse/scripts/unbind_job.rb
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+require 'yaml'
+pipe = YAML.load(STDIN)
+
+def remove_passed(obj)
+  case obj
+    when Array
+      obj.each {|v| remove_passed(v)}
+    when Hash
+      if obj.has_key?('get') and obj['get']=='paas-cf' then
+        obj.delete('passed')
+      else
+        obj.each {|k,v| remove_passed(v) if k == 'do' or k == 'aggregate'}
+      end
+  end
+end
+
+abort "Unable to parse YAML hash from the input" if pipe.class != Hash
+abort "Can't find job definitions in the input"  if pipe['jobs'].nil?
+abort "Jobs definition not an array"             if pipe['jobs'].class != Array
+
+myJob=pipe['jobs'].find{|j| j['name']==ARGV[0]}
+abort "Job " + ARGV[0] + " not found in the pipeline" if myJob.nil?
+
+remove_passed(myJob['plan'])
+puts YAML.dump(pipe)


### PR DESCRIPTION
## What

[Run specific Pipeline Jobs / Tasks](https://www.pivotaltracker.com/n/projects/1275640/stories/120654489)

Add a makefile target to run pipeline from specific job, ensuring that job is able to pick up latest changes in paas-cf. We do this by adjusting the pipeline by removing 'passed' for paas-cf in the given job.

## How to review

Run `JOB=myjob make dev run`. Observe that job having it's paas-cf "unbound" from previous jobs and being triggered.

## Who can review

not @mtekel or @combor 