### PR TITLE
[#133431043] Remove old garden-linux release, stemcell and cell_3_3 job

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -15,13 +15,6 @@ releases:
     version: 0.1487.0
     url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=0.1487.0
     sha1: f173af7117baa34cff97cf4355f958ea536a45d0
-    # Temporary reference to garden-linux to be able to quickly rollback
-    # in case of issues with the migration to stemcell 3263 with kernel 4.4
-    # and garden-runc in the cells.
-  - name: garden-linux
-    version: 0.342.0
-    url: https://bosh.io/d/github.com/cloudfoundry/garden-linux-release?v=0.342.0
-    sha1: 5da920b05879f66d813526793e2a73706b36b9cb
   - name: garden-runc
     version: 0.9.0
     url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=0.9.0
@@ -43,12 +36,6 @@ stemcells:
   - alias: default
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
     version: "3263.8"
-    # Temporary reference to 3262.22 to be able to quickly rollback
-    # in case of issues with the migration to stemcell 3263 with kernel 4.4
-    # and garden-runc in the cells.
-  - alias: default_kernel_3_3
-    name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3262.22"
 
 update:
   canaries: 0

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -335,24 +335,6 @@ jobs:
         job: brain
         tags: (( inject meta.datadog_tags ))
 
-    # Temporary job definition with instances 0 that uses the stemcell 3262
-    # and release garden-linux, which we keep to easily rollback in case of
-    # issues with the migration to stemcell 3263 with kernel 4.4
-    #
-    # Adding this job will prevent `bosh cleanup` from deleting
-    # the stemcel 6262 and the release.
-  - name: cell_3_3
-    data: ((inject jobs.cell))
-    stemcell: default_kernel_3_3
-    instances: 0
-    templates:
-      - name: garden
-        release: garden-linux
-    properties:
-      tags:
-        job: cell_3_3
-        tags: (( inject meta.datadog_tags ))
-
   - name: cell
     azs: [z1, z2, z3]
     templates:


### PR DESCRIPTION
[#133431043 Clean-up stemcell+release from upgrade stemcell and garden-run](https://www.pivotaltracker.com/n/projects/1275640/stories/133431043)

What?
-----

After #565 has been deployed and it run on prod without issues for a while, we can remove the references to the old garden-linux, the stemcell 3262 and the temporary job cell_3_3.

How to test?
------------

Nothing really, simply check it makes sense.

Who?
----

Anyone but @keymon