### PR TITLE
[#119717141] BOSH version bump

### DIFF
--- a/manifests/bosh-manifest/deployments/010-bosh-template.yml
+++ b/manifests/bosh-manifest/deployments/010-bosh-template.yml
@@ -8,8 +8,8 @@ name: (( grab meta.environment ))
 
 releases:
 - name: bosh
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=255.8
-  sha1: 6b12652650b87810dcef1be1f6a6d23f1c0c13a7
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=257.14
+  sha1: b41821dccee78ad7bd44466cd0160920c183787a
 
 disk_pools:
 - name: disks
@@ -21,7 +21,6 @@ jobs:
 
   templates:
   - {name: nats, release: bosh}
-  - {name: redis, release: bosh}
   - {name: director, release: bosh}
   - {name: health_monitor, release: bosh}
 
@@ -42,9 +41,6 @@ jobs:
       address: 127.0.0.1
       user: nats
       password: (( grab secrets.bosh_nats_password ))
-
-    redis:
-      password: (( grab secrets.bosh_redis_password ))
 
     director:
       address: 127.0.0.1

--- a/manifests/bosh-manifest/scripts/generate-bosh-secrets.rb
+++ b/manifests/bosh-manifest/scripts/generate-bosh-secrets.rb
@@ -8,7 +8,6 @@ generator = SecretGenerator.new(
   "bosh_postgres_password" => :simple,
   "bosh_nats_password" => :simple,
   "bosh_registry_password" => :simple,
-  "bosh_redis_password" => :simple,
   "bosh_hm_director_password" => :simple,
   "bosh_admin_password" => :simple,
   "bosh_vcap_password" => :sha512_crypted,

--- a/manifests/bosh-manifest/spec/fixtures/bosh-secrets.yml
+++ b/manifests/bosh-manifest/spec/fixtures/bosh-secrets.yml
@@ -3,7 +3,6 @@ secrets:
   bosh_postgres_password: BOSH_POSTGRES_PASSWORD
   bosh_nats_password: BOSH_NATS_PASSWORD
   bosh_registry_password: BOSH_REGISTRY_PASSWORD
-  bosh_redis_password: BOSH_REDIS_PASSWORD
   bosh_hm_director_password: BOSH_HM_DIRECTOR_PASSWORD
   bosh_admin_password: BOSH_ADMIN_PASSWORD
   bosh_vcap_password: BOSH_VCAP_PASSWORD


### PR DESCRIPTION
## What

Story: https://www.pivotaltracker.com/story/show/119717141

This is BOSH upgrade to the v257.14. Release notes:
https://github.com/cloudfoundry/bosh/releases/tag/stable-3262.14

Apart from [Redis removal](https://github.com/cloudfoundry/bosh/releases/tag/stable-3232) there are no other manifest changes mentioned neither by BOSH release notes nor by CF release notes. 
We bumped the version to the latest stable version as there are no recommendations in cf-release notes. Recommended stemcell version is 3262.X family - we are using 3262.9. 

## How to review

- apply this on top of existing env
- deploy env from scratch
- autodele pipeline
- all should work, no test failures

## Who can review

not @combor or @paroxp 