### PR TITLE
[#122188819] Fix capture of bosh-init state on error.

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -769,7 +769,7 @@ jobs:
             - name: bosh-init-state
             - name: ssh-private-key
           outputs:
-            - name: updated-bosh-init-state
+            - name: bosh-init-working-dir
           params:
             BOSH_MANIFEST_STATE: {{bosh_manifest_state}}
           run:
@@ -778,16 +778,16 @@ jobs:
               - -e
               - -c
               - |
-                mkdir -p bosh-manifest/.ssh
-                cp ssh-private-key/id_rsa bosh-manifest/.ssh/id_rsa
-                chmod 400 bosh-manifest/.ssh/id_rsa
-                cp bosh-init-state/"${BOSH_MANIFEST_STATE}" bosh-manifest/bosh-manifest-state.json
-                bosh-init deploy bosh-manifest/bosh-manifest.yml
-                cp bosh-manifest/bosh-manifest-state.json updated-bosh-init-state/"${BOSH_MANIFEST_STATE}"
+                mkdir -p bosh-init-working-dir/.ssh
+                cp ssh-private-key/id_rsa bosh-init-working-dir/.ssh/id_rsa
+                chmod 400 bosh-init-working-dir/.ssh/id_rsa
+                cp bosh-manifest/bosh-manifest.yml bosh-init-working-dir/bosh-manifest.yml
+                cp bosh-init-state/"${BOSH_MANIFEST_STATE}" bosh-init-working-dir/bosh-manifest-state.json
+                bosh-init deploy bosh-init-working-dir/bosh-manifest.yml
         ensure:
           put: bosh-init-state
           params:
-            file: "updated-bosh-init-state/bosh-manifest-state-*.json"
+            file: "bosh-init-working-dir/bosh-manifest-state.json"
 
   - name: cf-terraform
     serial_groups: [cf-deploy]

--- a/concourse/pipelines/destroy-microbosh.yml
+++ b/concourse/pipelines/destroy-microbosh.yml
@@ -142,25 +142,24 @@ jobs:
           params:
             BOSH_MANIFEST_STATE: {{bosh_manifest_state}}
           outputs:
-            - name: updated-bosh-init-state
+            - name: bosh-init-working-dir
           run:
             path: sh
             args:
               - -e
               - -c
               - |
-                cp bosh-init-state/"${BOSH_MANIFEST_STATE}" bosh-manifest/bosh-manifest-state.json
-                bosh-init delete bosh-manifest/bosh-manifest.yml
+                cp bosh-manifest/bosh-manifest.yml bosh-init-working-dir/bosh-manifest.yml
+                cp bosh-init-state/"${BOSH_MANIFEST_STATE}" bosh-init-working-dir/bosh-manifest-state.json
+                bosh-init delete bosh-init-working-dir/bosh-manifest.yml
                 # If the delete is successful, the file will be missing
-                if [ -f bosh-manifest/bosh-manifest-state.json ] ; then
-                  cp bosh-manifest/bosh-manifest-state.json updated-bosh-init/"${BOSH_MANIFEST_STATE}"
-                else
-                  cp paas-cf/concourse/init_files/bosh-init-state.json.tpl updated-bosh-init-state/"${BOSH_MANIFEST_STATE}"
+                if [ ! -f bosh-init-working-dir/bosh-manifest-state.json ]; then
+                  cp paas-cf/concourse/init_files/bosh-init-state.json.tpl bosh-init-working-dir/bosh-manifest-state.json
                 fi
         ensure:
           put: bosh-init-state
           params:
-            file: "updated-bosh-init-state/bosh-manifest-state-*.json"
+            file: "bosh-init-working-dir/bosh-manifest-state.json"
 
   - name: bosh-terraform-destroy
     serial: true


### PR DESCRIPTION
## What

Because the updated state file was only copied into the output directory
after the bosh-init run, if bosh-init errored for any reason, this would
not happen, and the ensure block had no file available to upload.

This refactors the task to use the output dir as the working dir for
bosh-init meaning that the updated state file is always available to the
ensure block.

## How to review

Given an environment with an existing bosh VM:

* Rename the existing bosh-manifest-state file in your S3 bucket.
* Run the pipeline from this branch.
* Observe bosh-init error when trying to create a new bosh vm due to an IP conflict.
* Verify that the updated state file is uploaded to S3
* Restore the original state file.
* Run the pipeline again, and verify that it succeeds.

## Who can review

Anyone but myself.