### PR TITLE
[#132651425] Change timeout for test python_buildpack Procfile

### DIFF
--- a/platform-tests/src/acceptance/python_buildpack_test.go
+++ b/platform-tests/src/acceptance/python_buildpack_test.go
@@ -25,7 +25,7 @@ var _ = Describe("PythonBuildpack", func() {
 			"-c", "python hello.py",
 			"-d", config.AppsDomain,
 		).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
-		Expect(cf.Cf("start", appName).Wait(DEFAULT_TIMEOUT * 2)).To(Exit(0))
+		Expect(cf.Cf("start", appName).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 	})
 
 })


### PR DESCRIPTION
[#132651425 Full fix for CVE 2016-6655: Utility script command injection (aka Upgrade to CF 245)](https://www.pivotaltracker.com/n/projects/1275640/stories/132651425)

What
----

The Python apps take longer to stage. We found out that the current
`cf start` for the python buildpack test is timing out, specially
when running the test.

That is very likely due the multiple nodes causing load on the platform.

To reduce the number of failures, we will increase the timeout by using
CF_PUSH_TIMEOUT (2 minutes) instead of DEFAULT_TIMEOUT*2 (1 minute) in
the `cf start` of the python app.

How to test?
-----------

Run the pipelines and the tests

Who
---

Anyone but @keymon