### PR TITLE
[#130379909] Refactor Datadog credential storage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
     export PATH=~/bin:$PATH
   - |
     echo "Fetching shellcheck"
-    wget -O ~/bin/shellcheck https://github.com/alphagov/paas-cf/releases/download/shellcheck_binary_0.3.7/shellcheck_linux_amd64
+    wget -O ~/bin/shellcheck https://github.com/alphagov/paas-cf/releases/download/shellcheck_binary_0.4.4/shellcheck_linux_amd64
     chmod +x ~/bin/shellcheck
   - |
     echo "Fetching Terraform"

--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,14 @@ showenv: ## Display environment information
 		--query 'Reservations[].Instances[].PublicIpAddress' --output text)
 	@concourse/scripts/environment.sh
 
+.PHONY: upload-datadog-secrets
+upload-datadog-secrets: check-env-vars ## Decrypt and upload Datadog credentials to S3
+	$(eval export DATADOG_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
+	$(if ${AWS_ACCOUNT},,$(error Must set environment to ci/staging/prod))
+	$(if ${DATADOG_PASSWORD_STORE_DIR},,$(error Must pass DATADOG_PASSWORD_STORE_DIR=<path_to_password_store>))
+	$(if $(wildcard ${DATADOG_PASSWORD_STORE_DIR}),,$(error Password store ${DATADOG_PASSWORD_STORE_DIR} does not exist))
+	@scripts/upload-datadog-secrets.sh
+
 .PHONY: manually_upload_certs
 CERT_PASSWORD_STORE_DIR?=~/.paas-pass-high
 manually_upload_certs: check-tf-version ## Manually upload to AWS the SSL certificates for public facing endpoints

--- a/README.md
+++ b/README.md
@@ -406,5 +406,8 @@ Visit [BOSH failover page](https://github.com/alphagov/paas-cf/blob/master/doc/b
 ## Pingdom checks
 Visit [Pingdom documentation page](https://github.com/alphagov/paas-cf/blob/master/doc/pingdom.md)
 
+## Datadog credentials
+These must be published in each new environment. Visit the [Datadog documentation page](https://github.com/alphagov/paas-cf/blob/master/doc/datadog.md)
+
 ## Other useful commands
 Type `make` to get the list of all available commands.

--- a/concourse/scripts/lib/datadog.sh
+++ b/concourse/scripts/lib/datadog.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+set -u
+
+get_datadog_secrets() {
+  # shellcheck disable=SC2154
+  secrets_uri="s3://${env}-state/datadog-secrets.yml"
+  export datadog_api_key
+  export datadog_app_key
+  if aws s3 ls "${secrets_uri}" > /dev/null ; then
+    secrets_file=$(mktemp -t datadog-secrets.XXXXXX)
+
+    aws s3 cp "${secrets_uri}" "${secrets_file}"
+    datadog_api_key=$("${SCRIPT_DIR}"/val_from_yaml.rb datadog_api_key "${secrets_file}")
+    datadog_app_key=$("${SCRIPT_DIR}"/val_from_yaml.rb datadog_app_key "${secrets_file}")
+
+    rm -f "${secrets_file}"
+  else
+    datadog_api_key="disabled"
+    datadog_app_key="disabled"
+  fi
+}

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -6,6 +6,9 @@ export TARGET_CONCOURSE=deployer
 # shellcheck disable=SC2091
 $("${SCRIPT_DIR}/environment.sh" "$@")
 
+# shellcheck disable=1090
+. "${SCRIPT_DIR}/lib/datadog.sh"
+
 download_git_id_rsa() {
   git_id_rsa_file=$(mktemp -t id_rsa.XXXXXX)
 
@@ -53,16 +56,9 @@ prepare_environment() {
 
   download_git_id_rsa
   get_git_concourse_pool_clone_full_url_ssh
+  get_datadog_secrets
 
   export EXPOSE_PIPELINE=1
-
-  if [ "${ENABLE_DATADOG:-}" = "true" ]; then
-    export PASSWORD_STORE_DIR=~/.paas-pass
-    datadog_api_key=$(pass datadog/api_key)
-    datadog_app_key=$(pass datadog/app_key)
-  else
-    datadog_api_key="disabled"
-  fi
 }
 
 generate_vars_file() {

--- a/concourse/scripts/pipelines-deployer.sh
+++ b/concourse/scripts/pipelines-deployer.sh
@@ -8,13 +8,12 @@ export TARGET_CONCOURSE=bootstrap
 $("${SCRIPT_DIR}/environment.sh" "$@")
 "${SCRIPT_DIR}/fly_sync_and_login.sh"
 
+# shellcheck source=./concourse/scripts/lib/datadog.sh
+. "${SCRIPT_DIR}/lib/datadog.sh"
+
 env=${DEPLOY_ENV}
-if [ "${ENABLE_DATADOG:-}" = "true" ]; then
-  export PASSWORD_STORE_DIR=~/.paas-pass
-  datadog_api_key=$(pass datadog/api_key)
-else
-  datadog_api_key="disabled"
-fi
+
+get_datadog_secrets
 
 generate_vars_file() {
    cat <<EOF

--- a/doc/datadog.md
+++ b/doc/datadog.md
@@ -1,0 +1,38 @@
+# Datadog credentials
+
+### What this is for
+
+When setting up an environment the Datadog credentials need to be decrypted and pushed into the S3 state bucket as they are required during pipeline runs. Each environment (ci, staging, and prod) has its own set of Application and API credentials in the PaaS credential store.
+
+### Requirements
+
+* Make sure you have access to the PaaS credential store, this is required for Datadog credentials.
+* Load the AWS credentials for the environment you are setting up datadog for. These are required as the Datadog secrets file is stored in an S3 bucket.
+
+### Usage
+```
+make <ENV> upload-datadog-secrets
+```
+
+### Example for testing in a dev environment
+
+1. Switch to a test password store dir
+
+```
+export DATADOG_PASSWORD_STORE_DIR="tmp/datadog-password-store"
+```
+
+2. Insert your test datadog keys
+
+```
+pass insert datadog/dev/datadog_api_key
+pass insert datadog/dev/datadog_app_key
+```
+
+3. Upload the new keys to your state bucket
+
+```
+make dev upload-datadog-secrets
+```
+
+4. Re-run your pipelines

--- a/scripts/upload-datadog-secrets.sh
+++ b/scripts/upload-datadog-secrets.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -eu
+
+export PASSWORD_STORE_DIR=${DATADOG_PASSWORD_STORE_DIR}
+
+DATADOG_API_KEY=$(pass "datadog/${AWS_ACCOUNT}/datadog_api_key")
+DATADOG_APP_KEY=$(pass "datadog/${AWS_ACCOUNT}/datadog_app_key")
+
+SECRETS=$(mktemp secrets.yml.XXXXXX)
+trap 'rm  "${SECRETS}"' EXIT
+
+cat > "${SECRETS}" << EOF
+---
+datadog_api_key: ${DATADOG_API_KEY}
+datadog_app_key: ${DATADOG_APP_KEY}
+EOF
+
+aws s3 cp "${SECRETS}" "s3://${DEPLOY_ENV}-state/datadog-secrets.yml"


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/130379909

## What

This moves Datadog API and App keys into the state bucket and adds a Makefile target for populating the state bucket from the credentials repo.

## How to review

1. Deploy an environment, login to datadog, observe that nothing is showing up there.
2. Create a datadog API key and an app key, and place them in `~/.paas-pass/datadog/dev/datadog_api_key.gpg` and `~/.paas-pass/datadog/dev/datadog_app_key.gpg`
3. Run `make dev upload-datadog-secrets`, observe that these credentials have been inserted into your environment s3 state bucket as `datadog-secrets.yml`
4. Redeploy your pipelines, then redeploy the environment
5. Type your environment name into "filter" on https://app.datadoghq.com/infrastructure/map and observe that all your hosts are monitored

## Who can review

Not @jonty or @richardc.