### PR TITLE
[#121604537] Move EBS volumes to SSD

### DIFF
--- a/manifests/cf-manifest/cloud-config/025-cf-disk-types.yml
+++ b/manifests/cf-manifest/cloud-config/025-cf-disk-types.yml
@@ -1,0 +1,10 @@
+---
+disk_types:
+  - name: consul
+    disk_size: 1024
+    cloud_properties:
+      type: gp2
+  - name: etcd
+    disk_size: 10024
+    cloud_properties:
+      type: gp2

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -116,7 +116,7 @@ jobs:
     azs: [z1, z2, z3]
     templates: (( grab meta.consul_templates ))
     instances: 3
-    persistent_disk: 1024
+    persistent_disk_type: consul
     vm_type: small
     stemcell: default
     networks:
@@ -153,7 +153,7 @@ jobs:
     azs: [z1, z2, z3]
     templates: (( grab meta.etcd_templates ))
     instances: 3
-    persistent_disk: 10024
+    persistent_disk_type: etcd
     vm_type: medium
     stemcell: default
     networks:

--- a/manifests/cf-manifest/manifest/030-logsearch.yml
+++ b/manifests/cf-manifest/manifest/030-logsearch.yml
@@ -64,7 +64,7 @@ jobs:
     static_ips:
       - 10.0.16.13
       - 10.0.17.13
-  disk_type: queue
+  persistent_disk_type: queue
   update: (( grab meta.update ))
 
 - name: parser_z1

--- a/manifests/cf-manifest/spec/integration/integration_spec.rb
+++ b/manifests/cf-manifest/spec/integration/integration_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe "generic manifest validations" do
         next unless job["persistent_disk_type"]
 
         expect(disk_type_names).to include(job["persistent_disk_type"]),
-          "disk_pool #{job['persistent_disk_pool']} not found for job #{job['name']}"
+          "disk_type #{job['persistent_disk_type']} not found for job #{job['name']}"
       end
     end
   end


### PR DESCRIPTION
## What

[#121604537 - Move EBS volumes to SSD storage where appropriate](https://www.pivotaltracker.com/n/projects/1275640)

We want the etcd and consul VMs to use gp2 solid state drives, instead of the standard drives, to achieve [greater I/O performance](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-io-characteristics.html) and to be more consistent with the other VMs in our deployment. 

Create disk type definitions and reference them in the jobs. This will cause Bosh to migrate the persistent disks to gp2.

## How to review

* Deploy from master
* Deploy from this branch and ensure all tests pass (particularly availability tests).
* If you want to be really thorough you could check in the AWS console that all persistent disks have been added.

## Who can review

Anyone but me.
