### PR TITLE
[#130844201] More distinctive concourses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,7 @@ prod: globals check-env-vars ## Set Environment to Production
 	$(eval export ENABLE_CF_ACCEPTANCE_TESTS=false)
 	$(eval export ENABLE_DATADOG=true)
 	$(eval export DECRYPT_CONCOURSE_ATC_PASSWORD=prod_deployment)
+	$(eval export CONCOURSE_AUTH_DURATION=5m)
 	@true
 
 .PHONY: bootstrap

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ dev: globals check-env-vars ## Set Environment to DEV
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-default.yml)
 	$(eval export ENABLE_HEALTHCHECK_DB=false)
 	$(eval export ENABLE_DATADOG ?= false)
+	$(eval export CONCOURSE_AUTH_DURATION=48h)
 	@true
 
 .PHONY: ci
@@ -146,7 +147,6 @@ prod: globals check-env-vars ## Set Environment to Production
 	$(eval export ENABLE_CF_ACCEPTANCE_TESTS=false)
 	$(eval export ENABLE_DATADOG=true)
 	$(eval export DECRYPT_CONCOURSE_ATC_PASSWORD=prod_deployment)
-	$(eval export CONCOURSE_AUTH_DURATION=5m)
 	@true
 
 .PHONY: bootstrap

--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -442,6 +442,7 @@ jobs:
           AWS_ACCOUNT: {{aws_account}}
           DATADOG_API_KEY: {{datadog_api_key}}
           ENABLE_DATADOG: {{enable_datadog}}
+          CONCOURSE_AUTH_DURATION: {{concourse_auth_duration}}
           CONCOURSE_MANIFEST_STUBS: |
             ./paas-cf/manifests/concourse-manifest/concourse-base.yml
             predefined-concourse-secrets/predefined-concourse-secrets.yml

--- a/concourse/pipelines/create-deployer.yml
+++ b/concourse/pipelines/create-deployer.yml
@@ -485,6 +485,7 @@ jobs:
     - get: concourse-ssh-private-key
     - get: concourse-manifest
       passed: ['concourse-prepare-deploy']
+    - get: paas-cf
 
     - task: concourse-deploy
       timeout: 30m
@@ -513,6 +514,30 @@ jobs:
         put: concourse-bosh-state
         params:
           file: concourse-deploy/concourse-manifest-state.json
+
+    - task: add-env-specific-team
+      config:
+        image: docker:///governmentpaas/self-update-pipelines
+        inputs:
+          - name: paas-cf
+          - name: concourse-manifest
+        params:
+          SYSTEM_DNS_ZONE_NAME: {{system_dns_zone_name}}
+          CONCOURSE_ATC_PASSWORD: {{concourse_atc_password}}
+          CONCOURSE_ATC_USER: admin
+          FLY_TEAM: {{aws_account}}
+          FLY_TARGET: {{deploy_env}}
+          FLY_CMD: ./paas-cf/bin/fly
+        run:
+          path: sh
+          args:
+            - -e
+            - -c
+            - |
+              export CONCOURSE_URL="https://deployer.${SYSTEM_DNS_ZONE_NAME}"
+              ./paas-cf/concourse/scripts/fly_sync_and_login.sh
+              echo y | ./paas-cf/bin/fly -t ${FLY_TARGET} set-team -n ${FLY_TEAM} \
+                         --basic-auth-username admin --basic-auth-password ${CONCOURSE_ATC_PASSWORD}
 
   - name: expunge-vagrant
     serial: true

--- a/concourse/scripts/pipelines-deployer.sh
+++ b/concourse/scripts/pipelines-deployer.sh
@@ -32,6 +32,7 @@ system_dns_zone_name: ${SYSTEM_DNS_ZONE_NAME}
 aws_account: ${AWS_ACCOUNT:-dev}
 datadog_api_key: ${datadog_api_key:-}
 enable_datadog: ${ENABLE_DATADOG}
+concourse_auth_duration: ${CONCOURSE_AUTH_DURATION:-24h}
 EOF
 }
 

--- a/concourse/scripts/pipelines-deployer.sh
+++ b/concourse/scripts/pipelines-deployer.sh
@@ -32,7 +32,7 @@ system_dns_zone_name: ${SYSTEM_DNS_ZONE_NAME}
 aws_account: ${AWS_ACCOUNT:-dev}
 datadog_api_key: ${datadog_api_key:-}
 enable_datadog: ${ENABLE_DATADOG}
-concourse_auth_duration: ${CONCOURSE_AUTH_DURATION:-24h}
+concourse_auth_duration: ${CONCOURSE_AUTH_DURATION:-5m}
 EOF
 }
 

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -73,7 +73,7 @@ jobs:
           databases:
             - name: atc
               role: atc
-              password: dummy-password
+              password: (( grab secrets.concourse_postgres_password ))
 
       - name: atc
         release: concourse
@@ -87,7 +87,7 @@ jobs:
             database: atc
             role:
               name: atc
-              password: dummy-password
+              password: (( grab secrets.concourse_postgres_password ))
 
       - name: groundcrew
         release: concourse

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -81,6 +81,7 @@ jobs:
           external_url: (( concat "https://" terraform_outputs.concourse_dns_name ))
           basic_auth_username: admin
           basic_auth_password: (( grab secrets.concourse_atc_password ))
+          auth_duration: (( grab $CONCOURSE_AUTH_DURATION ))
 
           postgresql:
             address: 127.0.0.1:5432

--- a/manifests/concourse-manifest/scripts/generate-concourse-secrets.rb
+++ b/manifests/concourse-manifest/scripts/generate-concourse-secrets.rb
@@ -7,6 +7,7 @@ require File.expand_path("../../../shared/lib/secret_generator", __FILE__)
 generator = SecretGenerator.new(
   "concourse_nats_password" => :simple,
   "concourse_vcap_password" => :sha512_crypted,
+  "concourse_postgres_password" => :simple,
 )
 
 option_parser = OptionParser.new do |opts|

--- a/manifests/concourse-manifest/spec/fixtures/generated-concourse-secrets.yml
+++ b/manifests/concourse-manifest/spec/fixtures/generated-concourse-secrets.yml
@@ -2,3 +2,4 @@
 secrets:
   concourse_nats_password: CONCOURSE_NATS_PASSWORD
   concourse_vcap_password: CONCOURSE_VCAP_PASSWORD
+  concourse_postgres_password: dummy-password

--- a/manifests/concourse-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/concourse-manifest/spec/support/manifest_helpers.rb
@@ -17,6 +17,7 @@ private
   def load_default_manifest
     ENV["AWS_ACCOUNT"] = "dev"
     ENV["DATADOG_API_KEY"] = "abcd1234"
+    ENV["CONCOURSE_AUTH_DURATION"] = "24h"
     output, error, status = Open3.capture3(
       [
         File.expand_path("../../../../shared/build_manifest.sh", __FILE__),

--- a/manifests/concourse-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/concourse-manifest/spec/support/manifest_helpers.rb
@@ -17,7 +17,7 @@ private
   def load_default_manifest
     ENV["AWS_ACCOUNT"] = "dev"
     ENV["DATADOG_API_KEY"] = "abcd1234"
-    ENV["CONCOURSE_AUTH_DURATION"] = "24h"
+    ENV["CONCOURSE_AUTH_DURATION"] = "5m"
     output, error, status = Open3.capture3(
       [
         File.expand_path("../../../../shared/build_manifest.sh", __FILE__),

--- a/terraform/concourse/elb.tf
+++ b/terraform/concourse/elb.tf
@@ -46,21 +46,11 @@ resource "aws_security_group" "concourse-elb" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-
-  /* FIXME: Merge these two ingress block back together once */
-  /* https://github.com/hashicorp/terraform/issues/5301 is resolved. */
   ingress {
     from_port       = 443
     to_port         = 443
     protocol        = "tcp"
-    cidr_blocks     = ["${compact(split(",", var.admin_cidrs))}"]
-  }
-
-  ingress {
-    from_port       = 443
-    to_port         = 443
-    protocol        = "tcp"
-    cidr_blocks     = ["${aws_eip.concourse.public_ip}/32"]
+    cidr_blocks     = ["${compact(concat(split(",", var.admin_cidrs), list("${aws_eip.concourse.public_ip}/32"), list(var.vagrant_cidr)))}" ]
   }
 
   tags {


### PR DESCRIPTION
## What

[Make it more difficult to run actions manually on Production Concourse](https://www.pivotaltracker.com/n/projects/1275640/stories/130844201)

To make our concourses more distinctive in order to avoid operator accidentally operating on different environments:
* add team with aws account specific name
* set login timeout to 5 minutes on prod

Note that this PR does not migrate the pipelines to the new team yet. We'll implement that later if we see the need.

## How to review

`make dev bootstrap`. Deploy. See team being created. Go to your concourse and try logging in using the new team. Password and user are the same (admin/usual PW). To test 5m timeout, edit pipeline & change the condition to check against 'dev' instead of 'prod' [here](https://github.com/alphagov/paas-cf/commit/6e80e34acc555b151ec3ed836dfd07527a5bc286#diff-5eac5d6fc041d1da10144e10c0fa2ed0R471), upload (`make dev bootstrap`), deploy, log in, wait 5 mins, click somewhere in pipeline (e.g. try to start a job) & be prompted to log in.

## Who can review

you!