### PR TITLE
Pipeline shellcheck fixes

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1835,14 +1835,16 @@ jobs:
               - -e
               - -c
               - |
-                VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
-                SCRIPTS_PATH="./paas-cf/concourse/scripts"
-                TF_VARS_SCRIPT="extract_tf_vars_from_terraform_state.rb"
-                $SCRIPTS_PATH/$TF_VARS_SCRIPT < cf-tfstate/cf.tfstate | grep logsearch_elastic_master_elb_dns_name > ./logsearch_var.sh
-                . ./logsearch_var.sh
-                export ES_HOST="${TF_VAR_logsearch_elastic_master_elb_dns_name}"
+                SCRIPT_DIR="./paas-cf/concourse/scripts"
+
+                ruby "${SCRIPT_DIR}/extract_terraform_state_to_yaml.rb" \
+                  < cf-tfstate/cf.tfstate \
+                  > cf-tfstate.yaml
+
+                export ES_HOST
+                ES_HOST=$(ruby "${SCRIPT_DIR}/val_from_yaml.rb" terraform_outputs.logsearch_elastic_master_elb_dns_name cf-tfstate.yaml)
                 export ES_PORT="9200"
-                $(pwd)/paas-cf/concourse/scripts/kibana_set_utc.rb
+                ruby "${SCRIPT_DIR}/kibana_set_utc.rb"
 
         - task: datadog-terraform-apply
           config:

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1867,7 +1867,7 @@ jobs:
                 - -e
                 - -c
                 - |
-                  if [ -n "${TF_VAR_datadog_api_key}" -a -n "${TF_VAR_datadog_app_key}" -a "${ENABLE_DATADOG}" = "false" ]; then
+                  if [ -n "${TF_VAR_datadog_api_key}" ] && [ -n "${TF_VAR_datadog_app_key}" ] && [ "${ENABLE_DATADOG}" = "false" ]; then
                     echo "Datadog disabled but keys present, running check cleanup..."
                     terraform destroy -force \
                        -state=datadog-tfstate/datadog.tfstate \
@@ -2355,7 +2355,7 @@ jobs:
               cd pipeline-pool
               current_time=$(date +%s)
               lock_time=$(git log -1  --pretty=format:'%ct')
-              delta=$((${current_time} - ${lock_time}))
+              delta=$((current_time - lock_time))
               dd_env=$(echo ${ENV} | sed 's/-/_/g')
               echo "Total pipeline time was: ${delta}s"
 

--- a/concourse/pipelines/destroy-deployer.yml
+++ b/concourse/pipelines/destroy-deployer.yml
@@ -50,6 +50,13 @@ resources:
       versioned_file: concourse-manifest-state.json
       region_name: {{aws_region}}
 
+  - name: ssh-private-key
+    type: s3-iam
+    source:
+      bucket: {{state_bucket}}
+      versioned_file: id_rsa
+      region_name: {{aws_region}}
+
 jobs:
   - name: destroy-concourse
     serial: true
@@ -59,6 +66,7 @@ jobs:
     - get: concourse-bosh-state
     - get: vpc-terraform-state
     - get: concourse-terraform-state
+    - get: ssh-private-key
 
     - task: destroy-concourse
       timeout: 30m
@@ -68,6 +76,7 @@ jobs:
         - name: paas-cf
         - name: concourse-manifest
         - name: concourse-bosh-state
+        - name: ssh-private-key
         run:
           path: sh
           args:
@@ -78,7 +87,7 @@ jobs:
             [ "$(cat concourse-bosh-state/concourse-manifest-state.json)" = "{}" ] \
               && echo Concourse bosh state empty, assuming already destroyed \
               && exit 0
-            echo -n "${private_ssh_key}" > id_rsa
+            cp ssh-private-key/id_rsa id_rsa
             chmod 400 id_rsa
             ls -l id_rsa
             cp -v concourse-manifest/concourse-manifest.yml .

--- a/concourse/scripts/pipecleaner.py
+++ b/concourse/scripts/pipecleaner.py
@@ -185,7 +185,7 @@ class Pipecleaner(object):
                                     'job': job['name'],
                                     'task': item['task'],
                                     '~': output,
-                                    'fatal': False,
+                                    'fatal': True,
                                 })
 
             overall_used_resources = overall_used_resources.union(used_resources).union(get_resources)

--- a/concourse/scripts/pipecleaner_test.go
+++ b/concourse/scripts/pipecleaner_test.go
@@ -52,9 +52,9 @@ var _ = Describe("PipeCleaner", func() {
 				command = exec.Command("./pipecleaner.py", "spec/fixtures/pipecleaner_shellcheck.yml")
 			})
 
-			It("should warn about the non-portable compare", func() {
-				Eventually(session).Should(gexec.Exit(0))
-				Expect(session.Out).To(gbytes.Say("WARNING.*?job='shellcheck', task='bad-compare'"))
+			It("should fatal with non-portable compare", func() {
+				Eventually(session).Should(gexec.Exit(10))
+				Expect(session.Out).To(gbytes.Say("ERROR.*?job='shellcheck', task='bad-compare'"))
 				Expect(session.Err.Contents()).To(BeEmpty())
 			})
 		})
@@ -67,18 +67,6 @@ var _ = Describe("PipeCleaner", func() {
 			It("should not report an issue", func() {
 				Eventually(session).Should(gexec.Exit(0))
 				Expect(session.Out.Contents()).To(BeEmpty())
-				Expect(session.Err.Contents()).To(BeEmpty())
-			})
-		})
-
-		Context("with --fatal-warnings", func() {
-			BeforeEach(func() {
-				command = exec.Command("./pipecleaner.py", "--fatal-warnings", "spec/fixtures/pipecleaner_shellcheck.yml")
-			})
-
-			It("should warn about the non-portable compare, and exit as though fatal", func() {
-				Eventually(session).Should(gexec.Exit(20))
-				Expect(session.Out).To(gbytes.Say("WARNING.*?job='shellcheck', task='bad-compare'"))
 				Expect(session.Err.Contents()).To(BeEmpty())
 			})
 		})

--- a/concourse/tasks/terraform_destroy_datadog.yml
+++ b/concourse/tasks/terraform_destroy_datadog.yml
@@ -16,12 +16,12 @@ run:
     - -c
     - |
       cleanup=false
-      if [ -n "${TF_VAR_datadog_api_key}" -a -n "${TF_VAR_datadog_app_key}" -a "${ENABLE_DATADOG}" = "false" ]; then
+      if [ -n "${TF_VAR_datadog_api_key}" ] && [ -n "${TF_VAR_datadog_app_key}" ] && [ "${ENABLE_DATADOG}" = "false" ]; then
         cleanup=true
         echo "Datadog disabled but keys present, running check cleanup..."
       fi
 
-      if [ "${ENABLE_DATADOG}" = "true" -o "${cleanup}" = "true" ]; then
+      if [ "${ENABLE_DATADOG}" = "true" ] || [ "${cleanup}" = "true" ]; then
         terraform destroy -force \
           -state=datadog-tfstate/datadog.tfstate \
           -state-out=updated-datadog-tfstate/datadog.tfstate \


### PR DESCRIPTION
## What

This resolves all the remaining shellcheck errors that pipecleaner finds in the concourse pipelines and then makes shellcheck warnings fatal, as we aim for shellcheck zero.

This also fixes the deployer destroy pipeline which was broken when we refactored SSH key handling - the bug was spotted by shellcheck.

## How to review

1. Run the pipeline and ensure the tests pass, ideally in a fresh environment.

## Who can review

You.