### PR TITLE
[120765225] Disable healthcheck DB on DEV

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ dev: globals check-env-vars ## Set Environment to DEV
 	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipelineapps.digital)
 	$(eval export SKIP_COMMIT_VERIFICATION=true)
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-default.yml)
+	$(eval export ENABLE_HEALTHCHECK_DB=false)
 	@true
 
 .PHONY: ci

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1762,6 +1762,8 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/cf-cli
+          params:
+            ENABLE_HEALTHCHECK_DB: {{enable_healthcheck_db}}
           inputs:
             - name: paas-cf
             - name: config
@@ -1783,13 +1785,14 @@ jobs:
                 cf target -o testers -s healthcheck
                 cd paas-cf/platform-tests/example-apps/healthcheck
                 cf push --no-start
-
-                cf create-service postgres M-dedicated-9.5 healthcheck-db
-                while ! cf service healthcheck-db | grep -q 'Status: create succeeded'; do
-                  echo "Waiting for creation of service to complete..."
-                  sleep 30
-                done
-                cf bind-service healthcheck healthcheck-db
+                if  [ "$ENABLE_HEALTHCHECK_DB" != "false" ] ; then
+                  cf create-service postgres M-dedicated-9.5 healthcheck-db
+                  while ! cf service healthcheck-db | grep -q 'Status: create succeeded'; do
+                    echo "Waiting for creation of service to complete..."
+                    sleep 30
+                  done
+                  cf bind-service healthcheck healthcheck-db
+                fi
 
                 cf start healthcheck
 

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -86,6 +86,7 @@ apps_dns_zone_name: ${APPS_DNS_ZONE_NAME}
 git_concourse_pool_clone_full_url_ssh: ${git_concourse_pool_clone_full_url_ssh}
 ALERT_EMAIL_ADDRESS: ${ALERT_EMAIL_ADDRESS:-}
 NEW_ACCOUNT_EMAIL_ADDRESS: ${NEW_ACCOUNT_EMAIL_ADDRESS:-}
+enable_healthcheck_db: ${ENABLE_HEALTHCHECK_DB:-}
 bosh_az: ${bosh_az}
 bosh_manifest_state: bosh-manifest-state-${bosh_az}.json
 bosh_fqdn: bosh.${SYSTEM_DNS_ZONE_NAME}


### PR DESCRIPTION
## What

Disable healthcheck DB on DEV

This commit disables provisioning of healthcheck DB on DEV environments to
save space,time and money :). It keeps it enabled on non-dev envs.

Changes consists of default setting in Makefile, that is passed via
pipeline upload script and new condition in deploy-healthcheck to test it.

## How to review

Deploy pipeline - during running of post-deploy.deploy-healthcheck note the new order of operations doesn't include provisioning a `healthcheck-db` service.

## Who can review

Cannot be reviewed by @combor or @richardc