### PR TITLE
[#130730169] Fix vm update settings

### DIFF
--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -43,7 +43,7 @@ prepare_environment() {
   cf_graphite_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.graphite.version "${cf_manifest_dir}/040-graphite.yml")
   cf_aws_broker_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.aws-broker.version "${cf_manifest_dir}/050-rds-broker.yml")
   cf_os_conf_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.os-conf.version "${cf_manifest_dir}/../runtime-config/runtime-config-base.yml")
-  cf_logsearch_for_cloudfoundry_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.logsearch-for-cloudfoundry.version "${cf_manifest_dir}/030-logsearch.yml")
+  cf_logsearch_for_cloudfoundry_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.logsearch-for-cloudfoundry.version "${cf_manifest_dir}/800-logsearch.yml")
 
   if [ -z "${SKIP_COMMIT_VERIFICATION:-}" ] ; then
     gpg_ids="[$(xargs < "${SCRIPT_DIR}/../../.gpg-id" | tr ' ' ',')]"

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -35,7 +35,7 @@ stemcells:
 
 update:
   canaries: 0
-  max_in_flight: 2
+  max_in_flight: 1
   canary_watch_time: 30000-600000
   update_watch_time: 5000-600000
   serial: false

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -175,6 +175,27 @@ jobs:
         job: etcd
         tags: (( inject meta.datadog_tags ))
 
+  - name: database
+    azs: [z1, z2]
+    templates:
+      - name: consul_agent
+        release: cf
+      - name: bbs
+        release: diego
+      - name: metron_agent
+        release: cf
+    instances: 2
+    vm_type: medium
+    stemcell: default
+    networks:
+      - name: cf
+    properties:
+      tags:
+        job: database
+        tags: (( inject meta.datadog_tags ))
+    update:
+      serial: true
+
   - name: uaa
     azs: [z1, z2]
     templates: (( grab meta.uaa_templates ))
@@ -276,28 +297,6 @@ jobs:
       tags:
         job: router
         tags: (( inject meta.datadog_tags ))
-# Diego
-
-  - name: database
-    azs: [z1, z2]
-    templates:
-      - name: consul_agent
-        release: cf
-      - name: bbs
-        release: diego
-      - name: metron_agent
-        release: cf
-    instances: 2
-    vm_type: medium
-    stemcell: default
-    networks:
-      - name: cf
-    properties:
-      tags:
-        job: database
-        tags: (( inject meta.datadog_tags ))
-    update:
-      serial: true
 
   - name: brain
     azs: [z1, z2]

--- a/manifests/cf-manifest/manifest/030-logsearch.yml
+++ b/manifests/cf-manifest/manifest/030-logsearch.yml
@@ -27,6 +27,8 @@ jobs:
     tags:
       job: ingestor_z1
       tags: (( inject meta.datadog_tags ))
+  update:
+    serial: true
 
 - name: ingestor_z2
   release: logsearch
@@ -48,6 +50,8 @@ jobs:
     tags:
       job: ingestor_z2
       tags: (( inject meta.datadog_tags ))
+  update:
+    serial: true
 
 - name: queue
   release: logsearch

--- a/manifests/cf-manifest/manifest/030-logsearch.yml
+++ b/manifests/cf-manifest/manifest/030-logsearch.yml
@@ -1,9 +1,3 @@
-meta:
-  update:
-    serial: false
-    canaries: 1
-    max_in_flight: 1
-
 releases:
 - name: logsearch
   url: https://bosh.io/d/github.com/logsearch/logsearch-boshrelease?v=200.0.0
@@ -27,7 +21,6 @@ jobs:
     default: [gateway, dns]
     static_ips:
       - 10.0.16.12
-  update: (( grab meta.update ))
   properties:
     redis:
       host: (( grab jobs.queue.networks.cf.static_ips.[0] ))
@@ -49,7 +42,6 @@ jobs:
     default: [gateway, dns]
     static_ips:
       - 10.0.17.12
-  update: (( grab meta.update ))
   properties:
     redis:
       host: (( grab jobs.queue.networks.cf.static_ips.[1] ))
@@ -71,7 +63,6 @@ jobs:
       - 10.0.16.13
       - 10.0.17.13
   persistent_disk_type: queue
-  update: (( grab meta.update ))
   properties:
     tags:
       job: queue
@@ -90,7 +81,6 @@ jobs:
   - name: cf
     static_ips:
       - 10.0.16.14
-  update: (( grab meta.update ))
   properties:
     redis:
       host: (( grab jobs.queue.networks.cf.static_ips.[0] ))
@@ -115,7 +105,6 @@ jobs:
   - name: cf
     static_ips:
       - 10.0.17.14
-  update: (( grab meta.update ))
   properties:
     redis:
       host: (( grab jobs.queue.networks.cf.static_ips.[1] ))
@@ -153,7 +142,6 @@ jobs:
     tags:
       job: elasticsearch_master
       tags: (( inject meta.datadog_tags ))
-  update: (( grab meta.update ))
 
 - name: maintenance
   instances: 1
@@ -167,7 +155,6 @@ jobs:
   stemcell: default
   networks:
   - name: cf
-  update: (( grab meta.update ))
   properties:
     elasticsearch_config:
       templates:
@@ -187,7 +174,6 @@ jobs:
   instances: 1
   networks:
   - name: cf
-  update: (( grab meta.update ))
   properties:
     tags:
       job: kibana

--- a/manifests/cf-manifest/manifest/800-logsearch.yml
+++ b/manifests/cf-manifest/manifest/800-logsearch.yml
@@ -7,52 +7,7 @@ releases:
   version: v203.0.0-gds
 
 jobs:
-- name: ingestor_z1
-  release: logsearch
-  azs: [z1]
-  templates:
-  - {name: ingestor_syslog, release: logsearch}
-  - {name: ingestor_relp, release: logsearch}
-  vm_type: ingestor
-  stemcell: default
-  instances: 1
-  networks:
-  - name: cf
-    default: [gateway, dns]
-    static_ips:
-      - 10.0.16.12
-  properties:
-    redis:
-      host: (( grab jobs.queue.networks.cf.static_ips.[0] ))
-    tags:
-      job: ingestor_z1
-      tags: (( inject meta.datadog_tags ))
-  update:
-    serial: true
-
-- name: ingestor_z2
-  release: logsearch
-  azs: [z2]
-  templates:
-  - {name: ingestor_syslog, release: logsearch}
-  - {name: ingestor_relp, release: logsearch}
-  vm_type: ingestor
-  stemcell: default
-  instances: 1
-  networks:
-  - name: cf
-    default: [gateway, dns]
-    static_ips:
-      - 10.0.17.12
-  properties:
-    redis:
-      host: (( grab jobs.queue.networks.cf.static_ips.[1] ))
-    tags:
-      job: ingestor_z2
-      tags: (( inject meta.datadog_tags ))
-  update:
-    serial: true
-
+- (( append ))
 - name: queue
   release: logsearch
   azs: [z1, z2]
@@ -182,6 +137,52 @@ jobs:
     tags:
       job: kibana
       tags: (( inject meta.datadog_tags ))
+
+- name: ingestor_z1
+  release: logsearch
+  azs: [z1]
+  templates:
+  - {name: ingestor_syslog, release: logsearch}
+  - {name: ingestor_relp, release: logsearch}
+  vm_type: ingestor
+  stemcell: default
+  instances: 1
+  networks:
+  - name: cf
+    default: [gateway, dns]
+    static_ips:
+      - 10.0.16.12
+  properties:
+    redis:
+      host: (( grab jobs.queue.networks.cf.static_ips.[0] ))
+    tags:
+      job: ingestor_z1
+      tags: (( inject meta.datadog_tags ))
+  update:
+    serial: true
+
+- name: ingestor_z2
+  release: logsearch
+  azs: [z2]
+  templates:
+  - {name: ingestor_syslog, release: logsearch}
+  - {name: ingestor_relp, release: logsearch}
+  vm_type: ingestor
+  stemcell: default
+  instances: 1
+  networks:
+  - name: cf
+    default: [gateway, dns]
+    static_ips:
+      - 10.0.17.12
+  properties:
+    redis:
+      host: (( grab jobs.queue.networks.cf.static_ips.[1] ))
+    tags:
+      job: ingestor_z2
+      tags: (( inject meta.datadog_tags ))
+  update:
+    serial: true
 
 properties:
   syslog_daemon_config:

--- a/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe "base properties" do
     expect(manifest["name"]).to eq(terraform_fixture(:environment))
   end
 
+  it "has global max_in_flight set to 1" do
+    expect(manifest["update"].fetch("max_in_flight")).to eq(1)
+  end
+
   it "sets the system_domain from the terraform outputs" do
     expect(properties["system_domain"]).to eq(terraform_fixture(:cf_root_domain))
   end


### PR DESCRIPTION
## What

[Make sure ingestor vms have completely restarted before we launch other vms](https://www.pivotaltracker.com/n/projects/1275640/stories/130730169)
This PR
* Improves safety of deployment by
    * Setting global update max-in-fligh to 1
    * Updating diego database before other diego components
* Improves cleanness of manifests by removing custom logsearch update settings that had in practice the same effect as global settings
* Improves deployment speed by creating only one parallel deployment group
* Mostly alleviates metron agent restart failed issue (by ~90%). See story for more details.

Last point will require further PRs to fully fix.

## How to review

Apply to your existing environment. Make it deploy all the CF VMs by either having your environment built from branch that e.g. has different stemcell, or no datadog agent or similar. You could perhaps manually change job tags for all the VMs (`make dev bosh-cli`, `bosh download manifest <envname> >a`, `sed -r 's/job: (.+)/job: x\1/' -i a`, `bosh deployment a`, `bosh deploy`). Notice that update order during the deploy is:
1. consul
2. NATS
3. ETCD
4. DATABASE
5. all jobs except ingestor in parallel
6. ingestor serially 

## Who can review

not @mtekel