### PR TITLE
More shellcheck fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ lint_shellcheck:
 	find . -name '*.sh' -not -path '*/vendor/*' | xargs $(SHELLCHECK)
 
 lint_concourse:
-	cd .. && SHELLCHECK_OPTS="-e SC1091,SC2034,SC2046,SC2086" python paas-cf/concourse/scripts/pipecleaner.py paas-cf/concourse/pipelines/*.yml
+	cd .. && SHELLCHECK_OPTS="-e SC1091,SC2034,SC2046,SC2086" python paas-cf/concourse/scripts/pipecleaner.py --fatal-warnings paas-cf/concourse/pipelines/*.yml
 
 .PHONY: lint_ruby
 lint_ruby:

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -464,10 +464,7 @@ jobs:
               - |
                 if  [ -z "$(tar -tvzf existing-bosh-CA/bosh-CA.tar.gz)" ] ; then
                   certstrap init --passphrase "" --common-name bosh-CA
-                  cd out
-                  tar -cvzf ../generated-bosh-CA/bosh-CA.tar.gz bosh-CA.*
-                  # shellcheck disable=SC2103
-                  cd .. || true
+                  (cd out && tar -cvzf ../generated-bosh-CA/bosh-CA.tar.gz bosh-CA.*)
                 else
                   echo "The CA cert already exists, skipping generation..."
                   cp existing-bosh-CA/bosh-CA.tar.gz generated-bosh-CA/bosh-CA.tar.gz

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -2520,7 +2520,6 @@ jobs:
                 ALERT_EMAIL_ADDRESS: {{ALERT_EMAIL_ADDRESS}}
               inputs:
                 - name: paas-cf
-                - name: smoke-tests-log
               run:
                 path: sh
                 args:

--- a/concourse/scripts/pipecleaner.py
+++ b/concourse/scripts/pipecleaner.py
@@ -227,9 +227,9 @@ class Pipecleaner(object):
 if __name__ == '__main__':
     def usage():
         print """
-pipecleaner.py pipeline.yml [pipeline2.yml..]
-                            [--ignore-types=unused_fetch,unused_resource]
-                            [--fatal-warnings]"""
+pipecleaner.py [--ignore-types=unused_fetch,unused_resource]
+               [--fatal-warnings]
+               pipeline1.yml [pipelineN.yml...]"""
         sys.exit(2)
 
     try:

--- a/concourse/scripts/pipecleaner_test.go
+++ b/concourse/scripts/pipecleaner_test.go
@@ -29,7 +29,7 @@ var _ = Describe("PipeCleaner", func() {
 
 		It("should return non-zero, with Usage on STDOUT, nothing on STDERR", func() {
 			Eventually(session).Should(gexec.Exit(2))
-			Expect(session.Out).To(gbytes.Say("pipecleaner.py pipeline.yml"))
+			Expect(session.Out).To(gbytes.Say("pipecleaner.py [--ignore-types=unused_fetch,unused_resource]"))
 			Expect(session.Err.Contents()).To(BeEmpty())
 		})
 	})

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -6,7 +6,7 @@ export TARGET_CONCOURSE=deployer
 # shellcheck disable=SC2091
 $("${SCRIPT_DIR}/environment.sh" "$@")
 
-# shellcheck disable=1090
+# shellcheck disable=SC1090
 . "${SCRIPT_DIR}/lib/datadog.sh"
 
 download_git_id_rsa() {

--- a/concourse/tasks/smoke-tests-run.yml
+++ b/concourse/tasks/smoke-tests-run.yml
@@ -9,8 +9,6 @@ inputs:
   - name: cf-release
   - name: test-config
   - name: bosh-CA
-outputs:
-  - name: smoke-tests-log
 run:
   path: bash
   args:
@@ -25,5 +23,4 @@ run:
       ln -snf /usr/local/go /var/vcap/packages/golang1.6
       ln -snf $(pwd)/cf-release/src/smoke-tests /var/vcap/packages/smoke-tests/src/github.com/cloudfoundry/cf-smoke-tests
       set -o pipefail
-      git --git-dir paas-cf/.git log -1 > smoke-tests-log/last-commit.log
-      /var/vcap/jobs/smoke-tests/bin/run | tee smoke-tests-log/smoke-tests.log
+      /var/vcap/jobs/smoke-tests/bin/run


### PR DESCRIPTION
## What

Add few more fixes for issues discovered during review of #518 . Most importantly, there should be no more errors or warnings from shellcheck after this, making it much easier to spot any new issues. To enforce that, we enable `--fatal-warnings` for pipecleaner.

## How to review

Make sure you have shellcheck 0.4.4.
* `make lint_concourse` should return no errors. 
* `make lint_shellcheck` should return no errors.
* bosh manifest generation in the pipeline should not be changed. You can test by temporarily removing your original bosh-ca from bucket & running pipeline again from init. Make sure generate-secrets picks the version of bosh-ca uploaded in init and not the cached one. You don't need to run your pipeline any further than this task. You can then compare generated bosh-ca tarball to the one you had before - mainly file names and paths. Once done, you can upload your original bosh-ca back. Or do nothing in case you let your pipeline run and finish.
* introduce a shellcheck warning by e.g. adding an output to some task that's not being used (e.g. into init) and checking that `make lint_shellcheck` exits with non-zero code.

## Who can review

anyone from the team but me