### PR TITLE
[#130182525] Control datadog terraform

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -93,6 +93,7 @@ jobs:
           TF_VAR_datadog_api_key: {{datadog_api_key}}
           TF_VAR_datadog_app_key: {{datadog_app_key}}
           TF_VAR_env: {{deploy_env}}
+          DEPLOY_DATADOG_AGENT: {{deploy_datadog_agent}}
         ensure:
           put: datadog-tfstate
           params:

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1856,6 +1856,15 @@ jobs:
                 - -e
                 - -c
                 - |
+                  if [ -n "${TF_VAR_datadog_api_key}" -a -n "${TF_VAR_datadog_app_key}" -a "${DEPLOY_DATADOG_AGENT}" = "false" ]; then
+                    echo "Datadog disabled but keys present, running check cleanup..."
+                    terraform destroy -force \
+                       -state=datadog-tfstate/datadog.tfstate \
+                       -state-out=updated-tfstate/datadog.tfstate \
+                       paas-cf/terraform/datadog
+                    exit 0
+                  fi
+
                   if [ "${DEPLOY_DATADOG_AGENT}" = "true" ]; then
                     terraform apply -state=datadog-tfstate/datadog.tfstate -state-out=updated-tfstate/datadog.tfstate paas-cf/terraform/datadog
                   else

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1849,13 +1849,14 @@ jobs:
               TF_VAR_env: {{deploy_env}}
               TF_VAR_datadog_api_key: {{datadog_api_key}}
               TF_VAR_datadog_app_key: {{datadog_app_key}}
+              DEPLOY_DATADOG_AGENT: {{deploy_datadog_agent}}
             run:
               path: sh
               args:
                 - -e
                 - -c
                 - |
-                  if [ "${TF_VAR_datadog_api_key}" != "disabled" ]; then
+                  if [ "${DEPLOY_DATADOG_AGENT}" = "true" ]; then
                     terraform apply -state=datadog-tfstate/datadog.tfstate -state-out=updated-tfstate/datadog.tfstate paas-cf/terraform/datadog
                   else
                     echo "Datadog disabled, skipping terraform run..."

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -165,6 +165,7 @@ jobs:
           TF_VAR_datadog_api_key: {{datadog_api_key}}
           TF_VAR_datadog_app_key: {{datadog_app_key}}
           TF_VAR_env: {{deploy_env}}
+          DEPLOY_DATADOG_AGENT: {{deploy_datadog_agent}}
         ensure:
           put: datadog-tfstate
           params:

--- a/concourse/scripts/lib/datadog.sh
+++ b/concourse/scripts/lib/datadog.sh
@@ -15,8 +15,5 @@ get_datadog_secrets() {
     datadog_app_key=$("${SCRIPT_DIR}"/val_from_yaml.rb datadog_app_key "${secrets_file}")
 
     rm -f "${secrets_file}"
-  else
-    datadog_api_key="disabled"
-    datadog_app_key="disabled"
   fi
 }

--- a/concourse/tasks/terraform_destroy_datadog.yml
+++ b/concourse/tasks/terraform_destroy_datadog.yml
@@ -15,7 +15,7 @@ run:
     - -e
     - -c
     - |
-      if [ "${TF_VAR_datadog_api_key}" != "disabled" ]; then
+      if [ "${DEPLOY_DATADOG_AGENT}" = "true" ]; then
         terraform destroy -force \
           -state=datadog-tfstate/datadog.tfstate \
           -state-out=updated-datadog-tfstate/datadog.tfstate \

--- a/concourse/tasks/terraform_destroy_datadog.yml
+++ b/concourse/tasks/terraform_destroy_datadog.yml
@@ -15,7 +15,13 @@ run:
     - -e
     - -c
     - |
-      if [ "${DEPLOY_DATADOG_AGENT}" = "true" ]; then
+      cleanup=false
+      if [ -n "${TF_VAR_datadog_api_key}" -a -n "${TF_VAR_datadog_app_key}" -a "${DEPLOY_DATADOG_AGENT}" = "false" ]; then
+        cleanup=true
+        echo "Datadog disabled but keys present, running check cleanup..."
+      fi
+
+      if [ "${DEPLOY_DATADOG_AGENT}" = "true" -o "${cleanup}" = "true" ]; then
         terraform destroy -force \
           -state=datadog-tfstate/datadog.tfstate \
           -state-out=updated-datadog-tfstate/datadog.tfstate \


### PR DESCRIPTION
## What

We now have real datadog keys available for our environments, so we can get rid of "disabled" workaround. This PR also adds functionality to clean up datadog checks after datadog is disabled - when you run deploy pipeline again and when you run autodelete/destroy pipelines.

## How to review

Upload dev datadog keys to your dev env (`make dev upload-datadog-secrets`). Deploy with datadog enabled (`DEPLOY_DATADOG_AGENT=true make dev pipelines`). Run the deploy pipeline. Then disable datadog & upload your pipeline (`make dev pipelines`). Run deploy pipeline again & verify that terraform does clean up previously created checks. Then also check in autodelete/destroy pipelines that terraform tasks there run cleanup. You can do so by e.g. running these pipelines. (hint: edit your pipelines locally, place `exit 0` in real destroy tasks so that you skip them - if you don't really want to destroy your environment).

## Who can review

not @mtekel