### PR TITLE
[#127281697] Hide credentials when configuring acceptance tests

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1867,7 +1867,6 @@ jobs:
                   my['properties']['acceptance_tests']['password'] = File.read('admin-creds/password').strip()
 
                   puts YAML.dump(my)" > acceptance_test_properties.yml
-                  cat acceptance_test_properties.yml
 
                   ./paas-cf/platform-tests/bosh-template-renderer/render.rb \
                     ./cf-release/jobs/acceptance-tests/templates/run.erb \


### PR DESCRIPTION
## What

Acceptance tests currently `cat` generated config. It contains sensitive credentials. Don't display it.

## How to review

Apply. Run acceptance tests, check that they don't cat the rendered config any more.

## Who can review

you