### PR TITLE
[#122117381] Set Bosh RDS backup window.

### DIFF
--- a/terraform/bosh/rds.tf
+++ b/terraform/bosh/rds.tf
@@ -46,6 +46,7 @@ resource "aws_db_instance" "bosh" {
   password = "${var.secrets_bosh_postgres_password}"
   db_subnet_group_name = "${aws_db_subnet_group.bosh_rds.name}"
   parameter_group_name = "${aws_db_parameter_group.default.id}"
+  backup_window = "01:00-02:00"
   maintenance_window = "Thu:03:00-Thu:04:00"
   multi_az = "${var.bosh_db_multi_az}"
   backup_retention_period = "${var.bosh_db_backup_retention_period}"


### PR DESCRIPTION
## What

When this is not specified, RDS will pick a random window that's
appropriate for the region. There's therefore a chance that this will
conflict with the maintenance window that we're specifying here.

Specifying the backup window avoids the possibility of these
conflicting.

## How to review

Deploy from this branch, and verify that it applies cleanly.

## Who can review

Anyone but myself.