### PR TITLE
Adjust graphite instance

### DIFF
--- a/manifests/cf-manifest/cloud-config/040-graphite.yml
+++ b/manifests/cf-manifest/cloud-config/040-graphite.yml
@@ -11,7 +11,7 @@ vm_types:
     cloud_properties:
       instance_type: t2.medium
       ephemeral_disk:
-        size: 65536
+        size: 10240
         type: gp2
       elbs:
         - (( grab terraform_outputs.metrics_elb_name ))

--- a/manifests/cf-manifest/cloud-config/040-graphite.yml
+++ b/manifests/cf-manifest/cloud-config/040-graphite.yml
@@ -9,7 +9,7 @@ vm_types:
     network: cf
     env: (( grab meta.default_env ))
     cloud_properties:
-      instance_type: m3.large
+      instance_type: t2.medium
       ephemeral_disk:
         size: 65536
         type: gp2


### PR DESCRIPTION
## What

Reduce graphite instance ephemeral disk and instance size. There's only 0,5G usage on ephemeral disk, reduce from 64G to 10. The instance is using about 7% cpu, reduce from m3.large to t2.medium. 

## How to review

Deploy. Observe graphite being updated. Update preserves all the metrics, but creates about 3 minute gap (which is how long the update takes).

## Who can review

not @mtekel
