### PR TITLE
[#127449817] Increase timeout for tag_release tests to 30s

### DIFF
--- a/concourse/scripts/tag_release_test.go
+++ b/concourse/scripts/tag_release_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	ExecutionTimeout = 3 * time.Second
+	ExecutionTimeout = 30 * time.Second
 )
 
 var _ = Describe("TagRelease", func() {


### PR DESCRIPTION
What?
-----

Similar to #388 and #435

This script sometimes takes more than Eventually's default timeout of 1sec to
return when running in travis. Probably git operations are too heavy for
the container based travis build.

This happened in travis several times[1]. Dan was able to reproduce it
by running `ginkgo --untilItFails`, but I couldn't.

I set the timeout to 30. Even with 3 seconds it timeouts sometimes, and it is
not really important to add more time if it eventually timeouts in a reasonable
time.

The failure looked like this:
``` 
  • Failure in Spec Setup (BeforeEach) [3.847 seconds]
  TagRelease
  /home/travis/build/alphagov/paas-cf/concourse/scripts/tag_release_test.go:147
    when there are multiple 'previous-*' tags to be promoted
    /home/travis/build/alphagov/paas-cf/concourse/scripts/tag_release_test.go:146
      and the before last tag of 'previous-*' is promoted [BeforeEach]
      /home/travis/build/alphagov/paas-cf/concourse/scripts/tag_release_test.go:115
        should promote the same tag version for 'next-*'
        /home/travis/build/alphagov/paas-cf/concourse/scripts/tag_release_test.go:89
        Timed out after 3.000s.
        Expected process to exit.  It did not.
        /home/travis/build/alphagov/paas-cf/concourse/scripts/tag_release_test.go:161
```

[1] https://travis-ci.org/alphagov/paas-cf/builds/153593309

How to test?
-----------

Travis should pass, or see #426

Who?
----

Anyone but me