### PR TITLE
[#128160309] Fix SSH to deployer concourse.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ pipelines: ## Upload pipelines to Concourse
 showenv: ## Display environment information
 	$(eval export TARGET_CONCOURSE=deployer)
 	@echo CONCOURSE_IP=$$(aws ec2 describe-instances \
-		--filters 'Name=tag:Name,Values=concourse/0' "Name=key-name,Values=${DEPLOY_ENV}_key_pair" \
+		--filters 'Name=tag:Name,Values=concourse/0' "Name=key-name,Values=${DEPLOY_ENV}_concourse_key_pair" \
 		--query 'Reservations[].Instances[].PublicIpAddress' --output text)
 	@concourse/scripts/environment.sh
 

--- a/README.md
+++ b/README.md
@@ -310,10 +310,10 @@ You can get both from command line. You will need [aws-cli](#aws-cli), to do thi
 ```
 eval $(make dev showenv | grep CONCOURSE_IP=)
 
-aws s3 cp "s3://${DEPLOY_ENV}-state/id_rsa" ./deployer_id_rsa && \
-chmod 400 deployer_id_rsa
+aws s3 cp "s3://${DEPLOY_ENV}-state/concourse_id_rsa" ./concourse_id_rsa && \
+  chmod 400 concourse_id_rsa
 
-ssh -i deployer_id_rsa -o IdentitiesOnly=yes -o UserKnownHostsFile=/dev/null vcap@$CONCOURSE_IP
+ssh -i concourse_id_rsa -o IdentitiesOnly=yes -o UserKnownHostsFile=/dev/null vcap@$CONCOURSE_IP
 ```
 
 If you get a "Too many authentication failures for vcap" message it is likely that you've got too many keys registered with your ssh-agent and it will fail to authenticate before trying the correct key - generally it will only allow three keys to be tried before disconnecting you. You can list all the keys registered with your ssh-agent with `ssh-add -l` and remove unwanted keys with `ssh-add -d PATH_TO_KEY`.


### PR DESCRIPTION
## What

#437 changed the deployer concourse to use its own ssh key. We
therefore need to update the Makefile to filter by the correct key name,
and update the instructions to fetch the correct key from S3, otherwise
access won't work.

## How to review

Verify that you can ssh to the deployer-concourse using the updated instructions/Makefile.

## Who can review

Anyone but myself.