### PR TITLE
[#120100877] Set check URL for Pingdom HTTPS check

### DIFF
--- a/terraform/pingdom/pingdom.tf
+++ b/terraform/pingdom/pingdom.tf
@@ -17,6 +17,7 @@ resource "pingdom_check" "paas_http_healthcheck" {
     type = "http"
     name = "PaaS HTTPS - ${var.env}"
     host = "healthcheck.${var.apps_dns_zone_name}"
+    url  = "/"
     encryption = true
     resolution = 1
     uselegacynotifications = true


### PR DESCRIPTION
## What

So that Terraform doesn't attempt to set the URL on every run:

    Initialized blank state with remote state enabled!
    Remote state configured and pulled.
    pingdom_check.paas_http_healthcheck: Refreshing state... (ID: 2247550)
    pingdom_check.paas_db_healthcheck: Refreshing state... (ID: 2247551)
    pingdom_check.paas_http_healthcheck: Modifying...
      url: "/" => ""
    pingdom_check.paas_http_healthcheck: Modifications complete

    Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

This happens because the Pingdom API has a default by the Terraform provider
doesn't. Longer term I hope to fix the upstream provider as discussed in
russellcardullo/terraform-provider-pingdom#4, but shorter term this change
will make it easier to see whether Terraform is making real changes.

## How to review

1. Export AWS keys for the CI account.
1. Set the environment name for CI: `export DEPLOY_ENV=master`
1. Deploy: `make ci pingdom`
1. Confirm that it shows: `0 changed`

## Who can review

Not @dcarley