### PR TITLE
[#121933113] Fix gorouter issue for zero downtime deploy

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -119,6 +119,13 @@ resources:
       tag_filter: {{cf_os_conf_version}}
       branch: gds_master
 
+  - name: routing-release
+    type: git
+    source:
+      uri: https://github.com/alphagov/paas-routing-release.git
+      tag_filter: {{cf_routing_version}}
+      branch: cf_237
+
   - name: graphite-nozzle
     type: git
     source:
@@ -1141,6 +1148,7 @@ jobs:
             passed: ['generate-cf-config']
           - get: bosh-CA
           - get: graphite-nozzle
+          - get: routing-release
 
       - aggregate:
         - task: upload-releases
@@ -1156,6 +1164,7 @@ jobs:
               - name: aws-broker-boshrelease
               - name: collectd-boshrelease
               - name: os-conf-boshrelease
+              - name: routing-release
             run:
               path: sh
               args:
@@ -1182,6 +1191,8 @@ jobs:
                   paas-cf/concourse/scripts/bosh_create_and_upload_release.rb collectd \
                     {{cf_collectd_version}} collectd-boshrelease
 
+                  paas-cf/concourse/scripts/bosh_create_and_upload_release.rb routing \
+                    {{cf_routing_version}} routing-release
         - task: get-and-upload-stemcell
           config:
             platform: linux

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1493,7 +1493,7 @@ jobs:
                 CF_PASS=$($VAL_FROM_YAML secrets.uaa_admin_password cf-secrets/cf-secrets.yml)
                 API_ENDPOINT=$($VAL_FROM_YAML properties.cc.srv_api_uri cf-manifest/cf-manifest.yml)
 
-                for var_name in CF_ADMIN CF_PASS API_ENDPOINT; do 
+                for var_name in CF_ADMIN CF_PASS API_ENDPOINT; do
                   echo export "${var_name}"=\"$(eval echo \$${var_name})\"
                 done > config/config.sh
 

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -43,6 +43,7 @@ prepare_environment() {
   cf_aws_broker_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.aws-broker.version "${cf_manifest_dir}/050-rds-broker.yml")
   cf_os_conf_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.os-conf.version "${cf_manifest_dir}/runtime/runtime.yml")
   cf_collectd_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.collectd.version "${cf_manifest_dir}/runtime/runtime.yml")
+  cf_routing_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.routing.version "${cf_manifest_dir}/000-base-cf-deployment.yml")
 
   if [ -z "${SKIP_COMMIT_VERIFICATION:-}" ] ; then
     gpg_ids="[$(xargs < "${SCRIPT_DIR}/../../.gpg-id" | tr ' ' ',')]"
@@ -76,6 +77,7 @@ cf_grafana_version: ${cf_grafana_version}
 cf_aws_broker_version: ${cf_aws_broker_version}
 cf_os_conf_version: ${cf_os_conf_version}
 cf_collectd_version: ${cf_collectd_version}
+cf_routing_version: ${cf_routing_version}
 cf_env_specific_manifest: ${ENV_SPECIFIC_CF_MANIFEST}
 paas_cf_tag_filter: ${PAAS_CF_TAG_FILTER:-}
 TAG_PREFIX: ${TAG_PREFIX:-}

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -26,7 +26,7 @@ releases:
     url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-rootfs-release?v=1.5.0
     sha1: 4ab6166d800668ad3e9c2c10cfd3403a7de5885f
   - name: paas-haproxy
-    version: 0.0.2
+    version: 0.0.3
 
 stemcells:
   - alias: default

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -27,6 +27,8 @@ releases:
     sha1: 4ab6166d800668ad3e9c2c10cfd3403a7de5885f
   - name: paas-haproxy
     version: 0.0.3
+  - name: routing
+    version: commit-bfe3632ad6a2d143279db865aa050aea076fef9e
 
 stemcells:
   - alias: default

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -97,7 +97,7 @@ meta:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
   - name: gorouter
-    release: (( grab meta.release.name ))
+    release: routing
   - name: metron_agent
     release: (( grab meta.release.name ))
   - name: haproxy

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -148,6 +148,7 @@ properties:
     extra_headers_to_log:
     debug_addr:
     enable_routing_api:
+    drain_wait: 15
 
   cc:
     jobs:

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -131,6 +131,7 @@ properties:
     additional_frontend_config: |
       capture response header strict-transport-security len 128
       http-response add-header Strict-Transport-Security max-age=31536000 unless { capture.res.hdr(0) -m found }
+    enable_healthcheck_frontend: true
 
   router:
     enable_ssl: false


### PR DESCRIPTION
## What
Story: https://www.pivotaltracker.com/story/show/121933113

It's a part of zero downtime deployment epic. 

This PR implements custom healthcheck for haproxy to enable connection draining to make sure we don't server any errors during cf-deploy.

Also we split routing-release from main cf-release and use our fork to deliver gorouter fix for early exit when more than one signal is received. More details about that fix in routing-release PR: https://github.com/alphagov/paas-routing-release/pull/1

As a result of above listed changes we increase the availability test success rate threshold to 100% as we expect true zero downtime deployment now  

## How to review

- [x] Review: https://github.com/alphagov/paas-haproxy-release/pull/3
- [x] Review: https://github.com/alphagov/paas-routing-release/pull/1
- [x] Run pipeline from `121933113_routers` branch, it will force full router update as it contains  https://github.com/alphagov/paas-cf/commit/9292aae6d40b45aa9e2703b5eb297264ab8904fd. Later you will remove it. Check if availability test passes.
- [x] Merge: https://github.com/alphagov/paas-haproxy-release/pull/3
- [x] Remove https://github.com/alphagov/paas-cf/blob/2937b4c8d0ff8612256503607c4393ac1f2de145/concourse/pipelines/create-bosh-cloudfoundry.yml#L89, put a new tag on `paas-haproxy` and update https://github.com/alphagov/paas-cf/blob/2937b4c8d0ff8612256503607c4393ac1f2de145/manifests/cf-manifest/manifest/000-base-cf-deployment.yml#L29
- [x] Remove https://github.com/alphagov/paas-cf/commit/2c2e606cd1c3641e47440edb7b258cc1a254a249 , put new tag on `routing-release` and update https://github.com/alphagov/paas-cf/blob/758e0b5eef87228e640f6a33fb79c69d1bb251f1/manifests/cf-manifest/manifest/000-base-cf-deployment.yml#L31
- [x] Remove https://github.com/alphagov/paas-cf/commit/9292aae6d40b45aa9e2703b5eb297264ab8904fd
- [x] Merge this PR

## Who can review

Not @saliceti , @timmow or @combor
