### PR TITLE
Fix DEPLOY_ENV checking on OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ SHELLCHECK=shellcheck
 YAMLLINT=yamllint
 
 DEPLOY_ENV_MAX_LENGTH=12
-DEPLOY_ENV_VALID_LENGTH=$(shell if [ $$(echo -n $(DEPLOY_ENV) | wc -c) -gt $(DEPLOY_ENV_MAX_LENGTH) ]; then echo ""; else echo "OK"; fi)
+DEPLOY_ENV_VALID_LENGTH=$(shell if [ $$(printf "%s" $(DEPLOY_ENV) | wc -c) -gt $(DEPLOY_ENV_MAX_LENGTH) ]; then echo ""; else echo "OK"; fi)
 DEPLOY_ENV_VALID_CHARS=$(shell if echo $(DEPLOY_ENV) | grep -q '^[a-zA-Z0-9-]*$$'; then echo "OK"; else echo ""; fi)
 
 check-env-vars:


### PR DESCRIPTION
## What

On OSX, the embedded `echo -n $(DEPLOY_ENV)` actually echoes "-n FOO\n"
expanding the character count of the counted thing by 3 bytes.

This makefile seems to reproduce some of the oddness:

~~~
$ cat foo.mk

FOO="foo"
WEIRD=$(shell echo -- $$(echo -n $(FOO)))
all:
        @echo $(WEIRD)

$ make -f foo.mk
-- -n foo
~~~

Here we bypass the weirdness by using printf instead of echo, which
seems more portable.

## How to review

On OSX and more interestingly linux

`make dev showenv DEPLOY_ENV=123456789`

This should no longer error.

## Who can review

Not @richardc   Ideally a linux-haver