### PR TITLE
[#126600839] Auto-refresh user-impact dashboard every 30s

### DIFF
--- a/manifests/cf-manifest/grafana/user-impact.json
+++ b/manifests/cf-manifest/grafana/user-impact.json
@@ -692,7 +692,7 @@
   "annotations": {
     "list": []
   },
-  "refresh": false,
+  "refresh": "30s",
   "schemaVersion": 12,
   "version": 0,
   "links": []


### PR DESCRIPTION
## What

So that we can see the most recent metrics, rather than the metrics at the
time the tab was last loaded or manually refreshed.

We could have chosen an auto-refresh value of 10s or more, because that's
the max resolution we collect metrics at. Alex and I decided that 10s was
probably too frequent for a large screen that we only look at occasionally
and it *could* generate some load on Graphite. 1m didn't seem frequent
enough. So we went for 30s, which is in the middle.

The value can be changed in your browser if you're viewing the dashboard
locally on your own laptop.

Our dashboard screen will need to be manually refreshed to pick up this
change. It seemed to take a few minutes between the time that BOSH deployed
the change and the updated dashboard was available, possibly because BOSH
restarted all services on the VM and it was waiting for Graphite and Carbon
to start due to:

- CloudCredo/graphite-statsd-boshrelease#9
- CloudCredo/graphite-statsd-boshrelease#10

## How to review

1. Checkout this branch:

  ```
git fetch && git checkout origin/feature/126600839-user_impact_dashboard_refresh
```
1. Deploy the pipelines from this branch:

  ```
BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines
```
1. Run the `create-bosh-cloudfoundry` pipeline up to at least `cf-deploy`.
1. Open up Grafana in a browser.
  - URL: `make dev showenv | grep GRAFANA_URL`
  - Username: `admin`
  - Password: `aws s3 cp s3://${DEPLOY_ENV}-state/cf-secrets.yml - | grep grafana_admin_password`
1. Click "Home" in the top left and load the "User Impact" dashboard.
1. Check that the graphs appear to be moving and that the top-right says "Refresh every 30s".

## Who can review

Not @dcarley