### PR TITLE
Parameterise hardcoded domain and emails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,9 @@ list_merge_keys: ## List all GPG keys allowed to sign merge commits.
 		fi;\
 	done
 
+# pass password store unhelpfully dumps it's not-found message to stdout, so we're using a macro to grep the output and remove it
+get_from_pass_or_default = $(eval export $(1)=$(shell paas-pass $(2) | grep -v not\ in\ the || echo $(3)))
+
 .PHONY: globals
 PASSWORD_STORE_DIR?=${HOME}/.paas-pass
 globals:
@@ -90,8 +93,8 @@ dev: globals check-env-vars ## Set Environment to DEV
 	$(eval export AWS_ACCOUNT=dev)
 	$(eval export ENABLE_DESTROY=true)
 	$(eval export ENABLE_AUTODELETE=true)
-	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
-	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipelineapps.digital)
+	$(call get_from_pass_or_default,SYSTEM_DNS_ZONE_NAME,paas-cf/dev-sys-domain,${DEPLOY_ENV}.dev.cloudpipeline.digital)
+	$(call get_from_pass_or_default,APPS_DNS_ZONE_NAME,paas-cf/dev-app-domain,${DEPLOY_ENV}.dev.cloudpipelineapps.digital)
 	$(eval export SKIP_COMMIT_VERIFICATION=true)
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-default.yml)
 	$(eval export DISABLE_HEALTHCHECK_DB=true)
@@ -106,9 +109,9 @@ ci: globals check-env-vars ## Set Environment to CI
 	$(eval export AWS_ACCOUNT=ci)
 	$(eval export ENABLE_AUTO_DEPLOY=true)
 	$(eval export TAG_PREFIX=staging-)
-	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.ci.cloudpipeline.digital)
-	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.ci.cloudpipelineapps.digital)
-	$(eval export ALERT_EMAIL_ADDRESS=the-multi-cloud-paas-team+ci@digital.cabinet-office.gov.uk)
+	$(call get_from_pass_or_default,SYSTEM_DNS_ZONE_NAME,paas-cf/ci-sys-domain,${DEPLOY_ENV}.ci.cloudpipeline.digital)
+	$(call get_from_pass_or_default,APPS_DNS_ZONE_NAME,paas-cf/ci-app-domain,${DEPLOY_ENV}.ci.cloudpipelineapps.digital)
+	$(call get_from_pass_or_default,ALERT_EMAIL_ADDRESS,paas-cf/ci-alert-email-address,the-multi-cloud-paas-team+ci@digital.cabinet-office.gov.uk)
 	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS=${ALERT_EMAIL_ADDRESS})
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-default.yml)
 	$(eval export ENABLE_DATADOG=true)
@@ -123,9 +126,9 @@ staging: globals check-env-vars ## Set Environment to Staging
 	$(eval export SKIP_UPLOAD_GENERATED_CERTS=true)
 	$(eval export TAG_PREFIX=prod-)
 	$(eval export PAAS_CF_TAG_FILTER=staging-*)
-	$(eval export SYSTEM_DNS_ZONE_NAME=staging.cloudpipeline.digital)
-	$(eval export APPS_DNS_ZONE_NAME=staging.cloudpipelineapps.digital)
-	$(eval export ALERT_EMAIL_ADDRESS=the-multi-cloud-paas-team+staging@digital.cabinet-office.gov.uk)
+	$(call get_from_pass_or_default,SYSTEM_DNS_ZONE_NAME,paas-cf/staging-sys-domain,staging.cloudpipeline.digital)
+	$(call get_from_pass_or_default,APPS_DNS_ZONE_NAME,paas-cf/staging-app-domain,staging.cloudpipelineapps.digital)
+	$(call get_from_pass_or_default,ALERT_EMAIL_ADDRESS,paas-cf/staging-alert-email-address,the-multi-cloud-paas-team+staging@digital.cabinet-office.gov.uk)
 	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS=${ALERT_EMAIL_ADDRESS})
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-default.yml)
 	$(eval export DISABLE_CF_ACCEPTANCE_TESTS=true)
@@ -140,9 +143,9 @@ prod: globals check-env-vars ## Set Environment to Production
 	$(eval export ENABLE_AUTO_DEPLOY=true)
 	$(eval export SKIP_UPLOAD_GENERATED_CERTS=true)
 	$(eval export PAAS_CF_TAG_FILTER=prod-*)
-	$(eval export SYSTEM_DNS_ZONE_NAME=cloud.service.gov.uk)
-	$(eval export APPS_DNS_ZONE_NAME=cloudapps.digital)
-	$(eval export ALERT_EMAIL_ADDRESS=the-multi-cloud-paas-team+prod@digital.cabinet-office.gov.uk)
+	$(call get_from_pass_or_default,SYSTEM_DNS_ZONE_NAME,paas-cf/prod-sys-domain,cloud.service.gov.uk)
+	$(call get_from_pass_or_default,APPS_DNS_ZONE_NAME,paas-cf/prod-app-domain,cloudapps.digital)
+	$(call get_from_pass_or_default,ALERT_EMAIL_ADDRESS,paas-cf/prod-alert-email-address,the-multi-cloud-paas-team+prod@digital.cabinet-office.gov.uk)
 	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS=${ALERT_EMAIL_ADDRESS})
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-prod.yml)
 	$(eval export DISABLE_CF_ACCEPTANCE_TESTS=true)


### PR DESCRIPTION
## What

We are now getting stuck into our epic for doing Paas-CF on AWS and our first story is to find a solution whereby we can override the default GDS values for domain names and email addresses in a way that does not displease the GDS folks.

This PR adds a macro function into the Makefile which is used to attempt to look up domain/email values in `paas-pass`, and if not found it will default to the currently used GDS values

If we've done everything correctly, then this should have no impact on existing GDS workflow, but will make it easier for other non-GDS people to make their own deployments.

New values which can now be configured in `paas-pass` are as follows:

├── paas-cf
│   ├── dev-app-domain.gpg
│   ├── dev-sys-domain.gpg
│   ├── ci-app-domain.gpg
│   ├── ci-sys-domain.gpg
│   ├── staging-app-domain.gpg
│   ├── staging-sys-domain.gpg
│   ├── prod-app-domain.gpg
│   ├── prod-sys-domain.gpg
│   ├── dev-alert-email-address.gpg
│   ├── ci-alert-email-address.gpg
│   ├── prod-alert-email-address.gpg
│   └── staging-alert-email-address.gpg

## How to review

Review changes to the `Makefile`
Follow the normal deployment procedure

## Who can review

Anyone on the GDS team.
