### PR TITLE
[#127558109] collectd: Only get interface metrics for lo0/eth0

### DIFF
--- a/manifests/bosh-manifest/reference-bosh-manifest.yml
+++ b/manifests/bosh-manifest/reference-bosh-manifest.yml
@@ -159,11 +159,17 @@ properties:
       LoadPlugin cpu
       LoadPlugin disk
       LoadPlugin entropy
-      LoadPlugin interface
       LoadPlugin load
       LoadPlugin memory
       LoadPlugin swap
       LoadPlugin uptime
+
+      LoadPlugin interface
+      <Plugin interface>
+        IgnoredSelected false
+        Interface lo0
+        Interface eth0
+      </Plugin>
 
       LoadPlugin df
       <Plugin df>

--- a/manifests/shared/deployments/collectd.yml
+++ b/manifests/shared/deployments/collectd.yml
@@ -13,11 +13,17 @@ meta:
       LoadPlugin cpu
       LoadPlugin disk
       LoadPlugin entropy
-      LoadPlugin interface
       LoadPlugin load
       LoadPlugin memory
       LoadPlugin swap
       LoadPlugin uptime
+
+      LoadPlugin interface
+      <Plugin interface>
+        IgnoredSelected false
+        Interface lo0
+        Interface eth0
+      </Plugin>
 
       LoadPlugin df
       <Plugin df>


### PR DESCRIPTION
## What

VMs that host containers, such as Concourse and Diego cells, create and
destroy virtual network interfaces very frequently. With collectd's default
configuration of the `interface` plugin this results in Graphite/Carbon
allocating storage for a new Whisper file every time a container is started.

These metrics aren't useful because we can't tell what container each
randomly-generated interface name belonged to. They consume a lot of space
on disk, even with automatic pruning of stale metrics after 10 days. Current
usage on prod:

    bosh_zczgqkgrr@91b8d5a4-55ee-4a6e-ac9f-27f6a2b945f9:~$ du -csh /var/vcap/store/graphite/storage/whisper/collectd/{concourse,cell}_*/interface
    61G     /var/vcap/store/graphite/storage/whisper/collectd/concourse_collectd_0/interface
    10G     /var/vcap/store/graphite/storage/whisper/collectd/cell_0/interface
    40G     /var/vcap/store/graphite/storage/whisper/collectd/cell_1/interface
    14G     /var/vcap/store/graphite/storage/whisper/collectd/cell_2/interface
    29G     /var/vcap/store/graphite/storage/whisper/collectd/cell_3/interface
    153G    total

To stop us collecting these I am restricting collectd to only get metrics
for interfaces that relate to the host; `lo0` and `eth0`.

This configuration *might* result in no network interface metrics being
collected if we upgrade to a stemcell with a later Ubuntu release because of
changes to udev device naming. I can't see a nice way to guard against it
though:

- https://bugs.launchpad.net/ubuntu/+source/ubuntu-meta/+bug/1347859

This change will deploy automatically to BOSH and CF, although it will take
some time to re-provision BOSH with `bosh-init`. It will need to be manually
deployed to the Deployer Concourse by re-running the `create-deployer`
pipeline. The stale metrics will be removed after 10 days but we might need
to intervene if `graphite/0` runs out of disk space in the meantime.

## How to review

1. Deploy the change from this branch.
1. Confirm that Graphite has metrics for `lo0` and `eth0` for time periods *after* the deployment, e.g.:

  ```
derivative(collectd.cell_*.interface.{lo0,eth0}.if_octets.*)
```
1. Confirm that interface metrics aren't being collected for containers anymore. This is kind of fiddly - I'd suggest waiting 5mins after `cf-deploy`, starting another job in Concourse, and confirming that the following commands only show `lo0` and `eth0`:

  ```
make dev bosh-cli
bosh ssh graphite/0
find /var/vcap/store/graphite/storage/whisper/collectd/concourse_collectd_0/interface -mmin -5 -ls
```

## Who can review

Not @dcarley