### PR TITLE
[#131426645] Restructure datadog terraform config

### DIFF
--- a/terraform/datadog/concourse-jobs.tf
+++ b/terraform/datadog/concourse-jobs.tf
@@ -1,6 +1,5 @@
 resource "datadog_timeboard" "concourse-jobs" {
-
-  title = "${format("%s job runtime difference", var.env) }"
+  title = "${data.null_data_source.datadog.inputs.env} job runtime difference"
   description = "vs previous hour"
   read_only = false
 
@@ -8,7 +7,7 @@ resource "datadog_timeboard" "concourse-jobs" {
     title = "Runtime changes vs hour ago"
     viz = "change"
     request {
-       q = "${format("avg:%s_concourse.build.finished{*} by {job}", replace(var.env, "-", "_"))}"
+       q = "avg:${data.null_data_source.datadog.inputs.env}_concourse.build.finished{*} by {job}"
     }
   }
 }

--- a/terraform/datadog/concourse-pipeline.tf
+++ b/terraform/datadog/concourse-pipeline.tf
@@ -1,0 +1,13 @@
+resource "datadog_timeboard" "pipeline" {
+  title = "${data.null_data_source.datadog.inputs.env} - Concourse timeboard"
+  description = "Concourse metrics"
+  read_only = true
+
+  graph {
+    title = "Pipeline run time"
+    viz = "timeseries"
+    request {
+      q = "avg:${data.null_data_source.datadog.inputs.env}.pipeline_time{environment:${data.null_data_source.datadog.inputs.env}}"
+    }
+  }
+}

--- a/terraform/datadog/datadog-variables.tf
+++ b/terraform/datadog/datadog-variables.tf
@@ -1,0 +1,10 @@
+variable "datadog_api_key" {}
+variable "datadog_app_key" {}
+variable "env" {}
+
+# Work around https://github.com/hashicorp/terraform/issues/4084
+data "null_data_source" "datadog" {
+  inputs = {
+    env = "${replace(var.env, "-", "_")}"
+  }
+}

--- a/terraform/datadog/datadog.tf
+++ b/terraform/datadog/datadog.tf
@@ -1,45 +1,4 @@
-variable "datadog_api_key" {}
-variable "datadog_app_key" {}
-variable "env" {}
-
 provider "datadog" {
     api_key = "${var.datadog_api_key}"
     app_key = "${var.datadog_app_key}"
-}
-
-resource "datadog_monitor" "router" {
-  name = "${format("%s router hosts", var.env)}"
-  type = "service check"
-  message = "Missing router hosts in environment {{host.environment}}. Notify: @the-multi-cloud-paas-team@digital.cabinet-office.gov.uk"
-  escalation_message = "Missing router hosts! Check VM state."
-  no_data_timeframe = "2"
-  query = "${format("'datadog.agent.up'.over('environment:%s','job:router').by('*').last(1).pct_by_status()", var.env)}"
-
-  thresholds {
-    ok = 0
-    warning = 0
-    critical = 10
-  }
-
-  require_full_window = true
-  tags {
-    "environment" = "${var.env}"
-    "job" = "router"
-  }
-}
-
-resource "datadog_timeboard" "pipeline" {
-
-  title = "${format("%s - Concourse timeboard", var.env)}"
-  description = "Concourse metrics"
-  read_only = true
-
-  graph {
-    title = "Pipeline run time"
-    viz = "timeseries"
-    request {
-      q = "${format("avg:%s.pipeline_time{environment:%s}", replace(var.env, "-", "_"), replace(var.env, "-", "_"))}"
-    }
-  }
-
 }

--- a/terraform/datadog/router-hosts.tf
+++ b/terraform/datadog/router-hosts.tf
@@ -1,0 +1,20 @@
+resource "datadog_monitor" "router" {
+  name = "${data.null_data_source.datadog.inputs.env} router hosts"
+  type = "service check"
+  message = "Missing router hosts in environment {{host.environment}}. Notify: @the-multi-cloud-paas-team@digital.cabinet-office.gov.uk"
+  escalation_message = "Missing router hosts! Check VM state."
+  no_data_timeframe = "2"
+  query = "'datadog.agent.up'.over('environment:${data.null_data_source.datadog.inputs.env}','job:router').by('*').last(1).pct_by_status()"
+
+  thresholds {
+    ok = 0
+    warning = 0
+    critical = 10
+  }
+
+  require_full_window = true
+  tags {
+    "environment" = "${data.null_data_source.datadog.inputs.env}"
+    "job" = "router"
+  }
+}


### PR DESCRIPTION
[#131426645 Create datadog checks and graphs for gorouter](https://www.pivotaltracker.com/story/show/131426645)

What?
----

We are about to start writing a bunch of datadog checks.

Restructure beforehand to establish a convention that each check goes into its own file. For instance move gorouter datadog check definitions to specific file

Make a home for variables, and extract variable for the deploy env into a `null_data_source` to establish a convention for working around terraform's inability to interpolate in variable declarations.

See https://github.com/hashicorp/terraform/issues/4084

How to review this?
-------------------

Run the deployment with `DATADOG_ENABLED=true` in master and later in this branch.

```
SELF_UPDATE_PIPELINE=false ENABLE_DATADOG=true BRANCH=master make dev pipelines DEPLOY_ENV=...

SELF_UPDATE_PIPELINE=false ENABLE_DATADOG=true BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines DEPLOY_ENV=...
```

No changes should be applied to the datadog terraform.

Who?
---

Anyone but @benhyland or @keymon