### PR TITLE
[SUPPORT TASK] Use non-slim ruby container for bosh-cli test

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -2171,7 +2171,7 @@ jobs:
             type: docker-image
             source:
               repository: ruby
-              tag: 2.2-slim
+              tag: "2.2"
           params:
             SYSTEM_DNS_ZONE_NAME: {{system_dns_zone_name}}
             DEPLOY_ENV: {{deploy_env}}


### PR DESCRIPTION
## What

Ruby slim container no longer has `curl` included: https://github.com/docker-library/ruby/commit/281978ef87397763e377774740d82c8d87674ae9#diff-a68c083598cb36cf70eaaead1ae18581L25. 
This breaks test-bosh-cli task.

Non-slim container still has curl.

## How to review

Run the pipeline and check if `bosh-tests` job passes. 

## Who can review

Not @combor