### PR TITLE
[#121483833] Capture API calls during pipeline tests

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -2181,6 +2181,11 @@ jobs:
 
         - task: smoke-tests-run
           file: paas-cf/concourse/tasks/smoke-tests-run.yml
+          ensure:
+            task: upload-test-artifacts
+            file: paas-cf/concourse/tasks/upload-test-artifacts.yml
+            params:
+              TEST_ARTIFACTS_BUCKET: {{test_artifacts_bucket}}
 
         ensure:
           task: remove-temp-user
@@ -2268,6 +2273,8 @@ jobs:
               - name: cf-manifest
               - name: test-config
               - name: bosh-CA
+            outputs:
+              - name: artifacts
             run:
               path: sh
               args:
@@ -2275,7 +2282,8 @@ jobs:
                 - -c
                 - |
                   ./paas-cf/concourse/scripts/import_bosh_ca.sh
-
+                  mkdir -p /var/vcap/sys
+                  ln -s $(pwd)/artifacts /var/vcap/sys/log
                   mkdir -p /var/vcap/jobs/acceptance-tests/bin/ /var/vcap/packages/acceptance-tests/src/github.com/cloudfoundry
                   ln -snf $(pwd)/test-config/config.json /var/vcap/jobs/acceptance-tests/bin/config.json
                   ln -snf $(pwd)/test-config/run /var/vcap/jobs/acceptance-tests/bin/run
@@ -2286,6 +2294,13 @@ jobs:
                   else
                     /var/vcap/jobs/acceptance-tests/bin/run
                   fi
+
+          ensure:
+            task: upload-test-artifacts
+            file: paas-cf/concourse/tasks/upload-test-artifacts.yml
+            params:
+              TEST_ARTIFACTS_BUCKET: {{test_artifacts_bucket}}
+
         ensure:
           task: remove-temp-user
           file: paas-cf/concourse/tasks/delete_admin.yml
@@ -2320,6 +2335,12 @@ jobs:
           file: paas-cf/concourse/tasks/custom-acceptance-tests-run.yml
           params:
             DISABLE_CUSTOM_ACCEPTANCE_TESTS: {{disable_custom_acceptance_tests}}
+
+          ensure:
+            task: upload-test-artifacts
+            file: paas-cf/concourse/tasks/upload-test-artifacts.yml
+            params:
+              TEST_ARTIFACTS_BUCKET: {{test_artifacts_bucket}}
 
         ensure:
           task: remove-temp-user
@@ -2703,6 +2724,11 @@ jobs:
                 - |
                   paas-cf/concourse/scripts/smoke_tests_email.sh \
                     ${DEPLOY_ENV} ${SYSTEM_DNS_ZONE_NAME} ${ALERT_EMAIL_ADDRESS}
+          ensure:
+            task: upload-test-artifacts
+            file: paas-cf/concourse/tasks/upload-test-artifacts.yml
+            params:
+              TEST_ARTIFACTS_BUCKET: {{test_artifacts_bucket}}
 
         ensure:
           task: remove-temp-user

--- a/concourse/pipelines/failure-testing.yml
+++ b/concourse/pipelines/failure-testing.yml
@@ -127,6 +127,11 @@ jobs:
           file: paas-cf/concourse/tasks/smoke-tests-config.yml
         - task: run-tests
           file: paas-cf/concourse/tasks/smoke-tests-run.yml
+          ensure:
+            task: upload-test-artifacts
+            file: paas-cf/concourse/tasks/upload-test-artifacts.yml
+            params:
+              TEST_ARTIFACTS_BUCKET: {{test_artifacts_bucket}}
         ensure:
           aggregate:
             - task: recover
@@ -169,6 +174,11 @@ jobs:
           file: paas-cf/concourse/tasks/smoke-tests-config.yml
         - task: run-tests
           file: paas-cf/concourse/tasks/smoke-tests-run.yml
+          ensure:
+            task: upload-test-artifacts
+            file: paas-cf/concourse/tasks/upload-test-artifacts.yml
+            params:
+              TEST_ARTIFACTS_BUCKET: {{test_artifacts_bucket}}
         ensure:
           aggregate:
             - task: recover
@@ -211,6 +221,11 @@ jobs:
           file: paas-cf/concourse/tasks/smoke-tests-config.yml
         - task: run-tests
           file: paas-cf/concourse/tasks/smoke-tests-run.yml
+          ensure:
+            task: upload-test-artifacts
+            file: paas-cf/concourse/tasks/upload-test-artifacts.yml
+            params:
+              TEST_ARTIFACTS_BUCKET: {{test_artifacts_bucket}}
         ensure:
           aggregate:
             - task: recover
@@ -253,6 +268,11 @@ jobs:
           file: paas-cf/concourse/tasks/smoke-tests-config.yml
         - task: run-tests
           file: paas-cf/concourse/tasks/smoke-tests-run.yml
+          ensure:
+            task: upload-test-artifacts
+            file: paas-cf/concourse/tasks/upload-test-artifacts.yml
+            params:
+              TEST_ARTIFACTS_BUCKET: {{test_artifacts_bucket}}
         ensure:
           aggregate:
             - task: recover
@@ -295,6 +315,11 @@ jobs:
           file: paas-cf/concourse/tasks/smoke-tests-config.yml
         - task: run-tests
           file: paas-cf/concourse/tasks/smoke-tests-run.yml
+          ensure:
+            task: upload-test-artifacts
+            file: paas-cf/concourse/tasks/upload-test-artifacts.yml
+            params:
+              TEST_ARTIFACTS_BUCKET: {{test_artifacts_bucket}}
         ensure:
           aggregate:
             - task: recover
@@ -337,6 +362,11 @@ jobs:
           file: paas-cf/concourse/tasks/smoke-tests-config.yml
         - task: run-tests
           file: paas-cf/concourse/tasks/smoke-tests-run.yml
+          ensure:
+            task: upload-test-artifacts
+            file: paas-cf/concourse/tasks/upload-test-artifacts.yml
+            params:
+              TEST_ARTIFACTS_BUCKET: {{test_artifacts_bucket}}
         ensure:
           aggregate:
             - task: recover
@@ -379,6 +409,12 @@ jobs:
           file: paas-cf/concourse/tasks/custom-acceptance-tests-run.yml
           params:
             GINKGO_FOCUS: 'RDS broker'
+
+          ensure:
+            task: upload-test-artifacts
+            file: paas-cf/concourse/tasks/upload-test-artifacts.yml
+            params:
+              TEST_ARTIFACTS_BUCKET: {{test_artifacts_bucket}}
 
         ensure:
           aggregate:

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -73,6 +73,7 @@ skip_upload_generated_certs: ${SKIP_UPLOAD_GENERATED_CERTS:-false}
 aws_account: ${AWS_ACCOUNT:-dev}
 deploy_env: ${env}
 state_bucket: ${env}-state
+test_artifacts_bucket: gds-paas-${env}-test-artifacts
 pipeline_trigger_file: ${pipeline_name}.trigger
 branch_name: ${BRANCH:-master}
 aws_region: ${AWS_DEFAULT_REGION}

--- a/concourse/tasks/custom-acceptance-tests-run.yml
+++ b/concourse/tasks/custom-acceptance-tests-run.yml
@@ -8,6 +8,8 @@ inputs:
   - name: paas-cf
   - name: test-config
   - name: bosh-CA
+outputs:
+  - name: artifacts
 run:
   path: sh
   args:
@@ -15,7 +17,8 @@ run:
     - -c
     - |
       ./paas-cf/concourse/scripts/import_bosh_ca.sh
-
+      mkdir -p /var/vcap/sys
+      ln -s $(pwd)/artifacts /var/vcap/sys/log
       echo "Running tests"
       export CONFIG
       CONFIG="$(pwd)/test-config/config.json"

--- a/concourse/tasks/smoke-tests-config.yml
+++ b/concourse/tasks/smoke-tests-config.yml
@@ -38,3 +38,8 @@ run:
         ./cf-release/jobs/smoke-tests/spec \
         smoke_test_properties.yml \
           > ./test-config/config.json
+
+      #FIXME: in v245 config.json.erb does not allow setting the artifacts directory:
+      # https://github.com/cloudfoundry/cf-release/issues/1089
+      # https://github.com/cloudfoundry/cf-release/blob/v245/jobs/smoke-tests/templates/config.json.erb
+      ruby -rjson -e "j=JSON.load(File.read('./test-config/config.json')); j['artifacts_directory']='/var/vcap/sys/log/smoke_tests'; File.write('./test-config/config.json', j.to_json)"

--- a/concourse/tasks/smoke-tests-run.yml
+++ b/concourse/tasks/smoke-tests-run.yml
@@ -9,6 +9,8 @@ inputs:
   - name: cf-release
   - name: test-config
   - name: bosh-CA
+outputs:
+  - name: artifacts
 run:
   path: bash
   args:
@@ -16,7 +18,8 @@ run:
     - -c
     - |
       ./paas-cf/concourse/scripts/import_bosh_ca.sh
-
+      mkdir -p /var/vcap/sys
+      ln -s $(pwd)/artifacts /var/vcap/sys/log
       mkdir -p /var/vcap/jobs/smoke-tests/bin/ /var/vcap/packages/smoke-tests/src/github.com/cloudfoundry
       ln -snf $(pwd)/test-config/config.json /var/vcap/jobs/smoke-tests/bin/config.json
       ln -snf $(pwd)/test-config/run /var/vcap/jobs/smoke-tests/bin/run

--- a/concourse/tasks/upload-test-artifacts.yml
+++ b/concourse/tasks/upload-test-artifacts.yml
@@ -1,0 +1,25 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/awscli
+inputs:
+  - name: paas-cf
+  - name: artifacts
+run:
+  path: sh
+  args:
+    - -e
+    - -c
+    - |
+      echo "Archiving test artifacts..."
+      RAND=$(hexdump -n 2 -e '/2 "%u"' /dev/urandom)
+      ARTIFACT_NAME="test-artifact-$(date '+%Y-%m-%d-%H-%M-%S')-$RAND.tgz"
+
+      cd artifacts && tar -czvf "${ARTIFACT_NAME}" -- *
+      aws s3 cp "${ARTIFACT_NAME}" "s3://${TEST_ARTIFACTS_BUCKET}"
+
+      echo "To fetch the artifact from the bucket run:"
+      echo aws s3 cp s3://"${TEST_ARTIFACTS_BUCKET}/${ARTIFACT_NAME}" /tmp/
+

--- a/manifests/cf-manifest/manifest/900-cf-tests.yml
+++ b/manifests/cf-manifest/manifest/900-cf-tests.yml
@@ -19,6 +19,7 @@ properties:
     include_operator: true
     include_services: true
     include_route_services: false
+    artifacts_directory: "/var/vcap/sys/log/test_artifacts"
 
   smoke_tests:
     api: (( grab properties.acceptance_tests.api ))

--- a/platform-tests/generate_test_config.rb
+++ b/platform-tests/generate_test_config.rb
@@ -12,6 +12,7 @@ admin_password = File.read('admin-creds/password').strip
 api_url = manifest.fetch("properties").fetch("cc").fetch("srv_api_uri")
 apps_domain = manifest.fetch("properties").fetch("app_domains").first
 system_domain = manifest.fetch("properties").fetch("system_domain")
+artifacts_directory = manifest.fetch("properties").fetch("acceptance_tests").fetch("artifacts_directory")
 
 config = {
   "api" => api_url,
@@ -20,5 +21,6 @@ config = {
   "apps_domain" => apps_domain,
   "system_domain" => system_domain,
   "use_http" => false,
+  "artifacts_directory" => artifacts_directory,
 }
 puts config.to_json

--- a/platform-tests/src/acceptance/init_test.go
+++ b/platform-tests/src/acceptance/init_test.go
@@ -56,5 +56,10 @@ func TestSuite(t *testing.T) {
 		environment.Teardown()
 	})
 
-	RunSpecs(t, "Acceptance tests")
+	componentName := "Custom-Acceptance-Tests"
+	if config.ArtifactsDirectory != "" {
+		helpers.EnableCFTrace(config, componentName)
+	}
+
+	RunSpecs(t, componentName)
 }

--- a/terraform/cloudfoundry/buckets.tf
+++ b/terraform/cloudfoundry/buckets.tf
@@ -21,3 +21,17 @@ resource "aws_s3_bucket" "resources-s3" {
     acl = "private"
     force_destroy = "true"
 }
+
+resource "aws_s3_bucket" "test-artifacts" {
+    bucket = "gds-paas-${var.env}-test-artifacts"
+    acl = "private"
+    force_destroy = "true"
+
+    lifecycle_rule {
+      enabled = true
+      prefix = ""
+      expiration {
+        days = 7
+      }
+    }
+}


### PR DESCRIPTION
## What

[#121483833 - Capture api calls made in pipeline tests](https://www.pivotaltracker.com/story/show/121483833)

We want to be able to capture the CF_TRACE output during Cloud Foundry tests in the pipeline, because it provides useful debugging information when investigating failed tests. We do not want to output this to the pipeline, as we cannot be certain it is free of secrets, so we will store it in a bucket.

## How to review

* Deploy from this branch
* Check the `upload-test-artifacts` task succeeds for the following jobs:
    * acceptance-tests
    * custom-acceptance-tests
    * smoke-tests
* Check the bucket `gds-paas-$DEPLOY_ENV-test-artifacts` for three files, which should be TAR files from the jobs listed above.
* Make one of the tests fail and check it still uploads the file.
* If you are really curious you can download them, un-TAR them and look inside.

## Who can review

Anyone but me.
