### PR TITLE
[#130814387] Metrics for concourse

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -89,6 +89,10 @@ jobs:
               name: atc
               password: dummy-password
 
+          riemann:
+            host: '127.0.0.1'
+            service_prefix: (( concat terraform_outputs.environment "-concourse." ))
+
       - name: groundcrew
         release: concourse
         properties:

--- a/manifests/concourse-manifest/extensions/datadog.yml
+++ b/manifests/concourse-manifest/extensions/datadog.yml
@@ -1,3 +1,9 @@
+releases:
+  - name: riemann
+    url: https://github.com/alphagov/paas-cf/releases/download/riemann-1/riemann-gds-1.tgz
+    sha1: 8a4220a039ce6a2a0383aab8d4a76746501e58ec
+    version: gds-1
+
 jobs:
   - name: concourse
     templates:
@@ -8,3 +14,9 @@ jobs:
           tags:
             job: concourse
             tags: (( inject meta.datadog_tags ))
+      - name: riemann
+        release: riemann
+        properties:
+          riemann:
+            datadog:
+              api_key: (( grab meta.datadog.api_key ))

--- a/terraform/datadog/concourse-jobs.tf
+++ b/terraform/datadog/concourse-jobs.tf
@@ -1,0 +1,14 @@
+resource "datadog_timeboard" "concourse-jobs" {
+
+  title = "${format("%s job runtime difference", var.env) }"
+  description = "vs previous hour"
+  read_only = false
+
+  graph {
+    title = "Runtime changes vs hour ago"
+    viz = "change"
+    request {
+       q = "${format("avg:%s_concourse.build.finished{*} by {job}", var.env)}"
+    }
+  }
+}


### PR DESCRIPTION
## What

Send concourse metrics to datadog and create a simple graph that shows time difference in job runtime for each job.

## How to review

Upload datadog secrets to your dev environmnent if you haven't done so already (`make dev upload-datadog-secrets`) then `DEPLOY_DATADOG_AGENT=true make dev bootstrap`, apply bootstrap pipeline.

Run pipeline on your concourse several time (this is to get some metrics). Log in to datadog. You should see metrics starting with `<env_name>_concourse.`. Created graph (" <env> job runtime difference") should show differences in run times of your jobs.

## Who can review

not @mtekel or @saliceti 