### PR TITLE
[#120590777] Add Continuous Smoke Tests to concourse jobs dasboard

### DIFF
--- a/terraform/datadog/concourse-jobs.tf
+++ b/terraform/datadog/concourse-jobs.tf
@@ -20,4 +20,23 @@ resource "datadog_timeboard" "concourse-jobs" {
     }
   }
 
+  graph {
+    title = "Continuous smoke tests"
+    viz = "timeseries"
+    request {
+      q = "${format("count_nonzero(avg:concourse.build.finished{build_status:failed,bosh-deployment:%s,job:continuous-smoke-tests})", var.env)}"
+      type = "bars"
+      style {
+        palette = "warm"
+      }
+    }
+    request {
+      q = "${format("count_nonzero(avg:concourse.build.finished{build_status:succeeded,bosh-deployment:%s,job:continuous-smoke-tests})", var.env)}"
+      type = "bars"
+      style {
+        palette = "cool"
+      }
+    }
+  }
 }
+


### PR DESCRIPTION
## What

[Improve Visibility of Continuous Smoke Tests](https://www.pivotaltracker.com/n/projects/1275640/stories/120590777)
Add a graph with continuous smoke test successes and failures into concourse job runtime dashboard.

## How to review
Run pipeline. Most importantly datadog terraform part which is in `cf-deploy` job. Go to datadog and observe new and strongly visible bar graph with continuous smoke tests successes and failures. If its empty then try running some continuous smoke tests. You can fail some of them to see the difference in the graph.

## Who can review

not @combor or @mtekel