### PR TITLE
[#132060265] Check the git tag of the boshreleases prior upload

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1507,21 +1507,27 @@ jobs:
                 - |
                   ./paas-cf/concourse/scripts/bosh_login.sh {{bosh_fqdn}} bosh-secrets/bosh-secrets.yml
 
+                  ./paas-cf/concourse/scripts/git_check_tag.sh {{cf_graphite_version}} graphite-statsd-boshrelease
                   paas-cf/concourse/scripts/bosh_create_and_upload_release.rb graphite \
                     {{cf_graphite_version}} graphite-statsd-boshrelease
 
+                  ./paas-cf/concourse/scripts/git_check_tag.sh {{cf-paas-haproxy-release-version}} paas-haproxy-release
                   paas-cf/concourse/scripts/bosh_create_and_upload_release.rb paas-haproxy \
                     {{cf-paas-haproxy-release-version}} paas-haproxy-release
 
+                  ./paas-cf/concourse/scripts/git_check_tag.sh {{cf_os_conf_version}} os-conf-boshrelease
                   paas-cf/concourse/scripts/bosh_create_and_upload_release.rb os-conf \
                     {{cf_os_conf_version}} os-conf-boshrelease
 
+                  ./paas-cf/concourse/scripts/git_check_tag.sh {{cf_aws_broker_version}} aws-broker-boshrelease
                   paas-cf/concourse/scripts/bosh_create_and_upload_release.rb aws-broker \
                     {{cf_aws_broker_version}} aws-broker-boshrelease
 
+                  ./paas-cf/concourse/scripts/git_check_tag.sh {{cf_logsearch_for_cloudfoundry_version}} logsearch-for-cloudfoundry-boshrelease
                   paas-cf/concourse/scripts/bosh_create_and_upload_release.rb logsearch-for-cloudfoundry \
                     {{cf_logsearch_for_cloudfoundry_version}} logsearch-for-cloudfoundry-boshrelease
 
+                  ./paas-cf/concourse/scripts/git_check_tag.sh {{cf_datadog_for_cloudfoundry_version}} datadog-for-cloudfoundry-boshrelease
                   paas-cf/concourse/scripts/bosh_create_and_upload_release.rb datadog-for-cloudfoundry \
                     {{cf_datadog_for_cloudfoundry_version}} datadog-for-cloudfoundry-boshrelease
 

--- a/concourse/scripts/git_check_tag.sh
+++ b/concourse/scripts/git_check_tag.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -eu
+
+if [ $# -lt 2 ]; then
+   echo "Usage: $0 <tag> <path>"
+fi
+
+expected_tag="$1"
+working_dir="$2"
+
+cd "${working_dir}"
+current_tags=$(git tag --points-at HEAD)
+if ! echo "${current_tags}" | grep -qe "^${expected_tag}\$"; then
+   echo "Current tags '$(echo "${current_tags}" | xargs)' != expected tag '${expected_tag}' in cloned repo '${working_dir}'"
+   exit 1
+fi


### PR DESCRIPTION
[#132060265 Support: Wrong version of aws-broker deployed in CI](https://www.pivotaltracker.com/story/show/132060265)

What?
-----

How git-resource and concourse works, and how we implemented the build and upload of bosh-releases, it can happen that we build an older version of the bosh-release and upload it with the wrong version number.

The reason is that regardless the tag-filter configured in the git resource, the versions previously reported  still valid versions for concourse, and likely cached.
If the new version defined in the tag filter is not discovered (e.g. we forgot to add the tag or there was a typo) Concourse might checkout the latest valid version, but not the one defined in `tag-filter`.

We cannot add a safe-check in the git-resource, as the `get` might not be executed when the resource is cached.

Instead, and meanwhile we do not migrate to published final bosh releases built in a dedicated CI server, we will add a check before uploading the release, checking if the git tag matches the version.

Dependencies
------------

The PR https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/74 should be merged first. After it is merged and the new container is generated, you can delete the WIP commit in this branch.

How to review?
--------------

 1. run the pipeline, it should pass
 2. Disable the latest version in the git-resource of any bosh release. Rerun cf-deploy. It should fail.

Who?
----

Anyone but @keymon