### PR TITLE
126965751 Test users not removed from CC DB

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1574,6 +1574,44 @@ jobs:
                   bundle
                   bundle exec sync-admin-users.rb ${API_ENDPOINT} ../config/admin_users.yml "{{NEW_ACCOUNT_EMAIL_ADDRESS}}"
 
+        - task: purge-unnamed-users
+          config:
+            platform: linux
+            inputs:
+              - name: paas-cf
+              - name: bosh-CA
+              - name: config
+              - name: cf-manifest
+            params:
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/cf-cli
+            run:
+              path: sh
+              args:
+                - -e
+                - -u
+                - -c
+                - |
+                  ./paas-cf/concourse/scripts/import_bosh_ca.sh
+                  . ./config/config.sh
+                  echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}"
+
+                  url="/v2/users"
+                  while [ "${url}" != "null" ] ; do
+                    cf curl $url > users.json
+                    # Identify users with null usernames - they were leaked by
+                    # deleting the user with uaac
+                    cat users.json \
+                       | jq -r '.resources[] | select(.entity.username == null) | .metadata.guid' >> users_to_delete
+
+                    # See if there's another page of data.  If "next_url" is null we can stop
+                    url=$(cat users.json | jq -r ".next_url")
+                  done
+
+                  # Schedule deletions
+                  cat users_to_delete |  xargs -t -r -I {} cf curl -X DELETE /v2/users/{}?async=true
         - task: register-rds-broker
           config:
             platform: linux

--- a/concourse/tasks/delete_admin.yml
+++ b/concourse/tasks/delete_admin.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: governmentpaas/cf-uaac
+    repository: governmentpaas/cf-cli
 inputs:
   - name: paas-cf
   - name: cf-secrets
@@ -14,21 +14,23 @@ run:
   path: sh
   args:
     - -e
+    - -u
     - -c
     - |
       NAME=$(cat admin-creds/username)
-      if [ "${ENABLE_ADMIN_USER_CREATION}" == "false" ]; then
+      if [ "${ENABLE_ADMIN_USER_CREATION:-}" == "false" ]; then
         echo "Temporary user creation is disabled (ENABLE_ADMIN_USER_CREATION=${ENABLE_ADMIN_USER_CREATION}). Skipping."
         exit 0
       fi
       ./paas-cf/concourse/scripts/import_bosh_ca.sh
 
       VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
-      UAA_ADMIN_CLIENT_PASS=$($VAL_FROM_YAML secrets.uaa_admin_client_secret cf-secrets/cf-secrets.yml)
-      UAA_ENDPOINT=$($VAL_FROM_YAML properties.uaa.url cf-manifest/cf-manifest.yml)
+      CF_ADMIN=admin
+      CF_PASS=$($VAL_FROM_YAML secrets.uaa_admin_password cf-secrets/cf-secrets.yml)
+      API_ENDPOINT=$($VAL_FROM_YAML properties.cc.srv_api_uri cf-manifest/cf-manifest.yml)
 
       echo "Removing user ${NAME}"
-      uaac target "${UAA_ENDPOINT}"
-      uaac token client get admin -s "${UAA_ADMIN_CLIENT_PASS}"
 
-      uaac user delete "${NAME}"
+      echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
+
+      cf delete-user "${NAME}" -f


### PR DESCRIPTION
## What

[#126965751](https://www.pivotaltracker.com/n/projects/1275640/stories/126965751) Test users not removed from CC DB

This series reworks the existing delete_admin task to be implemented in terms of `cf remove-user` rather than `uaac remove user` to prevent test admin users leaking, and then adds and additional task to the `cf-deploy` job to cleanup existing leaked users.

## How to review

Before deployment log into a developement environment with the `cf` tool and capture existing users with `cf curl /v2/users?results-per-page=1000 > users.json` (you may need to specify a larger value for results-per-page if this pages)

Deploy and run the pipeline.  After running repeat the `cf curl /v2/users?results-per-page=1000 > new_users.json`

Confirm that there are fewer/no users with a null username.

```
cat new_users.json | jq -r '.resources[] | select(.entity.username == null) | .metadata.guid'
```

Additionally, you should be able to observe the number of cc has dropped in your user impact dashboard in grafana (previous behaviour would have been only to grow).  

 
## Who can review

Anyone but @mtekel or @richardc or @keymon 
