### PR TITLE
[#128762469] Automate the rotation of a user's password

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+load_colors() {
+  if [ -t 1 ] ; then
+    export ESC_SEQ="\x1b["
+    export COL_RESET="${ESC_SEQ}39;49;00m"
+    export COL_LIGHT="${ESC_SEQ}1m"
+    export COL_DIM="${ESC_SEQ}2m"
+    export COL_BLINK="${ESC_SEQ}5m"
+    export COL_RED="${ESC_SEQ}31m"
+    export COL_GREEN="${ESC_SEQ}32m"
+    export COL_YELLOW="${ESC_SEQ}33m"
+    export COL_BLUE="${ESC_SEQ}34m"
+    export COL_MAGENTA="${ESC_SEQ}35m"
+    export COL_CYAN="${ESC_SEQ}36m"
+  fi
+}
+
+abort() {
+  echo -e "${COL_RED:-}${COL_LIGHT:-}ERROR:${COL_RESET:-} $*" 1>&2
+  exit 1
+}
+
+info() {
+  echo -e "${COL_CYAN:-}INFO:${COL_RESET:-} $*"
+}
+
+success() {
+  echo -e "${COL_GREEN:-}SUCCESSFUL:${COL_RESET:-} $*"
+}
+
+generate_password() {
+  PASSWORD=$(LC_CTYPE=C tr -cd '[:alpha:]0-9.,;:!?_/-' < /dev/urandom | head -c32 || true)
+  if [[ -z "${PASSWORD}" ]]; then
+    abort "Failure generating password"
+  fi
+}

--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euo pipefail
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 SCRIPT=$0
+
+# shellcheck disable=SC1090
+source "${SCRIPT_DIR}/common.sh"
 
 ###########################################################################
 # Defaults
@@ -65,33 +69,11 @@ EOF
   exit 1
 }
 
-load_colors() {
-  if [ -t 1 ] ; then
-    export ESC_SEQ="\x1b["
-    export COL_RESET="${ESC_SEQ}39;49;00m"
-    export COL_LIGHT="${ESC_SEQ}1m"
-    export COL_DIM="${ESC_SEQ}2m"
-    export COL_BLINK="${ESC_SEQ}5m"
-    export COL_RED="${ESC_SEQ}31m"
-    export COL_GREEN="${ESC_SEQ}32m"
-    export COL_YELLOW="${ESC_SEQ}33m"
-    export COL_BLUE="${ESC_SEQ}34m"
-    export COL_MAGENTA="${ESC_SEQ}35m"
-    export COL_CYAN="${ESC_SEQ}36m"
-  fi
-}
-
-abort() {
-  echo -e "${COL_RED:-}${COL_LIGHT:-}ERROR:${COL_RESET:-} $*" 1>&2
-  exit 1
-}
-
 abort_usage() {
   echo -e "${COL_RED:-}${COL_LIGHT:-}ERROR:${COL_RESET:-} $*" 1>&2
   usage
   exit 1
 }
-
 
 check_params_and_environment() {
   if [ -z "${EMAIL:-}" ]; then

--- a/scripts/rotate-user-password.sh
+++ b/scripts/rotate-user-password.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+SCRIPT=$(basename "$0")
+
+# shellcheck disable=SC1090
+source "${SCRIPT_DIR}/common.sh"
+
+FROM_ADDRESS='the-multi-cloud-paas-team@digital.cabinet-office.gov.uk'
+SUBJECT='Government PaaS Password Reset Request'
+# shellcheck disable=SC2016
+MESSAGE='Hello,
+
+We have received a request to reset the password associated with this email address.
+
+Your new password is: ${PASSWORD}
+
+For guidance on logging in and changing your password you can visit:
+https://government-paas-developer-docs.readthedocs.io/en/latest/getting_started/quick_setup_guide/#setting-up-the-command-line
+
+You should make sure to change your password, as explained in the documentation in the above link.
+
+Regards,
+Government PaaS team.
+'
+
+usage() {
+  cat <<EOF
+
+Usage:
+
+  ./$SCRIPT -e \$ENV -u \$USERNAME
+
+Example:
+
+  ./$SCRIPT -e prod -u user@example.com
+
+Description:
+
+  This script will generate a new password for an existing user, change their password to the newly generated one, and then email them the password.
+
+Requirements:
+
+  * You must set the \$DEPLOY_ENV environment variable
+  * You must have a functional aws client with credentials configured.
+  * You must have the UAA Command Line Interface installed
+  * The user must already exist
+
+EOF
+  exit 1
+}
+
+if [[ $# -lt 2 ]]
+then
+  usage
+fi
+
+while [[ $# -gt 1 ]]
+do
+key="$1"
+
+case $key in
+  -e|--env)
+  ENVIRONMENT="$2"
+  shift # past argument
+  ;;
+  -u|--username)
+  USERNAME="$2"
+  ;;
+  *)
+  echo "You have passed an unknown option: $key" >&2
+  usage
+  ;;
+esac
+shift # past argument or value
+done
+
+check_environment() {
+  if ! [[ "${ENVIRONMENT:-}" =~ ^(dev|ci|staging|prod)$ ]]; then
+    abort "You must supply an -e option with one of: dev|ci|staging|prod"
+  fi
+}
+
+check_params_and_environment() {
+
+  if [ -z "${USERNAME:-}" ]; then
+    echo "Username must be defined." >&2
+    usage
+  fi
+
+  local email_expr="^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}$"
+  if ! [[ "${USERNAME}" =~ ${email_expr} ]]; then
+    abort "The username must be a valid email address"
+  fi
+
+  if ! aws ses get-send-quota >/dev/null 2>&1; then
+    abort "You must have AWS cli installed and configured with valid credentials. Test it with: aws ses get-send-quota"
+  fi
+
+}
+
+check_deploy_env_set() {
+  if [ -z "${DEPLOY_ENV:-}" ]; then
+    echo "You must set the \$DEPLOY_ENV variable." >&2
+    exit 1
+  fi
+}
+
+set_uaac_target() {
+  SKIP_SSL_VALIDATION=""
+  case "$ENVIRONMENT" in
+    dev)
+    TARGET="https://uaa.${DEPLOY_ENV}.dev.cloudpipeline.digital"
+    SKIP_SSL_VALIDATION="--skip-ssl-validation"
+    ;;
+    ci)
+    TARGET="https://uaa.${DEPLOY_ENV}.ci.cloudpipeline.digital"
+    SKIP_SSL_VALIDATION="--skip-ssl-validation"
+    ;;
+    staging)
+    TARGET="https://uaa.staging.cloudpipeline.digital"
+    ;;
+    prod)
+    TARGET="https://uaa.cloud.service.gov.uk"
+    ;;
+  esac
+  echo
+  info "Setting uaac target:"
+  echo uaac target "$TARGET" ${SKIP_SSL_VALIDATION}
+  uaac target "$TARGET" ${SKIP_SSL_VALIDATION}
+}
+
+set_uaac_context() {
+  info "Fetching uaa_admin_client_secret using AWS cli."
+  echo
+  UAA_ADMIN_CLIENT_SECRET=$(aws s3 cp s3://"${DEPLOY_ENV}"-state/cf-secrets.yml - | awk '/uaa_admin_client_secret/ {print $2}')
+  info "Setting uaac client token:"
+  echo uaac token client get admin -s REDACTED
+  echo
+  uaac token client get admin -s "$UAA_ADMIN_CLIENT_SECRET"
+}
+
+change_password() {
+  info "Changing user password:"
+  echo uaac password set "${USERNAME}" -p REDACTED
+  uaac password set "${USERNAME}" -p "${PASSWORD}"
+}
+
+# Expand variables from subject, escaping quotes
+get_subject() {
+  eval "echo ${SUBJECT}" | \
+    awk '{gsub(/"/, "\\\""); print }'
+}
+
+# Expand variables from message body, escaping new lines and quotes
+get_body() {
+  eval "echo \"${MESSAGE}\"" | \
+    awk '{gsub(/"/, "\\\""); printf "%s\\n", $0}'
+}
+
+send_mail() {
+  MESSAGE_JSON="
+  {
+    \"Subject\": {
+      \"Data\": \"$(get_subject)\",
+      \"Charset\": \"utf8\"
+    },
+    \"Body\": {
+      \"Text\": {
+        \"Data\": \"$(get_body)\",
+        \"Charset\": \"utf8\"
+      }
+    }
+  }
+  "
+
+  aws ses send-email \
+    --destination "ToAddresses=${USERNAME}" \
+    --message "${MESSAGE_JSON}"\
+    --from "${FROM_ADDRESS}"  \
+    --region eu-west-1 \
+    --output text > /dev/null
+
+  success "An email has been sent to ${USERNAME} with their new credentials."
+  echo
+}
+
+delete_token() {
+  info "Deleting your uaac token..."
+  uaac token delete
+  info "Token deleted"
+  echo
+}
+
+load_colors
+check_deploy_env_set
+check_environment
+check_params_and_environment
+set_uaac_target
+set_uaac_context
+generate_password
+change_password
+send_mail
+delete_token


### PR DESCRIPTION
## What

[#128762469](https://www.pivotaltracker.com/n/projects/1275640/stories/128762469)

We want an automated, repeatable, and standardised way of rotating a Cloud Foundry user's password and emailing it to them when they are unable to log in.
    
Common functions have been taken from the `create-user.sh` script, so they have been split into a separate file.
    
Run the script without arguments to see its documentation.

## How to review

There may be an advantage of testing this with a non-Mac user. In theory this should be tested in all environments, but production is the only likely place this script will need to be used.

* Choose an email address you have access to, it will be used for a test user.
* For the dev environment you will need to run `aws ses verify-email-identity --email-address` and pass the email address you have chosen. Follow the link in the email to verify the email with AWS.
* Create a user using the `create-user.sh` script with the email address you have chosen.
* Login using `cf login` to check the user is set up correctly, then log out (`cf logout`).
* Run the `rotate-user-password.sh` script to rotate the password. 
* Check you received the email and use the password in it to log in.
* Delete any users left in persistent environments (log in as admin and `cf delete-user $EMAIL`).

## Who can review

Anyone but myself