### PR TITLE
Update resource pinning to simplify pipeline.

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -810,11 +810,11 @@ jobs:
           - get: cf-tfstate
           - get: cf-certs-tfstate
           - get: bosh-CA
-            passed: ['generate-secrets']
+            passed: ['pre-deploy']
           - get: cf-certs
             passed: ['generate-secrets']
           - get: cf-secrets
-            passed: ['generate-secrets']
+            passed: ['pre-deploy']
 
       - task: upload-certs-to-aws
         config:
@@ -1454,9 +1454,9 @@ jobs:
           - get: paas-cf
             passed: ['cf-deploy']
           - get: cf-manifest
-            passed: ['generate-cf-config']
+            passed: ['cf-deploy']
           - get: cf-secrets
-            passed: ['generate-cf-config']
+            passed: ['cf-deploy']
           - get: bosh-CA
 
       - task: retrieve-config
@@ -1535,10 +1535,10 @@ jobs:
           - get: paas-cf
             passed: ['post-deploy','availability-tests']
           - get: cf-manifest
-            passed: ['cf-deploy']
+            passed: ['post-deploy']
           - get: bosh-CA
           - get: cf-secrets
-            passed: ['cf-deploy']
+            passed: ['post-deploy']
 
       - do:
         - task: create-temp-user
@@ -1570,10 +1570,10 @@ jobs:
           - get: paas-cf
             passed: ['post-deploy','availability-tests']
           - get: cf-manifest
-            passed: ['cf-deploy']
+            passed: ['post-deploy']
           - get: bosh-CA
           - get: cf-secrets
-            passed: ['cf-deploy']
+            passed: ['post-deploy']
 
       - do:
         - task: create-temp-user
@@ -1660,10 +1660,10 @@ jobs:
           - get: paas-cf
             passed: ['post-deploy','availability-tests']
           - get: cf-manifest
-            passed: ['cf-deploy']
+            passed: ['post-deploy']
           - get: bosh-CA
           - get: cf-secrets
-            passed: ['cf-deploy']
+            passed: ['post-deploy']
 
       - do:
         - task: create-temp-user
@@ -1779,7 +1779,7 @@ jobs:
             passed: ['smoke-tests', 'acceptance-tests', 'custom-acceptance-tests']
           - get: bosh-CA
           - get: cf-secrets
-            passed: ['cf-deploy']
+            passed: ['smoke-tests', 'acceptance-tests', 'custom-acceptance-tests']
 
       - do:
         - task: create-temp-user


### PR DESCRIPTION
## What

This reduces the number of loops/bypasses in the pipeline and makes it
easier to see what's flowing where. It generally makes the input pinning
more consistent for several jobs - they're all pinned to the same
previous job if possible.

* Pin cf-terraform inputs to pre-deploy
* Pin post-deploy inputs to cf-deploy
* Pin cf-secrets and cf-manifest for smoke/acceptance tests to
  post-deploy.
* Pin cf-secrets in performange-tests to smoke/acceptance tests

### Early part of pipeline:

Before:
![image](https://cloud.githubusercontent.com/assets/5560/16338465/cd39e4ba-3a14-11e6-98e3-7dbfeab23b86.png)
After:
![image](https://cloud.githubusercontent.com/assets/5560/16338470/dc57a054-3a14-11e6-9d74-e28061e15e8c.png)

### Later part of pipeline:

Before:
![image](https://cloud.githubusercontent.com/assets/5560/16338479/eae622a8-3a14-11e6-8fd7-98d0805a57b1.png)

After:
![image](https://cloud.githubusercontent.com/assets/5560/16338480/eec6fd34-3a14-11e6-8175-07865df6fe8b.png)


## How to review

Check changes look sensible, and the pipeline dependencies are still correct.

## Who can review

Anyone but myself.