### PR TITLE
[#122183539] Visibility of important platform metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ gem 'bosh_cli'
 gem 'webmock', "~> 1.24"
 gem 'rubocop'
 gem 'mimic'
+gem 'json-minify', '~> 0.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,8 @@ GEM
     httpclient (2.7.1)
     jmespath (1.1.3)
     json (1.8.3)
+    json-minify (0.0.2)
+      json (> 0)
     json_pure (1.8.3)
     little-plugger (1.1.4)
     logging (1.8.2)
@@ -137,10 +139,11 @@ PLATFORMS
 DEPENDENCIES
   aruba
   bosh_cli
+  json-minify (~> 0.0.2)
   mimic
   rspec (~> 3.3)
   rubocop
   webmock (~> 1.24)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1013,32 +1013,51 @@ jobs:
             passed: ['bosh-terraform']
           - get: cf-tfstate
             passed: ['cf-terraform']
-      - task: extract-terraform-outputs
-        config:
-          platform: linux
-          image: docker:///ruby#2.2-slim
-          inputs:
-            - name: paas-cf
-            - name: vpc-tfstate
-            - name: bosh-tfstate
-            - name: concourse-tfstate
-            - name: cf-tfstate
-          outputs:
-            - name: terraform-outputs
-          run:
-            path: sh
-            args:
-              - -e
-              - -c
-              - |
-                for state in vpc bosh concourse cf; do
-                  ./paas-cf/concourse/scripts/extract_terraform_state_to_yaml.rb \
-                    < $state-tfstate/$state.tfstate \
-                    > terraform-outputs/$state.yml
-                  ./paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
-                    < ${state}-tfstate/${state}.tfstate \
-                    > terraform-outputs/${state}.tfvars.sh
-                done
+      - aggregate:
+        - task: extract-terraform-outputs
+          config:
+            platform: linux
+            image: docker:///ruby#2.2-slim
+            inputs:
+              - name: paas-cf
+              - name: vpc-tfstate
+              - name: bosh-tfstate
+              - name: concourse-tfstate
+              - name: cf-tfstate
+            outputs:
+              - name: terraform-outputs
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  for state in vpc bosh concourse cf; do
+                    ./paas-cf/concourse/scripts/extract_terraform_state_to_yaml.rb \
+                      < $state-tfstate/$state.tfstate \
+                      > terraform-outputs/$state.yml
+                    ./paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
+                      < ${state}-tfstate/${state}.tfstate \
+                      > terraform-outputs/${state}.tfvars.sh
+                  done
+
+        - task: generate-grafana-dashboards-manifest
+          config:
+            platform: linux
+            image: docker:///governmentpaas/json-minify
+            inputs:
+              - name: paas-cf
+            outputs:
+              - name: grafana-dashboards-manifest
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  CF_MANIFEST_DIR=./paas-cf/manifests/cf-manifest
+                  ${CF_MANIFEST_DIR}/scripts/grafana-dashboards-manifest.rb ${CF_MANIFEST_DIR}/grafana \
+                    > grafana-dashboards-manifest/grafana-dashboards-manifest.yml
 
       - aggregate:
         - task: generate-cloud-config
@@ -1080,6 +1099,7 @@ jobs:
               - name: cf-secrets
               - name: cf-certs
               - name: bosh-CA
+              - name: grafana-dashboards-manifest
             outputs:
               - name: cf-manifest
             params:
@@ -1090,6 +1110,7 @@ jobs:
                 ./cf-secrets/cf-secrets.yml
                 ./certs/*.yml
                 ./paas-cf/manifests/cf-manifest/manifest/env-specific/{{cf_env_specific_manifest}}
+                ./grafana-dashboards-manifest/grafana-dashboards-manifest.yml
             run:
               path: sh
               args:

--- a/manifests/cf-manifest/grafana/user-impact.json
+++ b/manifests/cf-manifest/grafana/user-impact.json
@@ -1,0 +1,699 @@
+{
+  "id": 4,
+  "title": "User Impact",
+  "originalTitle": "User Impact",
+  "tags": [],
+  "style": "dark",
+  "timezone": "utc",
+  "editable": true,
+  "hideControls": false,
+  "sharedCrosshair": true,
+  "rows": [
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "150px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "graphite",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)",
+            "thresholdLine": false
+          },
+          "height": "250",
+          "id": 3,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "hide": false,
+              "refId": "A",
+              "target": "alias(scale(sumSeries(stats.counters.cfstats.router.*.ops.total_requests.rate), 60), 'Apps requests per minute')",
+              "textEditor": false
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "graphite",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "height": "250",
+          "id": 6,
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "alias(summarize(derivative(sumSeries(stats.gauges.cfstats.api.*.ops.cc.requests.completed)), '1min', 'sum', false), 'API requests per minute')"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "title": "Row"
+    },
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {
+            "4xx Error rate": "#BF1B00",
+            "5xx Error Rate": "#EF843C"
+          },
+          "bars": false,
+          "datasource": "graphite",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "height": "250",
+          "id": 1,
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "B",
+              "target": "alias(scale(sumSeries(stats.counters.cfstats.router.*.ops.responses.4xx.rate), 60), 'Apps HTTP 4xx per minute')"
+            },
+            {
+              "refId": "A",
+              "target": "alias(scale(sumSeries(stats.counters.cfstats.router.*.ops.responses.5xx.rate), 60), 'Apps HTTP 5xx per minute')"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "graphite",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "height": "250",
+          "id": 7,
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "alias(summarize(derivative(sumSeries(stats.gauges.cfstats.api.*.ops.cc.http_status.4XX)), '1min', 'sum', false), 'API HTTP 4xx per minute')"
+            },
+            {
+              "refId": "B",
+              "target": "alias(summarize(derivative(sumSeries(stats.gauges.cfstats.api.*.ops.cc.http_status.5XX)), '1min', 'sum', false), 'API HTTP 5xx per minute')"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "title": "New row"
+    },
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {
+            "Response times mean 90": "#E0F9D7"
+          },
+          "bars": false,
+          "datasource": "graphite",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "height": "250",
+          "id": 4,
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "alias(averageSeries(stats.timers.cfstats.router.*.http.responsetimes.http.mean_90), 'Router response time')"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "graphite",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "height": "250",
+          "id": 5,
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "alias(maxSeries(stats.gauges.cfstats.api.*.ops.cc.total_users), 'Total users registered on CC')"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "title": "New row"
+    },
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "graphite",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "height": "250",
+          "id": 8,
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "hide": false,
+              "refId": "A",
+              "target": "alias(maxSeries(stats.gauges.cfstats.colocated.*.ops.bbs.LRPsDesired), 'Desired apps')"
+            },
+            {
+              "refId": "B",
+              "target": "alias(maxSeries(stats.gauges.cfstats.colocated.*.ops.bbs.LRPsRunning), 'Running apps')"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "graphite",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "height": "250",
+          "id": 9,
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "alias(maxSeries(stats.gauges.cfstats.api.*.ops.cc.job_queue_length.total), 'CC job queue length')"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "title": "New row"
+    }
+  ],
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  },
+  "refresh": false,
+  "schemaVersion": 12,
+  "version": 0,
+  "links": []
+}

--- a/manifests/cf-manifest/manifest/040-graphite.yml
+++ b/manifests/cf-manifest/manifest/040-graphite.yml
@@ -15,7 +15,7 @@ releases:
 - name: graphite
   version: commit-ccc206f3ba21fe5ba4f3e617bb7dca3e66a652ad
 - name: grafana
-  version: commit-4a9e3a322b72bfb4a76ae460a280acf04a5b445d
+  version: commit-6dce2ec39a6ffc00c092d5b0401dfaf8bbf3ae55
 
 jobs:
 - name: graphite

--- a/manifests/cf-manifest/manifest/040-graphite.yml
+++ b/manifests/cf-manifest/manifest/040-graphite.yml
@@ -62,5 +62,9 @@ jobs:
       root_url: "/"
       admin_username: "admin"
       admin_password: (( grab secrets.grafana_admin_password ))
+      datasources:
+        - name: graphite
+          url: http://localhost:3001
+          database_type: graphite
 
   templates: (( grab meta.graphite_templates ))

--- a/manifests/cf-manifest/scripts/grafana-dashboards-manifest.rb
+++ b/manifests/cf-manifest/scripts/grafana-dashboards-manifest.rb
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+
+require 'yaml'
+require 'json'
+require 'json/minify'
+
+dashboards_dir=ARGV[0]
+dashboard_files=Dir[dashboards_dir + '/*.json']
+dashboards_hash = { 'properties' => { 'grafana' => {'dashboards' => [] }}}
+
+dashboard_files.each{ |dashboard_file|
+  json = File.read(dashboard_file)
+  dashboard_definition = {
+    "name" => File.basename(dashboard_file, ".json"),
+    "content" => JSON.minify(json),
+  }
+  dashboards_hash['properties']['grafana']['dashboards'] << dashboard_definition
+}
+
+puts YAML.dump(dashboards_hash, :line_width => 1000000)
+


### PR DESCRIPTION
## Who

[#122183539 - Visibility of important platform metrics](https://www.pivotaltracker.com/story/show/122183539)

We want to be able to deploy Grafana with dashboard configuration files (JSON files) supplied via the manifest. This pull request configures Grafana to use Graphite as a datasource, updates the pipeline to generate YAML containing the minified JSON, and adds the dashboard JSON file.

## How to review

**Note:** review after [pull request 58 on paas-docker-cloudfoundry-tools](https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/58) has been merged and [this FIXME commit](https://github.com/alphagov/paas-cf/pull/351/commits/2287e3ad5cf794e8f4c3ae21faf08109084f00ee) on this repository has been removed.

* Complete the review in [pull request 1 on paas-grafana-boshrelease](https://github.com/alphagov/paas-grafana-boshrelease/pull/1). **This must be done first**.
* Once the pull request above is merged we can point to the new Grafana bosh release. I am happy to do that, but for reference the steps are:
    * removing [this FIXME commit](https://github.com/alphagov/paas-cf/pull/351/commits/bcd8ff44a8dcb2f7e05db87b30af5933de29e05e)
    * tagging the merge commit. The tag name tends to follow [this convention](https://github.com/alphagov/paas-cf/blob/master/manifests/cf-manifest/manifest/040-graphite.yml#L18)
    * updating the manifest so `releases.grafana.version` is the same as the new tag name
    * update the pipeline to use the new release via tag filter
* Re-deploy using the newly pinned resource.
* Log into Grafana using `make dev showenv` to get the URL. 
* Check the User Impact dashboard contains the metrics as defined in Pivotal Tracker.
* Consider whether the scales and times used are appropriate. Your development environment may not have a lot of metrics, so you can get creative generating some.

## Who

Anyone but @saliceti @combor or me