### PR TITLE
[#131981965] Add more disk&memory to ES vm types

### DIFF
--- a/manifests/cf-manifest/cloud-config/030-logsearch.yml
+++ b/manifests/cf-manifest/cloud-config/030-logsearch.yml
@@ -21,13 +21,16 @@ vm_types:
     network: (( grab vm_types.medium.network ))
     env: (( grab meta.default_env ))
     cloud_properties:
-      instance_type: (( grab vm_types.medium.cloud_properties.instance_type ))
+      instance_type: m4.large
+      ephemeral_disk:
+        size: 10240
+        type: gp2
       elbs:
         - (( grab terraform_outputs.logsearch_elastic_master_elb_name ))
 
 disk_types:
   - name: elasticsearch_master
-    disk_size: 102400
+    disk_size: 204800
     cloud_properties: {type: gp2}
   - name: queue
     disk_size: 102400


### PR DESCRIPTION
## What

[#131981965 Support: troubleshoot issues in logsearch/elasticsearch cluster](https://www.pivotaltracker.com/story/show/131981965)

This PR is a result of ES troubleshooting. 
We found out that all disks are almost full on all Elasticsearch VMs and ES process refuses to assign shards to any host that reached more than 90% of disk space used. As the volume of logs increases and we do more searches and indexing we need more memory and more CPUs to cope with the load. This PR updates ES VMs to m4.large that has 8GB of memory, 2 CPUs and increases disk space to 200GB. 

## How to review

- Deploy on top of existing environment. 
- check if you can still use Kibana
- check if you can access logs that were indexed before migration disks 

## Who can review

not @combor
