### PR TITLE
[#120590777] Fix datadog hyphen bug

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -2349,16 +2349,17 @@ jobs:
               current_time=$(date +%s)
               lock_time=$(git log -1  --pretty=format:'%ct')
               delta=$((${current_time} - ${lock_time}))
+              dd_env=$(echo ${ENV} | sed 's/-/_/g')
               echo "Total pipeline time was: ${delta}s"
 
               if [ "${DEPLOY_DATADOG_AGENT}" = "true" ]; then
                 curl  -X POST -H "Content-type: application/json" \
                   -d "{ \"series\" :
-                         [{\"metric\":\"${ENV}.pipeline_time\",
+                         [{\"metric\":\"${dd_env}.pipeline_time\",
                           \"points\":[[$current_time, ${delta}]],
                           \"type\":\"gauge\",
-                          \"host\":\"concourse.${ENV}\",
-                          \"tags\":[\"environment:${ENV}\", \"aws_account:${AWS_ACCOUNT}\"]}
+                          \"host\":\"concourse.${dd_env}\",
+                          \"tags\":[\"environment:${dd_env}\", \"aws_account:${AWS_ACCOUNT}\"]}
                         ]
                     }" \
                   "https://app.datadoghq.com/api/v1/series?api_key=${DATADOG_API_KEY}"

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -89,10 +89,6 @@ jobs:
               name: atc
               password: dummy-password
 
-          riemann:
-            host: '127.0.0.1'
-            service_prefix: (( concat terraform_outputs.environment "-concourse." ))
-
       - name: groundcrew
         release: concourse
         properties:

--- a/manifests/concourse-manifest/extensions/datadog.yml
+++ b/manifests/concourse-manifest/extensions/datadog.yml
@@ -20,3 +20,9 @@ jobs:
           riemann:
             datadog:
               api_key: (( grab meta.datadog.api_key ))
+
+      - name: atc
+        properties:
+          riemann:
+            host: '127.0.0.1'
+            service_prefix: (( concat terraform_outputs.environment "-concourse." ))

--- a/terraform/datadog/concourse-jobs.tf
+++ b/terraform/datadog/concourse-jobs.tf
@@ -8,7 +8,7 @@ resource "datadog_timeboard" "concourse-jobs" {
     title = "Runtime changes vs hour ago"
     viz = "change"
     request {
-       q = "${format("avg:%s_concourse.build.finished{*} by {job}", var.env)}"
+       q = "${format("avg:%s_concourse.build.finished{*} by {job}", replace(var.env, "-", "_"))}"
     }
   }
 }

--- a/terraform/datadog/datadog.tf
+++ b/terraform/datadog/datadog.tf
@@ -38,7 +38,7 @@ resource "datadog_timeboard" "pipeline" {
     title = "Pipeline run time"
     viz = "timeseries"
     request {
-      q = "${format("avg:%s.pipeline_time{environment:%s}", var.env, var.env)}"
+      q = "${format("avg:%s.pipeline_time{environment:%s}", replace(var.env, "-", "_"), replace(var.env, "-", "_"))}"
     }
   }
 


### PR DESCRIPTION
## What
Story: [Improve Visibility of Continuous Smoke Tests](https://www.pivotaltracker.com/story/show/120590777)

This has impacted me as the datadog terraform run failed for me because I have a hyphen in my environment name (`colin-sept`). We've noticed riemann actually converts hyphens to underscores automatically when it sends metrics to datadog. This does the same for our metrics, and change the queries accordingly.

## How to review
* Build an environment with hyphen(s) in the name
* It should not break in `datadog-terraform-apply`
* The dashboards should work in datadog

## Who can review

Anyone but @paroxp or myself