### PR TITLE
Self update pipelines before init

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -325,9 +325,11 @@ jobs:
   - name: pipeline-lock
     serial: true
     plan:
-      - get: paas-cf
-        trigger: {{auto_deploy}}
-      - get: git-ssh-private-key
+      - aggregate:
+        - get: paas-cf
+          trigger: {{auto_deploy}}
+        - get: git-ssh-private-key
+        - get: concourse-manifest
       - task: init-pipeline-pool
         config:
           platform: linux
@@ -359,19 +361,6 @@ jobs:
       - put: pipeline-pool
         params:
           claim: lock
-      - put: pipeline-trigger
-        params: {bump: patch}
-
-  - name: init
-    serial_groups: [bosh-deploy]
-    serial: true
-    plan:
-      - get: pipeline-trigger
-        trigger: true
-        passed: ['pipeline-lock']
-      - get: paas-cf
-        passed: ['pipeline-lock']
-      - get: concourse-manifest
       - task: self-update-pipeline
         config:
           platform: linux
@@ -391,7 +380,19 @@ jobs:
             BOSH_AZ: {{bosh_az}}
           run:
             path: ./paas-cf/concourse/scripts/self-update-pipeline.sh
+      - put: pipeline-trigger
+        params: {bump: patch}
 
+
+  - name: init
+    serial_groups: [bosh-deploy]
+    serial: true
+    plan:
+      - get: pipeline-trigger
+        trigger: true
+        passed: ['pipeline-lock']
+      - get: paas-cf
+        passed: ['pipeline-lock']
       - task: bootstrap-s3-state
         config:
           platform: linux


### PR DESCRIPTION
## What

When we run self update pipelines in the `init` job, even though that job might get updated by itself, it will not run again. This means that if there are any new resources to bootstrap in this job, they would not get bootstrapped and the remainder of the pipeline can get stuck waiting on these forever.

Move self update to lock. Self update after you have acquired lock and before triggering remaining jobs. This way if init job gets updated it will run in its latest instance and bootstrap all the things it really needs to.

## How to review

`make dev pipelines` or run pipeline and let self update pipelines that's currently in init do the update for you. Run the lock job and check that it updates pipeline after lock and before triggering the rest of the jobs.

## Who can review

not @mtekel
