### PR TITLE
[#127339659] Stop `cat`ing bosh manifest in pipeline

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -832,7 +832,6 @@ jobs:
               - -c
               - |
                 ./paas-cf/manifests/shared/build_manifest.sh $BOSH_MANIFEST_STUBS > bosh-manifest/bosh-manifest.yml
-                /bin/cat bosh-manifest/bosh-manifest.yml
         on_success:
           put: bosh-manifest
           params:


### PR DESCRIPTION
## What

Currently we're `cat`ing the bosh manifest to STDOUT during the pipeline, which means we're accidentally logging all the credentials in the concourse logs. Which is bad.

This removes the :crying_cat_face:

After this is deployed we need to rotate all bosh credentials.

## How to review

Run the pipeline, observe that you no longer have a bosh manifest scrolling up your screen during the `render-bosh-manifest` task.

## Who can review

Anyone but @jonty.