### PR TITLE
Add SPF and DMARC records

### DIFF
--- a/terraform/cloudfoundry/dns-records.tf
+++ b/terraform/cloudfoundry/dns-records.tf
@@ -77,3 +77,20 @@ resource "aws_route53_record" "rds_broker" {
   ttl = "60"
   records = ["${aws_elb.rds_broker.dns_name}"]
 }
+
+resource "aws_route53_record" "spf" {
+  zone_id = "${var.system_dns_zone_id}"
+  name = "${var.system_dns_zone_name}."
+  type = "TXT"
+  ttl = "300"
+  records = ["v=spf1 -all"]
+}
+
+resource "aws_route53_record" "dmarc" {
+  zone_id = "${var.system_dns_zone_id}"
+  name = "_dmarc.${var.system_dns_zone_name}."
+  type = "TXT"
+  ttl = "300"
+  records = ["v=DMARC1; p=reject; rua=mailto:dmarc-groups-test@digital.cabinet-office.gov.uk,dmarc-rua@dmarc.service.gov.uk;ruf=mailto:dmarc-groups-test@digital.cabinet-office.gov.uk,dmarc-ruf@dmarc.service.gov.uk;fo=1"]
+}
+


### PR DESCRIPTION
## What

We have implemented this for the cloud.service.gov.uk in accordance with [1].
We haven't put any restrictions onto this, therefore this will also
cover the following domains:

* ci.cloudpipeline.digital
* dev.cloudpipeline.digital
* staging.cloudpipeline.digital

https://www.gov.uk/guidance/set-up-government-email-services-securely#domain-based-message-authentication-reporting-and-conformance-dmarc

## How to review

Describe the steps required to test the changes.

## Who can review

Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.

