### PR TITLE
[#132170169] Configure apex domain to serve HSTS preload headers

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -118,7 +118,7 @@ properties:
       port: 80
     additional_frontend_config: |
       capture response header strict-transport-security len 128
-      http-response add-header Strict-Transport-Security max-age=31536000 unless { capture.res.hdr(0) -m found }
+      http-response add-header Strict-Transport-Security max-age=31536000;\ includeSubDomains;\ preload unless { capture.res.hdr(0) -m found }
     enable_healthcheck_frontend: true
 
   router:

--- a/terraform/cloudfoundry/dns-records.tf
+++ b/terraform/cloudfoundry/dns-records.tf
@@ -54,6 +54,18 @@ resource "aws_route53_record" "apps_wildcard" {
   records = ["${aws_elb.cf_router.dns_name}"]
 }
 
+resource "aws_route53_record" "apps_apex" {
+  zone_id = "${var.apps_dns_zone_id}"
+  name = "${var.apps_dns_zone_name}."
+  type = "A"
+
+  alias {
+    name = "${aws_elb.cf_router.dns_name}"
+    zone_id = "${aws_elb.cf_router.zone_id}"
+    evaluate_target_health = true
+  }
+}
+
 resource "aws_route53_record" "metrics" {
   zone_id = "${var.system_dns_zone_id}"
   name = "metrics.${var.system_dns_zone_name}."


### PR DESCRIPTION
## What

Story: [Fix credential leakage in aws-account-wide-terraform](https://www.pivotaltracker.com/story/show/132170169) 

We want to stop using the AWS API Gateway as it introduced the need to use the `aws_api_gateway_domain_name` resource in Terraform, which does not obfuscate sensitive fields, such as the certificate private key. However, we still need to serve valid HSTS headers from the apex domain (`cloudapps.digital`). We add the necessary HSTS header directives to the existing HSTS configuration in the manifest.

## How to review

To be reviewed in conjunction with https://github.gds/government-paas/aws-account-wide-terraform/pull/63, which must be deployed to staging and production first.
* Deploy from this branch
* Use `curl` to get the headers for the healthcheck application and the apex domain:
    ```
    $ curl -i https://healthcheck.colin-sept.dev.cloudpipelineapps.digital -k
    HTTP/1.1 200 OK
    ...
    Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
    
    $ curl -i https://colin-sept.dev.cloudpipelineapps.digital -k
    HTTP/1.1 404 Not Found
    ...
    Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
    ```
* Make sure the custom acceptance tests pass

## Who can review

Anyone but me or @saliceti 