### PR TITLE
[#130003999] Update Pingdom terraform to use 0.7.3

### DIFF
--- a/terraform/scripts/ensure_terraform_version.sh
+++ b/terraform/scripts/ensure_terraform_version.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+MIN_REQUIRED_VERSION=${1-}
+if [ -z "${MIN_REQUIRED_VERSION}" ]; then
+  echo "Usage: ${0} <min_required_version>"
+  exit 1
+fi
+
+terraform version | awk -v MinRequiredVersion="${MIN_REQUIRED_VERSION}" '
+BEGIN { FS = " v" } # to strip the leading v from the version
+NR==1 {
+  if ( MinRequiredVersion !~ /^([[:digit:]]{1,4}\.){1,2}[[:digit:]]{1,4}$/ ) {
+    print "ERR: Requested terraform version "MinRequiredVersion" is not a valid version number"
+    exit 1
+  }
+  if ( $2 !~ /^([[:digit:]]{1,4}\.){1,2}[[:digit:]]{1,4}$/ ) {
+    print "ERR: Matched terraform version "$2" is not a valid version number"
+    exit 1
+  }
+
+  # Split each version into an array
+  split(MinRequiredVersion, RequiredVersArr, ".")
+  split($2, ActualVersArr, ".")
+
+  # Translate into a large decimal
+  RequiredVersDec = RequiredVersArr[1] * 10^8 + RequiredVersArr[2] * 10^4 + RequiredVersArr[3]
+  ActualVersDec = ActualVersArr[1] * 10^8 + ActualVersArr[2] * 10^4 + ActualVersArr[3]
+
+  if ( ActualVersDec < RequiredVersDec ) {
+    print "ERR: Terraform version "$2" is less than required version "MinRequiredVersion""
+    exit 1
+  }
+}
+'

--- a/terraform/scripts/set-up-pingdom.sh
+++ b/terraform/scripts/set-up-pingdom.sh
@@ -35,7 +35,7 @@ terraform remote config \
 # Run Terraform Pingdom Provider
 terraform "${TERRAFORM_ACTION}" \
 	-var "env=${MAKEFILE_ENV_TARGET}" \
-	-var "contact_ids=${PINGDOM_CONTACT_IDS}" \
+	-var "contact_ids=\"${PINGDOM_CONTACT_IDS}\"" \
 	-var "pingdom_user=${PINGDOM_USER}" \
 	-var "pingdom_password=${PINGDOM_PASSWORD}" \
 	-var "pingdom_api_key=${PINGDOM_API_KEY}" \

--- a/terraform/scripts/set-up-pingdom.sh
+++ b/terraform/scripts/set-up-pingdom.sh
@@ -3,7 +3,7 @@
 set -eu
 TERRAFORM_ACTION=${1}
 VERSION=0.2.2
-BINARY=terraform-provider-pingdom-$(uname -s)-$(uname -m)
+BINARY=terraform-provider-pingdom-tf-0.7.3-$(uname -s)-$(uname -m)
 STATEFILE=pingdom-${MAKEFILE_ENV_TARGET}.tfstate
 
 # Get Pingdom credentials


### PR DESCRIPTION
## What

This updates the pingdom terraform job to use terraform 0.7.3. This means that all our terraform jobs will use the same version, which will avoid confusion.

## How to review

Export CI AWS key variables.

With an old terraform installed, run `make ci pingdom ACTION=plan`, and verify you get a hepful message indicating that your terraform is too old.

Install terraform 0.7.3
Run `make ci pingdom ACTION=plan`, and verify that there are no changes.

After merging, run with `ACTION=apply` against ci, staging and prod to update the state files to the new format.

## Who can review

Anyone but myself.