### PR TITLE
Specify container version as a string.

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1531,7 +1531,7 @@ jobs:
               type: docker-image
               source:
                 repository: ruby
-                tag: 2.2
+                tag: "2.2"
             inputs:
               - name: paas-cf
               - name: config


### PR DESCRIPTION
## What

Otherwise the pipeline fails with `failed to read request: json: cannot unmarshal number into Go value of type string`.

This is because the YAML parser is automagically inferring the type of
the value as a number, which then gets sent in the JSON to the
image_resource container leading to this error.

## How to review

Code review
`make def pipelines`, and then run the cf-deploy job. Verify that the sync_admin_users task doesn't error with the above error.

## Who can review

Anyone but myself.