### PR TITLE
[#130284275] Remove curl download details in fly login

### DIFF
--- a/concourse/scripts/fly_sync_and_login.sh
+++ b/concourse/scripts/fly_sync_and_login.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 
 FLY_CMD_URL="${CONCOURSE_URL}/api/v1/cli?arch=amd64&platform=$(uname | tr '[:upper:]' '[:lower:]')"
 echo "Downloading fly command..."
-curl "$FLY_CMD_URL" -L -f -k -z "$FLY_CMD" -o "$FLY_CMD" -u "${CONCOURSE_ATC_USER}:${CONCOURSE_ATC_PASSWORD}"
+curl "$FLY_CMD_URL" -# -L -f -k -z "$FLY_CMD" -o "$FLY_CMD" -u "${CONCOURSE_ATC_USER}:${CONCOURSE_ATC_PASSWORD}"
 chmod +x "$FLY_CMD"
 
 echo "Doing fly login"


### PR DESCRIPTION
## What

Story: [Fly login user (operator) experience](https://www.pivotaltracker.com/story/show/130284275)

Currently curl prints download details, even when there is no download:

```
Downloading fly command...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
```

This replaces them by a progress bar when there is a download, and an
empty line when there is no download.

## How to review

* Delete bin/fly
* Run `make dev bosh-cli`. It show show the progress bar
* Run `make dev bosh-cli`. It show show an empty line

## Who can review
Anyone but myself
