### PR TITLE
[#123862321] Upgrade to CloudFoundry 238

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -124,7 +124,7 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-routing-release.git
       tag_filter: {{cf_routing_version}}
-      branch: cf_237
+      branch: gds_master
 
   - name: graphite-nozzle
     type: git

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -33,7 +33,7 @@ releases:
 stemcells:
   - alias: default
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: 3232.4
+    version: 3232.11
 
 update:
   canaries: 0

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -6,9 +6,9 @@ director_uuid: ~
 
 releases:
   - name: cf
-    version: 237
-    url: https://bosh.io/d/github.com/cloudfoundry/cf-release?v=237
-    sha1: 8996122278b03b6ba21ec673812d2075c37f1097
+    version: 238
+    url: https://bosh.io/d/github.com/cloudfoundry/cf-release?v=238
+    sha1: fa6d35300f4fcd74a75fd8c7138f592acfcb32b0
   - name: diego
     version: 0.1472.0
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/diego-release?v=0.1472.0

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -10,21 +10,21 @@ releases:
     url: https://bosh.io/d/github.com/cloudfoundry/cf-release?v=238
     sha1: fa6d35300f4fcd74a75fd8c7138f592acfcb32b0
   - name: diego
-    version: 0.1472.0
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/diego-release?v=0.1472.0
-    sha1: a143e9e850ee794beb27bcd9ee9425406beb2987
+    version: 0.1476.0
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/diego-release?v=0.1476.0
+    sha1: 4b66fde250472e47eb2a0151bb676fc1be840f47
   - name: garden-linux
-    version: 0.337.0
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/garden-linux-release?v=0.337.0
-    sha1: d1d81d56c3c07f6f9f04ebddc68e51b8a3cf541d
+    version: 0.338.0
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/garden-linux-release?v=0.338.0
+    sha1: 432225d88edc9731be4453cb61eba33fa829ebdc
   - name: etcd
-    version: 49
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/etcd-release?v=49
-    sha1: 5d145db1ddda984faf4777e022a748b355060478
+    version: 55
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/etcd-release?v=55
+    sha1: b64fc693e658cee0ac07712646f8c7b67de0e8b6
   - name: cflinuxfs2-rootfs
-    version: 1.5.0
-    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-rootfs-release?v=1.5.0
-    sha1: 4ab6166d800668ad3e9c2c10cfd3403a7de5885f
+    version: 1.15.0
+    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-rootfs-release?v=1.15.0
+    sha1: 389ad7bb316ec5bbb7ff2ed085d551d83afc7a0f
   - name: paas-haproxy
     version: 0.0.4
   - name: routing

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -28,7 +28,7 @@ releases:
   - name: paas-haproxy
     version: 0.0.4
   - name: routing
-    version: commit-bfe3632ad6a2d143279db865aa050aea076fef9e
+    version: commit-0bad6993f4cb87fa6213fa957f4e8eacbd22f762
 
 stemcells:
   - alias: default

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -393,22 +393,6 @@ jobs:
       metron_agent:
         zone: ""
 
-  - name: cell
-    azs: [z1, z2]
-    templates: (( grab meta.diego_job_templates.cell ))
-    instances: (( grab meta.cell.instances ))
-    vm_type: cell
-    stemcell: default
-    networks:
-      - name: cell
-    properties:
-      metron_agent:
-        zone: ""
-    # FIXME: remove once deployed to prod.
-    migrated_from:
-      - {name: cell_z1, az: z1}
-      - {name: cell_z2, az: z2}
-
   - name: colocated
     azs: [z1, z2]
     templates: (( grab meta.diego_job_templates.colocated ))
@@ -438,6 +422,24 @@ jobs:
     properties:
       metron_agent:
         zone: ""
+    update:
+      serial: true
+
+  - name: cell
+    azs: [z1, z2]
+    templates: (( grab meta.diego_job_templates.cell ))
+    instances: (( grab meta.cell.instances ))
+    vm_type: cell
+    stemcell: default
+    networks:
+      - name: cell
+    properties:
+      metron_agent:
+        zone: ""
+    # FIXME: remove once deployed to prod.
+    migrated_from:
+      - {name: cell_z1, az: z1}
+      - {name: cell_z2, az: z2}
 
   - name: route_emitter
     azs: [z1, z2]

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -393,10 +393,10 @@ jobs:
       metron_agent:
         zone: ""
 
-  - name: cell_z1
-    azs: [z1]
+  - name: cell
+    azs: [z1, z2]
     templates: (( grab meta.diego_job_templates.cell ))
-    instances: (( grab meta.cell_z1.instances ))
+    instances: (( grab meta.cell.instances ))
     vm_type: cell
     stemcell: default
     networks:
@@ -404,56 +404,28 @@ jobs:
     properties:
       metron_agent:
         zone: ""
-      diego:
-        rep:
-          zone: z1
+    # FIXME: remove once deployed to prod.
+    migrated_from:
+      - {name: cell_z1, az: z1}
+      - {name: cell_z2, az: z2}
 
-  - name: colocated_z1
-    azs: [z1]
+  - name: colocated
+    azs: [z1, z2]
     templates: (( grab meta.diego_job_templates.colocated ))
-    instances: 1
+    instances: 2
     vm_type: medium
     stemcell: default
     networks:
       - name: cf
     properties:
-      diego:
-        rep:
-          zone: z1
       metron_agent:
         zone: ""
     update:
       serial: true
-
-  - name: colocated_z2
-    azs: [z2]
-    templates: (( grab meta.diego_job_templates.colocated ))
-    instances: 1
-    vm_type: medium
-    stemcell: default
-    networks:
-      - name: cf
-    properties:
-      diego:
-        rep:
-          zone: z2
-      metron_agent:
-        zone: ""
-
-  - name: cell_z2
-    azs: [z2]
-    templates: (( grab meta.diego_job_templates.cell ))
-    instances: (( grab meta.cell_z2.instances ))
-    vm_type: cell
-    stemcell: default
-    networks:
-      - name: cell
-    properties:
-      metron_agent:
-        zone: ""
-      diego:
-        rep:
-          zone: z2
+    # FIXME: remove once deployed to prod.
+    migrated_from:
+      - {name: colocated_z1, az: z1}
+      - {name: colocated_z2, az: z2}
 
   - name: database
     azs: [z1, z2]

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -1,6 +1,4 @@
 meta:
-  api_domain: (( concat "api." properties.domain ))
-
   release:
     name: cf
 

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -357,42 +357,6 @@ jobs:
 
 # Diego
 
-  - name: access
-    azs: [z1, z2]
-    templates: (( grab meta.diego_job_templates.access ))
-    instances: 0
-    vm_type: access
-    stemcell: default
-    networks:
-      - name: cf
-    properties:
-      metron_agent:
-        zone: ""
-
-  - name: brain
-    azs: [z1, z2]
-    templates: (( grab meta.diego_job_templates.brain ))
-    instances: 0
-    vm_type: medium
-    stemcell: default
-    networks:
-      - name: cf
-    properties:
-      metron_agent:
-        zone: ""
-
-  - name: cc_bridge
-    azs: [z1, z2]
-    templates: (( grab meta.diego_job_templates.cc_bridge ))
-    instances: 0
-    vm_type: medium
-    stemcell: default
-    networks:
-      - name: cf
-    properties:
-      metron_agent:
-        zone: ""
-
   - name: colocated
     azs: [z1, z2]
     templates: (( grab meta.diego_job_templates.colocated ))
@@ -425,6 +389,18 @@ jobs:
     update:
       serial: true
 
+  - name: brain
+    azs: [z1, z2]
+    templates: (( grab meta.diego_job_templates.brain ))
+    instances: 0
+    vm_type: medium
+    stemcell: default
+    networks:
+      - name: cf
+    properties:
+      metron_agent:
+        zone: ""
+
   - name: cell
     azs: [z1, z2]
     templates: (( grab meta.diego_job_templates.cell ))
@@ -441,11 +417,35 @@ jobs:
       - {name: cell_z1, az: z1}
       - {name: cell_z2, az: z2}
 
+  - name: cc_bridge
+    azs: [z1, z2]
+    templates: (( grab meta.diego_job_templates.cc_bridge ))
+    instances: 0
+    vm_type: medium
+    stemcell: default
+    networks:
+      - name: cf
+    properties:
+      metron_agent:
+        zone: ""
+
   - name: route_emitter
     azs: [z1, z2]
     templates: (( grab meta.diego_job_templates.route_emitter ))
     instances: 0
     vm_type: medium
+    stemcell: default
+    networks:
+      - name: cf
+    properties:
+      metron_agent:
+        zone: ""
+
+  - name: access
+    azs: [z1, z2]
+    templates: (( grab meta.diego_job_templates.access ))
+    instances: 0
+    vm_type: access
     stemcell: default
     networks:
       - name: cf

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -350,8 +350,8 @@ properties:
       password: ~
 
     links:
-      passwd: (( concat "https://console." properties.system_domain "/password_resets/new" ))
-      signup: (( concat "https://console." properties.system_domain "/register" ))
+      passwd: (( concat "https://login." properties.system_domain "/forgot_password" ))
+      signup: (( concat "https://login." properties.system_domain "/create_account" ))
 
     logout: ~
 

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -148,6 +148,10 @@ properties:
     enable_routing_api:
     drain_wait: 15
 
+  # FIXME: remove when no longer needed
+  hm9000:
+    port: 5155
+
   cc:
     jobs:
       global:

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -13,7 +13,6 @@ meta:
   etcd_consul_service: ["etcd.service.cf.internal"]
 
 properties:
-  domain: (( grab terraform_outputs.cf_root_domain ))
   system_domain: (( grab terraform_outputs.cf_root_domain ))
   system_domain_organization: admin
   app_domains:
@@ -195,7 +194,7 @@ properties:
 
     external_host: api
     external_port: 9022
-    srv_api_uri: (( concat "https://" properties.cc.external_host "." properties.domain ))
+    srv_api_uri: (( concat "https://" properties.cc.external_host "." properties.system_domain ))
 
     bulk_api_password: (( grab secrets.bulk_api_password ))
     internal_api_user: "internal_user"
@@ -351,8 +350,8 @@ properties:
       password: ~
 
     links:
-      passwd: (( concat "https://console." properties.domain "/password_resets/new" ))
-      signup: (( concat "https://console." properties.domain "/register" ))
+      passwd: (( concat "https://console." properties.system_domain "/password_resets/new" ))
+      signup: (( concat "https://console." properties.system_domain "/register" ))
 
     logout: ~
 
@@ -363,7 +362,7 @@ properties:
     restricted_ips_regex: ~
 
   uaa:
-    url: (( concat "https://uaa." properties.domain ))
+    url: (( concat "https://uaa." properties.system_domain ))
     issuer: (( grab properties.uaa.url ))
     ssh_proxy_client_secret: (( grab secrets.uaa_admin_client_secret ))
     token_url: (( concat properties.uaa.url "/oauth/token" ))
@@ -414,7 +413,7 @@ properties:
         scope: openid,oauth.approvals
         authorities: oauth.login,scim.write,clients.read,notifications.write,critical_notifications.write,emails.write,scim.userids,password.write
         authorized-grant-types: authorization_code,client_credentials,refresh_token
-        redirect-uri: (( concat "https://login." properties.domain ))
+        redirect-uri: (( concat "https://login." properties.system_domain ))
         secret: (( grab secrets.uaa_clients_login_secret ))
       cf:
         id: cf

--- a/manifests/cf-manifest/manifest/900-cf-tests.yml
+++ b/manifests/cf-manifest/manifest/900-cf-tests.yml
@@ -1,6 +1,6 @@
 properties:
   acceptance_tests:
-    api: (( grab meta.api_domain ))
+    api: (( concat "api." properties.system_domain ))
     apps_domain: (( grab properties.app_domains[0] ))
     system_domain: (( grab properties.system_domain ))
     admin_user: "admin"
@@ -21,7 +21,7 @@ properties:
     include_route_services: false
 
   smoke_tests:
-    api: (( grab meta.api_domain ))
+    api: (( grab properties.acceptance_tests.api ))
     apps_domain: (( grab properties.app_domains[0] ))
     user: "admin"
     password: (( grab secrets.uaa_admin_password ))

--- a/manifests/cf-manifest/manifest/env-specific/cf-default.yml
+++ b/manifests/cf-manifest/manifest/env-specific/cf-default.yml
@@ -1,6 +1,4 @@
 ---
 meta:
-  cell_z1:
-    instances: 1
-  cell_z2:
-    instances: 1
+  cell:
+    instances: 2

--- a/manifests/cf-manifest/manifest/env-specific/cf-prod.yml
+++ b/manifests/cf-manifest/manifest/env-specific/cf-prod.yml
@@ -1,6 +1,4 @@
 ---
 meta:
-  cell_z1:
-    instances: 2
-  cell_z2:
-    instances: 2
+  cell:
+    instances: 4

--- a/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
@@ -69,8 +69,8 @@ RSpec.describe "base properties" do
     describe "links" do
       subject(:links) { login.fetch("links") }
 
-      it { is_expected.to include("passwd" => "https://console.#{terraform_fixture(:cf_root_domain)}/password_resets/new") }
-      it { is_expected.to include("signup" => "https://console.#{terraform_fixture(:cf_root_domain)}/register") }
+      it { is_expected.to include("passwd" => "https://login.#{terraform_fixture(:cf_root_domain)}/forgot_password") }
+      it { is_expected.to include("signup" => "https://login.#{terraform_fixture(:cf_root_domain)}/create_account") }
     end
   end
 

--- a/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
@@ -7,11 +7,7 @@ RSpec.describe "base properties" do
     expect(manifest["name"]).to eq(terraform_fixture(:environment))
   end
 
-  it "sets the domain from the terraform outputs" do
-    expect(properties["domain"]).to eq(terraform_fixture(:cf_root_domain))
-  end
-
-  it "sets the system_domain" do
+  it "sets the system_domain from the terraform outputs" do
     expect(properties["system_domain"]).to eq(terraform_fixture(:cf_root_domain))
   end
 

--- a/manifests/cf-manifest/spec/manifest/env_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/env_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe "Environment specific configuration" do
 
   it "should allow a higher number of instances of cells in production" do
 
-    default_cell_z1_instances = get_job_instances(default_manifest, "cell_z1")
-    prod_cell_z1_instances = get_job_instances(prod_manifest, "cell_z1")
+    default_cell_instances = get_job_instances(default_manifest, "cell")
+    prod_cell_instances = get_job_instances(prod_manifest, "cell")
 
-    expect(default_cell_z1_instances).to be < prod_cell_z1_instances
+    expect(default_cell_instances).to be < prod_cell_instances
   end
 
 end

--- a/manifests/cf-manifest/spec/manifest/jobs_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/jobs_spec.rb
@@ -56,6 +56,24 @@ RSpec.describe "the jobs definitions block" do
     end
   end
 
+  describe "in order to apply BBS migrations before upgrading the cells" do
+    it "has database before the cells" do
+      expect("database").to be_ordered_before("cell")
+    end
+
+    it "has colocated before the cells" do
+      expect("colocated").to be_ordered_before("cell")
+    end
+
+    it "has database serial" do
+      expect("database").to be_updated_serially
+    end
+
+    it "has colocated serial" do
+      expect("colocated").to be_updated_serially
+    end
+  end
+
   it "should list consul_agent first if present" do
     jobs_with_consul = jobs.select{ |j|
       not j["templates"].select{ |t|


### PR DESCRIPTION
## What

In order to get the fix for CVE-2016-4468 (UAA SQL Injection). This upgrades to Cloudfoundry release 238.

This includes a release of Diego that supports the Bosh 2.0 zones feature, so I've also combined the cell_z*N* and colocated_z*N* jobs.

While upgrading, we ran into issues where existing deployed apps would stop working. This turned out to be because our diego jobs weren't ordered correctly so that the cells were upgraded before the database migrations had been applied.

## How to test

This should be tested twice, one as a clean deploy, and once upgrading from current master:

* test that a new deploy from this branch works correctly.
* Given an existing deployment running current master, test that deploying from this branch upgrades CF without downtime.

## Who can review

Anyone but myself or @bleach.