### PR TITLE
[#120100877] Fix terraform state issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 vagrant/.vagrant/
 bin/fly*
 .idea/
-.terraform/

--- a/terraform/scripts/set-up-pingdom.sh
+++ b/terraform/scripts/set-up-pingdom.sh
@@ -40,3 +40,6 @@ terraform apply \
 
 # Delete temporary directory
 rm -rf /tmp/terraform-pingdom
+
+# Delete local terraform state
+rm -rf .terraform


### PR DESCRIPTION
## What

Story: [Email Alerts from Pingdom](https://www.pivotaltracker.com/story/show/120100877)

Previously we used to download the state file from the bucket, reupload it after terraform run, then delete the local copy.

b01f941 changed this to use terraform built-in S3 storage. Unfortunately it still kept a local copy of the state file, and this confused terraform when we applied changes to different environments.

This PR deletes the local copy to avoid this issue and reverts the gitgnore change related to the state file.

## How to review
* In case of an issue, a terraform pingdom run in one environment was reconfiguring alerts from the previous environment.
* Run `make <env> pingdom` successively in different environments for example dev, ci, staging. It shouldn't do anything. 

## Who can review
Anyone but me