### PR TITLE
[#131355143] Remove duplicated uaa.client for datadog nozzle

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -462,13 +462,6 @@ properties:
         secret: (( grab secrets.uaa_clients_firehose_password ))
         scope: openid,oauth.approvals,doppler.firehose
         authorities: oauth.login,doppler.firehose
-      datadog-nozzle:
-        access-token-validity: 1209600
-        authorized-grant-types: authorization_code,client_credentials,refresh_token
-        override: true
-        secret: (( grab secrets.uaa_clients_datadog_firehose_password ))
-        scope: openid,oauth.approvals,doppler.firehose
-        authorities: oauth.login,doppler.firehose
 
     database: ~
 

--- a/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
@@ -111,6 +111,34 @@ RSpec.describe "base properties" do
           is_expected.to include("redirect-uri" => "https://login.#{terraform_fixture(:cf_root_domain)}")
         }
       end
+
+      def comma_tokenize(str)
+        str.split(",").map(&:strip)
+      end
+
+      describe "datadog-nozzle" do
+        subject(:client) { clients.fetch("datadog-nozzle") }
+        it {
+          expect(comma_tokenize(client["authorized-grant-types"])).to contain_exactly(
+            "authorization_code",
+            "client_credentials",
+            "refresh_token",
+          )
+        }
+        it {
+          expect(comma_tokenize(client["scope"])).to contain_exactly(
+            "openid",
+            "oauth.approvals",
+            "doppler.firehose",
+          )
+        }
+        it {
+          expect(comma_tokenize(client["authorities"])).to contain_exactly(
+            "oauth.login",
+            "doppler.firehose",
+          )
+        }
+      end
     end
   end
 end

--- a/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
@@ -84,8 +84,33 @@ RSpec.describe "base properties" do
     it { is_expected.to include("issuer" => "https://uaa.#{terraform_fixture(:cf_root_domain)}") }
     it { is_expected.to include("url" => "https://uaa.#{terraform_fixture(:cf_root_domain)}") }
 
-    specify {
-      expect(uaa["clients"]["login"]).to include("redirect-uri" => "https://login.#{terraform_fixture(:cf_root_domain)}")
-    }
+
+    describe "clients" do
+      subject(:clients) { uaa.fetch("clients") }
+
+      it {
+        expect(clients.keys).to contain_exactly(
+          "login",
+          "cf",
+          "notifications",
+          "doppler",
+          "cloud_controller_username_lookup",
+          "cc_routing",
+          "gorouter",
+          "tcp_emitter",
+          "tcp_router",
+          "ssh-proxy",
+          "graphite-nozzle",
+          "datadog-nozzle",
+        )
+      }
+
+      describe "login" do
+        subject(:client) { clients.fetch("login") }
+        it {
+          is_expected.to include("redirect-uri" => "https://login.#{terraform_fixture(:cf_root_domain)}")
+        }
+      end
+    end
   end
 end


### PR DESCRIPTION
[#131355143 Add metron metrics to datadog](https://www.pivotaltracker.com/story/show/131355143)

What?
----

In #520 we accidentally added a duplicated definition of datadog-nozzle UAA client.

This PR removes the duplication, and adds some checks to config that the required clients are present in the manifest definition.

How to review?
--------------

Sanity check. Travis should pass.

Who?
----

I suggest @mtekel, but anyone.