### PR TITLE
[#124720541] Configure metron_agent as a runtime-config addon

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1363,6 +1363,7 @@ jobs:
                 ./paas-cf/manifests/shared/deployments/collectd.yml
                 ./paas-cf/manifests/shared/deployments/datadog.yml
                 ./paas-cf/manifests/cf-manifest/manifest/env-specific/{{cf_env_specific_manifest}}
+                ./paas-cf/manifests/cf-manifest/common/*.yml
               AWS_ACCOUNT: {{aws_account}}
               DATADOG_API_KEY: {{datadog_api_key}}
             run:
@@ -1408,6 +1409,7 @@ jobs:
                 repository: governmentpaas/spruce
             inputs:
               - name: paas-cf
+              - name: terraform-outputs
             outputs:
               - name: runtime-config
             params:
@@ -1417,6 +1419,8 @@ jobs:
               MANIFEST_STUBS: |
                 ./paas-cf/manifests/cf-manifest/runtime-config/runtime-config-base.yml
                 ./paas-cf/manifests/shared/deployments/collectd.yml
+                ./paas-cf/manifests/cf-manifest/common/*.yml
+                ./terraform-outputs/*.yml
             run:
               path: sh
               args:

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -41,7 +41,7 @@ prepare_environment() {
   bosh_az=${BOSH_AZ:-eu-west-1a}
 
   cf_manifest_dir="${SCRIPT_DIR}/../../manifests/cf-manifest/manifest"
-  cf_release_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.cf.version "${cf_manifest_dir}/000-base-cf-deployment.yml")
+  cf_release_version=$("${SCRIPT_DIR}"/val_from_yaml.rb meta.cf-releases.cf.version "${cf_manifest_dir}/../common/releases.yml")
   cf_paas_haproxy_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.paas-haproxy.version "${cf_manifest_dir}/000-base-cf-deployment.yml")
   cf_graphite_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.graphite.version "${cf_manifest_dir}/040-graphite.yml")
   cf_aws_broker_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.aws-broker.version "${cf_manifest_dir}/050-rds-broker.yml")

--- a/manifests/cf-manifest/common/metron.yml
+++ b/manifests/cf-manifest/common/metron.yml
@@ -1,0 +1,5 @@
+---
+meta:
+  metron_agent:
+    dropsonde_incoming_port: 3457
+

--- a/manifests/cf-manifest/common/releases.yml
+++ b/manifests/cf-manifest/common/releases.yml
@@ -1,0 +1,8 @@
+---
+meta:
+  cf-releases:
+  - name: cf
+    version: 240
+    url: https://bosh.io/d/github.com/cloudfoundry/cf-release?v=240
+    sha1: 7dba7cc0c9c4beca699d8c876ac046890e13bb9e
+

--- a/manifests/cf-manifest/common/releases.yml
+++ b/manifests/cf-manifest/common/releases.yml
@@ -2,7 +2,7 @@
 meta:
   cf-releases:
   - name: cf
-    version: 240
+    version: "240"
     url: https://bosh.io/d/github.com/cloudfoundry/cf-release?v=240
     sha1: 7dba7cc0c9c4beca699d8c876ac046890e13bb9e
 

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -6,9 +6,7 @@ director_uuid: ~
 
 releases:
   - name: cf
-    version: 240
-    url: https://bosh.io/d/github.com/cloudfoundry/cf-release?v=240
-    sha1: 7dba7cc0c9c4beca699d8c876ac046890e13bb9e
+    data: (( inject meta.cf-releases.cf ))
   - name: diego
     version: 0.1482.0
     url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=0.1482.0

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -10,8 +10,6 @@ meta:
     release: (( grab meta.consul_templates.consul_agent.release ))
   - name: cloud_controller_ng
     release: (( grab meta.release.name ))
-  - name: metron_agent
-    release: (( grab meta.release.name ))
   - name: statsd-injector
     release: (( grab meta.release.name ))
   - name: java-buildpack
@@ -38,19 +36,13 @@ meta:
     release: (( grab meta.consul_templates.consul_agent.release ))
   - name: cloud_controller_worker
     release: (( grab meta.release.name ))
-  - name: metron_agent
-    release: (( grab meta.release.name ))
 
   clock_templates:
   - name: cloud_controller_clock
     release: (( grab meta.release.name ))
-  - name: metron_agent
-    release: (( grab meta.release.name ))
 
   consul_templates:
   - name: consul_agent
-    release: (( grab meta.release.name ))
-  - name: metron_agent
     release: (( grab meta.release.name ))
 
   etcd_templates:
@@ -60,8 +52,6 @@ meta:
     release: etcd
   - name: etcd_metrics_server
     release: etcd
-  - name: metron_agent
-    release: (( grab meta.release.name ))
 
   loggregator_templates:
   - name: consul_agent
@@ -70,15 +60,11 @@ meta:
     release: (( grab meta.release.name ))
   - name: syslog_drain_binder
     release: (( grab meta.release.name ))
-  - name: metron_agent
-    release: (( grab meta.release.name ))
 
   loggregator_trafficcontroller_templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
   - name: loggregator_trafficcontroller
-    release: (( grab meta.release.name ))
-  - name: metron_agent
     release: (( grab meta.release.name ))
 
   nats_templates:
@@ -88,15 +74,11 @@ meta:
     release: (( grab meta.release.name ))
   - name: nats_stream_forwarder
     release: (( grab meta.release.name ))
-  - name: metron_agent
-    release: (( grab meta.release.name ))
 
   router_templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
   - name: gorouter
-    release: (( grab meta.release.name ))
-  - name: metron_agent
     release: (( grab meta.release.name ))
   - name: haproxy
     release: paas-haproxy
@@ -105,8 +87,6 @@ meta:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
   - name: uaa
-    release: (( grab meta.release.name ))
-  - name: metron_agent
     release: (( grab meta.release.name ))
   - name: statsd-injector
     release: (( grab meta.release.name ))
@@ -182,8 +162,6 @@ jobs:
         release: cf
       - name: bbs
         release: diego
-      - name: metron_agent
-        release: cf
     instances: 2
     vm_type: medium
     stemcell: default
@@ -305,8 +283,6 @@ jobs:
         release: cf
       - name: auctioneer
         release: diego
-      - name: metron_agent
-        release: cf
     instances: 2
     vm_type: medium
     stemcell: default
@@ -328,8 +304,6 @@ jobs:
         release: garden-linux
       - name: cflinuxfs2-rootfs-setup
         release: cflinuxfs2-rootfs
-      - name: metron_agent
-        release: cf
     instances: (( grab meta.cell.instances ))
     vm_type: cell
     stemcell: default
@@ -353,8 +327,6 @@ jobs:
         release: cf
       - name: cc_uploader
         release: cf
-      - name: metron_agent
-        release: cf
     instances: 2
     vm_type: medium
     stemcell: default
@@ -372,8 +344,6 @@ jobs:
         release: cf
       - name: route_emitter
         release: diego
-      - name: metron_agent
-        release: cf
     instances: 2
     vm_type: medium
     stemcell: default
@@ -391,8 +361,6 @@ jobs:
         release: cf
       - name: ssh_proxy
         release: diego
-      - name: metron_agent
-        release: cf
       - name: file_server
         release: diego
     instances: 2

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -75,7 +75,7 @@ properties:
       - start: 10.10.0.0
         end: 10.10.255.255
     outgoing_dropsonde_port: 8081
-    dropsonde_incoming_port: 3457
+    dropsonde_incoming_port: (( grab meta.metron_agent.dropsonde_incoming_port ))
     traffic_controller_url: (( concat "wss://doppler." properties.system_domain ":443" ))
     tls:
       ca_cert: ~
@@ -103,16 +103,6 @@ properties:
 
   doppler_endpoint:
     shared_secret: (( grab properties.loggregator_endpoint.shared_secret ))
-
-  metron_agent:
-    deployment: (( grab meta.environment ))
-    preferred_protocol: ~
-    enable_buffer: ~
-    buffer_size: ~
-    dropsonde_incoming_port: (( grab properties.loggregator.dropsonde_incoming_port ))
-    tls:
-      client_cert: ~
-      client_key: ~
 
   metron_endpoint:
     shared_secret: (( grab properties.loggregator_endpoint.shared_secret ))
@@ -506,7 +496,7 @@ properties:
         client_cert: (( grab secrets.bbs_client_cert  ))
         client_key: (( grab secrets.bbs_client_key  ))
         require_ssl: true
-      dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
+      dropsonde_port: (( grab meta.metron_agent.dropsonde_incoming_port ))
 
     bbs:
       active_key_label: keylabel1
@@ -524,14 +514,14 @@ properties:
         client_cert: (( grab secrets.consul_agent_cert ))
         client_key: (( grab secrets.consul_agent_key ))
         require_ssl: false
-      dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
+      dropsonde_port: (( grab meta.metron_agent.dropsonde_incoming_port ))
       require_ssl: true
 
     file_server:
-      dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
+      dropsonde_port: (( grab meta.metron_agent.dropsonde_incoming_port ))
 
     rep:
-      dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
+      dropsonde_port: (( grab meta.metron_agent.dropsonde_incoming_port ))
       bbs:
         api_location: bbs.service.cf.internal:8889
         ca_cert: (( grab meta.secrets.bbs_ca_cert ))
@@ -542,7 +532,7 @@ properties:
         - "cflinuxfs2:/var/vcap/packages/cflinuxfs2/rootfs"
 
     route_emitter:
-      dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
+      dropsonde_port: (( grab meta.metron_agent.dropsonde_incoming_port ))
       bbs:
         api_location: bbs.service.cf.internal:8889
         ca_cert: (( grab meta.secrets.bbs_ca_cert ))
@@ -556,7 +546,7 @@ properties:
         port: (( grab properties.nats.port ))
 
     ssh_proxy:
-      dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
+      dropsonde_port: (( grab meta.metron_agent.dropsonde_incoming_port ))
       bbs:
         api_location: bbs.service.cf.internal:8889
         ca_cert: (( grab meta.secrets.bbs_ca_cert ))
@@ -572,7 +562,7 @@ properties:
 
   capi:
     cc_uploader:
-      dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
+      dropsonde_port: (( grab meta.metron_agent.dropsonde_incoming_port ))
       cc:
         base_url: (( grab properties.cc.srv_api_uri ))
         basic_auth_password: (( grab properties.cc.internal_api_password ))
@@ -580,7 +570,7 @@ properties:
         staging_upload_password: (( grab properties.cc.staging_upload_password ))
 
     nsync:
-      dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
+      dropsonde_port: (( grab meta.metron_agent.dropsonde_incoming_port ))
       bbs:
         api_location: bbs.service.cf.internal:8889
         ca_cert: (( grab meta.secrets.bbs_ca_cert ))
@@ -595,7 +585,7 @@ properties:
         staging_upload_password: (( grab properties.cc.staging_upload_password ))
 
     stager:
-      dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
+      dropsonde_port: (( grab meta.metron_agent.dropsonde_incoming_port ))
       bbs:
         api_location: bbs.service.cf.internal:8889
         ca_cert: (( grab meta.secrets.bbs_ca_cert ))
@@ -609,7 +599,7 @@ properties:
         staging_upload_password: (( grab properties.cc.staging_upload_password ))
 
     tps:
-      dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
+      dropsonde_port: (( grab meta.metron_agent.dropsonde_incoming_port ))
       cc:
         base_url: (( grab properties.cc.srv_api_uri ))
         basic_auth_password: (( grab properties.cc.internal_api_password ))

--- a/manifests/cf-manifest/manifest/040-graphite.yml
+++ b/manifests/cf-manifest/manifest/040-graphite.yml
@@ -1,7 +1,5 @@
 meta:
   graphite_templates:
-    - name: metron_agent
-      release: cf
     - name: carbon
       release: graphite
     - name: graphite-web

--- a/manifests/cf-manifest/runtime-config/runtime-config-base.yml
+++ b/manifests/cf-manifest/runtime-config/runtime-config-base.yml
@@ -1,9 +1,28 @@
 ---
+meta:
+  environment: (( grab terraform_outputs.environment ))
+
 releases:
   - name: os-conf
     version: commit-a2bc2ab32248c8edf7c4790b33902893b1f4db66
+  - name: cf
+    data: (( inject meta.cf-releases.cf ))
 
 addons:
+  - name: metron_agent
+    jobs:
+    - name: metron_agent
+      release: cf
+    properties:
+      metron_agent:
+        deployment: (( grab meta.environment ))
+        preferred_protocol: ~
+        enable_buffer: ~
+        buffer_size: ~
+        dropsonde_incoming_port: (( grab meta.metron_agent.dropsonde_incoming_port ))
+        tls:
+          client_cert: ~
+          client_key: ~
   - name: os-configuration
     jobs:
     - name: set_mtu

--- a/manifests/cf-manifest/spec/runtime-config/metron_agent_as_addon_spec.rb
+++ b/manifests/cf-manifest/spec/runtime-config/metron_agent_as_addon_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe "Runtime config" do
+  let(:runtime_config) { load_runtime_config }
+
+  it "the metron_agent is configured as a addon" do
+    metron_agent_addon = runtime_config.fetch("addons").find { |addon| addon["name"] == "metron_agent" }
+
+    expect(metron_agent_addon).not_to be_nil
+    metron_agent_job = metron_agent_addon.fetch("jobs").find { |job| job["name"] == "metron_agent" }
+    expect(metron_agent_job).not_to be_nil
+  end
+end

--- a/manifests/cf-manifest/spec/runtime-config/shared_config_spec.rb
+++ b/manifests/cf-manifest/spec/runtime-config/shared_config_spec.rb
@@ -1,6 +1,7 @@
-
-RSpec.describe "Runtime config" do
+RSpec.describe "Runtime config use shared config" do
   let(:runtime_config) { load_runtime_config }
+  let(:manifest) { manifest_with_defaults }
+  let(:properties) { manifest.fetch("properties") }
 
   it "uses a shared collectd config file" do
     collectd_addon = runtime_config.fetch("addons").find { |addon| addon["name"] == "collectd" }
@@ -10,5 +11,13 @@ RSpec.describe "Runtime config" do
   it "has datadog included with properties from shared config" do
     datadog_addon = runtime_config.fetch("addons").find { |addon| addon["name"] == "datadog-agent" }
     expect(datadog_addon.fetch("properties").fetch("use_dogstatsd")).to eq false
+  end
+
+  it "the dropsonde_incoming_port is the same metron_agent and loggregator" do
+    metron_agent_addon = runtime_config.fetch("addons").find { |addon| addon["name"] == "metron_agent" }
+    metron_agent_dropsonde_incoming_port = metron_agent_addon.fetch("properties").fetch("metron_agent").fetch("dropsonde_incoming_port")
+    loggregator_dropsonde_incoming_port = properties.fetch("loggregator").fetch("dropsonde_incoming_port")
+
+    expect(metron_agent_dropsonde_incoming_port).to eq loggregator_dropsonde_incoming_port
   end
 end

--- a/manifests/cf-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/cf-manifest/spec/support/manifest_helpers.rb
@@ -55,12 +55,13 @@ private
         File.expand_path("../../../../shared/build_manifest.sh", __FILE__),
         File.expand_path("../../../manifest/*.yml", __FILE__),
         File.expand_path("../../../manifest/data/*.yml", __FILE__),
-        File.expand_path("../../../../shared/spec/fixtures/terraform/*.yml", __FILE__),
-        File.expand_path("../../../../shared/spec/fixtures/cf-secrets.yml", __FILE__),
-        File.expand_path("../../../../shared/spec/fixtures/cf-ssl-certificates.yml", __FILE__),
         grafana_dashboards_manifest_path,
         File.expand_path("../../../manifest/env-specific/cf-#{environment}.yml", __FILE__),
         File.expand_path("../../../../shared/deployments/datadog.yml", __FILE__),
+        File.expand_path("../../../common/*.yml", __FILE__),
+        File.expand_path("../../../../shared/spec/fixtures/terraform/*.yml", __FILE__),
+        File.expand_path("../../../../shared/spec/fixtures/cf-secrets.yml", __FILE__),
+        File.expand_path("../../../../shared/spec/fixtures/cf-ssl-certificates.yml", __FILE__),
     ])
 
     cloud_config = render([
@@ -85,7 +86,9 @@ private
       File.expand_path("../../../runtime-config/runtime-config-base.yml", __FILE__),
       File.expand_path("../../../runtime-config/datadog-addon.yml", __FILE__),
       File.expand_path("../../../../shared/deployments/datadog.yml", __FILE__),
-      File.expand_path("../../../../shared/deployments/collectd.yml", __FILE__)
+      File.expand_path("../../../../shared/deployments/collectd.yml", __FILE__),
+      File.expand_path("../../../common/*.yml", __FILE__),
+      File.expand_path("../../../../shared/spec/fixtures/terraform/*.yml", __FILE__),
     ])
 
     # Deep freeze the object so that it's safe to use across multiple examples


### PR DESCRIPTION
[#124720541 Not all logs shipped to kibana/logsearch](https://www.pivotaltracker.com/story/show/124720541)

What
===

We want to get all the logs from all the machines in loggregator. Metron agent configures syslog to forward all the local logs, so we decided to install it in all the VMs.

To do so, we will add it as an addon.

To configure it as a addon, we had to refactor the manifest:
* We need to pass the terraform outputs to the runtime-config.yml  generation, so we can pass the environment config.
* We need to move some common config, like dropsonde_incoming_port to  a `common/metron.yml` file
* We need to move the definition of the cf release to  `common/releases.yml`

How to test?
===========

Travis should pass.

Deploy, it should pass the tests.

Verify that metron agent is running on the VMs and the logs are being ship to kibana

Who?
----

Anyone but @keymon or @richardc