### PR TITLE
[#122183539] Upgrade Grafana to the latest tagged version.

### DIFF
--- a/manifests/cf-manifest/manifest/040-graphite.yml
+++ b/manifests/cf-manifest/manifest/040-graphite.yml
@@ -15,7 +15,7 @@ releases:
 - name: graphite
   version: commit-ccc206f3ba21fe5ba4f3e617bb7dca3e66a652ad
 - name: grafana
-  version: commit-44564533c9d4d656bdcd5633b808f0bf6fb177ae
+  version: commit-4a9e3a322b72bfb4a76ae460a280acf04a5b445d
 
 jobs:
 - name: graphite


### PR DESCRIPTION
## What

As we are going to create a set of dashboards we want them to be compatible with recent versions of Grafana and avoid upgrade pain in the future.

## How to review

Deploy from this branch. Go to Grafana - you can check what the URL is with `make dev showenv` and confirm that the version is 3.0.3. You can find it on the bottom of the login screen. 

## Who can review

Not @combor or @saliceti 
