### PR TITLE
[#117991263] Use bosh-init from master

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -845,7 +845,6 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-init
-              tag: 117991263_upgrade_bosh_init
           inputs:
             - name: bosh-manifest
             - name: bosh-init-state

--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -460,7 +460,7 @@ jobs:
     - task: concourse-deploy
       timeout: 30m
       config:
-        image: docker:///governmentpaas/bosh-init#117991263_upgrade_bosh_init
+        image: docker:///governmentpaas/bosh-init
         inputs:
         - name: concourse-manifest
         - name: concourse-bosh-state

--- a/concourse/pipelines/destroy-deployer.yml
+++ b/concourse/pipelines/destroy-deployer.yml
@@ -63,7 +63,7 @@ jobs:
     - task: destroy-concourse
       timeout: 30m
       config:
-        image: docker:///governmentpaas/bosh-init#117991263_upgrade_bosh_init
+        image: docker:///governmentpaas/bosh-init
         inputs:
         - name: paas-cf
         - name: concourse-manifest

--- a/concourse/pipelines/destroy-microbosh.yml
+++ b/concourse/pipelines/destroy-microbosh.yml
@@ -164,7 +164,6 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-init
-              tag: 117991263_upgrade_bosh_init
           inputs:
             - name: paas-cf
             - name: bosh-manifest


### PR DESCRIPTION
## What

Concourses have now all been upgraded and we can use bosh-init from master once we merge https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/60.

## How to review

Run the pipeline, hijack the bosh-init container and check which version is it running.

## Who can review

not @mtekel