### PR TITLE
[#131355243] Datadog: Add monitor for cell memory

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -93,6 +93,7 @@ jobs:
           TF_VAR_datadog_api_key: {{datadog_api_key}}
           TF_VAR_datadog_app_key: {{datadog_app_key}}
           TF_VAR_env: {{deploy_env}}
+          TF_VAR_aws_account: {{aws_account}}
           ENABLE_DATADOG: {{enable_datadog}}
         ensure:
           put: datadog-tfstate

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1870,6 +1870,7 @@ jobs:
               TF_VAR_env: {{deploy_env}}
               TF_VAR_datadog_api_key: {{datadog_api_key}}
               TF_VAR_datadog_app_key: {{datadog_app_key}}
+              TF_VAR_aws_account: {{aws_account}}
               ENABLE_DATADOG: {{enable_datadog}}
             run:
               path: sh

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -165,6 +165,7 @@ jobs:
           TF_VAR_datadog_api_key: {{datadog_api_key}}
           TF_VAR_datadog_app_key: {{datadog_app_key}}
           TF_VAR_env: {{deploy_env}}
+          TF_VAR_aws_account: {{aws_account}}
           ENABLE_DATADOG: {{enable_datadog}}
         ensure:
           put: datadog-tfstate

--- a/terraform/datadog/cell.tf
+++ b/terraform/datadog/cell.tf
@@ -1,0 +1,19 @@
+resource "datadog_monitor" "cell-available-memory" {
+  name = "${format("%s cell available memory", var.env)}"
+  type = "query alert"
+  message = "${format("Less than {{threshold}}%% memory free on cells. There is only {{value}} %% memory free on average on cells. Review if this is temporary or we really need to scale... @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
+  escalation_message = "There is only {{value}} % memory free on average on cells. Check the deployment!"
+  no_data_timeframe = "5"
+  query = "${format("avg(last_1m):avg:system.mem.pct_usable{job:cell,environment:%s} * 100 < 50", var.env)}"
+
+  thresholds {
+    warning = "55.0"
+    critical = "50.0"
+  }
+
+  require_full_window = true
+  tags {
+    "environment" = "${var.env}"
+    "job" = "cell"
+  }
+}

--- a/terraform/datadog/datadog.tf
+++ b/terraform/datadog/datadog.tf
@@ -1,6 +1,7 @@
 variable "datadog_api_key" {}
 variable "datadog_app_key" {}
 variable "env" {}
+variable "aws_account" {}
 
 provider "datadog" {
     api_key = "${var.datadog_api_key}"


### PR DESCRIPTION
## What

[Add datadog check of cell memory usage](https://www.pivotaltracker.com/n/projects/1275640/stories/131355243)
Create a monitor which check total available memory on cells. Alert if less than 50% is free.

## How to review

Deploy. Check that the new monitor is correctly created. Try triggering the alert by using a lot of memory on cells. You can try running e.g. `ruby -e 'foo = "123234314234" * 2000000000; sleep' &` on a cell VM directly. Or deploy lots of apps to CF, but which have to really consume memory (it doesn't matter what quota you assign to the app, only real memory consumption is counted).

See https://github.com/alphagov/paas-team-manual/pull/68 for information about alerting google groups - you need to to subscribe to receive alerts.

## Who can review

not @mtekel or @richardc 