### PR TITLE
[#131377245] Add consul checks

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -34,7 +34,7 @@ releases:
     url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=12.6
     sha1: 8ffc7b9bfee004464bc8a81c322db7160dd7440f
   - name: datadog-for-cloudfoundry
-    version: "0.0.4"
+    version: "0.0.5"
 
 stemcells:
   - alias: default

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -8,6 +8,8 @@ meta:
   api_templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
+  - name: datadog-consul
+    release: datadog-for-cloudfoundry
   - name: cloud_controller_ng
     release: (( grab meta.release.name ))
   - name: statsd-injector
@@ -34,22 +36,30 @@ meta:
   api_worker_templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
+  - name: datadog-consul
+    release: datadog-for-cloudfoundry
   - name: cloud_controller_worker
     release: (( grab meta.release.name ))
 
   clock_templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
+  - name: datadog-consul
+    release: datadog-for-cloudfoundry
   - name: cloud_controller_clock
     release: (( grab meta.release.name ))
 
   consul_templates:
   - name: consul_agent
     release: (( grab meta.release.name ))
+  - name: datadog-consul
+    release: datadog-for-cloudfoundry
 
   etcd_templates:
   - name: consul_agent
     release: (( grab meta.release.name ))
+  - name: datadog-consul
+    release: datadog-for-cloudfoundry
   - name: etcd
     release: etcd
   - name: etcd_metrics_server
@@ -58,6 +68,8 @@ meta:
   loggregator_templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
+  - name: datadog-consul
+    release: datadog-for-cloudfoundry
   - name: doppler
     release: (( grab meta.release.name ))
   - name: syslog_drain_binder
@@ -66,12 +78,16 @@ meta:
   loggregator_trafficcontroller_templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
+  - name: datadog-consul
+    release: datadog-for-cloudfoundry
   - name: loggregator_trafficcontroller
     release: (( grab meta.release.name ))
 
   nats_templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
+  - name: datadog-consul
+    release: datadog-for-cloudfoundry
   - name: nats
     release: (( grab meta.release.name ))
   - name: nats_stream_forwarder
@@ -82,6 +98,8 @@ meta:
   router_templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
+  - name: datadog-consul
+    release: datadog-for-cloudfoundry
   - name: gorouter
     release: routing
   - name: haproxy
@@ -92,6 +110,8 @@ meta:
   uaa_templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
+  - name: datadog-consul
+    release: datadog-for-cloudfoundry
   - name: uaa
     release: uaa
   - name: statsd-injector
@@ -166,6 +186,8 @@ jobs:
     templates:
       - name: consul_agent
         release: cf
+      - name: datadog-consul
+        release: datadog-for-cloudfoundry
       - name: bbs
         release: diego
     instances: 2
@@ -287,6 +309,8 @@ jobs:
     templates:
       - name: consul_agent
         release: cf
+      - name: datadog-consul
+        release: datadog-for-cloudfoundry
       - name: auctioneer
         release: diego
     instances: 2
@@ -304,6 +328,8 @@ jobs:
     templates:
       - name: consul_agent
         release: cf
+      - name: datadog-consul
+        release: datadog-for-cloudfoundry
       - name: rep
         release: diego
       - name: garden
@@ -325,6 +351,8 @@ jobs:
     templates:
       - name: consul_agent
         release: cf
+      - name: datadog-consul
+        release: datadog-for-cloudfoundry
       - name: stager
         release: cf
       - name: nsync
@@ -348,6 +376,8 @@ jobs:
     templates:
       - name: consul_agent
         release: cf
+      - name: datadog-consul
+        release: datadog-for-cloudfoundry
       - name: route_emitter
         release: diego
     instances: 2
@@ -365,6 +395,8 @@ jobs:
     templates:
       - name: consul_agent
         release: cf
+      - name: datadog-consul
+        release: datadog-for-cloudfoundry
       - name: ssh_proxy
         release: diego
       - name: file_server

--- a/manifests/cf-manifest/manifest/040-graphite.yml
+++ b/manifests/cf-manifest/manifest/040-graphite.yml
@@ -2,6 +2,8 @@ meta:
   graphite_templates:
     - name: consul_agent
       release: (( grab meta.consul_templates.consul_agent.release ))
+    - name: datadog-consul
+      release: datadog-for-cloudfoundry
     - name: carbon
       release: graphite
     - name: graphite-web

--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -30,6 +30,8 @@ jobs:
     templates:
       - name: consul_agent
         release: (( grab meta.consul_templates.consul_agent.release ))
+      - name: datadog-consul
+        release: datadog-for-cloudfoundry
       - name: rds-broker
         release: aws-broker
     networks:

--- a/manifests/cf-manifest/manifest/800-logsearch.yml
+++ b/manifests/cf-manifest/manifest/800-logsearch.yml
@@ -14,6 +14,8 @@ jobs:
   templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
+  - name: datadog-consul
+    release: datadog-for-cloudfoundry
   - name: queue
     release: logsearch
   vm_type: small
@@ -36,6 +38,8 @@ jobs:
   templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
+  - name: datadog-consul
+    release: datadog-for-cloudfoundry
   - name: parser
     release: logsearch
   - name: logsearch-for-cloudfoundry-filters
@@ -64,6 +68,8 @@ jobs:
   templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
+  - name: datadog-consul
+    release: datadog-for-cloudfoundry
   - name: parser
     release: logsearch
   - name: logsearch-for-cloudfoundry-filters
@@ -92,6 +98,8 @@ jobs:
   templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
+  - name: datadog-consul
+    release: datadog-for-cloudfoundry
   - name: elasticsearch
     release: logsearch
   vm_type: elasticsearch_master
@@ -123,6 +131,8 @@ jobs:
   templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
+  - name: datadog-consul
+    release: datadog-for-cloudfoundry
   - name: elasticsearch_config
     release: logsearch
   - name: curator
@@ -147,6 +157,8 @@ jobs:
   templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
+  - name: datadog-consul
+    release: datadog-for-cloudfoundry
   - name: kibana
     release: logsearch
   vm_type: kibana
@@ -165,6 +177,8 @@ jobs:
   templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
+  - name: datadog-consul
+    release: datadog-for-cloudfoundry
   - name: ingestor_syslog
     release: logsearch
   - name: ingestor_relp
@@ -192,6 +206,8 @@ jobs:
   templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
+  - name: datadog-consul
+    release: datadog-for-cloudfoundry
   - name: ingestor_syslog
     release: logsearch
   - name: ingestor_relp

--- a/manifests/cf-manifest/stubs/datadog-nozzle.yml
+++ b/manifests/cf-manifest/stubs/datadog-nozzle.yml
@@ -10,6 +10,8 @@ jobs:
   templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
+  - name: datadog-consul
+    release: datadog-for-cloudfoundry
   - name: datadog-firehose-nozzle
     release: datadog-firehose-nozzle
     properties:

--- a/terraform/datadog/consul.tf
+++ b/terraform/datadog/consul.tf
@@ -1,0 +1,40 @@
+resource "datadog_monitor" "consul" {
+  name = "${format("%s Consul hosts", var.env)}"
+  type = "service check"
+  message = "Missing consul hosts in environment {{host.environment}}. Notify: @the-multi-cloud-paas-team@digital.cabinet-office.gov.uk"
+  escalation_message = "Missing consul hosts! Check VM state."
+  no_data_timeframe = "2"
+  query = "${format("'process.up'.over('environment:%s','process:consul').last(6).count_by_status()", var.env)}"
+
+  thresholds {
+    ok = 1
+    warning = 3
+    critical = 5
+  }
+
+  require_full_window = true
+  tags {
+    "environment" = "${var.env}"
+    "job" = "consul"
+  }
+}
+
+resource "datadog_monitor" "consul_connect_to_port" {
+  name = "${format("%s consul cluster service is accepting connections", var.env)}"
+  type = "service check"
+  message = "Large portion of consul service are not accepting connections. Check deployment state."
+  escalation_message = "Large portion of consul service are still not accepting connections. Check deployment state."
+  no_data_timeframe = "5"
+  require_full_window = true
+
+  query = "${format("'tcp.can_connect'.over('environment:%s','instance:consul_server').by('*').last(1).pct_by_status()", var.env)}"
+
+  thresholds {
+    critical = 50
+  }
+
+  tags {
+    "environment" = "${var.env}"
+    "job" = "router"
+  }
+}


### PR DESCRIPTION
## What

Story: [Check Consul cluster and agents](https://www.pivotaltracker.com/story/show/131377245)

This covers the most critical:

* Consul process
* Consul server

It depends on PR https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/5

## How to review
* Deploy with `ENABLE_DATADOG=true`
* Verify the Consul monitors have been created in Datadog
* Connect to a Consul host, stop or kill Consul processes, stop datadog agent... and check the monitors are failing

## How to merge
* When ready, merge PR https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/5
* Create and push tag `0.0.5` on `paas-datadog-for-cloudfoundry-boshrelease` master
* Remove commit 2a99f98d36b82ac4835cc7ed0ac1e8cdc486d6cb in this branch
* Merge this PR

## Who can review
Not @combor or @paroxp