### PR TITLE
[#120829637] Remove some dependencies from scripts/Gemfile

### DIFF
--- a/scripts/Gemfile
+++ b/scripts/Gemfile
@@ -1,10 +1,7 @@
 source "https://rubygems.org"
 
-gem 'aruba'
 gem 'rspec', '~> 3.3'
 gem 'webmock', "~> 1.24"
-gem 'rubocop'
-gem 'mimic'
 gem 'cf-uaac'
 gem 'gpgme'
 gem 'aws-sdk'

--- a/scripts/Gemfile.lock
+++ b/scripts/Gemfile.lock
@@ -2,21 +2,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.4.0)
-    aruba (0.14.1)
-      childprocess (~> 0.5.6)
-      contracts (~> 0.9)
-      cucumber (>= 1.3.19)
-      ffi (~> 1.9.10)
-      rspec-expectations (>= 2.99)
-      thor (~> 0.19)
-    ast (2.2.0)
     aws-sdk (2.3.8)
       aws-sdk-resources (= 2.3.8)
     aws-sdk-core (2.3.8)
       jmespath (~> 1.0)
     aws-sdk-resources (2.3.8)
       aws-sdk-core (= 2.3.8)
-    builder (3.2.2)
     cf-uaa-lib (3.4.0)
       multi_json
     cf-uaac (3.2.0)
@@ -27,23 +18,9 @@ GEM
       json_pure (~> 1.8.1)
       launchy (~> 2.4.2)
       rack (~> 1.5.2)
-    childprocess (0.5.9)
-      ffi (~> 1.0, >= 1.0.11)
-    contracts (0.14.0)
     cookiejar (0.3.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    cucumber (2.3.3)
-      builder (>= 2.1.2)
-      cucumber-core (~> 1.4.0)
-      cucumber-wire (~> 0.0.1)
-      diff-lcs (>= 1.1.3)
-      gherkin (~> 3.2.0)
-      multi_json (>= 1.7.5, < 2.0)
-      multi_test (>= 0.1.2)
-    cucumber-core (1.4.0)
-      gherkin (~> 3.2.0)
-    cucumber-wire (0.0.1)
     diff-lcs (1.2.5)
     em-http-request (1.1.3)
       addressable (>= 2.3.4)
@@ -54,8 +31,6 @@ GEM
     em-socksify (0.3.1)
       eventmachine (>= 1.0.0.beta.4)
     eventmachine (1.0.9.1)
-    ffi (1.9.10)
-    gherkin (3.2.0)
     gpgme (2.0.12)
       mini_portile2 (~> 2.1.0)
     hashdiff (0.3.0)
@@ -63,7 +38,6 @@ GEM
     http_parser.rb (0.6.0)
     jmespath (1.2.4)
       json_pure (>= 1.8.1)
-    json (1.8.3)
     json_pure (1.8.3)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -72,22 +46,9 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mimic (0.4.3)
-      json
-      plist
-      rack
-      sinatra
     mini_portile2 (2.1.0)
     multi_json (1.12.1)
-    multi_test (0.1.2)
-    parser (2.3.1.0)
-      ast (~> 2.2)
-    plist (3.2.0)
-    powerpack (0.1.1)
     rack (1.5.5)
-    rack-protection (1.5.3)
-      rack
-    rainbow (2.1.0)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -101,21 +62,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
-    rubocop (0.40.0)
-      parser (>= 2.3.1.0, < 3.0)
-      powerpack (~> 0.1)
-      rainbow (>= 1.99.1, < 3.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.8.1)
     safe_yaml (1.0.4)
-    sinatra (1.4.7)
-      rack (~> 1.5)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
-    thor (0.19.1)
-    tilt (2.0.4)
-    unicode-display_width (1.0.5)
     webmock (1.24.6)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -125,15 +72,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aruba
   aws-sdk
   cf-uaac
   gpgme
   mail
-  mimic
   rspec (~> 3.3)
-  rubocop
   webmock (~> 1.24)
 
 BUNDLED WITH
-   1.10.6
+   1.12.5


### PR DESCRIPTION
## What


`paas-cf/scripts/Gemfile` was forked from `paas-cf/Gemfile` in d271b43
because at the time `bosh_cli` and `cf-uaac` couldn't be loaded at the same
time due to cloudfoundry/cf-uaac#24. This has now been released but changing
it will require more changes to dependencies and testing.

Some of the dependencies that were copied are not needed by `scripts/`, at
either test-time in Travis or run-time in the pipeline. Removing them will
mean less dependencies to manage and a small speed improvement to how fast
the Travis tests and `sync-admin-users` task take to run.

NB: The referenced story has not been started. I noticed this was slowing me down slightly when working on something else.

## How to review

Foremost:

1. Check that the Travis build still passes.

I have tested that `sync-admin-users` still works. If you also want to confirm it:

1. Remove all users but yourself from `config/admin_users.yml`
1. Commit that change to a branch and push it.
1. Deploy the pipeline with user creation enabled:

  ```
NEW_ACCOUNT_EMAIL_ADDRESS=<your_email> BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipeline
````
1. Run `cf-deploy`:
  ```
make dev run_job JOB=cf-deploy
```

1. Confirm that `sync-admin-users` logs that it's creating users, though it may fail sending email because of SES sandbox:

  ```
Adding bosh-CA to root certificates
Updating certificates in /etc/ssl/certs... 1 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d....done.
Fetching gem metadata from https://rubygems.org/
Fetching version metadata from https://rubygems.org/
Installing addressable 2.4.0
Installing json_pure 1.8.3
Installing multi_json 1.12.1
Installing cookiejar 0.3.0
Installing eventmachine 1.0.9.1 with native extensions
Installing http_parser.rb 0.6.0 with native extensions
Installing highline 1.6.21
Installing rack 1.5.5
Installing safe_yaml 1.0.4
Installing diff-lcs 1.2.5
Installing mini_portile2 2.1.0
Installing hashdiff 0.3.0
Installing mime-types-data 3.2016.0521
Installing rspec-support 3.4.1
Using bundler 1.12.5
Installing launchy 2.4.3
Installing jmespath 1.2.4
Installing cf-uaa-lib 3.4.0
Installing em-socksify 0.3.1
Installing crack 0.4.3
Installing gpgme 2.0.12 with native extensions
Installing mime-types 3.1
Installing rspec-core 3.4.4
Installing rspec-expectations 3.4.0
Installing rspec-mocks 3.4.1
Installing aws-sdk-core 2.3.8
Installing em-http-request 1.1.3
Installing webmock 1.24.6
Installing mail 2.6.4
Installing rspec 3.4.0
Installing aws-sdk-resources 2.3.8
Installing cf-uaac 3.2.0
Installing aws-sdk 2.3.8
Bundle complete! 6 Gemfile dependencies, 33 gems now installed.
Bundled gems are installed into /usr/local/bundle.
Syncing Admin users in https://api.dcarley.dev.cloudpipeline.digital...
I, [2016-07-27T11:50:54.569415 #14946]  INFO -- : Creating user dan.carley@digital.cabinet-office.gov.uk
I, [2016-07-27T11:50:54.993730 #14946]  INFO -- : Adding user dan.carley@digital.cabinet-office.gov.uk to group cloud_controller.admin
I, [2016-07-27T11:50:54.993807 #14946]  INFO -- : Updating group cloud_controller.admin
I, [2016-07-27T11:50:55.160674 #14946]  INFO -- : Adding user dan.carley@digital.cabinet-office.gov.uk to group uaa.admin
I, [2016-07-27T11:50:55.160772 #14946]  INFO -- : Adding user admin to group uaa.admin
I, [2016-07-27T11:50:55.160812 #14946]  INFO -- : Updating group uaa.admin
I, [2016-07-27T11:50:55.241319 #14946]  INFO -- : Adding user dan.carley@digital.cabinet-office.gov.uk to group scim.read
I, [2016-07-27T11:50:55.241417 #14946]  INFO -- : Updating group scim.read
I, [2016-07-27T11:50:55.420724 #14946]  INFO -- : Adding user dan.carley@digital.cabinet-office.gov.uk to group scim.write
I, [2016-07-27T11:50:55.420819 #14946]  INFO -- : Updating group scim.write
I, [2016-07-27T11:50:55.516992 #14946]  INFO -- : Adding user dan.carley@digital.cabinet-office.gov.uk to group doppler.firehose
I, [2016-07-27T11:50:55.517116 #14946]  INFO -- : Updating group doppler.firehose
Sending credentials to new user dan.carley@digital.cabinet-office.gov.uk
Created users: 1
 - dan.carley@digital.cabinet-office.gov.uk
Deleted users: 0
```

## Who can review

Not @dcarley