### PR TITLE
[#123862321] Fix failure testing pipeline for merged diego jobs.

### DIFF
--- a/concourse/pipelines/failure-testing.yml
+++ b/concourse/pipelines/failure-testing.yml
@@ -145,7 +145,7 @@ jobs:
         file: paas-cf/concourse/tasks/get-instance-id.yml
         config:
           params:
-            VM_NAME: colocated_z1/0
+            VM_NAME: colocated/0
             BOSH_FQDN: {{bosh_fqdn}}
       - task: kill-instance
         file: paas-cf/concourse/tasks/kill-instance.yml
@@ -370,7 +370,7 @@ jobs:
         file: paas-cf/concourse/tasks/get-instance-id.yml
         config:
           params:
-            VM_NAME: cell_z1/0
+            VM_NAME: cell/0
             BOSH_FQDN: {{bosh_fqdn}}
       - task: kill-instance
         file: paas-cf/concourse/tasks/kill-instance.yml


### PR DESCRIPTION
## What

In 70b43c20 we merged the colocated_z* and cell_z* AZ specific jobs into
combined jobs using the new Bosh AZs feature. This change was not also
reflected in the failure testing pipeline, meaning that it was broken.
This fixes that.

## How to review

Deploy from this branch and verify that the failure testing pipeline works.

## Who can review

Anyone but myself.