### PR TITLE
[#128160309] Fix query of concourse IP with renamed SSH key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ pipelines: ## Upload pipelines to Concourse
 showenv: ## Display environment information
 	$(eval export TARGET_CONCOURSE=deployer)
 	@echo CONCOURSE_IP=$$(aws ec2 describe-instances \
-		--filters 'Name=tag:Name,Values=concourse/0' "Name=key-name,Values=${DEPLOY_ENV}_key_pair" \
+		--filters 'Name=tag:Name,Values=concourse/0' "Name=key-name,Values=${DEPLOY_ENV}_concourse_key_pair" \
 		--query 'Reservations[].Instances[].PublicIpAddress' --output text)
 	@concourse/scripts/environment.sh
 

--- a/README.md
+++ b/README.md
@@ -310,10 +310,10 @@ You can get both from command line. You will need [aws-cli](#aws-cli), to do thi
 ```
 eval $(make dev showenv | grep CONCOURSE_IP=)
 
-aws s3 cp "s3://${DEPLOY_ENV}-state/id_rsa" ./deployer_id_rsa && \
-chmod 400 deployer_id_rsa
+aws s3 cp "s3://${DEPLOY_ENV}-state/concourse_id_rsa" ./concourse_id_rsa && \
+  chmod 400 concourse_id_rsa
 
-ssh -i deployer_id_rsa -o IdentitiesOnly=yes -o UserKnownHostsFile=/dev/null vcap@$CONCOURSE_IP
+ssh -i concourse_id_rsa -o IdentitiesOnly=yes -o UserKnownHostsFile=/dev/null vcap@$CONCOURSE_IP
 ```
 
 If you get a "Too many authentication failures for vcap" message it is likely that you've got too many keys registered with your ssh-agent and it will fail to authenticate before trying the correct key - generally it will only allow three keys to be tried before disconnecting you. You can list all the keys registered with your ssh-agent with `ssh-add -l` and remove unwanted keys with `ssh-add -d PATH_TO_KEY`.


### PR DESCRIPTION
What
----

With the PR #437 we renamed the key associated to the concourse VM.

But that key name was used to retrieve the concourse IP when running
`make dev showenv DEPLOY_ENV=...`.

We change the name to fix the issue and be able to retrieve the IP from
concourse.

How to test?
------------

run  `make dev showenv DEPLOY_ENV=...` with and without this patch

Who?
---

Anyone but @keymon