### PR TITLE
[#117991263] Increase disk space&reduce cleanup threshold on deployer Concourse

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -28,7 +28,7 @@ resource_pools:
       elbs:
       - (( grab terraform_outputs.concourse_elb_name ))
       ephemeral_disk:
-        size: 50240
+        size: 65536
         type: gp2
     env:
       bosh:
@@ -106,7 +106,7 @@ jobs:
       garden:
         listen_network: tcp
         listen_address: 0.0.0.0:7777
-        graph_cleanup_threshold_in_mb: 41000
+        graph_cleanup_threshold_in_mb: 32768
         max_containers: 1024
         network_pool: "10.254.0.0/20"
         default_container_grace_time: 1m


### PR DESCRIPTION
## What

We found out that current disk size of Concourse ephemeral disk in combination with `graph_cleanup_threshold_in_mb` property can lead to disk space problems and failure of Concourse pipeline. 

New disk size set to 64GB and `graph_cleanup_threshold_in_mb` reduced to 32GB should allow Concourse to clean space proactively leaving enough headroom for new downloads of containers. 

## How to review

Use bootstrap concourse to provision Deployer Concourse and run create-bosh-cloudfoundry pipeline at least twice to check whether disk space problem will not appear.

## Who can review

Not @alext or @combor