### PR TITLE
[#128160309] Bosh only ssh key

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -212,11 +212,18 @@ resources:
       region_name: {{aws_region}}
       versioned_file: {{bosh_manifest_state}}
 
-  - name: ssh-private-key
+  - name: bosh-ssh-private-key
     type: s3-iam
     source:
       bucket: {{state_bucket}}
-      versioned_file: id_rsa
+      versioned_file: bosh_id_rsa
+      region_name: {{aws_region}}
+
+  - name: bosh-ssh-public-key
+    type: s3-iam
+    source:
+      bucket: {{state_bucket}}
+      versioned_file: bosh_id_rsa.pub
       region_name: {{aws_region}}
 
   - name: git-ssh-private-key
@@ -404,6 +411,9 @@ jobs:
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} cf-certs.tar.gz paas-cf/concourse/init_files/empty.tar.gz
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} cf-certs.tfstate paas-cf/concourse/init_files/terraform.tfstate.tpl
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} git-keys.tar.gz paas-cf/concourse/init_files/empty.tar.gz
+                paas-cf/concourse/scripts/s3init.sh {{state_bucket}} bosh_id_rsa paas-cf/concourse/init_files/zero_bytes
+                paas-cf/concourse/scripts/s3init.sh {{state_bucket}} bosh_id_rsa.pub paas-cf/concourse/init_files/zero_bytes
+
 
   - name: generate-secrets
     serial_groups: [cf-deploy]
@@ -419,6 +429,8 @@ jobs:
           - get: bosh-secrets
           - get: cf-certs
           - get: cf-secrets
+          - get: bosh-ssh-private-key
+          - get: bosh-ssh-public-key
 
       - task: generate-bosh-CA
         config:
@@ -484,6 +496,46 @@ jobs:
           put: bosh-secrets
           params:
             file: generated-bosh-secrets/bosh-secrets.yml
+
+      - task: generate-bosh-ssh-keypair
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/git-ssh
+          inputs:
+            - name: paas-cf
+            - name: bosh-ssh-private-key
+            - name: bosh-ssh-public-key
+          outputs:
+            - name: generated-bosh-ssh-private-key
+            - name: generated-bosh-ssh-public-key
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                if [ -s bosh-ssh-private-key/bosh_id_rsa ] ; then
+                  echo "BOSH private key non-zero size, skipping generation..."
+                  echo "Key uploads will fail and this is OK as no new keys have been generated."
+                  exit 0
+                fi
+
+                echo "Generating new ssh key pair for BOSH..."
+                ssh-keygen -t rsa -b 4096 -f bosh_id_rsa -N ''
+                cp bosh_id_rsa generated-bosh-ssh-private-key
+                cp bosh_id_rsa.pub generated-bosh-ssh-public-key
+        on_success:
+          try:
+            aggregate:
+              - put: bosh-ssh-private-key
+                params:
+                  file: generated-bosh-ssh-private-key/bosh_id_rsa
+              - put: bosh-ssh-public-key
+                params:
+                  file: generated-bosh-ssh-public-key/bosh_id_rsa.pub
 
       - task: generate-cf-certs
         config:
@@ -669,6 +721,7 @@ jobs:
           - get: bosh-tfstate
           - get: bosh-secrets
             passed: ['generate-secrets']
+          - get: bosh-ssh-public-key
 
       - task: extract-terraform-variables
         config:
@@ -709,6 +762,7 @@ jobs:
             - name: paas-cf
             - name: terraform-variables
             - name: bosh-tfstate
+            - name: bosh-ssh-public-key
           outputs:
             - name: updated-bosh-tfstate
           params:
@@ -726,7 +780,7 @@ jobs:
                 . terraform-variables/concourse.tfvars.sh
                 . terraform-variables/bosh-secrets.tfvars.sh
                 export TF_VAR_bosh_az="${BOSH_AZ}"
-
+                cp bosh-ssh-public-key/bosh_id_rsa.pub paas-cf/terraform/bosh
                 terraform apply -var env={{deploy_env}} -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
                   -state=bosh-tfstate/bosh.tfstate -state-out=updated-bosh-tfstate/bosh.tfstate paas-cf/terraform/bosh
         ensure:
@@ -848,7 +902,7 @@ jobs:
           - get: bosh-manifest
             passed: ['generate-bosh-config']
           - get: bosh-init-state
-          - get: ssh-private-key
+          - get: bosh-ssh-private-key
 
       - task: bosh-init-microbosh
         config:
@@ -860,7 +914,7 @@ jobs:
           inputs:
             - name: bosh-manifest
             - name: bosh-init-state
-            - name: ssh-private-key
+            - name: bosh-ssh-private-key
           outputs:
             - name: bosh-init-working-dir
           params:
@@ -872,8 +926,8 @@ jobs:
               - -c
               - |
                 mkdir -p bosh-init-working-dir/.ssh
-                cp ssh-private-key/id_rsa bosh-init-working-dir/.ssh/id_rsa
-                chmod 400 bosh-init-working-dir/.ssh/id_rsa
+                cp bosh-ssh-private-key/bosh_id_rsa bosh-init-working-dir/.ssh/bosh_id_rsa
+                chmod 400 bosh-init-working-dir/.ssh/bosh_id_rsa
                 cp bosh-manifest/bosh-manifest.yml bosh-init-working-dir/bosh-manifest.yml
                 cp bosh-init-state/"${BOSH_MANIFEST_STATE}" bosh-init-working-dir/bosh-manifest-state.json
                 bosh-init deploy bosh-init-working-dir/bosh-manifest.yml

--- a/manifests/bosh-manifest/deployments/015-cloud_provider.yml
+++ b/manifests/bosh-manifest/deployments/015-cloud_provider.yml
@@ -3,7 +3,7 @@ cloud_provider:
     host: (( grab terraform_outputs.bosh_fqdn ))
     port: 22
     user: vcap
-    private_key: .ssh/id_rsa
+    private_key: .ssh/bosh_id_rsa
 
   mbus: (( concat "https://mbus:" secrets.bosh_nats_password "@" terraform_outputs.bosh_fqdn ":6868" ))
 

--- a/manifests/bosh-manifest/deployments/aws/030-bosh-rds.yml
+++ b/manifests/bosh-manifest/deployments/aws/030-bosh-rds.yml
@@ -4,7 +4,6 @@ meta:
     host: (( grab terraform_outputs.bosh_db_address ))
     port: (( grab terraform_outputs.bosh_db_port ))
     user: (( grab terraform_outputs.bosh_db_username ))
-    password: (( grab terraform_outputs.bosh_db_password ))
+    password: (( grab secrets.bosh_postgres_password ))
     database: (( grab terraform_outputs.bosh_db_dbname ))
     adapter: postgres
-

--- a/manifests/bosh-manifest/deployments/aws/090-bosh-aws-stub.yml
+++ b/manifests/bosh-manifest/deployments/aws/090-bosh-aws-stub.yml
@@ -1,18 +1,17 @@
 meta:
   aws:
     common:
-      default_key_name: (( grab terraform_outputs.key_pair_name ))
       default_security_groups:
       - (( grab terraform_outputs.default_security_group ))
       region: (( grab terraform_outputs.region ))
     cloud_provider:
       credentials_source: env_or_profile
-      default_key_name: (( grab meta.aws.common.default_key_name ))
+      default_key_name: (( grab terraform_outputs.bosh_ssh_key_pair_name ))
       default_security_groups: (( grab meta.aws.common.default_security_groups ))
       region: (( grab meta.aws.common.region ))
     bosh_properties:
       credentials_source: env_or_profile
-      default_key_name: (( grab meta.aws.common.default_key_name ))
+      default_key_name: (( grab terraform_outputs.key_pair_name ))
       default_security_groups: (( grab meta.aws.common.default_security_groups ))
       default_iam_instance_profile: bosh-managed
       region: (( grab meta.aws.common.region ))
@@ -30,5 +29,3 @@ jobs:
   properties:
     aws: (( grab meta.aws.bosh_properties ))
     dns: null
-
-

--- a/manifests/bosh-manifest/spec/fixtures/bosh-terraform-outputs.yml
+++ b/manifests/bosh-manifest/spec/fixtures/bosh-terraform-outputs.yml
@@ -21,3 +21,4 @@ terraform_outputs:
   bosh_az: eu-west-1a
   bosh_default_gw: 10.0.0.1
   bosh_subnet_cidr: 10.0.0.0/24
+  bosh_ssh_key_pair_name: bosh_keypair

--- a/manifests/bosh-manifest/spec/fixtures/bosh-terraform-outputs.yml
+++ b/manifests/bosh-manifest/spec/fixtures/bosh-terraform-outputs.yml
@@ -10,8 +10,6 @@ terraform_outputs:
   microbosh_static_private_ip: 10.0.0.6
   microbosh_static_public_ip: 194.1.2.4
   region: eu-west-1
-  zone0: eu-west-1a
-  zone1: eu-west-1b
   bosh_db_address: 1.2.3.4
   bosh_db_port: 5432
   bosh_db_username: bosh

--- a/manifests/bosh-manifest/spec/fixtures/bosh-terraform-outputs.yml
+++ b/manifests/bosh-manifest/spec/fixtures/bosh-terraform-outputs.yml
@@ -13,7 +13,6 @@ terraform_outputs:
   bosh_db_address: 1.2.3.4
   bosh_db_port: 5432
   bosh_db_username: bosh
-  bosh_db_password: BOSH_POSTGRES_PASSWORD
   bosh_db_dbname: bosh
   bosh_fqdn: bosh.example.com
   bosh_az: eu-west-1a

--- a/manifests/bosh-manifest/spec/fixtures/vpc-terraform-outputs.yml
+++ b/manifests/bosh-manifest/spec/fixtures/vpc-terraform-outputs.yml
@@ -1,13 +1,3 @@
 ---
 terraform_outputs:
-  environment: test
-  infra_subnet_ids: subnet-12345678,subnet-23456789
   key_pair_name: ssh_key_pair
-  region: eu-west-1
-  ssh_security_group: alext-office-access-ssh
-  subnet0_id: subnet-12345678
-  vpc_cidr: 10.0.0.0/16
-  vpc_id: vpc-12345678
-  zone0: eu-west-1a
-  zone1: eu-west-1b
-  zone2: eu-west-1c

--- a/terraform/bosh/outputs.tf
+++ b/terraform/bosh/outputs.tf
@@ -81,3 +81,7 @@ output "bosh_az" {
 output "bosh_fqdn" {
   value = "${aws_route53_record.bosh.name}"
 }
+
+output "bosh_ssh_key_pair_name" {
+  value = "${aws_key_pair.bosh_ssh_key_pair.key_name}"
+}

--- a/terraform/bosh/outputs.tf
+++ b/terraform/bosh/outputs.tf
@@ -66,10 +66,6 @@ output "bosh_db_username" {
   value = "${aws_db_instance.bosh.username}"
 }
 
-output "bosh_db_password" {
-  value = "${aws_db_instance.bosh.password}"
-}
-
 output "bosh_db_dbname" {
   value = "${aws_db_instance.bosh.name}"
 }

--- a/terraform/bosh/ssh-key-pair.tf
+++ b/terraform/bosh/ssh-key-pair.tf
@@ -1,0 +1,4 @@
+resource "aws_key_pair" "bosh_ssh_key_pair" {
+  key_name = "${var.env}_bosh_ssh_key_pair"
+  public_key = "${file("${path.module}/bosh_id_rsa.pub")}"
+}


### PR DESCRIPTION
## What

[Rotate credentials](https://www.pivotaltracker.com/n/projects/1275640/stories/128160309)

## How to review

Run `create-bosh-cloudfoundry` pipeline. Observe new key being generated, uploaded to AWS by terraform and applied on BOSH server (which due to how bosh-init works will cause re-deployment). After deploying, you can check in AWS what key is BOSH using & compare that to key used by bosh deployed VMs.

## Implementation

Compared to https://github.com/alphagov/paas-cf/pull/437 , I have used (a different) mechanism of setting and getting the keys which is used in `create-bosh-cloudfoundry` pipeline, with a slight modification:
* use s3init to initialize empty files (so that we can `get` something instead of being blocked)
* use s3iam resource to `get` and `put` keys
* (new) only `put` keys when new ones are generated. This will cause upload jobs of generated keys to fail when there's nothing to upload, but it will not break the pipeline execution, as this is in `ensure` block. The advantages are:
  1. faster execution (as key only gets generated & uploaded when it is not present in state bucket)
  2. less concourse resources used (no need to create containers for put steps every time) 
  3. better caching - as there is not a "new" version of the resource after every put
  4. less storage used in the bucket (we don't re-upload the same file again) - less $ spent
  5. better auditability - bucked only contains file versions which have been used. We can track when new key was generated by upload times.

## Who can review

not @mtekel
