### PR TITLE
[#121843167] Ensure Collectd is configured on all VMs

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -106,6 +106,12 @@ resources:
       uri: https://github.com/alphagov/paas-aws-broker-boshrelease.git
       tag_filter: {{cf_aws_broker_version}}
 
+  - name: collectd-boshrelease
+    type: git
+    source:
+      uri: https://github.com/alphagov/paas-collectd-boshrelease.git
+      tag_filter: {{cf_collectd_version}}
+
   - name: os-conf-boshrelease
     type: git
     source:
@@ -1129,6 +1135,7 @@ jobs:
           - get: grafana-boshrelease
           - get: paas-haproxy-release
           - get: aws-broker-boshrelease
+          - get: collectd-boshrelease
           - get: os-conf-boshrelease
           - get: cf-secrets
             passed: ['generate-cf-config']
@@ -1147,6 +1154,7 @@ jobs:
               - name: grafana-boshrelease
               - name: paas-haproxy-release
               - name: aws-broker-boshrelease
+              - name: collectd-boshrelease
               - name: os-conf-boshrelease
             run:
               path: sh
@@ -1170,6 +1178,9 @@ jobs:
 
                   paas-cf/concourse/scripts/bosh_create_and_upload_release.rb aws-broker \
                     {{cf_aws_broker_version}} aws-broker-boshrelease
+
+                  paas-cf/concourse/scripts/bosh_create_and_upload_release.rb collectd \
+                    {{cf_collectd_version}} collectd-boshrelease
 
         - task: get-and-upload-stemcell
           config:

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -42,6 +42,7 @@ prepare_environment() {
   cf_grafana_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.grafana.version "${cf_manifest_dir}/040-graphite.yml")
   cf_aws_broker_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.aws-broker.version "${cf_manifest_dir}/050-rds-broker.yml")
   cf_os_conf_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.os-conf.version "${cf_manifest_dir}/runtime/runtime.yml")
+  cf_collectd_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.collectd.version "${cf_manifest_dir}/runtime/runtime.yml")
 
   if [ -z "${SKIP_COMMIT_VERIFICATION:-}" ] ; then
     gpg_ids="[$(xargs < "${SCRIPT_DIR}/../../.gpg-id" | tr ' ' ',')]"
@@ -74,6 +75,7 @@ cf_graphite_version: ${cf_graphite_version}
 cf_grafana_version: ${cf_grafana_version}
 cf_aws_broker_version: ${cf_aws_broker_version}
 cf_os_conf_version: ${cf_os_conf_version}
+cf_collectd_version: ${cf_collectd_version}
 cf_env_specific_manifest: ${ENV_SPECIFIC_CF_MANIFEST}
 paas_cf_tag_filter: ${PAAS_CF_TAG_FILTER:-}
 TAG_PREFIX: ${TAG_PREFIX:-}

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -4,10 +4,6 @@ meta:
   release:
     name: cf
 
-  logsearch_shipper:
-    release:
-      name: "logsearch-shipper"
-
   api_consul_services:
     cloud_controller_ng: {}
 
@@ -20,8 +16,6 @@ meta:
     release: (( grab meta.release.name ))
   - name: statsd-injector
     release: (( grab meta.release.name ))
-  - name: logsearch-shipper
-    release: (( grab meta.logsearch_shipper.release.name ))
   - name: java-buildpack
     release: (( grab meta.release.name ))
   - name: java-offline-buildpack
@@ -48,24 +42,18 @@ meta:
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - name: logsearch-shipper
-    release: (( grab meta.logsearch_shipper.release.name ))
 
   clock_templates:
   - name: cloud_controller_clock
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - name: logsearch-shipper
-    release: (( grab meta.logsearch_shipper.release.name ))
 
   consul_templates:
   - name: consul_agent
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - name: logsearch-shipper
-    release: (( grab meta.logsearch_shipper.release.name ))
 
   etcd_templates:
   - name: consul_agent
@@ -76,8 +64,6 @@ meta:
     release: etcd
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - name: logsearch-shipper
-    release: (( grab meta.logsearch_shipper.release.name ))
 
   loggregator_templates:
   - name: consul_agent
@@ -88,8 +74,6 @@ meta:
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - name: logsearch-shipper
-    release: (( grab meta.logsearch_shipper.release.name ))
 
   loggregator_trafficcontroller_templates:
   - name: consul_agent
@@ -98,8 +82,6 @@ meta:
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - name: logsearch-shipper
-    release: (( grab meta.logsearch_shipper.release.name ))
 
   nats_templates:
   - name: consul_agent
@@ -118,8 +100,6 @@ meta:
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - name: logsearch-shipper
-    release: (( grab meta.logsearch_shipper.release.name ))
   - name: haproxy
     release: paas-haproxy
 
@@ -130,8 +110,6 @@ meta:
     release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - name: logsearch-shipper
-    release: (( grab meta.logsearch_shipper.release.name ))
 
   uaa_templates:
   - name: consul_agent
@@ -142,8 +120,6 @@ meta:
     release: (( grab meta.release.name ))
   - name: statsd-injector
     release: (( grab meta.release.name ))
-  - name: logsearch-shipper
-    release: (( grab meta.logsearch_shipper.release.name ))
 
   diego_job_templates:
     brain:

--- a/manifests/cf-manifest/manifest/030-logsearch.yml
+++ b/manifests/cf-manifest/manifest/030-logsearch.yml
@@ -9,10 +9,6 @@ releases:
   url: https://bosh.io/d/github.com/logsearch/logsearch-boshrelease?v=200.0.0
   version: 200.0.0
   sha1: 527c35db31cd66810accf128ceffee4f5fde80c3
-- name: logsearch-shipper
-  url: https://bosh.io/d/github.com/logsearch/logsearch-shipper-boshrelease?v=4
-  version: 4
-  sha1: c92ce357c5e1e77a4fb7944d58a1971c7aee06b0
 
 jobs:
 - name: ingestor_z1
@@ -181,8 +177,3 @@ properties:
       host: (( grab terraform_outputs.logsearch_elastic_master_elb_dns_name ))
     templates:
       - index_template: /var/vcap/packages/logsearch-config/default-mappings.json
-  logsearch:
-    metrics:
-      enabled: false
-    logs:
-      server: (( concat terraform_outputs.logsearch_ingestor_elb_dns_name ":5514" ))

--- a/manifests/cf-manifest/manifest/040-graphite.yml
+++ b/manifests/cf-manifest/manifest/040-graphite.yml
@@ -27,6 +27,8 @@ jobs:
   networks:
     - name: cf
       static_ips:
+        # This IP is replicated in runtime.yml:52 because grab cannot be used
+        # to interpolate in a multi-line string.
         - 10.0.16.20
   properties:
     metron_agent:

--- a/manifests/cf-manifest/manifest/runtime/runtime.yml
+++ b/manifests/cf-manifest/manifest/runtime/runtime.yml
@@ -1,9 +1,60 @@
 releases:
   - name: os-conf
     version: commit-a2bc2ab32248c8edf7c4790b33902893b1f4db66
+  - name: collectd
+    version: 0.3
 
 addons:
   - name: os-configuration
     jobs:
     - name: set_mtu
       release: os-conf
+  - name: collectd
+    jobs:
+    - name: collectd
+      release: collectd
+    properties:
+      collectd:
+        interval: 10
+        config: |
+          LoadPlugin cpu
+          LoadPlugin disk
+          LoadPlugin entropy
+          LoadPlugin interface
+          LoadPlugin load
+          LoadPlugin memory
+          LoadPlugin swap
+          LoadPlugin uptime
+
+          LoadPlugin df
+          <Plugin df>
+            ReportInodes true
+            ReportReserved true
+          </Plugin>
+
+          LoadPlugin syslog
+          <Plugin syslog>
+            LogLevel warning
+            NotifyLevel WARNING
+          </Plugin>
+
+          LoadPlugin vmem
+          <Plugin vmem>
+            Verbose false
+          </Plugin>
+
+          LoadPlugin "write_graphite"
+          <Plugin "write_graphite">
+           <Node "myNode">
+             #FIXME: hard coded static IP to be removed during #121602315
+             # This address comes from 040-graphite.yml:31 and has been copied
+             # as `grab` cannot interpolate in a multi-line string.
+             Host "10.0.16.20"
+             Port "2003"
+             Prefix "collectd."
+             EscapeCharacter "_"
+             SeparateInstances true
+             StoreRates false
+             AlwaysAppendDS false
+           </Node>
+          </Plugin>


### PR DESCRIPTION
## What

https://www.pivotaltracker.com/projects/1275640/stories/121843167

A Collectd release has been forked from the CloudFoundry Community respositories and applied as an addon in Bosh, making it available on all VMs managed by Bosh. Collectd is configured to send metrics directly to Graphite. Logsearch-shipper has been removed as most of the logs were duplicates of what is already sent by Metron. See commit message for full details.

## How to review

* Deploy using the branch `collectd_121843167`.
* Check Collectd data is sent to Graphite (get Graphite URL using `make dev showenv`).

## Who can review

Anyone but @Jonty or me
