### PR TITLE
[#127345741] CVE notifier improvements

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1993,6 +1993,7 @@ jobs:
               TF_VAR_datadog_api_key: {{datadog_api_key}}
               TF_VAR_datadog_app_key: {{datadog_app_key}}
               TF_VAR_aws_account: {{aws_account}}
+              ENABLE_CVE_NOTIFIER: {{enable_cve_notifier}}
               ENABLE_DATADOG: {{enable_datadog}}
             run:
               path: sh
@@ -2010,6 +2011,7 @@ jobs:
                   fi
 
                   if [ "${ENABLE_DATADOG}" = "true" ]; then
+                    [ "${ENABLE_CVE_NOTIFIER}" = "true" ] && export TF_VAR_enable_cve_notifier=1
                     terraform apply -state=datadog-tfstate/datadog.tfstate -state-out=updated-tfstate/datadog.tfstate paas-cf/terraform/datadog
                   else
                     echo "Datadog disabled, skipping terraform run..."

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -2036,6 +2036,7 @@ jobs:
               - name: bosh-CA
             params:
               ENABLE_CVE_NOTIFIER: {{enable_cve_notifier}}
+              DEPLOY_ENV: {{deploy_env}}
             run:
               path: sh
               args:
@@ -2054,6 +2055,7 @@ jobs:
                   cf target -o admin -s admin
                   cf push --no-route --no-start -m 100M -b python_buildpack \
                     --health-check-type none -p cve-notifier cve-notifier
+                  cf set-env cve-notifier DEPLOY_ENV "${DEPLOY_ENV}"
                   echo Setting DD_API_KEY...
                   cf set-env cve-notifier DD_API_KEY {{datadog_api_key}} > /dev/null
                   echo Setting DD_APP_KEY...

--- a/terraform/datadog/cve-notifier.tf
+++ b/terraform/datadog/cve-notifier.tf
@@ -5,7 +5,7 @@ resource "datadog_monitor" "cve-notifier" {
   message = "${format("{{#is_alert}} No data from cve-notifier. Check the cve-notifier application in org admin space admin, account: %s. It should be up and running. {{/is_alert}}", var.aws_account)}"
   escalation_message = "${format("{{#is_alert}} Still no data from cve-notifier. Check the cve-notifier application in org admin space admin, account: %s. It should be up and running. {{/is_alert}}", var.aws_account)}"
   no_data_timeframe = "130"
-  query = "'cve.notifier.ok'.over('host:cve-notifier').last(1).count_by_status()"
+  query = "${format("'cve.notifier.ok'.over('host:cve-notifier-%s').last(1).count_by_status()", var.env)}"
 
   thresholds {
     warning = "1"

--- a/terraform/datadog/cve-notifier.tf
+++ b/terraform/datadog/cve-notifier.tf
@@ -1,4 +1,5 @@
 resource "datadog_monitor" "cve-notifier" {
+  count = "${var.enable_cve_notifier}"
   name = "${format("%s cve-notifier", var.env)}"
   type = "service check"
   message = "${format("{{#is_alert}} No data from cve-notifier. Check the cve-notifier application in org admin space admin, account: %s. It should be up and running. {{/is_alert}}", var.aws_account)}"

--- a/terraform/datadog/variables.tf
+++ b/terraform/datadog/variables.tf
@@ -1,0 +1,4 @@
+variable "enable_cve_notifier" {
+  description = "Enable CVE notifier. 1 to enable, 0 to disable."
+  default = 0
+}


### PR DESCRIPTION
## What
Story: [SPIKE: Ensure we are notified quickly about CF security patches (CVEs)](https://www.pivotaltracker.com/story/show/127345741)

The solution required a few improvements: enable/disable the app monitoring according to the environments and better tagging to identify the checks.

Depends on https://github.com/alphagov/paas-cve-notifier/pull/2

## How to review
Review along https://github.com/alphagov/paas-cve-notifier/pull/2
* Deploy CF. The TEMP commits will enable datadog just for creating the monitor and deploy the cve-notifier app, so you don't have to redeploy bosh.
* It should create a new `<env> cve-notifier` monitor and it should become green
* Remove the TEMP commits and redeploy. It should remove the monitor. You should delete the app.

## How to review
* Merge https://github.com/alphagov/paas-cve-notifier/pull/2
* Remove TEMP commits
* Merge this PR

## Who can review
Not @paroxp or me
