### PR TITLE
[#130089419] Work around race condition in sync_admin_users

### DIFF
--- a/scripts/lib/uaa_sync_admin_users.rb
+++ b/scripts/lib/uaa_sync_admin_users.rb
@@ -176,7 +176,8 @@ class UaaSyncAdminUsers
     to_delete_user_ids.each { |user_id|
       user_info = self.get_user_by_id(user_id)
       if user_info.nil?
-        raise "User #{user_id} not found"
+        get_logger.info("User #{user_id} not found. Skipping.")
+        next
       end
 
       if Time.parse(user_info.fetch("meta").fetch("created")) < (Time.now - HOURS_TO_KEEP_TEST_USERS * 60 * 60)


### PR DESCRIPTION
## What

Story: [Fix the build: User not found in sync-admin-users](https://www.pivotaltracker.com/story/show/130089419)

This should fix the cause of [this build failure](https://deployer.staging.cloudpipeline.digital/pipelines/create-bosh-cloudfoundry/jobs/cf-deploy/builds/220). The script gets a list of users and determine which ones it should remove. When it tries to remove the user, it may have already been deleted by another process. In the case above, the user was created and deleted by [this continuous smoke test](https://deployer.staging.cloudpipeline.digital/pipelines/create-bosh-cloudfoundry/jobs/continuous-smoke-tests/builds/41032). As the code raised an exception, this would break the build.

It is safe to ignore as we would have deleted the user anyway. Now we only log a message and continue.

## How to review

I would review the code only, as this is not easy to reproduce. If we found valuable to add unit testing, we would need to refactor the code in easily testable separate blocks.

## Who can review
Anyone but myself.