### PR TITLE
Add swap to VM Resource Usage grafana dashboard

### DIFF
--- a/manifests/cf-manifest/grafana/vm-resource-usage.json
+++ b/manifests/cf-manifest/grafana/vm-resource-usage.json
@@ -228,7 +228,7 @@
           "renderer": "flot",
           "repeat": null,
           "seriesOverrides": [],
-          "span": 12,
+          "span": 6,
           "stack": true,
           "steppedLine": false,
           "targets": [
@@ -283,6 +283,92 @@
               "show": false
             }
           ]
+        },
+        {
+          "title": "Swap",
+          "error": false,
+          "span": 6,
+          "editable": true,
+          "type": "graph",
+          "isNew": true,
+          "id": 5,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "alias(collectd.$Host.swap.swap.used, 'swap.used')"
+            },
+            {
+              "target": "alias(derivative(collectd.$Host.swap.swap_io.in), 'swap_io.in')",
+              "refId": "B"
+            },
+            {
+              "target": "alias(derivative(collectd.$Host.swap.swap_io.out), 'swap_io.out')",
+              "refId": "C"
+            }
+          ],
+          "datasource": "graphite",
+          "renderer": "flot",
+          "yaxes": [
+            {
+              "label": null,
+              "show": true,
+              "logBase": 1,
+              "min": 0,
+              "max": null,
+              "format": "bytes"
+            },
+            {
+              "label": null,
+              "show": true,
+              "logBase": 1,
+              "min": 0,
+              "max": null,
+              "format": "none"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "grid": {
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "lines": true,
+          "fill": 1,
+          "linewidth": 1,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false
+          },
+          "nullPointMode": "null",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": true,
+            "msResolution": false
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "aliasColors": {},
+          "seriesOverrides": [
+            {
+              "alias": "/swap_io/",
+              "yaxis": 2
+            }
+          ],
+          "links": []
         }
       ],
       "title": "New row"


### PR DESCRIPTION
## What

Add a swap graph to the VM Resource Usage dashboard. This can be useful to see when a machine is stressed.

![image](https://cloud.githubusercontent.com/assets/5560/17251449/c4878294-55a0-11e6-909e-f42e62a6a726.png)

## How to review

Upload this dashboard to grafana and verify that it works, and looks sensible.

## Who can review

Anyone but myself.
