### PR TITLE
Update .tf files to work with latest terraform

### DIFF
--- a/terraform/bosh/outputs.tf
+++ b/terraform/bosh/outputs.tf
@@ -3,11 +3,11 @@ output "environment" {
 }
 
 output "zone0" {
-  value = "${var.zones.zone0}"
+  value = "${var.zones["zone0"]}"
 }
 
 output "zone1" {
-  value = "${var.zones.zone1}"
+  value = "${var.zones.["zone1"]}"
 }
 
 output "region" {

--- a/terraform/vpc/outputs.tf
+++ b/terraform/vpc/outputs.tf
@@ -23,15 +23,15 @@ output "subnet0_id" {
 }
 
 output "zone0" {
-  value = "${var.zones.zone0}"
+  value = "${var.zones["zone0"]}"
 }
 
 output "zone1" {
-  value = "${var.zones.zone1}"
+  value = "${var.zones["zone1"]}"
 }
 
 output "zone2" {
-  value = "${var.zones.zone2}"
+  value = "${var.zones["zone2"]}"
 }
 
 output "key_pair_name" {


### PR DESCRIPTION
## What

Running lint_terraform with the latest terraform
version (v0.7.1-dev) gives errors of the form:

```
Error loading Terraform: Error loading config:
Error loading terraform/vpc/outputs.tf:
Error reading config for output zone0: Invalid dot index found: 'var.zones.zone0'.
Values in maps and lists can be referenced using square bracket indexing,
like: 'var.mymap["key"]' or 'var.mylist[1]'.
```

Since we don't specify the version of terraform to use
for local development (we only specify 0.6.15 for travis), we should
try to keep up to date.

This commit updates the syntax to the square-bracket style, which
appears to work in the old version as well.

I'm making this change because we don't have a standard dev environment and
so I think we must support a wide range of possible environments - in this case I
happened to install terraform via `go get`.

## How to review

Verify that the tf files still make sense and that they work with any versions of terraform
that we know are in use somewhere in our system.

## Who can review

Anyone who knows terraform.