### PR TITLE
[#131890677] Update Rieman to custom release

### DIFF
--- a/manifests/concourse-manifest/extensions/datadog-agent.yml
+++ b/manifests/concourse-manifest/extensions/datadog-agent.yml
@@ -1,8 +1,8 @@
 releases:
   - name: riemann
-    url: https://github.com/alphagov/paas-cf/releases/download/riemann-1/riemann-gds-1.tgz
-    sha1: 8a4220a039ce6a2a0383aab8d4a76746501e58ec
-    version: gds-1
+    url: https://github.com/alphagov/paas-riemann-boshrelease/releases/download/v0.5.0-dev/riemann-gds-4.tgz
+    sha1: 76bbc59dfb46052353226839c67ad1f011ed2225
+    version: gds-4
 
 jobs:
   - name: concourse


### PR DESCRIPTION
## What

This PR updates Rieman to our custom release build on top of Rieman `master` branch.  It brings batch processing of events that is fixing Rieman problem with getting stuck after 15-30 mins of forwarding to Datadog. Also, it should improve performance and reduce latency of forwarding. 

## How to review

Review changes on our fork of Rieman bosh release: https://github.com/xoebus/riemann-boshrelease/compare/master...alphagov:feature/events_batch_processing?expand=1

Rieman jar was created manually according to instructions from docs: http://riemann.io/howto.html#work-with-the-riemann-source

than on paas-cf:

```
make dev bootstrap
```
Check if `concourse.*` metrics are being send from your env. You can wait for half an hour to ensure that Rieman doesn't stop sending them.

## Who can review

Not @mtekel or @combor
