### PR TITLE
[#124755971] Fix rdsbroker master password reset

### DIFF
--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -19,7 +19,7 @@ meta:
 
 releases:
   - name: aws-broker
-    version: 0.0.7
+    version: 0.0.8
 
 jobs:
   - name: rds_broker


### PR DESCRIPTION
## What

Fix a bug with the master password reset where it would use the wrong password. See https://github.com/alphagov/paas-rds-broker/pull/14 for details.

## How to review

Deploy from this branch and verify that the custom acceptance tests still pass.

## Before merging

* [x] Merge the [rds-broker PR](https://github.com/alphagov/paas-rds-broker/pull/14)
* [x] Update the [aws-broker PR](https://github.com/alphagov/paas-aws-broker-boshrelease/pull/11) to use the latest rds-broker master.
* [x] Merge the [aws-broker PR](https://github.com/alphagov/paas-aws-broker-boshrelease/pull/11) and tag the repo with `0.0.8`
* [x] Remove the "Temp: use rds-broker from branch" commit from this branch.

## Who can review

Anyone but myself.