### PR TITLE
secret_generator: s/ignores/removes/ in test desc

### DIFF
--- a/manifests/shared/spec/secret_generator_spec.rb
+++ b/manifests/shared/spec/secret_generator_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe SecretGenerator do
       expect(results["host_key"]["public_fingerprint"]).to eq("2345")
     end
 
-    it "ignores passwords in the existing set that aren't in the requested set" do
+    it "removes passwords in the existing set that aren't in the requested set" do
       generator.existing_secrets = {
         "other" => "something",
       }


### PR DESCRIPTION
## What

Change the test description to make it clearer that existing passwords which
are no longer "requested" will be removed from the output. This is based on
a discussion with Alex when reviewing #442, where I asked if we needed to do
this manually and he pointed out that the code already does it.

## How to review

1. Confirm that the change and commit message makes sense.
1. Confirm that Travis build passes.

## Who can review

Not @dcarley