### PR TITLE
[#130899727] Enable gorouter access logs

### DIFF
--- a/manifests/cf-manifest/env-specific/cf-default.yml
+++ b/manifests/cf-manifest/env-specific/cf-default.yml
@@ -3,4 +3,4 @@ meta:
   cell:
     instances: 3
   elasticsearch_master:
-    disk_size: 307200
+    disk_size: 307300

--- a/manifests/cf-manifest/env-specific/cf-prod.yml
+++ b/manifests/cf-manifest/env-specific/cf-prod.yml
@@ -3,4 +3,4 @@ meta:
   cell:
     instances: 33
   elasticsearch_master:
-    disk_size: 768000
+    disk_size: 1536000

--- a/manifests/cf-manifest/env-specific/cf-staging.yml
+++ b/manifests/cf-manifest/env-specific/cf-staging.yml
@@ -3,4 +3,4 @@ meta:
   cell:
     instances: 6
   elasticsearch_master:
-    disk_size: 307200
+    disk_size: 307300

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -173,6 +173,7 @@ properties:
 
   router:
     enable_ssl: false
+    enable_access_log_streaming: true
     status:
       user: router_user
       password: (( grab secrets.router_password ))

--- a/manifests/cf-manifest/manifest/800-logsearch.yml
+++ b/manifests/cf-manifest/manifest/800-logsearch.yml
@@ -185,6 +185,23 @@ properties:
           '
         }
       }
+      if [@source][component] == "gorouter" {
+        mutate { replace => { "type" => "gorouter" } }
+        grok {
+          match => {
+            "@message" =>
+              '%{HOSTNAME:[gorouter][host]} - \[%{TIMESTAMP_ISO8601:[gorouter][timestamp]}\] "%{WORD:[gorouter][method]} %{URIPATHPARAM:[gorouter][request]} %{NOTSPACE:[gorouter][httpversion]}" %{BASE10NUM:[gorouter][status]} %{BASE10NUM:[gorouter][bytesreceived]} %{BASE10NUM:[gorouter][bytessent]} %{QUOTEDSTRING:[gorouter][referer]} %{QUOTEDSTRING:[gorouter][useragent]} %{QUOTEDSTRING:[gorouter][clientaddr]} %{QUOTEDSTRING:[gorouter][upstreamaddr]} %{GREEDYDATA:routerkeys}'
+            }
+          tag_on_failure => ["fail/cloudfoundry/gorouter/grok"]
+          add_tag => ["gorouter"]
+        }
+        kv {
+          source => "router_keys"
+          target => "[gorouter][header]"
+          value_split => ":"
+          remove_field => "router_keys"
+        }
+      }
       if [@source][component] == "vcap_nginx_access" {
         grok {
           match => {

--- a/manifests/cf-manifest/spec/manifest/router_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/router_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe "router properties" do
+  let(:manifest) { manifest_with_defaults }
+  let(:properties) { manifest.fetch("properties") }
+
+  it "streams the access_logs to logging" do
+    enable_access_log_streaming = properties.fetch("router").fetch("enable_access_log_streaming")
+    expect(enable_access_log_streaming).to be true
+  end
+end


### PR DESCRIPTION
# What

We want to get all the logs from the router in our logsearch.

Gorouter is configured to send the logs to syslog, but it is not configured to stream the access logs.

This enables these logs to be sent to syslog, and from there, to be parsed correctly by logsearch.

Due to the expected increase in log volume (~10%) and the current high disk usage, we will increase the elasticsearch disk sizes as part of this changeset.

## How to review

Check the code, deploy, and execute some queries to some app in CF.

Then search in kibana for `*gorouter*`. access_log entries should appear

## Notes

This pull request has been resurrected on it's anniversary and brought up to date.

## Who?

Not @chrisfarms or @samcrang 
...also not @keymon or @richardc ;-)
