### PR TITLE
Add .idea directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/*.tfstate
 vagrant/.vagrant/
 bin/fly*
+.idea/


### PR DESCRIPTION
What
==

Add `.idea/` to `.gitignore`.

Prefer adding to the project rather than the global gitignore,
since other non-PaaS projects may choose to commit IDE config files.

How to review
-----

No special advice.

Who can review
-----

Anyone except @benhyland