### PR TITLE
[#130186203] add datadog to concourse

### DIFF
--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -438,6 +438,8 @@ jobs:
       config:
         image: docker:///governmentpaas/spruce
         params:
+          AWS_ACCOUNT: {{aws_account}}
+          DATADOG_API_KEY: {{datadog_api_key}}
           CONCOURSE_MANIFEST_STUBS: |
             ./paas-cf/manifests/concourse-manifest/concourse-base.yml
             predefined-concourse-secrets/predefined-concourse-secrets.yml
@@ -445,6 +447,7 @@ jobs:
             terraform-outputs/concourse-terraform-outputs.yml
             terraform-outputs/vpc-terraform-outputs.yml
             ./paas-cf/manifests/shared/deployments/collectd.yml
+            ./paas-cf/manifests/shared/deployments/datadog.yml
         inputs:
         - name: paas-cf
         - name: predefined-concourse-secrets

--- a/concourse/scripts/pipelines-deployer.sh
+++ b/concourse/scripts/pipelines-deployer.sh
@@ -9,6 +9,12 @@ $("${SCRIPT_DIR}/environment.sh" "$@")
 "${SCRIPT_DIR}/fly_sync_and_login.sh"
 
 env=${DEPLOY_ENV}
+if [ "${ENABLE_DATADOG:-}" = "true" ]; then
+  export PASSWORD_STORE_DIR=~/.paas-pass
+  datadog_api_key=$(pass datadog/api_key)
+else
+  datadog_api_key="disabled"
+fi
 
 generate_vars_file() {
    cat <<EOF
@@ -24,6 +30,8 @@ concourse_atc_password: ${CONCOURSE_ATC_PASSWORD}
 log_level: ${LOG_LEVEL:-}
 paas_cf_tag_filter: ${PAAS_CF_TAG_FILTER:-}
 system_dns_zone_name: ${SYSTEM_DNS_ZONE_NAME}
+aws_account: ${AWS_ACCOUNT:-dev}
+datadog_api_key: ${datadog_api_key:-}
 EOF
 }
 

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -1,4 +1,7 @@
 ---
+meta:
+  environment: (( grab terraform_outputs.environment ))
+
 name: concourse
 
 releases:
@@ -122,6 +125,14 @@ jobs:
             hostname_prefix: concourse_
             interval: (( grab meta.collectd.interval ))
             config: (( grab meta.collectd.config ))
+
+      - name: datadog-agent
+        release: datadog-agent
+        properties:
+          datadog: (( inject meta.datadog ))
+          tags:
+            job: concourse
+            tags: (( inject meta.datadog_tags ))
 
     networks:
       - name: public

--- a/manifests/concourse-manifest/spec/fixtures/vpc-terraform-outputs.yml
+++ b/manifests/concourse-manifest/spec/fixtures/vpc-terraform-outputs.yml
@@ -4,3 +4,4 @@ terraform_outputs:
   ssh_security_group: alext-office-access-ssh
   subnet0_id: subnet-12345678
   zone0: eu-west-1a
+  environment: dev

--- a/manifests/concourse-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/concourse-manifest/spec/support/manifest_helpers.rb
@@ -15,6 +15,8 @@ module ManifestHelpers
 private
 
   def load_default_manifest
+    ENV["AWS_ACCOUNT"] = "dev"
+    ENV["DATADOG_API_KEY"] = "abcd1234"
     output, error, status = Open3.capture3(
       [
         File.expand_path("../../../../shared/build_manifest.sh", __FILE__),
@@ -23,6 +25,7 @@ private
         File.expand_path("../../fixtures/generated-concourse-secrets.yml", __FILE__),
         File.expand_path("../../fixtures/concourse-terraform-outputs.yml", __FILE__),
         File.expand_path("../../fixtures/vpc-terraform-outputs.yml", __FILE__),
+        File.expand_path("../../../../shared/deployments/datadog.yml", __FILE__),
         File.expand_path("../../../../shared/deployments/collectd.yml", __FILE__)
       ].join(' ')
     )


### PR DESCRIPTION
## What

[Add datadog to concourse](https://www.pivotaltracker.com/n/projects/1275640/stories/130186203). This is now possible thanks to https://github.com/alphagov/paas-cf/pull/482. Use same approach and shared files as in #481 

## How to review

Run bootstrap pipeline. Then `make dev ssh_concourse`, sudo su and monit summary. Datadog agent should be present and running. Depending if you did `export ENABLE_DATADOG=true` before creating bootstrap pipelines (make dev bootstrap), the agent would either be "disabled" - logging 403s in the forwarder log (/var/vcap/sys/log/datadog-agent/forwarder.log) or sending metrics to our trial account in datadog, where you should be able to see a host with `concourse` tag (+aws account type + your envirnment name tags).

![concourse-dog](https://cloud.githubusercontent.com/assets/483891/18476166/e9948174-79c0-11e6-9679-6e8cf851e458.png)

### needs rebase after #481 is merged 

## Who can review

not @mtekel or @combor or @paroxp 

