### PR TITLE
[#131797171] Use datadog nozzle from gds_master

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -136,7 +136,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-graphite-nozzle
-      branch: upgrade_go
+      branch: gds_master
 
   - name: vpc-tfstate
     type: s3-iam


### PR DESCRIPTION
## What

For some reason we were still deploying from upgrade_go branch.
But we have since fast forwarded gds_master to bring in updates from
upstream and also to hide credentials in log outputs, see

https://github.com/alphagov/paas-graphite-nozzle/pull/4
https://github.com/alphagov/paas-graphite-nozzle/pull/3

## How to review

Deploy by running pipeline (cf-deploy job is enough). Check that nozzle is deployed from `gds_master` branch.

## Who can review

not @mtekel