### PR TITLE
[#133085655] Faster dev pipeline execution - no locking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ staging: globals check-env-vars ## Set Environment to Staging
 	$(eval export ALERT_EMAIL_ADDRESS=the-multi-cloud-paas-team+staging@digital.cabinet-office.gov.uk)
 	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS=${ALERT_EMAIL_ADDRESS})
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-default.yml)
-	$(eval export ENABLE_CF_ACCEPTANCE_TESTS=false)
+	$(eval export DISABLE_CF_ACCEPTANCE_TESTS=true)
 	$(eval export ENABLE_DATADOG=true)
 	$(eval export DECRYPT_CONCOURSE_ATC_PASSWORD=staging_deployment)
 	@true
@@ -144,7 +144,7 @@ prod: globals check-env-vars ## Set Environment to Production
 	$(eval export ALERT_EMAIL_ADDRESS=the-multi-cloud-paas-team+prod@digital.cabinet-office.gov.uk)
 	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS=${ALERT_EMAIL_ADDRESS})
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-prod.yml)
-	$(eval export ENABLE_CF_ACCEPTANCE_TESTS=false)
+	$(eval export DISABLE_CF_ACCEPTANCE_TESTS=true)
 	$(eval export ENABLE_DATADOG=true)
 	$(eval export DECRYPT_CONCOURSE_ATC_PASSWORD=prod_deployment)
 	@true

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ dev: globals check-env-vars ## Set Environment to DEV
 	$(eval export DISABLE_HEALTHCHECK_DB=true)
 	$(eval export ENABLE_DATADOG ?= false)
 	$(eval export CONCOURSE_AUTH_DURATION=48h)
+	$(eval export DISABLE_PIPELINE_LOCKING=true)
 	@true
 
 .PHONY: ci

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ dev: globals check-env-vars ## Set Environment to DEV
 	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipelineapps.digital)
 	$(eval export SKIP_COMMIT_VERIFICATION=true)
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-default.yml)
-	$(eval export ENABLE_HEALTHCHECK_DB=false)
+	$(eval export DISABLE_HEALTHCHECK_DB=true)
 	$(eval export ENABLE_DATADOG ?= false)
 	$(eval export CONCOURSE_AUTH_DURATION=48h)
 	@true

--- a/README.md
+++ b/README.md
@@ -249,6 +249,16 @@ This will only disable the execution of the test, but the job will be still conf
 
 *Note:* `SELF_UPDATE_PIPELINE` is also disabled because enabling it would result in the first run reverting to default, which is to run the tests.
 
+## Optionally disable pipeline locking
+
+Pipeline locking is turned on by default to prevent jobs in the pipeline run while previous changes are still being applied. You can optionally
+disable this by setting the environment variable `DISABLE_PIPELINE_LOCKING=true`. This is default in dev to speed up pipeline execution.
+
+```
+DISABLE_PIPELINE_LOCKING=true SELF_UPDATE_PIPELINE=false make dev pipelines
+```
+
+Self update pipeline has to be disabled, otherwise it would revert to default value in the pipeline and unlock job would fail since pipeline was not locked before it self updated.
 
 ## Optionally deploy failure-testing pipeline
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,20 @@ be still configured in concourse.
 
 *Note:* `SELF_UPDATE_PIPELINE` is also disabled because enabling it would result in the first run immediately enabling the acceptance tests again.
 
+## Optionally disable run of custom acceptance tests
+
+Custom acceptance tests can be optionally disabled by setting the environment
+variable `DISABLE_CUSTOM_ACCEPTANCE_TESTS=true`.
+
+```
+DISABLE_CUSTOM_ACCEPTANCE_TESTS=true SELF_UPDATE_PIPELINE=false make dev pipelines
+```
+
+This will only disable the execution of the test, but the job will be still configured in concourse.
+
+*Note:* `SELF_UPDATE_PIPELINE` is also disabled because enabling it would result in the first run reverting to default, which is to run the tests.
+
+
 ## Optionally deploy failure-testing pipeline
 
 `failure-testing` is a pipeline created for purpose of resiliency testing of CF components. We don't deploy this pipeline by default to our deployments.

--- a/README.md
+++ b/README.md
@@ -225,13 +225,12 @@ See [doc/non_dev_deployments.md](doc/non_dev_deployments.md).
 ## Optionally disable run of acceptance tests
 
 Acceptance tests can be optionally disabled by setting the environment
-variable `ENABLE_CF_ACCEPTANCE_TESTS=false`.
+variable `DISABLE_CF_ACCEPTANCE_TESTS=true`. This is default in staging and prod.
 
 ```
-ENABLE_CF_ACCEPTANCE_TESTS=false SELF_UPDATE_PIPELINE=false make dev pipelines
+DISABLE_CF_ACCEPTANCE_TESTS=true SELF_UPDATE_PIPELINE=false make dev pipelines
 ```
 
-It is enabled in all the environments except in `staging` and `prod`.
 This will only disable the execution of the test, but the job will
 be still configured in concourse.
 

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -349,12 +349,17 @@ jobs:
           params:
             DEPLOY_ENV: {{deploy_env}}
             AWS_ACCOUNT: {{aws_account}}
+            DISABLE_PIPELINE_LOCKING: {{disable_pipeline_locking}}
           run:
             path: sh
             args:
             - -e
             - -c
             - |
+              if [ "${DISABLE_PIPELINE_LOCKING:-}" = "true" ] ; then
+                 echo "Pipeline locking is disabled, skipping..."
+                 exit 0
+              fi
               chmod 600 git-ssh-private-key/git_id_rsa
               git config --global push.default simple
               git config --global user.email "concourse@${DEPLOY_ENV}.${AWS_ACCOUNT}"
@@ -364,9 +369,35 @@ jobs:
                 {{git_concourse_pool_clone_full_url_ssh}} \
                 $(pwd)/git-ssh-private-key/git_id_rsa \
                 {{pipeline_name}} lock
-      - put: pipeline-pool
-        params:
-          claim: lock
+
+      - try:
+          task: lock-the-pipeline
+          config:
+            image_resource:
+              type: docker-image
+              source:
+                repository: alpine
+                tag: "3.4"
+            platform: linux
+            params:
+              DISABLE_PIPELINE_LOCKING: {{disable_pipeline_locking}}
+            run:
+              path: sh
+              args:
+              - -e
+              - -c
+              - |
+                if [ "${DISABLE_PIPELINE_LOCKING:-}" = "true" ] ; then
+                   echo "Pipeline locking is disabled, skipping..."
+                   exit 0
+                fi
+                echo "About to lock. This job will fail and this is OK."
+                exit 1
+          on_failure:
+            put: pipeline-pool
+            params:
+              claim: lock
+
       - task: self-update-pipeline
         config:
           platform: linux
@@ -2441,9 +2472,31 @@ jobs:
                     }" \
                   "https://app.datadoghq.com/api/v1/series?api_key=${DATADOG_API_KEY}"
               fi
-      - put: pipeline-pool
-        params:
-          release: pipeline-pool
+      - try:
+          task: unlock-the-pipeline
+          config:
+            image_resource:
+              type: docker-image
+              source:
+                repository: alpine
+                tag: "3.4"
+            platform: linux
+            params:
+              DISABLE_PIPELINE_LOCKING: {{disable_pipeline_locking}}
+            run:
+              path: sh
+              args:
+              - -e
+              - -c
+              - |
+                if [ "${DISABLE_PIPELINE_LOCKING:-}" = "true" ] ; then
+                   echo "Pipeline locking is disabled, this task will fail and this is OK."
+                   exit 1
+                fi
+          on_success:
+            put: pipeline-pool
+            params:
+              release: pipeline-pool
 
   - name: pipeline-check-lock
     plan:

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -2124,7 +2124,7 @@ jobs:
           file: paas-cf/concourse/tasks/create_admin.yml
           params:
             PREFIX: acceptance-test-user
-            ENABLE_ADMIN_USER_CREATION: {{enable_cf_acceptance_tests}}
+            DISABLE_ADMIN_USER_CREATION: {{disable_cf_acceptance_tests}}
 
         - task: generate-test-config
           config:
@@ -2176,7 +2176,7 @@ jobs:
               source:
                 repository: governmentpaas/cf-acceptance-tests
             params:
-              ENABLE_CF_ACCEPTANCE_TESTS: {{enable_cf_acceptance_tests}}
+              DISABLE_CF_ACCEPTANCE_TESTS: {{disable_cf_acceptance_tests}}
             inputs:
               - name: paas-cf
               - name: cf-release
@@ -2196,16 +2196,16 @@ jobs:
                   ln -snf $(pwd)/test-config/run /var/vcap/jobs/acceptance-tests/bin/run
                   ln -snf /usr/local/go /var/vcap/packages/golang1.6
                   ln -snf $(pwd)/cf-release/src/github.com/cloudfoundry/cf-acceptance-tests /var/vcap/packages/acceptance-tests/src/github.com/cloudfoundry/
-                  if  [ "$ENABLE_CF_ACCEPTANCE_TESTS" != "false" ]; then
-                    /var/vcap/jobs/acceptance-tests/bin/run
+                  if  [ "${DISABLE_CF_ACCEPTANCE_TESTS:-}" = "true" ]; then
+                    echo "WARNING: The acceptance tests have been disabled. Unset DISABLE_CF_ACCEPTANCE_TESTS when uploading the pipelines to enable them. You can still hijack this container to run them manually, but you must update the admin user in ./test-config/config.json."
                   else
-                    echo "WARNING: The acceptance tests have been disabled. Set ENABLE_CF_ACCEPTANCE_TESTS=true when uploading the pipelines to enable them. You can still hijack this container to run them manually, but you must update the admin user in ./test-config/config.json."
+                    /var/vcap/jobs/acceptance-tests/bin/run
                   fi
         ensure:
           task: remove-temp-user
           file: paas-cf/concourse/tasks/delete_admin.yml
           params:
-            ENABLE_ADMIN_USER_CREATION: {{enable_cf_acceptance_tests}}
+            DISABLE_ADMIN_USER_CREATION: {{disable_cf_acceptance_tests}}
 
   - name: custom-acceptance-tests
     plan:

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -2024,7 +2024,7 @@ jobs:
             source:
               repository: governmentpaas/cf-cli
           params:
-            ENABLE_HEALTHCHECK_DB: {{enable_healthcheck_db}}
+            DISABLE_HEALTHCHECK_DB: {{disable_healthcheck_db}}
           inputs:
             - name: paas-cf
             - name: config
@@ -2049,7 +2049,7 @@ jobs:
                 BUILD_ROOT=$(pwd)
                 cd paas-cf/platform-tests/example-apps/healthcheck
                 cf push --no-start
-                if  [ "$ENABLE_HEALTHCHECK_DB" != "false" ] ; then
+                if  [ "${DISABLE_HEALTHCHECK_DB:-}" != "true" ] ; then
                   cf create-service postgres M-dedicated-9.5 healthcheck-db
                   while ! cf service healthcheck-db | grep -q 'Status: create succeeded'; do
                     echo "Waiting for creation of service to complete..."

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -2226,16 +2226,21 @@ jobs:
           file: paas-cf/concourse/tasks/create_admin.yml
           params:
             PREFIX: custom-acceptance-test-user
+            DISABLE_ADMIN_USER_CREATION: {{disable_custom_acceptance_tests}}
 
         - task: generate-test-config
           file: paas-cf/concourse/tasks/generate-test-config.yml
 
         - task: "Run custom acceptance tests"
           file: paas-cf/concourse/tasks/custom-acceptance-tests-run.yml
+          params:
+            DISABLE_CUSTOM_ACCEPTANCE_TESTS: {{disable_custom_acceptance_tests}}
 
         ensure:
           task: remove-temp-user
           file: paas-cf/concourse/tasks/delete_admin.yml
+          params:
+            DISABLE_ADMIN_USER_CREATION: {{disable_custom_acceptance_tests}}
 
   - name: bosh-tests
     plan:

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -97,7 +97,7 @@ bosh_az: ${bosh_az}
 bosh_manifest_state: bosh-manifest-state-${bosh_az}.json
 bosh_fqdn: bosh.${SYSTEM_DNS_ZONE_NAME}
 disable_cf_acceptance_tests: ${DISABLE_CF_ACCEPTANCE_TESTS:-}
-disable_custom_acceptance_tests: ${DISABLE_CUSTOM_ACCEPTANCE_TESTS}
+disable_custom_acceptance_tests: ${DISABLE_CUSTOM_ACCEPTANCE_TESTS:-}
 disable_pipeline_locking: ${DISABLE_PIPELINE_LOCKING}
 datadog_api_key: ${datadog_api_key:-}
 datadog_app_key: ${datadog_app_key:-}

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -92,7 +92,7 @@ apps_dns_zone_name: ${APPS_DNS_ZONE_NAME}
 git_concourse_pool_clone_full_url_ssh: ${git_concourse_pool_clone_full_url_ssh}
 ALERT_EMAIL_ADDRESS: ${ALERT_EMAIL_ADDRESS:-}
 NEW_ACCOUNT_EMAIL_ADDRESS: ${NEW_ACCOUNT_EMAIL_ADDRESS:-}
-enable_healthcheck_db: ${ENABLE_HEALTHCHECK_DB:-}
+disable_healthcheck_db: ${DISABLE_HEALTHCHECK_DB:-}
 bosh_az: ${bosh_az}
 bosh_manifest_state: bosh-manifest-state-${bosh_az}.json
 bosh_fqdn: bosh.${SYSTEM_DNS_ZONE_NAME}

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -96,7 +96,9 @@ disable_healthcheck_db: ${DISABLE_HEALTHCHECK_DB:-}
 bosh_az: ${bosh_az}
 bosh_manifest_state: bosh-manifest-state-${bosh_az}.json
 bosh_fqdn: bosh.${SYSTEM_DNS_ZONE_NAME}
-enable_cf_acceptance_tests: ${ENABLE_CF_ACCEPTANCE_TESTS:-true}
+disable_cf_acceptance_tests: ${DISABLE_CF_ACCEPTANCE_TESTS:-}
+disable_custom_acceptance_tests: ${DISABLE_CUSTOM_ACCEPTANCE_TESTS}
+disable_pipeline_locking: ${DISABLE_PIPELINE_LOCKING}
 datadog_api_key: ${datadog_api_key:-}
 datadog_app_key: ${datadog_app_key:-}
 enable_datadog: ${ENABLE_DATADOG}

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -98,7 +98,7 @@ bosh_manifest_state: bosh-manifest-state-${bosh_az}.json
 bosh_fqdn: bosh.${SYSTEM_DNS_ZONE_NAME}
 disable_cf_acceptance_tests: ${DISABLE_CF_ACCEPTANCE_TESTS:-}
 disable_custom_acceptance_tests: ${DISABLE_CUSTOM_ACCEPTANCE_TESTS:-}
-disable_pipeline_locking: ${DISABLE_PIPELINE_LOCKING}
+disable_pipeline_locking: ${DISABLE_PIPELINE_LOCKING:-}
 datadog_api_key: ${datadog_api_key:-}
 datadog_app_key: ${datadog_app_key:-}
 enable_datadog: ${ENABLE_DATADOG}

--- a/concourse/tasks/create_admin.yml
+++ b/concourse/tasks/create_admin.yml
@@ -18,8 +18,8 @@ run:
     - -c
     - |
       [ -z "${PREFIX}" ] && echo "You need to specify \$PREFIX" && exit 1
-      if [ "${ENABLE_ADMIN_USER_CREATION}" = "false" ]; then
-        echo "Temporary user creation is disabled (ENABLE_ADMIN_USER_CREATION=${ENABLE_ADMIN_USER_CREATION}). Skipping."
+      if [ "${DISABLE_ADMIN_USER_CREATION:-}" = "true" ]; then
+        echo "Temporary user creation is disabled (DISABLE_ADMIN_USER_CREATION=${DISABLE_ADMIN_USER_CREATION}). Skipping."
         echo "none" >admin-creds/username
         echo "none" >admin-creds/password
         exit 0

--- a/concourse/tasks/custom-acceptance-tests-run.yml
+++ b/concourse/tasks/custom-acceptance-tests-run.yml
@@ -19,4 +19,8 @@ run:
       echo "Running tests"
       export CONFIG
       CONFIG="$(pwd)/test-config/config.json"
-      ./paas-cf/platform-tests/run_tests.sh ./paas-cf/platform-tests/src/acceptance/
+      if  [ "${DISABLE_CUSTOM_ACCEPTANCE_TESTS:-}" = "true" ]; then
+        echo "WARNING: The custom acceptance tests have been disabled. Unset DISABLE_CUSTOM_ACCEPTANCE_TESTS when uploading the pipelines to enable them. You can still hijack this container to run them manually, but you must update the admin user in ./test-config/config.json."
+      else
+        ./paas-cf/platform-tests/run_tests.sh ./paas-cf/platform-tests/src/acceptance/
+      fi

--- a/concourse/tasks/delete_admin.yml
+++ b/concourse/tasks/delete_admin.yml
@@ -18,8 +18,8 @@ run:
     - -c
     - |
       NAME=$(cat admin-creds/username)
-      if [ "${ENABLE_ADMIN_USER_CREATION:-}" = "false" ]; then
-        echo "Temporary user creation is disabled (ENABLE_ADMIN_USER_CREATION=${ENABLE_ADMIN_USER_CREATION}). Skipping."
+      if [ "${DISABLE_ADMIN_USER_CREATION:-}" = "true" ]; then
+        echo "Temporary user creation is disabled (DISABLE_ADMIN_USER_CREATION=${DISABLE_ADMIN_USER_CREATION}). Skipping."
         exit 0
       fi
       ./paas-cf/concourse/scripts/import_bosh_ca.sh


### PR DESCRIPTION
## What

Improve dev pipeline execution by disabling pipeline locking by default and making disabling custom acceptance test optional via env. variable. Also refactor variable names, where VERB_something still meant yes/true if the variable was undefined previously. This doesn't fix all variables yet.

## How to review

1. `make dev pipelines`. Go for lunch (acceptance tests take 1h+). Check that pipeline didn't lock and unlock, acceptance and custom acceptance tests ran and healthcheck DB was not deployed.
2. Remove defaults from makefile:
```
--- a/Makefile
+++ b/Makefile
@@ -94,10 +94,8 @@ dev: globals check-env-vars ## Set Environment to DEV
        $(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipelineapps.digital)
        $(eval export SKIP_COMMIT_VERIFICATION=true)
        $(eval export ENV_SPECIFIC_CF_MANIFEST=cf-default.yml)
-       $(eval export DISABLE_HEALTHCHECK_DB=true)
        $(eval export ENABLE_DATADOG ?= false)
        $(eval export CONCOURSE_AUTH_DURATION=48h)
-       $(eval export DISABLE_PIPELINE_LOCKING=true)
```
then `DISABLE_CF_ACCEPTANCE_TESTS=true DISABLE_CUSTOM_ACCEPTANCE_TESTS=true SELF_UPDATE_PIPELINE=false make dev pipelines`
Check that pipeline did lock and unlock, acceptance and custom acceptance were skipped and that healthcheckDB was created.

## Who can review

you can do it!