### PR TITLE
Allow login to fail during `remove-healthcheck-db`

### DIFF
--- a/concourse/tasks/remove-healthcheck-db.yml
+++ b/concourse/tasks/remove-healthcheck-db.yml
@@ -20,7 +20,10 @@ run:
         echo "CF API unavailable. Skipping..."
         exit 0
       fi
-      echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
+      if ! echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}; then
+        echo "Login failed.  Skipping..."
+        exit 0
+      fi
       if ! cf org testers > /dev/null; then
         echo "Org 'testers' not found. Skipping..."
         exit 0


### PR DESCRIPTION
## What

If the API is up, it's still possible that you may not be able to login,
say if UAA is down.

Here we allow the `cf login` to fail also.

## How to review

Turn off UAA then delete a deployment.

## Who can review

Not @richardc