### PR TITLE
[#128492081] Increase the RDS creation timeout

### DIFF
--- a/platform-tests/src/acceptance/rds_broker_test.go
+++ b/platform-tests/src/acceptance/rds_broker_test.go
@@ -38,7 +38,7 @@ var _ = Describe("RDS broker", func() {
 		// slow (several minutes).
 
 		const (
-			DB_CREATE_TIMEOUT = 15 * time.Minute
+			DB_CREATE_TIMEOUT = 30 * time.Minute
 			testPlanName      = "M-dedicated-9.5"
 		)
 


### PR DESCRIPTION
## What

While RDS instances take <10mins to create once the creation starts, we're seeing the creation itself not start for quite some time after it's requested. This is leading to the the tests failing and orphaned RDS instances being left behind.

Doubling the creation time should hopefully avoid this problem, but we should also query this with AWS themselves as we're frequently seeing extended creation times.

## How to review

Run the pipeline, observe the custom acceptance tests passing.

## Who can review

Not me, guv.