### PR TITLE
[#118909613] HA Postgres Service Broker

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1691,24 +1691,7 @@ jobs:
               PREFIX: custom-acceptance-test-user
 
         - task: generate-test-config
-          config:
-            platform: linux
-            image: docker:///ruby#2.2-slim
-            inputs:
-              - name: paas-cf
-              - name: cf-manifest
-              - name: admin-creds
-            outputs:
-              - name: test-config
-            run:
-              path: sh
-              args:
-                - -e
-                - -c
-                - |
-                  export CF_MANIFEST=cf-manifest/cf-manifest.yml
-                  ./paas-cf/platform-tests/generate_test_config.rb \
-                    > test-config/config.json
+          file: paas-cf/concourse/tasks/generate-test-config.yml
 
         - task: run-tests
           config:
@@ -1807,24 +1790,7 @@ jobs:
               PREFIX: performance-tests-user
 
         - task: generate-test-config
-          config:
-            platform: linux
-            image: docker:///ruby#2.2-slim
-            inputs:
-              - name: paas-cf
-              - name: cf-manifest
-              - name: admin-creds
-            outputs:
-              - name: test-config
-            run:
-              path: sh
-              args:
-                - -e
-                - -c
-                - |
-                  export CF_MANIFEST=cf-manifest/cf-manifest.yml
-                  ./paas-cf/platform-tests/generate_test_config.rb \
-                    > test-config/config.json
+          file: paas-cf/concourse/tasks/generate-test-config.yml
 
         - task: run-tests
           config:

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1388,7 +1388,7 @@ jobs:
                   . ./config/config.sh
                   echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
 
-                  if cf service-brokers | grep "rds-broker\s*http://$RDS_BROKER_SERVER"; then
+                  if cf service-brokers | grep "rds-broker\s"; then
                     cf update-service-broker rds-broker rds-broker $RDS_BROKER_PASS http://$RDS_BROKER_SERVER
                   else
                     cf create-service-broker rds-broker rds-broker $RDS_BROKER_PASS http://$RDS_BROKER_SERVER

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1137,6 +1137,8 @@ jobs:
             passed: ['generate-cf-config']
           - get: cf-manifest
             passed: ['generate-cf-config']
+          - get: cf-tfstate
+            passed: ['generate-cf-config']
           - get: bosh-secrets
           - get: graphite-statsd-boshrelease
           - get: grafana-boshrelease
@@ -1265,6 +1267,7 @@ jobs:
             - name: paas-cf
             - name: cf-secrets
             - name: cf-manifest
+            - name: cf-tfstate
           outputs:
             - name: config
           params:
@@ -1277,6 +1280,10 @@ jobs:
               - |
                 VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
 
+                ./paas-cf/concourse/scripts/extract_terraform_state_to_yaml.rb \
+                  < cf-tfstate/cf.tfstate \
+                  > cf-terraform-outputs.yml
+
                 CF_ADMIN=admin
                 CF_PASS=$($VAL_FROM_YAML secrets.uaa_admin_password cf-secrets/cf-secrets.yml)
                 FIREHOSE_USER=graphite-nozzle
@@ -1285,7 +1292,7 @@ jobs:
                 UAA_ENDPOINT=$($VAL_FROM_YAML properties.uaa.url cf-manifest/cf-manifest.yml)
                 DOPPLER_ENDPOINT=$($VAL_FROM_YAML properties.loggregator.traffic_controller_url cf-manifest/cf-manifest.yml)
                 GRAPHITE_SERVER=$($VAL_FROM_YAML jobs.graphite.networks.cf.static_ips.0 cf-manifest/cf-manifest.yml)
-                RDS_BROKER_SERVER=$($VAL_FROM_YAML jobs.rds_broker.networks.cf.static_ips.0 cf-manifest/cf-manifest.yml)
+                RDS_BROKER_SERVER=$($VAL_FROM_YAML terraform_outputs.rds_broker_elb_dns_name cf-terraform-outputs.yml)
                 RDS_BROKER_PASS=$($VAL_FROM_YAML secrets.rds_broker_admin_password cf-secrets/cf-secrets.yml)
 
                 for var_name in CF_ADMIN CF_PASS FIREHOSE_USER FIREHOSE_PASS API_ENDPOINT UAA_ENDPOINT DOPPLER_ENDPOINT GRAPHITE_SERVER RDS_BROKER_SERVER RDS_BROKER_PASS; do

--- a/concourse/pipelines/failure-testing.yml
+++ b/concourse/pipelines/failure-testing.yml
@@ -393,3 +393,69 @@ jobs:
                   BOSH_FQDN: {{bosh_fqdn}}
             - task: remove-temp-user
               file: paas-cf/concourse/tasks/delete_admin.yml
+
+  - name: rds-broker
+    serial_groups: [ failure ]
+    serial: true
+    plan:
+      - aggregate:
+          - get: cf-release
+            params:
+              submodules:
+                - src/smoke-tests
+          - get: paas-cf
+          - get: cf-manifest
+          - get: cf-secrets
+          - get: bosh-secrets
+          - get: bosh-CA
+          - get: pipeline-trigger
+            passed: ['cell']
+            trigger: true
+      - task: get-instance-id
+        file: paas-cf/concourse/tasks/get-instance-id.yml
+        config:
+          params:
+            VM_NAME: rds_broker/0
+            BOSH_FQDN: {{bosh_fqdn}}
+      - task: kill-instance
+        file: paas-cf/concourse/tasks/kill-instance.yml
+      - do:
+        - task: create-temp-user
+          file: paas-cf/concourse/tasks/create_admin.yml
+          config:
+            params:
+              PREFIX: rds-broker-test-user
+
+        - task: generate-test-config
+          file: paas-cf/concourse/tasks/generate-test-config.yml
+
+        - task: run-tests
+          config:
+            platform: linux
+            image: docker:///governmentpaas/cf-acceptance-tests
+            inputs:
+              - name: paas-cf
+              - name: test-config
+              - name: bosh-CA
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  ./paas-cf/concourse/scripts/import_bosh_ca.sh
+
+                  echo "Running tests"
+                  export CONFIG="$(pwd)/test-config/config.json"
+                  export GINKGO_FOCUS='RDS broker'
+                  ./paas-cf/platform-tests/run_tests.sh ./paas-cf/platform-tests/src/acceptance/
+
+        ensure:
+          aggregate:
+            - task: recover
+              file: paas-cf/concourse/tasks/recover.yml
+              config:
+                params:
+                  BOSH_FQDN: {{bosh_fqdn}}
+            - task: remove-temp-user
+              file: paas-cf/concourse/tasks/delete_admin.yml

--- a/concourse/tasks/generate-test-config.yml
+++ b/concourse/tasks/generate-test-config.yml
@@ -1,0 +1,18 @@
+---
+platform: linux
+image: docker:///ruby#2.2-slim
+inputs:
+  - name: paas-cf
+  - name: cf-manifest
+  - name: admin-creds
+outputs:
+  - name: test-config
+run:
+  path: sh
+  args:
+    - -e
+    - -c
+    - |
+      export CF_MANIFEST=cf-manifest/cf-manifest.yml
+      ./paas-cf/platform-tests/generate_test_config.rb \
+        > test-config/config.json

--- a/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
+++ b/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
@@ -37,6 +37,7 @@ vm_types:
       security_groups:
         - (( grab terraform_outputs.default_security_group ))
         - (( grab terraform_outputs.cf_rds_client_security_group ))
+        - (( grab terraform_outputs.cloud_controller_security_group ))
 
   - name: clock_global
     network: cf
@@ -49,6 +50,7 @@ vm_types:
       security_groups:
         - (( grab terraform_outputs.default_security_group ))
         - (( grab terraform_outputs.cf_rds_client_security_group ))
+        - (( grab terraform_outputs.cloud_controller_security_group ))
 
   - name: api_worker
     network: cf
@@ -62,6 +64,7 @@ vm_types:
       security_groups:
         - (( grab terraform_outputs.default_security_group ))
         - (( grab terraform_outputs.cf_rds_client_security_group ))
+        - (( grab terraform_outputs.cloud_controller_security_group ))
 
   - name: uaa
     network: cf

--- a/manifests/cf-manifest/cloud-config/050-rds-broker.yml
+++ b/manifests/cf-manifest/cloud-config/050-rds-broker.yml
@@ -4,7 +4,7 @@ vm_types:
     network: cf
     env: (( grab meta.default_env ))
     cloud_properties:
-      instance_type: m3.medium
+      instance_type: t2.nano
       iam_instance_profile: rds-broker
       ephemeral_disk:
         size: 10240

--- a/manifests/cf-manifest/cloud-config/050-rds-broker.yml
+++ b/manifests/cf-manifest/cloud-config/050-rds-broker.yml
@@ -12,3 +12,5 @@ vm_types:
       security_groups:
         - (( grab terraform_outputs.rds_broker_db_clients_security_group ))
         - (( grab terraform_outputs.default_security_group ))
+      elbs:
+        - (( grab terraform_outputs.rds_broker_elb_name ))

--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -23,8 +23,8 @@ releases:
 
 jobs:
   - name: rds_broker
-    azs: [z1]
-    instances: 1
+    azs: [z1, z2]
+    instances: 2
     vm_type: rds_broker
     stemcell: default
     templates:
@@ -32,8 +32,6 @@ jobs:
         release: aws-broker
     networks:
       - name: cf
-        static_ips:
-          - 10.0.16.25
     properties:
       rds-broker:
         aws_access_key_id: ""

--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -19,7 +19,7 @@ meta:
 
 releases:
   - name: aws-broker
-    version: 0.0.5
+    version: 0.0.7
 
 jobs:
   - name: rds_broker

--- a/manifests/shared/spec/fixtures/terraform/terraform-outputs.yml
+++ b/manifests/shared/spec/fixtures/terraform/terraform-outputs.yml
@@ -36,3 +36,4 @@ terraform_outputs:
   rds_broker_dbs_security_group_id: stub_rds_broker_dbs_security_group_id
   rds_broker_dbs_subnet_group: stub_rds_broker_dbs_subnet_group
   rds_broker_postgres95_db_parameter_group: stub_rds_broker_postgres95_db_parameter_group
+  cloud_controller_security_group: sg-0000000

--- a/manifests/shared/spec/fixtures/terraform/terraform-outputs.yml
+++ b/manifests/shared/spec/fixtures/terraform/terraform-outputs.yml
@@ -36,4 +36,6 @@ terraform_outputs:
   rds_broker_dbs_security_group_id: stub_rds_broker_dbs_security_group_id
   rds_broker_dbs_subnet_group: stub_rds_broker_dbs_subnet_group
   rds_broker_postgres95_db_parameter_group: stub_rds_broker_postgres95_db_parameter_group
+  rds_broker_elb_dns_name: rds-broker.com
+  rds_broker_elb_name: rds_broker_elb
   cloud_controller_security_group: sg-0000000

--- a/platform-tests/src/acceptance/run_tests.sh
+++ b/platform-tests/src/acceptance/run_tests.sh
@@ -2,4 +2,8 @@
 
 set -eu
 
-go test -timeout 30m
+if [ -n "${GINKGO_FOCUS:-}" ]; then
+  go test -timeout 30m -ginkgo.focus "${GINKGO_FOCUS}"
+else
+  go test -timeout 30m
+fi

--- a/terraform/cloudfoundry/component_security_groups.tf
+++ b/terraform/cloudfoundry/component_security_groups.tf
@@ -1,0 +1,10 @@
+
+resource "aws_security_group" "cloud_controller" {
+  name = "${var.env}-cloud-controller"
+  description = "Group for VMs acting as part of the Cloud Controller"
+  vpc_id = "${var.vpc_id}"
+
+  tags {
+    Name = "${var.env}-cloud-controller"
+  }
+}

--- a/terraform/cloudfoundry/dns-records.tf
+++ b/terraform/cloudfoundry/dns-records.tf
@@ -70,3 +70,10 @@ resource "aws_route53_record" "logsearch" {
   records = ["${aws_elb.logsearch_kibana.dns_name}"]
 }
 
+resource "aws_route53_record" "rds_broker" {
+  zone_id = "${var.system_dns_zone_id}"
+  name = "rds-broker.${var.system_dns_zone_name}."
+  type = "CNAME"
+  ttl = "60"
+  records = ["${aws_elb.rds_broker.dns_name}"]
+}

--- a/terraform/cloudfoundry/outputs.tf
+++ b/terraform/cloudfoundry/outputs.tf
@@ -110,6 +110,14 @@ output "rds_broker_postgres95_db_parameter_group" {
   value = "${aws_db_parameter_group.rds_broker_postgres95.id}"
 }
 
+output "rds_broker_elb_name" {
+  value = "${aws_elb.rds_broker.name}"
+}
+
+output "rds_broker_elb_dns_name" {
+  value = "${aws_route53_record.rds_broker.fqdn}"
+}
+
 output "cloud_controller_security_group" {
   value = "${aws_security_group.cloud_controller.name}"
 }

--- a/terraform/cloudfoundry/outputs.tf
+++ b/terraform/cloudfoundry/outputs.tf
@@ -109,3 +109,7 @@ output "rds_broker_dbs_subnet_group" {
 output "rds_broker_postgres95_db_parameter_group" {
   value = "${aws_db_parameter_group.rds_broker_postgres95.id}"
 }
+
+output "cloud_controller_security_group" {
+  value = "${aws_security_group.cloud_controller.name}"
+}

--- a/terraform/cloudfoundry/rds_broker.tf
+++ b/terraform/cloudfoundry/rds_broker.tf
@@ -1,3 +1,26 @@
+resource "aws_elb" "rds_broker" {
+  name = "${var.env}-rds-broker"
+  subnets = ["${split(",", var.infra_subnet_ids)}"]
+  idle_timeout = "${var.elb_idle_timeout}"
+  cross_zone_load_balancing = "true"
+  internal = true
+  security_groups = ["${aws_security_group.service_brokers.id}"]
+
+  health_check {
+    target = "HTTP:80/healthcheck"
+    interval = "${var.health_check_interval}"
+    timeout = "${var.health_check_timeout}"
+    healthy_threshold = "${var.health_check_healthy}"
+    unhealthy_threshold = "${var.health_check_unhealthy}"
+  }
+  listener {
+    instance_port = 80
+    instance_protocol = "http"
+    lb_port = 80
+    lb_protocol = "http"
+  }
+}
+
 resource "aws_db_subnet_group" "rds_broker" {
   name = "rdsbroker-${var.env}"
   description = "Subnet group for RDS broker managed instances"

--- a/terraform/cloudfoundry/service_broker_security_groups.tf
+++ b/terraform/cloudfoundry/service_broker_security_groups.tf
@@ -1,0 +1,23 @@
+
+resource "aws_security_group" "service_brokers" {
+  name = "${var.env}-service-brokers"
+  description = "Group for service brokers"
+  vpc_id = "${var.vpc_id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 80
+    to_port   = 80
+    protocol  = "tcp"
+  }
+
+  tags {
+    Name = "${var.env}-service-brokers"
+  }
+}

--- a/terraform/cloudfoundry/service_broker_security_groups.tf
+++ b/terraform/cloudfoundry/service_broker_security_groups.tf
@@ -15,6 +15,9 @@ resource "aws_security_group" "service_brokers" {
     from_port = 80
     to_port   = 80
     protocol  = "tcp"
+    security_groups = [
+      "${aws_security_group.cloud_controller.id}",
+    ]
   }
 
   tags {


### PR DESCRIPTION
## What

[#118909613 - HA Postgres Service Broker](https://www.pivotaltracker.com/story/show/118909613)

To minimise downtime of the RDS broker we have made it highly available. This has been achieved by increasing the instance count to 2 and using an ELB.

In order to put the broker behind an ELB, we've added a healthcheck endpoint to it. [These](https://github.com/alphagov/paas-aws-broker-boshrelease/pull/10) [PRs](https://github.com/alphagov/paas-rds-broker/pull/13) have already been merged, and the broker boshrelease tagged as `0.0.7`.

As part of this work we've reduced the size of the `rds_broker` VMs as they were much larget than they needed to be. See commit "Reduce size of rds_broker VMs to t2.nano" for full details.

## How to review

Deploy from this branch. Verify that all the tests pass.

Run the failure-testing pipeline (optionally just run the `rds_broker` job from this pipeline) to verify that the broker is highly available.

## Who can review

Anyone but @HenryTK, @mtekel or myself.