### PR TITLE
[#125830841] Create bucket and enable ELB access log shipping for CF API and router

### DIFF
--- a/terraform/cloudfoundry/cf_api_elb.tf
+++ b/terraform/cloudfoundry/cf_api_elb.tf
@@ -6,6 +6,11 @@ resource "aws_elb" "cf_cc" {
   security_groups = [
     "${aws_security_group.cf_api_elb.id}",
   ]
+  access_logs {
+    bucket = "${aws_s3_bucket.elb_access_log.id}"
+    bucket_prefix = "cf-cc"
+    interval = 5
+  }
 
   health_check {
     target = "HTTP:9022/info"
@@ -31,6 +36,11 @@ resource "aws_elb" "cf_uaa" {
   security_groups = [
     "${aws_security_group.cf_api_elb.id}",
   ]
+  access_logs {
+    bucket = "${aws_s3_bucket.elb_access_log.id}"
+    bucket_prefix = "cf-uaa"
+    interval = 5
+  }
 
   health_check {
     target = "TCP:8080"
@@ -56,6 +66,11 @@ resource "aws_elb" "cf_loggregator" {
   security_groups = [
     "${aws_security_group.cf_api_elb.id}",
   ]
+  access_logs {
+    bucket = "${aws_s3_bucket.elb_access_log.id}"
+    bucket_prefix = "cf-loggregator"
+    interval = 5
+  }
 
   health_check {
     target = "TCP:8080"
@@ -81,6 +96,11 @@ resource "aws_elb" "cf_doppler" {
   security_groups = [
     "${aws_security_group.cf_api_elb.id}",
   ]
+  access_logs {
+    bucket = "${aws_s3_bucket.elb_access_log.id}"
+    bucket_prefix = "cf-doppler"
+    interval = 5
+  }
 
   health_check {
     target = "TCP:8081"

--- a/terraform/cloudfoundry/elb_access_log_bucket.tf
+++ b/terraform/cloudfoundry/elb_access_log_bucket.tf
@@ -1,0 +1,26 @@
+variable "elb_access_log_bucket_name" {
+  default     = "elb-access-log"
+}
+
+resource "template_file" "elb_access_log_bucket_policy" {
+  template = "${file("${path.module}/policies/elb_access_log_bucket.json.tpl")}"
+  vars {
+    bucket_name = "${var.env}-${var.elb_access_log_bucket_name}"
+    principal = "${lookup(var.elb_account_ids, var.region)}"
+  }
+}
+
+resource "aws_s3_bucket" "elb_access_log" {
+    bucket = "${var.env}-${var.elb_access_log_bucket_name}"
+    acl = "private"
+    force_destroy = "true"
+    policy = "${template_file.elb_access_log_bucket_policy.rendered}"
+
+    lifecycle_rule {
+      enabled = true
+      prefix = ""
+      expiration {
+        days = 30
+      }
+    }
+}

--- a/terraform/cloudfoundry/policies/elb_access_log_bucket.json.tpl
+++ b/terraform/cloudfoundry/policies/elb_access_log_bucket.json.tpl
@@ -3,16 +3,10 @@
   "Statement": [
     {
       "Effect": "Allow",
-      "Action": [
-        "s3:PutObject"
-      ],
-      "Resource": [
-        "arn:aws:s3:::${bucket_name}/*/AWSLogs/*/*"
-      ],
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::${bucket_name}/*/AWSLogs/*/*",
       "Principal": {
-        "AWS": [
-          "${principal}"
-        ]
+        "AWS": "arn:aws:iam::${principal}:root"
       }
     }
   ]

--- a/terraform/cloudfoundry/policies/elb_access_log_bucket.json.tpl
+++ b/terraform/cloudfoundry/policies/elb_access_log_bucket.json.tpl
@@ -1,0 +1,19 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}/*/AWSLogs/*/*"
+      ],
+      "Principal": {
+        "AWS": [
+          "${principal}"
+        ]
+      }
+    }
+  ]
+}

--- a/terraform/cloudfoundry/router_elb.tf
+++ b/terraform/cloudfoundry/router_elb.tf
@@ -9,6 +9,11 @@ resource "aws_elb" "cf_router" {
     "${aws_security_group.pingdom-probes-1.id}",
     "${aws_security_group.pingdom-probes-2.id}"
   ]
+  access_logs {
+    bucket = "${aws_s3_bucket.elb_access_log.id}"
+    bucket_prefix = "cf-router"
+    interval = 5
+  }
 
   health_check {
     target = "HTTP:82/"

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -104,3 +104,23 @@ variable "web_access_cidrs" {
   description = "CSV of CIDR addresses with access to "
   default     = ""
 }
+
+# List of Elastic Load Balancing Account ID to configure ELB access log policies
+# Provided by AWS in http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/enable-access-logs.html
+variable "elb_account_ids" {
+  default = {
+    us-east-1 = "127311923021"
+    us-west-1 = "027434742980"
+    us-west-2 = "797873946194"
+    eu-west-1 = "156460612806"
+    eu-central-1 = "054676820928"
+    ap-northeast-1 = "582318560864"
+    ap-northeast-2 = "600734575887"
+    ap-southeast-1 = "114774131450"
+    ap-southeast-2 = "783225319266"
+    ap-south-1 = "718504428378"
+    sa-east-1 = "507241528517"
+    us-gov-west-1 = "048591011584"
+    cn-north-1 = "638102146993"
+  }
+}


### PR DESCRIPTION
What
====

We want to enable access log shipping in the ELBs to be able to troubleshoot and track any access. The logs will be ship to a S3 bucket and stored for up to 30 days (same as logsearch).

Out of scope: ingest the logs in logsearch.

Dependencies
----------

https://github.gds/government-paas/aws-account-wide-terraform/pull/52 must be merged and applied first to allow the deployer to create the bucket.

Once merged, remove the WIP commit that workarounds the lack of permissions.

How to review?
------------

 1. Check the commits and review that make sense.
 2. Deploy up to the cf-terraform job.
 3. Check that the new bucket is created. You can wait some minutes and check that there are logs being generated for each ELB.
 4. Check that the expiration lifecycle is defined, by downloading the policy with aws cli:

    ```
 aws s3api  get-bucket-lifecycle --bucket ${DEPLOY_ENV}-elb-access-log # Or ${DEPLOY_ENV}-elb-access-log-cf-droplets
```

Who?
----

Anyone but @keymon