### PR TITLE
[#115884129] Switch to separate diego job distribution

### DIFF
--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -370,10 +370,6 @@ jobs:
         zone: ""
     update:
       serial: true
-    # FIXME: remove once deployed to prod.
-    migrated_from:
-      - {name: colocated_z1, az: z1}
-      - {name: colocated_z2, az: z2}
 
   - name: database
     azs: [z1, z2]
@@ -412,10 +408,6 @@ jobs:
     properties:
       metron_agent:
         zone: ""
-    # FIXME: remove once deployed to prod.
-    migrated_from:
-      - {name: cell_z1, az: z1}
-      - {name: cell_z2, az: z2}
 
   - name: cc_bridge
     azs: [z1, z2]

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -274,6 +274,7 @@ jobs:
 
 # Diego
 
+  # FIXME: Remove this job when separate diego jobs have been deployed to prod.
   - name: colocated
     azs: [z1, z2]
     templates:
@@ -321,7 +322,7 @@ jobs:
         release: diego
       - name: metron_agent
         release: cf
-    instances: 0
+    instances: 2
     vm_type: medium
     stemcell: default
     networks:
@@ -343,7 +344,7 @@ jobs:
         release: diego
       - name: metron_agent
         release: cf
-    instances: 0
+    instances: 2
     vm_type: medium
     stemcell: default
     networks:
@@ -389,7 +390,7 @@ jobs:
         release: cf
       - name: metron_agent
         release: cf
-    instances: 0
+    instances: 2
     vm_type: medium
     stemcell: default
     networks:
@@ -407,7 +408,7 @@ jobs:
         release: diego
       - name: metron_agent
         release: cf
-    instances: 0
+    instances: 2
     vm_type: medium
     stemcell: default
     networks:
@@ -427,7 +428,7 @@ jobs:
         release: cf
       - name: file_server
         release: diego
-    instances: 0
+    instances: 2
     vm_type: access
     stemcell: default
     networks:

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -111,89 +111,6 @@ meta:
   - name: statsd-injector
     release: (( grab meta.release.name ))
 
-  diego_job_templates:
-    brain:
-      - name: consul_agent
-        release: cf
-      - name: auctioneer
-        release: diego
-      - name: converger
-        release: diego
-      - name: metron_agent
-        release: cf
-    cell:
-      - name: consul_agent
-        release: cf
-      - name: rep
-        release: diego
-      - name: garden
-        release: garden-linux
-      - name: cflinuxfs2-rootfs-setup
-        release: cflinuxfs2-rootfs
-      - name: metron_agent
-        release: cf
-    cc_bridge:
-      - name: consul_agent
-        release: cf
-      - name: stager
-        release: cf
-      - name: nsync
-        release: cf
-      - name: tps
-        release: cf
-      - name: cc_uploader
-        release: cf
-      - name: metron_agent
-        release: cf
-    route_emitter:
-      - name: consul_agent
-        release: cf
-      - name: route_emitter
-        release: diego
-      - name: metron_agent
-        release: cf
-    access:
-      - name: consul_agent
-        release: cf
-      - name: ssh_proxy
-        release: diego
-      - name: metron_agent
-        release: cf
-      - name: file_server
-        release: diego
-    database:
-      - name: consul_agent
-        release: cf
-      - name: bbs
-        release: diego
-      - name: metron_agent
-        release: cf
-    colocated:
-      - name: consul_agent
-        release: cf
-      - name: auctioneer
-        release: diego
-      - name: bbs
-        release: diego
-      - name: cc_uploader
-        release: cf
-      - name: converger
-        release: diego
-      - name: file_server
-        release: diego
-      - name: metron_agent
-        release: cf
-      - name: nsync
-        release: cf
-      - name: route_emitter
-        release: diego
-      - name: ssh_proxy
-        release: diego
-      - name: stager
-        release: cf
-      - name: tps
-        release: cf
-
 jobs:
   - name: consul
     azs: [z1, z2, z3]
@@ -359,7 +276,31 @@ jobs:
 
   - name: colocated
     azs: [z1, z2]
-    templates: (( grab meta.diego_job_templates.colocated ))
+    templates:
+      - name: consul_agent
+        release: cf
+      - name: auctioneer
+        release: diego
+      - name: bbs
+        release: diego
+      - name: cc_uploader
+        release: cf
+      - name: converger
+        release: diego
+      - name: file_server
+        release: diego
+      - name: metron_agent
+        release: cf
+      - name: nsync
+        release: cf
+      - name: route_emitter
+        release: diego
+      - name: ssh_proxy
+        release: diego
+      - name: stager
+        release: cf
+      - name: tps
+        release: cf
     instances: 2
     vm_type: colocated
     stemcell: default
@@ -373,7 +314,13 @@ jobs:
 
   - name: database
     azs: [z1, z2]
-    templates: (( grab meta.diego_job_templates.database ))
+    templates:
+      - name: consul_agent
+        release: cf
+      - name: bbs
+        release: diego
+      - name: metron_agent
+        release: cf
     instances: 0
     vm_type: medium
     stemcell: default
@@ -387,7 +334,15 @@ jobs:
 
   - name: brain
     azs: [z1, z2]
-    templates: (( grab meta.diego_job_templates.brain ))
+    templates:
+      - name: consul_agent
+        release: cf
+      - name: auctioneer
+        release: diego
+      - name: converger
+        release: diego
+      - name: metron_agent
+        release: cf
     instances: 0
     vm_type: medium
     stemcell: default
@@ -399,7 +354,17 @@ jobs:
 
   - name: cell
     azs: [z1, z2]
-    templates: (( grab meta.diego_job_templates.cell ))
+    templates:
+      - name: consul_agent
+        release: cf
+      - name: rep
+        release: diego
+      - name: garden
+        release: garden-linux
+      - name: cflinuxfs2-rootfs-setup
+        release: cflinuxfs2-rootfs
+      - name: metron_agent
+        release: cf
     instances: (( grab meta.cell.instances ))
     vm_type: cell
     stemcell: default
@@ -411,7 +376,19 @@ jobs:
 
   - name: cc_bridge
     azs: [z1, z2]
-    templates: (( grab meta.diego_job_templates.cc_bridge ))
+    templates:
+      - name: consul_agent
+        release: cf
+      - name: stager
+        release: cf
+      - name: nsync
+        release: cf
+      - name: tps
+        release: cf
+      - name: cc_uploader
+        release: cf
+      - name: metron_agent
+        release: cf
     instances: 0
     vm_type: medium
     stemcell: default
@@ -423,7 +400,13 @@ jobs:
 
   - name: route_emitter
     azs: [z1, z2]
-    templates: (( grab meta.diego_job_templates.route_emitter ))
+    templates:
+      - name: consul_agent
+        release: cf
+      - name: route_emitter
+        release: diego
+      - name: metron_agent
+        release: cf
     instances: 0
     vm_type: medium
     stemcell: default
@@ -435,7 +418,15 @@ jobs:
 
   - name: access
     azs: [z1, z2]
-    templates: (( grab meta.diego_job_templates.access ))
+    templates:
+      - name: consul_agent
+        release: cf
+      - name: ssh_proxy
+        release: diego
+      - name: metron_agent
+        release: cf
+      - name: file_server
+        release: diego
     instances: 0
     vm_type: access
     stemcell: default

--- a/manifests/cf-manifest/spec/manifest/jobs_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/jobs_spec.rb
@@ -74,6 +74,28 @@ RSpec.describe "the jobs definitions block" do
     end
   end
 
+  describe "in order to match the upstream Diego job ordering" do
+    it "has database before brain" do
+      expect("database").to be_ordered_before("brain")
+    end
+
+    it "has brain before the cells" do
+      expect("brain").to be_ordered_before("cell")
+    end
+
+    it "has the cells before cc_bridge" do
+      expect("cell").to be_ordered_before("cc_bridge")
+    end
+
+    it "has cc_bridge before route_emitter" do
+      expect("cc_bridge").to be_ordered_before("route_emitter")
+    end
+
+    it "has route_emitter before access" do
+      expect("route_emitter").to be_ordered_before("access")
+    end
+  end
+
   it "should list consul_agent first if present" do
     jobs_with_consul = jobs.select{ |j|
       not j["templates"].select{ |t|


### PR DESCRIPTION
## What

We want to switch to using separate VMs for the diego components, as recommended by upstream. From http://cf-dev.70369.x6.nabble.com/cf-dev-How-to-minimize-VMs-used-in-cf-diego-td4216.html:

> Also, as a warning, the Diego team doesn't regularly test the colocated-VM deployment configuration, so it's possible that it may accidentally break in the future (or even that it's broken now!). So I wouldn't recommend its use in a production deployment.

To avoid downtime, we're doing this as a 2 phase approach. This first step, adds the new VMs, but leaves the collocated VMs in place for now. This means that we'll have 4 instances of each component for the moment. Once this has been deployed to prod, we'll do a follow-up PR to remove the collocated VMs.

This PR also cleans up a couple of `FIXME`s, and inlines the job templates (see relevant commits for details)

## How to review

Deploy from master, then deploy from this branch. Verify that everything still works paying particular attention to the availability tests.

## Who can review

Anyone but @HenryTK, @benhyland or myself.