### PR TITLE
[#128160309] Concourse only ssh key

### DIFF
--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -67,6 +67,13 @@ resources:
       versioned_file: id_rsa
       region_name: {{aws_region}}
 
+  - name: concourse-ssh-private-key
+    type: s3-iam
+    source:
+      bucket: {{state_bucket}}
+      versioned_file: concourse_id_rsa
+      region_name: {{aws_region}}
+
   - name: git-ssh-public-key
     type: s3-iam
     source:
@@ -280,6 +287,28 @@ jobs:
         params:
           file: generated-concourse-cert/concourse-cert.tar.gz
 
+    - task: generate-concourse-ssh-key
+      config:
+        image: docker:///governmentpaas/curl-ssl
+        inputs:
+        - name: paas-cf
+        outputs:
+        - name: concourse-ssh-key
+        params:
+          AWS_DEFAULT_REGION: {{aws_region}}
+        run:
+          path: sh
+          args:
+          - -e
+          - -c
+          - |
+            apk add --update openssh
+            cd concourse-ssh-key
+            ssh-keygen -t rsa -b 4096 -f generated_concourse_id_rsa -N ''
+            ../paas-cf/concourse/scripts/s3init.sh {{state_bucket}} concourse_id_rsa generated_concourse_id_rsa
+            ../paas-cf/concourse/scripts/s3init.sh {{state_bucket}} concourse_id_rsa.pub generated_concourse_id_rsa.pub
+
+
     - task: terraform-apply
       config:
         image: docker:///governmentpaas/terraform
@@ -289,6 +318,7 @@ jobs:
         - name: concourse-terraform-state
         - name: generated-concourse-cert
         - name: git-ssh-public-key
+        - name: concourse-ssh-key
         params:
           VAGRANT_IP: {{vagrant_ip}}
           TF_VAR_env: {{deploy_env}}
@@ -300,6 +330,7 @@ jobs:
           - -e
           - -c
           - |
+            cp concourse-ssh-key/concourse_id_rsa.pub paas-cf/terraform/concourse
             tar xzvf generated-concourse-cert/concourse-cert.tar.gz
             . vpc-terraform-outputs/tfvars.sh
             export TF_VAR_git_rsa_id_pub=$(cat git-ssh-public-key/git_id_rsa.pub)
@@ -453,7 +484,7 @@ jobs:
       trigger: true
       passed: ['concourse-prepare-deploy']
     - get: concourse-bosh-state
-    - get: ssh-private-key
+    - get: concourse-ssh-private-key
     - get: concourse-manifest
       passed: ['concourse-prepare-deploy']
 
@@ -464,22 +495,22 @@ jobs:
         inputs:
         - name: concourse-manifest
         - name: concourse-bosh-state
-        - name: ssh-private-key
+        - name: concourse-ssh-private-key
         run:
           path: sh
           args:
           - -e
           - -c
           - |
-            cp ssh-private-key/id_rsa id_rsa
-            chmod 400 id_rsa
-            ls -l id_rsa
+            cp concourse-ssh-private-key/concourse_id_rsa concourse_id_rsa
+            chmod 400 concourse_id_rsa
+            ls -l concourse_id_rsa
             cp -v concourse-bosh-state/concourse-manifest-state.json .
             cp -v concourse-manifest/concourse-manifest.yml .
             export BOSH_INIT_LOG_LEVEL={{log_level}}
             bosh-init deploy concourse-manifest.yml
             rm concourse-manifest/concourse-manifest.yml
-            rm id_rsa
+            rm concourse_id_rsa
       ensure:
         put: concourse-bosh-state
         params:

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -123,14 +123,14 @@ cloud_provider:
     host: (( grab terraform_outputs.concourse_elastic_ip ))
     port: 22
     user: vcap
-    private_key: id_rsa # Appears to be relative to working dir
+    private_key: concourse_id_rsa # Appears to be relative to working dir
 
   mbus: (( concat "https://mbus:" secrets.concourse_nats_password "@" terraform_outputs.concourse_elastic_ip ":6868" ))
 
   properties:
     aws:
       credentials_source: env_or_profile
-      default_key_name: (( grab terraform_outputs.key_pair_name ))
+      default_key_name: (( grab terraform_outputs.concourse_key_pair_name ))
       default_security_groups:
       - (( grab terraform_outputs.concourse_security_group ))
       - (( grab terraform_outputs.ssh_security_group ))

--- a/manifests/concourse-manifest/spec/fixtures/concourse-terraform-outputs.yml
+++ b/manifests/concourse-manifest/spec/fixtures/concourse-terraform-outputs.yml
@@ -5,3 +5,4 @@ terraform_outputs:
   concourse_security_group_id: sg-a1b2c3d4
   concourse_elb_name: env1234-concourse
   concourse_dns_name: deployer.env1234.dev.cloudpipeline.digital
+  concourse_key_pair_name: concourse_ssh_key_pair

--- a/manifests/concourse-manifest/spec/fixtures/concourse-terraform-outputs.yml
+++ b/manifests/concourse-manifest/spec/fixtures/concourse-terraform-outputs.yml
@@ -2,7 +2,6 @@
 terraform_outputs:
   concourse_elastic_ip: 1.2.3.4
   concourse_security_group: concourse_sg
-  concourse_security_group_id: sg-a1b2c3d4
   concourse_elb_name: env1234-concourse
   concourse_dns_name: deployer.env1234.dev.cloudpipeline.digital
   concourse_key_pair_name: concourse_ssh_key_pair

--- a/manifests/concourse-manifest/spec/fixtures/vpc-terraform-outputs.yml
+++ b/manifests/concourse-manifest/spec/fixtures/vpc-terraform-outputs.yml
@@ -2,7 +2,6 @@
 terraform_outputs:
   environment: test
   infra_subnet_ids: subnet-12345678,subnet-23456789
-  key_pair_name: ssh_key_pair
   region: eu-west-1
   ssh_security_group: alext-office-access-ssh
   subnet0_id: subnet-12345678

--- a/manifests/concourse-manifest/spec/fixtures/vpc-terraform-outputs.yml
+++ b/manifests/concourse-manifest/spec/fixtures/vpc-terraform-outputs.yml
@@ -1,12 +1,6 @@
 ---
 terraform_outputs:
-  environment: test
-  infra_subnet_ids: subnet-12345678,subnet-23456789
   region: eu-west-1
   ssh_security_group: alext-office-access-ssh
   subnet0_id: subnet-12345678
-  vpc_cidr: 10.0.0.0/16
-  vpc_id: vpc-12345678
   zone0: eu-west-1a
-  zone1: eu-west-1b
-  zone2: eu-west-1c

--- a/terraform/concourse/outputs.tf
+++ b/terraform/concourse/outputs.tf
@@ -22,3 +22,7 @@ output "git_concourse_pool_clone_full_url_ssh" {
   # convert the ssh:// url to a scp like connect string and add the git user
   value = "ssh://${aws_iam_user_ssh_key.git.ssh_public_key_id}@${replace(aws_codecommit_repository.concourse-pool.clone_url_ssh, "/^ssh://([^/]+)//", "$1/")}"
 }
+
+output "concourse_key_pair_name" {
+  value = "${aws_key_pair.concourse_key_pair.key_name}"
+}

--- a/terraform/concourse/ssh-key-pair.tf
+++ b/terraform/concourse/ssh-key-pair.tf
@@ -1,0 +1,4 @@
+resource "aws_key_pair" "concourse_key_pair" {
+  key_name = "${var.env}_concourse_key_pair"
+  public_key = "${file("${path.module}/concourse_id_rsa.pub")}"
+}


### PR DESCRIPTION
## What

[Rotate credentials](https://www.pivotaltracker.com/n/projects/1275640/stories/128160309)

Generate and use a separate, concourse only ssh key for deployer concourse. This improves security and our ability to rotate credentials specific only to concourse, instead of having to rotate shared SSH key, which in practice means additional re-deployment of bosh and every VM deployed by it.

## How to review

Run bootstrap concourse pipeline. Observe new key being generated, uploaded and concourse being re-deployed using this key. In AWS you can check the keypair name for rebuilt concourse instance. Try ssh-ing to concourse using new key.

## Merging & deploying
As a part of the rotate credentials story we also want to change concourse ATC passwords. These also require re-deployment of concourse. It is possible to do this change together with this PR, saving one concourse deployment. Review (TODO: link to credentials rotate PR) and deploy concourse using new passwords after this PR is merged.

## Who can review

not @mtekel
