### PR TITLE
[#115404231] Remove collector

### DIFF
--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -103,14 +103,6 @@ meta:
   - name: haproxy
     release: paas-haproxy
 
-  stats_templates:
-  - name: consul_agent
-    release: (( grab meta.consul_templates.consul_agent.release ))
-  - name: collector
-    release: (( grab meta.release.name ))
-  - name: metron_agent
-    release: (( grab meta.release.name ))
-
   uaa_templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
@@ -264,19 +256,6 @@ jobs:
         agent:
           services:
             etcd: {}
-
-  - name: stats
-    azs: [z1]
-    templates: (( grab meta.stats_templates ))
-    instances: 1
-    vm_type: small
-    stemcell: default
-    networks:
-      - name: cf
-    properties:
-      metron_agent:
-        zone: ""
-
 
   - name: uaa
     azs: [z1, z2]

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -60,8 +60,6 @@ meta:
     release: (( grab meta.release.name ))
   - name: etcd
     release: etcd
-  - name: etcd_metrics_server
-    release: etcd
   - name: metron_agent
     release: (( grab meta.release.name ))
 

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -89,8 +89,6 @@ properties:
     port: 443
   syslog_daemon_config: ~
 
-  collector:
-
   doppler:
     maxRetainedLogMessages: 100
     debug: false

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -62,12 +62,6 @@ properties:
     require_ssl: false
     peer_require_ssl: false
 
-  etcd_metrics_server:
-    nats:
-      machines: (( grab properties.nats.machines ))
-      username: (( grab properties.nats.user ))
-      password: (( grab properties.nats.password ))
-
   loggregator:
     maxRetainedLogMessages: 100
     debug: false


### PR DESCRIPTION
## What

[Remove collector](https://www.pivotaltracker.com/projects/1275640/stories/115404231)

In our current deployment, collector is not configured to send metrics anywhere (even though it might seem so from logs, but historian has no targets configured). Also remove etcd_metrics_server, as that was sending etcd metrics to NATS for them to be picked up by collector.

## How to review

Deploy to new/existing env. In existing env observe collector being deleted and etcd upgated. Check that there is no metrics job on etcd servers.

## Who can review

not @mtekel
