### PR TITLE
Add small and large instance sizes

### DIFF
--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -1,7 +1,39 @@
 meta:
   rds_broker:
+    small_postgres_rds_properties:
+      db_instance_class: "db.t2.small"
+      engine: "postgres"
+      engine_version: "9.5.2"
+      storage_type: "gp2"
+      allocated_storage: 20
+      auto_minor_version_upgrade: true
+      multi_az: false
+      publicly_accessible: false
+      copy_tags_to_snapshot: true
+      skip_final_snapshot: false
+      backup_retention_period: 7
+      db_subnet_group_name: (( grab terraform_outputs.rds_broker_dbs_subnet_group ))
+      vpc_security_group_ids:
+        - (( grab terraform_outputs.rds_broker_dbs_security_group_id ))
+      db_parameter_group_name: (( grab terraform_outputs.rds_broker_postgres95_db_parameter_group ))
     medium_postgres_rds_properties:
       db_instance_class: "db.m4.large"
+      engine: "postgres"
+      engine_version: "9.5.2"
+      storage_type: "gp2"
+      allocated_storage: 20
+      auto_minor_version_upgrade: true
+      multi_az: false
+      publicly_accessible: false
+      copy_tags_to_snapshot: true
+      skip_final_snapshot: false
+      backup_retention_period: 7
+      db_subnet_group_name: (( grab terraform_outputs.rds_broker_dbs_subnet_group ))
+      vpc_security_group_ids:
+        - (( grab terraform_outputs.rds_broker_dbs_security_group_id ))
+      db_parameter_group_name: (( grab terraform_outputs.rds_broker_postgres95_db_parameter_group ))
+    large_postgres_rds_properties:
+      db_instance_class: "db.m4.2xlarge"
       engine: "postgres"
       engine_version: "9.5.2"
       storage_type: "gp2"
@@ -67,9 +99,40 @@ jobs:
                 supportUrl: "https://forums.aws.amazon.com/forum.jspa?forumID=60"
               plan_updateable: true
               plans:
+                - id: "b7d0a368-ac92-4eff-9b8d-ab4ba45bed0e"
+                  name: "S-dedicated-9.5"
+                  description: "20GB Storage, Dedicated Instance, Max 200 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t2.small."
+                  free: false
+                  metadata:
+                    costs:
+                      - amount:
+                          usd: 0.039
+                        unit: "HOUR"
+                    bullets:
+                      - "Dedicated Postgres 9.5 server"
+                      - "AWS RDS"
+                  rds_properties:
+                    inject: (( inject meta.rds_broker.small_postgres_rds_properties ))
+
+                - id: "359bcb39-0264-46bd-9120-0182c3829067"
+                  name: "S-HA-dedicated-9.5"
+                  description: "20GB Storage, Dedicated Instance, Highly Available, Max 200 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t2.small."
+                  free: false
+                  metadata:
+                    costs:
+                      - amount:
+                          usd: 0.078
+                        unit: "HOUR"
+                    bullets:
+                      - "Dedicated Postgres 9.5 server"
+                      - "AWS RDS"
+                  rds_properties:
+                    inject: (( inject meta.rds_broker.small_postgres_rds_properties ))
+                    multi_az: true
+
                 - id: "9b882524-ab58-4c18-b501-d2a3f4619104"
                   name: "M-dedicated-9.5"
-                  description: "20GB Storage, Dedicated Instance, Max 500 Concurrent Connections. Postgres Version 9.5"
+                  description: "20GB Storage, Dedicated Instance, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.large."
                   free: false
                   metadata:
                     costs:
@@ -84,7 +147,7 @@ jobs:
 
                 - id: "bf5b99c2-7990-4b66-b341-1bb83566d76e"
                   name: "M-HA-dedicated-9.5"
-                  description: "20GB Storage, Dedicated Instance, Highly Available, Max 500 Concurrent Connections. Postgres Version 9.5"
+                  description: "20GB Storage, Dedicated Instance, Highly Available, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.large."
                   free: false
                   metadata:
                     costs:
@@ -98,6 +161,36 @@ jobs:
                     inject: (( inject meta.rds_broker.medium_postgres_rds_properties ))
                     multi_az: true
 
+                - id: "238a1328-4f77-4b70-9bd9-2cdbbfb999c8"
+                  name: "L-dedicated-9.5"
+                  description: "20GB Storage, Dedicated Instance, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.2xlarge."
+                  free: false
+                  metadata:
+                    costs:
+                      - amount:
+                          usd: 0.806
+                        unit: "HOUR"
+                    bullets:
+                      - "Dedicated Postgres 9.5 server"
+                      - "AWS RDS"
+                  rds_properties:
+                    inject: (( inject meta.rds_broker.large_postgres_rds_properties ))
+
+                - id: "dfe4ab2b-2069-41a5-ba08-2be21b0c76d3"
+                  name: "L-HA-dedicated-9.5"
+                  description: "20GB Storage, Dedicated Instance, Highly Available, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.2xlarge."
+                  free: false
+                  metadata:
+                    costs:
+                      - amount:
+                          usd: 1.612
+                        unit: "HOUR"
+                    bullets:
+                      - "Dedicated Postgres 9.5 server"
+                      - "AWS RDS"
+                  rds_properties:
+                    inject: (( inject meta.rds_broker.large_postgres_rds_properties ))
+                    multi_az: true
 properties:
   cc:
     security_group_definitions:

--- a/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
@@ -73,9 +73,9 @@ RSpec.describe "RDS broker properties" do
       let(:pg_service) { services.find { |s| s["name"] == "postgres" } }
       let(:pg_plans) { pg_service.fetch("plans") }
 
-      it "contains only M-dedicated-9.5 and M-HA-dedicated-9.5 plans" do
+      it "contains only specific plans" do
         pg_plan_names = pg_plans.map { |p| p["name"] }
-        expect(pg_plan_names).to contain_exactly("M-dedicated-9.5", "M-HA-dedicated-9.5")
+        expect(pg_plan_names).to contain_exactly("S-dedicated-9.5", "S-HA-dedicated-9.5", "M-dedicated-9.5", "M-HA-dedicated-9.5", "L-dedicated-9.5", "L-HA-dedicated-9.5")
       end
 
       describe "plan rds_properties" do

--- a/platform-tests/src/acceptance/rds_broker_test.go
+++ b/platform-tests/src/acceptance/rds_broker_test.go
@@ -39,8 +39,12 @@ var _ = Describe("RDS broker", func() {
 	It("has the expected plans available", func() {
 		plans := cf.Cf("marketplace", "-s", serviceName).Wait(DEFAULT_TIMEOUT)
 		Expect(plans).To(Exit(0))
-		Expect(plans).To(Say("M-dedicated-9.5"))
-		Expect(plans).To(Say("M-HA-dedicated-9.5"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("S-dedicated-9.5"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("S-HA-dedicated-9.5"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("M-dedicated-9.5"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("M-HA-dedicated-9.5"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("L-dedicated-9.5"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("L-HA-dedicated-9.5"))
 	})
 
 	Context("creating a database instance with default settings", func() {


### PR DESCRIPTION
# Provide additional Postgres instance sizes to tenants
[Pivotal story](https://www.pivotaltracker.com/story/show/128397007)

## What

In order to meet user needs, we'd like to allow them to have a choice of
two additional RDS Postgres instance sizes.

We've added the `db.t2.small` and `db.m4.2xlarge`, along with
appropriate description and metadata. Extended and amended two sets of
tests, in order to cover the new instance choices.

We have also covered a common request of mentioning the actual instance
name, in the description.

## How to review

  - Deploy the changes
  - Run `cf marketplace -s postgres`
    - You should see, four additional plans, `S-dedicated-9.5` and `L-dedicated-9.5` along, with their HA version.
  - Attempt to create one of the new instances.
  - Check if the correct instance has been initialised.

## Who can review

Neither @paroxp nor @Jonty 
