### PR TITLE
[#132909443] Upgrade to stemcell 3262.x to fix CVE-2016-5195

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -35,7 +35,7 @@ releases:
 stemcells:
   - alias: default
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3262.9"
+    version: "3262.22"
 
 update:
   canaries: 0


### PR DESCRIPTION
[#132909443 Respond to CVE-2016-5195 kernel vulnerabilty](https://www.pivotaltracker.com/story/show/132909443)

What
-----

We want to upgrade to a newer stemcell which includes the patch for CVE-2016-5195 [1]. The CF bosh team has recently release a patched version of the stemcell[2], despite being reticent at the beginning

[1] http://dirtycow.ninja/
[2] https://cloudfoundry.slack.com/archives/bosh/p1477113219004741


How to test
-----------

Deploy this branch, should deploy and pass the tests.

References
----------

Related code in #559 and #557, but they are not dependencies.

If #557 is merge, we should rebase, ofc

Who?
---

Anyone but @keymon