### PR TITLE
[#131426461] Use meta.environment for concourse & bosh deployment name and change concourse datadog metrics prefix

### DIFF
--- a/manifests/bosh-manifest/deployments/010-bosh-template.yml
+++ b/manifests/bosh-manifest/deployments/010-bosh-template.yml
@@ -4,7 +4,7 @@ meta:
   default_agent:
     mbus: (( concat "nats://nats:" secrets.bosh_nats_password "@" terraform_outputs.bosh_fqdn ":4222" ))
 
-name: bosh
+name: (( grab meta.environment ))
 
 releases:
 - name: bosh

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   environment: (( grab terraform_outputs.environment ))
 
-name: concourse
+name: (( grab meta.environment ))
 
 releases:
   - name: concourse

--- a/manifests/concourse-manifest/extensions/datadog-agent.yml
+++ b/manifests/concourse-manifest/extensions/datadog-agent.yml
@@ -25,4 +25,4 @@ jobs:
         properties:
           riemann:
             host: '127.0.0.1'
-            service_prefix: (( concat terraform_outputs.environment "-concourse." ))
+            service_prefix: 'concourse.'

--- a/terraform/datadog/concourse-jobs.tf
+++ b/terraform/datadog/concourse-jobs.tf
@@ -8,7 +8,7 @@ resource "datadog_timeboard" "concourse-jobs" {
     title = "Runtime changes vs hour ago"
     viz = "change"
     request {
-       q = "${format("avg:%s_concourse.build.finished{*} by {job}", replace(var.env, "-", "_"))}"
+       q = "${format("avg:concourse.build.finished{bosh-deployment:%s} by {job}", var.env)}"
     }
   }
 }


### PR DESCRIPTION
[#131426461 Improve concourse metrics naming](https://www.pivotaltracker.com/n/projects/1275640/stories/131426461)

What?
-----

We are using concourse riemann reporting function to get metrics from concourse, as per the PR #511.

But we want to tag the metrics from concourse with a specific tag that refers environment, and keep the same names for the metrics. 

We will extend concourse release to add additional custom tags, but as currently concourse sends the deployment name as a tag[1], we will use that. Later, if our custom tags PR is merged upstream, we can add additional tags as desired, but we won't revert this change.

Additionally, in the CF manifest we also use the environment name as deployment name[2], so this commit will add homogeneity.

The change of the deployment name does not have any other impact, as we use bosh-init that ignores it.

We will do the same in bosh for consistency.

[1] https://github.com/concourse/concourse/blob/master/jobs/atc/templates/atc_ctl.erb#L157
[2] https://github.com/alphagov/paas-cf/blob/master/manifests/cf-manifest/manifest/000-base-cf-deployment.yml#L1-L5

How to review?
---------------

Deploy concourse and bosh from this branch, usiing `ENABLE_DATADOG=true` . They should deploy OK

You can ssh into concourse and check that the right argument is passed as an option:

```
grep deployment /var/vcap/jobs/atc/bin/atc_ctl
```

In datadog, you should see the right metrics, like `concourse.frees` with the deployment tag set with the deployment name.

Who?
---

Anyone but @combor or @keymon