### PR TITLE
Improve space usage of concourse cleaner chrome plugin.

### DIFF
--- a/misc/chrome_plugins/clean_concourse_pipeline/src/inject.user.js
+++ b/misc/chrome_plugins/clean_concourse_pipeline/src/inject.user.js
@@ -18,9 +18,16 @@ var readyStateCheckInterval = setInterval(function() {
         var element = document.getElementsByClassName("lower-right-info")[0];
         element.parentNode.removeChild(element);
 
-        var hostname = location.hostname.replace("deployer.", "").replace(".cloudpipeline.digital","")
+        var hostname = location.hostname.replace("deployer.", "").replace(".cloudpipeline.digital","");
 
         var element = document.getElementById("top-bar-app");
         element.innerHTML = "&nbsp;<font size=5>" + hostname + "</font>";
+        // Move it to the bottom because there's more space there.
+        element.style.position = "absolute";
+        element.style.bottom = "0";
+
+        var element = document.getElementsByClassName("bottom")[0];
+        // Remove the padding because the top bar isn't there any more.
+        element.style.paddingTop = "0";
     }
 }, 10);


### PR DESCRIPTION
## What

At present, there's some unnecessary padding at the top of the pipeline
display causing the scrollbars to appear etc.

This cleans thing up by allowing the main content block to use the full
space. As part of this, the enviuronment label has been moved to the
bottom, and floated on top to avoid it conflicting with the actual
pipeline elements - there's generally more room at the bottom of the
screen due to how the pipelines are layed out.

## How to review

* Add the plugin to your browser as described in the [README](../blob/master/misc/chrome_plugins/clean_concourse_pipeline/README.md). 
* Verify that the pipeline displays correctly, and the scrollbars don't appear.

## Who can review

Anyone but myself.