### PR TITLE
[#132681767] Upgrade stemcells for bosh to 3263.8

### DIFF
--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -149,8 +149,8 @@ resource_pools:
 - name: bosh
   network: private
   stemcell:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3232.13
-    sha1: 477371a335d172f4728c7a8806448edb9703104c
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3263.8
+    sha1: 95ecc2709ac62f21d0a1c6cac023585c3919b825
   cloud_properties:
     instance_type: t2.medium
     ephemeral_disk: {size: 40000, type: gp2}


### PR DESCRIPTION
[#132681767 Upgrade BOSH #2: stemcell, CPI and new features](https://www.pivotaltracker.com/story/show/132681767)

What
----

We upgraded bosh release, and later the CF stemcell. Now we want to upgrade the stemcell for bosh.

~~We also upgrade the stemcell of concourse, to keep consistency.~~

The change basically changes from the kernel 3.3 to 4.4

~~In the case of concourse, the change is only minor bugs.~~

Dependencies
-----------------

I suggest to merge #565 first, but it is not really required.

How to review
-------------

 * Check that the change makes sense (urls, hash)
 * Optionally deploy the environment and check that bosh is working (e.g. run all the pipeline). ~~The same for concourse.~~

~~I do not think it is required to redeploy concourse in all the environments after this is merged.~~

Who?
----

Anyone but @keymon