### PR TITLE
[#126965751] Make errors from pipecleaner more explicit

### DIFF
--- a/concourse/scripts/pipecleaner.py
+++ b/concourse/scripts/pipecleaner.py
@@ -218,15 +218,15 @@ if __name__ == '__main__':
                 del err['fatal']
 
                 if err_type in ['unknown_resource', 'unfetched_resource']:
-                    colour = '\033[91m'
+                    msg_prefix = '\033[91mERROR '
                 if err_type in ['unused_fetch', 'unused_resource', 'unused_output']:
-                    colour = '\033[93m'
+                    msg_prefix = '\033[93mWARNING '
 
                 error_strings = []
                 for k, v in err.items():
                     error_strings.append("%s='%s'" % (k, v))
 
-                print FMT % (colour, err_type.replace('_', ' ').title(), ', '.join(error_strings))
+                print FMT % (msg_prefix, err_type.replace('_', ' ').title(), ', '.join(error_strings))
 
     if fatal is True:
         sys.exit(10)


### PR DESCRIPTION
[#126965751 Test users not removed from CC DB.](https://www.pivotaltracker.com/story/show/126965751)


What?
-----
Currently the script to lint concourse pipelines, pipecleaner.py, uses a color code to report the warnings (yellow) or errors (red).

This is not so intuitive, and also in the [travis output there are no colors, making it difficult to identify the root cause of the failure.](https://travis-ci.org/alphagov/paas-cf/builds/152994177#L751)

We add a text "WARNING" or "ERROR" in each case, keeping the colors, to make it more explicit.


How to test it?
-------------

Run `make dev lint_concourse DEPLOY_ENV=hector`. You can add an error in the pipelines to see the ERROR message

Who?
---

Anyone but @richardc or @keymon