### PR TITLE
[#115884129] Fix LRP metrics

### DIFF
--- a/manifests/cf-manifest/grafana/user-impact.json
+++ b/manifests/cf-manifest/grafana/user-impact.json
@@ -541,11 +541,11 @@
             {
               "hide": false,
               "refId": "A",
-              "target": "alias(maxSeries(stats.gauges.cfstats.colocated.*.ops.bbs.LRPsDesired), 'Desired apps')"
+              "target": "alias(maxSeries(stats.gauges.cfstats.database.*.ops.bbs.LRPsDesired), 'Desired apps')"
             },
             {
               "refId": "B",
-              "target": "alias(maxSeries(stats.gauges.cfstats.colocated.*.ops.bbs.LRPsRunning), 'Running apps')"
+              "target": "alias(maxSeries(stats.gauges.cfstats.database.*.ops.bbs.LRPsRunning), 'Running apps')"
             }
           ],
           "timeFrom": null,


### PR DESCRIPTION
## What
The LRP metrics come from BBS but BBS has moved from 'colocated' to
'database' VM. The metric name contains the VM name so it must be
updated.

## How to review
Deploy and load the metrics dashboard, it should show the LRP metrics.

## Who can review
Anyone but myself
