### PR TITLE
Add reminder to change password

### DIFF
--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -11,15 +11,17 @@ SUBJECT='Welcome to the Government PaaS'
 # shellcheck disable=SC2016,SC1078
 MESSAGE='Hello,
 
-Your account has been created for the  Government PaaS service.
+Your account for the Government PaaS service has been created.
 
-Your organisation is \"${ORG}\" and your login and password:
+Your organisation is \"${ORG}\" and your login and password are:
 
  - login: ${EMAIL}
  - password: ${PASSWORD}
 
-To get started you can follow our Quick Setup Guide:
+To get started, look at our Quick Setup Guide:
 https://government-paas-developer-docs.readthedocs.io/en/latest/getting_started/quick_setup_guide/
+
+You should make sure to change your password, as explained in the Quick Setup Guide.
 
 Regards,
 Government PaaS team.


### PR DESCRIPTION
## What

Change to the welcome email text, reminding user to change password.

This addresses user concern about receiving emails in plain text, found in user research.

See [Include Change Password Instructions in Welcome Mail][1] for
details. There is no point putting the actual command to change
password in the welcome email, because that won't work until user is
logged in, but adding this reminder makes clear that the password that was
included in the email can be changed by the tenant.

Also style fixes to email copy.

## How to review

Check the email copy makes sense. Check the email is still sent correctly when a the script runs.

## Who can review

Anyone but BH.





[1]: https://www.pivotaltracker.com/story/show/125537351