### PR TITLE
[#128311015] Use HTTP healthcheck for UAA ELB

### DIFF
--- a/terraform/cloudfoundry/cf_api_elb.tf
+++ b/terraform/cloudfoundry/cf_api_elb.tf
@@ -43,7 +43,7 @@ resource "aws_elb" "cf_uaa" {
   }
 
   health_check {
-    target = "TCP:8080"
+    target = "HTTP:8080/healthz"
     interval = "${var.health_check_interval}"
     timeout = "${var.health_check_timeout}"
     healthy_threshold = "${var.health_check_healthy}"


### PR DESCRIPTION
[#128311015 Change healthcheck of UAA elb to HTTP  /healthz](https://www.pivotaltracker.com/story/show/128311015)

What
====

UAA ELB is configured as a HTTPS-HTTPS ELB, but the healthcheck is simply checking the TCP port 8080. Using TCP is not really checking the service and the healthcheck access is not being logged by the UAA service. We were having some issues in the ELB with instances being mark as unhealthy, but there are no logs of the healthchecks.

UAA provides an endpoint `/healthz`[1], that is being used by monit[2][3] and which we can use from the ELB.

Note that although monit uses 8989, that is only accessible locally, to access from the ELB we must use the public port 8080.

[1] https://github.com/cloudfoundry/uaa/blob/616e8bcc58f9bc16f9d9ec806da1b0bf0f5dae85/server/src/main/java/org/cloudfoundry/identity/uaa/health/HealthzEndpoint.java#L30
[2] https://github.com/cloudfoundry/uaa-release/blob/9946ec1323b8175a0ea3e8dc68286441e5fc682e/jobs/uaa/templates/health_check
[3] https://github.com/cloudfoundry/uaa-release/blob/9946ec1323b8175a0ea3e8dc68286441e5fc682e/jobs/uaa/monit#L7

How to review
-----------

Run the deployment pipeline. Tests should pass.

Check that the ELB healthcheck is HTTP:8080/healthz in the AWS console

Who?
---

Anyone but @keymon