### PR TITLE
[#130814387] Measure pipeline runtime

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -2325,6 +2325,44 @@ jobs:
         passed: ['tag-release']
         trigger: true
       - get: pipeline-pool
+      - task: update-datadog
+        config:
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/git-ssh
+          platform: linux
+          params:
+            DATADOG_API_KEY: {{datadog_api_key}}
+            ENV: {{deploy_env}}
+            AWS_ACCOUNT: {{aws_account}}
+            DEPLOY_DATADOG_AGENT: {{deploy_datadog_agent}}
+          inputs:
+          - name: pipeline-pool
+          run:
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              cd pipeline-pool
+              current_time=$(date +%s)
+              lock_time=$(git log -1  --pretty=format:'%ct')
+              delta=$((${current_time} - ${lock_time}))
+              echo "Total pipeline time was: ${delta}s"
+
+              if [ "${DEPLOY_DATADOG_AGENT}" = "true" ]; then
+                curl  -X POST -H "Content-type: application/json" \
+                  -d "{ \"series\" :
+                         [{\"metric\":\"${ENV}.pipeline_time\",
+                          \"points\":[[$current_time, ${delta}]],
+                          \"type\":\"gauge\",
+                          \"host\":\"concourse.${ENV}\",
+                          \"tags\":[\"environment:${ENV}\", \"aws_account:${AWS_ACCOUNT}\"]}
+                        ]
+                    }" \
+                  "https://app.datadoghq.com/api/v1/series?api_key=${DATADOG_API_KEY}"
+              fi
       - put: pipeline-pool
         params:
           release: pipeline-pool

--- a/terraform/datadog/datadog.tf
+++ b/terraform/datadog/datadog.tf
@@ -27,3 +27,19 @@ resource "datadog_monitor" "router" {
     "job" = "router"
   }
 }
+
+resource "datadog_timeboard" "pipeline" {
+
+  title = "${format("%s - Concourse timeboard", var.env)}"
+  description = "Concourse metrics"
+  read_only = true
+
+  graph {
+    title = "Pipeline run time"
+    viz = "timeseries"
+    request {
+      q = "${format("avg:%s.pipeline_time{environment:%s}", var.env, var.env)}"
+    }
+  }
+
+}


### PR DESCRIPTION
## What

Measure how long the pipeline run took. Ignore time initial lock spent waiting. Send metric to datadog & create a graph for them.

## How to review

* Upload datadog credentials to your environment

```
DEPLOY_ENV=test123 make dev upload-datadog-secrets
```

* Apply to your environment with `DEPLOY_DATADOG_AGENT=true`
* Check metric being sent to datadog. Run pipeline several times (hint: you can put `exit 0` in the beginning of custom acceptance tests to skip them) and observe metric being sent on every run.
* Check the timeboard "[env] - Concourse timeboard is present in datadog and has data

## Who can review

not @mtekel or @saliceti 