### PR TITLE
Fix dev mode, which doesn't specify this variable

### DIFF
--- a/concourse/scripts/environment.sh
+++ b/concourse/scripts/environment.sh
@@ -36,7 +36,7 @@ esac
 
 CONCOURSE_ATC_USER=${CONCOURSE_ATC_USER:-admin}
 if [ -z "${CONCOURSE_ATC_PASSWORD:-}" ]; then
-  if [ -n "${DECRYPT_CONCOURSE_ATC_PASSWORD}" ]; then
+  if [ -n "${DECRYPT_CONCOURSE_ATC_PASSWORD:-}" ]; then
     CONCOURSE_ATC_PASSWORD=$(pass "${DECRYPT_CONCOURSE_ATC_PASSWORD}/concourse_password")
   else
     CONCOURSE_ATC_PASSWORD=$(hashed_password "${AWS_SECRET_ACCESS_KEY}:${DEPLOY_ENV}:atc")


### PR DESCRIPTION
## What

https://github.com/alphagov/paas-cf/pull/515 accidentially broke environment.sh in dev mode, as we don't set the DECRYPT_CONCOURSE_ATC_PASSWORD variable and there was no default.

## How to review

Run `make dev showenv` and it should not error.

## Who can review

Not @jonty, who is very sorry.