### PR TITLE
[#132649921] Use patched gorouter with hotfix for logging CVE

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -7,6 +7,10 @@ director_uuid: ~
 releases:
   - name: cf
     data: (( inject meta.cf-releases.cf ))
+  - name: routing
+    version: 0.136.0.gds1
+    url: https://github.com/alphagov/paas-routing-release/releases/download/0.136.0.gds1/routing-0.136.0.gds1.tgz
+    sha1: da9f95958119030ae2a95179c59511c90be8c33e
   - name: diego
     version: 0.1482.0
     url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=0.1482.0

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -83,7 +83,7 @@ meta:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
   - name: gorouter
-    release: (( grab meta.release.name ))
+    release: routing
   - name: haproxy
     release: paas-haproxy
   - name: datadog-router


### PR DESCRIPTION
[#132649921 Respond to CVE 2016-6655: Utility script command injection](https://www.pivotaltracker.com/story/show/132649921)

What?
-----

Use patched version of gorouter v0.136.0-gds1

Temporary fix for CVE 2016-6655 [1]. This is a temporary fix to address the issue for gorouter while we work on upgrading CF.

[1]https://lists.cloudfoundry.org/archives/list/cf-dev@lists.cloudfoundry.org/thread/42YUJU2N27HBPFVMZR2QM7JI6YSEKORR/

How to review
-------------

Deploy it, tests should pass. Check that this command on router/{0,1} does not return a process in the gorouter group:

```
ps -feax | grep -B5 -e "system(lineWithDate)"
```

Who?
---

Anyone but @alext or @keymon