### PR TITLE
[#127260745] Replace REP from diego-release with our own custom one

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -137,6 +137,12 @@ resources:
       tag_filter: {{cf_routing_version}}
       branch: gds_master
 
+  - name: rep-boshrelease
+    type: git
+    source:
+      uri: https://github.com/alphagov/paas-rep-boshrelease.git
+      tag_filter: {{cf_rep_version}}
+
   - name: graphite-nozzle
     type: git
     source:
@@ -1304,6 +1310,7 @@ jobs:
           - get: bosh-CA
           - get: graphite-nozzle
           - get: routing-release
+          - get: rep-boshrelease
 
       - aggregate:
         - task: upload-releases
@@ -1322,6 +1329,7 @@ jobs:
               - name: aws-broker-boshrelease
               - name: os-conf-boshrelease
               - name: routing-release
+              - name: rep-boshrelease
             run:
               path: sh
               args:
@@ -1347,6 +1355,10 @@ jobs:
 
                   paas-cf/concourse/scripts/bosh_create_and_upload_release.rb routing \
                     {{cf_routing_version}} routing-release
+
+                  paas-cf/concourse/scripts/bosh_create_and_upload_release.rb rep \
+                    {{cf_rep_version}} rep-boshrelease
+
         - task: get-and-upload-stemcell
           config:
             platform: linux

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -43,6 +43,7 @@ prepare_environment() {
   cf_aws_broker_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.aws-broker.version "${cf_manifest_dir}/050-rds-broker.yml")
   cf_os_conf_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.os-conf.version "${cf_manifest_dir}/../runtime-config/runtime-config-base.yml")
   cf_routing_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.routing.version "${cf_manifest_dir}/000-base-cf-deployment.yml")
+  cf_rep_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.rep.version "${cf_manifest_dir}/000-base-cf-deployment.yml")
 
   if [ -z "${SKIP_COMMIT_VERIFICATION:-}" ] ; then
     gpg_ids="[$(xargs < "${SCRIPT_DIR}/../../.gpg-id" | tr ' ' ',')]"
@@ -76,6 +77,7 @@ cf_grafana_version: ${cf_grafana_version}
 cf_aws_broker_version: ${cf_aws_broker_version}
 cf_os_conf_version: ${cf_os_conf_version}
 cf_routing_version: ${cf_routing_version}
+cf_rep_version: ${cf_rep_version}
 cf_env_specific_manifest: ${ENV_SPECIFIC_CF_MANIFEST}
 paas_cf_tag_filter: ${PAAS_CF_TAG_FILTER:-}
 TAG_PREFIX: ${TAG_PREFIX:-}

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -29,6 +29,8 @@ releases:
     version: 0.0.4
   - name: routing
     version: commit-0bad6993f4cb87fa6213fa957f4e8eacbd22f762
+  - name: rep
+    version: 0.0.1
 
 stemcells:
   - alias: default

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -320,7 +320,7 @@ jobs:
       - name: consul_agent
         release: cf
       - name: rep
-        release: diego
+        release: rep
       - name: garden
         release: garden-linux
       - name: cflinuxfs2-rootfs-setup


### PR DESCRIPTION
## What

Story: https://www.pivotaltracker.com/story/show/127260745

This PR brings custom version of REP via bosh-release that was compiled against patched version of locket library and fixed cloudfoundry/diego-release#177 issue. You will be testing this together with https://github.com/alphagov/paas-rep-boshrelease/pull/1

## How to review

- review https://github.com/alphagov/paas-rep-boshrelease/pull/1 first
- upload and deploy pipeline
- check if rep release was created and deployed
- check if availability test passes
- now you can change the stemcell for consul VMS
  - create wip branch based on this one
  - cherry-pick https://github.com/alphagov/paas-cf/commit/589c546430f93aeb97fba67653807f8c25349ab7 and deploy
- before merging remove https://github.com/alphagov/paas-cf/pull/395/commits/1841608e645a06ab36709d6ecfb5382a44cd2634 

## Who can review

Not @keymon or @combor
