### PR TITLE
[#131355575] Check NATS health

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -30,7 +30,7 @@ releases:
     url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=12.6
     sha1: 8ffc7b9bfee004464bc8a81c322db7160dd7440f
   - name: datadog-for-cloudfoundry
-    version: "0.0.2"
+    version: "0.0.3"
 
 stemcells:
   - alias: default

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -76,6 +76,8 @@ meta:
     release: (( grab meta.release.name ))
   - name: nats_stream_forwarder
     release: (( grab meta.release.name ))
+  - name: datadog-nats
+    release: datadog-for-cloudfoundry
 
   router_templates:
   - name: consul_agent

--- a/terraform/datadog/nats.tf
+++ b/terraform/datadog/nats.tf
@@ -1,0 +1,105 @@
+
+resource "datadog_monitor" "nats" {
+  name = "${format("%s NATS hosts", var.env)}"
+  type = "service check"
+  message = "Missing nats hosts in environment {{host.environment}}. Notify: @the-multi-cloud-paas-team@digital.cabinet-office.gov.uk"
+  escalation_message = "Missing nats hosts! Check VM state."
+  no_data_timeframe = "2"
+  query = "${format("'datadog.agent.up'.over('environment:%s','job:nats').by('*').last(1).pct_by_status()", var.env)}"
+
+  thresholds {
+    ok = 0
+    warning = 0
+    critical = 10
+  }
+
+  require_full_window = true
+  tags {
+    "environment" = "${var.env}"
+    "job" = "nats"
+  }
+}
+
+resource "datadog_monitor" "nats_process_running" {
+  name = "${format("%s NATS process running", var.env)}"
+  type = "service check"
+  message = "nats process not running. Check nats state."
+  escalation_message = "nats process still not running. Check nats state."
+  no_data_timeframe = "5"
+  require_full_window = true
+
+  query = "${format("'process.up'.over('environment:%s','process:nats').last(4).count_by_status()", var.env)}"
+
+  thresholds {
+    ok = 1
+    warning = 2
+    critical = 3
+  }
+
+  tags {
+    "environment" = "${var.env}"
+    "job" = "nats"
+  }
+}
+
+resource "datadog_monitor" "nats_stream_forwarded_process_running" {
+  name = "${format("%s NATS stream forwarder process running", var.env)}"
+  type = "service check"
+  message = "NATS stream forwarder process not running. Check nats state."
+  escalation_message = "NATS stream forwarder process still not running. Check NATS state."
+  no_data_timeframe = "5"
+  require_full_window = true
+
+  query = "${format("'process.up'.over('environment:%s','process:nats_stream_forwarder').last(4).count_by_status()", var.env)}"
+
+  thresholds {
+    ok = 1
+    warning = 2
+    critical = 3
+  }
+
+  tags {
+    "environment" = "${var.env}"
+    "job" = "nats"
+  }
+}
+
+resource "datadog_monitor" "nats_service_open" {
+  name = "${format("%s NATS service is accepting connections", var.env)}"
+  type = "service check"
+  message = "Large portion of NATS service are not accepting connections. Check deployment state."
+  escalation_message = "Large portion of NATS service are still not accepting connections. Check deployment state."
+  no_data_timeframe = "5"
+  require_full_window = true
+
+  query = "${format("'tcp.can_connect'.over('environment:%s','instance:nats_server').by('*').last(1).pct_by_status()", var.env)}"
+
+  thresholds {
+    critical = 50
+  }
+
+  tags {
+    "environment" = "${var.env}"
+    "job" = "router"
+  }
+}
+
+resource "datadog_monitor" "nats_cluster_service_open" {
+  name = "${format("%s NATS cluster service is accepting connections", var.env)}"
+  type = "service check"
+  message = "Large portion of NATS cluster service are not accepting connections. Check deployment state."
+  escalation_message = "Large portion of NATS cluster service are still not accepting connections. Check deployment state."
+  no_data_timeframe = "5"
+  require_full_window = true
+
+  query = "${format("'tcp.can_connect'.over('environment:%s','instance:nats_cluster').by('*').last(1).pct_by_status()", var.env)}"
+
+  thresholds {
+    critical = 50
+  }
+
+  tags {
+    "environment" = "${var.env}"
+    "job" = "router"
+  }
+}


### PR DESCRIPTION
## What

Story: [Check health of nats component](https://www.pivotaltracker.com/story/show/131355575)

This covers the most critical:

* NATS process
* NATS stream forwarder process
* NATS server TCP port
* NATS cluster management TCP port

It depends on PR https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/3

## How to review
* Deploy with `ENABLE_DATADOG=true`
* Verify the NATS monitors have been created in Datadog
* Connect to a NATS host, stop or kill NATS processes, stop datadog agent... and check the monitors are failing

# How to merge
* When ready, merge PR https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/3
* Create and push tag `0.0.3` on paas-datadog-for-cloudfoundry-boshrelease master
* Remove commit 7d3240807b6c4c96133c0958c7e3a7df3565ccd9 in this branch
* Commit new version in [paas-cf](https://github.com/alphagov/paas-cf/blob/de42ce2dfae6267cbcd0e0454c2edb2b97a91b4e/manifests/cf-manifest/manifest/000-base-cf-deployment.yml#L33) in this branch
* Merge this PR

## Who can review
Not @combor or me