### PR TITLE
[#131635247] Install consul_agent in all VMs

### DIFF
--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -38,6 +38,8 @@ meta:
     release: (( grab meta.release.name ))
 
   clock_templates:
+  - name: consul_agent
+    release: (( grab meta.consul_templates.consul_agent.release ))
   - name: cloud_controller_clock
     release: (( grab meta.release.name ))
 

--- a/manifests/cf-manifest/manifest/040-graphite.yml
+++ b/manifests/cf-manifest/manifest/040-graphite.yml
@@ -1,5 +1,7 @@
 meta:
   graphite_templates:
+    - name: consul_agent
+      release: (( grab meta.consul_templates.consul_agent.release ))
     - name: carbon
       release: graphite
     - name: graphite-web

--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -28,6 +28,8 @@ jobs:
     vm_type: rds_broker
     stemcell: default
     templates:
+      - name: consul_agent
+        release: (( grab meta.consul_templates.consul_agent.release ))
       - name: rds-broker
         release: aws-broker
     networks:

--- a/manifests/cf-manifest/manifest/800-logsearch.yml
+++ b/manifests/cf-manifest/manifest/800-logsearch.yml
@@ -12,7 +12,10 @@ jobs:
   release: logsearch
   azs: [z1, z2]
   templates:
-  - {name: queue, release: logsearch}
+  - name: consul_agent
+    release: (( grab meta.consul_templates.consul_agent.release ))
+  - name: queue
+    release: logsearch
   vm_type: small
   stemcell: default
   instances: 2
@@ -31,8 +34,12 @@ jobs:
   release: logsearch
   azs: [z1]
   templates:
-  - {name: parser, release: logsearch}
-  - {name: logsearch-for-cloudfoundry-filters, release: logsearch-for-cloudfoundry}
+  - name: consul_agent
+    release: (( grab meta.consul_templates.consul_agent.release ))
+  - name: parser
+    release: logsearch
+  - name: logsearch-for-cloudfoundry-filters
+    release: logsearch-for-cloudfoundry
   vm_type: medium
   stemcell: default
   instances: 1
@@ -55,8 +62,12 @@ jobs:
   release: logsearch
   azs: [z2]
   templates:
-  - {name: parser, release: logsearch}
-  - {name: logsearch-for-cloudfoundry-filters, release: logsearch-for-cloudfoundry}
+  - name: consul_agent
+    release: (( grab meta.consul_templates.consul_agent.release ))
+  - name: parser
+    release: logsearch
+  - name: logsearch-for-cloudfoundry-filters
+    release: logsearch-for-cloudfoundry
   vm_type: medium
   stemcell: default
   instances: 1
@@ -79,7 +90,10 @@ jobs:
   release: logsearch
   azs: [z1, z2, z3]
   templates:
-  - {name: elasticsearch, release: logsearch}
+  - name: consul_agent
+    release: (( grab meta.consul_templates.consul_agent.release ))
+  - name: elasticsearch
+    release: logsearch
   vm_type: elasticsearch_master
   stemcell: default
   instances: 3
@@ -107,9 +121,14 @@ jobs:
   release: logsearch
   azs: [z1, z2]
   templates:
-  - {name: elasticsearch_config, release: logsearch}
-  - {name: curator, release: logsearch}
-  - {name: logsearch-for-cloudfoundry-filters, release: logsearch-for-cloudfoundry}
+  - name: consul_agent
+    release: (( grab meta.consul_templates.consul_agent.release ))
+  - name: elasticsearch_config
+    release: logsearch
+  - name: curator
+    release: logsearch
+  - name: logsearch-for-cloudfoundry-filters
+    release: logsearch-for-cloudfoundry
   vm_type: small
   stemcell: default
   networks:
@@ -126,8 +145,12 @@ jobs:
   release: logsearch
   azs: [z1, z2]
   templates:
-  - {name: kibana, release: logsearch}
-  - {name: haproxy, release: logsearch}
+  - name: consul_agent
+    release: (( grab meta.consul_templates.consul_agent.release ))
+  - name: kibana
+    release: logsearch
+  - name: haproxy
+    release: logsearch
   vm_type: kibana
   stemcell: default
   instances: 1
@@ -142,8 +165,12 @@ jobs:
   release: logsearch
   azs: [z1]
   templates:
-  - {name: ingestor_syslog, release: logsearch}
-  - {name: ingestor_relp, release: logsearch}
+  - name: consul_agent
+    release: (( grab meta.consul_templates.consul_agent.release ))
+  - name: ingestor_syslog
+    release: logsearch
+  - name: ingestor_relp
+    release: logsearch
   vm_type: ingestor
   stemcell: default
   instances: 1
@@ -165,8 +192,12 @@ jobs:
   release: logsearch
   azs: [z2]
   templates:
-  - {name: ingestor_syslog, release: logsearch}
-  - {name: ingestor_relp, release: logsearch}
+  - name: consul_agent
+    release: (( grab meta.consul_templates.consul_agent.release ))
+  - name: ingestor_syslog
+    release: logsearch
+  - name: ingestor_relp
+    release: logsearch
   vm_type: ingestor
   stemcell: default
   instances: 1

--- a/manifests/cf-manifest/spec/manifest/jobs_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/jobs_spec.rb
@@ -11,6 +11,14 @@ end
 RSpec.describe "the jobs definitions block" do
   let(:jobs) { manifest_with_defaults["jobs"] }
 
+  let(:jobs_with_consul) {
+    jobs.select { |j|
+      not j["templates"].select { |t|
+        t["name"] == "consul_agent"
+      }.empty?
+    }
+  }
+
   def get_job(job_name)
     job = jobs.select { |j| j["name"] == job_name }.first
     if job == nil
@@ -100,16 +108,14 @@ RSpec.describe "the jobs definitions block" do
   end
 
   it "should list consul_agent first if present" do
-    jobs_with_consul = jobs.select { |j|
-      not j["templates"].select { |t|
-        t["name"] == "consul_agent"
-      }.empty?
-    }
-
     jobs_with_consul.each { |j|
       expect(j["templates"].first["name"]).to eq("consul_agent"),
         "expected '#{j['name']}' job to list 'consul_agent' first"
     }
+  end
+
+  it "should install consul_agent in all the jobs" do
+    expect(jobs).to eq(jobs_with_consul)
   end
 
   describe "in order to monitor all hosts via datadog" do

--- a/manifests/cf-manifest/stubs/datadog-nozzle.yml
+++ b/manifests/cf-manifest/stubs/datadog-nozzle.yml
@@ -8,6 +8,8 @@ jobs:
 - name: nozzle
   azs: [z1, z2]
   templates:
+  - name: consul_agent
+    release: (( grab meta.consul_templates.consul_agent.release ))
   - name: datadog-firehose-nozzle
     release: datadog-firehose-nozzle
     properties:


### PR DESCRIPTION
[#131635247 Metron error messages in logs](https://www.pivotaltracker.com/story/show/131635247)

What?
=====

Install consul_agent in all VMs

We have setup metron_agent in all VMs as a addon in #495.

Metron agent requires connect to etcd to discover the dopplers, and it is currently setup to discover the etcd by using `etcd.service.cf.internal` that is served by consul.

We did not setup the consul_agent in all the VMs, so the ones missing it had metron_agent installed, but unable to resolv etcd and, in consequence, discover the dopplers. Because that, the metron_agents were logging constantly the following error:

```
   {
      "file" : "/var/vcap/data/compile/metron_agent/loggregator/src/doppler/dopplerservice/finder.go",
      "timestamp" : 1475669685.3659,
      "source" : "metron",
      "line" : 139,
      "log_level" : "error",
      "message" : "Finder: Watch sent an error",
      "method" : "doppler/dopplerservice.(*Finder).run",
      "data" : {
	 "error" : "store request timed out"
      },
      "process_id" : 9989
   }
``` 

We will do some work in the future to reconsider this solution. Alternative approaches are:

 * Configure etcd using static IPs
 * Do not install metron_agent just to configure rsyslog. (see https://www.pivotaltracker.com/story/show/131975557)

How to review?
------------------

There's a test for this in the manifest, so travis should pass. 

Then you can double check by:  Deploy this, check that consul agent is running in all the VM. Check the logs ` /var/vcap/sys/log/metron_agent/metron_agent.stdout.log` or ` /var/vcap/sys/log/metron_agent/metron_agent.stderr.log` to check if the above errors is gone.

Who?
---

Anyone but @keymon 