### PR TITLE
Only deploy the graphite nozzle if missing/changed

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1779,7 +1779,7 @@ jobs:
                       PREFIX_JOB: "true"
                   EOF
 
-                  cf push
+                  ../paas-cf/concourse/scripts/cf_push_on_git_change.sh graphite-nozzle
 
         - task: update-kibana-timezone
           config:

--- a/concourse/scripts/cf_push_on_git_change.sh
+++ b/concourse/scripts/cf_push_on_git_change.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+APPNAME=$1
+VERSION=$(git rev-parse --short HEAD)
+CURRENT=$(cf apps | grep -E "^${APPNAME}-${VERSION}" | cat)
+OTHERS=$(cf apps | grep -o -E "^${APPNAME}[^ ]*" | grep -E -v "^${APPNAME}-${VERSION}" | cat)
+
+# Delete all other running instances of this app
+if [ "$OTHERS" != "" ]; then
+    echo "$OTHERS" | xargs -n1 cf delete -f
+fi
+
+# And if this version is missing, push it
+if [ "$CURRENT" = "" ]; then
+    cf push "${APPNAME}-${VERSION}"
+fi


### PR DESCRIPTION
## What

Deploying the nozzle on every run means we lose some stats from the firehose while deployments are in progress.

This deploys the graphite-nozzle with the current nozzle git shorthash in the name. If the current version is missing from the cf deployment it is pushed, and all older versions are removed.

Carried out as a support task, taken from the PaaS Improvements doc.

## How to review

Run the pipeline. The graphite-nozzle app should not be pushed or restarted.

## Who can review

Not @jonty.