### PR TITLE
Auto-decrypt Concourse ATC password in prod envs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,10 @@ list_merge_keys: ## List all GPG keys allowed to sign merge commits.
 	done
 
 .PHONY: globals
+PASSWORD_STORE_DIR?=${HOME}/.paas-pass
 globals:
 	$(eval export AWS_DEFAULT_REGION=eu-west-1)
+	$(eval export PASSWORD_STORE_DIR=${PASSWORD_STORE_DIR})
 	@true
 
 .PHONY: dev
@@ -108,6 +110,7 @@ ci: globals check-env-vars ## Set Environment to CI
 	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS=${ALERT_EMAIL_ADDRESS})
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-default.yml)
 	$(eval export DEPLOY_DATADOG_AGENT=true)
+	$(eval export DECRYPT_CONCOURSE_ATC_PASSWORD=ci_deployments/master)
 	@true
 
 .PHONY: staging
@@ -125,6 +128,7 @@ staging: globals check-env-vars ## Set Environment to Staging
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-default.yml)
 	$(eval export ENABLE_CF_ACCEPTANCE_TESTS=false)
 	$(eval export DEPLOY_DATADOG_AGENT=true)
+	$(eval export DECRYPT_CONCOURSE_ATC_PASSWORD=staging_deployment)
 	@true
 
 .PHONY: prod
@@ -141,6 +145,7 @@ prod: globals check-env-vars ## Set Environment to Production
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-prod.yml)
 	$(eval export ENABLE_CF_ACCEPTANCE_TESTS=false)
 	$(eval export DEPLOY_DATADOG_AGENT=true)
+	$(eval export DECRYPT_CONCOURSE_ATC_PASSWORD=prod_deployment)
 	@true
 
 .PHONY: bootstrap

--- a/concourse/scripts/environment.sh
+++ b/concourse/scripts/environment.sh
@@ -36,7 +36,11 @@ esac
 
 CONCOURSE_ATC_USER=${CONCOURSE_ATC_USER:-admin}
 if [ -z "${CONCOURSE_ATC_PASSWORD:-}" ]; then
-  CONCOURSE_ATC_PASSWORD=$(hashed_password "${AWS_SECRET_ACCESS_KEY}:${DEPLOY_ENV}:atc")
+  if [ -n "${DECRYPT_CONCOURSE_ATC_PASSWORD}" ]; then
+    CONCOURSE_ATC_PASSWORD=$(pass "${DECRYPT_CONCOURSE_ATC_PASSWORD}/concourse_password")
+  else
+    CONCOURSE_ATC_PASSWORD=$(hashed_password "${AWS_SECRET_ACCESS_KEY}:${DEPLOY_ENV}:atc")
+  fi
 fi
 
 cat <<EOF


### PR DESCRIPTION
## What

This will automatically decrypt and load the Concourse ATC password from our credentials when running against production environments rather than requiring the user to manually do it.

## How to review

1. `unset CONCOURSE_ATC_PASSWORD` to be sure you have a clean environment.
2. `make prod showenv`, or `make ci showenv`, or get super fancy with a `make prod bosh-cli`.
3. Observe that it just worked.
4. Run `env | grep CONCOURSE_ATC_PASSWORD` and get nothing returned.

## Who can review

Someone else.