### PR TITLE
[#127345741] CVE notifer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,7 @@ prod: globals check-env-vars ## Set Environment to Production
 	$(eval export DISABLE_CF_ACCEPTANCE_TESTS=true)
 	$(eval export ENABLE_DATADOG=true)
 	$(eval export DECRYPT_CONCOURSE_ATC_PASSWORD=prod_deployment)
+	$(eval export ENABLE_CVE_NOTIFIER=true)
 	@true
 
 .PHONY: bootstrap

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -327,6 +327,11 @@ resources:
     source:
       interval: 5m
 
+  - name: cve-notifier
+    type: git
+    source:
+      uri: https://github.com/alphagov/paas-cve-notifier
+
 jobs:
   - name: pipeline-lock
     serial: true
@@ -1513,6 +1518,7 @@ jobs:
           - get: graphite-nozzle
           - get: logsearch-for-cloudfoundry-boshrelease
           - get: datadog-tfstate
+          - get: cve-notifier
 
       - aggregate:
         - task: extract-cf-terraform-outputs
@@ -2013,6 +2019,44 @@ jobs:
             put: datadog-tfstate
             params:
               file: updated-tfstate/datadog.tfstate
+
+        - task: deploy-cve-notifier
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/cf-cli
+            inputs:
+              - name: cve-notifier
+              - name: paas-cf
+              - name: config
+              - name: bosh-CA
+            params:
+              ENABLE_CVE_NOTIFIER: {{enable_cve_notifier}}
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  if [ "${ENABLE_CVE_NOTIFIER}" != "true" ]; then
+                    echo CVE notifier disabled
+                    exit 0
+                  fi
+                  ./paas-cf/concourse/scripts/import_bosh_ca.sh
+                  . ./config/config.sh
+                  echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
+                  echo | cf create-org admin
+                  cf create-space admin -o admin
+                  cf target -o admin -s admin
+                  cf push --no-route --no-start -m 100M -b python_buildpack \
+                    --health-check-type none -p cve-notifier cve-notifier
+                  echo Setting DD_API_KEY...
+                  cf set-env cve-notifier DD_API_KEY {{datadog_api_key}} > /dev/null
+                  echo Setting DD_APP_KEY...
+                  cf set-env cve-notifier DD_APP_KEY {{datadog_app_key}} > /dev/null
+                  cf start cve-notifier
 
   - name: post-deploy
     plan:

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -102,6 +102,7 @@ disable_pipeline_locking: ${DISABLE_PIPELINE_LOCKING:-}
 datadog_api_key: ${datadog_api_key:-}
 datadog_app_key: ${datadog_app_key:-}
 enable_datadog: ${ENABLE_DATADOG}
+enable_cve_notifier: ${ENABLE_CVE_NOTIFIER:-false}
 EOF
   echo -e "pipeline_lock_git_private_key: |\n  ${git_id_rsa//$'\n'/$'\n'  }"
 }

--- a/terraform/datadog/cve-notifier.tf
+++ b/terraform/datadog/cve-notifier.tf
@@ -1,0 +1,18 @@
+resource "datadog_monitor" "cve-notifier" {
+  name = "${format("%s cve-notifier", var.env)}"
+  type = "service check"
+  message = "${format("{{#is_alert}} No data from cve-notifier. Check the cve-notifier application in org admin space admin, account: %s. It should be up and running. {{/is_alert}}", var.aws_account)}"
+  escalation_message = "${format("{{#is_alert}} Still no data from cve-notifier. Check the cve-notifier application in org admin space admin, account: %s. It should be up and running. {{/is_alert}}", var.aws_account)}"
+  no_data_timeframe = "130"
+  query = "'cve.notifier.ok'.over('host:cve-notifier').last(1).count_by_status()"
+
+  thresholds {
+    warning = "1"
+    critical = "1"
+  }
+
+  require_full_window = true
+  tags {
+    "environment" = "${var.env}"
+  }
+}


### PR DESCRIPTION
## What

Story: [Ensure we are notified quickly about CF security patches (CVEs)](https://www.pivotaltracker.com/story/show/127345741)

This deploys the cve-notifier application to the platform so we can be notified of new CVEs.
Depends on PR: https://github.com/alphagov/paas-cve-notifier/pull/1
## How to review
- Access the [CVEs dashboard](https://app.datadoghq.com/screen/131796/published-cves)
- Deploy to your environment
- Access the [CVEs dashboard](https://app.datadoghq.com/screen/131796/published-cves). There should be test CVEs now.
- Delete the app
- It should trigger monitor cve-notifier
# How to merge
- Delete TEMP commits in this branch and in  paas-cve-notifier PR
- Merge paas-cve-notifier PR
- Merge this PR
- Rerun your pipeline from master, it should delete the monitor (or delete manually)
## Who can review

Not @paroxp or me
