### PR TITLE
Reduce maximum DEPLOY_ENV string length

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ help:
 SHELLCHECK=shellcheck
 YAMLLINT=yamllint
 
-DEPLOY_ENV_MAX_LENGTH=15
+DEPLOY_ENV_MAX_LENGTH=12
 DEPLOY_ENV_VALID_LENGTH=$(shell if [ $${\#DEPLOY_ENV} -gt $(DEPLOY_ENV_MAX_LENGTH) ]; then echo ""; else echo "OK"; fi)
 DEPLOY_ENV_VALID_CHARS=$(shell if echo $(DEPLOY_ENV) | grep -q '^[a-zA-Z0-9-]*$$'; then echo "OK"; else echo ""; fi)
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ SHELLCHECK=shellcheck
 YAMLLINT=yamllint
 
 DEPLOY_ENV_MAX_LENGTH=12
-DEPLOY_ENV_VALID_LENGTH=$(shell if [ $${\#DEPLOY_ENV} -gt $(DEPLOY_ENV_MAX_LENGTH) ]; then echo ""; else echo "OK"; fi)
+DEPLOY_ENV_VALID_LENGTH=$(shell if [ $$(echo -n $(DEPLOY_ENV) | wc -c) -gt $(DEPLOY_ENV_MAX_LENGTH) ]; then echo ""; else echo "OK"; fi)
 DEPLOY_ENV_VALID_CHARS=$(shell if echo $(DEPLOY_ENV) | grep -q '^[a-zA-Z0-9-]*$$'; then echo "OK"; else echo ""; fi)
 
 check-env-vars:


### PR DESCRIPTION
## What

In 88f7e59 the maximum length of the DEPLOY_ENV variable was declared
as being 15 characters, however the derived name of the
aws_elb.logsearch_es-master enforces a hard limit of 32 characters,
leading to an error when terraforming the environment.

~~~
 * aws_elb.logsearch_es_master: "name" cannot be longer than 32 characters: "richardc-sept-logsearch-es-master"
~~~

Working backwards from this limit, this actually leaves us 12
characters to work with when naming our development environments, assuming this is the longest derived substring.

~~~
irb(main):001:0> "richardc-sept-logsearch-es-master".size
=> 33
irb(main):002:0> "richardc-sept".size
=> 13
~~~

## How to review

Checkout this branch, ensure we get an error at 13 characters supplied for DEPLOY_ENV

~~~
$ DEPLOY_ENV=1234567890123 make dev showenv > /dev/null ; echo $?
Makefile:16: *** Sorry, DEPLOY_ENV (1234567890123) has a max length of 12, otherwise derived names will be too long.  Stop.
2

$ DEPLOY_ENV=123456789012 make dev showenv > /dev/null ; echo $?
0
~~~

DEPLY_ENV=1234567
Attempt to Describe the steps required to test the changes.

## Who can review

Not @richardc