### PR TITLE
Add shellcheck to pipecleaner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ lint_shellcheck:
 	find . -name '*.sh' -not -path '*/vendor/*' | xargs $(SHELLCHECK)
 
 lint_concourse:
-	cd .. && python paas-cf/concourse/scripts/pipecleaner.py paas-cf/concourse/pipelines/*.yml
+	cd .. && SHELLCHECK_OPTS="-e SC1091,SC2034,SC2046,SC2086" python paas-cf/concourse/scripts/pipecleaner.py paas-cf/concourse/pipelines/*.yml
 
 .PHONY: lint_ruby
 lint_ruby:

--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -122,7 +122,7 @@ jobs:
               # how it works.
               - |
                 sum=$(echo {{deploy_env}} | md5sum);
-                short=${sum:0:15};
+                short=$(echo $sum | cut -b 1-15)
                 decimal=$((0x$short));
                 sleeptime=$((${decimal##-} % 60*20));
                 echo "Sleeping for $sleeptime seconds before deletion.."

--- a/concourse/pipelines/concourse-lite-self-terminate.yml
+++ b/concourse/pipelines/concourse-lite-self-terminate.yml
@@ -23,9 +23,11 @@ jobs:
           - -e
           - -c
           - |
-            export AWS_AVAILIABILITY_ZONE=$(curl -qs http://169.254.169.254/latest/meta-data/placement/availability-zone)
-            export AWS_DEFAULT_REGION="${AWS_AVAILIABILITY_ZONE%%[a-z]}"
-            export AWS_INSTANCE_ID=$(curl -qs http://169.254.169.254/latest/meta-data/instance-id)
+            export AWS_AVAILIABILITY_ZONE
+            AWS_AVAILIABILITY_ZONE=$(curl -qs http://169.254.169.254/latest/meta-data/placement/availability-zone)
+            export AWS_DEFAULT_REGION
+            AWS_DEFAULT_REGION="${AWS_AVAILIABILITY_ZONE%%[a-z]}"
+            export AWS_INSTANCE_ID
+            AWS_INSTANCE_ID=$(curl -qs http://169.254.169.254/latest/meta-data/instance-id)
 
             aws ec2 terminate-instances --instance-ids ${AWS_INSTANCE_ID}
-

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -466,7 +466,8 @@ jobs:
                   certstrap init --passphrase "" --common-name bosh-CA
                   cd out
                   tar -cvzf ../generated-bosh-CA/bosh-CA.tar.gz bosh-CA.*
-                  cd ..
+                  # shellcheck disable=SC2103
+                  cd .. || true
                 else
                   echo "The CA cert already exists, skipping generation..."
                   cp existing-bosh-CA/bosh-CA.tar.gz generated-bosh-CA/bosh-CA.tar.gz
@@ -1381,7 +1382,8 @@ jobs:
                   done
 
                   ../paas-cf/concourse/scripts/file_to_yaml.sh secrets uaa_jwt_verification_key uaa_jwt_verification.pem > uaa_jwt_verification_key.yml
-                  cd ..
+                  # shellcheck disable=SC2103
+                  cd .. || true
 
                   echo "Generating manifests"
 

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1099,6 +1099,7 @@ jobs:
               - |
                 curl -Lfqs https://www.pingdom.com/rss/probe_servers.xml > probe_servers.xml
                 IPS_PER_BLOCK=32
+                # shellcheck disable=SC2002
                 cat probe_servers.xml | \
                   grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}' | \
                   sort | uniq | sed 's/$/\/32/' | xargs -n ${IPS_PER_BLOCK} | tr ' ' ',' | \

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1053,7 +1053,7 @@ jobs:
               - -e
               - -c
               - |
-                if [ "${SKIP_UPLOAD_GENERATED_CERTS}" == "true" ]; then
+                if [ "${SKIP_UPLOAD_GENERATED_CERTS}" = "true" ]; then
                   cp cf-certs-tfstate/cf-certs.tfstate updated-tfstate/cf-certs.tfstate
                   echo "Using pre-uploaded public certificates for ${TF_VAR_env}"
                 else

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -765,9 +765,12 @@ jobs:
 
                 ./paas-cf/concourse/scripts/import_bosh_ca.sh
 
-                export CONCOURSE_ATC_PASSWORD=$(awk '/basic_auth_password/ { print $2 }' concourse-manifest/concourse-manifest.yml | tr -d '"')
-                export CONCOURSE_ATC_URL=https://deployer.${SYSTEM_DNS_ZONE_NAME}
-                export PIPELINE_TRIGGER_VERSION=$(cat pipeline-trigger/number)
+                export CONCOURSE_ATC_PASSWORD
+                CONCOURSE_ATC_PASSWORD=$(awk '/basic_auth_password/ { print $2 }' concourse-manifest/concourse-manifest.yml | tr -d '"')
+                export CONCOURSE_ATC_URL
+                CONCOURSE_ATC_URL=https://deployer.${SYSTEM_DNS_ZONE_NAME}
+                export PIPELINE_TRIGGER_VERSION
+                PIPELINE_TRIGGER_VERSION=$(cat pipeline-trigger/number)
 
                 echo "Running tests"
                 ./paas-cf/platform-tests/run_tests.sh ./paas-cf/platform-tests/src/availability
@@ -1688,7 +1691,8 @@ jobs:
                   . ./config/config.sh
 
                   VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
-                  export UAA_CLIENT_SECRET=$($VAL_FROM_YAML secrets.uaa_admin_client_secret cf-secrets/cf-secrets.yml)
+                  export UAA_CLIENT_SECRET
+                  UAA_CLIENT_SECRET=$($VAL_FROM_YAML secrets.uaa_admin_client_secret cf-secrets/cf-secrets.yml)
                   cd paas-cf/scripts
                   bundle
                   bundle exec sync-admin-users.rb ${API_ENDPOINT} ../config/admin_users.yml "{{NEW_ACCOUNT_EMAIL_ADDRESS}}"
@@ -2127,7 +2131,8 @@ jobs:
                   ./paas-cf/concourse/scripts/import_bosh_ca.sh
 
                   echo "Running tests"
-                  export CONFIG="$(pwd)/test-config/config.json"
+                  export CONFIG
+                  CONFIG="$(pwd)/test-config/config.json"
                   ./paas-cf/platform-tests/run_tests.sh ./paas-cf/platform-tests/src/acceptance/
 
         ensure:
@@ -2235,7 +2240,8 @@ jobs:
                   ./paas-cf/concourse/scripts/import_bosh_ca.sh
 
                   echo "Running tests"
-                  export CONFIG="$(pwd)/test-config/config.json"
+                  export CONFIG
+                  CONFIG="$(pwd)/test-config/config.json"
                   ./paas-cf/platform-tests/run_tests.sh ./paas-cf/platform-tests/src/performance/
 
         ensure:

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1104,7 +1104,7 @@ jobs:
                 cat probe_servers.xml | \
                   grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}' | \
                   sort | uniq | sed 's/$/\/32/' | xargs -n ${IPS_PER_BLOCK} | tr ' ' ',' | \
-                  awk '{print "export TF_VAR_pingdom_probe_cidrs_" NR-1 "=" $0}'\
+                  awk '{print "export TF_VAR_pingdom_probe_cidrs_" NR-1 "=" $0}' \
                   > pingdom-probes-ips/pingdom-probes-ips.sh
 
       - task: extract-terraform-variables

--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -322,7 +322,8 @@ jobs:
             cp concourse-ssh-key/concourse_id_rsa.pub paas-cf/terraform/concourse
             tar xzvf generated-concourse-cert/concourse-cert.tar.gz
             . vpc-terraform-outputs/tfvars.sh
-            export TF_VAR_git_rsa_id_pub=$(cat git-ssh-public-key/git_id_rsa.pub)
+            export TF_VAR_git_rsa_id_pub
+            TF_VAR_git_rsa_id_pub=$(cat git-ssh-public-key/git_id_rsa.pub)
             terraform_params=${VAGRANT_IP:+-var vagrant_cidr=$VAGRANT_IP/32}
             terraform apply ${terraform_params} \
               -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
@@ -587,7 +588,8 @@ jobs:
           - -c
           - |
             . vpc-terraform-outputs/tfvars.sh
-            export TF_VAR_git_rsa_id_pub=$(cat git-ssh-public-key/git_id_rsa.pub)
+            export TF_VAR_git_rsa_id_pub
+            TF_VAR_git_rsa_id_pub=$(cat git-ssh-public-key/git_id_rsa.pub)
             terraform apply -target=aws_security_group.concourse \
               -state=concourse-terraform-state/concourse.tfstate -state-out=concourse.tfstate \
               -var-file=paas-cf/terraform/{{aws_account}}.tfvars paas-cf/terraform/concourse

--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -263,7 +263,7 @@ jobs:
           - |
             tar xzvf concourse-cert/concourse-cert.tar.gz
             if [ -f concourse.crt ] && [ -f concourse.key ]; then
-              echo Certificate and private key already created, nothing to do
+              echo "Certificate and private key already created, nothing to do"
               cp concourse-cert/concourse-cert.tar.gz generated-concourse-cert/
               exit 0
             fi

--- a/concourse/pipelines/failure-testing.yml
+++ b/concourse/pipelines/failure-testing.yml
@@ -395,7 +395,8 @@ jobs:
                   ./paas-cf/concourse/scripts/import_bosh_ca.sh
 
                   echo "Running tests"
-                  export CONFIG="$(pwd)/test-config/config.json"
+                  export CONFIG
+                  CONFIG="$(pwd)/test-config/config.json"
                   export GINKGO_FOCUS='RDS broker'
                   ./paas-cf/platform-tests/run_tests.sh ./paas-cf/platform-tests/src/acceptance/
 

--- a/concourse/scripts/pipecleaner_test.go
+++ b/concourse/scripts/pipecleaner_test.go
@@ -1,0 +1,74 @@
+package scripts_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"os/exec"
+
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("PipeCleaner", func() {
+	var (
+		command *exec.Cmd
+		session *gexec.Session
+	)
+
+	JustBeforeEach(func() {
+		var err error
+		session, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Context("when run with no arguments, get usage", func() {
+		BeforeEach(func() {
+			command = exec.Command("./pipecleaner.py")
+		})
+
+		It("should return non-zero, with Usage on STDOUT, nothing on STDERR", func() {
+			Eventually(session).Should(gexec.Exit(2))
+			Expect(session.Out).To(gbytes.Say("pipecleaner.py pipeline.yml"))
+			Expect(session.Err.Contents()).To(BeEmpty())
+		})
+	})
+
+	Context("shellcheck", func() {
+		Context("disabled", func() {
+			BeforeEach(func() {
+				command = exec.Command("./pipecleaner.py", "--ignore-types", "shellcheck", "spec/fixtures/pipecleaner_shellcheck.yml")
+			})
+
+			It("should not report anything", func() {
+				Eventually(session).Should(gexec.Exit(0))
+				Expect(session.Err.Contents()).To(BeEmpty())
+				Expect(session.Out.Contents()).To(BeEmpty())
+			})
+		})
+
+		Context("normal", func() {
+			BeforeEach(func() {
+				command = exec.Command("./pipecleaner.py", "spec/fixtures/pipecleaner_shellcheck.yml")
+			})
+
+			It("should warn about the non-portable compare", func() {
+				Eventually(session).Should(gexec.Exit(0))
+				Expect(session.Out).To(gbytes.Say("WARNING.*?job='shellcheck', task='bad-compare'"))
+				Expect(session.Err.Contents()).To(BeEmpty())
+			})
+		})
+
+		Context("with --fatal-warnings", func() {
+			BeforeEach(func() {
+				command = exec.Command("./pipecleaner.py", "--fatal-warnings", "spec/fixtures/pipecleaner_shellcheck.yml")
+			})
+
+			It("should warn about the non-portable compare, and exit as though fatal", func() {
+				Eventually(session).Should(gexec.Exit(20))
+				Expect(session.Out).To(gbytes.Say("WARNING.*?job='shellcheck', task='bad-compare'"))
+				Expect(session.Err.Contents()).To(BeEmpty())
+			})
+		})
+	})
+})

--- a/concourse/scripts/pipecleaner_test.go
+++ b/concourse/scripts/pipecleaner_test.go
@@ -59,6 +59,18 @@ var _ = Describe("PipeCleaner", func() {
 			})
 		})
 
+		Context("when params are supplied", func() {
+			BeforeEach(func() {
+				command = exec.Command("./pipecleaner.py", "spec/fixtures/pipecleaner_shellcheck_params.yml")
+			})
+
+			It("should not report an issue", func() {
+				Eventually(session).Should(gexec.Exit(0))
+				Expect(session.Out.Contents()).To(BeEmpty())
+				Expect(session.Err.Contents()).To(BeEmpty())
+			})
+		})
+
 		Context("with --fatal-warnings", func() {
 			BeforeEach(func() {
 				command = exec.Command("./pipecleaner.py", "--fatal-warnings", "spec/fixtures/pipecleaner_shellcheck.yml")

--- a/concourse/scripts/spec/fixtures/pipecleaner_shellcheck.yml
+++ b/concourse/scripts/spec/fixtures/pipecleaner_shellcheck.yml
@@ -1,0 +1,17 @@
+---
+resources: {}
+
+jobs:
+  - name: shellcheck
+    plan:
+      - task: bad-compare
+        config:
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                if [ "red" == "blue" ]; then
+                  echo "colour error!"
+                fi

--- a/concourse/scripts/spec/fixtures/pipecleaner_shellcheck_params.yml
+++ b/concourse/scripts/spec/fixtures/pipecleaner_shellcheck_params.yml
@@ -1,0 +1,21 @@
+---
+resources: {}
+
+jobs:
+  - name: shellcheck
+    plan:
+      - task: refers-to-params
+        params:
+          OTHER_pie: "apple"
+        config:
+          params:
+            BEST_pie: "meat"
+          run:
+            path: sh
+            args:
+              - -e
+              - -u
+              - -c
+              - |
+                echo "best pie is ${BEST_pie} pie"
+                echo "other pie is ${OTHER_pie} pie"

--- a/concourse/tasks/create_admin.yml
+++ b/concourse/tasks/create_admin.yml
@@ -18,7 +18,7 @@ run:
     - -c
     - |
       [ -z "${PREFIX}" ] && echo "You need to specify \$PREFIX" && exit 1
-      if [ "${ENABLE_ADMIN_USER_CREATION}" == "false" ]; then
+      if [ "${ENABLE_ADMIN_USER_CREATION}" = "false" ]; then
         echo "Temporary user creation is disabled (ENABLE_ADMIN_USER_CREATION=${ENABLE_ADMIN_USER_CREATION}). Skipping."
         echo "none" >admin-creds/username
         echo "none" >admin-creds/password

--- a/concourse/tasks/delete_admin.yml
+++ b/concourse/tasks/delete_admin.yml
@@ -18,7 +18,7 @@ run:
     - -c
     - |
       NAME=$(cat admin-creds/username)
-      if [ "${ENABLE_ADMIN_USER_CREATION:-}" == "false" ]; then
+      if [ "${ENABLE_ADMIN_USER_CREATION:-}" = "false" ]; then
         echo "Temporary user creation is disabled (ENABLE_ADMIN_USER_CREATION=${ENABLE_ADMIN_USER_CREATION}). Skipping."
         exit 0
       fi


### PR DESCRIPTION
## What

Here we add a new class of check to pipecleaner `shellcheck`

When enabled (and it is enabled by default) when linting we look for
tasks where the run property looks like it is an inline shell script,
and invoke `shellcheck` over it to see if the script looks valid.

When an issue is found, it will be reported like so:

    ==  spec/fixtures/pipecleaner_shellcheck.yml  ==
    WARNING * Shellcheck: job='shellcheck', task='bad-compare', ~='
    In - line 2:
    if [ "red" == "blue" ]; then
               ^-- SC2039: In POSIX sh, == in place of = is undefined.
               ^-- SC2050: This expression is constant. Did you forget the $ on a variable?

    '

We also add a ginkgo test for pipecleaner.py, with a test fixture of a
pipeline with an error we know shellcheck will pick up on.

There's some minor refactoring of pipecleaner here to reduce having to
explictly add error classes.

## How to review

* Review the code changes

* Test with the sample pipeline:

~~~
cd concourse/scripts
./pipecleaner.py spec/fixtures/pipecleaner_shellcheck.yml
~~~

* Check the unit tests work

~~~
cd concourse/scripts
ginkgo --focus=PipeCleaner
~~~

* From the top of the repo run `make lint_concourse` and see many shellcheck warnings.

## Who can review

Not @richardc