### PR TITLE
[#133184695] Revert "Update plan of existing healthcheck instances"

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -2081,17 +2081,6 @@ jobs:
                 cd paas-cf/platform-tests/example-apps/healthcheck
                 cf push --no-start
                 if  [ "${DISABLE_HEALTHCHECK_DB:-}" != "true" ] ; then
-
-                  # FIXME: Remove this block once it's run in all environments.
-                  if cf service healthcheck-db | grep -q 'Plan: M-dedicated-9.5'; then
-                    echo "Healthcheck DB is using the wrong plan... Re-creating."
-                    cf unbind-service healthcheck healthcheck-db
-                    # Rename so that we don't have to wait for the delete to
-                    # finish before re-creating
-                    cf rename-service healthcheck-db healthcheck-db-deleting
-                    cf delete-service -f healthcheck-db-deleting
-                  fi
-
                   cf create-service postgres Free healthcheck-db
                   while ! cf service healthcheck-db | grep -q 'Status: create succeeded'; do
                     echo "Waiting for creation of service to complete..."


### PR DESCRIPTION
## What

In #569 we switched the healthcheck DB to use the new Free plan. This required a temporary script to do this. Now that this has run everywhere, it can be removed.

## How to review

Verify that the healthcheck DB is using the Free plan in all persistent environments. Verify that this revert looks sensible.

## Who can review

Anyone but myself.

This reverts commit fccc839907ec9ed07cd23a3e6cee418d7b004864.