### PR TITLE
[#120100877] Pingdom send alerts when back up

### DIFF
--- a/terraform/pingdom/pingdom.tf
+++ b/terraform/pingdom/pingdom.tf
@@ -22,6 +22,7 @@ resource "pingdom_check" "paas_http_healthcheck" {
     uselegacynotifications = true
     sendtoemail = true
     sendnotificationwhendown = 2
+    notifywhenbackup = true
     contactids = ["${split(",", var.contact_ids)}"]
 }
 
@@ -35,5 +36,6 @@ resource "pingdom_check" "paas_db_healthcheck" {
     uselegacynotifications = true
     sendtoemail = true
     sendnotificationwhendown = 2
+    notifywhenbackup = true
     contactids = ["${split(",", var.contact_ids)}"]
 }


### PR DESCRIPTION
## What

This feature is useful to determine whether something needs to be
investigated urgently or how long it was down for.

I believe it was previously configured for all of our checks, by default,
but was disabled either when we changed the contact notification settings in
7024837 or recreated the checks as part of deploying that change.

Managing the attribute explicitly will make sure it is always enabled.

## How to review

1. Export AWS keys for the CI account.
1. Set the environment name for CI: `export DEPLOY_ENV=master`
1. Deploy: `make ci pingdom`
1. Confirm that it only changes the `notifywhenbackup` attribute.
1. Log into Pingdom (user and pass in credentials store).
1. Confirm that the "Alert when back up" checkbox is ticked for both CI checks.

Please apply to staging and production after merging.

## Who can review

Not @dcarley