### PR TITLE
Make the "small" VM type actually use t2.small

### DIFF
--- a/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
+++ b/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
@@ -9,7 +9,7 @@ vm_types:
     network: cf
     env: (( grab meta.default_env ))
     cloud_properties:
-      instance_type: m3.medium
+      instance_type: t2.small
       ephemeral_disk:
         size: 10240
         type: gp2


### PR DESCRIPTION
## What

We're currently using `m3.medium` for both "small" and "medium" VM types. Reducing the "small" VM's to being `t2.small` saves 62% of the cost per VM.

Carried out during support, task taken from the PaaS Improvements doc.

## How to review

* Deploy in an environment
* Observe all the m3.medium's being replaced with t2.small instances
* Check the platform still functions

## Who can review

Not @jonty.