### PR TITLE
[#132160889] Replace datadog tag naming 

### DIFF
--- a/manifests/bosh-manifest/extensions/datadog-agent.yml
+++ b/manifests/bosh-manifest/extensions/datadog-agent.yml
@@ -6,7 +6,5 @@ jobs:
   properties:
     datadog: (( inject meta.datadog ))
     tags:
-      job: bosh
       bosh-job: bosh
       bosh-az: (( grab terraform_outputs.bosh_az_label ))
-      tags: (( inject meta.datadog_tags ))

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -158,9 +158,6 @@ jobs:
       consul:
         agent:
           mode: server
-      tags:
-        job: consul
-        tags: (( inject meta.datadog_tags ))
 
   - name: nats
     azs: [z1, z2]
@@ -173,10 +170,6 @@ jobs:
         static_ips:
           - 10.0.16.11
           - 10.0.17.11
-    properties:
-      tags:
-        job: nats
-        tags: (( inject meta.datadog_tags ))
 
   - name: etcd
     azs: [z1, z2, z3]
@@ -198,9 +191,6 @@ jobs:
         agent:
           services:
             etcd: {}
-      tags:
-        job: etcd
-        tags: (( inject meta.datadog_tags ))
 
   - name: database
     azs: [z1, z2]
@@ -220,10 +210,6 @@ jobs:
     stemcell: default
     networks:
       - name: cf
-    properties:
-      tags:
-        job: database
-        tags: (( inject meta.datadog_tags ))
     update:
       serial: true
 
@@ -240,9 +226,6 @@ jobs:
         agent:
           services:
             uaa: {}
-      tags:
-        job: uaa
-        tags: (( inject meta.datadog_tags ))
 
   - name: api
     azs: [z1, z2]
@@ -256,9 +239,6 @@ jobs:
       consul:
         agent:
           services: (( grab meta.api_consul_services ))
-      tags:
-        job: api
-        tags: (( inject meta.datadog_tags ))
 
   - name: clock_global
     azs: [z1]
@@ -268,10 +248,6 @@ jobs:
     stemcell: default
     networks:
       - name: cf
-    properties:
-      tags:
-        job: clock_global
-        tags: (( inject meta.datadog_tags ))
 
   - name: api_worker
     azs: [z1, z2]
@@ -281,10 +257,6 @@ jobs:
     stemcell: default
     networks:
       - name: cf
-    properties:
-      tags:
-        job: api_worker
-        tags: (( inject meta.datadog_tags ))
 
   - name: doppler
     azs: [z1, z2]
@@ -294,10 +266,6 @@ jobs:
     stemcell: default
     networks:
       - name: cf
-    properties:
-      tags:
-        job: doppler
-        tags: (( inject meta.datadog_tags ))
 
   - name: loggregator_trafficcontroller
     azs: [z1, z2]
@@ -315,9 +283,6 @@ jobs:
         agent:
           services:
             loggregator_trafficcontroller: {}
-      tags:
-        job: loggregator_trafficcontroller
-        tags: (( inject meta.datadog_tags ))
 
   - name: router
     azs: [z1, z2]
@@ -332,9 +297,6 @@ jobs:
         agent:
           services:
             gorouter: {}
-      tags:
-        job: router
-        tags: (( inject meta.datadog_tags ))
 
   - name: brain
     azs: [z1, z2]
@@ -354,10 +316,6 @@ jobs:
     stemcell: default
     networks:
       - name: cf
-    properties:
-      tags:
-        job: brain
-        tags: (( inject meta.datadog_tags ))
 
   - name: cell
     azs: [z1, z2, z3]
@@ -381,10 +339,6 @@ jobs:
     stemcell: default
     networks:
       - name: cell
-    properties:
-      tags:
-        job: cell
-        tags: (( inject meta.datadog_tags ))
 
   - name: cc_bridge
     azs: [z1, z2]
@@ -410,10 +364,6 @@ jobs:
     stemcell: default
     networks:
       - name: cf
-    properties:
-      tags:
-        job: cc_bridge
-        tags: (( inject meta.datadog_tags ))
 
   - name: route_emitter
     azs: [z1, z2]
@@ -433,10 +383,6 @@ jobs:
     stemcell: default
     networks:
       - name: cf
-    properties:
-      tags:
-        job: route_emitter
-        tags: (( inject meta.datadog_tags ))
 
   - name: access
     azs: [z1, z2]
@@ -458,7 +404,3 @@ jobs:
     stemcell: default
     networks:
       - name: cf
-    properties:
-      tags:
-        job: access
-        tags: (( inject meta.datadog_tags ))

--- a/manifests/cf-manifest/manifest/040-graphite.yml
+++ b/manifests/cf-manifest/manifest/040-graphite.yml
@@ -64,8 +64,5 @@ jobs:
         - name: graphite
           type: graphite
           url: http://localhost:3001
-    tags:
-      job: graphite
-      tags: (( inject meta.datadog_tags ))
 
   templates: (( grab meta.graphite_templates ))

--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -45,9 +45,6 @@ jobs:
     networks:
       - name: cf
     properties:
-      tags:
-        job: rds_broker
-        tags: (( inject meta.datadog_tags ))
       rds-broker:
         allow_user_provision_parameters: true
         allow_user_update_parameters: true

--- a/manifests/cf-manifest/manifest/800-logsearch.yml
+++ b/manifests/cf-manifest/manifest/800-logsearch.yml
@@ -23,10 +23,6 @@ jobs:
       - 10.0.16.13
       - 10.0.17.13
   persistent_disk_type: queue
-  properties:
-    tags:
-      job: queue
-      tags: (( inject meta.datadog_tags ))
 
 - name: parser_z1
   release: logsearch
@@ -50,9 +46,6 @@ jobs:
     logstash_parser:
       filters:
         - logstash: /var/vcap/packages/logsearch-for-cloudfoundry-filters/logstash-filters-default.conf
-    tags:
-      job: parser_z1
-      tags: (( inject meta.datadog_tags ))
 
 - name: parser_z2
   release: logsearch
@@ -76,9 +69,6 @@ jobs:
     logstash_parser:
       filters:
         - logstash: /var/vcap/packages/logsearch-for-cloudfoundry-filters/logstash-filters-default.conf
-    tags:
-      job: parser_z2
-      tags: (( inject meta.datadog_tags ))
 
 - name: elasticsearch_master
   release: logsearch
@@ -104,9 +94,6 @@ jobs:
       discovery:
         minimum_master_nodes: 2
       master_hosts: (( grab properties.elasticsearch.master_hosts ))
-    tags:
-      job: elasticsearch_master
-      tags: (( inject meta.datadog_tags ))
 
 - name: maintenance
   instances: 1
@@ -127,9 +114,6 @@ jobs:
     elasticsearch_config:
       templates:
       - index_template: /var/vcap/packages/logsearch-for-cloudfoundry-filters/logs-template.json
-    tags:
-      job: maintenance
-      tags: (( inject meta.datadog_tags ))
 
 - name: kibana
   release: logsearch
@@ -142,10 +126,6 @@ jobs:
   instances: 1
   networks:
   - name: cf
-  properties:
-    tags:
-      job: kibana
-      tags: (( inject meta.datadog_tags ))
 
 - name: ingestor_z1
   release: logsearch
@@ -166,9 +146,6 @@ jobs:
   properties:
     redis:
       host: (( grab jobs.queue.networks.cf.static_ips.[0] ))
-    tags:
-      job: ingestor_z1
-      tags: (( inject meta.datadog_tags ))
   update:
     serial: true
 
@@ -191,9 +168,6 @@ jobs:
   properties:
     redis:
       host: (( grab jobs.queue.networks.cf.static_ips.[1] ))
-    tags:
-      job: ingestor_z2
-      tags: (( inject meta.datadog_tags ))
   update:
     serial: true
 

--- a/manifests/cf-manifest/spec/manifest/jobs_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/jobs_spec.rb
@@ -111,16 +111,4 @@ RSpec.describe "the jobs definitions block" do
         "expected '#{j['name']}' job to list 'consul_agent' first"
     }
   end
-
-  describe "in order to monitor all hosts via datadog" do
-    it "has datadog tags on each job" do
-      jobs.each { |job|
-        expect(job["properties"]["tags"]).not_to be_nil, "job '#{job['name']}' is missing the datadog 'tags' property"
-        expect(job["properties"]["tags"]["job"]).to eq(job["name"]),
-          "job '#{job['name']}' should have a tag 'job=#{job['name']}' instead of #{job['properties']['tags']['job']}"
-        expect(job["properties"]["tags"]["environment"]).to eq("unit-test")
-        expect(job["properties"]["tags"]["aws_account"]).to eq(ENV["AWS_ACCOUNT"])
-      }
-    end
-  end
 end

--- a/manifests/cf-manifest/spec/runtime-config/shared_config_spec.rb
+++ b/manifests/cf-manifest/spec/runtime-config/shared_config_spec.rb
@@ -7,9 +7,17 @@ RSpec.describe "Runtime config" do
     expect(collectd_addon.fetch("properties").fetch("collectd").fetch("interval")).to eq 10
   end
 
-  it "has datadog included with properties from shared config" do
-    datadog_addon = runtime_config.fetch("addons").find { |addon| addon["name"] == "datadog-agent" }
-    expect(datadog_addon.fetch("properties").fetch("use_dogstatsd")).to eq false
+  describe "in order to monitor all hosts via datadog" do
+    let(:datadog_addon) { runtime_config.fetch("addons").find { |addon| addon["name"] == "datadog-agent" } }
+
+    it "has datadog included with properties from shared config" do
+      expect(datadog_addon.fetch("properties").fetch("use_dogstatsd")).to eq false
+    end
+
+    it "with some tags like aws_account" do
+      expect(datadog_addon.fetch("properties").fetch("tags")).not_to be_nil
+      expect(datadog_addon.fetch("properties").fetch("tags").fetch("aws_account")).to eq(ENV["AWS_ACCOUNT"])
+    end
   end
 
   it "has syslog_forwarder configured with the address from terraform output" do

--- a/manifests/cf-manifest/stubs/datadog-nozzle.yml
+++ b/manifests/cf-manifest/stubs/datadog-nozzle.yml
@@ -29,10 +29,6 @@ jobs:
   instances: 2
   networks:
   - name: cf
-  properties:
-    tags:
-      job: nozzle
-      tags: (( inject meta.datadog_tags ))
 
 properties:
   uaa:

--- a/manifests/concourse-manifest/extensions/datadog-agent.yml
+++ b/manifests/concourse-manifest/extensions/datadog-agent.yml
@@ -12,10 +12,8 @@ jobs:
         properties:
           datadog: (( inject meta.datadog ))
           tags:
-            job: concourse
             bosh-job: concourse
             bosh-az: z1
-            tags: (( inject meta.datadog_tags ))
       - name: riemann
         release: riemann
         properties:

--- a/manifests/shared/deployments/datadog-agent.yml
+++ b/manifests/shared/deployments/datadog-agent.yml
@@ -10,6 +10,6 @@ meta:
     api_key: (( grab $DATADOG_API_KEY || "undefined" ))
     use_dogstatsd: false
     include_bosh_tags: true
-  datadog_tags:
-    environment: (( grab meta.environment || "undefined" ))
-    aws_account: (( grab $AWS_ACCOUNT ))
+    tags:
+      environment: (( grab meta.environment || "undefined" ))
+      aws_account: (( grab $AWS_ACCOUNT ))

--- a/manifests/shared/deployments/datadog-agent.yml
+++ b/manifests/shared/deployments/datadog-agent.yml
@@ -11,5 +11,4 @@ meta:
     use_dogstatsd: false
     include_bosh_tags: true
     tags:
-      environment: (( grab meta.environment || "undefined" ))
       aws_account: (( grab $AWS_ACCOUNT ))

--- a/terraform/datadog/cell.tf
+++ b/terraform/datadog/cell.tf
@@ -4,7 +4,7 @@ resource "datadog_monitor" "cell-available-memory" {
   message = "${format("Less than {{threshold}}%% memory free on cells. There is only {{value}} %% memory free on average on cells. Review if this is temporary or we really need to scale... @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "There is only {{value}} % memory free on average on cells. Check the deployment!"
   no_data_timeframe = "5"
-  query = "${format("avg(last_1m):avg:system.mem.pct_usable{bosh-job:cell,environment:%s} * 100 < 50", var.env)}"
+  query = "${format("avg(last_1m):avg:system.mem.pct_usable{bosh-job:cell,bosh-deployment:%s} * 100 < 50", var.env)}"
 
   thresholds {
     warning = "55.0"

--- a/terraform/datadog/cell.tf
+++ b/terraform/datadog/cell.tf
@@ -13,7 +13,7 @@ resource "datadog_monitor" "cell-available-memory" {
 
   require_full_window = true
   tags {
-    "environment" = "${var.env}"
+    "deployment" = "${var.env}"
     "job" = "cell"
   }
 }

--- a/terraform/datadog/cell.tf
+++ b/terraform/datadog/cell.tf
@@ -4,7 +4,7 @@ resource "datadog_monitor" "cell-available-memory" {
   message = "${format("Less than {{threshold}}%% memory free on cells. There is only {{value}} %% memory free on average on cells. Review if this is temporary or we really need to scale... @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "There is only {{value}} % memory free on average on cells. Check the deployment!"
   no_data_timeframe = "5"
-  query = "${format("avg(last_1m):avg:system.mem.pct_usable{job:cell,environment:%s} * 100 < 50", var.env)}"
+  query = "${format("avg(last_1m):avg:system.mem.pct_usable{bosh-job:cell,environment:%s} * 100 < 50", var.env)}"
 
   thresholds {
     warning = "55.0"

--- a/terraform/datadog/concourse-jobs.tf
+++ b/terraform/datadog/concourse-jobs.tf
@@ -16,7 +16,7 @@ resource "datadog_timeboard" "concourse-jobs" {
     title = "CF pipeline run time"
     viz = "timeseries"
     request {
-      q = "${format("avg:concourse.pipeline_time{environment:%s,pipeline_name:create-bosh-cloudfoundry}", var.env)}"
+      q = "${format("avg:concourse.pipeline_time{bosh-deployment:%s,pipeline_name:create-bosh-cloudfoundry}", var.env)}"
     }
   }
 

--- a/terraform/datadog/concourse-jobs.tf
+++ b/terraform/datadog/concourse-jobs.tf
@@ -24,14 +24,14 @@ resource "datadog_timeboard" "concourse-jobs" {
     title = "Continuous smoke tests"
     viz = "timeseries"
     request {
-      q = "${format("count_nonzero(avg:concourse.build.finished{build_status:failed,bosh-deployment:%s,job:continuous-smoke-tests})", var.env)}"
+      q = "${format("count_nonzero(avg:concourse.build.finished{build_status:failed,bosh-deployment:%s,bosh-job:continuous-smoke-tests})", var.env)}"
       type = "bars"
       style {
         palette = "warm"
       }
     }
     request {
-      q = "${format("count_nonzero(avg:concourse.build.finished{build_status:succeeded,bosh-deployment:%s,job:continuous-smoke-tests})", var.env)}"
+      q = "${format("count_nonzero(avg:concourse.build.finished{build_status:succeeded,bosh-deployment:%s,bosh-job:continuous-smoke-tests})", var.env)}"
       type = "bars"
       style {
         palette = "cool"
@@ -39,4 +39,3 @@ resource "datadog_timeboard" "concourse-jobs" {
     }
   }
 }
-

--- a/terraform/datadog/consul.tf
+++ b/terraform/datadog/consul.tf
@@ -4,7 +4,7 @@ resource "datadog_monitor" "consul" {
   message = "${format("Missing consul hosts in environment {{host.environment}}. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "Missing consul hosts! Check VM state."
   no_data_timeframe = "2"
-  query = "${format("'process.up'.over('environment:%s','process:consul').last(6).count_by_status()", var.env)}"
+  query = "${format("'process.up'.over('bosh-deployment:%s','process:consul').last(6).count_by_status()", var.env)}"
 
   thresholds {
     ok = 1
@@ -27,7 +27,7 @@ resource "datadog_monitor" "consul_connect_to_port" {
   no_data_timeframe = "5"
   require_full_window = true
 
-  query = "${format("'tcp.can_connect'.over('environment:%s','instance:consul_server').by('*').last(1).pct_by_status()", var.env)}"
+  query = "${format("'tcp.can_connect'.over('bosh-deployment:%s','instance:consul_server').by('*').last(1).pct_by_status()", var.env)}"
 
   thresholds {
     critical = 50

--- a/terraform/datadog/consul.tf
+++ b/terraform/datadog/consul.tf
@@ -14,7 +14,7 @@ resource "datadog_monitor" "consul" {
 
   require_full_window = true
   tags {
-    "environment" = "${var.env}"
+    "deployment" = "${var.env}"
     "job" = "consul"
   }
 }
@@ -34,7 +34,7 @@ resource "datadog_monitor" "consul_connect_to_port" {
   }
 
   tags {
-    "environment" = "${var.env}"
+    "deployment" = "${var.env}"
     "job" = "router"
   }
 }

--- a/terraform/datadog/cve-notifier.tf
+++ b/terraform/datadog/cve-notifier.tf
@@ -13,6 +13,6 @@ resource "datadog_monitor" "cve-notifier" {
 
   require_full_window = true
   tags {
-    "environment" = "${var.env}"
+    "deployment" = "${var.env}"
   }
 }

--- a/terraform/datadog/general.tf
+++ b/terraform/datadog/general.tf
@@ -4,7 +4,7 @@ resource "datadog_monitor" "disk-space" {
   message = "${format("More than {{threshold}}%% disk used. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "There is still {{value}} % disk used. Check the VM!"
   no_data_timeframe = "5"
-  query = "${format("max(last_5m):max:system.disk.in_use{environment:%s,!device:/dev/loop0,!device:tmpfs,!device:cgroup,!device:udev,!device:/var/vcap/data/root_log,!device:/var/vcap/data/root_tmp,!bosh-job:concourse} by {bosh-job,device,bosh-index} * 100 > 85", var.env)}"
+  query = "${format("max(last_5m):max:system.disk.in_use{bosh-deployment:%s,!device:/dev/loop0,!device:tmpfs,!device:cgroup,!device:udev,!device:/var/vcap/data/root_log,!device:/var/vcap/data/root_tmp,!bosh-job:concourse} by {bosh-job,device,bosh-index} * 100 > 85", var.env)}"
 
   thresholds {
     warning = "75.0"
@@ -24,7 +24,7 @@ resource "datadog_monitor" "concourse-disk-space" {
   message = "${format("More than {{threshold}}%% disk used. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "There is still {{value}} % disk used. Check the VM!"
   no_data_timeframe = "5"
-  query = "${format("max(last_5m):max:system.disk.in_use{environment:%s,!device:/dev/loop0,!device:tmpfs,!device:cgroup,!device:udev,!device:/var/vcap/data/root_log,!device:/var/vcap/data/root_tmp,bosh-job:concourse} by {bosh-job,device,bosh-index} * 100 > 97", var.env)}"
+  query = "${format("max(last_5m):max:system.disk.in_use{bosh-deployment:%s,!device:/dev/loop0,!device:tmpfs,!device:cgroup,!device:udev,!device:/var/vcap/data/root_log,!device:/var/vcap/data/root_tmp,bosh-job:concourse} by {bosh-job,device,bosh-index} * 100 > 97", var.env)}"
 
   thresholds {
     warning = "95.0"

--- a/terraform/datadog/general.tf
+++ b/terraform/datadog/general.tf
@@ -4,7 +4,7 @@ resource "datadog_monitor" "disk-space" {
   message = "${format("More than {{threshold}}%% disk used. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "There is still {{value}} % disk used. Check the VM!"
   no_data_timeframe = "5"
-  query = "${format("max(last_5m):max:system.disk.in_use{environment:%s,!device:/dev/loop0,!device:tmpfs,!device:cgroup,!device:udev,!device:/var/vcap/data/root_log,!device:/var/vcap/data/root_tmp,!job:concourse} by {bosh-job,device,bosh-index} * 100 > 85", var.env)}"
+  query = "${format("max(last_5m):max:system.disk.in_use{environment:%s,!device:/dev/loop0,!device:tmpfs,!device:cgroup,!device:udev,!device:/var/vcap/data/root_log,!device:/var/vcap/data/root_tmp,!bosh-job:concourse} by {bosh-job,device,bosh-index} * 100 > 85", var.env)}"
 
   thresholds {
     warning = "75.0"
@@ -24,7 +24,7 @@ resource "datadog_monitor" "concourse-disk-space" {
   message = "${format("More than {{threshold}}%% disk used. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "There is still {{value}} % disk used. Check the VM!"
   no_data_timeframe = "5"
-  query = "${format("max(last_5m):max:system.disk.in_use{environment:%s,!device:/dev/loop0,!device:tmpfs,!device:cgroup,!device:udev,!device:/var/vcap/data/root_log,!device:/var/vcap/data/root_tmp,job:concourse} by {bosh-job,device,bosh-index} * 100 > 97", var.env)}"
+  query = "${format("max(last_5m):max:system.disk.in_use{environment:%s,!device:/dev/loop0,!device:tmpfs,!device:cgroup,!device:udev,!device:/var/vcap/data/root_log,!device:/var/vcap/data/root_tmp,bosh-job:concourse} by {bosh-job,device,bosh-index} * 100 > 97", var.env)}"
 
   thresholds {
     warning = "95.0"

--- a/terraform/datadog/general.tf
+++ b/terraform/datadog/general.tf
@@ -13,7 +13,7 @@ resource "datadog_monitor" "disk-space" {
 
   require_full_window = true
   tags {
-    "environment" = "${var.env}"
+    "deployment" = "${var.env}"
     "job" = "all"
   }
 }
@@ -33,7 +33,7 @@ resource "datadog_monitor" "concourse-disk-space" {
 
   require_full_window = true
   tags {
-    "environment" = "${var.env}"
+    "deployment" = "${var.env}"
     "job" = "concourse"
   }
 }

--- a/terraform/datadog/nats.tf
+++ b/terraform/datadog/nats.tf
@@ -5,7 +5,7 @@ resource "datadog_monitor" "nats" {
   message = "${format("Missing nats hosts in environment {{host.environment}}. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "Missing nats hosts! Check VM state."
   no_data_timeframe = "2"
-  query = "${format("'datadog.agent.up'.over('environment:%s','bosh-job:nats').by('*').last(1).pct_by_status()", var.env)}"
+  query = "${format("'datadog.agent.up'.over('bosh-deployment:%s','bosh-job:nats').by('*').last(1).pct_by_status()", var.env)}"
 
   thresholds {
     ok = 0
@@ -28,7 +28,7 @@ resource "datadog_monitor" "nats_process_running" {
   no_data_timeframe = "5"
   require_full_window = true
 
-  query = "${format("'process.up'.over('environment:%s','process:nats').last(4).count_by_status()", var.env)}"
+  query = "${format("'process.up'.over('bosh-deployment:%s','process:nats').last(4).count_by_status()", var.env)}"
 
   thresholds {
     ok = 1
@@ -50,7 +50,7 @@ resource "datadog_monitor" "nats_stream_forwarded_process_running" {
   no_data_timeframe = "5"
   require_full_window = true
 
-  query = "${format("'process.up'.over('environment:%s','process:nats_stream_forwarder').last(4).count_by_status()", var.env)}"
+  query = "${format("'process.up'.over('bosh-deployment:%s','process:nats_stream_forwarder').last(4).count_by_status()", var.env)}"
 
   thresholds {
     ok = 1
@@ -72,7 +72,7 @@ resource "datadog_monitor" "nats_service_open" {
   no_data_timeframe = "5"
   require_full_window = true
 
-  query = "${format("'tcp.can_connect'.over('environment:%s','instance:nats_server').by('*').last(1).pct_by_status()", var.env)}"
+  query = "${format("'tcp.can_connect'.over('bosh-deployment:%s','instance:nats_server').by('*').last(1).pct_by_status()", var.env)}"
 
   thresholds {
     critical = 50
@@ -92,7 +92,7 @@ resource "datadog_monitor" "nats_cluster_service_open" {
   no_data_timeframe = "5"
   require_full_window = true
 
-  query = "${format("'tcp.can_connect'.over('environment:%s','instance:nats_cluster').by('*').last(1).pct_by_status()", var.env)}"
+  query = "${format("'tcp.can_connect'.over('bosh-deployment:%s','instance:nats_cluster').by('*').last(1).pct_by_status()", var.env)}"
 
   thresholds {
     critical = 50

--- a/terraform/datadog/nats.tf
+++ b/terraform/datadog/nats.tf
@@ -5,7 +5,7 @@ resource "datadog_monitor" "nats" {
   message = "${format("Missing nats hosts in environment {{host.environment}}. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "Missing nats hosts! Check VM state."
   no_data_timeframe = "2"
-  query = "${format("'datadog.agent.up'.over('environment:%s','job:nats').by('*').last(1).pct_by_status()", var.env)}"
+  query = "${format("'datadog.agent.up'.over('environment:%s','bosh-job:nats').by('*').last(1).pct_by_status()", var.env)}"
 
   thresholds {
     ok = 0

--- a/terraform/datadog/nats.tf
+++ b/terraform/datadog/nats.tf
@@ -15,7 +15,7 @@ resource "datadog_monitor" "nats" {
 
   require_full_window = true
   tags {
-    "environment" = "${var.env}"
+    "deployment" = "${var.env}"
     "job" = "nats"
   }
 }
@@ -37,7 +37,7 @@ resource "datadog_monitor" "nats_process_running" {
   }
 
   tags {
-    "environment" = "${var.env}"
+    "deployment" = "${var.env}"
     "job" = "nats"
   }
 }
@@ -59,7 +59,7 @@ resource "datadog_monitor" "nats_stream_forwarded_process_running" {
   }
 
   tags {
-    "environment" = "${var.env}"
+    "deployment" = "${var.env}"
     "job" = "nats"
   }
 }
@@ -79,7 +79,7 @@ resource "datadog_monitor" "nats_service_open" {
   }
 
   tags {
-    "environment" = "${var.env}"
+    "deployment" = "${var.env}"
     "job" = "router"
   }
 }
@@ -99,7 +99,7 @@ resource "datadog_monitor" "nats_cluster_service_open" {
   }
 
   tags {
-    "environment" = "${var.env}"
+    "deployment" = "${var.env}"
     "job" = "router"
   }
 }

--- a/terraform/datadog/router.tf
+++ b/terraform/datadog/router.tf
@@ -46,7 +46,7 @@ resource "datadog_monitor" "router" {
   message = "${format("Missing router hosts in environment {{host.environment}}. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "Missing router hosts! Check VM state."
   no_data_timeframe = "2"
-  query = "${format("'datadog.agent.up'.over('environment:%s','bosh-job:router').by('*').last(1).pct_by_status()", var.env)}"
+  query = "${format("'datadog.agent.up'.over('bosh-deployment:%s','bosh-job:router').by('*').last(1).pct_by_status()", var.env)}"
 
   thresholds {
     ok = 0
@@ -129,7 +129,7 @@ resource "datadog_monitor" "gorouter_process_running" {
   no_data_timeframe = "5"
   require_full_window = true
 
-  query = "${format("'process.up'.over('environment:%s','process:gorouter').last(4).count_by_status()", var.env)}"
+  query = "${format("'process.up'.over('bosh-deployment:%s','process:gorouter').last(4).count_by_status()", var.env)}"
 
   thresholds {
     ok = 1
@@ -151,7 +151,7 @@ resource "datadog_monitor" "gorouter_healthy" {
   no_data_timeframe = "5"
   require_full_window = true
 
-  query = "${format("'http.can_connect'.over('environment:%s','instance:gorouter','url:http://localhost:80/').by('*').last(1).pct_by_status()", var.env)}"
+  query = "${format("'http.can_connect'.over('bosh-deployment:%s','instance:gorouter','url:http://localhost:80/').by('*').last(1).pct_by_status()", var.env)}"
 
   thresholds {
     critical = 50

--- a/terraform/datadog/router.tf
+++ b/terraform/datadog/router.tf
@@ -46,7 +46,7 @@ resource "datadog_monitor" "router" {
   message = "${format("Missing router hosts in environment {{host.environment}}. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "Missing router hosts! Check VM state."
   no_data_timeframe = "2"
-  query = "${format("'datadog.agent.up'.over('environment:%s','job:router').by('*').last(1).pct_by_status()", var.env)}"
+  query = "${format("'datadog.agent.up'.over('environment:%s','bosh-job:router').by('*').last(1).pct_by_status()", var.env)}"
 
   thresholds {
     ok = 0

--- a/terraform/datadog/router.tf
+++ b/terraform/datadog/router.tf
@@ -56,7 +56,7 @@ resource "datadog_monitor" "router" {
 
   require_full_window = true
   tags {
-    "environment" = "${var.env}"
+    "deployment" = "${var.env}"
     "job" = "router"
   }
 }
@@ -77,7 +77,7 @@ resource "datadog_monitor" "route_update_latency" {
   }
 
   tags {
-    "environment" = "${var.env}"
+    "deployment" = "${var.env}"
     "job" = "router"
   }
 }
@@ -98,7 +98,7 @@ resource "datadog_monitor" "total_routes_drop" {
   }
 
   tags {
-    "environment" = "${var.env}"
+    "deployment" = "${var.env}"
     "job" = "router"
   }
 }
@@ -116,7 +116,7 @@ resource "datadog_monitor" "total_routes_discrepancy" {
   thresholds {}
 
   tags {
-    "environment" = "${var.env}"
+    "deployment" = "${var.env}"
     "job" = "router"
   }
 }
@@ -138,7 +138,7 @@ resource "datadog_monitor" "gorouter_process_running" {
   }
 
   tags {
-    "environment" = "${var.env}"
+    "deployment" = "${var.env}"
     "job" = "router"
   }
 }
@@ -158,7 +158,7 @@ resource "datadog_monitor" "gorouter_healthy" {
   }
 
   tags {
-    "environment" = "${var.env}"
+    "deployment" = "${var.env}"
     "job" = "router"
   }
 }


### PR DESCRIPTION
## What

With the new features in datadog agent, we don't need to create a `job` tag adhoc, as `bosh-job` is provided to us by the datadog bosh-release: https://github.com/onemedical/datadog-agent-boshrelease/pull/8.

We have refactored all the graphs and monitors, to use the new tag `bosh-job` and `bosh-deployment` instead.

Note: This does not apply for the metrics reported by datadog-nozzle, which will be tagged with `deployment` and `job` instead.

The datadog agent sets the bosh-job tag automatically. We're removing the specific tags added to each one of the jobs, as they have been deprecated.

As `environment` and `bosh-deployment` were actually the same concept, for consistency, we will delete `environment` and  use only `bosh-deployment`.

Test that the tags are defined globally in the runtime config instead of job by job. Only check that `aws_account` is set.

All the metrics are tagged as `deployment` or `bosh-deployment` and it makes sense to keep the same convention for the tags of the monitors.

## How to review

Run the deployment, check if all datadog graphs and monitors respond. Note that it will take time to get all the metrics in place.

## Who can review

Neither @keymon nor @paroxp
