### PR TITLE
[#121933113]  Enable HTTP healthcheck on router ELB

### DIFF
--- a/platform-tests/src/availability/healthcheck_availability_during_deployment_test.go
+++ b/platform-tests/src/availability/healthcheck_availability_during_deployment_test.go
@@ -18,7 +18,7 @@ const (
 	availabilityTestMaxDuration      = 2 * time.Hour
 	availabilityTestMaxLatency       = 300 * time.Millisecond
 	availabilityTestMaxErrors        = 0
-	availabilitySuccessRateThreshold = 99.9
+	availabilitySuccessRateThreshold = 100.0
 	minimumTestDuration              = 15 * time.Second
 	maximumErrorRate                 = 0.5
 

--- a/terraform/cloudfoundry/router_elb.tf
+++ b/terraform/cloudfoundry/router_elb.tf
@@ -11,7 +11,7 @@ resource "aws_elb" "cf_router" {
   ]
 
   health_check {
-    target = "TCP:81"
+    target = "HTTP:82/"
     interval = "${var.health_check_interval}"
     timeout = "${var.health_check_timeout}"
     healthy_threshold = "${var.health_check_healthy}"


### PR DESCRIPTION
## What

This is follow up to https://github.com/alphagov/paas-cf/pull/341 to enable custom haproxy healthcheck which sends specific user-agent to gorouter. 

Please merge it after its parent has been deployed to production.
 
## How to review

Apply on top of existing env and check if availability test passes.

## Who can review

Not @saliceti or @combor