### PR TITLE
[#support] Perform a fly sync after login

### DIFF
--- a/concourse/scripts/fly_sync_and_login.sh
+++ b/concourse/scripts/fly_sync_and_login.sh
@@ -16,3 +16,6 @@ chmod +x "$FLY_CMD"
 echo "Doing fly login"
 echo -e "${CONCOURSE_ATC_USER}\n${CONCOURSE_ATC_PASSWORD}" | \
   $FLY_CMD -t "${FLY_TARGET}" login -k --concourse-url "${CONCOURSE_URL}"
+
+echo "Doing fly sync"
+  $FLY_CMD -t "${FLY_TARGET}" sync


### PR DESCRIPTION
What?
----

Our fly_sync_and_login.sh file will download the fly command from the
fly server if the local file is older than the one in the server.

But if the file has been locally updated with a different version more
recently, for example because one environment has a different concourse
version, the curl command will not update the binary.

But concourse fly command provides a `fly sync` that will update the
binary if there is version mistmatch. We can execute this fly sync
command just after login.

How to test?
-----------

Download a different version of the fly command, for instance 2.4.0 from
the concourse ci itself:

```
curl 'https://ci.concourse.ci/api/v1/cli?arch=amd64&platform=linux' -O bin/fly && chmod +x bin/fly
```

run bosh-cli and check that gets updated

```
make dev bosh-cli DEPLOY_ENV=...
```

Who?
----

Anyone but @keymon