### PR TITLE
[#117991263] upgrade concourse to 1.5.1

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -84,7 +84,10 @@ jobs:
             - name: delete-timer
             - name: bosh-secrets
             - name: paas-cf
-          image: docker:///governmentpaas/bosh-cli
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/bosh-cli
           run:
             path: sh
             args:

--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -1,3 +1,20 @@
+---
+resource_types:
+- name: git-gpg
+  type: docker-image
+  source:
+    repository: governmentpaas/git-resource
+
+- name: s3-iam
+  type: docker-image
+  source:
+    repository: governmentpaas/s3-resource
+
+- name: semver-iam
+  type: docker-image
+  source:
+    repository: governmentpaas/semver-resource
+
 resources:
   - name: paas-cf
     type: git-gpg

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -65,6 +65,22 @@ groups:
     jobs:
       - continuous-smoke-tests
 
+resource_types:
+- name: git-gpg
+  type: docker-image
+  source:
+    repository: governmentpaas/git-resource
+
+- name: s3-iam
+  type: docker-image
+  source:
+    repository: governmentpaas/s3-resource
+
+- name: semver-iam
+  type: docker-image
+  source:
+    repository: governmentpaas/semver-resource
+
 resources:
   - name: pipeline-trigger
     type: semver-iam

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -305,7 +305,10 @@ jobs:
       - task: init-pipeline-pool
         config:
           platform: linux
-          image: docker:///governmentpaas/git-ssh
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/git-ssh
           inputs:
             - name: paas-cf
             - name: git-ssh-private-key
@@ -346,7 +349,10 @@ jobs:
       - task: self-update-pipeline
         config:
           platform: linux
-          image: docker:///governmentpaas/self-update-pipelines
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/self-update-pipelines
           inputs:
             - name: paas-cf
             - name: concourse-manifest
@@ -363,7 +369,10 @@ jobs:
       - task: bootstrap-s3-state
         config:
           platform: linux
-          image: docker:///governmentpaas/curl-ssl
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/curl-ssl
           inputs:
             - name: paas-cf
           run:
@@ -400,7 +409,10 @@ jobs:
       - task: generate-bosh-CA
         config:
           platform: linux
-          image: docker:///governmentpaas/certstrap
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/certstrap
           inputs:
             - name: paas-cf
             - name: bosh-CA
@@ -433,7 +445,11 @@ jobs:
       - task: generate-bosh-secrets
         config:
           platform: linux
-          image: docker:///ruby#2.2-slim
+          image_resource:
+            type: docker-image
+            source:
+              repository: ruby
+              tag: 2.2-slim
           inputs:
             - name: paas-cf
             - name: bosh-secrets
@@ -458,7 +474,10 @@ jobs:
       - task: generate-cf-certs
         config:
           platform: linux
-          image: docker:///governmentpaas/certstrap
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/certstrap
           inputs:
             - name: bosh-CA
             - name: paas-cf
@@ -494,7 +513,11 @@ jobs:
       - task: generate-cf-secrets
         config:
           platform: linux
-          image: docker:///ruby#2.2-slim
+          image_resource:
+            type: docker-image
+            source:
+              repository: ruby
+              tag: 2.2-slim
           inputs:
             - name: paas-cf
             - name: cf-secrets
@@ -541,7 +564,10 @@ jobs:
             params:
               SYSTEM_DNS_ZONE_NAME: {{system_dns_zone_name}}
               CF_ADMIN: admin
-            image: docker:///governmentpaas/cf-cli
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/cf-cli
             run:
               path: sh
               args:
@@ -582,7 +608,10 @@ jobs:
       - task: run-tests
         config:
           platform: linux
-          image: docker:///governmentpaas/cf-acceptance-tests
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/cf-acceptance-tests
           inputs:
             - name: paas-cf
             - name: pipeline-trigger
@@ -630,7 +659,11 @@ jobs:
       - task: extract-terraform-variables
         config:
           platform: linux
-          image: docker:///ruby#2.2-slim
+          image_resource:
+            type: docker-image
+            source:
+              repository: ruby
+              tag: 2.2-slim
           inputs:
             - name: paas-cf
             - name: vpc-tfstate
@@ -654,7 +687,10 @@ jobs:
       - task: terraform-apply
         config:
           platform: linux
-          image: docker:///governmentpaas/terraform
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/terraform
           inputs:
             - name: paas-cf
             - name: terraform-variables
@@ -705,7 +741,11 @@ jobs:
       - task: extract_terraform_outputs
         config:
           platform: linux
-          image: docker:///ruby#2.2-slim
+          image_resource:
+            type: docker-image
+            source:
+              repository: ruby
+              tag: 2.2-slim
           inputs:
             - name: paas-cf
             - name: vpc-tfstate
@@ -728,7 +768,10 @@ jobs:
       - task: extract-bosh-CA
         config:
           platform: linux
-          image: docker:///governmentpaas/certstrap
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/certstrap
           inputs:
             - name: paas-cf
             - name: bosh-CA
@@ -748,7 +791,10 @@ jobs:
       - task: render-bosh-manifest
         config:
           platform: linux
-          image: docker:///governmentpaas/spruce
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/spruce
           inputs:
             - name: paas-cf
             - name: terraform-outputs
@@ -794,7 +840,10 @@ jobs:
       - task: bosh-init-microbosh
         config:
           platform: linux
-          image: docker:///governmentpaas/bosh-init
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/bosh-init
           inputs:
             - name: bosh-manifest
             - name: bosh-init-state
@@ -844,7 +893,10 @@ jobs:
       - task: upload-certs-to-aws
         config:
           platform: linux
-          image: docker:///governmentpaas/terraform
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/terraform
           inputs:
             - name: paas-cf
             - name: cf-certs-tfstate
@@ -888,7 +940,10 @@ jobs:
       - task: retrieve-pingdom-probes-ips
         config:
           platform: linux
-          image: docker:///governmentpaas/curl-ssl
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/curl-ssl
           inputs:
             - name: paas-cf
           outputs:
@@ -910,7 +965,11 @@ jobs:
       - task: extract-terraform-variables
         config:
           platform: linux
-          image: docker:///ruby#2.2-slim
+          image_resource:
+            type: docker-image
+            source:
+              repository: ruby
+              tag: 2.2-slim
           inputs:
             - name: paas-cf
             - name: vpc-tfstate
@@ -936,7 +995,10 @@ jobs:
       - task: terraform-apply
         config:
           platform: linux
-          image: docker:///governmentpaas/terraform
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/terraform
           inputs:
             - name: terraform-variables
             - name: paas-cf
@@ -976,7 +1038,11 @@ jobs:
       - task: extract-cf-terraform-outputs
         config:
           platform: linux
-          image: docker:///ruby#2.2-slim
+          image_resource:
+            type: docker-image
+            source:
+              repository: ruby
+              tag: 2.2-slim
           inputs:
             - name: paas-cf
             - name: cf-tfstate
@@ -995,7 +1061,10 @@ jobs:
       - task: init-db
         config:
           platform: linux
-          image: docker:///governmentpaas/psql
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/psql
           inputs:
             - name: terraform-variables
             - name: paas-cf
@@ -1035,7 +1104,11 @@ jobs:
         - task: extract-terraform-outputs
           config:
             platform: linux
-            image: docker:///ruby#2.2-slim
+            image_resource:
+              type: docker-image
+              source:
+                repository: ruby
+                tag: 2.2-slim
             inputs:
               - name: paas-cf
               - name: vpc-tfstate
@@ -1062,7 +1135,10 @@ jobs:
         - task: generate-grafana-dashboards-manifest
           config:
             platform: linux
-            image: docker:///governmentpaas/json-minify
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/json-minify
             inputs:
               - name: paas-cf
             outputs:
@@ -1081,7 +1157,10 @@ jobs:
         - task: generate-cloud-config
           config:
             platform: linux
-            image: docker:///governmentpaas/spruce
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/spruce
             inputs:
               - name: paas-cf
               - name: terraform-outputs
@@ -1110,7 +1189,10 @@ jobs:
         - task: generate-cf-manifest
           config:
             platform: linux
-            image: docker:///governmentpaas/spruce
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/spruce
             inputs:
               - name: paas-cf
               - name: terraform-outputs
@@ -1166,7 +1248,10 @@ jobs:
         - task: generate-runtime-config
           config:
             platform: linux
-            image: docker:///governmentpaas/spruce
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/spruce
             inputs:
               - name: paas-cf
             outputs:
@@ -1223,7 +1308,10 @@ jobs:
         - task: upload-releases
           config:
             platform: linux
-            image: docker:///governmentpaas/bosh-cli
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/bosh-cli
             inputs:
               - name: paas-cf
               - name: bosh-secrets
@@ -1261,7 +1349,10 @@ jobs:
         - task: get-and-upload-stemcell
           config:
             platform: linux
-            image: docker:///governmentpaas/bosh-cli
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/bosh-cli
             inputs:
               - name: bosh-secrets
               - name: paas-cf
@@ -1283,7 +1374,10 @@ jobs:
         - task: update-cloud-config
           config:
             platform: linux
-            image: docker:///governmentpaas/bosh-cli
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/bosh-cli
             inputs:
               - name: cloud-config
               - name: bosh-secrets
@@ -1300,7 +1394,10 @@ jobs:
       - task: cf-deploy
         config:
           platform: linux
-          image: docker:///governmentpaas/bosh-cli
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/bosh-cli
           inputs:
             - name: paas-cf
             - name: cf-manifest
@@ -1335,7 +1432,11 @@ jobs:
           outputs:
             - name: config
           params:
-          image: docker:///ruby#2.2-slim
+          image_resource:
+            type: docker-image
+            source:
+              repository: ruby
+              tag: 2.2-slim
           run:
             path: sh
             args:
@@ -1373,7 +1474,10 @@ jobs:
               - name: config
               - name: cf-manifest
             params:
-            image: docker:///governmentpaas/cf-cli
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/cf-cli
             run:
               path: sh
               args:
@@ -1396,7 +1500,10 @@ jobs:
               - name: config
               - name: cf-manifest
             params:
-            image: docker:///governmentpaas/cf-cli
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/cf-cli
             run:
               path: sh
               args:
@@ -1418,7 +1525,11 @@ jobs:
         - task: sync-admin-users
           config:
             platform: linux
-            image: docker:///ruby#2.2
+            image_resource:
+              type: docker-image
+              source:
+                repository: ruby
+                tag: 2.2-slim
             inputs:
               - name: paas-cf
               - name: config
@@ -1446,7 +1557,10 @@ jobs:
         - task: register-rds-broker
           config:
             platform: linux
-            image: docker:///governmentpaas/cf-cli
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/cf-cli
             inputs:
               - name: paas-cf
               - name: config
@@ -1478,7 +1592,10 @@ jobs:
               - name: config
               - name: bosh-CA
             params:
-            image: docker:///governmentpaas/cf-cli
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/cf-cli
             run:
               path: sh
               args:
@@ -1533,7 +1650,11 @@ jobs:
         - task: update-kibana-timezone
           config:
             platform: linux
-            image: docker:///ruby#2.2-slim
+            image_resource:
+              type: docker-image
+              source:
+                repository: ruby
+                tag: 2.2-slim
             params:
               SYSTEM_DNS_ZONE_NAME: {{system_dns_zone_name}}
               DEPLOY_ENV: {{deploy_env}}
@@ -1580,7 +1701,11 @@ jobs:
           outputs:
             - name: config
           params:
-          image: docker:///ruby#2.2-slim
+          image_resource:
+            type: docker-image
+            source:
+              repository: ruby
+              tag: 2.2-slim
           run:
             path: sh
             args:
@@ -1602,7 +1727,10 @@ jobs:
       - task: update-rds-broker-backup-retention-period
         config:
           platform: linux
-          image: docker:///governmentpaas/awscli
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/awscli
           params:
             AWS_DEFAULT_REGION: {{aws_region}}
             DEPLOY_ENV: {{deploy_env}}
@@ -1621,7 +1749,10 @@ jobs:
       - task: deploy-healthcheck
         config:
           platform: linux
-          image: docker:///governmentpaas/cf-cli
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/cf-cli
           inputs:
             - name: paas-cf
             - name: config
@@ -1715,7 +1846,10 @@ jobs:
         - task: generate-test-config
           config:
             platform: linux
-            image: docker:///governmentpaas/bosh-cli
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/bosh-cli
             inputs:
               - name: cf-release
               - name: paas-cf
@@ -1755,7 +1889,10 @@ jobs:
         - task: run-tests
           config:
             platform: linux
-            image: docker:///governmentpaas/cf-acceptance-tests
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/cf-acceptance-tests
             inputs:
               - name: paas-cf
               - name: cf-release
@@ -1807,7 +1944,10 @@ jobs:
         - task: run-tests
           config:
             platform: linux
-            image: docker:///governmentpaas/cf-acceptance-tests
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/cf-acceptance-tests
             inputs:
               - name: paas-cf
               - name: test-config
@@ -1842,7 +1982,11 @@ jobs:
       - task: test-bosh-cli
         config:
           platform: linux
-          image: docker:///ruby#2.2-slim
+          image_resource:
+            type: docker-image
+            source:
+              repository: ruby
+              tag: 2.2-slim
           params:
             SYSTEM_DNS_ZONE_NAME: {{system_dns_zone_name}}
             DEPLOY_ENV: {{deploy_env}}
@@ -1863,7 +2007,10 @@ jobs:
       - task: test-bosh-vms
         config:
           platform: linux
-          image: docker:///governmentpaas/bosh-cli
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/bosh-cli
           inputs:
           - name: paas-cf
           - name: cf-manifest
@@ -1905,7 +2052,10 @@ jobs:
         - task: run-tests
           config:
             platform: linux
-            image: docker:///governmentpaas/cf-acceptance-tests
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/cf-acceptance-tests
             inputs:
               - name: paas-cf
               - name: test-config
@@ -1941,7 +2091,10 @@ jobs:
 
       - task: tag-release
         config:
-          image: docker:///governmentpaas/git-ssh
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/git-ssh
           platform: linux
           params:
             aws_account: {{aws_account}}
@@ -1981,7 +2134,10 @@ jobs:
       - get: pipeline-pool
       - task: print-pipeline-lock-state
         config:
-          image: docker:///governmentpaas/git-ssh
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/git-ssh
           platform: linux
           inputs:
           - name: pipeline-pool
@@ -2021,7 +2177,10 @@ jobs:
     plan:
       - task: ssh-keygen
         config:
-          image: docker:///governmentpaas/git-ssh
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/awscli
           platform: linux
           outputs:
           - name: generated-git-keys
@@ -2100,7 +2259,10 @@ jobs:
             task: alert
             config:
               platform: linux
-              image: docker:///governmentpaas/awscli
+              image_resource:
+                type: docker-image
+                source:
+                  repository: governmentpaas/awscli
               params:
                 AWS_DEFAULT_REGION: {{aws_region}}
                 DEPLOY_ENV: {{deploy_env}}

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -845,6 +845,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-init
+              tag: 117991263_upgrade_bosh_init
           inputs:
             - name: bosh-manifest
             - name: bosh-init-state

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1675,9 +1675,8 @@ jobs:
       - do:
         - task: create-temp-user
           file: paas-cf/concourse/tasks/create_admin.yml
-          config:
-            params:
-              PREFIX: smoketest-user
+          params:
+            PREFIX: smoketest-user
 
         - task: smoke-tests-config
           file: paas-cf/concourse/tasks/smoke-tests-config.yml
@@ -1710,9 +1709,8 @@ jobs:
       - do:
         - task: create-temp-user
           file: paas-cf/concourse/tasks/create_admin.yml
-          config:
-            params:
-              PREFIX: acceptance-test-user
+          params:
+            PREFIX: acceptance-test-user
 
         - task: generate-test-config
           config:
@@ -1800,9 +1798,8 @@ jobs:
       - do:
         - task: create-temp-user
           file: paas-cf/concourse/tasks/create_admin.yml
-          config:
-            params:
-              PREFIX: custom-acceptance-test-user
+          params:
+            PREFIX: custom-acceptance-test-user
 
         - task: generate-test-config
           file: paas-cf/concourse/tasks/generate-test-config.yml
@@ -1899,9 +1896,8 @@ jobs:
       - do:
         - task: create-temp-user
           file: paas-cf/concourse/tasks/create_admin.yml
-          config:
-            params:
-              PREFIX: performance-tests-user
+          params:
+            PREFIX: performance-tests-user
 
         - task: generate-test-config
           file: paas-cf/concourse/tasks/generate-test-config.yml
@@ -2092,9 +2088,8 @@ jobs:
       - do:
         - task: create-temp-user
           file: paas-cf/concourse/tasks/create_admin.yml
-          config:
-            params:
-              PREFIX: cont-smoketest-user
+          params:
+            PREFIX: cont-smoketest-user
 
         - task: smoke-tests-config
           file: paas-cf/concourse/tasks/smoke-tests-config.yml

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1843,7 +1843,7 @@ jobs:
             - -c
             - |
               VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
-              CONCOURSE_ATC_PASSWORD=$("$VAL_FROM_YAML" jobs.concourse.properties.atc.basic_auth_password concourse-manifest/concourse-manifest.yml)
+              CONCOURSE_ATC_PASSWORD=$("$VAL_FROM_YAML" jobs.concourse.properties.basic_auth_password concourse-manifest/concourse-manifest.yml)
               export CONCOURSE_ATC_PASSWORD
               echo Looking for non running VMs
               ./paas-cf/concourse/scripts/bosh-cli.sh bosh status

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -2230,6 +2230,7 @@ jobs:
 
   - name: continuous-smoke-tests
     serial_groups: [smoke-tests]
+    build_logs_to_retain: 10000
     plan:
       - get: cf-release
         params:

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -28,6 +28,7 @@ groups:
       - bosh-terraform
       - generate-bosh-config
       - bosh-deploy
+      - bosh-cli
   - name: cloudfoundry
     jobs:
       - pre-deploy
@@ -2283,3 +2284,33 @@ jobs:
         ensure:
           task: remove-temp-user
           file: paas-cf/concourse/tasks/delete_admin.yml
+
+  - name: bosh-cli
+    plan:
+      - aggregate:
+          - get: paas-cf
+          - get: bosh-secrets
+          - get: cf-manifest
+
+      - task: run-bosh-cli
+        config:
+          platform: linux
+          # FIXME: use image_resource once https://github.com/concourse/fly/issues/98 is implemented
+          image: docker:///governmentpaas/bosh-cli
+          inputs:
+            - name: paas-cf
+            - name: cf-manifest
+            - name: bosh-secrets
+          params:
+            SYSTEM_DNS_ZONE_NAME: {{system_dns_zone_name}}
+          run:
+            path: sh
+            args:
+            - -c
+            - -e
+            - |
+              ./paas-cf/concourse/scripts/bosh_login.sh bosh.${SYSTEM_DNS_ZONE_NAME} bosh-secrets/bosh-secrets.yml
+
+              uuid=$(bosh status --uuid)
+              sed -e "s/^director_uuid:.*$/director_uuid: ${uuid}/" cf-manifest/cf-manifest.yml > cf-manifest-with-uuid.yml
+              bosh deployment ./cf-manifest-with-uuid.yml

--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -460,7 +460,7 @@ jobs:
     - task: concourse-deploy
       timeout: 30m
       config:
-        image: docker:///governmentpaas/bosh-init
+        image: docker:///governmentpaas/bosh-init#117991263_upgrade_bosh_init
         inputs:
         - name: concourse-manifest
         - name: concourse-bosh-state

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -1,3 +1,20 @@
+---
+resource_types:
+- name: git-gpg
+  type: docker-image
+  source:
+    repository: governmentpaas/git-resource
+
+- name: s3-iam
+  type: docker-image
+  source:
+    repository: governmentpaas/s3-resource
+
+- name: semver-iam
+  type: docker-image
+  source:
+    repository: governmentpaas/semver-resource
+
 resources:
   - name: paas-cf
     type: git-gpg

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -110,7 +110,10 @@ jobs:
       - task: self-update-pipeline
         config:
           platform: linux
-          image: docker:///governmentpaas/self-update-pipelines
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/self-update-pipelines
           inputs:
             - name: paas-cf
             - name: concourse-manifest
@@ -149,7 +152,10 @@ jobs:
       - task: delete-deployment
         config:
           platform: linux
-          image: docker:///governmentpaas/bosh-cli
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/bosh-cli
           inputs:
             - name: bosh-secrets
             - name: paas-cf
@@ -182,7 +188,11 @@ jobs:
       - task: extract-terraform-variables
         config:
           platform: linux
-          image: docker:///ruby#2.2-slim
+          image_resource:
+            type: docker-image
+            source:
+              repository: ruby
+              tag: 2.2-slim
           inputs:
             - name: paas-cf
             - name: cf-tfstate
@@ -217,7 +227,10 @@ jobs:
       - task: cf-terraform-destroy
         config:
           platform: linux
-          image: docker:///governmentpaas/terraform
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/terraform
           inputs:
             - name: terraform-variables
             - name: paas-cf
@@ -256,7 +269,10 @@ jobs:
       - task: cf-certs-terraform-destroy
         config:
           platform: linux
-          image: docker:///governmentpaas/terraform
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/terraform
           inputs:
             - name: paas-cf
             - name: cf-certs-tfstate

--- a/concourse/pipelines/destroy-deployer.yml
+++ b/concourse/pipelines/destroy-deployer.yml
@@ -63,7 +63,7 @@ jobs:
     - task: destroy-concourse
       timeout: 30m
       config:
-        image: docker:///governmentpaas/bosh-init
+        image: docker:///governmentpaas/bosh-init#117991263_upgrade_bosh_init
         inputs:
         - name: paas-cf
         - name: concourse-manifest

--- a/concourse/pipelines/destroy-microbosh.yml
+++ b/concourse/pipelines/destroy-microbosh.yml
@@ -1,3 +1,20 @@
+---
+resource_types:
+- name: git-gpg
+  type: docker-image
+  source:
+    repository: governmentpaas/git-resource
+
+- name: s3-iam
+  type: docker-image
+  source:
+    repository: governmentpaas/s3-resource
+
+- name: semver-iam
+  type: docker-image
+  source:
+    repository: governmentpaas/semver-resource
+
 resources:
   - name: paas-cf
     type: git-gpg

--- a/concourse/pipelines/destroy-microbosh.yml
+++ b/concourse/pipelines/destroy-microbosh.yml
@@ -89,7 +89,10 @@ jobs:
       - task: self-update-pipeline
         config:
           platform: linux
-          image: docker:///governmentpaas/self-update-pipelines
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/self-update-pipelines
           inputs:
             - name: paas-cf
             - name: concourse-manifest
@@ -119,7 +122,10 @@ jobs:
       - task: check-existing-deployments
         config:
           platform: linux
-          image: docker:///governmentpaas/bosh-cli
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/bosh-cli
           inputs:
             - name: paas-cf
             - name: bosh-secrets
@@ -135,7 +141,10 @@ jobs:
       - task: cleanup-orphaned-disks
         config:
           platform: linux
-          image: docker:///governmentpaas/bosh-cli
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/bosh-cli
           inputs:
             - name: paas-cf
             - name: bosh-secrets
@@ -151,7 +160,10 @@ jobs:
       - task: bosh-init-microbosh
         config:
           platform: linux
-          image: docker:///governmentpaas/bosh-init
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/bosh-init
           inputs:
             - name: paas-cf
             - name: bosh-manifest
@@ -194,7 +206,11 @@ jobs:
       - task: extract-terraform-variables
         config:
           platform: linux
-          image: docker:///ruby#2.2-slim
+          image_resource:
+            type: docker-image
+            source:
+              repository: ruby
+              tag: 2.2-slim
           inputs:
             - name: paas-cf
             - name: vpc-tfstate
@@ -217,7 +233,10 @@ jobs:
       - task: terraform-destroy
         config:
           platform: linux
-          image: docker:///governmentpaas/terraform
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/terraform
           inputs:
             - name: paas-cf
             - name: terraform-variables

--- a/concourse/pipelines/destroy-microbosh.yml
+++ b/concourse/pipelines/destroy-microbosh.yml
@@ -164,6 +164,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-init
+              tag: 117991263_upgrade_bosh_init
           inputs:
             - name: paas-cf
             - name: bosh-manifest

--- a/concourse/pipelines/failure-testing.yml
+++ b/concourse/pipelines/failure-testing.yml
@@ -1,3 +1,20 @@
+---
+resource_types:
+- name: git-gpg
+  type: docker-image
+  source:
+    repository: governmentpaas/git-resource
+
+- name: s3-iam
+  type: docker-image
+  source:
+    repository: governmentpaas/s3-resource
+
+- name: semver-iam
+  type: docker-image
+  source:
+    repository: governmentpaas/semver-resource
+
 resources:
   - name: paas-cf
     type: git-gpg

--- a/concourse/pipelines/failure-testing.yml
+++ b/concourse/pipelines/failure-testing.yml
@@ -81,7 +81,10 @@ jobs:
       - task: self-update-pipeline
         config:
           platform: linux
-          image: docker:///governmentpaas/self-update-pipelines
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/self-update-pipelines
           inputs:
             - name: paas-cf
             - name: concourse-manifest
@@ -384,7 +387,10 @@ jobs:
         - task: run-tests
           config:
             platform: linux
-            image: docker:///governmentpaas/cf-acceptance-tests
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/self-update-pipelines
             inputs:
               - name: paas-cf
               - name: test-config

--- a/concourse/pipelines/failure-testing.yml
+++ b/concourse/pipelines/failure-testing.yml
@@ -115,18 +115,16 @@ jobs:
             trigger: true
       - task: get-instance-id
         file: paas-cf/concourse/tasks/get-instance-id.yml
-        config:
-          params:
-            VM_NAME: api/0
-            BOSH_FQDN: {{bosh_fqdn}}
+        params:
+          VM_NAME: api/0
+          BOSH_FQDN: {{bosh_fqdn}}
       - task: kill-instance
         file: paas-cf/concourse/tasks/kill-instance.yml
       - do:
         - task: create-temp-user
           file: paas-cf/concourse/tasks/create_admin.yml
-          config:
-            params:
-              PREFIX: controller-smoketest-user
+          params:
+            PREFIX: controller-smoketest-user
         - task: generate-test-config
           file: paas-cf/concourse/tasks/smoke-tests-config.yml
         - task: run-tests
@@ -135,9 +133,8 @@ jobs:
           aggregate:
             - task: recover
               file: paas-cf/concourse/tasks/recover.yml
-              config:
-                params:
-                  BOSH_FQDN: {{bosh_fqdn}}
+              params:
+                BOSH_FQDN: {{bosh_fqdn}}
             - task: remove-temp-user
               file: paas-cf/concourse/tasks/delete_admin.yml
 
@@ -160,18 +157,16 @@ jobs:
             trigger: true
       - task: get-instance-id
         file: paas-cf/concourse/tasks/get-instance-id.yml
-        config:
-          params:
-            VM_NAME: nats/0
-            BOSH_FQDN: {{bosh_fqdn}}
+        params:
+          VM_NAME: nats/0
+          BOSH_FQDN: {{bosh_fqdn}}
       - task: kill-instance
         file: paas-cf/concourse/tasks/kill-instance.yml
       - do:
         - task: create-temp-user
           file: paas-cf/concourse/tasks/create_admin.yml
-          config:
-            params:
-              PREFIX: nats-smoketest-user
+          params:
+            PREFIX: nats-smoketest-user
         - task: generate-test-config
           file: paas-cf/concourse/tasks/smoke-tests-config.yml
         - task: run-tests
@@ -180,9 +175,8 @@ jobs:
           aggregate:
             - task: recover
               file: paas-cf/concourse/tasks/recover.yml
-              config:
-                params:
-                  BOSH_FQDN: {{bosh_fqdn}}
+              params:
+                BOSH_FQDN: {{bosh_fqdn}}
             - task: remove-temp-user
               file: paas-cf/concourse/tasks/delete_admin.yml
 
@@ -205,18 +199,16 @@ jobs:
             trigger: true
       - task: get-instance-id
         file: paas-cf/concourse/tasks/get-instance-id.yml
-        config:
-          params:
-            VM_NAME: router/0
-            BOSH_FQDN: {{bosh_fqdn}}
+        params:
+          VM_NAME: router/0
+          BOSH_FQDN: {{bosh_fqdn}}
       - task: kill-instance
         file: paas-cf/concourse/tasks/kill-instance.yml
       - do:
         - task: create-temp-user
           file: paas-cf/concourse/tasks/create_admin.yml
-          config:
-            params:
-              PREFIX: router-smoketest-user
+          params:
+            PREFIX: router-smoketest-user
         - task: generate-test-config
           file: paas-cf/concourse/tasks/smoke-tests-config.yml
         - task: run-tests
@@ -225,9 +217,8 @@ jobs:
           aggregate:
             - task: recover
               file: paas-cf/concourse/tasks/recover.yml
-              config:
-                params:
-                  BOSH_FQDN: {{bosh_fqdn}}
+              params:
+                BOSH_FQDN: {{bosh_fqdn}}
             - task: remove-temp-user
               file: paas-cf/concourse/tasks/delete_admin.yml
 
@@ -250,18 +241,16 @@ jobs:
             trigger: true
       - task: get-instance-id
         file: paas-cf/concourse/tasks/get-instance-id.yml
-        config:
-          params:
-            VM_NAME: etcd/0
-            BOSH_FQDN: {{bosh_fqdn}}
+        params:
+          VM_NAME: etcd/0
+          BOSH_FQDN: {{bosh_fqdn}}
       - task: kill-instance
         file: paas-cf/concourse/tasks/kill-instance.yml
       - do:
         - task: create-temp-user
           file: paas-cf/concourse/tasks/create_admin.yml
-          config:
-            params:
-              PREFIX: etcd-smoketest-user
+          params:
+            PREFIX: etcd-smoketest-user
         - task: generate-test-config
           file: paas-cf/concourse/tasks/smoke-tests-config.yml
         - task: run-tests
@@ -270,9 +259,8 @@ jobs:
           aggregate:
             - task: recover
               file: paas-cf/concourse/tasks/recover.yml
-              config:
-                params:
-                  BOSH_FQDN: {{bosh_fqdn}}
+              params:
+                BOSH_FQDN: {{bosh_fqdn}}
             - task: remove-temp-user
               file: paas-cf/concourse/tasks/delete_admin.yml
 
@@ -295,18 +283,16 @@ jobs:
             trigger: true
       - task: get-instance-id
         file: paas-cf/concourse/tasks/get-instance-id.yml
-        config:
-          params:
-            VM_NAME: consul/0
-            BOSH_FQDN: {{bosh_fqdn}}
+        params:
+          VM_NAME: consul/0
+          BOSH_FQDN: {{bosh_fqdn}}
       - task: kill-instance
         file: paas-cf/concourse/tasks/kill-instance.yml
       - do:
         - task: create-temp-user
           file: paas-cf/concourse/tasks/create_admin.yml
-          config:
-            params:
-              PREFIX: consul-smoketest-user
+          params:
+            PREFIX: consul-smoketest-user
         - task: generate-test-config
           file: paas-cf/concourse/tasks/smoke-tests-config.yml
         - task: run-tests
@@ -315,9 +301,8 @@ jobs:
           aggregate:
             - task: recover
               file: paas-cf/concourse/tasks/recover.yml
-              config:
-                params:
-                  BOSH_FQDN: {{bosh_fqdn}}
+              params:
+                BOSH_FQDN: {{bosh_fqdn}}
             - task: remove-temp-user
               file: paas-cf/concourse/tasks/delete_admin.yml
 
@@ -340,18 +325,16 @@ jobs:
             trigger: true
       - task: get-instance-id
         file: paas-cf/concourse/tasks/get-instance-id.yml
-        config:
-          params:
-            VM_NAME: cell/0
-            BOSH_FQDN: {{bosh_fqdn}}
+        params:
+          VM_NAME: cell/0
+          BOSH_FQDN: {{bosh_fqdn}}
       - task: kill-instance
         file: paas-cf/concourse/tasks/kill-instance.yml
       - do:
         - task: create-temp-user
           file: paas-cf/concourse/tasks/create_admin.yml
-          config:
-            params:
-              PREFIX: cell-smoketest-user
+          params:
+            PREFIX: cell-smoketest-user
         - task: generate-test-config
           file: paas-cf/concourse/tasks/smoke-tests-config.yml
         - task: run-tests
@@ -360,9 +343,8 @@ jobs:
           aggregate:
             - task: recover
               file: paas-cf/concourse/tasks/recover.yml
-              config:
-                params:
-                  BOSH_FQDN: {{bosh_fqdn}}
+              params:
+                BOSH_FQDN: {{bosh_fqdn}}
             - task: remove-temp-user
               file: paas-cf/concourse/tasks/delete_admin.yml
 
@@ -385,18 +367,16 @@ jobs:
             trigger: true
       - task: get-instance-id
         file: paas-cf/concourse/tasks/get-instance-id.yml
-        config:
-          params:
-            VM_NAME: rds_broker/0
-            BOSH_FQDN: {{bosh_fqdn}}
+        params:
+          VM_NAME: rds_broker/0
+          BOSH_FQDN: {{bosh_fqdn}}
       - task: kill-instance
         file: paas-cf/concourse/tasks/kill-instance.yml
       - do:
         - task: create-temp-user
           file: paas-cf/concourse/tasks/create_admin.yml
-          config:
-            params:
-              PREFIX: rds-broker-test-user
+          params:
+            PREFIX: rds-broker-test-user
 
         - task: generate-test-config
           file: paas-cf/concourse/tasks/generate-test-config.yml
@@ -426,8 +406,7 @@ jobs:
           aggregate:
             - task: recover
               file: paas-cf/concourse/tasks/recover.yml
-              config:
-                params:
-                  BOSH_FQDN: {{bosh_fqdn}}
+              params:
+                BOSH_FQDN: {{bosh_fqdn}}
             - task: remove-temp-user
               file: paas-cf/concourse/tasks/delete_admin.yml

--- a/concourse/scripts/bosh-cli.sh
+++ b/concourse/scripts/bosh-cli.sh
@@ -17,9 +17,10 @@ generate_config(){
   cat <<EOF
 ---
 platform: linux
-
-image: docker:///governmentpaas/bosh-cli
-
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/bosh-cli
 inputs:
   - name: paas-cf
   - name: cf-manifest

--- a/concourse/scripts/bosh-cli.sh
+++ b/concourse/scripts/bosh-cli.sh
@@ -13,44 +13,9 @@ $("${SCRIPT_DIR}/environment.sh")
 OUTPUT_FILE=$(mktemp -t bosh-cli.XXXXXX)
 trap 'rm -f "${OUTPUT_FILE}"' EXIT
 
-generate_config(){
-  cat <<EOF
----
-platform: linux
-image_resource:
-  type: docker-image
-  source:
-    repository: governmentpaas/bosh-cli
-inputs:
-  - name: paas-cf
-  - name: cf-manifest
-  - name: bosh-secrets
-run:
-  path: sh
-  args:
-  - -c
-  - -e
-  - |
-    ./paas-cf/concourse/scripts/bosh_login.sh bosh.${SYSTEM_DNS_ZONE_NAME} bosh-secrets/bosh-secrets.yml
+$FLY_CMD -t "${FLY_TARGET}" trigger-job -j create-bosh-cloudfoundry/bosh-cli -w | tee "${OUTPUT_FILE}"
 
-    uuid=\$(bosh status --uuid)
-    sed -e "s/^director_uuid:.*$/director_uuid: \${uuid}/" cf-manifest/cf-manifest.yml > cf-manifest-with-uuid.yml
-    bosh deployment ./cf-manifest-with-uuid.yml
-EOF
-}
+BUILD_NUMBER=$(awk '/started create-bosh-cloudfoundry\/bosh-cli/ { print $3 }' "${OUTPUT_FILE}" | tr -d '#')
 
-generate_config > /dev/null
-
-$FLY_CMD -t "${FLY_TARGET}" \
-  execute \
-  --inputs-from=create-bosh-cloudfoundry/cf-deploy \
-  --config=<(generate_config) \
-  | tee "${OUTPUT_FILE}"
-
-BUILD_NUMBER=$(awk '/executing build/ { print $3 }' "${OUTPUT_FILE}")
-
-$FLY_CMD -t "${FLY_TARGET}" \
-  intercept \
-  --build="${BUILD_NUMBER}"\
-  --step=one-off \
-  "${@:-sh}"
+$FLY_CMD -t "${FLY_TARGET}" intercept -j create-bosh-cloudfoundry/bosh-cli -b "${BUILD_NUMBER}" \
+   -s run-bosh-cli "${@:-ash}"

--- a/concourse/scripts/self-update-pipeline.sh
+++ b/concourse/scripts/self-update-pipeline.sh
@@ -23,7 +23,7 @@ else
   echo "Self update pipeline is enabled. Updating. (set SELF_UPDATE_PIPELINE=false to disable)"
 
   VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
-  CONCOURSE_ATC_PASSWORD=$("$VAL_FROM_YAML" jobs.concourse.properties.atc.basic_auth_password concourse-manifest/concourse-manifest.yml)
+  CONCOURSE_ATC_PASSWORD=$("$VAL_FROM_YAML" jobs.concourse.properties.basic_auth_password concourse-manifest/concourse-manifest.yml)
   export CONCOURSE_ATC_PASSWORD
 
   make -C ./paas-cf "${MAKEFILE_ENV_TARGET}" pipelines

--- a/concourse/tasks/create_admin.yml
+++ b/concourse/tasks/create_admin.yml
@@ -1,6 +1,9 @@
 ---
 platform: linux
-image: docker:///governmentpaas/cf-uaac
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/cf-uaac
 inputs:
   - name: paas-cf
   - name: cf-secrets

--- a/concourse/tasks/delete_admin.yml
+++ b/concourse/tasks/delete_admin.yml
@@ -1,6 +1,9 @@
 ---
 platform: linux
-image: docker:///governmentpaas/cf-uaac
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/cf-uaac
 inputs:
   - name: paas-cf
   - name: cf-secrets

--- a/concourse/tasks/generate-test-config.yml
+++ b/concourse/tasks/generate-test-config.yml
@@ -1,6 +1,10 @@
 ---
 platform: linux
-image: docker:///ruby#2.2-slim
+image_resource:
+  type: docker-image
+  source:
+    repository: ruby
+    tag: 2.2-slim
 inputs:
   - name: paas-cf
   - name: cf-manifest

--- a/concourse/tasks/get-cf-cli-config.yml
+++ b/concourse/tasks/get-cf-cli-config.yml
@@ -1,6 +1,10 @@
 ---
 platform: linux
-image: docker:///ruby#2.2-slim
+image_resource:
+  type: docker-image
+  source:
+    repository: ruby
+    tag: 2.2-slim
 inputs:
   - name: paas-cf
   - name: cf-secrets

--- a/concourse/tasks/get-instance-id.yml
+++ b/concourse/tasks/get-instance-id.yml
@@ -4,7 +4,10 @@ inputs:
   - name: paas-cf
 outputs:
   - name: instance-id
-image: docker:///governmentpaas/bosh-cli
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/bosh-cli
 platform: linux
 run:
   path: sh

--- a/concourse/tasks/kill-instance.yml
+++ b/concourse/tasks/kill-instance.yml
@@ -1,7 +1,10 @@
 ---
 inputs:
   - name: instance-id
-image: docker:///governmentpaas/awscli
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/awscli
 platform: linux
 run:
   path: sh

--- a/concourse/tasks/recover.yml
+++ b/concourse/tasks/recover.yml
@@ -2,7 +2,10 @@ inputs:
   - name: paas-cf
   - name: bosh-secrets
   - name: cf-manifest
-image: docker:///governmentpaas/bosh-cli
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/bosh-cli
 platform: linux
 run:
   path: sh

--- a/concourse/tasks/remove-healthcheck-db.yml
+++ b/concourse/tasks/remove-healthcheck-db.yml
@@ -4,7 +4,10 @@ inputs:
   - name: paas-cf
   - name: bosh-CA
   - name: config
-image: docker:///governmentpaas/cf-cli
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/cf-cli
 run:
   path: sh
   args:

--- a/concourse/tasks/smoke-tests-config.yml
+++ b/concourse/tasks/smoke-tests-config.yml
@@ -1,6 +1,9 @@
 ---
 platform: linux
-image: docker:///governmentpaas/bosh-cli
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/bosh-cli
 inputs:
   - name: cf-release
   - name: paas-cf

--- a/concourse/tasks/smoke-tests-run.yml
+++ b/concourse/tasks/smoke-tests-run.yml
@@ -1,6 +1,9 @@
 ---
 platform: linux
-image: docker:///governmentpaas/cf-acceptance-tests
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/cf-acceptance-tests
 inputs:
   - name: paas-cf
   - name: cf-release

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -109,6 +109,7 @@ jobs:
         graph_cleanup_threshold_in_mb: 41000
         max_containers: 1024
         network_pool: "10.254.0.0/20"
+        default_container_grace_time: 1m
       baggageclaim:
         url: "http://127.0.0.1:7788"
       collectd:

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -3,11 +3,11 @@ name: concourse
 
 releases:
   - name: concourse
-    url: https://bosh.io/d/github.com/concourse/concourse?v=0.74.0
-    sha1: c99ef709e9d4468ac25cca31dd5be1444417011d
-  - name: garden-linux
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/garden-linux-release?v=0.334.0
-    sha1: 85170c5089fa4ff317f139c2f1da024860dbea85
+    url: https://bosh.io/d/github.com/concourse/concourse?v=1.5.1
+    sha1: 9f6797ddab15f3659bcfe81c63c697f22e488451
+  - name: garden-runc
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/garden-runc-release?v=0.4.0
+    sha1: b59fb02eeae70104486251c82099316af04b77b7
   # When updating the version of the CPI here, the version used in the
   # bosh-init container must also be updated so that the cached CPI compile
   # will be used.
@@ -69,7 +69,7 @@ jobs:
       - {release: concourse, name: groundcrew}
       - {release: concourse, name: tsa}
       - {release: concourse, name: baggageclaim}
-      - {release: garden-linux, name: garden}
+      - {release: garden-runc, name: garden}
       - {release: collectd, name: collectd}
 
     networks:

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -81,22 +81,25 @@ jobs:
         default: [dns, gateway]
 
     properties:
-      atc:
-        external_url: (( concat "https://" terraform_outputs.concourse_dns_name ))
-        basic_auth_username: admin
-        basic_auth_password: (( grab secrets.concourse_atc_password ))
-        publicly_viewable: true
-        postgresql:
-          address: 127.0.0.1:5432
-          role: &atc-role
-            name: atc
-            password: dummy-password
+      external_url: (( concat "https://" terraform_outputs.concourse_dns_name ))
+      basic_auth_username: admin
+      basic_auth_password: (( grab secrets.concourse_atc_password ))
+      publicly_viewable: true
+
+      databases:
+        - name: atc
+          role: atc
+          password: dummy-password
 
       postgresql:
-        databases: [{name: atc}]
-        roles:
-          - *atc-role
+        address: 127.0.0.1:5432
+        database: atc
+        role:
+          name: atc
+          password: dummy-password
       tsa:
+        host: 127.0.0.1
+        port: 2222
         forward_host: 127.0.0.1
         atc:
           address: 127.0.0.1:8080
@@ -104,15 +107,8 @@ jobs:
         listen_network: tcp
         listen_address: 0.0.0.0:7777
         graph_cleanup_threshold_in_mb: 3072
-      groundcrew:
-        baggageclaim:
-          url: "http://127.0.0.1:7788"
-        tsa:
-          host: 127.0.0.1
-        additional_resource_types:
-          - { type: s3-iam, image: "docker:///governmentpaas/s3-resource" }
-          - { type: semver-iam, image: "docker:///governmentpaas/semver-resource" }
-          - { type: git-gpg, image: "docker:///governmentpaas/git-resource" }
+      baggageclaim:
+        url: "http://127.0.0.1:7788"
       collectd:
         hostname_prefix: concourse_
         interval: (( grab meta.collectd.interval ))

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -106,7 +106,9 @@ jobs:
       garden:
         listen_network: tcp
         listen_address: 0.0.0.0:7777
-        graph_cleanup_threshold_in_mb: 3072
+        graph_cleanup_threshold_in_mb: 41000
+        max_containers: 1024
+        network_pool: "10.254.0.0/20"
       baggageclaim:
         url: "http://127.0.0.1:7788"
       collectd:

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -22,7 +22,7 @@ resource_pools:
       url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3232.13
       sha1: 477371a335d172f4728c7a8806448edb9703104c
     cloud_properties:
-      instance_type: t2.medium
+      instance_type: c4.large
       availability_zone: (( grab terraform_outputs.zone0 ))
       iam_instance_profile: deployer-concourse
       elbs:

--- a/manifests/concourse-manifest/spec/reference_comparison_spec.rb
+++ b/manifests/concourse-manifest/spec/reference_comparison_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "manifest generation" do
 
   it "gets values from concourse terraform outputs" do
     expect(
-      manifest_with_defaults["jobs"].first["properties"]["atc"]["external_url"]
+      manifest_with_defaults["jobs"].first["properties"]["external_url"]
     ).to eq("https://" + fixtures["terraform_outputs"]["concourse_dns_name"])
   end
 
@@ -41,7 +41,7 @@ RSpec.describe "manifest generation" do
 
   it "gets values from predefined secrets" do
     expect(
-      manifest_with_defaults["jobs"].first["properties"]["atc"]["basic_auth_password"]
+      manifest_with_defaults["jobs"].first["properties"]["basic_auth_password"]
     ).to eq(fixtures["secrets"]["concourse_atc_password"])
   end
 


### PR DESCRIPTION
## What

[Upgrade Deployer Concourse](https://www.pivotaltracker.com/n/projects/1275640/stories/117991263)

## How to review

Run bootstrap pipeline & watch it upgrade your concourse. Run your new concourse to confirm all still works fine. A good test is to run pipeline against existing environment and observe if anything is being changed.

## Merging
Before you merge check if any other PRs have been merged since this PR was opened. If so, check if any changes to pipelines use/introduce `image:` definition of container. If so, rebase on master and convert this to `image_resource` like the rest of container specifications in the pipelines. Note that bootstrap create/destroy and auto-delete pipelines should still use `image:` as they are meant for older bootstrap concourse.

This PR depends on https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/60. Review that as a part of reviewing this PR. Remove 922fec7 after https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/60 is merged.

## Who can review

not @combor @mtekel or @benhyland 