### PR TITLE
[#127161593] Retitle CPU graphs

### DIFF
--- a/manifests/cf-manifest/grafana/vm-resource-usage.json
+++ b/manifests/cf-manifest/grafana/vm-resource-usage.json
@@ -79,7 +79,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "CPU time",
+          "title": "CPU usage across all cores",
           "tooltip": {
             "msResolution": false,
             "shared": true,
@@ -92,7 +92,7 @@
           "yaxes": [
             {
               "format": "none",
-              "label": "Jiffies",
+              "label": "CPU % used",
               "logBase": 1,
               "max": null,
               "min": 0,


### PR DESCRIPTION
## What

The title and axis label of the SPU graph still referred to jiffies and time. 

In d64ddcf and d135733 we switched to storing rates of jiffies and displaying
in grafana as the sum of the percentage use across all cores. For example, on
a 2 core machine the usage will be between 0 and 200%.

This commit tries to make this clear in the VM resource usage dashboard CPU
graph.

## How to review

- Either apply this to a dev environment OR take a copy of `manifests/cf-manifest/grafana/vm-resource-usage.json`, change the title and upload it to a grafana using the UI. 
- Check that the new title and axes label make sense
- Delete any temporary dashboard you created

## Who can review

Anyone but @bleach
