### PR TITLE
[#133184695] Create a 'Free' RDS broker service plan.

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -2081,6 +2081,17 @@ jobs:
                 cd paas-cf/platform-tests/example-apps/healthcheck
                 cf push --no-start
                 if  [ "${DISABLE_HEALTHCHECK_DB:-}" != "true" ] ; then
+
+                  # FIXME: Remove this block once it's run in all environments.
+                  if cf service healthcheck-db | grep -q 'Plan: M-dedicated-9.5'; then
+                    echo "Healthcheck DB is using the wrong plan... Re-creating."
+                    cf unbind-service healthcheck healthcheck-db
+                    # Rename so that we don't have to wait for the delete to
+                    # finish before re-creating
+                    cf rename-service healthcheck-db healthcheck-db-deleting
+                    cf delete-service -f healthcheck-db-deleting
+                  fi
+
                   cf create-service postgres Free healthcheck-db
                   while ! cf service healthcheck-db | grep -q 'Status: create succeeded'; do
                     echo "Waiting for creation of service to complete..."

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -2081,7 +2081,7 @@ jobs:
                 cd paas-cf/platform-tests/example-apps/healthcheck
                 cf push --no-start
                 if  [ "${DISABLE_HEALTHCHECK_DB:-}" != "true" ] ; then
-                  cf create-service postgres M-dedicated-9.5 healthcheck-db
+                  cf create-service postgres Free healthcheck-db
                   while ! cf service healthcheck-db | grep -q 'Status: create succeeded'; do
                     echo "Waiting for creation of service to complete..."
                     sleep 30

--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -79,6 +79,21 @@ jobs:
                 supportUrl: "https://forums.aws.amazon.com/forum.jspa?forumID=60"
               plan_updateable: true
               plans:
+                - id: "5f2eec8a-0cad-4ab9-b81e-d6adade2fd42"
+                  name: "Free"
+                  description: "5GB Storage, NOT BACKED UP, Dedicated Instance, Max 50 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t2.micro."
+                  free: true
+                  metadata:
+                    bullets:
+                      - "Dedicated Postgres 9.5 server"
+                      - "AWS RDS"
+                  rds_properties:
+                    inject: (( inject meta.rds_broker.default_postgres_rds_properties ))
+                    db_instance_class: "db.t2.micro"
+                    allocated_storage: 5
+                    backup_retention_period: 0
+                    skip_final_snapshot: true
+
                 - id: "b7d0a368-ac92-4eff-9b8d-ab4ba45bed0e"
                   name: "S-dedicated-9.5"
                   description: "20GB Storage, Dedicated Instance, Max 200 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t2.small."

--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -2,7 +2,7 @@ meta:
   rds_broker:
     default_postgres_rds_properties:
       engine: "postgres"
-      engine_version: "9.5.2"
+      engine_version: "9.5.4"
       storage_type: "gp2"
       auto_minor_version_upgrade: true
       multi_az: false

--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -1,53 +1,31 @@
 meta:
   rds_broker:
+    default_postgres_rds_properties:
+      engine: "postgres"
+      engine_version: "9.5.2"
+      storage_type: "gp2"
+      auto_minor_version_upgrade: true
+      multi_az: false
+      publicly_accessible: false
+      copy_tags_to_snapshot: true
+      skip_final_snapshot: false
+      backup_retention_period: 7
+      db_subnet_group_name: (( grab terraform_outputs.rds_broker_dbs_subnet_group ))
+      vpc_security_group_ids:
+        - (( grab terraform_outputs.rds_broker_dbs_security_group_id ))
+      db_parameter_group_name: (( grab terraform_outputs.rds_broker_postgres95_db_parameter_group ))
     small_postgres_rds_properties:
+      inject: (( inject meta.rds_broker.default_postgres_rds_properties ))
       db_instance_class: "db.t2.small"
-      engine: "postgres"
-      engine_version: "9.5.2"
-      storage_type: "gp2"
       allocated_storage: 20
-      auto_minor_version_upgrade: true
-      multi_az: false
-      publicly_accessible: false
-      copy_tags_to_snapshot: true
-      skip_final_snapshot: false
-      backup_retention_period: 7
-      db_subnet_group_name: (( grab terraform_outputs.rds_broker_dbs_subnet_group ))
-      vpc_security_group_ids:
-        - (( grab terraform_outputs.rds_broker_dbs_security_group_id ))
-      db_parameter_group_name: (( grab terraform_outputs.rds_broker_postgres95_db_parameter_group ))
     medium_postgres_rds_properties:
+      inject: (( inject meta.rds_broker.default_postgres_rds_properties ))
       db_instance_class: "db.m4.large"
-      engine: "postgres"
-      engine_version: "9.5.2"
-      storage_type: "gp2"
       allocated_storage: 20
-      auto_minor_version_upgrade: true
-      multi_az: false
-      publicly_accessible: false
-      copy_tags_to_snapshot: true
-      skip_final_snapshot: false
-      backup_retention_period: 7
-      db_subnet_group_name: (( grab terraform_outputs.rds_broker_dbs_subnet_group ))
-      vpc_security_group_ids:
-        - (( grab terraform_outputs.rds_broker_dbs_security_group_id ))
-      db_parameter_group_name: (( grab terraform_outputs.rds_broker_postgres95_db_parameter_group ))
     large_postgres_rds_properties:
+      inject: (( inject meta.rds_broker.default_postgres_rds_properties ))
       db_instance_class: "db.m4.2xlarge"
-      engine: "postgres"
-      engine_version: "9.5.2"
-      storage_type: "gp2"
       allocated_storage: 20
-      auto_minor_version_upgrade: true
-      multi_az: false
-      publicly_accessible: false
-      copy_tags_to_snapshot: true
-      skip_final_snapshot: false
-      backup_retention_period: 7
-      db_subnet_group_name: (( grab terraform_outputs.rds_broker_dbs_subnet_group ))
-      vpc_security_group_ids:
-        - (( grab terraform_outputs.rds_broker_dbs_security_group_id ))
-      db_parameter_group_name: (( grab terraform_outputs.rds_broker_postgres95_db_parameter_group ))
 
 releases:
   - name: aws-broker

--- a/platform-tests/src/acceptance/rds_broker_test.go
+++ b/platform-tests/src/acceptance/rds_broker_test.go
@@ -39,6 +39,7 @@ var _ = Describe("RDS broker", func() {
 	It("has the expected plans available", func() {
 		plans := cf.Cf("marketplace", "-s", serviceName).Wait(DEFAULT_TIMEOUT)
 		Expect(plans).To(Exit(0))
+		Expect(plans.Out.Contents()).To(ContainSubstring("Free"))
 		Expect(plans.Out.Contents()).To(ContainSubstring("S-dedicated-9.5"))
 		Expect(plans.Out.Contents()).To(ContainSubstring("S-HA-dedicated-9.5"))
 		Expect(plans.Out.Contents()).To(ContainSubstring("M-dedicated-9.5"))


### PR DESCRIPTION
## What

This adds a new 'Free' service plan to the RDS broker. This plan is using the smallest available RDS instance with the smallest allowed storage allocation, and all snapshotting disabled. It's intended to be used for experimentation etc.

As part of this, I've also made the following changes:

* Updated the postgres version to 9.5.4 (from 9.5.2). (See commit message for details).
* Updated the acceptance tests to use this plan where possible (the snapshot related tests need to use one of the plans with snapshots available).
* Updated the healthcheck-db to use this Free plan (this includes a commit to re-create existing instances with the old plan that can be reverted once this has run everywhere).

## How to review

To test the updates to the healthcheck-db, you'll need an environment deployed form master with the DB created (remove the `$(eval export DISABLE_HEALTHCHECK_DB=true)` from the dev section of the makefile). Running the pipeline from this branch should then update this database instance to use the new Free plan.

Verify that the Instance on the Free plan has the correct parameters.

## Who can review

Anyone but myself.