### PR TITLE
[#131355143] Install datadog nozzle in a dedicated VM

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1365,11 +1365,13 @@ jobs:
                 ./paas-cf/manifests/cf-manifest/manifest/env-specific/{{cf_env_specific_manifest}}
                 ./paas-cf/manifests/cf-manifest/common/*.yml
               AWS_ACCOUNT: {{aws_account}}
+              ENABLE_DATADOG: {{enable_datadog}}
               DATADOG_API_KEY: {{datadog_api_key}}
             run:
               path: sh
               args:
                 - -e
+                - -u
                 - -c
                 - |
                   mkdir certs
@@ -1392,6 +1394,11 @@ jobs:
                   cd .. || true
 
                   echo "Generating manifests"
+
+                  if [ "${ENABLE_DATADOG}" = "true" ] ; then
+                     MANIFEST_STUBS="${MANIFEST_STUBS}
+                                    ./paas-cf/manifests/cf-manifest/stubs/datadog-nozzle.yml"
+                  fi
 
                   # FIXME: Remove eval after https://github.com/concourse/concourse/issues/360
                   eval ./paas-cf/manifests/shared/build_manifest.sh $MANIFEST_STUBS > cf-manifest/cf-manifest.yml

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -462,6 +462,13 @@ properties:
         secret: (( grab secrets.uaa_clients_firehose_password ))
         scope: openid,oauth.approvals,doppler.firehose
         authorities: oauth.login,doppler.firehose
+      datadog-nozzle:
+        access-token-validity: 1209600
+        authorized-grant-types: authorization_code,client_credentials,refresh_token
+        override: true
+        secret: (( grab secrets.uaa_clients_datadog_firehose_password ))
+        scope: openid,oauth.approvals,doppler.firehose
+        authorities: oauth.login,doppler.firehose
 
     database: ~
 

--- a/manifests/cf-manifest/scripts/generate-cf-secrets.rb
+++ b/manifests/cf-manifest/scripts/generate-cf-secrets.rb
@@ -26,6 +26,7 @@ generator = SecretGenerator.new(
   "uaa_clients_gorouter_secret" => :simple,
   "uaa_clients_ssh_proxy_secret" => :simple,
   "uaa_clients_firehose_password" => :simple,
+  "uaa_clients_datadog_firehose_password" => :simple,
   "loggregator_endpoint_shared_secret" => :simple,
   "consul_encrypt_keys" => :simple_in_array,
   "grafana_admin_password" => :simple,

--- a/manifests/cf-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/cf-manifest/spec/support/manifest_helpers.rb
@@ -59,6 +59,7 @@ private
         File.expand_path("../../../manifest/env-specific/cf-#{environment}.yml", __FILE__),
         File.expand_path("../../../../shared/deployments/datadog-agent.yml", __FILE__),
         File.expand_path("../../../common/*.yml", __FILE__),
+        File.expand_path("../../../stubs/datadog-nozzle.yml", __FILE__),
         File.expand_path("../../../../shared/spec/fixtures/terraform/*.yml", __FILE__),
         File.expand_path("../../../../shared/spec/fixtures/cf-secrets.yml", __FILE__),
         File.expand_path("../../../../shared/spec/fixtures/cf-ssl-certificates.yml", __FILE__),

--- a/manifests/cf-manifest/stubs/datadog-nozzle.yml
+++ b/manifests/cf-manifest/stubs/datadog-nozzle.yml
@@ -1,0 +1,46 @@
+releases:
+- name: datadog-firehose-nozzle
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/datadog-firehose-nozzle-release?v=51
+  version: "51"
+  sha1: b358712488c44a09e815f278d6b767f3e82cd3e3
+
+jobs:
+- name: nozzle
+  azs: [z1, z2]
+  templates:
+  - name: datadog-firehose-nozzle
+    release: datadog-firehose-nozzle
+    properties:
+      datadog:
+        api_key: (( grab meta.datadog.api_key ))
+        metric_prefix: "cf."
+      nozzle:
+        subscription_id: "datadog-nozzle"
+        deployment: (( grab meta.environment ))
+        insecure_ssl_skip_verify: false
+      uaa:
+        url: (( grab properties.uaa.url ))
+        client: "datadog-nozzle"
+        client_secret: (( grab secrets.uaa_clients_datadog_firehose_password ))
+      loggregator: (( grab properties.loggregator ))
+
+  vm_type: small
+  stemcell: default
+  instances: 2
+  networks:
+  - name: cf
+  properties:
+    tags:
+      job: nozzle
+      tags: (( inject meta.datadog_tags ))
+
+properties:
+  uaa:
+    clients:
+      datadog-nozzle:
+        access-token-validity: 1209600
+        authorized-grant-types: authorization_code,client_credentials,refresh_token
+        override: true
+        secret: (( grab secrets.uaa_clients_datadog_firehose_password ))
+        scope: openid,oauth.approvals,doppler.firehose
+        authorities: oauth.login,doppler.firehose

--- a/manifests/shared/spec/fixtures/cf-secrets.yml
+++ b/manifests/shared/spec/fixtures/cf-secrets.yml
@@ -26,6 +26,7 @@ secrets:
   uaa_clients_gorouter_secret: STUB_UAA_CLIENTS_GOROUTER_SECRET
   uaa_clients_ssh_proxy_secret: STUB_UAA_CLIENTS_SSH_PROXY_SECRET
   uaa_clients_firehose_password: STUB_UAA_CLIENTS_FIREHOSE_PASSWORD
+  uaa_clients_datadog_firehose_password: STUB_UAA_CLIENTS_DATADOG_FIREHOSE_PASSWORD
 
   # Same password than `paas-pass cloudfoundry/cf_admin_password`
   uaa_admin_password: STUB_UAA_ADMIN_PASSWORD


### PR DESCRIPTION
[#131355143 Add metron metrics to datadog](https://www.pivotaltracker.com/story/show/131355143)

What?
----

We want to get the metrics from the metron agents into datadog. We will use the [datadog nozzle](https://github.com/cloudfoundry-incubator/datadog-firehose-nozzle) for this.

Deploying it in dedicated VMs for nozzles, not as apps in CF, to reduce the dependencies of the monitoring on the platform itself.

We want to make this optional, enabled by `ENABLE_DATADOG` feature.

Dependencies
-----------

The PR #519 must be merged first, and then rebase this PR.

You can test both together.

How to test
-----------

You can start testing only the job `cf-generate-config` and confirm that enable/disable the setting changes the right parts of the manifest:

```
export DEPLOY_ENV=...
make dev pipelines ENABLE_DATADOG=false BRANCH=$(git rev-parse --abbrev-ref HEAD)
make dev run_job JOB=generate-cf-config
aws s3 cp s3://hector-state/cf-manifest.yml /tmp/cf-manifest-a.yml

make dev pipelines ENABLE_DATADOG=true BRANCH=$(git rev-parse --abbrev-ref HEAD)
make dev run_job JOB=generate-cf-config
aws s3 cp s3://hector-state/cf-manifest.yml /tmp/cf-manifest-b.yml

diff -Nur /tmp/cf-manifest-{a,b}.yml
```

After that, deploy all the environment setting `ENABLE_DATADOG=true`, which will deploy the agents and the nozzle. Confirm that all the metrics are in the datadog console by going to https://app.datadoghq.com/metric/explorer and searching for `cf.`

Who?
----

Anyone but @keymon or @richardc