### PR TITLE
[#124748631] Revert "Remove etcd_metrics_server"

### DIFF
--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -60,6 +60,8 @@ meta:
     release: (( grab meta.release.name ))
   - name: etcd
     release: etcd
+  - name: etcd_metrics_server
+    release: etcd
   - name: metron_agent
     release: (( grab meta.release.name ))
 

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -62,6 +62,12 @@ properties:
     require_ssl: false
     peer_require_ssl: false
 
+  etcd_metrics_server:
+    nats:
+      machines: (( grab properties.nats.machines ))
+      username: (( grab properties.nats.user ))
+      password: (( grab properties.nats.password ))
+
   loggregator:
     maxRetainedLogMessages: 100
     debug: false


### PR DESCRIPTION
## What

This reverts commit b3092a1da86a3236f93f67a51ba3ed74506bc18f.

As it turns out, ETCD metrics server was also sending metrics to doppler,
meaning they would make it to our graphite nozzle which was adding them
to graphite. Add this component back so that we have ETCD metrics again.

Unfortunately no etcd_metrics_server documentation mentioned this
feature. It was added in this commit:
https://github.com/cloudfoundry-incubator/etcd-metrics-server/commit/0668d4fcbb66105d1c13f6d72ac130792b52cc26

## How to review

Deploy. Verify that you can see metrics from ETCD in graphite, e.g. `stats.gauges.cfstats.etcd.0.ops.etcd.CreateFail`

## Who can review

not @mtekel