### PR TITLE
[SUPPORT] Fix CI healthcheck DB problem.

### DIFF
--- a/terraform/cloudfoundry/router_elb.tf
+++ b/terraform/cloudfoundry/router_elb.tf
@@ -7,7 +7,8 @@ resource "aws_elb" "cf_router" {
     "${aws_security_group.web.id}",
     "${aws_security_group.pingdom-probes-0.id}",
     "${aws_security_group.pingdom-probes-1.id}",
-    "${aws_security_group.pingdom-probes-2.id}"
+    "${aws_security_group.pingdom-probes-2.id}",
+    "${aws_security_group.pingdom-probes-3.id}"
   ]
   access_logs {
     bucket = "${aws_s3_bucket.elb_access_log.id}"

--- a/terraform/cloudfoundry/security-groups-pingdom.tf
+++ b/terraform/cloudfoundry/security-groups-pingdom.tf
@@ -10,6 +10,10 @@ variable "pingdom_probe_cidrs_2" {
   description = "CSV of additional CIDR addresses for which we allow web access, provided externally"
   default     = ""
 }
+variable "pingdom_probe_cidrs_3" {
+  description = "CSV of additional CIDR addresses for which we allow web access, provided externally"
+  default     = ""
+}
 resource "aws_security_group" "pingdom-probes-0" {
   name = "${var.env}-cf-pingdom-probes-0"
   description = "Security group for pingdom probes to reach the HTTPS port"
@@ -83,5 +87,30 @@ resource "aws_security_group" "pingdom-probes-2" {
 
   tags {
     Name = "${var.env}-cf-pingdom-probes-2"
+  }
+}
+resource "aws_security_group" "pingdom-probes-3" {
+  name = "${var.env}-cf-pingdom-probes-3"
+  description = "Security group for pingdom probes to reach the HTTPS port"
+  vpc_id = "${var.vpc_id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 443
+    to_port   = 443
+    protocol  = "tcp"
+    cidr_blocks = [
+      "${split(",", var.pingdom_probe_cidrs_3)}",
+    ]
+  }
+
+  tags {
+    Name = "${var.env}-cf-pingdom-probes-3"
   }
 }


### PR DESCRIPTION
## What

This is temporary fix to allow provisioning of more security groups to
allow more than 96 pingdom IPs ( 32 per group ) to access our
infrastructure. Right now pingdom reports 108 IPs  and some of them (for instance Amsterdam and Düsseldorf ) can't access `/db` on healthcheck app failing the check. 

## How to review

Run the pipeline and check if `cf-terraform` created `aws_security_group.pingdom-probes-3`

## Who can review

Not @combor

