### PR TITLE
[#127970229] Enable RDS Broker to Create Final Snapshot

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -2156,29 +2156,8 @@ jobs:
         - task: generate-test-config
           file: paas-cf/concourse/tasks/generate-test-config.yml
 
-        - task: run-tests
-          config:
-            platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: governmentpaas/cf-acceptance-tests
-            inputs:
-              - name: paas-cf
-              - name: test-config
-              - name: bosh-CA
-            run:
-              path: sh
-              args:
-                - -e
-                - -c
-                - |
-                  ./paas-cf/concourse/scripts/import_bosh_ca.sh
-
-                  echo "Running tests"
-                  export CONFIG
-                  CONFIG="$(pwd)/test-config/config.json"
-                  ./paas-cf/platform-tests/run_tests.sh ./paas-cf/platform-tests/src/acceptance/
+        - task: "Run custom acceptance tests"
+          file: paas-cf/concourse/tasks/custom-acceptance-tests-run.yml
 
         ensure:
           task: remove-temp-user

--- a/concourse/pipelines/failure-testing.yml
+++ b/concourse/pipelines/failure-testing.yml
@@ -109,7 +109,7 @@ jobs:
           - get: bosh-secrets
           - get: bosh-CA
           - get: pipeline-trigger
-            passed: ['init']
+            passed: ['rds-broker']
             trigger: true
       - task: get-instance-id
         file: paas-cf/concourse/tasks/get-instance-id.yml
@@ -357,7 +357,7 @@ jobs:
           - get: bosh-secrets
           - get: bosh-CA
           - get: pipeline-trigger
-            passed: ['cell']
+            passed: ['init']
             trigger: true
       - task: get-instance-id
         file: paas-cf/concourse/tasks/get-instance-id.yml
@@ -375,30 +375,10 @@ jobs:
         - task: generate-test-config
           file: paas-cf/concourse/tasks/generate-test-config.yml
 
-        - task: run-tests
-          config:
-            platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: governmentpaas/self-update-pipelines
-            inputs:
-              - name: paas-cf
-              - name: test-config
-              - name: bosh-CA
-            run:
-              path: sh
-              args:
-                - -e
-                - -c
-                - |
-                  ./paas-cf/concourse/scripts/import_bosh_ca.sh
-
-                  echo "Running tests"
-                  export CONFIG
-                  CONFIG="$(pwd)/test-config/config.json"
-                  export GINKGO_FOCUS='RDS broker'
-                  ./paas-cf/platform-tests/run_tests.sh ./paas-cf/platform-tests/src/acceptance/
+        - task: "Run custom aceptance tests with RDS broker focus"
+          file: paas-cf/concourse/tasks/custom-acceptance-tests-run.yml
+          params:
+            GINKGO_FOCUS: 'RDS broker'
 
         ensure:
           aggregate:

--- a/concourse/tasks/custom-acceptance-tests-run.yml
+++ b/concourse/tasks/custom-acceptance-tests-run.yml
@@ -1,0 +1,22 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/cf-acceptance-tests
+inputs:
+  - name: paas-cf
+  - name: test-config
+  - name: bosh-CA
+run:
+  path: sh
+  args:
+    - -e
+    - -c
+    - |
+      ./paas-cf/concourse/scripts/import_bosh_ca.sh
+
+      echo "Running tests"
+      export CONFIG
+      CONFIG="$(pwd)/test-config/config.json"
+      ./paas-cf/platform-tests/run_tests.sh ./paas-cf/platform-tests/src/acceptance/

--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -19,7 +19,7 @@ meta:
 
 releases:
   - name: aws-broker
-    version: 0.0.9
+    version: 0.0.10
 
 jobs:
   - name: rds_broker

--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -10,7 +10,7 @@ meta:
       multi_az: false
       publicly_accessible: false
       copy_tags_to_snapshot: true
-      skip_final_snapshot: true
+      skip_final_snapshot: false
       backup_retention_period: 7
       db_subnet_group_name: (( grab terraform_outputs.rds_broker_dbs_subnet_group ))
       vpc_security_group_ids:
@@ -39,6 +39,8 @@ jobs:
         job: rds_broker
         tags: (( inject meta.datadog_tags ))
       rds-broker:
+        allow_user_provision_parameters: true
+        allow_user_update_parameters: true
         aws_access_key_id: ""
         aws_secret_access_key: ""
         aws_region: "eu-west-1"
@@ -63,7 +65,7 @@ jobs:
                 providerDisplayName: "Amazon Web Services"
                 documentationUrl: "https://aws.amazon.com/documentation/rds/"
                 supportUrl: "https://forums.aws.amazon.com/forum.jspa?forumID=60"
-              plan_updateable: false
+              plan_updateable: true
               plans:
                 - id: "9b882524-ab58-4c18-b501-d2a3f4619104"
                   name: "M-dedicated-9.5"

--- a/platform-tests/src/acceptance/Godeps/Godeps.json
+++ b/platform-tests/src/acceptance/Godeps/Godeps.json
@@ -34,6 +34,11 @@
 			"ImportPath": "github.com/onsi/gomega",
 			"Comment": "v1.0-83-gc72df92",
 			"Rev": "c72df929b80ef4930aaa75d5e486887ff2f3e06a"
+		},
+		{
+			"ImportPath": "github.com/aws/aws-sdk-go",
+			"Comment": "v1.4.11",
+			"Rev": "7a81396c57134038e554b2ac86be4653018b20f9"
 		}
 	]
 }

--- a/platform-tests/src/acceptance/run_tests.sh
+++ b/platform-tests/src/acceptance/run_tests.sh
@@ -5,7 +5,7 @@ set -eu
 godep restore
 
 if [ -n "${GINKGO_FOCUS:-}" ]; then
-  go test -timeout 30m -ginkgo.focus "${GINKGO_FOCUS}"
+  ginkgo -p -nodes=16 -focus="${GINKGO_FOCUS}"
 else
-  go test -timeout 30m
+  ginkgo -p -nodes=16
 fi


### PR DESCRIPTION
## What

We have updated the broker to create a final snapshot of a database instance
upon its deletion. We have added custom acceptance tests to check for this creation and assert a user can override this behaviour when provisioning a database instance, and by using `cf update-service`.

We had to fix some of the configuration, as it was misplaced. We've enabled the `allow_user_provision_parameters`, allowing to pass some parameters into the command line on execution. We've created our own helper and prepared a set of tests, checking the setup while the pipeline is being run.

## How to review

The review of this pull request is dependent on the merging of [pull request 13](https://github.com/alphagov/paas-aws-broker-boshrelease/pull/13) in the paas-aws-broker-boshrelease repository. Only once that pull request is merged can we remove the temporary commit `[TMP] use broker release from branch `.

The commit `[TMP] - pin cf-acceptance-tests image to version which has ginkgo` can be removed once [pull request 71](https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/71) on paas-docker-cloudfoundry-tools has been merged and the docker build completes.

* Deploy using this branch
* Check the output of the `cf-deploy` task in the `cf-deploy` job to ensure you have picked up the correct version of the RDS Broker release.
* Check the custom acceptance tests pass
* Check the failure testing pipeline still works. We have re-ordered the jobs and changed the container used by the *rds-broker* job.
* If you want to be really thorough you can repeat the two manual test cases documented in [pull request 17](https://github.com/alphagov/paas-rds-broker/pull/17) of the paas-rds-broker repository.

## Before merging

Make sure https://github.gds/government-paas/aws-account-wide-terraform/pull/59 was merged and applied to ci/staging/prod.

## Who can review

Anyone but: @combor, @benhyland, @paroxp, @mtekel or @HenryTK
