### PR TITLE
[#133085245] Increase prod cell capacity

### DIFF
--- a/manifests/cf-manifest/manifest/env-specific/cf-prod.yml
+++ b/manifests/cf-manifest/manifest/env-specific/cf-prod.yml
@@ -1,4 +1,4 @@
 ---
 meta:
   cell:
-    instances: 6
+    instances: 9


### PR DESCRIPTION
## What

We have recently added new organizations and increased quotas for existing ones. Our total reserved memory is 322. To be able to provide 50% of that when a zone fails, we need 6 cells. That means 9 in total.

## How to review

Create a branch from this branch. `mv manifests/cf-manifest/manifest/env-specific/cf-prod.yml manifests/cf-manifest/manifest/env-specific/cf-default.yml`, push. Deploy to your dev environment. Verify that you have 9 cells, 3 in each zone.

## Who can review

not @mtekel