### PR TITLE
[#132681767] Upgrade bosh #2: bosh release, cpi and enable some features

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1450,6 +1450,7 @@ jobs:
             inputs:
               - name: paas-cf
               - name: terraform-outputs
+              - name: cf-secrets
             outputs:
               - name: runtime-config
             params:
@@ -1461,6 +1462,7 @@ jobs:
                 ./paas-cf/manifests/shared/deployments/collectd.yml
                 ./paas-cf/manifests/cf-manifest/common/*.yml
                 ./terraform-outputs/*.yml
+                ./cf-secrets/cf-secrets.yml
             run:
               path: sh
               args:

--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -71,6 +71,8 @@ jobs:
       events:
         record_events: true
       flush_arp: true
+      enable_dedicated_status_worker: true
+      workers: 4
 
     hm:
       director_account:

--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -68,6 +68,8 @@ jobs:
             - { name: admin, password: (( grab secrets.bosh_admin_password )) }
             - { name: hm, password: (( grab secrets.bosh_hm_director_password )) }
       trusted_certs: (( grab secrets.bosh_ca_cert ))
+      events:
+        record_events: true
 
     hm:
       director_account:

--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -70,6 +70,7 @@ jobs:
       trusted_certs: (( grab secrets.bosh_ca_cert ))
       events:
         record_events: true
+      flush_arp: true
 
     hm:
       director_account:

--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -15,8 +15,8 @@ name: (( grab meta.environment ))
 
 releases:
 - name: bosh
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=257.14
-  sha1: b41821dccee78ad7bd44466cd0160920c183787a
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=258
+  sha1: 66f7ce02eda71d63fc13e86a6d49fa5a8398c906
 
 # When updating the version of the CPI here, the version used in the
 # bosh-init container must also be updated so that the cached CPI compile

--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -22,8 +22,8 @@ releases:
 # bosh-init container must also be updated so that the cached CPI compile
 # will be used.
 - name: bosh-aws-cpi
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=52
-  sha1: dc4a0cca3b33dce291e4fbeb9e9948b6a7be3324
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=60
+  sha1: 8e40a9ff892204007889037f094a1b0d23777058
 
 jobs:
 - name: bosh

--- a/manifests/bosh-manifest/spec/properties_spec.rb
+++ b/manifests/bosh-manifest/spec/properties_spec.rb
@@ -42,4 +42,8 @@ RSpec.describe "manifest properties validations" do
   it "configures event recording in the director" do
     expect(bosh_properties["director"]["events"]["record_events"]).to be true
   end
+
+  it "enables explicit ARP flushing" do
+    expect(bosh_properties["director"]["flush_arp"]).to be true
+  end
 end

--- a/manifests/bosh-manifest/spec/properties_spec.rb
+++ b/manifests/bosh-manifest/spec/properties_spec.rb
@@ -38,4 +38,8 @@ RSpec.describe "manifest properties validations" do
   it "configures datadog tag bosh-az with the right AZ" do
     expect(bosh_properties["tags"]["bosh-az"]).to eq("z1")
   end
+
+  it "configures event recording in the director" do
+    expect(bosh_properties["director"]["events"]["record_events"]).to be true
+  end
 end

--- a/manifests/bosh-manifest/spec/properties_spec.rb
+++ b/manifests/bosh-manifest/spec/properties_spec.rb
@@ -46,4 +46,9 @@ RSpec.describe "manifest properties validations" do
   it "enables explicit ARP flushing" do
     expect(bosh_properties["director"]["flush_arp"]).to be true
   end
+
+  it "uses a dedicated worker for status tasks" do
+    expect(bosh_properties["director"]["enable_dedicated_status_worker"]).to be true
+    expect(bosh_properties["director"]["workers"]).to be >= 4
+  end
 end

--- a/manifests/cf-manifest/cloud-config/000-base-cloud-config.yml
+++ b/manifests/cf-manifest/cloud-config/000-base-cloud-config.yml
@@ -19,3 +19,6 @@ vm_types:
   cloud_properties:
     iam_instance_profile: bosh-director
     instance_type: c3.large
+    ephemeral_disk:
+      size: 20480
+      type: gp2

--- a/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
+++ b/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
@@ -117,6 +117,9 @@ vm_types:
     env: (( grab meta.default_env ))
     cloud_properties:
       instance_type: r3.xlarge
+      ephemeral_disk:
+        size: 102400
+        type: gp2
       security_groups:
         - (( grab terraform_outputs.rds_broker_db_clients_security_group ))
         - (( grab terraform_outputs.default_security_group ))

--- a/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
+++ b/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
@@ -109,6 +109,9 @@ vm_types:
     env: (( grab meta.default_env ))
     cloud_properties:
       instance_type: m3.medium
+      ephemeral_disk:
+        size: 10240
+        type: gp2
       elbs:
         - (( grab terraform_outputs.cf_ssh_proxy_elb_name ))
 

--- a/manifests/cf-manifest/cloud-config/030-logsearch.yml
+++ b/manifests/cf-manifest/cloud-config/030-logsearch.yml
@@ -14,6 +14,7 @@ vm_types:
     env: (( grab meta.default_env ))
     cloud_properties:
       instance_type: (( grab vm_types.medium.cloud_properties.instance_type ))
+      ephemeral_disk: (( grab vm_types.medium.cloud_properties.ephemeral_disk ))
       elbs:
         - (( grab terraform_outputs.logsearch_ingestor_elb_name ))
 

--- a/manifests/cf-manifest/common/metron.yml
+++ b/manifests/cf-manifest/common/metron.yml
@@ -2,4 +2,5 @@
 meta:
   metron_agent:
     dropsonde_incoming_port: 3457
-
+  etcd:
+    advertise_urls_dns_suffix: etcd.service.cf.internal

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -60,7 +60,7 @@ properties:
     machines: (( grab jobs.etcd.networks.cf.static_ips ))
     require_ssl: false
     peer_require_ssl: (( grab properties.etcd.require_ssl ))
-    advertise_urls_dns_suffix: etcd.service.cf.internal
+    advertise_urls_dns_suffix: (( grab meta.etcd.advertise_urls_dns_suffix ))
     ca_cert: ""
     client_cert: ""
     client_key: ""

--- a/manifests/cf-manifest/runtime-config/runtime-config-base.yml
+++ b/manifests/cf-manifest/runtime-config/runtime-config-base.yml
@@ -21,6 +21,10 @@ addons:
         tls:
           client_cert: ~
           client_key: ~
+      loggregator:
+        etcd:
+          machines:
+          - (( grab meta.etcd.advertise_urls_dns_suffix ))
   - name: os-configuration
     jobs:
     - name: set_mtu

--- a/manifests/cf-manifest/runtime-config/runtime-config-base.yml
+++ b/manifests/cf-manifest/runtime-config/runtime-config-base.yml
@@ -25,6 +25,8 @@ addons:
         etcd:
           machines:
           - (( grab meta.etcd.advertise_urls_dns_suffix ))
+      metron_endpoint:
+        shared_secret: (( grab secrets.loggregator_endpoint_shared_secret ))
   - name: os-configuration
     jobs:
     - name: set_mtu

--- a/manifests/cf-manifest/spec/cloud-config/vm_types_spec.rb
+++ b/manifests/cf-manifest/spec/cloud-config/vm_types_spec.rb
@@ -23,4 +23,16 @@ RSpec.describe "vm_types" do
       expect(ephemeral_disk['type']).to eq('gp2')
     end
   end
+
+  describe "ephemeral disk" do
+    it "all VM type should have a ephemeral disk of at least 10GB" do
+      vm_types.each do |pool|
+        ephemeral_disk = pool['cloud_properties']['ephemeral_disk']
+        expect(ephemeral_disk).to be_a_kind_of(Hash), "expected #{pool['name']} to have a ephemeral_disk definition"
+        expect(ephemeral_disk).to include('size', 'type')
+        expect(ephemeral_disk['size'].to_i).to be >= 10240
+        expect(ephemeral_disk['type']).to eq('gp2')
+      end
+    end
+  end
 end

--- a/manifests/cf-manifest/spec/cloud-config/vm_types_spec.rb
+++ b/manifests/cf-manifest/spec/cloud-config/vm_types_spec.rb
@@ -11,4 +11,16 @@ RSpec.describe "vm_types" do
       ])
     end
   end
+
+  describe "the cell pool" do
+    let(:pool) { vm_types.find { |p| p["name"] == "cell" } }
+
+    it "should have a gp2 ephemeral disk of at least 100G" do
+      ephemeral_disk = pool['cloud_properties']['ephemeral_disk']
+      expect(ephemeral_disk).to be_a_kind_of(Hash)
+      expect(ephemeral_disk).to include('size', 'type')
+      expect(ephemeral_disk['size'].to_i).to be >= 102400
+      expect(ephemeral_disk['type']).to eq('gp2')
+    end
+  end
 end

--- a/manifests/cf-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/cf-manifest/spec/support/manifest_helpers.rb
@@ -90,6 +90,7 @@ private
       File.expand_path("../../../../shared/deployments/collectd.yml", __FILE__),
       File.expand_path("../../../common/*.yml", __FILE__),
       File.expand_path("../../../../shared/spec/fixtures/terraform/*.yml", __FILE__),
+      File.expand_path("../../../../shared/spec/fixtures/cf-secrets.yml", __FILE__),
     ])
 
     # Deep freeze the object so that it's safe to use across multiple examples

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -15,8 +15,8 @@ releases:
   # bosh-init container must also be updated so that the cached CPI compile
   # will be used.
   - name: bosh-aws-cpi
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=52
-    sha1: dc4a0cca3b33dce291e4fbeb9e9948b6a7be3324
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=60
+    sha1: 8e40a9ff892204007889037f094a1b0d23777058
 
 resource_pools:
   - name: concourse


### PR DESCRIPTION
[#132681767 Upgrade BOSH #2: stemcell, CPI and new features](https://www.pivotaltracker.com/story/show/132681767)

What?
-----

We have upgraded bosh in #551 but left some things out of scope. We want to continue with the upgrade now.

We upgrade and change:

 * Bosh release one version more, to v258
 * CPI release
 * enable the event recording
 * reserve on worker for status tasks
 * implement arp flushing
 * add some ephemeral disk to the cells

It also includes #568, which has been merged under request of @mtekel 

Dependencies
------------

This can be reviewed with #568 and https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/76

This changes the runtime-config for the metron agent, so it either needs to be rebased after merging #561 or #561 must be rebased and remove these changes.


How to test?
------------

Deploy the environment. bosh and CF should deploy cleanly.

Optionally you can check that:
 * The cells have been added with more ephemeral disk
 * The related options are enabled by checking the logs. For instance `bosh events | less -S`

Who?
----

Anyone but @keymon