### PR TITLE
[#130182525] Define default value for datadog api key

### DIFF
--- a/manifests/shared/deployments/datadog.yml
+++ b/manifests/shared/deployments/datadog.yml
@@ -7,7 +7,7 @@ releases:
 
 meta:
   datadog:
-    api_key: (( grab $DATADOG_API_KEY ))
+    api_key: (( grab $DATADOG_API_KEY || "undefined" ))
     use_dogstatsd: false
   datadog_tags:
     environment: (( grab meta.environment || "undefined" ))


### PR DESCRIPTION
## What

Dadatog.yml is always included in the cf-manifest. This is because we
always define tags and other datadog properties and we grab from shared
datadog.yml file. In case we don't want to enable datadog and the api
key is missing for the environment, spruce rendering would fail as
there was no value defined for the api key.

Define default for this value.

This is an unspotted leftover from #503 

## How to review

Deploy in dev environment where you have no keys in the bucket. Run generate-cf-config job. It should succeed.

## Who can review

not @mtekel