### PR TITLE
[#122200041] gorouter component monitoring

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -106,6 +106,12 @@ resources:
       tag_filter: {{cf_graphite_version}}
       branch: gds_master
 
+  - name: datadog-for-cloudfoundry-boshrelease
+    type: git
+    source:
+      uri: https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease.git
+      tag_filter: {{cf_datadog_for_cloudfoundry_version}}
+
   - name: aws-broker-boshrelease
     type: git
     source:
@@ -1467,6 +1473,7 @@ jobs:
           - get: graphite-statsd-boshrelease
           - get: paas-haproxy-release
           - get: aws-broker-boshrelease
+          - get: datadog-for-cloudfoundry-boshrelease
           - get: os-conf-boshrelease
           - get: cf-secrets
             passed: ['generate-cf-config']
@@ -1491,6 +1498,7 @@ jobs:
               - name: aws-broker-boshrelease
               - name: os-conf-boshrelease
               - name: logsearch-for-cloudfoundry-boshrelease
+              - name: datadog-for-cloudfoundry-boshrelease
             run:
               path: sh
               args:
@@ -1513,6 +1521,9 @@ jobs:
 
                   paas-cf/concourse/scripts/bosh_create_and_upload_release.rb logsearch-for-cloudfoundry \
                     {{cf_logsearch_for_cloudfoundry_version}} logsearch-for-cloudfoundry-boshrelease
+
+                  paas-cf/concourse/scripts/bosh_create_and_upload_release.rb datadog-for-cloudfoundry \
+                    {{cf_datadog_for_cloudfoundry_version}} datadog-for-cloudfoundry-boshrelease
 
         - task: get-and-upload-stemcell
           config:

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -47,6 +47,7 @@ prepare_environment() {
   cf_aws_broker_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.aws-broker.version "${cf_manifest_dir}/050-rds-broker.yml")
   cf_os_conf_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.os-conf.version "${cf_manifest_dir}/../runtime-config/runtime-config-base.yml")
   cf_logsearch_for_cloudfoundry_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.logsearch-for-cloudfoundry.version "${cf_manifest_dir}/800-logsearch.yml")
+  cf_datadog_for_cloudfoundry_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.datadog-for-cloudfoundry.version "${cf_manifest_dir}/000-base-cf-deployment.yml")
 
   if [ -z "${SKIP_COMMIT_VERIFICATION:-}" ] ; then
     gpg_ids="[$(xargs < "${SCRIPT_DIR}/../../.gpg-id" | tr ' ' ',')]"
@@ -80,6 +81,7 @@ cf-release-version: v${cf_release_version}
 cf-paas-haproxy-release-version: ${cf_paas_haproxy_version}
 cf_graphite_version: ${cf_graphite_version}
 cf_aws_broker_version: ${cf_aws_broker_version}
+cf_datadog_for_cloudfoundry_version: ${cf_datadog_for_cloudfoundry_version}
 cf_os_conf_version: ${cf_os_conf_version}
 cf_logsearch_for_cloudfoundry_version: ${cf_logsearch_for_cloudfoundry_version}
 cf_env_specific_manifest: ${ENV_SPECIFIC_CF_MANIFEST}

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -29,6 +29,8 @@ releases:
     version: "12.6"
     url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=12.6
     sha1: 8ffc7b9bfee004464bc8a81c322db7160dd7440f
+  - name: datadog-for-cloudfoundry
+    version: "0.0.1"
 
 stemcells:
   - alias: default

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -82,6 +82,8 @@ meta:
     release: (( grab meta.release.name ))
   - name: haproxy
     release: paas-haproxy
+  - name: datadog-router
+    release: datadog-for-cloudfoundry
 
   uaa_templates:
   - name: consul_agent

--- a/manifests/shared/deployments/datadog-agent.yml
+++ b/manifests/shared/deployments/datadog-agent.yml
@@ -1,9 +1,9 @@
 ---
 releases:
 - name: datadog-agent
-  sha1: e26ac31091d4577c3aec4569e740e662007b36af
-  url: https://github.com/alphagov/paas-datadog-agent-boshrelease/releases/download/custom_006/datadog-agent-custom_006.tgz
-  version: "custom_006"
+  sha1: 7ba4b58c95812ecda39fd0bcf16cb8d3635c2ecd
+  url: https://github.com/alphagov/paas-datadog-agent-boshrelease/releases/download/custom_007/datadog-agent-custom_007.tgz
+  version: "custom_007"
 
 meta:
   datadog:


### PR DESCRIPTION
[#122200041 Gather metrics to check health of go router in datadog](https://www.pivotaltracker.com/n/projects/1275640/stories/122200041)

## What

We want to gather metrics about gorouter to implement checks in datadog. We will use the datadog nozzle #520 and also integrations from the agent.

We in this PR add a [new version of the datadog-agent](https://github.com/alphagov/paas-datadog-agent-boshrelease/pull/5) and the [`datadog-for-cloudfoundry/datadog-router` job to the router job templates](https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/1)

## Dependencies

The  https://github.com/alphagov/paas-datadog-agent-boshrelease/pull/5 and https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/1 should be merged first and updated accordingly.

It would be convenient to get the nozzle changes from https://github.com/alphagov/paas-cf/pull/520

## How to review

Deploy this branch, setting `ENABLE_DATADOG=true` or `DEPLOY_DATADOG_AGENT` depending if #519 has been merged or not:

```
SELF_UPDATE_PIPELINE=false ENABLE_DATADOG=true DEPLOY_DATADOG_AGENT=true BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines DEPLOY_ENV=...
``` 

 * Datadog agent should be deployed on all machines
 * on gorouter, the file `/var/vcap/packages/datadog-agent/agent/conf.d/process.yaml` and `/var/vcap/packages/datadog-agent/agent/conf.d/http_check.yaml` should be populated with the config for gorouter.
 * On datadog, you should have metrics in https://app.datadoghq.com/metric/explorer `network.http.reponse_time` for the tag url `/healthz` and `system.process.*` for `gorouter`

## Who can review

Not @richardc or @keymon 