### PR TITLE
Fix the concourse link in smoke test emails

### DIFF
--- a/concourse/scripts/smoke_tests_email.sh
+++ b/concourse/scripts/smoke_tests_email.sh
@@ -21,7 +21,7 @@ write_message_json() {
   "Body": {
     "Html": {
       "Data": "The smoke tests have failed in environment <b>${DEPLOY_ENV}</b>. See \
-      <a href='https://deployer.${SYSTEM_DNS_ZONE_NAME}/pipelines/create-bosh-cloudfoundry?groups=health'>Concourse</a> \
+      <a href='https://deployer.${SYSTEM_DNS_ZONE_NAME}/teams/main/pipelines/create-bosh-cloudfoundry?groups=health'>Concourse</a> \
       for details<br/>"
     }
   }


### PR DESCRIPTION
## What

The link to the continuous smoke tests was broken when the concourse upgrade added teams.

## How to review

Check that the link is now correct for a deployed concourse.

## Who can review

You! A friend! The person next to you! (As long as it isn't me)