### PR TITLE
[#129441797] Fix role assignments in create_user.sh

### DIFF
--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -105,6 +105,14 @@ generate_password() {
 create_org_space() {
   cf create-org "${ORG}"
   cf create-space "${DEFAULT_SPACE}" -o "${ORG}"
+
+  # cf create-{org|space} has the side-effect of giving roles in the org/space
+  # to the user making the request. We don't want this, so have to undo it.
+  local admin_user
+  admin_user=$(cf target | awk '/User:/ { print $2}')
+  cf unset-org-role "${admin_user}" "${ORG}" OrgManager
+  cf unset-space-role "${admin_user}" "${ORG}" "${DEFAULT_SPACE}" SpaceManager
+  cf unset-space-role "${admin_user}" "${ORG}" "${DEFAULT_SPACE}" SpaceDeveloper
 }
 
 create_user() {


### PR DESCRIPTION
## What

When using the cf CLI to create an org or space, it automatically
assigns the user making the request roles in the created org/space.

In our use-case, we don't want this, so this PR adds steps to remove
these roles immediately after they've been created.

Note: only tangentially related to the above story, but this saves having to do it manually each time.

## How to review

* Comment out the last line of the script (`send_email`).
* `cf login` to your dev environment.
* Run the script to create a new org and user.
* Verify that your admin user does not have any roles in the new org and space.

## Who can review

Anyone but myself.
