### PR TITLE
[#127564379] Upgrade Logsearch to v203

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1483,6 +1483,30 @@ jobs:
           - get: datadog-tfstate
 
       - aggregate:
+        - task: extract-cf-terraform-outputs
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: ruby
+                tag: 2.2-slim
+            inputs:
+              - name: paas-cf
+              - name: cf-tfstate
+            outputs:
+              - name: cf-terraform-outputs
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  SCPATH="./paas-cf/concourse/scripts"
+                  SCFILE="extract_tf_vars_from_terraform_state.rb"
+                  $SCPATH/$SCFILE < cf-tfstate/cf.tfstate > cf-terraform-outputs/cf.tfstate.sh
+                  ls -l cf-terraform-outputs/cf.tfstate.sh
+
         - task: upload-releases
           config:
             platform: linux
@@ -1859,6 +1883,30 @@ jobs:
                 ES_HOST=$(ruby "${SCRIPT_DIR}/val_from_yaml.rb" terraform_outputs.logsearch_elastic_master_elb_dns_name cf-tfstate.yaml)
                 export ES_PORT="9200"
                 ruby "${SCRIPT_DIR}/kibana_set_utc.rb"
+
+        - task: enable-elasticsearch-shard-reallocation
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/curl-ssl
+            inputs:
+            - name: paas-cf
+            - name: cf-terraform-outputs
+            run:
+              path: sh
+              args:
+              - -e
+              - -c
+              - |
+                export TF_VAR_logsearch_elastic_master_elb_dns_name
+                . cf-terraform-outputs/cf.tfstate.sh
+
+                curl -s \
+                  -X PUT \
+                  -d '{"transient":{"cluster.routing.allocation.enable":"all"}}' \
+                  "${TF_VAR_logsearch_elastic_master_elb_dns_name}:9200/_cluster/settings"
 
         - task: datadog-terraform-apply
           config:

--- a/concourse/scripts/kibana_set_utc.rb
+++ b/concourse/scripts/kibana_set_utc.rb
@@ -4,7 +4,7 @@ require 'net/http'
 require 'json'
 
 def config_uri(es_url)
-  config_url = "#{es_url}/.kibana/config/4.3.1"
+  config_url = "#{es_url}/.kibana/config/4.4.0"
   URI(config_url)
 end
 

--- a/concourse/scripts/kibana_set_utc_test.go
+++ b/concourse/scripts/kibana_set_utc_test.go
@@ -26,7 +26,7 @@ type ConfigSource struct {
 
 var _ = Describe("KibanaSetUtc", func() {
 	const (
-		KibanaConfigPath = "/.kibana/config/4.3.1"
+		KibanaConfigPath = "/.kibana/config/4.4.0"
 		KibanaIndexPath  = "/.kibana"
 	)
 

--- a/manifests/cf-manifest/manifest/800-logsearch.yml
+++ b/manifests/cf-manifest/manifest/800-logsearch.yml
@@ -1,8 +1,8 @@
 releases:
 - name: logsearch
-  url: https://bosh.io/d/github.com/logsearch/logsearch-boshrelease?v=200.0.0
-  version: 200.0.0
-  sha1: 527c35db31cd66810accf128ceffee4f5fde80c3
+  url: https://bosh.io/d/github.com/logsearch/logsearch-boshrelease?v=203.0.0
+  version: 203.0.0
+  sha1: 4872c3d89fb2587d844dabbc93b124fb43b720d8
 - name: logsearch-for-cloudfoundry
   version: v203.0.0-gds
 
@@ -53,7 +53,7 @@ jobs:
     logstash: (( grab properties.parser_logstash ))
     logstash_parser:
       filters:
-      - /var/vcap/packages/logsearch-for-cloudfoundry-filters/logstash-filters-default.conf
+        - logstash: /var/vcap/packages/logsearch-for-cloudfoundry-filters/logstash-filters-default.conf
     tags:
       job: parser_z1
       tags: (( inject meta.datadog_tags ))
@@ -81,7 +81,7 @@ jobs:
     logstash: (( grab properties.parser_logstash ))
     logstash_parser:
       filters:
-      - /var/vcap/packages/logsearch-for-cloudfoundry-filters/logstash-filters-default.conf
+        - logstash: /var/vcap/packages/logsearch-for-cloudfoundry-filters/logstash-filters-default.conf
     tags:
       job: parser_z2
       tags: (( inject meta.datadog_tags ))
@@ -148,8 +148,6 @@ jobs:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
   - name: kibana
-    release: logsearch
-  - name: haproxy
     release: logsearch
   vm_type: kibana
   stemcell: default
@@ -225,16 +223,15 @@ properties:
       elasticsearch:
         data_hosts: (( grab properties.elasticsearch.master_hosts ))
   curator:
-    elasticsearch_host: (( grab terraform_outputs.logsearch_elastic_master_elb_dns_name ))
+    elasticsearch:
+      host: (( grab terraform_outputs.logsearch_elastic_master_elb_dns_name ))
   elasticsearch:
     master_hosts: (( grab jobs.elasticsearch_master.networks.cf.static_ips[0] jobs.elasticsearch_master.networks.cf.static_ips[1] jobs.elasticsearch_master.networks.cf.static_ips[2] ))
     cluster_name: logsearch
   kibana:
-    elasticsearch: (( concat terraform_outputs.logsearch_elastic_master_elb_dns_name ":9200" ))
-  haproxy:
-    inbound_port: 5602
-    backend_servers: ["localhost"]
-    backend_port: 5601
+    elasticsearch:
+      host: (( grab terraform_outputs.logsearch_elastic_master_elb_dns_name ))
+      port: 9200
   elasticsearch_config:
     elasticsearch:
       host: (( grab terraform_outputs.logsearch_elastic_master_elb_dns_name ))

--- a/manifests/cf-manifest/manifest/800-logsearch.yml
+++ b/manifests/cf-manifest/manifest/800-logsearch.yml
@@ -40,7 +40,7 @@ jobs:
     release: logsearch
   - name: logsearch-for-cloudfoundry-filters
     release: logsearch-for-cloudfoundry
-  vm_type: medium
+  vm_type: small
   stemcell: default
   instances: 1
   networks:
@@ -68,7 +68,7 @@ jobs:
     release: logsearch
   - name: logsearch-for-cloudfoundry-filters
     release: logsearch-for-cloudfoundry
-  vm_type: medium
+  vm_type: small
   stemcell: default
   instances: 1
   networks:

--- a/terraform/cloudfoundry/logsearch_elb.tf
+++ b/terraform/cloudfoundry/logsearch_elb.tf
@@ -64,7 +64,7 @@ resource "aws_elb" "logsearch_kibana" {
   ]
 
   health_check {
-    target = "TCP:5602"
+    target = "TCP:5601"
     interval = "${var.health_check_interval}"
     timeout = "${var.health_check_timeout}"
     healthy_threshold = "${var.health_check_healthy}"
@@ -72,7 +72,7 @@ resource "aws_elb" "logsearch_kibana" {
   }
 
   listener {
-    instance_port = 5602
+    instance_port = 5601
     instance_protocol = "tcp"
     lb_port = 443
     lb_protocol = "ssl"


### PR DESCRIPTION
## What

This is the minimal set of changes needed to upgrade our existing Logsearch install from v200 to v203. We took the approach of modifying our existing manifests to accommodate upstream changes rather than outright replacing them because we have previously heavily customised the Logsearch install to make it highly available.

Notable things:

* We no longer install HAProxy on the Kibana VM as it was totally unnecessary in our deployment with ELB's. As a result we needed to change the Kibana ELB port to correctly address Kibana itself rather than the HAProxy port.

* There may be a better way to set the Kibana timezone, however we chose not to implement it. Future versions of us may wish to look at: https://github.com/alphagov/paas-logsearch-for-cloudfoundry/blob/master/src/logsearch-config/src/es-mappings/logs-template.json.erb

* The drain/undrain process has totally changed in the new version of Logsearch and requires the administrator to re-enable shard reallocation after the upgrade, as the drain script disables it cluster-wide. An errand is shipped with Logsearch for this purpose, however we chose to simply duplicate it's single `curl` command in our pipeline for performance reasons - errands spin up a VM to run the command.

* We duplicate the Terraform state extraction as we can't reuse it from other jobs. We would simply extract the needed state as part of the new `curl` task, however we do not have a container available that both has `curl` and `ruby` available. This is ridiculous, and we should be refactoring our Terraform state extraction to be centralised and performed after each Terraform run.

* We needed to recreate the Parser VM's in all environments as the previous Logsearch deployment (v200) also deployed an Elasticsearch node on all the Parsers running as a client. It has been removed in the new version of Logsearch (v203) but Bosh will not remove the old Elasticsearch nodes, or upgrade them. The parser machines were oversized for their load, so we simply shrank them to `small` instances which will cause them to be recreated in all
environments.

## How to review

1. Deploy this branch in an existing environment.
2. Observe that the `parser` instances are recreated.
3. Visit `https://logsearch.$DEPLOY_ENV.dev.cloudpipeline.digital`, check that logs are still being received, and that no existing log data has been lost.
4. Visit `https://logsearch.$DEPLOY_ENV.dev.cloudpipeline.digital/app/kibana#/settings/about`, check that the kibana version is `4.4.0`.
5. `make dev bosh-cli` / `bosh ssh elasticsearch_master/0` / `curl http://localhost:9200` and check the version number outputted is `2.2.0`:
```
bosh_ewj1z4ls0@b90ea467-bcee-4849-bf05-5cef5de11d38:~$ curl http://localhost:9200
{
  "name" : "elasticsearch_master/0",
  "cluster_name" : "logsearch",
  "version" : {
    "number" : "2.2.0",
    "build_hash" : "8ff36d139e16f8720f2947ef62c8167a888992fe",
    "build_timestamp" : "2016-01-27T13:32:39Z",
    "build_snapshot" : false,
    "lucene_version" : "5.4.1"
  },
  "tagline" : "You Know, for Search"
}
```

🎉 

## Who can review

Not @benhyland or @jonty.
