### PR TITLE
Add cell memory usage dashboard

### DIFF
--- a/manifests/cf-manifest/grafana/cell-memory-usage.json
+++ b/manifests/cf-manifest/grafana/cell-memory-usage.json
@@ -1,0 +1,155 @@
+{
+  "id": 5,
+  "title": "Cell Memory Usage",
+  "originalTitle": "Cell Memory Usage",
+  "tags": [],
+  "style": "dark",
+  "timezone": "utc",
+  "editable": true,
+  "hideControls": false,
+  "sharedCrosshair": false,
+  "rows": [
+    {
+      "height": "600px",
+      "panels": [
+        {
+          "title": "Cluster Memory Usage",
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "type": "graph",
+          "isNew": true,
+          "id": 1,
+          "targets": [
+            {
+              "target": "alias(diffSeries(sumSeries(keepLastValue(stats.gauges.cfstats.cell.*.ops.rep.CapacityTotalMemory)),sumSeries(keepLastValue(stats.gauges.cfstats.cell.*.ops.rep.CapacityRemainingMemory))),\"Memory used\")",
+              "refId": "A",
+              "textEditor": true
+            },
+            {
+              "target": "alias(scale(sumSeries(keepLastValue(stats.gauges.cfstats.cell.*.ops.rep.CapacityTotalMemory)), 0.6666),\"AZ Failure\")",
+              "refId": "B",
+              "textEditor": true
+            },
+            {
+              "target": "alias(sumSeries(keepLastValue(limit(stats.gauges.cfstats.cell.*.ops.rep.CapacityTotalMemory, -1))),\"Cell Failure\")",
+              "refId": "C",
+              "textEditor": true
+            },
+            {
+              "target": "alias(sumSeries(keepLastValue(stats.gauges.cfstats.cell.*.ops.rep.CapacityTotalMemory)),\"Total Available\")",
+              "refId": "D",
+              "textEditor": true
+            }
+          ],
+          "datasource": "graphite",
+          "renderer": "flot",
+          "yaxes": [
+            {
+              "label": null,
+              "show": true,
+              "logBase": 1,
+              "min": null,
+              "max": null,
+              "format": "short"
+            },
+            {
+              "label": null,
+              "show": true,
+              "logBase": 1,
+              "min": null,
+              "max": null,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "grid": {
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "lines": true,
+          "fill": 0,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false
+          },
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": true,
+            "msResolution": false
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "aliasColors": {
+            "Memory used": "#1F78C1",
+            "AZ Failure": "#BF1B00",
+            "Cell Failure": "#C15C17",
+            "Total Available": "#629E51"
+          },
+          "seriesOverrides": [],
+          "links": [],
+          "transparent": true
+        }
+      ],
+      "title": "Row",
+      "collapse": false,
+      "editable": true
+    }
+  ],
+  "time": {
+    "from": "now-12h",
+    "to": "now"
+  },
+  "timepicker": {
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ],
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  },
+  "refresh": "30s",
+  "schemaVersion": 12,
+  "version": 0,
+  "links": []
+}


### PR DESCRIPTION
## What

As part of [120268263](https://www.pivotaltracker.com/n/projects/1275640/stories/120268263) we want to have visibility over how much memory is currently in use in the cell cluster, how much we have available in total, and how much we'll have after losing a cell and losing an AZ.

This PR introduces a new default grafana dashboard that shows all of these metrics.

![screen shot 2016-09-27 at 14 54 15](https://cloud.githubusercontent.com/assets/1553/18881612/e865c2c2-84d3-11e6-9505-dca319af4301.png)

*Note:* We currently have no way of passing the number of zones into the manifest at build time so the scale factor representing the number of zones after a failure (2) is currently [hardcoded in this template](https://github.com/alphagov/paas-cf/pull/514/files#diff-a013cd33b85234fd1ce5f574c7a8196cR30) as "0.6666" for the AZ failure graph. We need to revisit this if we introduce another zone.

## How to review

Alter your `manifests/cf-manifest/manifest/env-specific/cf-dev.yml` to deploy 6 instances and temporarily commit it. Deploy this in an env.

Visit `https://metrics.${DEPLOY_ENV}.dev.cloudpipeline.digital/dashboard/file/cell-memory-usage.json` and view the new dashboard. Check it is correct.

## Who can review

Not I, nor any of my clones.