### PR TITLE
Remove `.terraformrc` config file

### DIFF
--- a/doc/pingdom.md
+++ b/doc/pingdom.md
@@ -54,9 +54,9 @@ You may need to ensure your Terraform version is compatible with the terraform l
 #### Install
 Run `go install github.com/russellcardullo/terraform-provider-pingdom`. This will build and install the binary in `$GOPATH/bin`. Make sure `$GOPATH/bin` is in your `$PATH`.
 
-Add the content of `terraform/providers/terraformrc` to `$HOME/.terraformrc`.
+Terraform will look in various places to find plugin binaries, see the [discover](https://github.com/hashicorp/terraform/blob/10cc8b8c63f0e780c022c2e9b25e954bf7a7bca8/config.go#L80) function.
 
-The binary should now be installed and Terraform knows where to find it.
+For temporary work, it should be sufficient create a symlink of the same name in the directory from which you will run `terraform`.
 
 ## Publishing the custom provider
 Build from inside directory `$GOPATH/src/github.com/russellcardullo/terraform-provider-pingdom`.

--- a/terraform/providers/.terraformrc
+++ b/terraform/providers/.terraformrc
@@ -1,3 +1,0 @@
-providers {
-    pingdom = "/tmp/terraform-pingdom/terraform-provider-pingdom"
-}

--- a/terraform/scripts/set-up-pingdom.sh
+++ b/terraform/scripts/set-up-pingdom.sh
@@ -21,7 +21,6 @@ trap 'rm -r "${PAAS_CF_DIR}/${WORKING_DIR}"' EXIT
 wget "https://github.com/alphagov/paas-terraform-provider-pingdom/releases/download/${VERSION}/${BINARY}" \
   -O "${WORKING_DIR}"/terraform-provider-pingdom
 chmod +x "${WORKING_DIR}"/terraform-provider-pingdom
-cp terraform/providers/.terraformrc "${WORKING_DIR}"
 
 # Work in tmp dir to ensure there's no local state before we kick off terraform, it prioritises it
 cd "${WORKING_DIR}"
@@ -33,8 +32,7 @@ terraform remote config \
     -backend-config="key=${STATEFILE}" \
     -backend-config="region=${AWS_DEFAULT_REGION}"
 
-# Run Terraform Pingdom Provider. We change $HOME so Terraform can find terraformrc
-HOME=${WORKING_DIR} \
+# Run Terraform Pingdom Provider
 terraform "${TERRAFORM_ACTION}" \
 	-var "env=${MAKEFILE_ENV_TARGET}" \
 	-var "contact_ids=${PINGDOM_CONTACT_IDS}" \


### PR DESCRIPTION
## What

The `.terraformrc` config file was overlooked in a previous PR
(https://github.com/alphagov/paas-cf/pull/448), and doesn't currently point
to the correct location to find the provider plugin binary.

Happily, terraform finds the binary anyway since it has been placed
in what will be terraform's working directory earlier in the script.

For the plugin discovery logic see https://github.com/hashicorp/terraform/blob/10cc8b8c63f0e780c022c2e9b25e954bf7a7bca8/config.go#L80

We remove the file, and adjust the script and readme so they no longer refer to it.

## How to review

The part of the review advice related to Pingdom in https://github.com/alphagov/paas-cf/pull/448
should still work.

## Who can review

Probably best for @alext or @saliceti to take a look, but in the end anyone but @benhyland.