### PR TITLE
[#133003305] Upgrade stemcell 3263 and migrate to garden-runc

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1564,6 +1564,7 @@ jobs:
             inputs:
               - name: bosh-secrets
               - name: paas-cf
+              - name: cf-manifest
             run:
               path: sh
               args:
@@ -1572,12 +1573,21 @@ jobs:
                 - |
                   VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
 
-                  STEMCELL_VERSION=$($VAL_FROM_YAML stemcells.0.version paas-cf/manifests/cf-manifest/manifest/000-base-cf-deployment.yml)
-                  STEMCELL_NAME=$($VAL_FROM_YAML stemcells.0.name paas-cf/manifests/cf-manifest/manifest/000-base-cf-deployment.yml)
+                  stemcell_index=0
+                  while true; do
+                    if ! $VAL_FROM_YAML "stemcells.${stemcell_index}" cf-manifest/cf-manifest.yml > /dev/null 2>&1; then
+                      break
+                    fi
 
-                  wget https://bosh.io/d/stemcells/${STEMCELL_NAME}?v=${STEMCELL_VERSION} -O stemcell.tgz
-                  ./paas-cf/concourse/scripts/bosh_login.sh {{bosh_fqdn}} bosh-secrets/bosh-secrets.yml
-                  bosh upload stemcell stemcell.tgz --skip-if-exists
+                    STEMCELL_VERSION=$($VAL_FROM_YAML "stemcells.${stemcell_index}.version" cf-manifest/cf-manifest.yml)
+                    STEMCELL_NAME=$($VAL_FROM_YAML "stemcells.${stemcell_index}.name" cf-manifest/cf-manifest.yml)
+
+                    wget https://bosh.io/d/stemcells/${STEMCELL_NAME}?v=${STEMCELL_VERSION} -O stemcell.tgz
+                    ./paas-cf/concourse/scripts/bosh_login.sh {{bosh_fqdn}} bosh-secrets/bosh-secrets.yml
+                    bosh upload stemcell stemcell.tgz --skip-if-exists
+
+                    stemcell_index=$((stemcell_index + 1))
+                  done
 
         - task: update-cloud-config
           config:
@@ -1924,7 +1934,7 @@ jobs:
                 - -c
                 - |
                   ./paas-cf/concourse/scripts/bosh_login.sh {{bosh_fqdn}} bosh-secrets/bosh-secrets.yml
-  
+
                   bosh cleanup --all
 
         - task: datadog-terraform-apply

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -15,10 +15,10 @@ releases:
     version: 0.1487.0
     url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=0.1487.0
     sha1: f173af7117baa34cff97cf4355f958ea536a45d0
-  - name: garden-linux
-    version: 0.342.0
-    url: https://bosh.io/d/github.com/cloudfoundry/garden-linux-release?v=0.342.0
-    sha1: 5da920b05879f66d813526793e2a73706b36b9cb
+  - name: garden-runc
+    version: 0.9.0
+    url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=0.9.0
+    sha1: f0f51762fd470128539ad335934b0319b07b9a04
   - name: etcd
     version: 75
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/etcd-release?v=75

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -35,7 +35,7 @@ releases:
 stemcells:
   - alias: default
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3262.22"
+    version: "3263.8"
 
 update:
   canaries: 0

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -15,6 +15,13 @@ releases:
     version: 0.1487.0
     url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=0.1487.0
     sha1: f173af7117baa34cff97cf4355f958ea536a45d0
+    # Temporary reference to garden-linux to be able to quickly rollback
+    # in case of issues with the migration to stemcell 3263 with kernel 4.4
+    # and garden-runc in the cells.
+  - name: garden-linux
+    version: 0.342.0
+    url: https://bosh.io/d/github.com/cloudfoundry/garden-linux-release?v=0.342.0
+    sha1: 5da920b05879f66d813526793e2a73706b36b9cb
   - name: garden-runc
     version: 0.9.0
     url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=0.9.0
@@ -36,6 +43,12 @@ stemcells:
   - alias: default
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
     version: "3263.8"
+    # Temporary reference to 3262.22 to be able to quickly rollback
+    # in case of issues with the migration to stemcell 3263 with kernel 4.4
+    # and garden-runc in the cells.
+  - alias: default_kernel_3_3
+    name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
+    version: "3262.22"
 
 update:
   canaries: 0

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -335,6 +335,24 @@ jobs:
         job: brain
         tags: (( inject meta.datadog_tags ))
 
+    # Temporary job definition with instances 0 that uses the stemcell 3262
+    # and release garden-linux, which we keep to easily rollback in case of
+    # issues with the migration to stemcell 3263 with kernel 4.4
+    #
+    # Adding this job will prevent `bosh cleanup` from deleting
+    # the stemcel 6262 and the release.
+  - name: cell_3_3
+    data: ((inject jobs.cell))
+    stemcell: default_kernel_3_3
+    instances: 0
+    templates:
+      - name: garden
+        release: garden-linux
+    properties:
+      tags:
+        job: cell_3_3
+        tags: (( inject meta.datadog_tags ))
+
   - name: cell
     azs: [z1, z2, z3]
     templates:

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -345,7 +345,7 @@ jobs:
       - name: rep
         release: diego
       - name: garden
-        release: garden-linux
+        release: garden-runc
       - name: cflinuxfs2-rootfs-setup
         release: cflinuxfs2-rootfs
       - name: cfdot


### PR DESCRIPTION
[#133003305 Upgrade to stemcells with kernel 4.4 and garden-linux to garden-runc](https://www.pivotaltracker.com/story/show/133003305)

and

[#132909443 Respond to CVE-2016-5195 kernel vulnerability (AKA upgrade to stemcell 3263 and garden-runc)](https://www.pivotaltracker.com/story/show/132909443)

What?
-----

In the story #132909443 we apply the patch for [a vulnerability that allows escalation of privileges CVE-2016-5195 (aka dirtycow)](http://dirtycow.ninja/) in the linux kernel that has been reported recently. Our systems are affected, but specially worrying are the cells and the containers running on it.

Despite being reticent, Cloud Foundry community included a [patched version in a older series with 3.3](https://cloudfoundry.slack.com/archives/bosh/p1477113219004741) on 3262.22. That has been done in the PR #560

But in this PR we want to upgrade to stemcell 3263 and migrate to garden-linux:

 * We learn that the stemcell 3263 includes the patch, but it runs the kernel 4.4. But this kernel can cause problems with garden-linux.
 * Also, garden-linux is not supported anymore.

This change represents some risk in the cells running the garden containers. To allow a quick manual rollback if required, we keep in the manifest the definitions of the garden-linux release and stemcell 3262. We need to add a dummy job definition `cell_3_3` to avoid the stemcell and release being deleted by the bosh-clean job (see #558)

How to test?
------------

 * Review that the changes make sense.
 * Deploy this release. All test should pass OK.
 * You can test the rollback procedure described here in [the summary](https://www.pivotaltracker.com/story/show/133003305/comments/153730755)

Note: As it is a stemcell change, all VMs will be reprovision.

Note: We should send a mail to the tenants, in the review or approval. See the card for details.

Who?
----

Anyone but @keymon or @benhyland