### PR TITLE
[#124720541] Bump aws-broker-release to 0.0.9

### DIFF
--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -19,7 +19,7 @@ meta:
 
 releases:
   - name: aws-broker
-    version: 0.0.8
+    version: 0.0.9
 
 jobs:
   - name: rds_broker


### PR DESCRIPTION
[#124720541 Not all logs shipped to kibana/logsearch](https://www.pivotaltracker.com/story/show/124720541)

What
----

We want all the logs from RDS broker in syslog, to forward then to loggregator using metron_agent.

Version of the aws-broker-release [0.0.9 will forward all the logs to syslog](https://github.com/alphagov/paas-aws-broker-boshrelease/pull/12)

How to review
------------

Deploy this, and check that rds-broker logs the messages to syslog as in https://github.com/alphagov/paas-aws-broker-boshrelease/pull/12

Who?
---

Anyone but @keymon