### PR TITLE
[#128160309] Concourse-destroy: touch concourse ssh key

### DIFF
--- a/concourse/pipelines/destroy-deployer.yml
+++ b/concourse/pipelines/destroy-deployer.yml
@@ -132,7 +132,7 @@ jobs:
           - -c
           - |
             . vpc-terraform-outputs/tfvars.sh
-            touch concourse.crt concourse.key
+            touch concourse.crt concourse.key paas-cf/terraform/concourse/concourse_id_rsa.pub
             terraform destroy -force \
               -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
               -state=concourse-terraform-state/concourse.tfstate \


### PR DESCRIPTION
## What

Almost like in https://github.com/alphagov/paas-cf/pull/450, unblock TF destroy. It is good enough to touch the file, as TF is not checking contents against what's in AWS before destroying.

## How to review

Run destroy-deployer pipeline in your bootstrap concourse. Check that `destroy-contourse` job succeeds.

## Who can review

not @mtekel