### PR TITLE
[#122187235] Fix delete-deployment when testers org doesn't exist.

### DIFF
--- a/concourse/tasks/remove-healthcheck-db.yml
+++ b/concourse/tasks/remove-healthcheck-db.yml
@@ -13,11 +13,17 @@ run:
     - |
       ./paas-cf/concourse/scripts/import_bosh_ca.sh
       . ./config/config.sh
-      if curl -I -f $API_ENDPOINT/info; then
-        echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
-        cf target -o testers -s healthcheck
-        cf delete healthcheck -f -r
-        if cf services | grep -q healthcheck-db; then
-          cf delete-service healthcheck-db -f
-        fi
+      if ! curl -I -f $API_ENDPOINT/info; then
+        echo "CF API unavailable. Skipping..."
+        exit 0
+      fi
+      echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
+      if ! cf org testers > /dev/null; then
+        echo "Org 'testers' not found. Skipping..."
+        exit 0
+      fi
+      cf target -o testers -s healthcheck
+      cf delete healthcheck -f -r
+      if cf services | grep -q healthcheck-db; then
+        cf delete-service healthcheck-db -f
       fi


### PR DESCRIPTION
## What

At present the remove-healthcheck-db task in the destroy-cloudfoundry
and autodelete-cloudfoundry pipelines will error if the CF api is
available, but the testers org doesn't exist. This can happen if the
cf-deployment succeeds, but one of the post-deploy tasks fails for some
reason.

This updates the task to check for the exsitence of the testers org
before attempting to delete the healthcheck app and db. If the org isn't
present, the app and db can't exist, so it's safe to just skip the task.

## How to review

* Use the cf cli to delete the healthcheck app, db and then delete the whole testers org.
* Run the `destroy-cloudfoundry` pipeline (you may want to pause the terraform destroy job if you don't want the dstroy to go this far), and observe it fail.
* Update concourse to use this branch, and re-run. It should now succeed.

## Who can review

Anyone but myself.
