### PR TITLE
[#130921001] Add two new cells in zone 3, for a total of 6.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,3 +209,7 @@ tunnel: check-env-vars ## SSH tunnel to internal IPs
 
 stop-tunnel: check-env-vars ## Stop SSH tunnel
 	@./concourse/scripts/ssh.sh stop
+
+show-cf-memory-usage: ## Show the memory usage of the current CF cluster
+	$(eval export API_ENDPOINT=https://api.${SYSTEM_DNS_ZONE_NAME})
+	@./scripts/show-cf-memory-usage.rb

--- a/manifests/cf-manifest/cloud-config/010-cf-networks.yml
+++ b/manifests/cf-manifest/cloud-config/010-cf-networks.yml
@@ -62,6 +62,15 @@ networks:
       cloud_properties:
         subnet: (( grab terraform_outputs.cell2_subnet_id ))
       az: z2
+    - range: 10.0.34.0/24
+      reserved:
+        - 10.0.34.2 - 10.0.34.3
+      gateway: 10.0.34.1
+      dns:
+        - 10.0.0.2
+      cloud_properties:
+        subnet: (( grab terraform_outputs.cell3_subnet_id ))
+      az: z3
 - name: router
   subnets:
     - range: 10.0.48.0/24

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -294,7 +294,7 @@ jobs:
         tags: (( inject meta.datadog_tags ))
 
   - name: cell
-    azs: [z1, z2]
+    azs: [z1, z2, z3]
     templates:
       - name: consul_agent
         release: cf

--- a/manifests/cf-manifest/manifest/env-specific/cf-prod.yml
+++ b/manifests/cf-manifest/manifest/env-specific/cf-prod.yml
@@ -1,4 +1,4 @@
 ---
 meta:
   cell:
-    instances: 4
+    instances: 6

--- a/manifests/shared/spec/fixtures/terraform/terraform-outputs.yml
+++ b/manifests/shared/spec/fixtures/terraform/terraform-outputs.yml
@@ -5,6 +5,7 @@ terraform_outputs:
   cf3_subnet_id: subnet-34567812
   cell1_subnet_id: subnet-09876543
   cell2_subnet_id: subnet-98765432
+  cell3_subnet_id: subnet-98765433
   router1_subnet_id: subnet-09876543
   router2_subnet_id: subnet-98765432
   cf_root_domain: unit-test.dev.paas.example.com

--- a/scripts/show-cf-memory-usage.rb
+++ b/scripts/show-cf-memory-usage.rb
@@ -1,0 +1,62 @@
+#!/usr/bin/env ruby
+
+require 'json'
+
+config_path = File.expand_path('~/.cf/config.json')
+if File.exist?(config_path)
+  current_target = JSON.load(File.read(config_path))["Target"]
+  if current_target != ENV['API_ENDPOINT']
+    puts
+    puts "WARNING: This script runs against the environment you are currently logged into, not the one you are targetting."
+    puts
+    puts "You are currently logged into: #{current_target}"
+    puts "You are currently targetting: #{ENV['API_ENDPOINT']}"
+    puts
+    puts "This might not do what you expect. To run against the environment you indicated, please:"
+    puts
+    puts "1. `cf api #{current_target}`"
+    puts "2. `cf login`"
+    puts "3. Run this command again."
+    puts
+    puts "If you are sure you want to continue, press enter, or ctrl-c to abort."
+    puts
+    gets
+  end
+end
+
+orgs = JSON.load(`cf curl /v2/organizations`)['resources']
+quotas = JSON.load(`cf curl /v2/quota_definitions`)['resources']
+
+orgs_reserved_memory = 0
+apps_reserved_memory = 0
+allocated_services = 0
+allocated_routes = 0
+
+orgs.each { |org|
+  quota_id = org['entity']['quota_definition_guid']
+  quota_def = quotas.select { |quota| quota['metadata']['guid'] == quota_id }[0]
+  orgs_reserved_memory += quota_def['entity']['memory_limit'].to_i
+  allocated_services += quota_def['entity']['total_services'].to_i
+  allocated_routes += quota_def['entity']['total_routes'].to_i
+  org_id = org['metadata']['guid']
+  org_apps_reserved_memory = JSON.load(`cf curl /v2/organizations/#{org_id}/memory_usage`)['memory_usage_in_mb']
+  apps_reserved_memory += org_apps_reserved_memory.to_i
+  puts "Memory reserved by apps in org '#{org['entity']['name']}': #{org_apps_reserved_memory} MB"
+}
+
+puts
+puts "Allocated services: #{allocated_services}"
+puts "Allocated routes: #{allocated_routes}"
+puts
+puts "Memory reserved by orgs: #{orgs_reserved_memory} MB (#{orgs_reserved_memory / 1024} GB)"
+puts "Memory reserved by apps: #{apps_reserved_memory} MB (#{apps_reserved_memory / 1024} GB)"
+
+apps_used_memory = 0
+apps = JSON.load(`cf curl /v2/apps`)['resources']
+apps.each { |app|
+  apps_used_memory += app['entity']['memory'].to_i
+}
+
+puts
+puts "Memory actually used by apps: #{apps_used_memory} (#{apps_used_memory / 1024} GB)"
+puts

--- a/terraform/cloudfoundry/outputs.tf
+++ b/terraform/cloudfoundry/outputs.tf
@@ -18,6 +18,10 @@ output "cell2_subnet_id" {
   value = "${aws_subnet.cell.1.id}"
 }
 
+output "cell3_subnet_id" {
+  value = "${aws_subnet.cell.2.id}"
+}
+
 output "router1_subnet_id" {
   value = "${aws_subnet.router.0.id}"
 }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/130921001

## What

Currently if we lose a zone we won't have enough capacity to support all deployed instances of apps on the platform. This adds two more cells in zone 3, thus meeting our requirement of being able to support all currently deployed apps on zone failure and lessening our reliance on z1 & z2.

This also adds a new makefile target that invokes @saliceti's script to show current cluster memory usage.

## How to review

* Edit `paas-cf/manifests/cf-manifest/manifest/env-specific/cf-default.yml` and increase the number of instances to 6 so that your development environment matches the new production configuration.
* Temporarily commit and deploy this to an environment.
* Log in to the AWS console and verify that your environment now has 6 cells spread across three zones.
* If you're feeling extra-cautious, log in to the BOSH CLI and verify the same information by running `bosh vms`.

## Who can review

Not I!