### PR TITLE
[#126686741] Create some standard quotas

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -261,6 +261,21 @@ properties:
         total_services: 10
         non_basic_services_allowed: false
         total_routes: 1000
+      small:
+        memory_limit: 10240
+        total_services: 10
+        non_basic_services_allowed: true
+        total_routes: 1000
+      medium:
+        memory_limit: 61440
+        total_services: 10
+        non_basic_services_allowed: true
+        total_routes: 1000
+      large:
+        memory_limit: 102400
+        total_services: 10
+        non_basic_services_allowed: true
+        total_routes: 1000
       trade_tariff:
         memory_limit: 61440
         total_services: 10

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -276,16 +276,6 @@ properties:
         total_services: 10
         non_basic_services_allowed: true
         total_routes: 1000
-      trade_tariff:
-        memory_limit: 61440
-        total_services: 10
-        non_basic_services_allowed: true
-        total_routes: 1000
-      paas_demo:
-        memory_limit: 10240
-        total_services: 10
-        non_basic_services_allowed: true
-        total_routes: 1000
       test_apps:
         memory_limit: 2048
         total_services: 10


### PR DESCRIPTION
## What

Now that we're creating more orgs we want some standard quota definitions that can be applied to to these orgs.

This PR also removes the `paas_demo` quota as this is identical to the new `small` quota. The quota setting script doesn't delete quotas not present in the manifest (it's create/update only), so this won't actually remove the quota from the deployment. Once this is deployed, the quota for the paas_demo org can be updated to use, and then I'll add a temporary task to clean up this quota.

## How to review

Deploy against an existing environment from this branch. Verify that the new quotas are created. Verify that the existing `paas_demo` quota isn't removed.

## Who can review

Anyone but myself.