### PR TITLE
[#124496741] Alert on temp. admin removal failure

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -2012,3 +2012,23 @@ jobs:
         ensure:
           task: remove-temp-user
           file: paas-cf/concourse/tasks/delete_admin.yml
+          on_failure:
+            task: alert
+            config:
+              platform: linux
+              image: docker:///governmentpaas/awscli
+              params:
+                AWS_DEFAULT_REGION: {{aws_region}}
+                DEPLOY_ENV: {{deploy_env}}
+                SYSTEM_DNS_ZONE_NAME: {{system_dns_zone_name}}
+                ALERT_EMAIL_ADDRESS: {{ALERT_EMAIL_ADDRESS}}
+              inputs:
+                - name: paas-cf
+              run:
+                path: sh
+                args:
+                - -e
+                - -c
+                - |
+                  paas-cf/concourse/scripts/failed_admin_removal_email.sh \
+                    ${DEPLOY_ENV} ${SYSTEM_DNS_ZONE_NAME} ${ALERT_EMAIL_ADDRESS}

--- a/concourse/scripts/failed_admin_removal_email.sh
+++ b/concourse/scripts/failed_admin_removal_email.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -eu
+
+DEPLOY_ENV=$1
+SYSTEM_DNS_ZONE_NAME=$2
+EMAIL=$3
+
+write_message_json() {
+  cat <<EOF > message.json
+{
+  "Subject": {
+    "Data": "Temporary admin removal failed in ${DEPLOY_ENV}"
+  },
+  "Body": {
+    "Html": {
+      "Data": "Removal of the temporary admin user has failed in continuous smoketests in environment <b>${DEPLOY_ENV}</b>. See \
+      <a href='https://deployer.${SYSTEM_DNS_ZONE_NAME}/pipelines/create-bosh-cloudfoundry?groups=health'>Concourse</a> \
+      for details<br/>"
+    }
+  }
+}
+EOF
+}
+
+write_message_json
+aws ses send-email --to "${EMAIL}" --message file://message.json --from "${EMAIL}"


### PR DESCRIPTION
## What

[Alert on temp. admin removal failure](https://www.pivotaltracker.com/projects/1275640/stories/124496741)

We have noticed that we are having a lot of temporary admin user removal
failures. We would like to receive notification when this happens, as
this indicates that there are possible issues with UAA and also leaves
an admin user behind. This can impact UAA (as we are leaking an user)
and security (as there would be many admin users that are not supposed
to exist).

## How to review

Deploy against your existing environments. Enable continuous smoketests by specifying `ALERT_EMAIL_ADDRESS`. e.g.
`SELF_UPDATE_PIPELINE=false ALERT_EMAIL_ADDRESS=my@email.address make dev pipelines`. Stop UAA by using bosh ssh and `monit stop uaa` on both servers. Then
* if your continuous smoketests are running, they might fail & send you smoketests failed email and then attempt temp. admin removal
* if smoketests are not running, you may trigger them by hand or wait until they get triggered by the timer resource. Creating temp user would fail and then removal will be attempted.
* removal will fail (as UAA is down) and notification email would be sent.

Recover your environment by starting UAA again on both servers. Smoketests should start passing again.

On an environment that is not deployed - it is possible that smoketests will start running (and failing) straight away. In that case it is enough to verify receival of the alert email.

## Who can review

not @mtekel