### PR TITLE
[#127256345] Fix issues with concourse running out of disk space

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,11 +292,10 @@ You can get both from command line. You will need [aws-cli](#aws-cli), to do thi
 ```
 eval $(make dev showenv | grep CONCOURSE_IP=)
 
-aws s3 cp "s3://${DEPLOY_ENV}-state/id_rsa" . && \
-chmod 400 id_rsa && \
-ssh-add $(pwd)/id_rsa
+aws s3 cp "s3://${DEPLOY_ENV}-state/id_rsa" ./deployer_id_rsa && \
+chmod 400 deployer_id_rsa
 
-ssh vcap@$CONCOURSE_IP
+ssh -i deployer_id_rsa -o IdentitiesOnly=yes -o UserKnownHostsFile=/dev/null vcap@$CONCOURSE_IP
 ```
 
 If you get a "Too many authentication failures for vcap" message it is likely that you've got too many keys registered with your ssh-agent and it will fail to authenticate before trying the correct key - generally it will only allow three keys to be tried before disconnecting you. You can list all the keys registered with your ssh-agent with `ssh-add -l` and remove unwanted keys with `ssh-add -d PATH_TO_KEY`.

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -28,7 +28,7 @@ resource_pools:
       elbs:
       - (( grab terraform_outputs.concourse_elb_name ))
       ephemeral_disk:
-        size: 50240
+        size: 102400
         type: gp2
     env:
       bosh:

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -106,7 +106,7 @@ jobs:
       garden:
         listen_network: tcp
         listen_address: 0.0.0.0:7777
-        graph_cleanup_threshold_in_mb: 41000
+        graph_cleanup_threshold_in_mb: 3072
         max_containers: 1024
         network_pool: "10.254.0.0/20"
         default_container_grace_time: 1m

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -3,8 +3,8 @@ name: concourse
 
 releases:
   - name: concourse
-    url: https://bosh.io/d/github.com/concourse/concourse?v=1.5.1
-    sha1: 9f6797ddab15f3659bcfe81c63c697f22e488451
+    url: https://github.com/alphagov/paas-concourse/releases/download/v1.5.1.gds1/concourse-1.5.1.gds1.tgz
+    sha1: 363c959751685658593661855339418dafed02e5
   - name: garden-runc
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/garden-runc-release?v=0.4.0
     sha1: b59fb02eeae70104486251c82099316af04b77b7


### PR DESCRIPTION
## What

We've been running into issues where the concourse machine will grind to a halt. Investigation lead to baggageclaim running into 'no space left on device' errors form it's loopback mounted volumes filesystem. This was created as a sparse file set to the full size of the `/var/vcap/data` filesystem. This causes problems because this filesystem is also used by other things (bosh packages and jobs, garden's graph and depot, logs etc). When this volume starts to get full, this can lead to errors when the btrfs driver gets a `no space left on device` error when writing to the sparse image file. This in turn causes a kernel error, and the loopback filesystem gets remounted read-only.

This PR does a few things to address this:

* Increase the ephemeral disk size to give more headroom
* Pull in a forked concourse release that includes https://github.com/alphagov/paas-concourse/pull/2 to make the sparse image not use 100% of the filesystem.

This also updates the instructions for SSH access to the concourse VM to make it a little easier.

## How to review

Code review of this and https://github.com/alphagov/paas-concourse/pull/2

Run the bootstrap pipeline from this branch.

Verify that the deployer concourse is working by running the pipeline a couple of times.

SSH onto the deployer concourse (using instructions in the README), and verify that the `/var/vcap/data/baggageclaim/volumes.img` file is less than the size of the filesystem.

## Before merging

Before this is merged, the [concourse PR](https://github.com/alphagov/paas-concourse/pull/2) will need to be merged, and the resulting boshrelease generated and uploaded to a github release. The last commit in this PR will then need to be updated to point at that release.

## Who can review

Anyone but @mtekel or myself.