### PR TITLE
[#124841811] setup logsearch-for-cloudfoundry filters

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -143,6 +143,13 @@ resources:
       uri: https://github.com/alphagov/paas-rep-boshrelease.git
       tag_filter: {{cf_rep_version}}
 
+  - name: logsearch-for-cloudfoundry-boshrelease
+    type: git
+    source:
+      uri: https://github.com/alphagov/paas-logsearch-for-cloudfoundry.git
+      tag_filter: {{cf_logsearch_for_cloudfoundry_version}}
+      branch: gds_master
+
   - name: graphite-nozzle
     type: git
     source:
@@ -1309,6 +1316,7 @@ jobs:
             passed: ['generate-cf-config']
           - get: bosh-CA
           - get: graphite-nozzle
+          - get: logsearch-for-cloudfoundry-boshrelease
           - get: routing-release
           - get: rep-boshrelease
 
@@ -1330,6 +1338,7 @@ jobs:
               - name: os-conf-boshrelease
               - name: routing-release
               - name: rep-boshrelease
+              - name: logsearch-for-cloudfoundry-boshrelease
             run:
               path: sh
               args:
@@ -1358,6 +1367,9 @@ jobs:
 
                   paas-cf/concourse/scripts/bosh_create_and_upload_release.rb rep \
                     {{cf_rep_version}} rep-boshrelease
+
+                  paas-cf/concourse/scripts/bosh_create_and_upload_release.rb logsearch-for-cloudfoundry \
+                    {{cf_logsearch_for_cloudfoundry_version}} logsearch-for-cloudfoundry-boshrelease
 
         - task: get-and-upload-stemcell
           config:

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -44,6 +44,7 @@ prepare_environment() {
   cf_os_conf_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.os-conf.version "${cf_manifest_dir}/../runtime-config/runtime-config-base.yml")
   cf_routing_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.routing.version "${cf_manifest_dir}/000-base-cf-deployment.yml")
   cf_rep_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.rep.version "${cf_manifest_dir}/000-base-cf-deployment.yml")
+  cf_logsearch_for_cloudfoundry_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.logsearch-for-cloudfoundry.version "${cf_manifest_dir}/030-logsearch.yml")
 
   if [ -z "${SKIP_COMMIT_VERIFICATION:-}" ] ; then
     gpg_ids="[$(xargs < "${SCRIPT_DIR}/../../.gpg-id" | tr ' ' ',')]"
@@ -78,6 +79,7 @@ cf_aws_broker_version: ${cf_aws_broker_version}
 cf_os_conf_version: ${cf_os_conf_version}
 cf_routing_version: ${cf_routing_version}
 cf_rep_version: ${cf_rep_version}
+cf_logsearch_for_cloudfoundry_version: ${cf_logsearch_for_cloudfoundry_version}
 cf_env_specific_manifest: ${ENV_SPECIFIC_CF_MANIFEST}
 paas_cf_tag_filter: ${PAAS_CF_TAG_FILTER:-}
 TAG_PREFIX: ${TAG_PREFIX:-}

--- a/manifests/cf-manifest/manifest/030-logsearch.yml
+++ b/manifests/cf-manifest/manifest/030-logsearch.yml
@@ -9,6 +9,8 @@ releases:
   url: https://bosh.io/d/github.com/logsearch/logsearch-boshrelease?v=200.0.0
   version: 200.0.0
   sha1: 527c35db31cd66810accf128ceffee4f5fde80c3
+- name: logsearch-for-cloudfoundry
+  version: v203.0.0-gds
 
 jobs:
 - name: ingestor_z1
@@ -70,6 +72,7 @@ jobs:
   azs: [z1]
   templates:
   - {name: parser, release: logsearch}
+  - {name: logsearch-for-cloudfoundry-filters, release: logsearch-for-cloudfoundry}
   vm_type: medium
   stemcell: default
   instances: 1
@@ -82,12 +85,16 @@ jobs:
     redis:
       host: (( grab jobs.queue.networks.cf.static_ips.[0] ))
     logstash: (( grab properties.parser_logstash ))
+    logstash_parser:
+      filters:
+      - /var/vcap/packages/logsearch-for-cloudfoundry-filters/logstash-filters-default.conf
 
 - name: parser_z2
   release: logsearch
   azs: [z2]
   templates:
   - {name: parser, release: logsearch}
+  - {name: logsearch-for-cloudfoundry-filters, release: logsearch-for-cloudfoundry}
   vm_type: medium
   stemcell: default
   instances: 1
@@ -100,6 +107,9 @@ jobs:
     redis:
       host: (( grab jobs.queue.networks.cf.static_ips.[1] ))
     logstash: (( grab properties.parser_logstash ))
+    logstash_parser:
+      filters:
+      - /var/vcap/packages/logsearch-for-cloudfoundry-filters/logstash-filters-default.conf
 
 - name: elasticsearch_master
   release: logsearch
@@ -133,11 +143,16 @@ jobs:
   templates:
   - {name: elasticsearch_config, release: logsearch}
   - {name: curator, release: logsearch}
+  - {name: logsearch-for-cloudfoundry-filters, release: logsearch-for-cloudfoundry}
   vm_type: small
   stemcell: default
   networks:
   - name: cf
   update: (( grab meta.update ))
+  properties:
+    elasticsearch_config:
+      templates:
+      - index_template: /var/vcap/packages/logsearch-for-cloudfoundry-filters/logs-template.json
 
 - name: kibana
   release: logsearch


### PR DESCRIPTION
# What 

Cloudfoundry component logs can be parsed and structured before sending them to elasticsearch in logsearch, specially the "structured" log messages (json). That will ease a lot troubleshooting, analyse, and correlate the log messages in kibana.

logsearch used to provide logsearch-for-cloudfoundry [which has been moved to cloudfoundry-community](https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry). Since then, it had a lot of contributions and the code seem to have improved a lot, with better testing (even travis) and better code structure and documentation

# Context 

We add the logsearch-for-cloudfoundry filters to our logsearch parsers.

# Out of context:
 
 * We won't install the kibana dashboards or type indexes
 * We won't setup the firehose
 * Upgrade logsearch (currently we have v200.0.0, the latest version is v203.0.0)

# How to test

 1. Deploy the project as usual.
 2. Go to kibana (e.g. https://logsearch.hector.dev.cloudpipeline.digital). Check that the logs are being parsed and we got keys like: `@source.component`, `@shipper.name`, `@source.job`, etc.

# Known issues.

The logs for haproxy are not being parsed properly. 

The reason is that the logsearch v200.0.0 filters first [the haproxy message here](https://github.com/logsearch/logsearch-boshrelease/blob/v200.0.0/src/logsearch-config/src/logstash-filters/snippets/haproxy.conf) and deletes the @message (copied to haproxy.message), so that the [logsearch-for-cloudfoundry filter fails](https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry/blob/master/src/logsearch-config/src/logstash-filters/snippets/platform.conf). This is fix after v202.0.0 as described in this issue https://github.com/logsearch/logsearch-boshrelease/issues/226

# Who?

Anyone but @richardc or @keymon or @combor 