### PR TITLE
[#131426461] Improve concourse metrics naming

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -2355,17 +2355,19 @@ jobs:
               current_time=$(date +%s)
               lock_time=$(git log -1  --pretty=format:'%ct')
               delta=$((current_time - lock_time))
-              dd_env=$(echo ${ENV} | sed 's/-/_/g')
               echo "Total pipeline time was: ${delta}s"
 
               if [ "${ENABLE_DATADOG}" = "true" ]; then
                 curl  -X POST -H "Content-type: application/json" \
                   -d "{ \"series\" :
-                         [{\"metric\":\"${dd_env}.pipeline_time\",
+                         [{\"metric\":\"concourse.pipeline_time\",
                           \"points\":[[$current_time, ${delta}]],
                           \"type\":\"gauge\",
-                          \"host\":\"concourse.${dd_env}\",
-                          \"tags\":[\"environment:${dd_env}\", \"aws_account:${AWS_ACCOUNT}\"]}
+                          \"tags\":[
+                            \"environment:${ENV}\",
+                            \"pipeline_name:create-bosh-cloudfoundry\",
+                            \"aws_account:${AWS_ACCOUNT}\"
+                          ]}
                         ]
                     }" \
                   "https://app.datadoghq.com/api/v1/series?api_key=${DATADOG_API_KEY}"

--- a/terraform/datadog/concourse-jobs.tf
+++ b/terraform/datadog/concourse-jobs.tf
@@ -16,7 +16,7 @@ resource "datadog_timeboard" "concourse-jobs" {
     title = "CF pipeline run time"
     viz = "timeseries"
     request {
-      q = "${format("avg:%s.pipeline_time{environment:%s}", replace(var.env, "-", "_"), replace(var.env, "-", "_"))}"
+      q = "${format("avg:concourse.pipeline_time{environment:%s,pipeline_name:create-bosh-cloudfoundry}", var.env)}"
     }
   }
 

--- a/terraform/datadog/concourse-jobs.tf
+++ b/terraform/datadog/concourse-jobs.tf
@@ -11,4 +11,13 @@ resource "datadog_timeboard" "concourse-jobs" {
        q = "${format("avg:concourse.build.finished{bosh-deployment:%s} by {job}", var.env)}"
     }
   }
+
+  graph {
+    title = "CF pipeline run time"
+    viz = "timeseries"
+    request {
+      q = "${format("avg:%s.pipeline_time{environment:%s}", replace(var.env, "-", "_"), replace(var.env, "-", "_"))}"
+    }
+  }
+
 }

--- a/terraform/datadog/datadog.tf
+++ b/terraform/datadog/datadog.tf
@@ -28,18 +28,3 @@ resource "datadog_monitor" "router" {
   }
 }
 
-resource "datadog_timeboard" "pipeline" {
-
-  title = "${format("%s - Concourse timeboard", var.env)}"
-  description = "Concourse metrics"
-  read_only = true
-
-  graph {
-    title = "Pipeline run time"
-    viz = "timeseries"
-    request {
-      q = "${format("avg:%s.pipeline_time{environment:%s}", replace(var.env, "-", "_"), replace(var.env, "-", "_"))}"
-    }
-  }
-
-}


### PR DESCRIPTION
## What
Story: [Improve concourse metrics naming](https://www.pivotaltracker.com/story/show/131426461)

The environment name is passed as a tag as `bosh-deployment` by #525. We can add `environment` for the metrics we push so we don't need to add the environment name in the metric name and we keep consistency.

As a consequence, we don't have to remove hyphens as it is fine to have hyphens in tags. We also put the concourse graphs in the same dashboard.

## Dependencies

#525 should be merged first

## How to review
* Deploy Concourse and run the CF pipeline
* Observe the metrics and dashboards make sense

## Who can review
Anyone but @paroxp or @keymon or @saliceti 