### PR TITLE
Avoid unnecessary godep restore in platform-tests

### DIFF
--- a/platform-tests/run_tests.sh
+++ b/platform-tests/run_tests.sh
@@ -10,8 +10,6 @@ export GOPATH
 TESTS_DIR="${1}"
 cd "${TESTS_DIR}"
 
-godep restore
-
 if [ -x ./run_tests.sh ]; then
   ./run_tests.sh
 else

--- a/platform-tests/src/acceptance/run_tests.sh
+++ b/platform-tests/src/acceptance/run_tests.sh
@@ -2,6 +2,8 @@
 
 set -eu
 
+godep restore
+
 if [ -n "${GINKGO_FOCUS:-}" ]; then
   go test -timeout 30m -ginkgo.focus "${GINKGO_FOCUS}"
 else

--- a/platform-tests/src/performance/run_tests.sh
+++ b/platform-tests/src/performance/run_tests.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -eu
+
+godep restore
+
+go test


### PR DESCRIPTION
## What

The availability tests have vendored dependenvies, so there's no need to
run `godep restore`. Not doing this will reduce the startup time for
this suite.

`godep restore` was previously run in the global `run_tests.sh` script.
This moves it into the run scripts for the individual suites that need it.

## How to review

Run the pipeline, and verify that all the tests start successfully.

## Who can review

Anyone but myself.