### PR TITLE
[#126398487] Set RDS Broker backup retention period to 7 days

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1547,10 +1547,31 @@ jobs:
                 CF_ADMIN=admin
                 CF_PASS=$($VAL_FROM_YAML secrets.uaa_admin_password cf-secrets/cf-secrets.yml)
                 API_ENDPOINT=$($VAL_FROM_YAML properties.cc.srv_api_uri cf-manifest/cf-manifest.yml)
+                RDS_BROKER_BACKUP_RETENTION_PERIOD=$($VAL_FROM_YAML jobs.rds_broker.properties.rds-broker.catalog.services.0.plans.0.rds_properties.backup_retention_period cf-manifest/cf-manifest.yml)
 
-                for var_name in CF_ADMIN CF_PASS API_ENDPOINT; do
+                for var_name in CF_ADMIN CF_PASS API_ENDPOINT RDS_BROKER_BACKUP_RETENTION_PERIOD; do
                   echo export "${var_name}"=\"$(eval echo \$${var_name})\"
                 done > config/config.sh
+
+      # FIXME: Remove this task once the retention is updated in all running instances
+      - task: update-rds-broker-backup-retention-period
+        config:
+          platform: linux
+          image: docker:///governmentpaas/awscli
+          params:
+            AWS_DEFAULT_REGION: {{aws_region}}
+            DEPLOY_ENV: {{deploy_env}}
+          inputs:
+            - name: paas-cf
+            - name: config
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                . ./config/config.sh
+                . ./paas-cf/concourse/scripts/set_rds_backup_retention.sh "${DEPLOY_ENV}" "${RDS_BROKER_BACKUP_RETENTION_PERIOD}"
 
       - task: deploy-healthcheck
         config:

--- a/concourse/scripts/set_rds_backup_retention.sh
+++ b/concourse/scripts/set_rds_backup_retention.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+set -eu
+
+if [ $# -lt 2 ]; then
+  echo "Usage $0 <deploy_env> <retention_in_days>"
+  exit 1
+fi
+
+DEPLOY_ENV=$1
+RETENTION=$2
+
+export AWS_DEFAULT_REGION=eu-west-1
+
+echo "Changing retention period to ${RETENTION} for RDS Broker instances:"
+
+account_id=$(aws sts get-caller-identity --output text --query Account)
+if [ -z "$account_id" ]; then
+  echo "Unable to retrieve the account id"
+  exit 1
+fi
+
+echo "Retrieving all rdsbroker-* RDS instances for Account ID: ${account_id}"
+
+DB_INSTANCES=$(
+  aws rds describe-db-instances --output text \
+  --query "DBInstances[?starts_with(DBInstanceIdentifier, 'rdsbroker-')] | [*].DBInstanceIdentifier"
+)
+
+
+echo "Filtering instances of environment '${DEPLOY_ENV}' (tag[Broker Name] == '${DEPLOY_ENV}')"
+ENV_DB_INSTANCES=""
+for instance in $DB_INSTANCES; do
+    if aws rds list-tags-for-resource \
+        --output=text --region eu-west-1 \
+        --resource-name "arn:aws:rds:eu-west-1:${account_id}:db:${instance}" \
+        --query "TagList[?Key=='Broker Name' && Value=='${DEPLOY_ENV}']" \
+        | grep -q 'Broker Name'; then
+        ENV_DB_INSTANCES="$instance ${ENV_DB_INSTANCES}"
+    fi
+done
+
+for instance in $ENV_DB_INSTANCES; do
+  echo "Setting $instance retention to ${RETENTION} days..."
+  aws rds modify-db-instance \
+    --db-instance-identifier "${instance}" \
+    --backup-retention-period "${RETENTION}" \
+    --no-apply-immediately > /dev/null
+done
+
+echo Done

--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -11,7 +11,7 @@ meta:
       publicly_accessible: false
       copy_tags_to_snapshot: true
       skip_final_snapshot: true
-      backup_retention_period: 0
+      backup_retention_period: 7
       db_subnet_group_name: (( grab terraform_outputs.rds_broker_dbs_subnet_group ))
       vpc_security_group_ids:
         - (( grab terraform_outputs.rds_broker_dbs_security_group_id ))

--- a/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
@@ -74,6 +74,11 @@ RSpec.describe "RDS broker properties" do
       let(:pg_service) { services.find {|s| s["name"] == "postgres" } }
       let(:pg_plans) { pg_service.fetch("plans") }
 
+      it "contains only M-dedicated-9.5 and M-HA-dedicated-9.5 plans" do
+        pg_plan_names = pg_plans.map {|p| p["name"] }
+        expect(pg_plan_names).to contain_exactly("M-dedicated-9.5", "M-HA-dedicated-9.5")
+      end
+
       describe "plan rds_properties" do
         shared_examples "all postgres plans" do
           it "uses postgres 9.5" do
@@ -86,6 +91,11 @@ RSpec.describe "RDS broker properties" do
             expect(subject).to include(
               "db_subnet_group_name" => terraform_fixture("rds_broker_dbs_subnet_group"),
               "vpc_security_group_ids" => [terraform_fixture("rds_broker_dbs_security_group_id")],
+            )
+          end
+          it "has a backup retention period of 7 days" do
+            expect(subject).to include(
+              "backup_retention_period" => 7
             )
           end
         end

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-awscli>=1.10.16
+awscli>=1.10.38
 yamllint>=1.0.0
 PyGithub>=1.26.0


### PR DESCRIPTION
[#126398487 Enable Backups for Postgres instances](https://www.pivotaltracker.com/n/projects/1275640/stories/126398487)

## What

We want to ensure that RDS instances created by the broker have backups enabled and retained for 7 days.

We also want to change the existing provisioned instances to this default value.

## Dependencies

- [x]  All tenants must be contacted about the downtime when enabling the retention period for preexisting instances.
- [ ] We must allow deployer to update the instances by applying https://github.gds/government-paas/aws-account-wide-terraform/pull/51 

## Context

## How to review

 1. Deploy the environment with `master`
 2. In AWS console, change the "Maintenance window" of the `healthcheck-db` (search for a `rdsbroker-*` RDS instance in your VPC) to something in the next 20-30 minutes or so. Be aware it is UTC time, so 1h less than London. Check the "Apply immediately" checkbox. 
 3. Deploy this branch. The RDS broker instances should be updated and the post-deploy job should update the existing instances.

Check that new instances have the right retention:

 1. Try to create a new RDS broker instance:

     ```
DEPLOY_ENV=...
CF_ADMIN_PWD=$(aws s3 cp s3://${DEPLOY_ENV}-state/cf-secrets.yml  - | grep uaa_admin_password | awk '{print $2}')
cf login --skip-ssl-validation -a https://api.${DEPLOY_ENV}.dev.cloudpipeline.digital -u admin -p ${CF_ADMIN_PWD}
cf target -o testers -s healthcheck
cf create-service postgres  M-dedicated-9.5  test-retention-db
```
 2. Wait for the new instance to be created, go to the AWS console and check that it has retention policy 7 days. 

Check that the existing instances are updated: 

After the maintenance window has passed, check that the existing instance for `healthcheck-db` has the right retention period. You can see that has been restarted in the logs.
    
## Who can review

Anyone but @keymon or @timmow 