### PR TITLE
Remove null router variables

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -123,20 +123,9 @@ properties:
 
   router:
     enable_ssl: false
-    requested_route_registration_interval_in_seconds:
-    ssl_skip_validation:
     status:
-      port:
       user: router_user
       password: (( grab secrets.router_password ))
-    secure_cookies:
-    route_services_secret:
-    route_services_secret_decrypt_only:
-    route_services_timeout:
-    logrotate:
-    extra_headers_to_log:
-    debug_address:
-    enable_routing_api:
     drain_wait: 15
 
   # FIXME: remove when no longer needed


### PR DESCRIPTION
## What

For some reason, these variables were present but not set. When going through spruce they get set to 'null'. This means that default value is being used for these properties. And this also means that there is no reason to include these properties in the manifest if we don't intend to set them to any value.

## How to review

all cf-manifest tests should pass. When you generate manifest via spruce (both generation for tests but also for pipeline), the removed properties should not be present vs their value set to `null` previously. You can e.g. run generate-cf-config job in deploy-bosh-cloudfoundry pipeline and compare the generated manifest to previous version.

## Who can review

not @mtekel