### PR TITLE
[#121566765] Fix and disable bosh resurrector

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,3 @@ DEPENDENCIES
   rspec (~> 3.3)
   rubocop
   webmock (~> 1.24)
-
-BUNDLED WITH
-   1.12.5

--- a/manifests/bosh-manifest/deployments/010-bosh-template.yml
+++ b/manifests/bosh-manifest/deployments/010-bosh-template.yml
@@ -71,10 +71,11 @@ jobs:
         local:
           users:
             - { name: admin, password: (( grab secrets.bosh_admin_password )) }
+            - { name: hm, password: (( grab secrets.bosh_hm_director_password )) }
 
     hm:
       director_account:
-        user: admin
+        user: hm
         password: (( grab secrets.bosh_hm_director_password ))
       resurrector_enabled: true
 

--- a/manifests/bosh-manifest/deployments/010-bosh-template.yml
+++ b/manifests/bosh-manifest/deployments/010-bosh-template.yml
@@ -77,7 +77,7 @@ jobs:
       director_account:
         user: hm
         password: (( grab secrets.bosh_hm_director_password ))
-      resurrector_enabled: true
+      resurrector_enabled: false
 
     ntp: (( grab meta.ntp ))
 

--- a/manifests/bosh-manifest/deployments/aws/090-bosh-aws-stub.yml
+++ b/manifests/bosh-manifest/deployments/aws/090-bosh-aws-stub.yml
@@ -28,8 +28,6 @@ meta:
 jobs:
 - name: bosh
   properties:
-    hm:
-      resurrector_enabled: true
     aws: (( grab meta.aws.bosh_properties ))
     dns: null
 

--- a/manifests/bosh-manifest/spec/properties_spec.rb
+++ b/manifests/bosh-manifest/spec/properties_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe "manifest properties validations" do
+  let(:manifest) { manifest_with_defaults }
+  let(:properties) { manifest.fetch("properties") }
+  let(:bosh_job) { manifest.fetch("jobs").select{|x| x["name"] == "bosh"}.first }
+  let(:bosh_properties) { properties.merge(bosh_job["properties"]) }
+
+  it "uses local user management" do
+    expect(bosh_properties["director"]["user_management"]["provider"]).to eq("local")
+  end
+
+  it "creates a local user for health manager" do
+    users = bosh_properties["director"]["user_management"]["local"]["users"]
+    expected_user = { "name" => "hm", "password" => "BOSH_HM_DIRECTOR_PASSWORD" }
+    expect(users).to include(expected_user)
+  end
+
+  it "configures the hm bosh user as director account of the health manager" do
+    expect(bosh_properties["hm"]["director_account"]["user"]).to eq("hm")
+    expect(bosh_properties["hm"]["director_account"]["password"]).to eq("BOSH_HM_DIRECTOR_PASSWORD")
+  end
+
+  it "enables the health manager resurrector" do
+    expect(bosh_properties["hm"]["resurrector_enabled"]).to eq(true)
+  end
+end

--- a/manifests/bosh-manifest/spec/properties_spec.rb
+++ b/manifests/bosh-manifest/spec/properties_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "manifest properties validations" do
     expect(bosh_properties["hm"]["director_account"]["password"]).to eq("BOSH_HM_DIRECTOR_PASSWORD")
   end
 
-  it "enables the health manager resurrector" do
-    expect(bosh_properties["hm"]["resurrector_enabled"]).to eq(true)
+  it "disables the health manager resurrector" do
+    expect(bosh_properties["hm"]["resurrector_enabled"]).to eq(false)
   end
 end

--- a/platform-tests/bosh-template-renderer/render_lib.rb
+++ b/platform-tests/bosh-template-renderer/render_lib.rb
@@ -1,4 +1,5 @@
 require 'erb'
+require 'json'
 require 'bosh/template/evaluation_context'
 
 class Hash


### PR DESCRIPTION
What
===
We are not sure if we want to use the features covered by Bosh Resurrector. Meanwhile we do [Spike to determine if we want to use it](https://www.pivotaltracker.com/n/projects/1275640/stories/119516757), we will disable the feature.

But the feature was broken because an incorrect password, so we will fix it before disable it.


How to test?
-------

You can check that the new manifest will disable the resurrector because the property `director.hm.resurrector_enabled` is set to `true`:

```
aws s3 cp s3://hector-state/bosh-manifest.yml /tmp
./platform-tests/bosh-template-renderer/render.rb ~/workspace/bosh/release/jobs/health_monitor/templates/health_monitor.yml.erb ~/workspace/bosh/release/jobs/health_monitor/spec /tmp/bosh-manifest.yml bosh | json_pp
``` 

Change the value to see the effect in the template.

First test that resurrector is fixed by:

 1. Create a custom branch reverting the last commit
    ```
git checkout -b resurrector_wip
git revert HEAD
git push
```

 2. Deploy bosh running the pipeline (see README.md)
   ```
BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines DEPLOY_ENV=...
```

 3. SSH on the bosh machine (via concourse) and check that the logs indicate that resurrector is working:

    ```
$ less /var/vcap/sys/log/health_monitor/health_monitor.log
...
I, [2016-08-11T14:37:07.946532 #19625]  INFO : Adding agent 547e8bff-aa6b-4efc-9b6c-29136e04071b (elasticsearch_master/553475a7-1c63-4633-9ff8-b71bf63bcf46) to hector...
I, [2016-08-11T14:37:07.946579 #19625]  INFO : Adding agent 9cec89fc-1f50-43f7-9546-ffcd86506c90 (elasticsearch_master/38ab835e-9319-452a-95be-47a79930bd37) to hector...
I, [2016-08-11T14:37:07.946629 #19625]  INFO : Adding agent 9b834ea3-8275-4a86-8e29-8da4b36a7945 (maintenance/eff717f7-8ba8-45f6-afda-fc77c3780236) to hector...
I, [2016-08-11T14:37:07.946676 #19625]  INFO : Adding agent e607d566-58ac-425e-92e2-d47dc1f425b2 (rds_broker/71e94328-b348-49c9-a004-440be55ab04b) to hector...
I, [2016-08-11T14:37:07.946721 #19625]  INFO : Adding agent 29b4ab30-f983-4a66-aff9-0bf6e45f98f0 (parser_z2/8259c347-cfce-43b9-be43-4e4ca1e68e6b) to hector...
I, [2016-08-11T14:37:07.946792 #19625]  INFO : Adding agent c26e4b4b-ce6d-476a-a478-7122e89e8c83 (queue/2a1e103a-be3b-49b7-a151-d6950cb1efcf) to hector...
I, [2016-08-11T14:37:07.981550 #19625]  INFO : [ALERT] Alert @ 2016-08-11 14:37:07 UTC, severity 1: process is not running
W, [2016-08-11T14:37:07.981627 #19625]  WARN : (Resurrector) event did not have deployment, job and id: Alert @ 2016-08-11 14:37:07 UTC, severity 1: process is not running
I, [2016-08-11T14:37:08.184654 #19625]  INFO : Managing 1 deployment, 47 agents
I, [2016-08-11T14:37:08.184767 #19625]  INFO : Agent heartbeats received = 170
I, [2016-08-11T14:37:09.033584 #19625]  INFO : [ALERT] Alert @ 2016-08-11 14:37:08 UTC, severity 1: process is not running
W, [2016-08-11T14:37:09.033710 #19625]  WARN : (Resurrector) event did not have deployment, job and id: Alert @ 2016-08-11 14:37:08 UTC, severity 1: process is not running
I, [2016-08-11T14:37:21.900812 #19625]  INFO : Agent `30c2ebbf-e414-4faa-a482-9d14131b61a0' shutting down...
I, [2016-08-11T14:37:21.900906 #19625]  INFO : Removing agent 30c2ebbf-e414-4faa-a482-9d14131b61a0 from all deployments...
```

Second, try to deploy the branch. To do so:

 1. Checkout the original branch `git checkout bugfix/121566765_turn_off_bosh_resurrector`
 2. Redeploy bosh: `BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines DEPLOY_ENV=...`
 3. check the log, to see if the resurrector is disabled.

Who?
----

Anyone but @keymon