### PR TITLE
[#127449817] Increase timeout for tag_release tests

### DIFF
--- a/concourse/scripts/tag_release_test.go
+++ b/concourse/scripts/tag_release_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -13,6 +14,10 @@ import (
 	"os/exec"
 
 	"github.com/onsi/gomega/gexec"
+)
+
+const (
+	ExecutionTimeout = 3 * time.Second
 )
 
 var _ = Describe("TagRelease", func() {
@@ -28,7 +33,7 @@ var _ = Describe("TagRelease", func() {
 
 		session, err := gexec.Start(gitVersionCommand, GinkgoWriter, GinkgoWriter)
 		Expect(err).ToNot(HaveOccurred())
-		Eventually(session).Should(gexec.Exit(0))
+		Eventually(session, ExecutionTimeout).Should(gexec.Exit(0))
 		Expect(session.Out.Contents()).To(MatchRegexp(".* [2-9]\\.[0-9]+\\.[0-9]+.*"), "Expected git version 2.0.0 or bigger")
 		Expect(session.Err.Contents()).To(BeEmpty())
 	})
@@ -158,7 +163,7 @@ func runBashScript(baseCmd *exec.Cmd, script string) *gexec.Session {
 	cmd := bashScript(baseCmd, script)
 	session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 	Expect(err).ToNot(HaveOccurred())
-	Eventually(session).Should(gexec.Exit(0))
+	Eventually(session, ExecutionTimeout).Should(gexec.Exit(0))
 	return session
 }
 


### PR DESCRIPTION
What?
-----

Similar to #388

This script sometimes takes more than Eventually's default timeout of 1sec to return when running in travis. Probably git operations are too heavy for the container based travis build.

This happened in travis several times[1]. Dan was able to reproduce it by running `ginkgo --untilItFails`, but I couldn't.

I set the timeout to 3 as I don't mind wait one second extra in the rare case it timeouts and it is a nice number.

The failure looked like this:
```
  • Failure in Spec Setup (BeforeEach) [2.847 seconds]
  TagRelease
  /home/travis/build/alphagov/paas-cf/concourse/scripts/tag_release_test.go:147
    when there are multiple 'previous-*' tags to be promoted
    /home/travis/build/alphagov/paas-cf/concourse/scripts/tag_release_test.go:146
      and the before last tag of 'previous-*' is promoted [BeforeEach]
      /home/travis/build/alphagov/paas-cf/concourse/scripts/tag_release_test.go:115
        should promote the same tag version for 'next-*'
        /home/travis/build/alphagov/paas-cf/concourse/scripts/tag_release_test.go:89
        Timed out after 1.000s.
        Expected process to exit.  It did not.
        /home/travis/build/alphagov/paas-cf/concourse/scripts/tag_release_test.go:161
``` 
[1] https://travis-ci.org/alphagov/paas-cf/builds/153593309

How to test?
-----------

See #426

Who?
---

Anyone but @keymon