### PR TITLE
[#128217001] Upgrade to stemcell 3262.5 with kernel 4.4

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -19,8 +19,8 @@ resource_pools:
   - name: concourse
     network: concourse
     stemcell:
-      url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3232.13
-      sha1: 477371a335d172f4728c7a8806448edb9703104c
+      url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3262.5
+      sha1: 13c73b82675742012ba3ded6528524b8f3ce9ec3
     cloud_properties:
       instance_type: m4.large
       availability_zone: (( grab terraform_outputs.zone0 ))


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/128217001

What?
===

The new stemcell with kernel 4.4 will bring several performance improvements,  specially in the btrfs driver.

In the concourse channel the recommend upgrade, and they claim that they were running it for a while without issues.

Note that this image had issues with garden-linux, but not with garden-runc

How to review?
-----------

Deploy concourse. SSH and check the kernel version

Who?
---
anyone but @keymon