### PR TITLE
[#115884129] Diego distribution remove colocated (master)

### DIFF
--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -274,45 +274,6 @@ jobs:
 
 # Diego
 
-  # FIXME: Remove this job when separate diego jobs have been deployed to prod.
-  - name: colocated
-    azs: [z1, z2]
-    templates:
-      - name: consul_agent
-        release: cf
-      - name: auctioneer
-        release: diego
-      - name: bbs
-        release: diego
-      - name: cc_uploader
-        release: cf
-      - name: converger
-        release: diego
-      - name: file_server
-        release: diego
-      - name: metron_agent
-        release: cf
-      - name: nsync
-        release: cf
-      - name: route_emitter
-        release: diego
-      - name: ssh_proxy
-        release: diego
-      - name: stager
-        release: cf
-      - name: tps
-        release: cf
-    instances: 2
-    vm_type: colocated
-    stemcell: default
-    networks:
-      - name: cf
-    properties:
-      metron_agent:
-        zone: ""
-    update:
-      serial: true
-
   - name: database
     azs: [z1, z2]
     templates:

--- a/manifests/cf-manifest/spec/manifest/jobs_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/jobs_spec.rb
@@ -61,16 +61,8 @@ RSpec.describe "the jobs definitions block" do
       expect("database").to be_ordered_before("cell")
     end
 
-    it "has colocated before the cells" do
-      expect("colocated").to be_ordered_before("cell")
-    end
-
     it "has database serial" do
       expect("database").to be_updated_serially
-    end
-
-    it "has colocated serial" do
-      expect("colocated").to be_updated_serially
     end
   end
 


### PR DESCRIPTION
What
===

Remove `colocated` job, since it has been split into separate jobs for the separate Diego components.

The PR for the split was https://github.com/alphagov/paas-cf/pull/355

This is the last phase of the 2-phase deploy we decided on.
It should only be merged once the first PR has been deployed.

How to review
-----

Deploy from master, then deploy from this branch. Verify that everything still works paying particular attention to the availability tests.

Who can review
-----

Anyone except @alext @HenryTK @benhyland