### PR TITLE
[#126686741] Remove unneeded org-specific quotas.

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1395,6 +1395,9 @@ jobs:
 
                   ./paas-cf/concourse/scripts/set_quotas_from_manifest.rb cf-manifest/cf-manifest.yml
 
+                  # FIXME Remove these once they've run on prod.
+                  cf delete-quota -f trade_tariff
+                  cf delete-quota -f paas_demo
 
         - task: sync-admin-users
           config:


### PR DESCRIPTION
[#126686741 Create digitalmarketplace Org and Users](https://www.pivotaltracker.com/n/projects/1275640/stories/126686741)

## What

Now that we have some standard quotas in place (#368), these org-specific quotas are no
longer needed. This cleans them up from existing environments.

I've manually verified that these quotas are not currently in use by anything on production.

Once this has run everywhere, we'll need a follow-up PR to revert this.

## How to review

Run the deploy against an existing environment that has the `paas_demo` and/or `trade_tariff` quotas defined. Verify that the quotas get removed. Verify that a second run of the cf-deploy job doesn't error.

## Who can review

Anyone but myself.