### PR TITLE
[#127464417] Use latest release of paas-terraform-provider-pingdom

### DIFF
--- a/doc/pingdom.md
+++ b/doc/pingdom.md
@@ -41,15 +41,28 @@ For bleeding-edge features, it may be necessary to build the provider from our f
 ```
 # go-pingdom library
 cd $GOPATH/src/github.com/russellcardullo/go-pingdom
-git remote add alphagov https://github.com/russellcardullo/go-pingdom.git
+git remote add alphagov git@github.com:alphagov/paas-go-pingdom.git
+git fetch alphagov
+git checkout gds_master
 
 # terraform-provider-pingdom
 cd $GOPATH/src/github.com/russellcardullo/terraform-provider-pingdom
-git remote add alphagov https://github.com/russellcardullo/terraform-provider-pingdom.git
+git remote add alphagov git@github.com:alphagov/paas-terraform-provider-pingdom.git
+git fetch alphagov
+git checkout gds_master
 ```
 
 #### Terraform version
-You may need to ensure your Terraform version is compatible with the terraform library used to compile the provider. You can run `terraform -v` to get your version of Terraform and find the corresponding git tag for this version in `$GOPATH/src/github.com/hashicorp/terraform`. Use the tag to checkout that version of the terraform library prior to installing the provider.
+You may need to ensure your Terraform version is compatible with the terraform library used to compile the provider.
+You can run `terraform -v` to get your version of Terraform and find the corresponding git tag for this version in `$GOPATH/src/github.com/hashicorp/terraform`.
+Use the tag to checkout that version of the terraform library prior to installing the provider.
+
+```
+cd $GOPATH/src/github.com/hashicorp/terraform
+git fetch
+git tag -l
+git checkout v0.6.15
+```
 
 #### Install
 Run `go install github.com/russellcardullo/terraform-provider-pingdom`. This will build and install the binary in `$GOPATH/bin`. Make sure `$GOPATH/bin` is in your `$PATH`.

--- a/terraform/scripts/set-up-pingdom.sh
+++ b/terraform/scripts/set-up-pingdom.sh
@@ -2,7 +2,7 @@
 
 set -eu
 TERRAFORM_ACTION=${1}
-VERSION=0.2.1
+VERSION=0.2.2
 BINARY=terraform-provider-pingdom-$(uname -s)-$(uname -m)
 STATEFILE=pingdom-${MAKEFILE_ENV_TARGET}.tfstate
 


### PR DESCRIPTION
## What

We updated our fork and released new binaries.

Update the pingdom setup script to use the new release, and improve
the docs that describe the build and release process for the fork.

## How to review

For some healthy CF deploy, follow the instructions in `pingdom.md` to set up pingdom checks.
Note the the healthcheck app is deployed in `post-deploy` not `deploy-cf`.

Confirm the check appears as expected, e.g. in the webui https://my.pingdom.com - credentials are in `paas-pass`.
Remove the new checks when you are finished.

Check that the documentation changes make sense.

## Who can review

Anyone but @benhyland