### PR TITLE
No failure-testing pipeline by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,12 @@ be still configured in concourse.
 
 *Note:* `SELF_UPDATE_PIPELINE` is also disabled because enabling it would result in the first run immediately enabling the acceptance tests again.
 
+## Optionally deploy failure-testing pipeline
+
+`failure-testing` is a pipeline created for purpose of resiliency testing of CF components. We don't deploy this pipeline by default to our deployments.
+In case you want to deploy the pipeline, set `ENABLE_FAILURE_TESTING` environment variable to true, e.g.
+`ENABLE_FAILURE_TESTING=true make dev pipelines`.
+
 ## Optionally run specific job in the create-bosh-cloudfoundry pipeline
 
 `create-bosh-cloudfoundry` is our main pipeline. When we are making changes or

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -131,8 +131,15 @@ update_pipeline() {
   pipeline_name=$1
 
   case $pipeline_name in
-    create-bosh-cloudfoundry|failure-testing)
+    create-bosh-cloudfoundry)
       upload_pipeline
+    ;;
+    failure-testing)
+      if [ "${ENABLE_FAILURE_TESTING:-}" = "true" ]; then
+        upload_pipeline
+      else
+        remove_pipeline
+      fi
     ;;
     destroy-*)
       if [ -n "${ENABLE_DESTROY:-}" ]; then

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -49,10 +49,10 @@ prepare_environment() {
   cf_logsearch_for_cloudfoundry_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.logsearch-for-cloudfoundry.version "${cf_manifest_dir}/800-logsearch.yml")
   cf_datadog_for_cloudfoundry_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.datadog-for-cloudfoundry.version "${cf_manifest_dir}/000-base-cf-deployment.yml")
 
-  if [ -z "${SKIP_COMMIT_VERIFICATION:-}" ] ; then
-    gpg_ids="[$(xargs < "${SCRIPT_DIR}/../../.gpg-id" | tr ' ' ',')]"
-  else
+  if [ "${SKIP_COMMIT_VERIFICATION:-}" = "true" ] ; then
     gpg_ids="[]"
+  else
+    gpg_ids="[$(xargs < "${SCRIPT_DIR}/../../.gpg-id" | tr ' ' ',')]"
   fi
 
   download_git_id_rsa
@@ -142,14 +142,14 @@ update_pipeline() {
       fi
     ;;
     destroy-*)
-      if [ -n "${ENABLE_DESTROY:-}" ]; then
+      if [ "${ENABLE_DESTROY:-}" = "true" ]; then
         upload_pipeline
       else
         remove_pipeline
       fi
     ;;
     autodelete-cloudfoundry)
-      if [ -n "${ENABLE_AUTODELETE:-}" ]; then
+      if [ "${ENABLE_AUTODELETE:-}" = "true" ]; then
         upload_pipeline
 
         echo

--- a/concourse/scripts/pipelines-deployer.sh
+++ b/concourse/scripts/pipelines-deployer.sh
@@ -39,10 +39,10 @@ EOF
 generate_vars_file > /dev/null # Check for missing vars
 
 generate_manifest_file() {
-  if [ -z "${SKIP_COMMIT_VERIFICATION:-}" ] ; then
-    gpg_ids="[$(xargs < "${SCRIPT_DIR}/../../.gpg-id" | tr ' ' ',')]"
-  else
+  if [ "${SKIP_COMMIT_VERIFICATION:-}" = "true" ] ; then
     gpg_ids="[]"
+  else
+    gpg_ids="[$(xargs < "${SCRIPT_DIR}/../../.gpg-id" | tr ' ' ',')]"
   fi
 
   # This exists because concourse does not support multiline value interpolation by design


### PR DESCRIPTION
## What

Don't deploy failure-testing pipeline by default. We rarely run this pipeline and
* it consumes concourse resources for version checks
* it is a bit dangerous to be run on prod/staging, but is still present on that concourse...

## How to review

`make dev pipelines`. If you had it uploaded before, observe it being removed. To enable it, follow instructions in readme.

## Who can review

not me