### PR TITLE
[#130899659] Monitor disk space

### DIFF
--- a/terraform/datadog/general.tf
+++ b/terraform/datadog/general.tf
@@ -1,0 +1,39 @@
+resource "datadog_monitor" "disk-space" {
+  name = "${format("%s disk space", var.env)}"
+  type = "query alert"
+  message = "${format("More than {{threshold}}%% disk used. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
+  escalation_message = "There is still {{value}} % disk used. Check the VM!"
+  no_data_timeframe = "5"
+  query = "${format("max(last_5m):max:system.disk.in_use{environment:%s,!device:/dev/loop0,!device:tmpfs,!device:cgroup,!device:udev,!device:/var/vcap/data/root_log,!device:/var/vcap/data/root_tmp,!job:concourse} by {bosh-job,device,bosh-index} * 100 > 85", var.env)}"
+
+  thresholds {
+    warning = "75.0"
+    critical = "85.0"
+  }
+
+  require_full_window = true
+  tags {
+    "environment" = "${var.env}"
+    "job" = "all"
+  }
+}
+
+resource "datadog_monitor" "concourse-disk-space" {
+  name = "${format("%s concourse disk space", var.env)}"
+  type = "query alert"
+  message = "${format("More than {{threshold}}%% disk used. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
+  escalation_message = "There is still {{value}} % disk used. Check the VM!"
+  no_data_timeframe = "5"
+  query = "${format("max(last_5m):max:system.disk.in_use{environment:%s,!device:/dev/loop0,!device:tmpfs,!device:cgroup,!device:udev,!device:/var/vcap/data/root_log,!device:/var/vcap/data/root_tmp,job:concourse} by {bosh-job,device,bosh-index} * 100 > 97", var.env)}"
+
+  thresholds {
+    warning = "95.0"
+    critical = "97.0"
+  }
+
+  require_full_window = true
+  tags {
+    "environment" = "${var.env}"
+    "job" = "concourse"
+  }
+}


### PR DESCRIPTION
## What

[Monitor disk space usage](https://www.pivotaltracker.com/n/projects/1275640/stories/130899659)

Alert when any VM in the given environment uses more than 85% of disk, warn at 75% of usage. This excludes concourse which after deployment uses 90% of the stemcell root disk because bosh init places about 1GB of package cache there. Thus concourse gets own check with 97% critical and 95% warn thresholds.

## Depends on #541 
We use same google groups that were created for #541 to send alerts to. We also depend on addition of aws_account TF variable in that PR. This PR might need re-basing after #541 is merged. For now, we include it in this PR so that you can review directly and that travis passes tests.

## How to review

Deploy. Verify monitors are created with correct thresholds, messages and alert group emails. Try filling disk of some random job (e.g. `cat /dev/zero >zeroes`). That should trigger an alert sent to the dev alert group. Afterwards free up the space (e.g. `rm zeroes`) and the alert should recover (again notification sent to the group)

See alphagov/paas-team-manual#68 for information about alerting google groups - you need to to subscribe to receive alerts.

## Who can review

not @mtekel or @richardc 