### PR TITLE
[#128084861] Add a max length check for DEPLOY_ENV to the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,14 @@ help:
 SHELLCHECK=shellcheck
 YAMLLINT=yamllint
 
+DEPLOY_ENV_MAX_LENGTH=15
+DEPLOY_ENV_VALID_LENGTH=$(shell if [ $${\#DEPLOY_ENV} -gt $(DEPLOY_ENV_MAX_LENGTH) ]; then echo ""; else echo "OK"; fi)
+DEPLOY_ENV_VALID_CHARS=$(shell if echo $(DEPLOY_ENV) | grep -q '^[a-zA-Z0-9-]*$$'; then echo "OK"; else echo ""; fi)
+
 check-env-vars:
 	$(if ${DEPLOY_ENV},,$(error Must pass DEPLOY_ENV=<name>))
+	$(if ${DEPLOY_ENV_VALID_LENGTH},,$(error Sorry, DEPLOY_ENV ($(DEPLOY_ENV)) has a max length of $(DEPLOY_ENV_MAX_LENGTH), otherwise derived names will be too long))
+	$(if ${DEPLOY_ENV_VALID_CHARS},,$(error Sorry, DEPLOY_ENV ($(DEPLOY_ENV)) must use only alphanumeric chars and hyphens, otherwise derived names will be malformatted))
 
 test: spec lint_yaml lint_terraform lint_shellcheck lint_concourse lint_ruby ## Run linting tests
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ state files).
 [instance profiles]: http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html
 [aws-account-wide-terraform]: https://github.gds/government-paas/aws-account-wide-terraform
 
-* Declare you environment name using the variable DEPLOY_ENV. It must be 18 characters maximum and contain only alphanumeric characters and hyphens.
+* Declare your environment name using the variable DEPLOY_ENV.
 
 ```
 $ export DEPLOY_ENV=environment-name


### PR DESCRIPTION
## What

We have a length restriction and a restriction on characters
used in the DEPLOY_ENV variable, because we use this
variable to construct values used in AWS which themselves
have those restrictions.

To be more humane, we detect these cases and apologise to the
user with the unlucky name :/

We also remove the mention in the readme - it's better for
the makefile to be self-documenting since then we don't get out
of sync with the docs.

## How to review

Run `make check-env-vars` and play with your `DEPLOY_ENV`
var length and character composition,

It would be good to get this reviewed by someone with a non-bash shell.

## Who can review

Anyone except @benhyland or @paroxp 