### PR TITLE
[SECURITY FIX] CVE-2016-6651 uaa update

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -25,6 +25,10 @@ releases:
     sha1: bf95dfc4593e1a9f291e4bb3e50c85575483e618
   - name: paas-haproxy
     version: 0.0.4
+  - name: uaa
+    version: "12.6"
+    url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=12.6
+    sha1: 8ffc7b9bfee004464bc8a81c322db7160dd7440f
 
 stemcells:
   - alias: default

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -87,7 +87,7 @@ meta:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
   - name: uaa
-    release: (( grab meta.release.name ))
+    release: uaa
   - name: statsd-injector
     release: (( grab meta.release.name ))
 


### PR DESCRIPTION
## What

This PR brings fix for [CVE-2016-6651 Privilege Escalation in UAA](https://pivotal.io/security/cve-2016-6651). It updates UAA to the latest version from 3.4.X branch that has the fix.

https://github.com/cloudfoundry/uaa/releases/tag/3.4.5


## How to review

Run the pipeline from this branch and check if all tests are passing.

Run
```
cf login -a https://api.$DEPLOY_ENV.dev.cloudpipeline.digital --skip-ssl-validation
cf create-user test test
```

Now you can test if vulnerability is fixed:

```
curl -k -H 'Accept:application/json' -H 'Authorization:Basic Y2Y6' \
-H 'Content-Type:application/x-www-form-urlencoded' \
-X POST "https://login.$DEPLOY_ENV.dev.cloudpipeline.digital/oauth/token" \
--data-binary "grant_type=password&password=test&scope=&username=test&external_scopes=cloud_controller.detect_vuln" \
| python -m json.tool
```

The response *SHOULD NOT* reflect the external_scopes in the “scope” part of the JSON response.

## Who can review

Not @combor or @davbo

