### PR TITLE
Cleanup bosh properties

### DIFF
--- a/manifests/bosh-manifest/deployments/010-bosh-template.yml
+++ b/manifests/bosh-manifest/deployments/010-bosh-template.yml
@@ -57,7 +57,6 @@ jobs:
       disks:
         max_orphaned_age_in_days: 0
       cpi_job: (( grab cloud_provider.template.name ))
-      ignore_missing_gateway: "false"
       user_management:
         provider: local
         local:

--- a/manifests/bosh-manifest/deployments/010-bosh-template.yml
+++ b/manifests/bosh-manifest/deployments/010-bosh-template.yml
@@ -58,7 +58,6 @@ jobs:
         max_orphaned_age_in_days: 0
       cpi_job: (( grab cloud_provider.template.name ))
       user_management:
-        provider: local
         local:
           users:
             - { name: admin, password: (( grab secrets.bosh_admin_password )) }

--- a/manifests/bosh-manifest/deployments/010-bosh-template.yml
+++ b/manifests/bosh-manifest/deployments/010-bosh-template.yml
@@ -79,8 +79,6 @@ jobs:
         password: (( grab secrets.bosh_hm_director_password ))
       resurrector_enabled: false
 
-    ntp: (( grab meta.ntp ))
-
     agent:
       mbus: (( concat "nats://nats:" secrets.bosh_nats_password "@" terraform_outputs.bosh_fqdn ":4222" ))
 

--- a/manifests/bosh-manifest/deployments/010-bosh-template.yml
+++ b/manifests/bosh-manifest/deployments/010-bosh-template.yml
@@ -33,7 +33,7 @@ jobs:
   - {name: director, release: bosh}
   - {name: health_monitor, release: bosh}
 
-  resource_pool: vms
+  resource_pool: bosh
   persistent_disk_pool: disks
 
   networks:

--- a/manifests/bosh-manifest/deployments/010-bosh-template.yml
+++ b/manifests/bosh-manifest/deployments/010-bosh-template.yml
@@ -21,7 +21,7 @@ releases:
 
 disk_pools:
 - name: disks
-  disk_size: 32_768
+  disk_size: 32768
 
 jobs:
 - name: bosh

--- a/manifests/bosh-manifest/deployments/010-bosh-template.yml
+++ b/manifests/bosh-manifest/deployments/010-bosh-template.yml
@@ -2,12 +2,6 @@
 meta:
   environment: (( grab terraform_outputs.environment ))
 
-  default_dns:
-    address: (( grab meta.bosh_public_ip ))
-    domain_name: microbosh
-    db: (( grab meta.postgres ))
-    recursor: 8.8.8.8
-
   default_agent:
     mbus: (( concat "nats://nats:" secrets.bosh_nats_password "@" terraform_outputs.bosh_fqdn ":4222" ))
 
@@ -90,7 +84,5 @@ jobs:
       host: (( grab terraform_outputs.bosh_fqdn ))
       username: admin
       password: (( grab secrets.bosh_registry_password ))
-
-    dns: (( grab meta.default_dns ))
 
 properties: ~

--- a/manifests/bosh-manifest/deployments/010-bosh-template.yml
+++ b/manifests/bosh-manifest/deployments/010-bosh-template.yml
@@ -48,12 +48,10 @@ jobs:
     redis:
       password: (( grab secrets.bosh_redis_password ))
 
-    postgres: (( grab meta.postgres ))
-
     director:
       address: 127.0.0.1
       name: my-bosh
-      db: (( grab meta.postgres ))
+      db: (( grab meta.rds ))
       disks:
         max_orphaned_age_in_days: 0
       cpi_job: (( grab cloud_provider.template.name ))
@@ -73,7 +71,7 @@ jobs:
       mbus: (( concat "nats://nats:" secrets.bosh_nats_password "@" terraform_outputs.bosh_fqdn ":4222" ))
 
     registry:
-      db: (( grab meta.postgres ))
+      db: (( grab meta.rds ))
       http:
         # Properties used by director and registry jobs
         user: admin

--- a/manifests/bosh-manifest/deployments/010-bosh-template.yml
+++ b/manifests/bosh-manifest/deployments/010-bosh-template.yml
@@ -52,8 +52,6 @@ jobs:
       password: (( grab secrets.bosh_nats_password ))
 
     redis:
-      listen_address: 127.0.0.1
-      address: 127.0.0.1
       password: (( grab secrets.bosh_redis_password ))
 
     postgres: (( grab meta.postgres ))

--- a/manifests/bosh-manifest/deployments/010-bosh-template.yml
+++ b/manifests/bosh-manifest/deployments/010-bosh-template.yml
@@ -1,7 +1,5 @@
 ---
 meta:
-  environment: (( grab terraform_outputs.environment ))
-
   default_agent:
     mbus: (( concat "nats://nats:" secrets.bosh_nats_password "@" terraform_outputs.bosh_fqdn ":4222" ))
 
@@ -11,7 +9,6 @@ releases:
 - name: bosh
   url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=255.8
   sha1: 6b12652650b87810dcef1be1f6a6d23f1c0c13a7
-
 
 disk_pools:
 - name: disks

--- a/manifests/bosh-manifest/deployments/010-bosh-template.yml
+++ b/manifests/bosh-manifest/deployments/010-bosh-template.yml
@@ -83,18 +83,16 @@ jobs:
       mbus: (( concat "nats://nats:" secrets.bosh_nats_password "@" terraform_outputs.bosh_fqdn ":4222" ))
 
     registry:
-      host: (( grab terraform_outputs.bosh_fqdn ))
       db: (( grab meta.postgres ))
       http:
-        # Variables used by official job release
+        # Properties used by director and registry jobs
         user: admin
         password: (( grab secrets.bosh_registry_password ))
-      # Variables used by Google job release
+      # Properties used by AWS CPI
+      host: (( grab terraform_outputs.bosh_fqdn ))
       username: admin
       password: (( grab secrets.bosh_registry_password ))
 
     dns: (( grab meta.default_dns ))
 
 properties: ~
-
-

--- a/manifests/bosh-manifest/deployments/015-cloud_provider.yml
+++ b/manifests/bosh-manifest/deployments/015-cloud_provider.yml
@@ -13,5 +13,3 @@ cloud_provider:
     blobstore:
       provider: local
       path: /var/vcap/micro_bosh/data/cache
-    ntp: (( grab meta.ntp ))
-

--- a/manifests/bosh-manifest/deployments/020-compiled-package-cache.yml
+++ b/manifests/bosh-manifest/deployments/020-compiled-package-cache.yml
@@ -5,4 +5,3 @@ jobs:
       options:
         credentials_source: env_or_profile
         bucket_name: (( grab terraform_outputs.compiled_cache_bucket_name ))
-        host: (( grab terraform_outputs.compiled_cache_bucket_host ))

--- a/manifests/bosh-manifest/deployments/020-compiled-package-cache.yml
+++ b/manifests/bosh-manifest/deployments/020-compiled-package-cache.yml
@@ -2,10 +2,7 @@ jobs:
 - name: bosh
   properties:
     compiled_package_cache:
-      provider: s3
       options:
         credentials_source: env_or_profile
         bucket_name: (( grab terraform_outputs.compiled_cache_bucket_name ))
         host: (( grab terraform_outputs.compiled_cache_bucket_host ))
-
-

--- a/manifests/bosh-manifest/deployments/aws/000-bosh-infrastructure.yml
+++ b/manifests/bosh-manifest/deployments/aws/000-bosh-infrastructure.yml
@@ -7,7 +7,7 @@ resource_pools:
     sha1: 477371a335d172f4728c7a8806448edb9703104c
   cloud_properties:
     instance_type: t2.medium
-    ephemeral_disk: {size: 40_000, type: gp2}
+    ephemeral_disk: {size: 40000, type: gp2}
     availability_zone: (( grab terraform_outputs.bosh_az ))
     iam_instance_profile: bosh-director
   env:

--- a/manifests/bosh-manifest/deployments/aws/000-bosh-infrastructure.yml
+++ b/manifests/bosh-manifest/deployments/aws/000-bosh-infrastructure.yml
@@ -1,6 +1,6 @@
 ---
 resource_pools:
-- name: vms
+- name: bosh
   network: private
   stemcell:
     url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3232.13

--- a/manifests/bosh-manifest/deployments/aws/010-bosh-aws-cpi.yml
+++ b/manifests/bosh-manifest/deployments/aws/010-bosh-aws-cpi.yml
@@ -6,7 +6,6 @@ releases:
   url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=52
   sha1: dc4a0cca3b33dce291e4fbeb9e9948b6a7be3324
 
-
 jobs:
 - name: bosh
   templates:
@@ -20,4 +19,3 @@ cloud_provider:
 
   properties:
     aws: (( grab meta.aws.cloud_provider ))
-

--- a/manifests/bosh-manifest/deployments/aws/030-bosh-rds.yml
+++ b/manifests/bosh-manifest/deployments/aws/030-bosh-rds.yml
@@ -6,4 +6,3 @@ meta:
     user: (( grab terraform_outputs.bosh_db_username ))
     password: (( grab secrets.bosh_postgres_password ))
     database: (( grab terraform_outputs.bosh_db_dbname ))
-    adapter: postgres

--- a/manifests/bosh-manifest/deployments/aws/030-bosh-rds.yml
+++ b/manifests/bosh-manifest/deployments/aws/030-bosh-rds.yml
@@ -1,6 +1,6 @@
 ---
 meta:
-  postgres:
+  rds:
     host: (( grab terraform_outputs.bosh_db_address ))
     port: (( grab terraform_outputs.bosh_db_port ))
     user: (( grab terraform_outputs.bosh_db_username ))

--- a/manifests/bosh-manifest/deployments/aws/090-bosh-aws-stub.yml
+++ b/manifests/bosh-manifest/deployments/aws/090-bosh-aws-stub.yml
@@ -23,4 +23,3 @@ jobs:
 - name: bosh
   properties:
     aws: (( grab meta.aws.bosh_properties ))
-    dns: null

--- a/manifests/bosh-manifest/deployments/aws/090-bosh-aws-stub.yml
+++ b/manifests/bosh-manifest/deployments/aws/090-bosh-aws-stub.yml
@@ -19,11 +19,6 @@ meta:
   bosh_private_ip: (( grab terraform_outputs.microbosh_static_private_ip ))
   bosh_public_ip: (( grab terraform_outputs.microbosh_static_public_ip ))
 
-  ntp:
-  - 0.pool.ntp.org
-  - 1.pool.ntp.org
-
-
 jobs:
 - name: bosh
   properties:

--- a/manifests/bosh-manifest/spec/properties_spec.rb
+++ b/manifests/bosh-manifest/spec/properties_spec.rb
@@ -4,8 +4,18 @@ RSpec.describe "manifest properties validations" do
   let(:bosh_job) { manifest.fetch("jobs").select { |x| x["name"] == "bosh" }.first }
   let(:bosh_properties) { properties.merge(bosh_job["properties"]) }
 
-  it "uses local user management" do
-    expect(bosh_properties["director"]["user_management"]["provider"]).to eq("local")
+  it "configures hm bosh user with password" do
+    users = bosh_properties["director"]["user_management"]["local"]["users"]
+    hm = users.find { |u| u['name'] == 'hm' }
+    expect(hm).to be
+    expect(hm["password"]).to eq("BOSH_HM_DIRECTOR_PASSWORD")
+  end
+
+  it "configures admin bosh user with password" do
+    users = bosh_properties["director"]["user_management"]["local"]["users"]
+    admin = users.find { |u| u['name'] == 'admin' }
+    expect(admin).to be
+    expect(admin["password"]).to eq("BOSH_ADMIN_PASSWORD")
   end
 
   it "creates a local user for health manager" do


### PR DESCRIPTION
## What

Over time we have accumulated various leftover properties. Many of them are not used any more. Others are set to default values for no specific reasons. This can create confusion when debugging problems and looking at those properties assuming they are significant. I have created a lot of smaller commits to explain why we can remove each given property. 

Also, this is a prequel to [Single file for BOSH manifest](https://www.pivotaltracker.com/n/projects/1275640/stories/128858813)

## How to review

Completely delete your CF deployment. Do `bosh cleanup --all` repeatedly until everything (packages, jobs, stemcells) have been cleaned up. Do a fresh deployment of CF (run the deploy-bosh-cf pipeline). Observe BOSH server being re-deployed and CF deployment and tests succeeding.

## Who can review

not @mtekel