### PR TITLE
[#132312331] Use latest aws-broker release from Github release.

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -112,12 +112,6 @@ resources:
       uri: https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease.git
       tag_filter: {{cf_datadog_for_cloudfoundry_version}}
 
-  - name: aws-broker-boshrelease
-    type: git
-    source:
-      uri: https://github.com/alphagov/paas-aws-broker-boshrelease.git
-      tag_filter: {{cf_aws_broker_version}}
-
   - name: os-conf-boshrelease
     type: git
     source:
@@ -1509,7 +1503,6 @@ jobs:
           - get: bosh-secrets
           - get: graphite-statsd-boshrelease
           - get: paas-haproxy-release
-          - get: aws-broker-boshrelease
           - get: datadog-for-cloudfoundry-boshrelease
           - get: os-conf-boshrelease
           - get: cf-secrets
@@ -1557,7 +1550,6 @@ jobs:
               - name: bosh-secrets
               - name: graphite-statsd-boshrelease
               - name: paas-haproxy-release
-              - name: aws-broker-boshrelease
               - name: os-conf-boshrelease
               - name: logsearch-for-cloudfoundry-boshrelease
               - name: datadog-for-cloudfoundry-boshrelease
@@ -1580,10 +1572,6 @@ jobs:
                   ./paas-cf/concourse/scripts/git_check_tag.sh {{cf_os_conf_version}} os-conf-boshrelease
                   paas-cf/concourse/scripts/bosh_create_and_upload_release.rb os-conf \
                     {{cf_os_conf_version}} os-conf-boshrelease
-
-                  ./paas-cf/concourse/scripts/git_check_tag.sh {{cf_aws_broker_version}} aws-broker-boshrelease
-                  paas-cf/concourse/scripts/bosh_create_and_upload_release.rb aws-broker \
-                    {{cf_aws_broker_version}} aws-broker-boshrelease
 
                   ./paas-cf/concourse/scripts/git_check_tag.sh {{cf_logsearch_for_cloudfoundry_version}} logsearch-for-cloudfoundry-boshrelease
                   paas-cf/concourse/scripts/bosh_create_and_upload_release.rb logsearch-for-cloudfoundry \

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -44,7 +44,6 @@ prepare_environment() {
   cf_release_version=$("${SCRIPT_DIR}"/val_from_yaml.rb meta.cf-releases.cf.version "${cf_manifest_dir}/../common/releases.yml")
   cf_paas_haproxy_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.paas-haproxy.version "${cf_manifest_dir}/000-base-cf-deployment.yml")
   cf_graphite_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.graphite.version "${cf_manifest_dir}/040-graphite.yml")
-  cf_aws_broker_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.aws-broker.version "${cf_manifest_dir}/050-rds-broker.yml")
   cf_os_conf_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.os-conf.version "${cf_manifest_dir}/../runtime-config/runtime-config-base.yml")
   cf_logsearch_for_cloudfoundry_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.logsearch-for-cloudfoundry.version "${cf_manifest_dir}/800-logsearch.yml")
   cf_datadog_for_cloudfoundry_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.datadog-for-cloudfoundry.version "${cf_manifest_dir}/000-base-cf-deployment.yml")
@@ -80,7 +79,6 @@ debug: ${DEBUG:-}
 cf-release-version: v${cf_release_version}
 cf-paas-haproxy-release-version: ${cf_paas_haproxy_version}
 cf_graphite_version: ${cf_graphite_version}
-cf_aws_broker_version: ${cf_aws_broker_version}
 cf_datadog_for_cloudfoundry_version: ${cf_datadog_for_cloudfoundry_version}
 cf_os_conf_version: ${cf_os_conf_version}
 cf_logsearch_for_cloudfoundry_version: ${cf_logsearch_for_cloudfoundry_version}

--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -29,7 +29,9 @@ meta:
 
 releases:
   - name: aws-broker
-    version: 0.0.10
+    version: 0.0.12
+    url: https://github.com/alphagov/paas-aws-broker-boshrelease/releases/download/0.0.12/aws-broker-0.0.12.tgz
+    sha1: 5de975ce69085df22870fc695986fc4331a37881
 
 jobs:
   - name: rds_broker


### PR DESCRIPTION
## What

This updates to the latest release of rds-broker. This is actually a
no-op change because there were some changes introduced to the
rds-broker[1] that were then reverted[2]. It's worth updating so that
the pipeline is up to date, making future changes easier.

This also changes the way we consume the release. We were previously
building a dev release in the pipeline from the git sources. This is
somewhat inefficient, and also has issues with the way that the version
is pinned in the git resource, especially when we have to go back a
version. Building a release once and uploading to a git release makes
this much simpler, and also means that we consume the release in the
same way as 3rd-party releases that are published to bosh.io.

[1]https://github.com/alphagov/paas-rds-broker/pull/18
[2]https://github.com/alphagov/paas-rds-broker/pull/20

## How to review

This is a no-op change to the rds-broker. It should therefore be sufficient to verify that this is true by comparing the rds-broker code that the 2 different versions point at. There should be no differences at all (even though they're different commits).

Verify that the pipeline changes are correct. This can be done by running the pipeline up to and including cf-deploy.

## Who can review

Anyone but myself.

