### PR TITLE
[#127256345] Revert "Reduce container grace to 1m"

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -109,7 +109,6 @@ jobs:
         graph_cleanup_threshold_in_mb: 3072
         max_containers: 1024
         network_pool: "10.254.0.0/20"
-        default_container_grace_time: 1m
       baggageclaim:
         url: "http://127.0.0.1:7788"
       collectd:


### PR DESCRIPTION
## What

This reverts commit bbeddf48a80b49d26ce6c86930d90d99a03c09f0

This was changed to reduce the number of containers in flight at a point
when concourse was creating a large number of them due to issues with
how image_resource worked. As of 1.5.1, this problem has been
significantly reduced, so this is no longer necessary.

We are currently seeing issues with concourse not releasing volumes,
resulting in baggagclaim's volumes filesystem filling up, leading to
errors, and high resource usage. I have a hypothesis that there's
something within concourse that breaks if garden reaps idle containers
in less than the default time (5mins).

I've tested reverting this setting on my dev environment to see if it
helps, and the problem isn't occurring there. This is not conclusive as
the problem appears to be intermittent.

Despite this uncertainty, It still makes sense to reset this to the
default value as we no longer have a reason to be setting it
differently.

## How to review

Run the bootstrap pipeline from this branch. Verify that the deployer concourse works. Monitor disk usage (the VM Resource Usage grafana dashboard is good for this).

## Who can review

Anyone but myself.