### PR TITLE
[#126795275] Start fake BOSH once in bosh_pre_destroy tests

### DIFF
--- a/concourse/scripts/spec/bosh_pre_destroy_spec.rb
+++ b/concourse/scripts/spec/bosh_pre_destroy_spec.rb
@@ -2,13 +2,11 @@ require 'yaml'
 require 'mimic'
 
 RSpec.describe "bosh_pre_destroy.rb", :type => :aruba do
-  before(:each) do
+  before(:all) do
     bosh_host = "127.0.0.1"
     bosh_port = 25555
 
-    @fake_bosh = Mimic.mimic(:hostname => bosh_host, :port => bosh_port) do
-      get("/info").returning('{}', 200)
-    end
+    @fake_bosh = Mimic.mimic(:hostname => bosh_host, :port => bosh_port)
 
     bosh_config = {'target' => "http://#{bosh_host}:#{bosh_port}"}
     bosh_config_file = Tempfile.new('bosh_config')
@@ -17,8 +15,16 @@ RSpec.describe "bosh_pre_destroy.rb", :type => :aruba do
     set_environment_variable('BOSH_CONFIG', bosh_config_file.path)
   end
 
-  after(:each) do
+  after(:all) do
     Mimic.cleanup!
+  end
+
+  before(:each) do
+    @fake_bosh.get("/info").returning('{}', 200)
+  end
+
+  after(:each) do
+    Mimic.reset_all!
   end
 
   context("no deployments") do


### PR DESCRIPTION
## What

Start fake BOSH just once for the bosh_pre_destroy test suite.

The motivation for the change is that we have intermittent failures in these
tests, caused by a race condition to do with how the `mimic` http server for faking
http services is started and stopped.

We currently start a new server at the beginning of each test and
stop it at the end of the test.

Normally the error seen is `ECONNRESET` during the check mimic does to ensure the server is started before tests proceed, but we have seen other failure modes as well.

With this change, we start it once at the beginning of the suite, remove all routes at the end of each test, and then shutdown the server at the end of the suite.

We introduce this change now rather than later because the build failed for this
reason during our mimic-related work on https://github.com/alphagov/paas-cf/pull/364
So, we're unblocking ourselves using Dan's WIP branch, with his OK.

## How to review

Run the `bosh_pre_destroy_spec.rb` tests multiple times and confirm no
intermittent failures caused by mimic server race conditions:

`cd concourse/scripts; echo 'set -e; for n in $(seq 100); do echo $n; bundle exec rspec spec/bosh_pre_destroy_spec.rb;  done' > foo.sh; ./foo.sh`

## Who can review

anyone except @benhyland, @combor, @dcarley 