### PR TITLE
Flatten try blocks when linting manifests

### DIFF
--- a/concourse/scripts/pipecleaner.py
+++ b/concourse/scripts/pipecleaner.py
@@ -71,7 +71,7 @@ class Pipecleaner(object):
                         del item[block_type]
 
                 # Flatten single blocks we don't care about
-                for block_type in ('on_success', 'on_failure', 'ensure'):
+                for block_type in ('on_success', 'on_failure', 'ensure', 'try'):
                     if block_type in item:
                         discovered_blocks.append(item[block_type])
                         del item[block_type]


### PR DESCRIPTION
## What

Try blocks are currently being skipped over as pipecleaner doesn't know to flatten them, leading to erroneous warnings when fetches are performed in them.

## How to review

Run `make lint_concourse` in `master`, observe the warnings being the following:

````
$ make lint_concourse
cd .. && python paas-cf/concourse/scripts/pipecleaner.py paas-cf/concourse/pipelines/*.yml

==  paas-cf/concourse/pipelines/create-bosh-cloudfoundry.yml  ==
WARNING * Unused Output: job='generate-secrets', resource='generated-ssh-private-key'
WARNING * Unused Output: job='generate-secrets', resource='generated-ssh-public-key'
WARNING * Unused Output: job='generate-secrets', resource='generated-bosh-ssh-public-key'
WARNING * Unused Output: job='generate-secrets', resource='generated-bosh-ssh-private-key'
WARNING * Unused Output: job='smoke-tests', resource='smoke-tests-log'
WARNING * Unused Fetch: job='pre-deploy', resource='bosh-CA'
WARNING * Unused Fetch: job='pre-deploy', resource='cf-secrets'
WARNING * Unused Fetch: job='pre-deploy', resource='paas-cf'
WARNING * Unused Fetch: job='pre-deploy', resource='deployed-healthcheck'
WARNING * Unused Fetch: job='post-deploy', resource='cf-tfstate'

==  paas-cf/concourse/pipelines/failure-testing.yml  ==
WARNING * Unused Output: job='cloud-controller', resource='smoke-tests-log'
WARNING * Unused Output: job='nats', resource='smoke-tests-log'
WARNING * Unused Output: job='router', resource='smoke-tests-log'
WARNING * Unused Output: job='etcd', resource='smoke-tests-log'
WARNING * Unused Output: job='consul', resource='smoke-tests-log'
WARNING * Unused Output: job='cell', resource='smoke-tests-log'
WARNING * Unused Fetch: job='rds-broker', resource='cf-release'
````

Checkout this branch, and run `make lint_terraform` again. Observe that the erroneous `Unused Output` and `Unused Fetch` warnings are no longer emitted:

````
$ make lint_concourse
cd .. && python paas-cf/concourse/scripts/pipecleaner.py paas-cf/concourse/pipelines/*.yml

==  paas-cf/concourse/pipelines/create-bosh-cloudfoundry.yml  ==
WARNING * Unused Output: job='smoke-tests', resource='smoke-tests-log'
WARNING * Unused Fetch: job='post-deploy', resource='cf-tfstate'

==  paas-cf/concourse/pipelines/failure-testing.yml  ==
WARNING * Unused Output: job='cloud-controller', resource='smoke-tests-log'
WARNING * Unused Output: job='nats', resource='smoke-tests-log'
WARNING * Unused Output: job='router', resource='smoke-tests-log'
WARNING * Unused Output: job='etcd', resource='smoke-tests-log'
WARNING * Unused Output: job='consul', resource='smoke-tests-log'
WARNING * Unused Output: job='cell', resource='smoke-tests-log'
WARNING * Unused Fetch: job='rds-broker', resource='cf-release'
````

## Who can review

Not me!