### PR TITLE
[#131355575] Fix NATS stream forwarder process check

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -30,7 +30,7 @@ releases:
     url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=12.6
     sha1: 8ffc7b9bfee004464bc8a81c322db7160dd7440f
   - name: datadog-for-cloudfoundry
-    version: "0.0.3"
+    version: "0.0.4"
 
 stemcells:
   - alias: default


### PR DESCRIPTION
## What
Story: [Check health of nats component](https://www.pivotaltracker.com/story/show/131355575)

https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/3 implemented checks for NATS and NATS stream forwarder. Unfortunately the NATS stream forwarder process check was checking for 'ruby' or 'nats_stream_forwarder.rb', and not 'ruby' and 'nats_stream_forwarder.rb'. The check now looks for the full string and doesn't give false positive.

This depends on https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/4.

## How to review
* Deploy with `ENABLE_DATADOG=true`
* Logon one of the NATS servers
* Start any ruby process, for example: `ruby -e "sleep 10000" &`
* Stop NATS stream forwarder: `monit stop nats_stream_forwarder`
* The monitor should fail in datadog

# How to merge
* Merge https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/4
* Create and push tag `0.0.4` on `paas-datadog-for-cloudfoundry-boshrelease` master
* Delete commit https://github.com/alphagov/paas-cf/commit/ae1af94e3a4d8da7084bf8f103233a54743d17d7 and push
* Merge this PR

## Who can review
Not me