### PR TITLE
[#129706079] Use upstream grafana

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -106,12 +106,6 @@ resources:
       tag_filter: {{cf_graphite_version}}
       branch: gds_master
 
-  - name: grafana-boshrelease
-    type: git
-    source:
-      uri: https://github.com/alphagov/paas-grafana-boshrelease.git
-      tag_filter: {{cf_grafana_version}}
-
   - name: aws-broker-boshrelease
     type: git
     source:
@@ -1445,7 +1439,6 @@ jobs:
             passed: ['generate-cf-config']
           - get: bosh-secrets
           - get: graphite-statsd-boshrelease
-          - get: grafana-boshrelease
           - get: paas-haproxy-release
           - get: aws-broker-boshrelease
           - get: os-conf-boshrelease
@@ -1468,7 +1461,6 @@ jobs:
               - name: paas-cf
               - name: bosh-secrets
               - name: graphite-statsd-boshrelease
-              - name: grafana-boshrelease
               - name: paas-haproxy-release
               - name: aws-broker-boshrelease
               - name: os-conf-boshrelease
@@ -1483,9 +1475,6 @@ jobs:
 
                   paas-cf/concourse/scripts/bosh_create_and_upload_release.rb graphite \
                     {{cf_graphite_version}} graphite-statsd-boshrelease
-
-                  paas-cf/concourse/scripts/bosh_create_and_upload_release.rb grafana \
-                    {{cf_grafana_version}} grafana-boshrelease
 
                   paas-cf/concourse/scripts/bosh_create_and_upload_release.rb paas-haproxy \
                     {{cf-paas-haproxy-release-version}} paas-haproxy-release

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -41,7 +41,6 @@ prepare_environment() {
   cf_release_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.cf.version "${cf_manifest_dir}/000-base-cf-deployment.yml")
   cf_paas_haproxy_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.paas-haproxy.version "${cf_manifest_dir}/000-base-cf-deployment.yml")
   cf_graphite_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.graphite.version "${cf_manifest_dir}/040-graphite.yml")
-  cf_grafana_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.grafana.version "${cf_manifest_dir}/040-graphite.yml")
   cf_aws_broker_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.aws-broker.version "${cf_manifest_dir}/050-rds-broker.yml")
   cf_os_conf_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.os-conf.version "${cf_manifest_dir}/../runtime-config/runtime-config-base.yml")
   cf_logsearch_for_cloudfoundry_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.logsearch-for-cloudfoundry.version "${cf_manifest_dir}/030-logsearch.yml")
@@ -84,7 +83,6 @@ debug: ${DEBUG:-}
 cf-release-version: v${cf_release_version}
 cf-paas-haproxy-release-version: ${cf_paas_haproxy_version}
 cf_graphite_version: ${cf_graphite_version}
-cf_grafana_version: ${cf_grafana_version}
 cf_aws_broker_version: ${cf_aws_broker_version}
 cf_os_conf_version: ${cf_os_conf_version}
 cf_logsearch_for_cloudfoundry_version: ${cf_logsearch_for_cloudfoundry_version}

--- a/manifests/cf-manifest/manifest/040-graphite.yml
+++ b/manifests/cf-manifest/manifest/040-graphite.yml
@@ -15,7 +15,9 @@ releases:
 - name: graphite
   version: commit-829b5920f4343cb9929c5fc219dfc4413a772e63
 - name: grafana
-  version: commit-6dce2ec39a6ffc00c092d5b0401dfaf8bbf3ae55
+  version: 5
+  url: https://bosh.io/d/github.com/vito/grafana-boshrelease?v=5
+  sha1: 0edd89d7b383a2556a79f6688f576aa4b6f33bc2
 
 jobs:
 - name: graphite
@@ -62,8 +64,8 @@ jobs:
       admin_password: (( grab secrets.grafana_admin_password ))
       datasources:
         - name: graphite
+          type: graphite
           url: http://localhost:3001
-          database_type: graphite
     tags:
       job: graphite
       tags: (( inject meta.datadog_tags ))


### PR DESCRIPTION
## What
Story: https://www.pivotaltracker.com/story/show/129706079

As new release of Grafana is out and it contains our fixes:
https://github.com/vito/grafana-boshrelease/commit/1fa3e221fde4369cad33ab612b18f35766a3a28e so we can stop using our fork and fall back to official bosh.io releases.

## How to review

Deploy from this branch, check if Grafana works ( displays dashboards ) and if version is 3.0.3 ( you can find thin on login screen )

## Who can review

not @paroxp or @combor
