### PR TITLE
[#132146447]  Upgrade datadog agent and enable bosh tags

### DIFF
--- a/manifests/bosh-manifest/extensions/datadog-agent.yml
+++ b/manifests/bosh-manifest/extensions/datadog-agent.yml
@@ -7,4 +7,6 @@ jobs:
     datadog: (( inject meta.datadog ))
     tags:
       job: bosh
+      bosh-job: bosh
+      bosh-az: (( grab terraform_outputs.bosh_az_label ))
       tags: (( inject meta.datadog_tags ))

--- a/manifests/bosh-manifest/spec/fixtures/bosh-terraform-outputs.yml
+++ b/manifests/bosh-manifest/spec/fixtures/bosh-terraform-outputs.yml
@@ -16,6 +16,7 @@ terraform_outputs:
   bosh_db_dbname: bosh
   bosh_fqdn: bosh.example.com
   bosh_az: eu-west-1a
+  bosh_az_label: z1
   bosh_default_gw: 10.0.0.1
   bosh_subnet_cidr: 10.0.0.0/24
   bosh_ssh_key_pair_name: bosh_keypair

--- a/manifests/bosh-manifest/spec/properties_spec.rb
+++ b/manifests/bosh-manifest/spec/properties_spec.rb
@@ -30,4 +30,12 @@ RSpec.describe "manifest properties validations" do
   it "disables the health manager resurrector" do
     expect(bosh_properties["hm"]["resurrector_enabled"]).to eq(false)
   end
+
+  it "configures datadog tag bosh-job" do
+    expect(bosh_properties["tags"]["bosh-job"]).to eq("bosh")
+  end
+
+  it "configures datadog tag bosh-az with the right AZ" do
+    expect(bosh_properties["tags"]["bosh-az"]).to eq("z1")
+  end
 end

--- a/manifests/concourse-manifest/extensions/datadog-agent.yml
+++ b/manifests/concourse-manifest/extensions/datadog-agent.yml
@@ -13,6 +13,8 @@ jobs:
           datadog: (( inject meta.datadog ))
           tags:
             job: concourse
+            bosh-job: concourse
+            bosh-az: z1
             tags: (( inject meta.datadog_tags ))
       - name: riemann
         release: riemann

--- a/manifests/concourse-manifest/spec/fixtures/vpc-terraform-outputs.yml
+++ b/manifests/concourse-manifest/spec/fixtures/vpc-terraform-outputs.yml
@@ -4,4 +4,5 @@ terraform_outputs:
   ssh_security_group: alext-office-access-ssh
   subnet0_id: subnet-12345678
   zone0: eu-west-1a
+  concourse_az_label: z1
   environment: dev

--- a/manifests/shared/deployments/datadog-agent.yml
+++ b/manifests/shared/deployments/datadog-agent.yml
@@ -1,14 +1,15 @@
 ---
 releases:
 - name: datadog-agent
-  sha1: 7ba4b58c95812ecda39fd0bcf16cb8d3635c2ecd
-  url: https://github.com/alphagov/paas-datadog-agent-boshrelease/releases/download/custom_007/datadog-agent-custom_007.tgz
-  version: "custom_007"
+  sha1: 14c7f9be2eb534fda1f4c70ea2355865ac93a87b
+  url: https://github.com/alphagov/paas-datadog-agent-boshrelease/releases/download/v5.8.5.3-gds/datadog-agent-v5.8.5.3-gds.tgz
+  version: "v5.8.5.3-gds"
 
 meta:
   datadog:
     api_key: (( grab $DATADOG_API_KEY || "undefined" ))
     use_dogstatsd: false
+    include_bosh_tags: true
   datadog_tags:
     environment: (( grab meta.environment || "undefined" ))
     aws_account: (( grab $AWS_ACCOUNT ))

--- a/terraform/bosh/outputs.tf
+++ b/terraform/bosh/outputs.tf
@@ -74,6 +74,10 @@ output "bosh_az" {
   value = "${var.bosh_az}"
 }
 
+output "bosh_az_label" {
+  value = "${lookup(var.zone_labels, var.bosh_az)}"
+}
+
 output "bosh_fqdn" {
   value = "${aws_route53_record.bosh.name}"
 }

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -39,6 +39,15 @@ variable "zone_index" {
   }
 }
 
+variable "zone_labels" {
+  description = "AWS availability zone labels as used in BOSH manifests (z1-z3)"
+  default     = {
+    eu-west-1a = "z1"
+    eu-west-1b = "z2"
+    eu-west-1c = "z3"
+  }
+}
+
 variable "zone_count" {
   description = "Number of zones to use"
   default = 3


### PR DESCRIPTION
[#132146447 Set human-readable hostname in Datadog](https://www.pivotaltracker.com/story/show/132146447)

What?
-----

The host names of our virtual machines are Bosh UUIDs in Datadog, which is not very user friendly and makes metrics hard to find and read.

This PR was merged upstream [1] which adds tags to identify the bosh job and index, which we can use in our checks and graphs. This PR is merged back to our fork [2].

We add these changes to the manifest.

[1] https://github.com/onemedical/datadog-agent-boshrelease/pull/8
[2] https://github.com/alphagov/paas-datadog-agent-boshrelease/pull/7

Dependencies
-------------

https://github.com/alphagov/paas-datadog-agent-boshrelease/pull/7 should be reviewed and merged first, a new release generated and uploaded and the commits of this PR point to the new release

How to test?
-------------

Redeploy with `ENABLE_DATADOG=true`. Tags should appear for your VMs.

Who?
----

Anyone but @keymon