### PR TITLE
Cf 239 upgrade

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -6,25 +6,25 @@ director_uuid: ~
 
 releases:
   - name: cf
-    version: 238
-    url: https://bosh.io/d/github.com/cloudfoundry/cf-release?v=238
-    sha1: fa6d35300f4fcd74a75fd8c7138f592acfcb32b0
+    version: 239
+    url: https://bosh.io/d/github.com/cloudfoundry/cf-release?v=239
+    sha1: 4d1d000ccdf34918738420a710f295977790df28
   - name: diego
     version: 0.1476.0
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/diego-release?v=0.1476.0
-    sha1: 4b66fde250472e47eb2a0151bb676fc1be840f47
+    url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=0.1480.0
+    sha1: c5c1cdde94665a55152f69238bb7476a124c3efd
   - name: garden-linux
-    version: 0.338.0
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/garden-linux-release?v=0.338.0
-    sha1: 432225d88edc9731be4453cb61eba33fa829ebdc
+    version: 0.339.0
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/garden-linux-release?v=0.339.0
+    sha1: fe72f86b00f9630b885d1b7ec74ccdb4788fb5c4
   - name: etcd
-    version: 55
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/etcd-release?v=55
-    sha1: b64fc693e658cee0ac07712646f8c7b67de0e8b6
+    version: 60
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/etcd-release?v=60
+    sha1: 66d233c86dd97760facb890f77777757317e9c86
   - name: cflinuxfs2-rootfs
-    version: 1.15.0
-    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-rootfs-release?v=1.15.0
-    sha1: 389ad7bb316ec5bbb7ff2ed085d551d83afc7a0f
+    version: 1.18.0
+    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-rootfs-release?v=1.18.0
+    sha1: 7ed6c55b53477cd96d7030aa8fa6e1c0cb1f4637
   - name: paas-haproxy
     version: 0.0.4
   - name: routing
@@ -33,7 +33,7 @@ releases:
 stemcells:
   - alias: default
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: 3232.11
+    version: 3262.2
 
 update:
   canaries: 0

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -33,7 +33,7 @@ releases:
 stemcells:
   - alias: default
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: 3262.2
+    version: 3232.11
 
 update:
   canaries: 0

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -502,6 +502,9 @@ properties:
         require_ssl: true
       dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
 
+    executor:
+      container_metrics_report_interval: 60
+
     bbs:
       active_key_label: keylabel1
       encryption_keys:

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -67,6 +67,8 @@ properties:
       machines: (( grab properties.nats.machines ))
       username: (( grab properties.nats.user ))
       password: (( grab properties.nats.password ))
+    etcd:
+      dns_suffix: (( grab properties.system_domain ))
 
   loggregator:
     maxRetainedLogMessages: 100

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -147,7 +147,7 @@ properties:
     route_services_timeout:
     logrotate:
     extra_headers_to_log:
-    debug_addr:
+    debug_address:
     enable_routing_api:
     drain_wait: 15
 


### PR DESCRIPTION
# What

Upgrade to CF v239

The most significant change in this release is the inclusion of gorouter Proxy support added by @Jonty
This release also paves the way for TLS encrypted etcd communications by the addition of a dns_suffix in the etcd properties to allow it to use a certificate.

# How to review

* Make a fresh deploy using the paas-cf pipeline as normal and confirm that everything works with a pristine build.
* Perform an incremental update on a v238 environment using the paas-cf concourse pipeline and confirm that the platofrm remains available throughout deployment and that all tests pass OK.

# Who can review

Anyone on the Government PaaS team