### PR TITLE
Run bosh cleanup after deploy

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1908,6 +1908,26 @@ jobs:
                   -d '{"transient":{"cluster.routing.allocation.enable":"all"}}' \
                   "${TF_VAR_logsearch_elastic_master_elb_dns_name}:9200/_cluster/settings"
 
+        - task: run-bosh-cleanup
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/bosh-cli
+            inputs:
+              - name: paas-cf
+              - name: bosh-secrets
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  ./paas-cf/concourse/scripts/bosh_login.sh {{bosh_fqdn}} bosh-secrets/bosh-secrets.yml
+  
+                  bosh cleanup --all
+
         - task: datadog-terraform-apply
           config:
             platform: linux


### PR DESCRIPTION
## What

This way we can remove previous releases/packages/stemcells immediately after they stop being used. This is also important for long running environments where we would not run cleanup otherwise and only accumulate previous versions forever, which can also potentially impact BOSH performance and reliability.

## How to review

Apply this PR. Run deploy job. Observe it running bosh cleanup task.

## Who can review

not @mtekel