### PR TITLE
[#132001409] Use stemcell 3263.5 with kernel 4.4 for concourse

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -22,8 +22,8 @@ resource_pools:
   - name: concourse
     network: concourse
     stemcell:
-      url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3262.12
-      sha1: 90e9825b814da801e1aff7b02508fdada8e155cb
+      url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3263.5
+      sha1: a4a3b387ee81cd0e1b73debffc39f0907b80f9c6
     cloud_properties:
       instance_type: m4.large
       availability_zone: (( grab terraform_outputs.zone0 ))


### PR DESCRIPTION
[#132001409 Upgrade stemcell for concourse to 3263 series](https://www.pivotaltracker.com/story/show/132001409)

What?
----

The stemcell 3263 series are based on 3262, but they use the kernel 4.4.[1]

This kernel contains multiple changes and optimisations for btrfs, which concourse relies on massively. We are experiencing some bottlenecks in the volume management in concourse, and it is recommended to use this kernel version.

The concourse development team did recommend several times upgrade to 4.4 for performance. I [confirmed it](https://concourseci.slack.com/archives/general/p1476117654007234).

[1] https://github.com/cloudfoundry/bosh/releases for latest stemcell
[2] https://www.phoronix.com/scan.php?page=news_item&px=Linux-4.4-Btrfs-Improvements


How to test?
-----------

Install the new concourse using the boostrap. Check the new version.

You can run for a while with the new version before merge.

Who?
----

Anyone but @keymon