### PR TITLE
[#122581781] Set system_domain_organization to 'admin'

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1277,7 +1277,10 @@ jobs:
                 RDS_BROKER_SERVER=$($VAL_FROM_YAML jobs.rds_broker.networks.cf.static_ips.0 cf-manifest/cf-manifest.yml)
                 RDS_BROKER_PASS=$($VAL_FROM_YAML secrets.rds_broker_admin_password cf-secrets/cf-secrets.yml)
 
-                for var_name in CF_ADMIN CF_PASS FIREHOSE_USER FIREHOSE_PASS API_ENDPOINT UAA_ENDPOINT DOPPLER_ENDPOINT GRAPHITE_SERVER RDS_BROKER_SERVER RDS_BROKER_PASS; do
+                # FIXME: remove once fix-system-domain-org task has run on prod
+                SYSTEM_DOMAIN=$($VAL_FROM_YAML properties.system_domain cf-manifest/cf-manifest.yml)
+
+                for var_name in CF_ADMIN CF_PASS FIREHOSE_USER FIREHOSE_PASS API_ENDPOINT UAA_ENDPOINT DOPPLER_ENDPOINT GRAPHITE_SERVER RDS_BROKER_SERVER RDS_BROKER_PASS SYSTEM_DOMAIN; do
                   echo export "${var_name}"=\"$(eval echo \$${var_name})\"
                 done > config/config.sh
 
@@ -1444,6 +1447,39 @@ jobs:
                   EOF
 
                   cf push
+
+        # FIXME: Remove once run on production
+        - task: fix-system-domain-org
+          config:
+            platform: linux
+            image: docker:///governmentpaas/cf-cli
+            inputs:
+              - name: paas-cf
+              - name: bosh-CA
+              - name: config
+            params:
+            run:
+              path: sh
+              args:
+                - -e
+                - -u
+                - -c
+                - |
+                  ./paas-cf/concourse/scripts/import_bosh_ca.sh
+                  . ./config/config.sh
+
+                  echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}"
+
+                  if cf org GDS > /dev/null; then
+                    cf delete-org GDS -f
+                  fi
+
+                  cf target -o admin
+                  if cf domains | grep -q "${SYSTEM_DOMAIN}"; then
+                    echo "domain ${SYSTEM_DOMAIN} is already exists in the admin org"
+                  else
+                    cf create-domain admin "${SYSTEM_DOMAIN}"
+                  fi
 
   - name: post-deploy
     plan:

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -15,7 +15,7 @@ meta:
 properties:
   domain: (( grab terraform_outputs.cf_root_domain ))
   system_domain: (( grab terraform_outputs.cf_root_domain ))
-  system_domain_organization: GDS
+  system_domain_organization: admin
   app_domains:
    - (( grab terraform_outputs.cf_apps_domain ))
 


### PR DESCRIPTION
## What

This was set to 'GDS' in 11318b0 for no real reason that I can remember
(I was working on that story). Having it set to 'GDS' could lead to
confusion as there are likely to be several services deployed to the
PaaS from teams within GDS.

This sets it back to 'admin' which is the cloudfoundry default. The
admin org is also where we deploy some system components like the
graphite nozzle, so seems like a good org to own this.

Note:
Changing the `system_domain_organization` in the manifest doesn't result
in this being applied when deployed to an existing deployment. This
therefore adds a task to remove the old org (and thereby delete the
domain), and add the system domain to the admin org.

I've therefore added a temporary task to the post-deploy jobs to clean this
up.  It should be reverted once it's run on production.

## How to review

Deploy from this branch.

* Verify that the 'GDS' org no longer exists.
* Verify that the 'amin' org owns the system_domain (it should be listed as an owned domain in `cf domains`)

## Who can review

Anyone but myself.