### PR TITLE
[SUPPORT TASK] Concourse 2.2.1 upgrade

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -6,11 +6,11 @@ name: concourse
 
 releases:
   - name: concourse
-    url: https://github.com/concourse/concourse/releases/download/v2.1.0/concourse-2.1.0.tgz
-    sha1: 753bb48c73c77e8881040d4c60a7b882ec56b228
+    url: https://bosh.io/d/github.com/concourse/concourse?v=2.2.1
+    sha1: 879d5cb45d12f173ff4c7912c7c7cdcd3e18c442
   - name: garden-runc
-    url: https://github.com/concourse/concourse/releases/download/v2.1.0/garden-runc-0.8.0.tgz
-    sha1: 406cb6da4abc38ef1924c0a81888c9c46decbc65
+    url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=0.8.0
+    sha1: 20e98ea84c8f4426bba00bbca17d931e27d3c07d
   # When updating the version of the CPI here, the version used in the
   # bosh-init container must also be updated so that the cached CPI compile
   # will be used.


### PR DESCRIPTION
## What

This release fixes the problem with disk space that we had a lot of
trouble with:

> "BOSH-deployed workers will now be named after a frankenguid taking
parts from the BOSH instance ID and their hostname. This is to make it
so you can correlate the worker to the BOSH instance, while also
guaranteeing that when the worker is recreated it comes back under a new
name."

As we use bosh-init to deploy Concourse the name was always "unknown".

> "the issue is that it comes back with the same name every time
to concourse, a worker coming back with the same name means all the
volumes that were previously on it should still be there
so it probably gets confused when it sees the imported volume for it in
the db and then it's not there"

Release notes promises big improvements to resources candidate selection
algorithm that should bring CPU usage down.

http://concourse.ci/downloads.html#v221
http://concourse.ci/downloads.html#v220

## How to review

- run the bootstrap pipeline
- run the deployer pipeline
- all tests should pass

## Who can review

Not ![image](https://cloud.githubusercontent.com/assets/163394/18784311/2f2398b8-8189-11e6-82f8-25d825dc6286.png)

