### PR TITLE
[#128845965] Revert "Cleanup users with no username"

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1574,44 +1574,6 @@ jobs:
                   bundle
                   bundle exec sync-admin-users.rb ${API_ENDPOINT} ../config/admin_users.yml "{{NEW_ACCOUNT_EMAIL_ADDRESS}}"
 
-        - task: purge-unnamed-users
-          config:
-            platform: linux
-            inputs:
-              - name: paas-cf
-              - name: bosh-CA
-              - name: config
-              - name: cf-manifest
-            params:
-            image_resource:
-              type: docker-image
-              source:
-                repository: governmentpaas/cf-cli
-            run:
-              path: sh
-              args:
-                - -e
-                - -u
-                - -c
-                - |
-                  ./paas-cf/concourse/scripts/import_bosh_ca.sh
-                  . ./config/config.sh
-                  echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}"
-
-                  url="/v2/users"
-                  while [ "${url}" != "null" ] ; do
-                    cf curl $url > users.json
-                    # Identify users with null usernames - they were leaked by
-                    # deleting the user with uaac
-                    cat users.json \
-                       | jq -r '.resources[] | select(.entity.username == null) | .metadata.guid' >> users_to_delete
-
-                    # See if there's another page of data.  If "next_url" is null we can stop
-                    url=$(cat users.json | jq -r ".next_url")
-                  done
-
-                  # Schedule deletions
-                  cat users_to_delete |  xargs -t -r -I {} cf curl -X DELETE /v2/users/{}?async=true
         - task: register-rds-broker
           config:
             platform: linux


### PR DESCRIPTION
## What

This reverts commit c39578ee7261336fb0f5b30c59af46bcf4e8b7fd.

The script is no longer needed now that: it has run in all persistent
environments (including production) and we have changed the tests in 7b63a98
to no longer leave these users behind.

Furthermore we had some concerns about the safety of running this long term,
as it is deleting users and we don't have any tests around it.

## How to review

1. Deploy the pipelines from this branch.
1. Run the `cf-deploy` job (you can speed it up with `make run JOB=cf-deploy`).
1. Confirm that there isn't a `purge-unnamed-users` task within that job.

## Who can review

Not @dcarley
