### PR TITLE
[#117991263] Fix sync_admin_users container version.

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1531,7 +1531,7 @@ jobs:
               type: docker-image
               source:
                 repository: ruby
-                tag: 2.2-slim
+                tag: 2.2
             inputs:
               - name: paas-cf
               - name: config


### PR DESCRIPTION
## What

This was erroneously changed from 2.2 to 2.2-slim in e36570f.

This script needs to use the fat container because it needs a compiler
to be able to do a bundle install. The slim container doesn't include a
compiler etc.

## How to review

Code review.
Verify that a bundle install works for the script directory using the ruby:2.2 container:
```sh
docker run --rm -t -i -v $(pwd):/paas-cf ruby:2.2 sh -c 'cd /paas-cf/scripts && bundle install'
```

## Who can review

Anyone but @combor or myself
