### PR TITLE
Aggregate the gets in continuous smoke tests

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -2275,19 +2275,20 @@ jobs:
     serial_groups: [smoke-tests]
     build_logs_to_retain: 10000
     plan:
-      - get: cf-release
-        params:
-          submodules:
-            - src/smoke-tests
-      - get: paas-cf
-        passed: ['cf-deploy']
-      - get: cf-manifest
-        passed: ['cf-deploy']
-      - get: bosh-CA
-      - get: smoke-tests-timer
-        trigger: {{continuous_smoke_tests_trigger}}
-      - get: cf-secrets
-        passed: ['cf-deploy']
+      - aggregate:
+        - get: cf-release
+          params:
+            submodules:
+              - src/smoke-tests
+        - get: paas-cf
+          passed: ['cf-deploy']
+        - get: cf-manifest
+          passed: ['cf-deploy']
+        - get: bosh-CA
+        - get: smoke-tests-timer
+          trigger: {{continuous_smoke_tests_trigger}}
+        - get: cf-secrets
+          passed: ['cf-deploy']
 
       - do:
         - task: create-temp-user


### PR DESCRIPTION
## What

Improves startup time of continuous smoke tests. Requested in the paas-improvements spreadsheet, implemented during support.

## How to review

Run the pipeline and observe it completes.

## Who can review

Someone other than @jonty.