### PR TITLE
[#128932735] Initial implementation of Datadog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ ci: globals check-env-vars ## Set Environment to CI
 	$(eval export ALERT_EMAIL_ADDRESS=the-multi-cloud-paas-team+ci@digital.cabinet-office.gov.uk)
 	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS=${ALERT_EMAIL_ADDRESS})
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-default.yml)
+	$(eval export ENABLE_DATADOG=true)
 	@true
 
 .PHONY: staging
@@ -118,6 +119,7 @@ staging: globals check-env-vars ## Set Environment to Staging
 	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS=${ALERT_EMAIL_ADDRESS})
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-default.yml)
 	$(eval export ENABLE_CF_ACCEPTANCE_TESTS=false)
+	$(eval export ENABLE_DATADOG=true)
 	@true
 
 .PHONY: prod
@@ -133,6 +135,7 @@ prod: globals check-env-vars ## Set Environment to Production
 	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS=${ALERT_EMAIL_ADDRESS})
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-prod.yml)
 	$(eval export ENABLE_CF_ACCEPTANCE_TESTS=false)
+	$(eval export ENABLE_DATADOG=true)
 	@true
 
 .PHONY: bootstrap

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,6 @@ ci: globals check-env-vars ## Set Environment to CI
 	$(eval export ALERT_EMAIL_ADDRESS=the-multi-cloud-paas-team+ci@digital.cabinet-office.gov.uk)
 	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS=${ALERT_EMAIL_ADDRESS})
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-default.yml)
-	$(eval export ENABLE_DATADOG=true)
 	@true
 
 .PHONY: staging
@@ -119,7 +118,6 @@ staging: globals check-env-vars ## Set Environment to Staging
 	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS=${ALERT_EMAIL_ADDRESS})
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-default.yml)
 	$(eval export ENABLE_CF_ACCEPTANCE_TESTS=false)
-	$(eval export ENABLE_DATADOG=true)
 	@true
 
 .PHONY: prod
@@ -135,7 +133,6 @@ prod: globals check-env-vars ## Set Environment to Production
 	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS=${ALERT_EMAIL_ADDRESS})
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-prod.yml)
 	$(eval export ENABLE_CF_ACCEPTANCE_TESTS=false)
-	$(eval export ENABLE_DATADOG=true)
 	@true
 
 .PHONY: bootstrap

--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -61,6 +61,13 @@ resources:
       region_name: {{aws_region}}
       versioned_file: healthcheck-deployed
 
+  - name: datadog-tfstate
+    type: s3-iam
+    source:
+      bucket: {{state_bucket}}
+      versioned_file: datadog.tfstate
+      region_name: eu-west-1
+
 jobs:
   - name: delete
     serial: true
@@ -72,12 +79,24 @@ jobs:
       - get: cf-secrets
       - get: cf-manifest
       - get: bosh-CA
+      - get: datadog-tfstate
 
       - task: get-cf-cli-config
         file: paas-cf/concourse/tasks/get-cf-cli-config.yml
 
       - task: remove-healthcheck-db
         file: paas-cf/concourse/tasks/remove-healthcheck-db.yml
+
+      - task: datadog-TF-destroy
+        file: paas-cf/concourse/tasks/terraform_destroy_datadog.yml
+        params:
+          TF_VAR_datadog_api_key: {{datadog_api_key}}
+          TF_VAR_datadog_app_key: {{datadog_app_key}}
+          TF_VAR_env: {{deploy_env}}
+        ensure:
+          put: datadog-tfstate
+          params:
+            file: updated-datadog-tfstate/datadog.tfstate
 
       - task: delete-deployment
         config:

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1153,6 +1153,8 @@ jobs:
             TF_VAR_system_dns_zone_name: {{system_dns_zone_name}}
             TF_VAR_apps_dns_zone_name: {{apps_dns_zone_name}}
             AWS_DEFAULT_REGION: {{aws_region}}
+            TF_VAR_datadog_api_key: {{datadog_api_key}}
+            TF_VAR_datadog_app_key: {{datadog_app_key}}
           run:
             path: sh
             args:

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -237,6 +237,13 @@ resources:
       versioned_file: cf.tfstate
       region_name: eu-west-1
 
+  - name: datadog-tfstate
+    type: s3-iam
+    source:
+      bucket: {{state_bucket}}
+      versioned_file: datadog.tfstate
+      region_name: eu-west-1
+
   - name: cf-secrets
     type: s3-iam
     source:
@@ -414,6 +421,7 @@ jobs:
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} cf.tfstate paas-cf/concourse/init_files/terraform.tfstate.tpl
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} cf-certs.tar.gz paas-cf/concourse/init_files/empty.tar.gz
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} cf-certs.tfstate paas-cf/concourse/init_files/terraform.tfstate.tpl
+                paas-cf/concourse/scripts/s3init.sh {{state_bucket}} datadog.tfstate paas-cf/concourse/init_files/terraform.tfstate.tpl
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} git-keys.tar.gz paas-cf/concourse/init_files/empty.tar.gz
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} bosh_id_rsa paas-cf/concourse/init_files/zero_bytes
                 paas-cf/concourse/scripts/s3init.sh {{state_bucket}} bosh_id_rsa.pub paas-cf/concourse/init_files/zero_bytes
@@ -1149,8 +1157,6 @@ jobs:
             TF_VAR_system_dns_zone_name: {{system_dns_zone_name}}
             TF_VAR_apps_dns_zone_name: {{apps_dns_zone_name}}
             AWS_DEFAULT_REGION: {{aws_region}}
-            TF_VAR_datadog_api_key: {{datadog_api_key}}
-            TF_VAR_datadog_app_key: {{datadog_app_key}}
           run:
             path: sh
             args:
@@ -1448,6 +1454,7 @@ jobs:
           - get: bosh-CA
           - get: graphite-nozzle
           - get: logsearch-for-cloudfoundry-boshrelease
+          - get: datadog-tfstate
 
       - aggregate:
         - task: upload-releases
@@ -1817,6 +1824,39 @@ jobs:
                 export ES_HOST="${TF_VAR_logsearch_elastic_master_elb_dns_name}"
                 export ES_PORT="9200"
                 $(pwd)/paas-cf/concourse/scripts/kibana_set_utc.rb
+
+        - task: datadog-terraform-apply
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/terraform
+            inputs:
+              - name: datadog-tfstate
+              - name: paas-cf
+            outputs:
+              - name: updated-tfstate
+            params:
+              TF_VAR_env: {{deploy_env}}
+              TF_VAR_datadog_api_key: {{datadog_api_key}}
+              TF_VAR_datadog_app_key: {{datadog_app_key}}
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  if [ "${TF_VAR_datadog_api_key}" != "disabled" ]; then
+                    terraform apply -state=datadog-tfstate/datadog.tfstate -state-out=updated-tfstate/datadog.tfstate paas-cf/terraform/datadog
+                  else
+                    echo "Datadog disabled, skipping terraform run..."
+                    cp datadog-tfstate/datadog.tfstate updated-tfstate/datadog.tfstate
+                  fi
+          ensure:
+            put: datadog-tfstate
+            params:
+              file: updated-tfstate/datadog.tfstate
 
   - name: post-deploy
     plan:

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1405,6 +1405,7 @@ jobs:
               MANIFEST_STUBS: |
                 ./paas-cf/manifests/cf-manifest/runtime-config/runtime-config-base.yml
                 ./paas-cf/manifests/shared/deployments/collectd.yml
+                ./paas-cf/manifests/shared/deployments/datadog.yml
             run:
               path: sh
               args:

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1871,7 +1871,6 @@ jobs:
           - get: cf-secrets
             passed: ['cf-deploy']
           - get: bosh-CA
-          - get: cf-tfstate
 
       - task: retrieve-config
         config:

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -93,13 +93,6 @@ resources:
       tag_filter: {{paas_cf_tag_filter}}
       commit_verification_key_ids: {{gpg_ids}}
 
-  - name: datadog-agent-boshrelease
-    type: git
-    source:
-      uri: https://github.com/alphagov/paas-datadog-agent-boshrelease.git
-      tag_filter: {{cf_datadog_agent_version}}
-      branch: custom_config
-
   - name: paas-haproxy-release
     type: git
     source:
@@ -1357,8 +1350,10 @@ jobs:
                 ./certs/*.yml
                 ./grafana-dashboards-manifest/grafana-dashboards-manifest.yml
                 ./paas-cf/manifests/shared/deployments/collectd.yml
+                ./paas-cf/manifests/shared/deployments/datadog.yml
                 ./paas-cf/manifests/cf-manifest/manifest/env-specific/{{cf_env_specific_manifest}}
               AWS_ACCOUNT: {{aws_account}}
+              DATADOG_API_KEY: {{datadog_api_key}}
             run:
               path: sh
               args:
@@ -1405,6 +1400,7 @@ jobs:
               - name: runtime-config
             params:
               DATADOG_API_KEY: {{datadog_api_key}}
+              AWS_ACCOUNT: {{aws_account}}
               MANIFEST_STUBS: |
                 ./paas-cf/manifests/cf-manifest/runtime-config/runtime-config-base.yml
                 ./paas-cf/manifests/shared/deployments/collectd.yml
@@ -1452,7 +1448,6 @@ jobs:
           - get: bosh-CA
           - get: graphite-nozzle
           - get: logsearch-for-cloudfoundry-boshrelease
-          - get: datadog-agent-boshrelease
 
       - aggregate:
         - task: upload-releases
@@ -1471,7 +1466,6 @@ jobs:
               - name: aws-broker-boshrelease
               - name: os-conf-boshrelease
               - name: logsearch-for-cloudfoundry-boshrelease
-              - name: datadog-agent-boshrelease
             run:
               path: sh
               args:
@@ -1497,9 +1491,6 @@ jobs:
 
                   paas-cf/concourse/scripts/bosh_create_and_upload_release.rb logsearch-for-cloudfoundry \
                     {{cf_logsearch_for_cloudfoundry_version}} logsearch-for-cloudfoundry-boshrelease
-
-                  paas-cf/concourse/scripts/bosh_create_and_upload_release.rb datadog-agent \
-                    {{cf_datadog_agent_version}} datadog-agent-boshrelease
 
         - task: get-and-upload-stemcell
           config:

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -945,6 +945,8 @@ jobs:
           outputs:
             - name: bosh-manifest
           params:
+            AWS_ACCOUNT: {{aws_account}}
+            DATADOG_API_KEY: {{datadog_api_key}}
             BOSH_MANIFEST_STUBS: |
               ./paas-cf/manifests/bosh-manifest/deployments/*.yml
               ./paas-cf/manifests/bosh-manifest/deployments/aws/*.yml
@@ -953,6 +955,7 @@ jobs:
               ./terraform-outputs/bosh.terraform-outputs.yml
               ./terraform-outputs/vpc.terraform-outputs.yml
               ./paas-cf/manifests/shared/deployments/collectd.yml
+              ./paas-cf/manifests/shared/deployments/datadog.yml
           run:
             path: sh
             args:

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -93,6 +93,13 @@ resources:
       tag_filter: {{paas_cf_tag_filter}}
       commit_verification_key_ids: {{gpg_ids}}
 
+  - name: datadog-agent-boshrelease
+    type: git
+    source:
+      uri: https://github.com/alphagov/paas-datadog-agent-boshrelease.git
+      tag_filter: {{cf_datadog_agent_version}}
+      branch: custom_config
+
   - name: paas-haproxy-release
     type: git
     source:
@@ -1391,6 +1398,7 @@ jobs:
             outputs:
               - name: runtime-config
             params:
+              DATADOG_API_KEY: {{datadog_api_key}}
               MANIFEST_STUBS: |
                 ./paas-cf/manifests/cf-manifest/runtime-config/runtime-config-base.yml
                 ./paas-cf/manifests/shared/deployments/collectd.yml
@@ -1437,6 +1445,7 @@ jobs:
           - get: bosh-CA
           - get: graphite-nozzle
           - get: logsearch-for-cloudfoundry-boshrelease
+          - get: datadog-agent-boshrelease
 
       - aggregate:
         - task: upload-releases
@@ -1455,6 +1464,7 @@ jobs:
               - name: aws-broker-boshrelease
               - name: os-conf-boshrelease
               - name: logsearch-for-cloudfoundry-boshrelease
+              - name: datadog-agent-boshrelease
             run:
               path: sh
               args:
@@ -1480,6 +1490,9 @@ jobs:
 
                   paas-cf/concourse/scripts/bosh_create_and_upload_release.rb logsearch-for-cloudfoundry \
                     {{cf_logsearch_for_cloudfoundry_version}} logsearch-for-cloudfoundry-boshrelease
+
+                  paas-cf/concourse/scripts/bosh_create_and_upload_release.rb datadog-agent \
+                    {{cf_datadog_agent_version}} datadog-agent-boshrelease
 
         - task: get-and-upload-stemcell
           config:

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1353,6 +1353,7 @@ jobs:
                 ./grafana-dashboards-manifest/grafana-dashboards-manifest.yml
                 ./paas-cf/manifests/shared/deployments/collectd.yml
                 ./paas-cf/manifests/cf-manifest/manifest/env-specific/{{cf_env_specific_manifest}}
+              AWS_ACCOUNT: {{aws_account}}
             run:
               path: sh
               args:

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -33,6 +33,13 @@ resources:
       versioned_file: cf-certs.tfstate
       region_name: eu-west-1
 
+  - name: datadog-tfstate
+    type: s3-iam
+    source:
+      bucket: {{state_bucket}}
+      versioned_file: datadog.tfstate
+      region_name: eu-west-1
+
   - name: concourse-tfstate
     type: s3-iam
     source:
@@ -144,12 +151,24 @@ jobs:
           - get: paas-cf
           - get: cf-secrets
           - get: cf-manifest
+          - get: datadog-tfstate
 
       - task: get-cf-cli-config
         file: paas-cf/concourse/tasks/get-cf-cli-config.yml
 
       - task: remove-healthcheck-db
         file: paas-cf/concourse/tasks/remove-healthcheck-db.yml
+
+      - task: datadog-TF-destroy
+        file: paas-cf/concourse/tasks/terraform_destroy_datadog.yml
+        params:
+          TF_VAR_datadog_api_key: {{datadog_api_key}}
+          TF_VAR_datadog_app_key: {{datadog_app_key}}
+          TF_VAR_env: {{deploy_env}}
+        ensure:
+          put: datadog-tfstate
+          params:
+            file: updated-datadog-tfstate/datadog.tfstate
 
       - task: delete-deployment
         config:

--- a/concourse/pipelines/failure-testing.yml
+++ b/concourse/pipelines/failure-testing.yml
@@ -351,10 +351,6 @@ jobs:
     serial: true
     plan:
       - aggregate:
-          - get: cf-release
-            params:
-              submodules:
-                - src/smoke-tests
           - get: paas-cf
           - get: cf-manifest
           - get: cf-secrets

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -45,6 +45,7 @@ prepare_environment() {
   cf_aws_broker_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.aws-broker.version "${cf_manifest_dir}/050-rds-broker.yml")
   cf_os_conf_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.os-conf.version "${cf_manifest_dir}/../runtime-config/runtime-config-base.yml")
   cf_logsearch_for_cloudfoundry_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.logsearch-for-cloudfoundry.version "${cf_manifest_dir}/030-logsearch.yml")
+  cf_datadog_agent_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.datadog-agent.version "${cf_manifest_dir}/../runtime-config/runtime-config-base.yml")
 
   if [ -z "${SKIP_COMMIT_VERIFICATION:-}" ] ; then
     gpg_ids="[$(xargs < "${SCRIPT_DIR}/../../.gpg-id" | tr ' ' ',')]"
@@ -56,6 +57,12 @@ prepare_environment() {
   get_git_concourse_pool_clone_full_url_ssh
 
   export EXPOSE_PIPELINE=1
+
+  if [ "${ENABLE_DATADOG:-}" = "true" ]; then
+    export PASSWORD_STORE_DIR=~/.paas-pass
+    datadog_api_key=$(pass datadog/api_key)
+    datadog_app_key=$(pass datadog/app_key)
+  fi
 }
 
 generate_vars_file() {
@@ -80,6 +87,7 @@ cf_grafana_version: ${cf_grafana_version}
 cf_aws_broker_version: ${cf_aws_broker_version}
 cf_os_conf_version: ${cf_os_conf_version}
 cf_logsearch_for_cloudfoundry_version: ${cf_logsearch_for_cloudfoundry_version}
+cf_datadog_agent_version: ${cf_datadog_agent_version}
 cf_env_specific_manifest: ${ENV_SPECIFIC_CF_MANIFEST}
 paas_cf_tag_filter: ${PAAS_CF_TAG_FILTER:-}
 TAG_PREFIX: ${TAG_PREFIX:-}
@@ -93,6 +101,8 @@ bosh_az: ${bosh_az}
 bosh_manifest_state: bosh-manifest-state-${bosh_az}.json
 bosh_fqdn: bosh.${SYSTEM_DNS_ZONE_NAME}
 enable_cf_acceptance_tests: ${ENABLE_CF_ACCEPTANCE_TESTS:-true}
+datadog_api_key: ${datadog_api_key:-}
+datadog_app_key: ${datadog_app_key:-}
 EOF
   echo -e "pipeline_lock_git_private_key: |\n  ${git_id_rsa//$'\n'/$'\n'  }"
 }

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -45,7 +45,7 @@ prepare_environment() {
   cf_aws_broker_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.aws-broker.version "${cf_manifest_dir}/050-rds-broker.yml")
   cf_os_conf_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.os-conf.version "${cf_manifest_dir}/../runtime-config/runtime-config-base.yml")
   cf_logsearch_for_cloudfoundry_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.logsearch-for-cloudfoundry.version "${cf_manifest_dir}/030-logsearch.yml")
-  cf_datadog_agent_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.datadog-agent.version "${cf_manifest_dir}/../runtime-config/runtime-config-base.yml")
+  cf_datadog_agent_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.datadog-agent.version "${cf_manifest_dir}/../../shared/deployments/datadog.yml")
 
   if [ -z "${SKIP_COMMIT_VERIFICATION:-}" ] ; then
     gpg_ids="[$(xargs < "${SCRIPT_DIR}/../../.gpg-id" | tr ' ' ',')]"

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -61,6 +61,8 @@ prepare_environment() {
     export PASSWORD_STORE_DIR=~/.paas-pass
     datadog_api_key=$(pass datadog/api_key)
     datadog_app_key=$(pass datadog/app_key)
+  else
+    datadog_api_key="disabled"
   fi
 }
 

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -45,7 +45,6 @@ prepare_environment() {
   cf_aws_broker_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.aws-broker.version "${cf_manifest_dir}/050-rds-broker.yml")
   cf_os_conf_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.os-conf.version "${cf_manifest_dir}/../runtime-config/runtime-config-base.yml")
   cf_logsearch_for_cloudfoundry_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.logsearch-for-cloudfoundry.version "${cf_manifest_dir}/030-logsearch.yml")
-  cf_datadog_agent_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.datadog-agent.version "${cf_manifest_dir}/../../shared/deployments/datadog.yml")
 
   if [ -z "${SKIP_COMMIT_VERIFICATION:-}" ] ; then
     gpg_ids="[$(xargs < "${SCRIPT_DIR}/../../.gpg-id" | tr ' ' ',')]"
@@ -87,7 +86,6 @@ cf_grafana_version: ${cf_grafana_version}
 cf_aws_broker_version: ${cf_aws_broker_version}
 cf_os_conf_version: ${cf_os_conf_version}
 cf_logsearch_for_cloudfoundry_version: ${cf_logsearch_for_cloudfoundry_version}
-cf_datadog_agent_version: ${cf_datadog_agent_version}
 cf_env_specific_manifest: ${ENV_SPECIFIC_CF_MANIFEST}
 paas_cf_tag_filter: ${PAAS_CF_TAG_FILTER:-}
 TAG_PREFIX: ${TAG_PREFIX:-}

--- a/concourse/tasks/terraform_destroy_datadog.yml
+++ b/concourse/tasks/terraform_destroy_datadog.yml
@@ -1,0 +1,26 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/terraform
+inputs:
+  - name: paas-cf
+  - name: datadog-tfstate
+outputs:
+  - name: updated-datadog-tfstate
+run:
+  path: sh
+  args:
+    - -e
+    - -c
+    - |
+      if [ "${TF_VAR_datadog_api_key}" != "disabled" ]; then
+        terraform destroy -force \
+          -state=datadog-tfstate/datadog.tfstate \
+          -state-out=updated-datadog-tfstate/datadog.tfstate \
+        paas-cf/terraform/datadog
+      else
+        echo "Datadog disabled, skipping terraform run..."
+        cp datadog-tfstate/datadog.tfstate updated-datadog-tfstate/datadog.tfstate
+      fi

--- a/manifests/bosh-manifest/deployments/010-bosh-template.yml
+++ b/manifests/bosh-manifest/deployments/010-bosh-template.yml
@@ -1,5 +1,6 @@
 ---
 meta:
+  environment: (( grab terraform_outputs.environment ))
   default_agent:
     mbus: (( concat "nats://nats:" secrets.bosh_nats_password "@" terraform_outputs.bosh_fqdn ":4222" ))
 

--- a/manifests/bosh-manifest/deployments/030-trusted_certs.yml
+++ b/manifests/bosh-manifest/deployments/030-trusted_certs.yml
@@ -1,4 +1,6 @@
 ---
-properties:
-  director:
-    trusted_certs: (( grab secrets.bosh_ca_cert ))
+jobs:
+- name: bosh
+  properties:
+    director:
+      trusted_certs: (( grab secrets.bosh_ca_cert ))

--- a/manifests/bosh-manifest/deployments/040-collectd.yml
+++ b/manifests/bosh-manifest/deployments/040-collectd.yml
@@ -3,9 +3,8 @@ jobs:
 - name: bosh
   templates:
   - {name: collectd, release: collectd}
-
-properties:
-  collectd:
-    hostname_prefix: bosh_
-    interval: (( grab meta.collectd.interval ))
-    config: (( grab meta.collectd.config ))
+  properties:
+    collectd:
+      hostname_prefix: bosh_
+      interval: (( grab meta.collectd.interval ))
+      config: (( grab meta.collectd.config ))

--- a/manifests/bosh-manifest/deployments/050-datadog.yml
+++ b/manifests/bosh-manifest/deployments/050-datadog.yml
@@ -7,5 +7,4 @@ jobs:
     datadog: (( inject meta.datadog ))
     tags:
       job: bosh
-      environment: (( grab terraform_outputs.environment ))
-      aws_account: (( grab $AWS_ACCOUNT ))
+      tags: (( inject meta.datadog_tags ))

--- a/manifests/bosh-manifest/deployments/050-datadog.yml
+++ b/manifests/bosh-manifest/deployments/050-datadog.yml
@@ -3,10 +3,9 @@ jobs:
 - name: bosh
   templates:
   - {name: datadog-agent, release: datadog-agent}
-
-properties:
-  datadog: (( inject meta.datadog ))
-  tags:
-    job: bosh
-    environment: (( grab terraform_outputs.environment ))
-    aws_account: (( grab $AWS_ACCOUNT ))
+  properties:
+    datadog: (( inject meta.datadog ))
+    tags:
+      job: bosh
+      environment: (( grab terraform_outputs.environment ))
+      aws_account: (( grab $AWS_ACCOUNT ))

--- a/manifests/bosh-manifest/deployments/050-datadog.yml
+++ b/manifests/bosh-manifest/deployments/050-datadog.yml
@@ -1,0 +1,12 @@
+---
+jobs:
+- name: bosh
+  templates:
+  - {name: datadog-agent, release: datadog-agent}
+
+properties:
+  datadog: (( inject meta.datadog ))
+  tags:
+    job: bosh
+    environment: (( grab terraform_outputs.environment ))
+    aws_account: (( grab $AWS_ACCOUNT ))

--- a/manifests/bosh-manifest/spec/properties_spec.rb
+++ b/manifests/bosh-manifest/spec/properties_spec.rb
@@ -1,8 +1,6 @@
 RSpec.describe "manifest properties validations" do
   let(:manifest) { manifest_with_defaults }
-  let(:properties) { manifest.fetch("properties") }
-  let(:bosh_job) { manifest.fetch("jobs").select { |x| x["name"] == "bosh" }.first }
-  let(:bosh_properties) { properties.merge(bosh_job["properties"]) }
+  let(:bosh_properties) { manifest.fetch("jobs").select { |x| x["name"] == "bosh" }.first["properties"] }
 
   it "configures hm bosh user with password" do
     users = bosh_properties["director"]["user_management"]["local"]["users"]

--- a/manifests/bosh-manifest/spec/shared_config_spec.rb
+++ b/manifests/bosh-manifest/spec/shared_config_spec.rb
@@ -1,8 +1,11 @@
-
-RSpec.describe "Bosh collectd properties" do
+RSpec.describe "Gets properties from shared config" do
   let(:manifest) { manifest_with_defaults }
 
-  it "pulls from a shared config file" do
+  it "for collectd" do
     expect(manifest.fetch("properties").fetch("collectd").fetch("interval")).to eq 10
+  end
+
+  it "for datadog" do
+    expect(manifest.fetch("properties").fetch("use_dogstatsd")).to eq false
   end
 end

--- a/manifests/bosh-manifest/spec/shared_config_spec.rb
+++ b/manifests/bosh-manifest/spec/shared_config_spec.rb
@@ -1,11 +1,12 @@
 RSpec.describe "Gets properties from shared config" do
   let(:manifest) { manifest_with_defaults }
+  let(:bosh_properties) { manifest.fetch("jobs").select { |x| x["name"] == "bosh" }.first["properties"] }
 
   it "for collectd" do
-    expect(manifest.fetch("properties").fetch("collectd").fetch("interval")).to eq 10
+    expect(bosh_properties["collectd"]["interval"]).to eq 10
   end
 
   it "for datadog" do
-    expect(manifest.fetch("properties").fetch("use_dogstatsd")).to eq false
+    expect(bosh_properties["use_dogstatsd"]).to eq false
   end
 end

--- a/manifests/bosh-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/bosh-manifest/spec/support/manifest_helpers.rb
@@ -15,6 +15,9 @@ module ManifestHelpers
 private
 
   def load_default_manifest
+    ENV["AWS_ACCOUNT"] = "dev"
+    ENV["DATADOG_API_KEY"] = "abcd1234"
+
     output, error, status = Open3.capture3(
       [
         File.expand_path("../../../../shared/build_manifest.sh", __FILE__),
@@ -23,6 +26,7 @@ private
         File.expand_path("../../fixtures/bosh-secrets.yml", __FILE__),
         File.expand_path("../../fixtures/bosh-ssl-certificates.yml", __FILE__),
         File.expand_path("../../fixtures/bosh-terraform-outputs.yml", __FILE__),
+        File.expand_path("../../../../shared/deployments/datadog.yml", __FILE__),
         File.expand_path("../../../../shared/deployments/collectd.yml", __FILE__)
       ].join(' ')
     )

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -133,8 +133,7 @@ jobs:
           mode: server
       tags:
         job: consul
-        environment: (( grab meta.environment ))
-        aws_account: (( grab $AWS_ACCOUNT ))
+        tags: (( inject meta.datadog_tags ))
 
   - name: nats
     azs: [z1, z2]
@@ -150,8 +149,7 @@ jobs:
     properties:
       tags:
         job: nats
-        environment: (( grab meta.environment ))
-        aws_account: (( grab $AWS_ACCOUNT ))
+        tags: (( inject meta.datadog_tags ))
 
   - name: etcd
     azs: [z1, z2, z3]
@@ -175,8 +173,7 @@ jobs:
             etcd: {}
       tags:
         job: etcd
-        environment: (( grab meta.environment ))
-        aws_account: (( grab $AWS_ACCOUNT ))
+        tags: (( inject meta.datadog_tags ))
 
   - name: uaa
     azs: [z1, z2]
@@ -193,8 +190,7 @@ jobs:
             uaa: {}
       tags:
         job: uaa
-        environment: (( grab meta.environment ))
-        aws_account: (( grab $AWS_ACCOUNT ))
+        tags: (( inject meta.datadog_tags ))
 
   - name: api
     azs: [z1, z2]
@@ -210,8 +206,7 @@ jobs:
           services: (( grab meta.api_consul_services ))
       tags:
         job: api
-        environment: (( grab meta.environment ))
-        aws_account: (( grab $AWS_ACCOUNT ))
+        tags: (( inject meta.datadog_tags ))
 
   - name: clock_global
     azs: [z1]
@@ -224,8 +219,7 @@ jobs:
     properties:
       tags:
         job: clock_global
-        environment: (( grab meta.environment ))
-        aws_account: (( grab $AWS_ACCOUNT ))
+        tags: (( inject meta.datadog_tags ))
 
   - name: api_worker
     azs: [z1, z2]
@@ -238,8 +232,7 @@ jobs:
     properties:
       tags:
         job: api_worker
-        environment: (( grab meta.environment ))
-        aws_account: (( grab $AWS_ACCOUNT ))
+        tags: (( inject meta.datadog_tags ))
 
   - name: doppler
     azs: [z1, z2]
@@ -252,8 +245,7 @@ jobs:
     properties:
       tags:
         job: doppler
-        environment: (( grab meta.environment ))
-        aws_account: (( grab $AWS_ACCOUNT ))
+        tags: (( inject meta.datadog_tags ))
 
   - name: loggregator_trafficcontroller
     azs: [z1, z2]
@@ -266,8 +258,7 @@ jobs:
     properties:
       tags:
         job: loggregator_trafficcontroller
-        environment: (( grab meta.environment ))
-        aws_account: (( grab $AWS_ACCOUNT ))
+        tags: (( inject meta.datadog_tags ))
 
   - name: router
     azs: [z1, z2]
@@ -284,8 +275,7 @@ jobs:
             gorouter: {}
       tags:
         job: router
-        environment: (( grab meta.environment ))
-        aws_account: (( grab $AWS_ACCOUNT ))
+        tags: (( inject meta.datadog_tags ))
 # Diego
 
   - name: database
@@ -305,8 +295,7 @@ jobs:
     properties:
       tags:
         job: database
-        environment: (( grab meta.environment ))
-        aws_account: (( grab $AWS_ACCOUNT ))
+        tags: (( inject meta.datadog_tags ))
     update:
       serial: true
 
@@ -327,8 +316,7 @@ jobs:
     properties:
       tags:
         job: brain
-        environment: (( grab meta.environment ))
-        aws_account: (( grab $AWS_ACCOUNT ))
+        tags: (( inject meta.datadog_tags ))
 
   - name: cell
     azs: [z1, z2]
@@ -351,8 +339,7 @@ jobs:
     properties:
       tags:
         job: cell
-        environment: (( grab meta.environment ))
-        aws_account: (( grab $AWS_ACCOUNT ))
+        tags: (( inject meta.datadog_tags ))
 
   - name: cc_bridge
     azs: [z1, z2]
@@ -377,8 +364,7 @@ jobs:
     properties:
       tags:
         job: cc_bridge
-        environment: (( grab meta.environment ))
-        aws_account: (( grab $AWS_ACCOUNT ))
+        tags: (( inject meta.datadog_tags ))
 
   - name: route_emitter
     azs: [z1, z2]
@@ -397,8 +383,7 @@ jobs:
     properties:
       tags:
         job: route_emitter
-        environment: (( grab meta.environment ))
-        aws_account: (( grab $AWS_ACCOUNT ))
+        tags: (( inject meta.datadog_tags ))
 
   - name: access
     azs: [z1, z2]
@@ -419,5 +404,4 @@ jobs:
     properties:
       tags:
         job: access
-        environment: (( grab meta.environment ))
-        aws_account: (( grab $AWS_ACCOUNT ))
+        tags: (( inject meta.datadog_tags ))

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -131,6 +131,10 @@ jobs:
       consul:
         agent:
           mode: server
+      tags:
+        job: consul
+        environment: (( grab meta.environment ))
+        aws_account: (( grab $AWS_ACCOUNT ))
 
   - name: nats
     azs: [z1, z2]
@@ -143,6 +147,11 @@ jobs:
         static_ips:
           - 10.0.16.11
           - 10.0.17.11
+    properties:
+      tags:
+        job: nats
+        environment: (( grab meta.environment ))
+        aws_account: (( grab $AWS_ACCOUNT ))
 
   - name: etcd
     azs: [z1, z2, z3]
@@ -164,6 +173,10 @@ jobs:
         agent:
           services:
             etcd: {}
+      tags:
+        job: etcd
+        environment: (( grab meta.environment ))
+        aws_account: (( grab $AWS_ACCOUNT ))
 
   - name: uaa
     azs: [z1, z2]
@@ -178,6 +191,10 @@ jobs:
         agent:
           services:
             uaa: {}
+      tags:
+        job: uaa
+        environment: (( grab meta.environment ))
+        aws_account: (( grab $AWS_ACCOUNT ))
 
   - name: api
     azs: [z1, z2]
@@ -191,6 +208,10 @@ jobs:
       consul:
         agent:
           services: (( grab meta.api_consul_services ))
+      tags:
+        job: api
+        environment: (( grab meta.environment ))
+        aws_account: (( grab $AWS_ACCOUNT ))
 
   - name: clock_global
     azs: [z1]
@@ -200,6 +221,11 @@ jobs:
     stemcell: default
     networks:
       - name: cf
+    properties:
+      tags:
+        job: clock_global
+        environment: (( grab meta.environment ))
+        aws_account: (( grab $AWS_ACCOUNT ))
 
   - name: api_worker
     azs: [z1, z2]
@@ -209,6 +235,11 @@ jobs:
     stemcell: default
     networks:
       - name: cf
+    properties:
+      tags:
+        job: api_worker
+        environment: (( grab meta.environment ))
+        aws_account: (( grab $AWS_ACCOUNT ))
 
   - name: doppler
     azs: [z1, z2]
@@ -218,6 +249,11 @@ jobs:
     stemcell: default
     networks:
       - name: cf
+    properties:
+      tags:
+        job: doppler
+        environment: (( grab meta.environment ))
+        aws_account: (( grab $AWS_ACCOUNT ))
 
   - name: loggregator_trafficcontroller
     azs: [z1, z2]
@@ -227,6 +263,11 @@ jobs:
     stemcell: default
     networks:
       - name: cf
+    properties:
+      tags:
+        job: loggregator_trafficcontroller
+        environment: (( grab meta.environment ))
+        aws_account: (( grab $AWS_ACCOUNT ))
 
   - name: router
     azs: [z1, z2]
@@ -241,6 +282,10 @@ jobs:
         agent:
           services:
             gorouter: {}
+      tags:
+        job: router
+        environment: (( grab meta.environment ))
+        aws_account: (( grab $AWS_ACCOUNT ))
 # Diego
 
   - name: database
@@ -257,6 +302,11 @@ jobs:
     stemcell: default
     networks:
       - name: cf
+    properties:
+      tags:
+        job: database
+        environment: (( grab meta.environment ))
+        aws_account: (( grab $AWS_ACCOUNT ))
     update:
       serial: true
 
@@ -274,6 +324,11 @@ jobs:
     stemcell: default
     networks:
       - name: cf
+    properties:
+      tags:
+        job: brain
+        environment: (( grab meta.environment ))
+        aws_account: (( grab $AWS_ACCOUNT ))
 
   - name: cell
     azs: [z1, z2]
@@ -293,6 +348,11 @@ jobs:
     stemcell: default
     networks:
       - name: cell
+    properties:
+      tags:
+        job: cell
+        environment: (( grab meta.environment ))
+        aws_account: (( grab $AWS_ACCOUNT ))
 
   - name: cc_bridge
     azs: [z1, z2]
@@ -314,6 +374,11 @@ jobs:
     stemcell: default
     networks:
       - name: cf
+    properties:
+      tags:
+        job: cc_bridge
+        environment: (( grab meta.environment ))
+        aws_account: (( grab $AWS_ACCOUNT ))
 
   - name: route_emitter
     azs: [z1, z2]
@@ -329,6 +394,11 @@ jobs:
     stemcell: default
     networks:
       - name: cf
+    properties:
+      tags:
+        job: route_emitter
+        environment: (( grab meta.environment ))
+        aws_account: (( grab $AWS_ACCOUNT ))
 
   - name: access
     azs: [z1, z2]
@@ -346,3 +416,8 @@ jobs:
     stemcell: default
     networks:
       - name: cf
+    properties:
+      tags:
+        job: access
+        environment: (( grab meta.environment ))
+        aws_account: (( grab $AWS_ACCOUNT ))

--- a/manifests/cf-manifest/manifest/030-logsearch.yml
+++ b/manifests/cf-manifest/manifest/030-logsearch.yml
@@ -33,8 +33,7 @@ jobs:
       host: (( grab jobs.queue.networks.cf.static_ips.[0] ))
     tags:
       job: ingestor_z1
-      environment: (( grab meta.environment ))
-      aws_account: (( grab $AWS_ACCOUNT ))
+      tags: (( inject meta.datadog_tags ))
 
 - name: ingestor_z2
   release: logsearch
@@ -56,8 +55,7 @@ jobs:
       host: (( grab jobs.queue.networks.cf.static_ips.[1] ))
     tags:
       job: ingestor_z2
-      environment: (( grab meta.environment ))
-      aws_account: (( grab $AWS_ACCOUNT ))
+      tags: (( inject meta.datadog_tags ))
 
 - name: queue
   release: logsearch
@@ -77,8 +75,7 @@ jobs:
   properties:
     tags:
       job: queue
-      environment: (( grab meta.environment ))
-      aws_account: (( grab $AWS_ACCOUNT ))
+      tags: (( inject meta.datadog_tags ))
 
 - name: parser_z1
   release: logsearch
@@ -103,8 +100,7 @@ jobs:
       - /var/vcap/packages/logsearch-for-cloudfoundry-filters/logstash-filters-default.conf
     tags:
       job: parser_z1
-      environment: (( grab meta.environment ))
-      aws_account: (( grab $AWS_ACCOUNT ))
+      tags: (( inject meta.datadog_tags ))
 
 - name: parser_z2
   release: logsearch
@@ -129,8 +125,7 @@ jobs:
       - /var/vcap/packages/logsearch-for-cloudfoundry-filters/logstash-filters-default.conf
     tags:
       job: parser_z2
-      environment: (( grab meta.environment ))
-      aws_account: (( grab $AWS_ACCOUNT ))
+      tags: (( inject meta.datadog_tags ))
 
 - name: elasticsearch_master
   release: logsearch
@@ -157,8 +152,7 @@ jobs:
       master_hosts: (( grab properties.elasticsearch.master_hosts ))
     tags:
       job: elasticsearch_master
-      environment: (( grab meta.environment ))
-      aws_account: (( grab $AWS_ACCOUNT ))
+      tags: (( inject meta.datadog_tags ))
   update: (( grab meta.update ))
 
 - name: maintenance
@@ -180,8 +174,7 @@ jobs:
       - index_template: /var/vcap/packages/logsearch-for-cloudfoundry-filters/logs-template.json
     tags:
       job: maintenance
-      environment: (( grab meta.environment ))
-      aws_account: (( grab $AWS_ACCOUNT ))
+      tags: (( inject meta.datadog_tags ))
 
 - name: kibana
   release: logsearch
@@ -198,8 +191,7 @@ jobs:
   properties:
     tags:
       job: kibana
-      environment: (( grab meta.environment ))
-      aws_account: (( grab $AWS_ACCOUNT ))
+      tags: (( inject meta.datadog_tags ))
 
 properties:
   syslog_daemon_config:

--- a/manifests/cf-manifest/manifest/030-logsearch.yml
+++ b/manifests/cf-manifest/manifest/030-logsearch.yml
@@ -31,6 +31,10 @@ jobs:
   properties:
     redis:
       host: (( grab jobs.queue.networks.cf.static_ips.[0] ))
+    tags:
+      job: ingestor_z1
+      environment: (( grab meta.environment ))
+      aws_account: (( grab $AWS_ACCOUNT ))
 
 - name: ingestor_z2
   release: logsearch
@@ -50,6 +54,10 @@ jobs:
   properties:
     redis:
       host: (( grab jobs.queue.networks.cf.static_ips.[1] ))
+    tags:
+      job: ingestor_z2
+      environment: (( grab meta.environment ))
+      aws_account: (( grab $AWS_ACCOUNT ))
 
 - name: queue
   release: logsearch
@@ -66,6 +74,11 @@ jobs:
       - 10.0.17.13
   persistent_disk_type: queue
   update: (( grab meta.update ))
+  properties:
+    tags:
+      job: queue
+      environment: (( grab meta.environment ))
+      aws_account: (( grab $AWS_ACCOUNT ))
 
 - name: parser_z1
   release: logsearch
@@ -88,6 +101,10 @@ jobs:
     logstash_parser:
       filters:
       - /var/vcap/packages/logsearch-for-cloudfoundry-filters/logstash-filters-default.conf
+    tags:
+      job: parser_z1
+      environment: (( grab meta.environment ))
+      aws_account: (( grab $AWS_ACCOUNT ))
 
 - name: parser_z2
   release: logsearch
@@ -110,6 +127,10 @@ jobs:
     logstash_parser:
       filters:
       - /var/vcap/packages/logsearch-for-cloudfoundry-filters/logstash-filters-default.conf
+    tags:
+      job: parser_z2
+      environment: (( grab meta.environment ))
+      aws_account: (( grab $AWS_ACCOUNT ))
 
 - name: elasticsearch_master
   release: logsearch
@@ -134,6 +155,10 @@ jobs:
       discovery:
         minimum_master_nodes: 2
       master_hosts: (( grab properties.elasticsearch.master_hosts ))
+    tags:
+      job: elasticsearch_master
+      environment: (( grab meta.environment ))
+      aws_account: (( grab $AWS_ACCOUNT ))
   update: (( grab meta.update ))
 
 - name: maintenance
@@ -153,6 +178,10 @@ jobs:
     elasticsearch_config:
       templates:
       - index_template: /var/vcap/packages/logsearch-for-cloudfoundry-filters/logs-template.json
+    tags:
+      job: maintenance
+      environment: (( grab meta.environment ))
+      aws_account: (( grab $AWS_ACCOUNT ))
 
 - name: kibana
   release: logsearch
@@ -166,6 +195,11 @@ jobs:
   networks:
   - name: cf
   update: (( grab meta.update ))
+  properties:
+    tags:
+      job: kibana
+      environment: (( grab meta.environment ))
+      aws_account: (( grab $AWS_ACCOUNT ))
 
 properties:
   syslog_daemon_config:

--- a/manifests/cf-manifest/manifest/040-graphite.yml
+++ b/manifests/cf-manifest/manifest/040-graphite.yml
@@ -66,7 +66,6 @@ jobs:
           database_type: graphite
     tags:
       job: graphite
-      environment: (( grab meta.environment ))
-      aws_account: (( grab $AWS_ACCOUNT ))
+      tags: (( inject meta.datadog_tags ))
 
   templates: (( grab meta.graphite_templates ))

--- a/manifests/cf-manifest/manifest/040-graphite.yml
+++ b/manifests/cf-manifest/manifest/040-graphite.yml
@@ -64,5 +64,9 @@ jobs:
         - name: graphite
           url: http://localhost:3001
           database_type: graphite
+    tags:
+      job: graphite
+      environment: (( grab meta.environment ))
+      aws_account: (( grab $AWS_ACCOUNT ))
 
   templates: (( grab meta.graphite_templates ))

--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -35,8 +35,7 @@ jobs:
     properties:
       tags:
         job: rds_broker
-        environment: (( grab meta.environment ))
-        aws_account: (( grab $AWS_ACCOUNT ))
+        tags: (( inject meta.datadog_tags ))
       rds-broker:
         aws_access_key_id: ""
         aws_secret_access_key: ""

--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -33,6 +33,10 @@ jobs:
     networks:
       - name: cf
     properties:
+      tags:
+        job: rds_broker
+        environment: (( grab meta.environment ))
+        aws_account: (( grab $AWS_ACCOUNT ))
       rds-broker:
         aws_access_key_id: ""
         aws_secret_access_key: ""

--- a/manifests/cf-manifest/runtime-config/runtime-config-base.yml
+++ b/manifests/cf-manifest/runtime-config/runtime-config-base.yml
@@ -1,3 +1,7 @@
+---
+meta:
+  environment: for_datadog
+
 releases:
   - name: os-conf
     version: commit-a2bc2ab32248c8edf7c4790b33902893b1f4db66

--- a/manifests/cf-manifest/runtime-config/runtime-config-base.yml
+++ b/manifests/cf-manifest/runtime-config/runtime-config-base.yml
@@ -1,8 +1,6 @@
 releases:
   - name: os-conf
     version: commit-a2bc2ab32248c8edf7c4790b33902893b1f4db66
-  - name: datadog-agent
-    version: custom_005
 
 addons:
   - name: os-configuration
@@ -19,6 +17,4 @@ addons:
     jobs:
     - name: datadog-agent
       release: datadog-agent
-    properties:
-      api_key: (( grab $DATADOG_API_KEY ))
-      use_dogstatsd: no
+    properties: (( grab meta.datadog ))

--- a/manifests/cf-manifest/runtime-config/runtime-config-base.yml
+++ b/manifests/cf-manifest/runtime-config/runtime-config-base.yml
@@ -1,6 +1,8 @@
 releases:
   - name: os-conf
     version: commit-a2bc2ab32248c8edf7c4790b33902893b1f4db66
+  - name: datadog-agent
+    version: custom_005
 
 addons:
   - name: os-configuration
@@ -13,3 +15,9 @@ addons:
       release: collectd
     properties:
       collectd: (( grab meta.collectd ))
+  - name: datadog-agent
+    jobs:
+    - name: datadog-agent
+      release: datadog-agent
+    properties:
+      api_key: (( grab $DATADOG_API_KEY ))

--- a/manifests/cf-manifest/runtime-config/runtime-config-base.yml
+++ b/manifests/cf-manifest/runtime-config/runtime-config-base.yml
@@ -21,3 +21,4 @@ addons:
       release: datadog-agent
     properties:
       api_key: (( grab $DATADOG_API_KEY ))
+      use_dogstatsd: no

--- a/manifests/cf-manifest/spec/manifest/jobs_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/jobs_spec.rb
@@ -97,4 +97,16 @@ RSpec.describe "the jobs definitions block" do
         "expected '#{j['name']}' job to list 'consul_agent' first"
     }
   end
+
+  describe "in order to monitor all hosts via datadog" do
+    it "has datadog tags on each job" do
+      jobs.each { |job|
+        expect(job["properties"]["tags"]).not_to be_nil, "job '#{job['name']}' is missing the datadog 'tags' property"
+        expect(job["properties"]["tags"]["job"]).to eq(job["name"]),
+          "job '#{job['name']}' should have a tag 'job=#{job['name']}' instead of #{job['properties']['tags']['job']}"
+        expect(job["properties"]["tags"]["environment"]).to eq("unit-test")
+        expect(job["properties"]["tags"]["aws_account"]).to eq(ENV["AWS_ACCOUNT"])
+      }
+    end
+  end
 end

--- a/manifests/cf-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/cf-manifest/spec/support/manifest_helpers.rb
@@ -60,6 +60,7 @@ private
         File.expand_path("../../../../shared/spec/fixtures/cf-ssl-certificates.yml", __FILE__),
         grafana_dashboards_manifest_path,
         File.expand_path("../../../manifest/env-specific/cf-#{environment}.yml", __FILE__),
+        File.expand_path("../../../../shared/deployments/datadog.yml", __FILE__),
     ])
 
     cloud_config = render([

--- a/manifests/cf-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/cf-manifest/spec/support/manifest_helpers.rb
@@ -82,6 +82,7 @@ private
     runtime_config = render([
       File.expand_path("../../../../shared/build_manifest.sh", __FILE__),
       File.expand_path("../../../runtime-config/runtime-config-base.yml", __FILE__),
+      File.expand_path("../../../../shared/deployments/datadog.yml", __FILE__),
       File.expand_path("../../../../shared/deployments/collectd.yml", __FILE__)
     ])
 

--- a/manifests/cf-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/cf-manifest/spec/support/manifest_helpers.rb
@@ -21,7 +21,13 @@ module ManifestHelpers
 
 private
 
+  def fake_env_vars
+    ENV["AWS_ACCOUNT"] = "dev"
+    ENV["DATADOG_API_KEY"] = "abcd1234"
+  end
+
   def render(arg_list)
+    fake_env_vars
     output, error, status = Open3.capture3(arg_list.join(' '))
     expect(status).to be_success, "build_manifest.sh exited #{status.exitstatus}, stderr:\n#{error}"
     output

--- a/manifests/shared/deployments/datadog.yml
+++ b/manifests/shared/deployments/datadog.yml
@@ -9,3 +9,6 @@ meta:
   datadog:
     api_key: (( grab $DATADOG_API_KEY ))
     use_dogstatsd: false
+  datadog_tags:
+    environment: (( grab meta.environment ))
+    aws_account: (( grab $AWS_ACCOUNT ))

--- a/manifests/shared/deployments/datadog.yml
+++ b/manifests/shared/deployments/datadog.yml
@@ -1,0 +1,11 @@
+---
+releases:
+- name: datadog-agent
+  sha1: 1cefcc1981b3de2c549452974b41964eaa6637ec
+  url: https://github.com/alphagov/paas-datadog-agent-boshrelease/releases/download/custom_005/datadog-agent-custom_005.tgz
+  version: "custom_005"
+
+meta:
+  datadog:
+    api_key: (( grab $DATADOG_API_KEY ))
+    use_dogstatsd: false

--- a/manifests/shared/deployments/datadog.yml
+++ b/manifests/shared/deployments/datadog.yml
@@ -1,9 +1,9 @@
 ---
 releases:
 - name: datadog-agent
-  sha1: 1cefcc1981b3de2c549452974b41964eaa6637ec
-  url: https://github.com/alphagov/paas-datadog-agent-boshrelease/releases/download/custom_005/datadog-agent-custom_005.tgz
-  version: "custom_005"
+  sha1: e26ac31091d4577c3aec4569e740e662007b36af
+  url: https://github.com/alphagov/paas-datadog-agent-boshrelease/releases/download/custom_006/datadog-agent-custom_006.tgz
+  version: "custom_006"
 
 meta:
   datadog:

--- a/terraform/cloudfoundry/datadog.tf
+++ b/terraform/cloudfoundry/datadog.tf
@@ -1,0 +1,28 @@
+variable "datadog_api_key" {}
+variable "datadog_app_key" {}
+
+provider "datadog" {
+    api_key = "${var.datadog_api_key}"
+    app_key = "${var.datadog_app_key}"
+}
+
+resource "datadog_monitor" "router" {
+  name = "${format("%s router hosts", var.env)}"
+  type = "service check"
+  message = "Missing router hosts in environment {{host.environment}}. Notify: @the-multi-cloud-paas-team@digital.cabinet-office.gov.uk"
+  escalation_message = "Missing router hosts! Check VM state."
+
+  query = "${format("'datadog.agent.up'.over('environment:%s','job:router').by('*').last(1).pct_by_status()", var.env)}"
+
+  thresholds {
+    ok = 0
+    warning = 0
+    critical = 10
+  }
+
+  require_full_window = true
+  tags {
+    "environment" = "${var.env}"
+    "job" = "router"
+  }
+}

--- a/terraform/datadog/datadog.tf
+++ b/terraform/datadog/datadog.tf
@@ -12,7 +12,7 @@ resource "datadog_monitor" "router" {
   type = "service check"
   message = "Missing router hosts in environment {{host.environment}}. Notify: @the-multi-cloud-paas-team@digital.cabinet-office.gov.uk"
   escalation_message = "Missing router hosts! Check VM state."
-
+  no_data_timeframe = "2"
   query = "${format("'datadog.agent.up'.over('environment:%s','job:router').by('*').last(1).pct_by_status()", var.env)}"
 
   thresholds {

--- a/terraform/datadog/datadog.tf
+++ b/terraform/datadog/datadog.tf
@@ -1,5 +1,6 @@
 variable "datadog_api_key" {}
 variable "datadog_app_key" {}
+variable "env" {}
 
 provider "datadog" {
     api_key = "${var.datadog_api_key}"


### PR DESCRIPTION
## What

Story: https://www.pivotaltracker.com/story/show/128932735

This PR brings initial support for Datadog agent on (almost) all out VMs.
Concourse VM has a separate story as this requires significant manifest changes.

- We add tags on on VMs so we can easily find them in Datadog UI.
- We had to disable Dogstatsd due to port conflict
- new terraform job provisions basic router alert 

## How to review
Test together with https://github.com/alphagov/paas-datadog-agent-boshrelease/pull/1
Deploy `create-bosh-cloudfoundry` pipeline from this branch with `ENABLE_DATADOG=true`
Check if tests pass and if router alert works.
Merge https://github.com/alphagov/paas-datadog-agent-boshrelease/pull/1, put a tag on `paas-datadog-agent-boshrelease` and update https://github.com/alphagov/paas-cf/blob/749ec4f581bfdf77346d187e43571a550813b9c9/manifests/cf-manifest/runtime-config/runtime-config-base.yml#L5

## Who can review
Not @mtekel or @combor
