### PR TITLE
[#128160309] Simplify key presence requirement for bosh destroy

### DIFF
--- a/concourse/pipelines/destroy-microbosh.yml
+++ b/concourse/pipelines/destroy-microbosh.yml
@@ -45,20 +45,6 @@ resources:
       region_name: {{aws_region}}
       versioned_file: {{bosh_manifest_state}}
 
-  - name: bosh-ssh-public-key
-    type: s3-iam
-    source:
-      bucket: {{state_bucket}}
-      versioned_file: bosh_id_rsa.pub
-      region_name: {{aws_region}}
-
-  - name: ssh-public-key
-    type: s3-iam
-    source:
-      bucket: {{state_bucket}}
-      versioned_file: id_rsa.pub
-      region_name: {{aws_region}}
-
   - name: bosh-manifest
     type: s3-iam
     source:
@@ -217,8 +203,6 @@ jobs:
           - get: concourse-tfstate
           - get: bosh-tfstate
           - get: bosh-secrets
-          - get: bosh-ssh-public-key
-          - get: ssh-public-key
       - task: extract-terraform-variables
         config:
           platform: linux
@@ -257,8 +241,6 @@ jobs:
             - name: paas-cf
             - name: terraform-variables
             - name: bosh-tfstate
-            - name: bosh-ssh-public-key
-            - name: ssh-public-key
           outputs:
             - name: updated-bosh-tfstate
           params:
@@ -276,8 +258,7 @@ jobs:
                 . terraform-variables/concourse.tfvars.sh
                 . terraform-variables/bosh-secrets.tfvars.sh
 
-                cp ssh-public-key/id_rsa.pub paas-cf/terraform/bosh
-                cp bosh-ssh-public-key/bosh_id_rsa.pub paas-cf/terraform/bosh
+                touch paas-cf/terraform/bosh/id_rsa.pub paas-cf/terraform/bosh/bosh_id_rsa.pub
                 terraform destroy -force -var env={{deploy_env}} -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
                   -state=bosh-tfstate/bosh.tfstate -state-out=updated-bosh-tfstate/bosh.tfstate paas-cf/terraform/bosh
         ensure:


### PR DESCRIPTION
## What

Simplify #450 : For destroy, TF doesn't really need the actual key to be present, as it never checks its contents against AWS. It is enough that empty file is present. This is similar to what we do in destroy-deployer pipeline (#455).

## How to review

Run destroy microbosh pipeline. Check that TF completes successfully.

## Who can review

not @mtekel