### PR TITLE
Shellcheck errors are now fatal in pipecleaner

### DIFF
--- a/concourse/scripts/pipecleaner.py
+++ b/concourse/scripts/pipecleaner.py
@@ -12,8 +12,8 @@ It can check for the following issues:
 * Resources that have been `get:`-ted and are not used in the job.
   (Warning)
 * `output:`s that are not used later in the job. (Warning)
-* scriptlets that fail the tests implemented by `shellcheck`
-  http://www.shellcheck.net/ (Warning)
+* Scriptlets that fail the tests implemented by `shellcheck`
+  http://www.shellcheck.net/ (Fatal)
 
 By default it will exit with a nonzero exit code for any Fatal errors,
 and will exit with a nonzero code for Warnings if you pass the


### PR DESCRIPTION
## What

We recently changed shellcheck errors to be fatal in pipecleaner, but missed the documentation. This commit fixes it.

## How to review

Check that it really does say "Fatal" instead of "Warning" for shellcheck errors now.

## Who can review

You!