### PR TITLE
[#122581781] Revert "Temporary pipeline task to fix system domain org"

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1277,10 +1277,7 @@ jobs:
                 RDS_BROKER_SERVER=$($VAL_FROM_YAML jobs.rds_broker.networks.cf.static_ips.0 cf-manifest/cf-manifest.yml)
                 RDS_BROKER_PASS=$($VAL_FROM_YAML secrets.rds_broker_admin_password cf-secrets/cf-secrets.yml)
 
-                # FIXME: remove once fix-system-domain-org task has run on prod
-                SYSTEM_DOMAIN=$($VAL_FROM_YAML properties.system_domain cf-manifest/cf-manifest.yml)
-
-                for var_name in CF_ADMIN CF_PASS FIREHOSE_USER FIREHOSE_PASS API_ENDPOINT UAA_ENDPOINT DOPPLER_ENDPOINT GRAPHITE_SERVER RDS_BROKER_SERVER RDS_BROKER_PASS SYSTEM_DOMAIN; do
+                for var_name in CF_ADMIN CF_PASS FIREHOSE_USER FIREHOSE_PASS API_ENDPOINT UAA_ENDPOINT DOPPLER_ENDPOINT GRAPHITE_SERVER RDS_BROKER_SERVER RDS_BROKER_PASS; do
                   echo export "${var_name}"=\"$(eval echo \$${var_name})\"
                 done > config/config.sh
 
@@ -1447,39 +1444,6 @@ jobs:
                   EOF
 
                   cf push
-
-        # FIXME: Remove once run on production
-        - task: fix-system-domain-org
-          config:
-            platform: linux
-            image: docker:///governmentpaas/cf-cli
-            inputs:
-              - name: paas-cf
-              - name: bosh-CA
-              - name: config
-            params:
-            run:
-              path: sh
-              args:
-                - -e
-                - -u
-                - -c
-                - |
-                  ./paas-cf/concourse/scripts/import_bosh_ca.sh
-                  . ./config/config.sh
-
-                  echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}"
-
-                  if cf org GDS > /dev/null; then
-                    cf delete-org GDS -f
-                  fi
-
-                  cf target -o admin
-                  if cf domains | grep -q "${SYSTEM_DOMAIN}"; then
-                    echo "domain ${SYSTEM_DOMAIN} is already exists in the admin org"
-                  else
-                    cf create-domain admin "${SYSTEM_DOMAIN}"
-                  fi
 
   - name: post-deploy
     plan:


### PR DESCRIPTION
## What

#337 Changes the system domain org back to 'admin', and retuired a temporary task to cleanup the existing state. This is no longer needed now that it's run on production. This reverts commit 1beca4e35a2ed7e466289dcd6930319e253011e9.

## How to review

Code review. Verify that this reverts the above commit and nothing else.

## Who can review

Anyone but myself.
