### PR TITLE
[#146888305] Generate secrets when they are missing

### DIFF
--- a/manifests/shared/spec/secret_generator_spec.rb
+++ b/manifests/shared/spec/secret_generator_spec.rb
@@ -200,5 +200,28 @@ RSpec.describe SecretGenerator do
 
       expect(results).not_to have_key("other")
     end
+
+    it "generates empty paswords in the existing set that are in the required set" do
+      generator.existing_secrets = {
+        "simple1" => "",
+        "simple2" => nil,
+      }
+      results = generator.generate
+
+      expect(results["simple1"]).to match(SIMPLE_PASSWORD_REGEX)
+      expect(results["simple2"]).to match(SIMPLE_PASSWORD_REGEX)
+    end
+
+    it "generates all the required secrets if existing_secrets is nil" do
+      required_secrets = {
+        "foo" => :simple,
+        "bar" => :simple,
+      }
+      generator = SecretGenerator.new(required_secrets)
+      generator.existing_secrets = nil
+      results = generator.generate
+
+      expect(results.keys).to match_array(%w(foo bar))
+    end
   end
 end


### PR DESCRIPTION
## What

This allows the secret generator to handle two cases we ran into while attempting to rotate passwords as part of [#146888305](https://www.pivotaltracker.com/n/projects/1275640/stories/127339659/comments/146888305):

1) Secrets that have a key but no value are not generated, so the following will result in no new secrets being generated:

````
  ---
  secrets:
    preserved_secret: yay
    will_not_be_generated:
````

2) A yaml file with a `secrets:` key but no values defined in it will result in the SecretGenerator crashing as it expects a Hash:
````
  ---
  secrets:
````
## How to review

In `manifests/shared` run `rspec` and observe the tests passing.

## Who can review

Not @jonty.