### PR TITLE
[#118275583] Upgrade to CF v240

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -135,12 +135,6 @@ resources:
       tag_filter: {{cf_os_conf_version}}
       branch: gds_master
 
-  - name: rep-boshrelease
-    type: git
-    source:
-      uri: https://github.com/alphagov/paas-rep-boshrelease.git
-      tag_filter: {{cf_rep_version}}
-
   - name: logsearch-for-cloudfoundry-boshrelease
     type: git
     source:
@@ -1453,7 +1447,6 @@ jobs:
           - get: bosh-CA
           - get: graphite-nozzle
           - get: logsearch-for-cloudfoundry-boshrelease
-          - get: rep-boshrelease
 
       - aggregate:
         - task: upload-releases
@@ -1471,7 +1464,6 @@ jobs:
               - name: paas-haproxy-release
               - name: aws-broker-boshrelease
               - name: os-conf-boshrelease
-              - name: rep-boshrelease
               - name: logsearch-for-cloudfoundry-boshrelease
             run:
               path: sh
@@ -1495,9 +1487,6 @@ jobs:
 
                   paas-cf/concourse/scripts/bosh_create_and_upload_release.rb aws-broker \
                     {{cf_aws_broker_version}} aws-broker-boshrelease
-
-                  paas-cf/concourse/scripts/bosh_create_and_upload_release.rb rep \
-                    {{cf_rep_version}} rep-boshrelease
 
                   paas-cf/concourse/scripts/bosh_create_and_upload_release.rb logsearch-for-cloudfoundry \
                     {{cf_logsearch_for_cloudfoundry_version}} logsearch-for-cloudfoundry-boshrelease

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -135,13 +135,6 @@ resources:
       tag_filter: {{cf_os_conf_version}}
       branch: gds_master
 
-  - name: routing-release
-    type: git
-    source:
-      uri: https://github.com/alphagov/paas-routing-release.git
-      tag_filter: {{cf_routing_version}}
-      branch: gds_master
-
   - name: rep-boshrelease
     type: git
     source:
@@ -1460,7 +1453,6 @@ jobs:
           - get: bosh-CA
           - get: graphite-nozzle
           - get: logsearch-for-cloudfoundry-boshrelease
-          - get: routing-release
           - get: rep-boshrelease
 
       - aggregate:
@@ -1479,7 +1471,6 @@ jobs:
               - name: paas-haproxy-release
               - name: aws-broker-boshrelease
               - name: os-conf-boshrelease
-              - name: routing-release
               - name: rep-boshrelease
               - name: logsearch-for-cloudfoundry-boshrelease
             run:
@@ -1504,9 +1495,6 @@ jobs:
 
                   paas-cf/concourse/scripts/bosh_create_and_upload_release.rb aws-broker \
                     {{cf_aws_broker_version}} aws-broker-boshrelease
-
-                  paas-cf/concourse/scripts/bosh_create_and_upload_release.rb routing \
-                    {{cf_routing_version}} routing-release
 
                   paas-cf/concourse/scripts/bosh_create_and_upload_release.rb rep \
                     {{cf_rep_version}} rep-boshrelease

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -42,7 +42,6 @@ prepare_environment() {
   cf_grafana_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.grafana.version "${cf_manifest_dir}/040-graphite.yml")
   cf_aws_broker_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.aws-broker.version "${cf_manifest_dir}/050-rds-broker.yml")
   cf_os_conf_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.os-conf.version "${cf_manifest_dir}/../runtime-config/runtime-config-base.yml")
-  cf_routing_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.routing.version "${cf_manifest_dir}/000-base-cf-deployment.yml")
   cf_rep_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.rep.version "${cf_manifest_dir}/000-base-cf-deployment.yml")
   cf_logsearch_for_cloudfoundry_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.logsearch-for-cloudfoundry.version "${cf_manifest_dir}/030-logsearch.yml")
 
@@ -77,7 +76,6 @@ cf_graphite_version: ${cf_graphite_version}
 cf_grafana_version: ${cf_grafana_version}
 cf_aws_broker_version: ${cf_aws_broker_version}
 cf_os_conf_version: ${cf_os_conf_version}
-cf_routing_version: ${cf_routing_version}
 cf_rep_version: ${cf_rep_version}
 cf_logsearch_for_cloudfoundry_version: ${cf_logsearch_for_cloudfoundry_version}
 cf_env_specific_manifest: ${ENV_SPECIFIC_CF_MANIFEST}

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -42,7 +42,6 @@ prepare_environment() {
   cf_grafana_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.grafana.version "${cf_manifest_dir}/040-graphite.yml")
   cf_aws_broker_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.aws-broker.version "${cf_manifest_dir}/050-rds-broker.yml")
   cf_os_conf_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.os-conf.version "${cf_manifest_dir}/../runtime-config/runtime-config-base.yml")
-  cf_rep_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.rep.version "${cf_manifest_dir}/000-base-cf-deployment.yml")
   cf_logsearch_for_cloudfoundry_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.logsearch-for-cloudfoundry.version "${cf_manifest_dir}/030-logsearch.yml")
 
   if [ -z "${SKIP_COMMIT_VERIFICATION:-}" ] ; then
@@ -76,7 +75,6 @@ cf_graphite_version: ${cf_graphite_version}
 cf_grafana_version: ${cf_grafana_version}
 cf_aws_broker_version: ${cf_aws_broker_version}
 cf_os_conf_version: ${cf_os_conf_version}
-cf_rep_version: ${cf_rep_version}
 cf_logsearch_for_cloudfoundry_version: ${cf_logsearch_for_cloudfoundry_version}
 cf_env_specific_manifest: ${ENV_SPECIFIC_CF_MANIFEST}
 paas_cf_tag_filter: ${PAAS_CF_TAG_FILTER:-}

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -27,8 +27,6 @@ releases:
     sha1: b6a7e32d04bafb2a11afd246f9123524ee703a02
   - name: paas-haproxy
     version: 0.0.4
-  - name: rep
-    version: 0.0.1
 
 stemcells:
   - alias: default

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -31,7 +31,7 @@ releases:
 stemcells:
   - alias: default
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3262.4"
+    version: "3262.9"
 
 update:
   canaries: 0

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -14,17 +14,17 @@ releases:
     url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=0.1482.0
     sha1: 4d7740d58d2245b531d5fb5a3c87ab55cdd4a76b
   - name: garden-linux
-    version: 0.339.0
-    url: https://bosh.io/d/github.com/cloudfoundry/garden-linux-release?v=0.339.0
-    sha1: 0a4624190d77fc9cc2d91caf7c98419cc2b651b6
+    version: 0.341.0
+    url: https://bosh.io/d/github.com/cloudfoundry/garden-linux-release?v=0.341.0
+    sha1: 9d95512cc32d5a356928539af111dbfd16333d40
   - name: etcd
-    version: 63
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/etcd-release?v=63
-    sha1: cd802637d7de984fdc83f777b4bc6e362c97dd82
+    version: 64
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/etcd-release?v=64
+    sha1: 7345569e73c80681124d3cd97a3dc1be372b0381
   - name: cflinuxfs2-rootfs
-    version: 1.21.0
-    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-rootfs-release?v=1.21.0
-    sha1: b6a7e32d04bafb2a11afd246f9123524ee703a02
+    version: 1.22.0
+    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-rootfs-release?v=1.22.0
+    sha1: bf95dfc4593e1a9f291e4bb3e50c85575483e618
   - name: paas-haproxy
     version: 0.0.4
 

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -10,9 +10,9 @@ releases:
     url: https://bosh.io/d/github.com/cloudfoundry/cf-release?v=240
     sha1: 7dba7cc0c9c4beca699d8c876ac046890e13bb9e
   - name: diego
-    version: 0.1481.0
-    url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=0.1481.0
-    sha1: d3b4b73cd86432c1ec644f3fbe6eb51f3ffc5407
+    version: 0.1482.0
+    url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=0.1482.0
+    sha1: 4d7740d58d2245b531d5fb5a3c87ab55cdd4a76b
   - name: garden-linux
     version: 0.339.0
     url: https://bosh.io/d/github.com/cloudfoundry/garden-linux-release?v=0.339.0

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -6,25 +6,25 @@ director_uuid: ~
 
 releases:
   - name: cf
-    version: 238
-    url: https://bosh.io/d/github.com/cloudfoundry/cf-release?v=238
-    sha1: fa6d35300f4fcd74a75fd8c7138f592acfcb32b0
+    version: 240
+    url: https://bosh.io/d/github.com/cloudfoundry/cf-release?v=240
+    sha1: 7dba7cc0c9c4beca699d8c876ac046890e13bb9e
   - name: diego
-    version: 0.1476.0
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/diego-release?v=0.1476.0
-    sha1: 4b66fde250472e47eb2a0151bb676fc1be840f47
+    version: 0.1481.0
+    url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=0.1481.0
+    sha1: d3b4b73cd86432c1ec644f3fbe6eb51f3ffc5407
   - name: garden-linux
-    version: 0.338.0
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/garden-linux-release?v=0.338.0
-    sha1: 432225d88edc9731be4453cb61eba33fa829ebdc
+    version: 0.339.0
+    url: https://bosh.io/d/github.com/cloudfoundry/garden-linux-release?v=0.339.0
+    sha1: 0a4624190d77fc9cc2d91caf7c98419cc2b651b6
   - name: etcd
-    version: 55
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/etcd-release?v=55
-    sha1: b64fc693e658cee0ac07712646f8c7b67de0e8b6
+    version: 63
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/etcd-release?v=63
+    sha1: cd802637d7de984fdc83f777b4bc6e362c97dd82
   - name: cflinuxfs2-rootfs
-    version: 1.15.0
-    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-rootfs-release?v=1.15.0
-    sha1: 389ad7bb316ec5bbb7ff2ed085d551d83afc7a0f
+    version: 1.21.0
+    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-rootfs-release?v=1.21.0
+    sha1: b6a7e32d04bafb2a11afd246f9123524ee703a02
   - name: paas-haproxy
     version: 0.0.4
   - name: routing
@@ -35,7 +35,7 @@ releases:
 stemcells:
   - alias: default
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3232.11"
+    version: "3262.4"
 
 update:
   canaries: 0

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -27,8 +27,6 @@ releases:
     sha1: b6a7e32d04bafb2a11afd246f9123524ee703a02
   - name: paas-haproxy
     version: 0.0.4
-  - name: routing
-    version: commit-0bad6993f4cb87fa6213fa957f4e8eacbd22f762
   - name: rep
     version: 0.0.1
 

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -131,8 +131,6 @@ jobs:
       consul:
         agent:
           mode: server
-      metron_agent:
-        zone: ""
 
   - name: nats
     azs: [z1, z2]
@@ -145,9 +143,6 @@ jobs:
         static_ips:
           - 10.0.16.11
           - 10.0.17.11
-    properties:
-      metron_agent:
-        zone: ""
 
   - name: etcd
     azs: [z1, z2, z3]
@@ -165,8 +160,6 @@ jobs:
     update:
       serial: true
     properties:
-      metron_agent:
-        zone: ""
       consul:
         agent:
           services:
@@ -185,8 +178,6 @@ jobs:
         agent:
           services:
             uaa: {}
-      metron_agent:
-        zone: ""
 
   - name: api
     azs: [z1, z2]
@@ -200,8 +191,6 @@ jobs:
       consul:
         agent:
           services: (( grab meta.api_consul_services ))
-      metron_agent:
-        zone: ""
 
   - name: clock_global
     azs: [z1]
@@ -211,9 +200,6 @@ jobs:
     stemcell: default
     networks:
       - name: cf
-    properties:
-      metron_agent:
-        zone: ""
 
   - name: api_worker
     azs: [z1, z2]
@@ -223,10 +209,6 @@ jobs:
     stemcell: default
     networks:
       - name: cf
-    properties:
-      metron_agent:
-        zone: ""
-
 
   - name: doppler
     azs: [z1, z2]
@@ -236,11 +218,6 @@ jobs:
     stemcell: default
     networks:
       - name: cf
-    properties:
-      doppler:
-        zone: ""
-      metron_agent:
-        zone: ""
 
   - name: loggregator_trafficcontroller
     azs: [z1, z2]
@@ -250,11 +227,6 @@ jobs:
     stemcell: default
     networks:
       - name: cf
-    properties:
-      traffic_controller:
-        zone: ""
-      metron_agent:
-        zone: ""
 
   - name: router
     azs: [z1, z2]
@@ -269,9 +241,6 @@ jobs:
         agent:
           services:
             gorouter: {}
-      metron_agent:
-        zone: ""
-
 # Diego
 
   - name: database
@@ -288,9 +257,6 @@ jobs:
     stemcell: default
     networks:
       - name: cf
-    properties:
-      metron_agent:
-        zone: ""
     update:
       serial: true
 
@@ -308,9 +274,6 @@ jobs:
     stemcell: default
     networks:
       - name: cf
-    properties:
-      metron_agent:
-        zone: ""
 
   - name: cell
     azs: [z1, z2]
@@ -330,9 +293,6 @@ jobs:
     stemcell: default
     networks:
       - name: cell
-    properties:
-      metron_agent:
-        zone: ""
 
   - name: cc_bridge
     azs: [z1, z2]
@@ -354,9 +314,6 @@ jobs:
     stemcell: default
     networks:
       - name: cf
-    properties:
-      metron_agent:
-        zone: ""
 
   - name: route_emitter
     azs: [z1, z2]
@@ -372,9 +329,6 @@ jobs:
     stemcell: default
     networks:
       - name: cf
-    properties:
-      metron_agent:
-        zone: ""
 
   - name: access
     azs: [z1, z2]
@@ -392,6 +346,3 @@ jobs:
     stemcell: default
     networks:
       - name: cf
-    properties:
-      metron_agent:
-        zone: ""

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -281,7 +281,7 @@ jobs:
       - name: consul_agent
         release: cf
       - name: rep
-        release: rep
+        release: diego
       - name: garden
         release: garden-linux
       - name: cflinuxfs2-rootfs-setup

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -95,7 +95,7 @@ meta:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
   - name: gorouter
-    release: routing
+    release: (( grab meta.release.name ))
   - name: metron_agent
     release: (( grab meta.release.name ))
   - name: haproxy

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -301,8 +301,6 @@ jobs:
         release: cf
       - name: auctioneer
         release: diego
-      - name: converger
-        release: diego
       - name: metron_agent
         release: cf
     instances: 2

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -527,15 +527,6 @@ properties:
       dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
       require_ssl: true
 
-    converger:
-      bbs:
-        api_location: bbs.service.cf.internal:8889
-        ca_cert: (( grab meta.secrets.consul_ca_cert ))
-        client_cert: (( grab secrets.bbs_client_cert  ))
-        client_key: (( grab secrets.bbs_client_key  ))
-        require_ssl: true
-      dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
-
     file_server:
       dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
 

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -478,6 +478,9 @@ properties:
     restricted_ips_regex: 10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}
 
     zones:
+      internal:
+        hostnames:
+          - uaa.service.cf.internal
 
   uaadb:
     db_scheme: postgresql

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -428,7 +428,7 @@ properties:
         id: cf
         override: true
         authorized-grant-types: password,refresh_token
-        scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,cloud_controller.admin_read_only,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read
+        scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,cloud_controller.admin_read_only,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read,routing.router_groups.write
         authorities: uaa.none
         access-token-validity: 600
         refresh-token-validity: 2592000

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -428,7 +428,7 @@ properties:
         id: cf
         override: true
         authorized-grant-types: password,refresh_token
-        scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read
+        scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,cloud_controller.admin_read_only,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read
         authorities: uaa.none
         access-token-validity: 600
         refresh-token-validity: 2592000

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -145,7 +145,7 @@ properties:
     route_services_timeout:
     logrotate:
     extra_headers_to_log:
-    debug_addr:
+    debug_address:
     enable_routing_api:
     drain_wait: 15
 

--- a/manifests/cf-manifest/manifest/040-graphite.yml
+++ b/manifests/cf-manifest/manifest/040-graphite.yml
@@ -31,8 +31,6 @@ jobs:
         # because grab cannot be used to interpolate in a multi-line string.
         - 10.0.16.20
   properties:
-    metron_agent:
-      zone: ""
     statsd:
       deleteIdleStats: true
     carbon:


### PR DESCRIPTION
[#118275583 Upgrade to CF v240](https://www.pivotaltracker.com/story/show/118275583)

What
====

We want to upgrade to CF v240 as part of our regular upgrades.

We chose v240 because:
 * It has > 3 weeks
 * v241 seems to new and has more changes

Additionally, we have decided to upgrade to Diego 0.1482.0 instead of the  suggested version from CF v240, 0.1481.0. The reason is that 0.1482.0 includes a [required patch for rep](https://github.com/alphagov/paas-cf/pull/395), and using this release will prevent us from using a custom release to use a patched version of rep.

Finally we upgrade the stemcell to the lates version 3262.9 to benefit from bugfixes and fixed CVEs.

See more notes about all the changes included in this PR in a comment below.

Changes that affect tenants
------------------------------

 * Several bug-fixes and CVEs fixed, in CF and in the buildpacks
 * Users can remove themselves from Orgs and Spaces
 * Several buildpacks changed. Follow release note links for more info [v239](https://github.com/cloudfoundry/cf-release/releases/tag/v239#buildpacks-and-stacks) and [v340](https://github.com/cloudfoundry/cf-release/releases/tag/v240#buildpacks-and-stacks)

How to review
-------------

 1. Check the changes and commits, if they make sense and are well documented.
 2. Deploy from master
 3. Redeploy from this branch
 4. Tests should pass

Before merging
------------------

 * Discuss with the team: Shall we notify the tenants?


Who?
---

Anyone but @combor or @keymon