### PR TITLE
[#125830841] Add prefix for ELB access log bucket

### DIFF
--- a/terraform/cloudfoundry/elb_access_log_bucket.tf
+++ b/terraform/cloudfoundry/elb_access_log_bucket.tf
@@ -5,13 +5,13 @@ variable "elb_access_log_bucket_name" {
 resource "template_file" "elb_access_log_bucket_policy" {
   template = "${file("${path.module}/policies/elb_access_log_bucket.json.tpl")}"
   vars {
-    bucket_name = "${var.env}-${var.elb_access_log_bucket_name}"
+    bucket_name = "${var.assets_prefix}-${var.env}-${var.elb_access_log_bucket_name}"
     principal = "${lookup(var.elb_account_ids, var.region)}"
   }
 }
 
 resource "aws_s3_bucket" "elb_access_log" {
-    bucket = "${var.env}-${var.elb_access_log_bucket_name}"
+    bucket = "${var.assets_prefix}-${var.env}-${var.elb_access_log_bucket_name}"
     acl = "private"
     force_destroy = "true"
     policy = "${template_file.elb_access_log_bucket_policy.rendered}"

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -124,3 +124,8 @@ variable "elb_account_ids" {
     cn-north-1 = "638102146993"
   }
 }
+
+variable "assets_prefix" {
+  description = "Prefix for global assests like S3 buckets"
+  default = "gds-paas"
+}


### PR DESCRIPTION
From comment in [#125830841 Enable ELB Logs](https://www.pivotaltracker.com/n/projects/1275640/stories/125830841/comments/146017503)

What
----

> We've hit a conflict for the bucket name in production. The bucket name prod-elb-access-log has already been taken. We'll need to add a prefix, or some up with another way of avoiding this.

S3 bucket names are global and shared across all AWS users. This can cause trouble, as the name for some buckets might have been already used by other users. This was the case for `prod-elb-access-log`.

To avoid this, we add a prefix to the ELB access log bucket to "ensure" uniqueness and avoid collision with other 3rd parties names.

We create a variable `assets_prefix` to be used in any other place.

How to review
--------------

Apply this change. The new bucket will have a prefix `gds-paas-`. Terraform shall delete and create the new bucket if the old one is there.

Who?
----

Anyone but @keymon