### PR TITLE
[#132082633] Use version 0.0.5 of paas-haproxy-release

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -28,7 +28,7 @@ releases:
     url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-rootfs-release?v=1.34.0
     sha1: b1e367e228f5400439d4031a63df2600a9e213c4
   - name: paas-haproxy
-    version: 0.0.4
+    version: 0.0.5
   - name: datadog-for-cloudfoundry
     version: "0.0.5"
 


### PR DESCRIPTION
## What

[#132082633 - Router HAProxy restarts rsyslog without reason](https://www.pivotaltracker.com/n/projects/1275640/stories/132082633)

We want to reduce the number of unnecessary restarts of rsyslog, as the amount of time it takes to restart has been known to cause deployment failures.

This pull request changes our version of the HAProxy release to 0.0.5. This version changes the start script so it only restarts rsyslog if the configuration changes.

## How to review

* Deploy from this branch.
* Check tests pass

## Who can review

Anyone but me