### PR TITLE
Re-tidy secret-generators after lint auto-correct

### DIFF
--- a/manifests/bosh-manifest/scripts/generate-bosh-secrets.rb
+++ b/manifests/bosh-manifest/scripts/generate-bosh-secrets.rb
@@ -4,13 +4,15 @@ require 'optparse'
 require 'yaml'
 require File.expand_path("../../../shared/lib/secret_generator", __FILE__)
 
-generator = SecretGenerator.new("bosh_postgres_password" => :simple,
+generator = SecretGenerator.new(
+  "bosh_postgres_password" => :simple,
   "bosh_nats_password" => :simple,
   "bosh_registry_password" => :simple,
   "bosh_redis_password" => :simple,
   "bosh_hm_director_password" => :simple,
   "bosh_admin_password" => :simple,
-  "bosh_vcap_password" => :sha512_crypted)
+  "bosh_vcap_password" => :sha512_crypted,
+)
 
 option_parser = OptionParser.new do |opts|
   opts.on('--existing-secrets FILE') do |file|

--- a/manifests/cf-manifest/scripts/generate-cf-secrets.rb
+++ b/manifests/cf-manifest/scripts/generate-cf-secrets.rb
@@ -4,7 +4,8 @@ require 'optparse'
 require 'yaml'
 require File.expand_path("../../../shared/lib/secret_generator", __FILE__)
 
-generator = SecretGenerator.new("vcap_password" => :sha512_crypted,
+generator = SecretGenerator.new(
+  "vcap_password" => :sha512_crypted,
   "cf_db_master_password" => :simple,
   "cf_db_api_password" => :simple,
   "cf_db_uaa_password" => :simple,
@@ -33,7 +34,8 @@ generator = SecretGenerator.new("vcap_password" => :sha512_crypted,
   "rds_broker_admin_password" => :simple,
   "rds_broker_master_password_seed" => :simple,
   "rds_broker_state_encryption_key" => :simple,
-  "ssh_proxy_host_key" => :ssh_key)
+  "ssh_proxy_host_key" => :ssh_key,
+)
 
 option_parser = OptionParser.new do |opts|
   opts.on('--existing-secrets FILE') do |file|

--- a/manifests/concourse-manifest/scripts/generate-concourse-secrets.rb
+++ b/manifests/concourse-manifest/scripts/generate-concourse-secrets.rb
@@ -4,8 +4,10 @@ require 'optparse'
 require 'yaml'
 require File.expand_path("../../../shared/lib/secret_generator", __FILE__)
 
-generator = SecretGenerator.new("concourse_nats_password" => :simple,
-  "concourse_vcap_password" => :sha512_crypted)
+generator = SecretGenerator.new(
+  "concourse_nats_password" => :simple,
+  "concourse_vcap_password" => :sha512_crypted,
+)
 
 option_parser = OptionParser.new do |opts|
   opts.on('--existing-secrets FILE') do |file|


### PR DESCRIPTION
## What

In the secret generates, we should have each secret definition on a line by itself to make it easier to read. The rubocop autocorrect went a bit OTT on these (in e24e653), which made
them a little harder to read.

## How to review

Review the changes and marvel at the magnificence of the new version.

## Who can review

Anyone but myself.

