### PR TITLE
[#126296129] Upgrade graphite to fix start timeout

### DIFF
--- a/manifests/cf-manifest/manifest/040-graphite.yml
+++ b/manifests/cf-manifest/manifest/040-graphite.yml
@@ -13,7 +13,7 @@ meta:
 
 releases:
 - name: graphite
-  version: commit-ccc206f3ba21fe5ba4f3e617bb7dca3e66a652ad
+  version: commit-56c91e87f5b569daf730c4b50797dcd952f1a9af
 - name: grafana
   version: commit-6dce2ec39a6ffc00c092d5b0401dfaf8bbf3ae55
 


### PR DESCRIPTION
## What

Story: [Fix timeouts starting graphite](https://www.pivotaltracker.com/story/show/126296129)

Graphite upgrade to fix recursive `chown` in the start script that becomes very slow when there are lots of metrics. 

## How to review

* Review together with https://github.com/alphagov/paas-graphite-statsd-boshrelease/pull/6
* Deploy from this branch and follow the instructions from https://github.com/alphagov/paas-graphite-statsd-boshrelease/pull/6
* After merging https://github.com/alphagov/paas-graphite-statsd-boshrelease/pull/6 :
  -  create tag on https://github.com/alphagov/paas-graphite-statsd-boshrelease ( based on commit sha)
 - update https://github.com/alphagov/paas-cf/pull/360/commits/1409ca0bb658d15ced486c33d7e573fa346fc81c to include the tag
  - remove https://github.com/alphagov/paas-cf/pull/360/commits/84926d90881f4c2745758537ce94411d4d1a36f8

## Who can review

Not @saliceti or @combor