### PR TITLE
[#126399333] Specify stemcell version as string

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -33,7 +33,7 @@ releases:
 stemcells:
   - alias: default
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: 3232.11
+    version: "3232.11"
 
 update:
   canaries: 0

--- a/manifests/cf-manifest/spec/integration/integration_spec.rb
+++ b/manifests/cf-manifest/spec/integration/integration_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe "generic manifest validations" do
     expect(manifest["name"]).to match(/\S+/)
   end
 
+  it "sets stemcell versions as strings" do
+    manifest.fetch("stemcells").each do |stemcell|
+      expect(stemcell.fetch("version")).to be_a(String)
+    end
+  end
+
   describe "name uniqueness" do
     %w(
       disk_pools


### PR DESCRIPTION
## What

BOSH normalises stemcell versions to strings in v1 manifests, but not
currently for v2 manifests. This causes a misleading prompt about
outstanding changes when you try to use some BOSH operations like:

    /tmp/build/e55deab7 # bosh recreate api/1
    Acting as user 'admin' on deployment 'dcarley' on 'my-bosh'
    You are about to recreate api/1

    Detecting deployment changes
    ----------------------------
    Releases
    No changes

    …

    Stemcells
    No changes

    Cannot perform job management when other deployment changes are present. Please use '--force' to override.

This should be fixed in future bosh_cli versions by cloudfoundry/bosh#1365.

Until then we can, we can ensure that it doesn't happen by specifying the
value as a string. I've added a test to prevent regressions. It probably
doesn't matter if we leave both changes in place after bosh_cli is fixed.

## How to review

1. Deploy the pipeline from this branch.
1. Get a BOSH shell: `make dev bosh-cli`
1. Confirm that it doesn't warn you about outstanding changes: `bosh recreate api/1`

## Who can review

Not @dcarley