### PR TITLE
[#133085073] Use govpaas-alerting-* mail lists for all alerts

### DIFF
--- a/terraform/datadog/consul.tf
+++ b/terraform/datadog/consul.tf
@@ -1,7 +1,7 @@
 resource "datadog_monitor" "consul" {
   name = "${format("%s Consul hosts", var.env)}"
   type = "service check"
-  message = "Missing consul hosts in environment {{host.environment}}. Notify: @the-multi-cloud-paas-team@digital.cabinet-office.gov.uk"
+  message = "${format("Missing consul hosts in environment {{host.environment}}. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "Missing consul hosts! Check VM state."
   no_data_timeframe = "2"
   query = "${format("'process.up'.over('environment:%s','process:consul').last(6).count_by_status()", var.env)}"

--- a/terraform/datadog/nats.tf
+++ b/terraform/datadog/nats.tf
@@ -2,7 +2,7 @@
 resource "datadog_monitor" "nats" {
   name = "${format("%s NATS hosts", var.env)}"
   type = "service check"
-  message = "Missing nats hosts in environment {{host.environment}}. Notify: @the-multi-cloud-paas-team@digital.cabinet-office.gov.uk"
+  message = "${format("Missing nats hosts in environment {{host.environment}}. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "Missing nats hosts! Check VM state."
   no_data_timeframe = "2"
   query = "${format("'datadog.agent.up'.over('environment:%s','job:nats').by('*').last(1).pct_by_status()", var.env)}"

--- a/terraform/datadog/router.tf
+++ b/terraform/datadog/router.tf
@@ -43,7 +43,7 @@ resource "datadog_timeboard" "gorouter" {
 resource "datadog_monitor" "router" {
   name = "${format("%s router hosts", var.env)}"
   type = "service check"
-  message = "Missing router hosts in environment {{host.environment}}. Notify: @the-multi-cloud-paas-team@digital.cabinet-office.gov.uk"
+  message = "${format("Missing router hosts in environment {{host.environment}}. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "Missing router hosts! Check VM state."
   no_data_timeframe = "2"
   query = "${format("'datadog.agent.up'.over('environment:%s','job:router').by('*').last(1).pct_by_status()", var.env)}"


### PR DESCRIPTION
[#133085073 Use new mailing lists for datadog alerting](https://www.pivotaltracker.com/story/show/133085073)

What
-----

Currently some monitoring alert emails go to the team list and:

 * cause noise for people looking out for prod alerts
 * annoy people who are subscribed to the team list who can't do anything about the alerts

We got dedicated maillists for that in @govpaas-alerting-%s@digital.cabinet-office.gov.uk

But some alerts are misconfigured.

How to test?
------------

 * Check it makes sense.
 * Check syntax

I do not recomment to apply it as that means redeploy everything, I think it is safe to merge a check the configuration in CI, staging and prod.

Who?
----

Anyone but @keymon