### PR TITLE
[#129847885] Fix run_job make target for new concourse.

### DIFF
--- a/concourse/scripts/run_job.sh
+++ b/concourse/scripts/run_job.sh
@@ -17,5 +17,5 @@ FLY="$FLY_CMD -t ${FLY_TARGET}"
 ${FLY} get-pipeline -p ${PIPE} | "${SCRIPT_DIR}"/unbind_job.rb "${JOB}" >$TEMP
 ${FLY} set-pipeline -p ${PIPE} -c=$TEMP -n
 
-curl -k -u "${CONCOURSE_ATC_USER}:${CONCOURSE_ATC_PASSWORD}" "${CONCOURSE_URL}/api/v1/pipelines/${PIPE}/jobs/${JOB}/builds" -d ''
+${FLY} trigger-job -j "${PIPE}/${JOB}"
 rm -f $TEMP


### PR DESCRIPTION
## What

The API endpoints in concourse have changed with the introduction of
teams[1]. The `fly` command has also gained a `trigger-job` command, so
let's use it. This will insulate us against future changes to the API
layout.

[1] http://concourse.ci/downloads.html#v200

## How to review

Use the `run_job` make task and observe that it now works again.

## Who can review

Anyone but myself.