### PR TITLE
[#123510111] Do not run Acceptance Test in prod and staging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ staging: globals check-env-vars ## Set Environment to Staging
 	$(eval export ALERT_EMAIL_ADDRESS=the-multi-cloud-paas-team+staging@digital.cabinet-office.gov.uk)
 	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS=${ALERT_EMAIL_ADDRESS})
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-default.yml)
+	$(eval export ENABLE_CF_ACCEPTANCE_TESTS=false)
 	@true
 
 .PHONY: prod
@@ -107,6 +108,7 @@ prod: globals check-env-vars ## Set Environment to Production
 	$(eval export ALERT_EMAIL_ADDRESS=the-multi-cloud-paas-team+prod@digital.cabinet-office.gov.uk)
 	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS=${ALERT_EMAIL_ADDRESS})
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-prod.yml)
+	$(eval export ENABLE_CF_ACCEPTANCE_TESTS=false)
 	@true
 
 .PHONY: bootstrap

--- a/README.md
+++ b/README.md
@@ -217,6 +217,19 @@ can use SELF_UPDATE_PIPELINE environment variable, set to false (true is default
 
 See [doc/non_dev_deployments.md](doc/non_dev_deployments.md).
 
+## Optionally disable run of acceptance tests
+
+Acceptance tests can be optionally disabled by setting the environment
+variable `ENABLE_CF_ACCEPTANCE_TESTS=false`.
+
+```
+ENABLE_CF_ACCEPTANCE_TESTS=false make dev pipelines
+```
+
+It is enabled in all the environments except in `staging` and `prod`.
+This will only disable the execution of the test, but the job will
+be still configured in concourse.
+
 ## Optionally run specific job in the create-bosh-cloudfoundry pipeline
 
 `create-bosh-cloudfoundry` is our main pipeline. When we are making changes or

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1866,6 +1866,7 @@ jobs:
           file: paas-cf/concourse/tasks/create_admin.yml
           params:
             PREFIX: acceptance-test-user
+            ENABLE_ADMIN_USER_CREATION: {{enable_cf_acceptance_tests}}
 
         - task: generate-test-config
           config:
@@ -1945,6 +1946,8 @@ jobs:
         ensure:
           task: remove-temp-user
           file: paas-cf/concourse/tasks/delete_admin.yml
+          params:
+            ENABLE_ADMIN_USER_CREATION: {{enable_cf_acceptance_tests}}
 
   - name: custom-acceptance-tests
     plan:

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1916,6 +1916,8 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/cf-acceptance-tests
+            params:
+              ENABLE_CF_ACCEPTANCE_TESTS: {{enable_cf_acceptance_tests}}
             inputs:
               - name: paas-cf
               - name: cf-release
@@ -1935,8 +1937,11 @@ jobs:
                   ln -snf $(pwd)/test-config/run /var/vcap/jobs/acceptance-tests/bin/run
                   ln -snf /usr/local/go /var/vcap/packages/golang1.6
                   ln -snf $(pwd)/cf-release/src/github.com/cloudfoundry/cf-acceptance-tests /var/vcap/packages/acceptance-tests/src/github.com/cloudfoundry/
-                  /var/vcap/jobs/acceptance-tests/bin/run
-
+                  if  [ "$ENABLE_CF_ACCEPTANCE_TESTS" != "false" ]; then
+                    /var/vcap/jobs/acceptance-tests/bin/run
+                  else
+                    echo "WARNING: The acceptance tests have been disabled. Set ENABLE_CF_ACCEPTANCE_TESTS=true when uploading the pipelines to enable them. You can still hijack this container to run them manually, but you must update the admin user in ./test-config/config.json."
+                  fi
         ensure:
           task: remove-temp-user
           file: paas-cf/concourse/tasks/delete_admin.yml

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -92,6 +92,7 @@ enable_healthcheck_db: ${ENABLE_HEALTHCHECK_DB:-}
 bosh_az: ${bosh_az}
 bosh_manifest_state: bosh-manifest-state-${bosh_az}.json
 bosh_fqdn: bosh.${SYSTEM_DNS_ZONE_NAME}
+enable_cf_acceptance_tests: ${ENABLE_CF_ACCEPTANCE_TESTS:-true}
 EOF
   echo -e "pipeline_lock_git_private_key: |\n  ${git_id_rsa//$'\n'/$'\n'  }"
 }

--- a/concourse/tasks/create_admin.yml
+++ b/concourse/tasks/create_admin.yml
@@ -18,6 +18,12 @@ run:
     - -c
     - |
       [ -z "${PREFIX}" ] && echo "You need to specify \$PREFIX" && exit 1
+      if [ "${ENABLE_ADMIN_USER_CREATION}" == "false" ]; then
+        echo "Temporary user creation is disabled (ENABLE_ADMIN_USER_CREATION=${ENABLE_ADMIN_USER_CREATION}). Skipping."
+        echo "none" >admin-creds/username
+        echo "none" >admin-creds/password
+        exit 0
+      fi
       ./paas-cf/concourse/scripts/import_bosh_ca.sh
 
       SUFFIX=$(tr -cd '[:alpha:]0-9' < /dev/urandom | head -c10)

--- a/concourse/tasks/delete_admin.yml
+++ b/concourse/tasks/delete_admin.yml
@@ -17,6 +17,10 @@ run:
     - -c
     - |
       NAME=$(cat admin-creds/username)
+      if [ "${ENABLE_ADMIN_USER_CREATION}" == "false" ]; then
+        echo "Temporary user creation is disabled (ENABLE_ADMIN_USER_CREATION=${ENABLE_ADMIN_USER_CREATION}). Skipping."
+        exit 0
+      fi
       ./paas-cf/concourse/scripts/import_bosh_ca.sh
 
       VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
@@ -26,5 +30,5 @@ run:
       echo "Removing user ${NAME}"
       uaac target "${UAA_ENDPOINT}"
       uaac token client get admin -s "${UAA_ADMIN_CLIENT_PASS}"
-      
+
       uaac user delete "${NAME}"


### PR DESCRIPTION
[#123510111 Stop running cf-acceptance-tests in staging and production](https://www.pivotaltracker.com/story/show/123510111)

What
====

We want to disable the execution of acceptance tests in staging and prod, and allow disable it in any other environment providing a flag.

The reason is that running the tests in prod/staging do not provide so much value, and some of the acceptance tests are not safe to run in production, as they occasionally fail in an unsafe way.

Context
-------

We add a new environment variable `ENABLE_CF_ACCEPTANCE_TESTS` which is by default `true`, but `false` for prod and staging. The operator can optionally enable this variable if required.

This will only stop the tests from running, but we will continue configuring the jobs in concourse, and even execute all the preparation steps: render configuration, prepare container, etc.

Temporary user creation is also disabled if `ENABLED_CF_ACCEPTANCE_TESTS` is `false`


How to test?
------------

Run this to upload the pipeline disabling the tests:

```
ENABLE_CF_ACCEPTANCE_TESTS=false BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines DEPLOY_ENV=hector
```

Run up to the acceptance tests. Check the output of the temporary user creation, acceptance tests and delete user. They should indicate that they are disabled and not run.

Upload the tests as usual:

```
BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines DEPLOY_ENV=hector
```

and rerun the acceptance tests. They should run as usual.

Double check the code and the defaults in the makefile.

Who?
----

Anyone but @keymon