### PR TITLE
[#126965751] Test users not removed from CC DB

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1817,6 +1817,8 @@ jobs:
         ensure:
           task: remove-temp-user
           file: paas-cf/concourse/tasks/delete_admin.yml
+          params:
+            PREFIX: smoketest-user
 
   - name: acceptance-tests
     plan:
@@ -1922,6 +1924,7 @@ jobs:
           task: remove-temp-user
           file: paas-cf/concourse/tasks/delete_admin.yml
           params:
+            PREFIX: acceptance-test-user
             ENABLE_ADMIN_USER_CREATION: {{enable_cf_acceptance_tests}}
 
   - name: custom-acceptance-tests
@@ -1973,6 +1976,8 @@ jobs:
         ensure:
           task: remove-temp-user
           file: paas-cf/concourse/tasks/delete_admin.yml
+          params:
+            PREFIX: custom-acceptance-test-user
 
   - name: bosh-tests
     plan:
@@ -2081,6 +2086,8 @@ jobs:
         ensure:
           task: remove-temp-user
           file: paas-cf/concourse/tasks/delete_admin.yml
+          params:
+            PREFIX: performance-tests-user
 
   - name: tag-release
     plan:
@@ -2290,6 +2297,8 @@ jobs:
         ensure:
           task: remove-temp-user
           file: paas-cf/concourse/tasks/delete_admin.yml
+          params:
+            PREFIX: cont-smoketest-user
 
   - name: bosh-cli
     plan:

--- a/concourse/pipelines/failure-testing.yml
+++ b/concourse/pipelines/failure-testing.yml
@@ -140,6 +140,8 @@ jobs:
                 BOSH_FQDN: {{bosh_fqdn}}
             - task: remove-temp-user
               file: paas-cf/concourse/tasks/delete_admin.yml
+              params:
+                PREFIX: controller-smoketest-user
 
   - name: nats
     serial_groups: [ failure ]
@@ -182,6 +184,8 @@ jobs:
                 BOSH_FQDN: {{bosh_fqdn}}
             - task: remove-temp-user
               file: paas-cf/concourse/tasks/delete_admin.yml
+              params:
+                PREFIX: nats-smoketest-user
 
   - name: router
     serial_groups: [ failure ]
@@ -224,6 +228,8 @@ jobs:
                 BOSH_FQDN: {{bosh_fqdn}}
             - task: remove-temp-user
               file: paas-cf/concourse/tasks/delete_admin.yml
+              params:
+                PREFIX: router-smoketest-user
 
   - name: etcd
     serial_groups: [ failure ]
@@ -266,6 +272,8 @@ jobs:
                 BOSH_FQDN: {{bosh_fqdn}}
             - task: remove-temp-user
               file: paas-cf/concourse/tasks/delete_admin.yml
+              params:
+                PREFIX: etcd-smoketest-user
 
   - name: consul
     serial_groups: [ failure ]
@@ -308,6 +316,8 @@ jobs:
                 BOSH_FQDN: {{bosh_fqdn}}
             - task: remove-temp-user
               file: paas-cf/concourse/tasks/delete_admin.yml
+              params:
+                PREFIX: consul-smoketest-user
 
   - name: cell
     serial_groups: [ failure ]
@@ -350,6 +360,8 @@ jobs:
                 BOSH_FQDN: {{bosh_fqdn}}
             - task: remove-temp-user
               file: paas-cf/concourse/tasks/delete_admin.yml
+              params:
+                PREFIX: cell-smoketest-user
 
   - name: rds-broker
     serial_groups: [ failure ]
@@ -416,3 +428,5 @@ jobs:
                 BOSH_FQDN: {{bosh_fqdn}}
             - task: remove-temp-user
               file: paas-cf/concourse/tasks/delete_admin.yml
+              params:
+                PREFIX: rds-broker-test-user

--- a/concourse/tasks/delete_admin.yml
+++ b/concourse/tasks/delete_admin.yml
@@ -34,3 +34,16 @@ run:
       echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
 
       cf delete-user "${NAME}" -f
+
+      echo "Removing leaked ${PREFIX} users"
+      url="/v2/users"
+      while [ "${url}" != "null" ] ; do
+        cf curl $url > users.json
+        # Delete users
+        cat users.json \
+           | jq -r ".resources[] | .entity.username | select(. != null) | select(test(\"^${PREFIX}\"))" \
+           | xargs -r -I {} cf delete-user {} -f
+
+        # See if there's another page of data.  If "next_url" is null we can stop
+        url=$(cat users.json | jq -r ".next_url")
+      done

--- a/concourse/tasks/delete_admin.yml
+++ b/concourse/tasks/delete_admin.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: governmentpaas/cf-uaac
+    repository: governmentpaas/cf-cli
 inputs:
   - name: paas-cf
   - name: cf-secrets
@@ -14,21 +14,23 @@ run:
   path: sh
   args:
     - -e
+    - -u
     - -c
     - |
       NAME=$(cat admin-creds/username)
-      if [ "${ENABLE_ADMIN_USER_CREATION}" == "false" ]; then
+      if [ "${ENABLE_ADMIN_USER_CREATION:-}" == "false" ]; then
         echo "Temporary user creation is disabled (ENABLE_ADMIN_USER_CREATION=${ENABLE_ADMIN_USER_CREATION}). Skipping."
         exit 0
       fi
       ./paas-cf/concourse/scripts/import_bosh_ca.sh
 
       VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
-      UAA_ADMIN_CLIENT_PASS=$($VAL_FROM_YAML secrets.uaa_admin_client_secret cf-secrets/cf-secrets.yml)
-      UAA_ENDPOINT=$($VAL_FROM_YAML properties.uaa.url cf-manifest/cf-manifest.yml)
+      CF_ADMIN=admin
+      CF_PASS=$($VAL_FROM_YAML secrets.uaa_admin_password cf-secrets/cf-secrets.yml)
+      API_ENDPOINT=$($VAL_FROM_YAML properties.cc.srv_api_uri cf-manifest/cf-manifest.yml)
 
       echo "Removing user ${NAME}"
-      uaac target "${UAA_ENDPOINT}"
-      uaac token client get admin -s "${UAA_ADMIN_CLIENT_PASS}"
 
-      uaac user delete "${NAME}"
+      echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
+
+      cf delete-user "${NAME}" -f


### PR DESCRIPTION
## What

[#126965751](https://www.pivotaltracker.com/n/projects/1275640/stories/126965751) Test users not removed from CC DB

This series reworks the existing delete_admin task to be implemented in terms of `cf remove-user` rather than `uaac remove user` to prevent test users leaking, and then adds extra steps to the task to delete any users that match the test user prefix for this job.

## Dependencies and requirements

The commits marked NOKEEP should also be either dropped or reverted before merging, as they deliberately point at in-flight forks, and nobble the running of smoke-tests so we just test the user creation/deletion cycle.

You should review first  https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/61 and https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/62 to add jq to the cf-cli image.

> note: remember install all dependencies: `uaac` with `bundle install`, `awscli`, export AWS credentials. See README.md for details. Also install `jq`  https://stedolan.github.io/jq/

## How to review

Deploy pipeline to a dev environment using the master branch. We recommend disable the payload of the `smoket-tests` by adding a exit 0 as in https://github.com/alphagov/paas-cf/pull/430/commits/bf57c75b402c9aa44ecb1a1b97dc175d09924e35.

Run the smoke-tests several times. That will create several temp users, and delete them in uaa but not in CF. You can see the users created in uaa and CF by running.

note: remember install all dependencies: `uaac` with `bundle install`, `awscli`, export AWS credentials. See README.md for details. Also install `jq`  https://stedolan.github.io/jq/

```
export DEPLOY_ENV=....
UAA_PASS=$(aws --region eu-west-1 s3 cp s3://${DEPLOY_ENV}-state/cf-secrets.yml - | grep 

# Login into UAA 
uaac target https://uaa.${DEPLOY_ENV}.dev.cloudpipeline.digital --skip-ssl-validation
UAA_PASS=$(aws --region eu-west-1 s3 cp s3://${DEPLOY_ENV}-state/cf-secrets.yml - | grep uaa_admin_client_secret | awk '{print $2}')
uaac token client get admin -s $UAA_PASS
# Get users
uaac users | grep smoketest-user

# Login in CF
CF_ADMIN_PASS=$(aws --region eu-west-1 s3 cp s3://${DEPLOY_ENV}-state/cf-secrets.yml - | grep uaa_admin_password | awk '{print $2}')
cf login --skip-ssl-validation -a https://api.${DEPLOY_ENV}.dev.cloudpipeline.digital -u admin -p  ${CF_ADMIN_PASS}
cf curl /v2/users | jq -r ".resources[] | .entity.username | select(. != null)" | grep smoketest-user
```

You will see that there are users in CF that are not in UAA.

Now run this branch of the pipelines:

```
BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines 
```

Run the `smoke-tests` job as it will complete quickly (thx to the disable commit). You can see that the users are now in sync, and additional users in UAA are deleted.

Additionally, you should be able to observe the number of cc users grows and then drops from the user impact dashboard in grafana (previous behaviour would have been only to grow).  

 

## Who can review

Anyone but @richardc or @keymon 
