### PR TITLE
[#132312331] Update aws-broker-release

### DIFF
--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -29,7 +29,7 @@ meta:
 
 releases:
   - name: aws-broker
-    version: 0.0.10
+    version: 0.0.11
 
 jobs:
   - name: rds_broker


### PR DESCRIPTION
## What

[#132312331](https://www.pivotaltracker.com/story/show/132312331) Update dependencies of rds-broker

This updates the version of paas-aws-broker-boshrelease to a version that includes the changes to paas-rds-broker https://github.com/alphagov/paas-rds-broker/pull/18

Note this is a [TMP] commit, it will need to be reworked with a good reference once https://github.com/alphagov/paas-aws-broker-boshrelease/pull/14 is merged and tagged
## How to review

Run through a development environment.
- aws-rds-broker should be redeployed
- Acceptance tests should continue to pass.
## Who can review

Not @richardc
