### PR TITLE
Make run_job work with concourse 2.1

### DIFF
--- a/concourse/scripts/run_job.sh
+++ b/concourse/scripts/run_job.sh
@@ -17,5 +17,5 @@ FLY="$FLY_CMD -t ${FLY_TARGET}"
 ${FLY} get-pipeline -p ${PIPE} | "${SCRIPT_DIR}"/unbind_job.rb "${JOB}" >$TEMP
 ${FLY} set-pipeline -p ${PIPE} -c=$TEMP -n
 
-curl -k -u "${CONCOURSE_ATC_USER}:${CONCOURSE_ATC_PASSWORD}" "${CONCOURSE_URL}/api/v1/pipelines/${PIPE}/jobs/${JOB}/builds" -d ''
+${FLY} trigger-job -j "${PIPE}/${JOB}"
 rm -f $TEMP


### PR DESCRIPTION
## What

Concourse 2.1 changed API. Triggering of the job via curl did not work
any more. Luckily, there's new trigger-job command for fly. Also,
concourse team encourages using fly instead of API. Fix the script to
use new command.

## How to review

`JOB=<your-favourite-job> make dev run_job` & see it trigger it.

## Who can review

not @mtekel