### PR TITLE
[#119272203] Fix data race in availability tests

### DIFF
--- a/tests/src/availability/healthcheck_availability_during_deployment_test.go
+++ b/tests/src/availability/healthcheck_availability_during_deployment_test.go
@@ -38,7 +38,7 @@ func loadTest(appUri string, endpoint string, rate uint64) (*vegeta.Attacker, <-
 	return attacker, res
 }
 
-func errorRateThreshold(metrics vegeta.Metrics, minimumTestDuration time.Duration, maximumErrorRate float64) bool {
+func errorRateThreshold(metrics *vegeta.Metrics, minimumTestDuration time.Duration, maximumErrorRate float64) bool {
 	// metrics.Close() does trigger the computation of metrics, but does not stop any process
 	metrics.Close()
 
@@ -75,7 +75,7 @@ var _ = Describe("Availability test", func() {
 				}
 				metricsLock.Lock()
 				defer metricsLock.Unlock()
-				if errorRateThreshold(metrics, minimumTestDuration, maximumErrorRate) {
+				if errorRateThreshold(&metrics, minimumTestDuration, maximumErrorRate) {
 					return true
 				}
 				return false


### PR DESCRIPTION
## What

We noticed that there was a data race in the availability tests in this run https://deployer.staging.cloudpipeline.digital/pipelines/create-bosh-cloudfoundry/jobs/availability-tests/builds/11. One of the output lines is:
```
 - Duration: 35m4.799999798s, Requests: 21049, Non 200 Requests: 18446744073709551615, Success Rate: 100.00%
```

This fixes the data race by introducing a lock around the metrics instance, and ensuring all metrics are consumed before the final assertion.

## How to review

Deploy from the `fix_availability_tests_race_with_detector` branch (This branch includes everything on the PR branch, and additionally enables the race detector) and verify that the availability tests pass without any race detector warnings. 

## Who can review

Anyone but myself.