### PR TITLE
[#131634733] Upgrade ETCD to v78

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -20,9 +20,9 @@ releases:
     url: https://bosh.io/d/github.com/cloudfoundry/garden-linux-release?v=0.342.0
     sha1: 5da920b05879f66d813526793e2a73706b36b9cb
   - name: etcd
-    version: 75
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/etcd-release?v=75
-    sha1: a046281bfeae54ac6d194af80aa2471c8f9b119c
+    version: 78
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/etcd-release?v=78
+    sha1: 56f7cbcbf72ff2c8f9be76f27d267aef621d3175
   - name: cflinuxfs2-rootfs
     version: 1.34.0
     url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-rootfs-release?v=1.34.0

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -56,6 +56,7 @@ properties:
     password: (( grab secrets.nats_password ))
 
   etcd:
+    disable_network_diagnostics: true
     machines: (( grab jobs.etcd.networks.cf.static_ips ))
     require_ssl: false
     peer_require_ssl: (( grab properties.etcd.require_ssl ))


### PR DESCRIPTION
## What

v78 fixes issue with ETCD network debugging being turned on all the time and being undisableable. This is a new property/functionality that was not present in previous ETCD release we were using in cf v240. Because of a bug in v75, it produces extreme amount of logs, quadrupling total amount of all logs from whole platform. Latest ETCD release contains fix for that and only runs this functionality for 5 minutes from just before ETCD restart.

We currently have v75 deployed which is spamming logsearch with these messages and disks are filling quickly (capacity is not planned for 4x log volume).

## How to review

Deploy. Go to logsearch and check that `etcd-network-diagnostics` components stops sending messages 5 mins after ETCD restart. If it doesn't check if there isn't hanging previous instance of the script on ETCD nodes. Logsearch will tell you which nodes are logging the messages.

## Who can review

anyone but @saliceti or @mtekel