### PR TITLE
[#129847885] Use native git resource instead of our fork

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -1,10 +1,5 @@
 ---
 resource_types:
-- name: git-gpg
-  type: docker-image
-  source:
-    repository: governmentpaas/git-resource
-
 - name: s3-iam
   type: docker-image
   source:
@@ -17,7 +12,7 @@ resource_types:
 
 resources:
   - name: paas-cf
-    type: git-gpg
+    type: git
     source:
       uri: https://github.com/alphagov/paas-cf.git
       branch: {{branch_name}}

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -67,11 +67,6 @@ groups:
       - continuous-smoke-tests
 
 resource_types:
-- name: git-gpg
-  type: docker-image
-  source:
-    repository: governmentpaas/git-resource
-
 - name: s3-iam
   type: docker-image
   source:
@@ -91,7 +86,7 @@ resources:
       key: {{pipeline_trigger_file}}
 
   - name: paas-cf
-    type: git-gpg
+    type: git
     source:
       uri: https://github.com/alphagov/paas-cf.git
       branch: {{branch_name}}

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -1,10 +1,5 @@
 ---
 resource_types:
-- name: git-gpg
-  type: docker-image
-  source:
-    repository: governmentpaas/git-resource
-
 - name: s3-iam
   type: docker-image
   source:
@@ -17,7 +12,7 @@ resource_types:
 
 resources:
   - name: paas-cf
-    type: git-gpg
+    type: git
     source:
       uri: https://github.com/alphagov/paas-cf.git
       branch: {{branch_name}}

--- a/concourse/pipelines/destroy-microbosh.yml
+++ b/concourse/pipelines/destroy-microbosh.yml
@@ -1,10 +1,5 @@
 ---
 resource_types:
-- name: git-gpg
-  type: docker-image
-  source:
-    repository: governmentpaas/git-resource
-
 - name: s3-iam
   type: docker-image
   source:
@@ -17,7 +12,7 @@ resource_types:
 
 resources:
   - name: paas-cf
-    type: git-gpg
+    type: git
     source:
       uri: https://github.com/alphagov/paas-cf.git
       branch: {{branch_name}}

--- a/concourse/pipelines/failure-testing.yml
+++ b/concourse/pipelines/failure-testing.yml
@@ -1,10 +1,5 @@
 ---
 resource_types:
-- name: git-gpg
-  type: docker-image
-  source:
-    repository: governmentpaas/git-resource
-
 - name: s3-iam
   type: docker-image
   source:
@@ -17,7 +12,7 @@ resource_types:
 
 resources:
   - name: paas-cf
-    type: git-gpg
+    type: git
     source:
       uri: https://github.com/alphagov/paas-cf.git
       branch: {{branch_name}}


### PR DESCRIPTION
🚨 **DO NOT MERGE:**

## What

Concourse 2.1.0 has included our pull request to add GPG signature verification into the git resource, therefore we no longer need to use our fork.

Remove the custom resource type from the pipelines used by the deployer Concourse. As stated in the commit message, we will have to keep using the fork in our bootstrap Concourse as the version is fixed in the AMI.

## How to review

* Create a test branch off of this branch
* Remove `SKIP_COMMIT_VERIFICATION=true` from the dev section of the Makefile (line 89)
* Run the pipeline against a signed commit:
    * It can be any signed commit, doesn't have to be a merge commit: `git commit -S -m 'foo'`
    * Check the `paas-cf` resource is fetched `in` successfully. You only need to run the pipeline-lock job at the start.
* Run the pipeline against an unsigned commit. Repeat as above, but asserting its failure.

## Who can review

Anyone but @alext or me.
