### PR TITLE
[#128217001] Scale up the instance type of concourse

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -22,7 +22,7 @@ resource_pools:
       url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3232.13
       sha1: 477371a335d172f4728c7a8806448edb9703104c
     cloud_properties:
-      instance_type: c4.large
+      instance_type: m4.large
       availability_zone: (( grab terraform_outputs.zone0 ))
       iam_instance_profile: deployer-concourse
       elbs:


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/128217001

What
----

We were using c4.large: 2x CPU, 3.5GB, ~$0.105 per Hour.
But we are having trouble with concourse consuming too much memory
and eventually collapses.

m4.large 2x CPU and 8GB is $0.12 per Hour, so it is a worth it to
upgrade.

How to review
----------

Deploy concourse as described in readme. Check VM type.

Who?
----

Anyone but @keymon