### PR TITLE
[#128160309] Generate deployment key in deployer concourse

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -226,6 +226,21 @@ resources:
       versioned_file: bosh_id_rsa.pub
       region_name: {{aws_region}}
 
+  - name: ssh-private-key
+    type: s3-iam
+    source:
+      bucket: {{state_bucket}}
+      versioned_file: id_rsa
+      region_name: {{aws_region}}
+
+  - name: ssh-public-key
+    type: s3-iam
+    source:
+      bucket: {{state_bucket}}
+      versioned_file: id_rsa.pub
+      region_name: {{aws_region}}
+
+
   - name: git-ssh-private-key
     type: s3-iam
     source:
@@ -431,6 +446,8 @@ jobs:
           - get: cf-secrets
           - get: bosh-ssh-private-key
           - get: bosh-ssh-public-key
+          - get: ssh-private-key
+          - get: ssh-public-key
 
       - task: generate-bosh-CA
         config:
@@ -536,6 +553,46 @@ jobs:
               - put: bosh-ssh-public-key
                 params:
                   file: generated-bosh-ssh-public-key/bosh_id_rsa.pub
+
+      - task: generate-deployments-ssh-keypair
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/git-ssh
+          inputs:
+            - name: paas-cf
+            - name: ssh-private-key
+            - name: ssh-public-key
+          outputs:
+            - name: generated-ssh-private-key
+            - name: generated-ssh-public-key
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                if [ -s ssh-private-key/id_rsa ] ; then
+                  echo "Deployments private key non-zero size, skipping generation..."
+                  echo "Key uploads will fail and this is OK as no new keys have been generated."
+                  exit 0
+                fi
+
+                echo "Generating new ssh key pair for deployments..."
+                ssh-keygen -t rsa -b 4096 -f id_rsa -N ''
+                cp id_rsa generated-ssh-private-key
+                cp id_rsa.pub generated-ssh-public-key
+        on_success:
+          try:
+            aggregate:
+              - put: ssh-private-key
+                params:
+                  file: generated-ssh-private-key/id_rsa
+              - put: ssh-public-key
+                params:
+                  file: generated-ssh-public-key/id_rsa.pub
 
       - task: generate-cf-certs
         config:
@@ -722,6 +779,7 @@ jobs:
           - get: bosh-secrets
             passed: ['generate-secrets']
           - get: bosh-ssh-public-key
+          - get: ssh-public-key
 
       - task: extract-terraform-variables
         config:
@@ -763,6 +821,7 @@ jobs:
             - name: terraform-variables
             - name: bosh-tfstate
             - name: bosh-ssh-public-key
+            - name: ssh-public-key
           outputs:
             - name: updated-bosh-tfstate
           params:
@@ -780,6 +839,7 @@ jobs:
                 . terraform-variables/concourse.tfvars.sh
                 . terraform-variables/bosh-secrets.tfvars.sh
                 export TF_VAR_bosh_az="${BOSH_AZ}"
+                cp ssh-public-key/id_rsa.pub paas-cf/terraform/bosh
                 cp bosh-ssh-public-key/bosh_id_rsa.pub paas-cf/terraform/bosh
                 terraform apply -var env={{deploy_env}} -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
                   -state=bosh-tfstate/bosh.tfstate -state-out=updated-bosh-tfstate/bosh.tfstate paas-cf/terraform/bosh

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -485,183 +485,183 @@ jobs:
           params:
             file: generated-bosh-CA/bosh-CA.tar.gz
 
-      - task: generate-bosh-secrets
-        config:
-          platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: ruby
-              tag: 2.2-slim
-          inputs:
-            - name: paas-cf
-            - name: bosh-secrets
-              path: existing-bosh-secrets
-          outputs:
-            - name: generated-bosh-secrets
-          run:
-            path: sh
-            args:
-              - -e
-              - -c
-              - |
-                ./paas-cf/manifests/bosh-manifest/scripts/generate-bosh-secrets.rb \
-                  --existing-secrets existing-bosh-secrets/bosh-secrets.yml \
-                  > generated-bosh-secrets/bosh-secrets.yml
-                ls -l generated-bosh-secrets
-        on_success:
-          put: bosh-secrets
-          params:
-            file: generated-bosh-secrets/bosh-secrets.yml
+      - aggregate:
+        - task: generate-bosh-secrets
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: ruby
+                tag: 2.2-slim
+            inputs:
+              - name: paas-cf
+              - name: bosh-secrets
+                path: existing-bosh-secrets
+            outputs:
+              - name: generated-bosh-secrets
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  ./paas-cf/manifests/bosh-manifest/scripts/generate-bosh-secrets.rb \
+                    --existing-secrets existing-bosh-secrets/bosh-secrets.yml \
+                    > generated-bosh-secrets/bosh-secrets.yml
+                  ls -l generated-bosh-secrets
+          on_success:
+            put: bosh-secrets
+            params:
+              file: generated-bosh-secrets/bosh-secrets.yml
 
-      - task: generate-bosh-ssh-keypair
-        config:
-          platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/git-ssh
-          inputs:
-            - name: paas-cf
-            - name: bosh-ssh-private-key
-            - name: bosh-ssh-public-key
-          outputs:
-            - name: generated-bosh-ssh-private-key
-            - name: generated-bosh-ssh-public-key
-          run:
-            path: sh
-            args:
-              - -e
-              - -c
-              - |
-                if [ -s bosh-ssh-private-key/bosh_id_rsa ] ; then
-                  echo "BOSH private key non-zero size, skipping generation..."
-                  echo "Key uploads will fail and this is OK as no new keys have been generated."
-                  exit 0
-                fi
+        - task: generate-bosh-ssh-keypair
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/git-ssh
+            inputs:
+              - name: paas-cf
+              - name: bosh-ssh-private-key
+              - name: bosh-ssh-public-key
+            outputs:
+              - name: generated-bosh-ssh-private-key
+              - name: generated-bosh-ssh-public-key
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  if [ -s bosh-ssh-private-key/bosh_id_rsa ] ; then
+                    echo "BOSH private key non-zero size, skipping generation..."
+                    echo "Key uploads will fail and this is OK as no new keys have been generated."
+                    exit 0
+                  fi
 
-                echo "Generating new ssh key pair for BOSH..."
-                ssh-keygen -t rsa -b 4096 -f bosh_id_rsa -N ''
-                cp bosh_id_rsa generated-bosh-ssh-private-key
-                cp bosh_id_rsa.pub generated-bosh-ssh-public-key
-        on_success:
-          try:
-            aggregate:
-              - put: bosh-ssh-private-key
-                params:
-                  file: generated-bosh-ssh-private-key/bosh_id_rsa
-              - put: bosh-ssh-public-key
-                params:
-                  file: generated-bosh-ssh-public-key/bosh_id_rsa.pub
+                  echo "Generating new ssh key pair for BOSH..."
+                  ssh-keygen -t rsa -b 4096 -f bosh_id_rsa -N ''
+                  cp bosh_id_rsa generated-bosh-ssh-private-key
+                  cp bosh_id_rsa.pub generated-bosh-ssh-public-key
+          on_success:
+            try:
+              aggregate:
+                - put: bosh-ssh-private-key
+                  params:
+                    file: generated-bosh-ssh-private-key/bosh_id_rsa
+                - put: bosh-ssh-public-key
+                  params:
+                    file: generated-bosh-ssh-public-key/bosh_id_rsa.pub
 
-      - task: generate-deployments-ssh-keypair
-        config:
-          platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/git-ssh
-          inputs:
-            - name: paas-cf
-            - name: ssh-private-key
-            - name: ssh-public-key
-          outputs:
-            - name: generated-ssh-private-key
-            - name: generated-ssh-public-key
-          run:
-            path: sh
-            args:
-              - -e
-              - -c
-              - |
-                if [ -s ssh-private-key/id_rsa ] ; then
-                  echo "Deployments private key non-zero size, skipping generation..."
-                  echo "Key uploads will fail and this is OK as no new keys have been generated."
-                  exit 0
-                fi
+        - task: generate-deployments-ssh-keypair
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/git-ssh
+            inputs:
+              - name: paas-cf
+              - name: ssh-private-key
+              - name: ssh-public-key
+            outputs:
+              - name: generated-ssh-private-key
+              - name: generated-ssh-public-key
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  if [ -s ssh-private-key/id_rsa ] ; then
+                    echo "Deployments private key non-zero size, skipping generation..."
+                    echo "Key uploads will fail and this is OK as no new keys have been generated."
+                    exit 0
+                  fi
 
-                echo "Generating new ssh key pair for deployments..."
-                ssh-keygen -t rsa -b 4096 -f id_rsa -N ''
-                cp id_rsa generated-ssh-private-key
-                cp id_rsa.pub generated-ssh-public-key
-        on_success:
-          try:
-            aggregate:
-              - put: ssh-private-key
-                params:
-                  file: generated-ssh-private-key/id_rsa
-              - put: ssh-public-key
-                params:
-                  file: generated-ssh-public-key/id_rsa.pub
+                  echo "Generating new ssh key pair for deployments..."
+                  ssh-keygen -t rsa -b 4096 -f id_rsa -N ''
+                  cp id_rsa generated-ssh-private-key
+                  cp id_rsa.pub generated-ssh-public-key
+          on_success:
+            try:
+              aggregate:
+                - put: ssh-private-key
+                  params:
+                    file: generated-ssh-private-key/id_rsa
+                - put: ssh-public-key
+                  params:
+                    file: generated-ssh-public-key/id_rsa.pub
 
-      - task: generate-cf-certs
-        config:
-          platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/certstrap
-          inputs:
-            - name: bosh-CA
-            - name: paas-cf
-            - name: cf-certs
-          outputs:
-            - name: generated-cf-certs
-          params:
-            SYSTEM_DNS_ZONE_NAME: {{system_dns_zone_name}}
-            APPS_DNS_ZONE_NAME: {{apps_dns_zone_name}}
-          run:
-            path: sh
-            args:
-              - -e
-              - -c
-              - |
-                mkdir certs
-                echo "Extracting extant certs"
-                tar -xvzf cf-certs/cf-certs.tar.gz -C certs
+        - task: generate-cf-certs
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/certstrap
+            inputs:
+              - name: bosh-CA
+              - name: paas-cf
+              - name: cf-certs
+            outputs:
+              - name: generated-cf-certs
+            params:
+              SYSTEM_DNS_ZONE_NAME: {{system_dns_zone_name}}
+              APPS_DNS_ZONE_NAME: {{apps_dns_zone_name}}
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  mkdir certs
+                  echo "Extracting extant certs"
+                  tar -xvzf cf-certs/cf-certs.tar.gz -C certs
 
-                ./paas-cf/manifests/cf-manifest/scripts/generate-cf-certs.sh certs bosh-CA/bosh-CA.tar.gz
+                  ./paas-cf/manifests/cf-manifest/scripts/generate-cf-certs.sh certs bosh-CA/bosh-CA.tar.gz
 
-                echo "Generating uaa_jwt_signing public key from private key"
-                openssl rsa -pubout -in certs/uaa_jwt_signing.key -out certs/uaa_jwt_verification.pem
+                  echo "Generating uaa_jwt_signing public key from private key"
+                  openssl rsa -pubout -in certs/uaa_jwt_signing.key -out certs/uaa_jwt_verification.pem
 
-                echo "Creating updated cert tarball"
-                cd certs
-                tar -cvzf ../generated-cf-certs/cf-certs.tar.gz .
-        on_success:
-          put: cf-certs
-          params:
-            file: generated-cf-certs/cf-certs.tar.gz
+                  echo "Creating updated cert tarball"
+                  cd certs
+                  tar -cvzf ../generated-cf-certs/cf-certs.tar.gz .
+          on_success:
+            put: cf-certs
+            params:
+              file: generated-cf-certs/cf-certs.tar.gz
 
-      - task: generate-cf-secrets
-        config:
-          platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: ruby
-              tag: 2.2-slim
-          inputs:
-            - name: paas-cf
-            - name: cf-secrets
-              path: existing-cf-secrets
-          outputs:
-            - name: generated-cf-secrets
-          run:
-            path: sh
-            args:
-              - -c
-              - -e
-              - |
-                ./paas-cf/manifests/cf-manifest/scripts/generate-cf-secrets.rb \
-                  --existing-secrets existing-cf-secrets/cf-secrets.yml \
-                  > generated-cf-secrets/cf-secrets.yml
-                ls -l generated-cf-secrets
-        on_success:
-          put: cf-secrets
-          params:
-            file: generated-cf-secrets/cf-secrets.yml
-
+        - task: generate-cf-secrets
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: ruby
+                tag: 2.2-slim
+            inputs:
+              - name: paas-cf
+              - name: cf-secrets
+                path: existing-cf-secrets
+            outputs:
+              - name: generated-cf-secrets
+            run:
+              path: sh
+              args:
+                - -c
+                - -e
+                - |
+                  ./paas-cf/manifests/cf-manifest/scripts/generate-cf-secrets.rb \
+                    --existing-secrets existing-cf-secrets/cf-secrets.yml \
+                    > generated-cf-secrets/cf-secrets.yml
+                  ls -l generated-cf-secrets
+          on_success:
+            put: cf-secrets
+            params:
+              file: generated-cf-secrets/cf-secrets.yml
 
   - name: pre-deploy
     plan:

--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -60,13 +60,6 @@ resources:
       versioned_file: concourse-manifest.yml
       region_name: {{aws_region}}
 
-  - name: ssh-private-key
-    type: s3-iam
-    source:
-      bucket: {{state_bucket}}
-      versioned_file: id_rsa
-      region_name: {{aws_region}}
-
   - name: concourse-ssh-private-key
     type: s3-iam
     source:
@@ -172,7 +165,7 @@ jobs:
       passed: ['init-bucket']
     - get: vpc-terraform-state
 
-    - task: generate-ssh-keys
+    - task: generate-git-ssh-key
       config:
         image: docker:///governmentpaas/curl-ssl
         inputs:
@@ -189,9 +182,6 @@ jobs:
           - |
             apk add --update openssh
             cd ssh-keys
-            ssh-keygen -t rsa -b 4096 -f generated_id_rsa -N ''
-            ../paas-cf/concourse/scripts/s3init.sh {{state_bucket}} id_rsa generated_id_rsa
-            ../paas-cf/concourse/scripts/s3init.sh {{state_bucket}} id_rsa.pub generated_id_rsa.pub
             ssh-keygen -t rsa -b 4096 -f generated_git_id_rsa -N ''
             ../paas-cf/concourse/scripts/s3init.sh {{state_bucket}} git_id_rsa generated_git_id_rsa
             ../paas-cf/concourse/scripts/s3init.sh {{state_bucket}} git_id_rsa.pub generated_git_id_rsa.pub
@@ -214,7 +204,6 @@ jobs:
           - -e
           - -c
           - |
-            cp ssh-keys/id_rsa.pub paas-cf/terraform/vpc
             terraform_params=${VAGRANT_IP:+-var vagrant_cidr=$VAGRANT_IP/32}
             terraform apply ${terraform_params} -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
               -state=vpc-terraform-state/vpc.tfstate -state-out=vpc.tfstate paas-cf/terraform/vpc

--- a/manifests/bosh-manifest/spec/fixtures/bosh-terraform-outputs.yml
+++ b/manifests/bosh-manifest/spec/fixtures/bosh-terraform-outputs.yml
@@ -19,3 +19,4 @@ terraform_outputs:
   bosh_default_gw: 10.0.0.1
   bosh_subnet_cidr: 10.0.0.0/24
   bosh_ssh_key_pair_name: bosh_keypair
+  key_pair_name: ssh_key_pair

--- a/manifests/bosh-manifest/spec/fixtures/vpc-terraform-outputs.yml
+++ b/manifests/bosh-manifest/spec/fixtures/vpc-terraform-outputs.yml
@@ -1,3 +1,0 @@
----
-terraform_outputs:
-  key_pair_name: ssh_key_pair

--- a/manifests/bosh-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/bosh-manifest/spec/support/manifest_helpers.rb
@@ -23,7 +23,6 @@ private
         File.expand_path("../../fixtures/bosh-secrets.yml", __FILE__),
         File.expand_path("../../fixtures/bosh-ssl-certificates.yml", __FILE__),
         File.expand_path("../../fixtures/bosh-terraform-outputs.yml", __FILE__),
-        File.expand_path("../../fixtures/vpc-terraform-outputs.yml", __FILE__),
         File.expand_path("../../../../shared/deployments/collectd.yml", __FILE__)
       ].join(' ')
     )

--- a/terraform/bosh/outputs.tf
+++ b/terraform/bosh/outputs.tf
@@ -81,3 +81,7 @@ output "bosh_fqdn" {
 output "bosh_ssh_key_pair_name" {
   value = "${aws_key_pair.bosh_ssh_key_pair.key_name}"
 }
+
+output "key_pair_name" {
+  value = "${aws_key_pair.env_key_pair.key_name}"
+}

--- a/terraform/bosh/ssh-key-pairs.tf
+++ b/terraform/bosh/ssh-key-pairs.tf
@@ -2,3 +2,8 @@ resource "aws_key_pair" "bosh_ssh_key_pair" {
   key_name = "${var.env}_bosh_ssh_key_pair"
   public_key = "${file("${path.module}/bosh_id_rsa.pub")}"
 }
+
+resource "aws_key_pair" "env_key_pair" {
+  key_name = "${var.env}_key_pair"
+  public_key = "${file("${path.module}/id_rsa.pub")}"
+}

--- a/terraform/vpc/outputs.tf
+++ b/terraform/vpc/outputs.tf
@@ -34,10 +34,6 @@ output "zone2" {
   value = "${var.zones.zone2}"
 }
 
-output "key_pair_name" {
-  value = "${aws_key_pair.env_key_pair.key_name}"
-}
-
 output "infra_subnet_ids" {
   value = "${join(",", aws_subnet.infra.*.id)}"
 }

--- a/terraform/vpc/ssh-key-pair.tf
+++ b/terraform/vpc/ssh-key-pair.tf
@@ -1,4 +1,0 @@
-resource "aws_key_pair" "env_key_pair" {
-  key_name = "${var.env}_key_pair"
-  public_key = "${file("${path.module}/id_rsa.pub")}"
-}


### PR DESCRIPTION
## What

Because we have now separate keys for concourse (#437) and BOSH (#441) we can move "deployment ssh key" generation to create-bosh-cf pipeline.

This is the key that BOSH uses for all the VMs it deploys. The key has thus be already available for BOSH creation, therefore we move it from VPC terraform (and outputs) to BOSH terraform. We generate it at the same time we generate other deployment credentials.

Advantage of having this key generated in `create-bosh-cloudfoundry` pipeline is that you don't have to start deployer concourse in order to generate new keys. Also, this key is not used by concourse any more (#437), meaning we don't have to handle it during the bootstrap already.

## How to review

Run bootstrap pipeline first. Observe key being removed from AWS, as it is removed from VPC terraform. Then run create-bosh-cf pipeline. Check key (be attepmted to) be generated in generate secrets job. Observe bosh terraform run uploading the same key under the same name back into AWS. (if you don't run bootstrap pipeline first, this step will fail as key with that name would already exist). The rest of pipeline should complete without any changes.

## Merging
#437 and #441 should be merged first. Then this PR re-based on master. Then it can be merged.

## Who can review

not @mtekel