### PR TITLE
use paas-pass to remove hardcoded values

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,25 +1,31 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+def secretFromPass(path, default)
+  secret = `paas-pass 2>/dev/null #{path}`
+  return default if secret == ""
+  secret.strip
+end
+
 Vagrant.require_version ">= 1.8.0"
 
 AWS_ACCOUNT = ENV.fetch("AWS_ACCOUNT", "dev")
 AWS_ACCOUNT_DATA = {
   "dev" => {
-    subnet_id: "subnet-d55defe8", # us-east-1e in default VPC, 172.31.32.0/20 range
-    security_group: "sg-99e0c0e0", # "Bootstrap Concourse" security group
+    subnet_id: secretFromPass('paas-cf/dev-subnet-id', 'subnet-d55defe8'), # us-east-1e in default VPC, 172.31.32.0/20 range
+    security_group: secretFromPass('paas-cf/dev-security-group', 'sg-99e0c0e0'), # "Bootstrap Concourse" security group
   },
   "ci" => {
-    subnet_id: "subnet-68bb7e30", # us-east-1a in default VPC, 172.31.16.0/20 range
-    security_group: "sg-23e1c15a", # "Bootstrap Concourse" security group
+    subnet_id: secretFromPass('paas-cf/ci-subnet-id', 'subnet-68bb7e30'), # us-east-1a in default VPC, 172.31.16.0/20 range
+    security_group: secretFromPass('paas-cf/ci-security-group', 'sg-23e1c15a'), # "Bootstrap Concourse" security group
   },
   "staging" => {
-    subnet_id: "subnet-9034fbc8", # us-east-1c in default VPC, 172.31.16.0/20 range
-    security_group: "sg-87e1c1fe", # "Bootstrap Concourse" security group
+    subnet_id: secretFromPass('paas-cf/staging-subnet-id', 'subnet-9034fbc8'), # us-east-1c in default VPC, 172.31.16.0/20 range
+    security_group: secretFromPass('paas-cf/staging-security-group', 'sg-87e1c1fe'), # "Bootstrap Concourse" security group
   },
   "prod" => {
-    subnet_id: "subnet-bc34fbe4", # us-east-1a in default VPC, 172.31.16.0/20 range
-    security_group: "sg-14e2c26d", # "Bootstrap Concourse" security group
+    subnet_id: secretFromPass('paas-cf/prod-subnet-id', 'subnet-bc34fbe4'), # us-east-1a in default VPC, 172.31.16.0/20 range
+    security_group: secretFromPass('paas-cf/prod-security-group', 'sg-14e2c26d'), # "Bootstrap Concourse" security group
   },
 }.freeze
 AWS_ACCOUNT_VARIABLES = AWS_ACCOUNT_DATA.fetch(AWS_ACCOUNT)

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-def secretFromPass(path, default)
+def secret_from_pass(path, default)
   secret = `paas-pass 2>/dev/null #{path}`
   return default if secret == ""
   secret.strip
@@ -12,20 +12,20 @@ Vagrant.require_version ">= 1.8.0"
 AWS_ACCOUNT = ENV.fetch("AWS_ACCOUNT", "dev")
 AWS_ACCOUNT_DATA = {
   "dev" => {
-    subnet_id: secretFromPass('paas-cf/dev-subnet-id', 'subnet-d55defe8'), # us-east-1e in default VPC, 172.31.32.0/20 range
-    security_group: secretFromPass('paas-cf/dev-security-group', 'sg-99e0c0e0'), # "Bootstrap Concourse" security group
+    subnet_id: secret_from_pass('paas-cf/dev-subnet-id', 'subnet-d55defe8'), # us-east-1e in default VPC, 172.31.32.0/20 range
+    security_group: secret_from_pass('paas-cf/dev-security-group', 'sg-99e0c0e0'), # "Bootstrap Concourse" security group
   },
   "ci" => {
-    subnet_id: secretFromPass('paas-cf/ci-subnet-id', 'subnet-68bb7e30'), # us-east-1a in default VPC, 172.31.16.0/20 range
-    security_group: secretFromPass('paas-cf/ci-security-group', 'sg-23e1c15a'), # "Bootstrap Concourse" security group
+    subnet_id: secret_from_pass('paas-cf/ci-subnet-id', 'subnet-68bb7e30'), # us-east-1a in default VPC, 172.31.16.0/20 range
+    security_group: secret_from_pass('paas-cf/ci-security-group', 'sg-23e1c15a'), # "Bootstrap Concourse" security group
   },
   "staging" => {
-    subnet_id: secretFromPass('paas-cf/staging-subnet-id', 'subnet-9034fbc8'), # us-east-1c in default VPC, 172.31.16.0/20 range
-    security_group: secretFromPass('paas-cf/staging-security-group', 'sg-87e1c1fe'), # "Bootstrap Concourse" security group
+    subnet_id: secret_from_pass('paas-cf/staging-subnet-id', 'subnet-9034fbc8'), # us-east-1c in default VPC, 172.31.16.0/20 range
+    security_group: secret_from_pass('paas-cf/staging-security-group', 'sg-87e1c1fe'), # "Bootstrap Concourse" security group
   },
   "prod" => {
-    subnet_id: secretFromPass('paas-cf/prod-subnet-id', 'subnet-bc34fbe4'), # us-east-1a in default VPC, 172.31.16.0/20 range
-    security_group: secretFromPass('paas-cf/prod-security-group', 'sg-14e2c26d'), # "Bootstrap Concourse" security group
+    subnet_id: secret_from_pass('paas-cf/prod-subnet-id', 'subnet-bc34fbe4'), # us-east-1a in default VPC, 172.31.16.0/20 range
+    security_group: secret_from_pass('paas-cf/prod-security-group', 'sg-14e2c26d'), # "Bootstrap Concourse" security group
   },
 }.freeze
 AWS_ACCOUNT_VARIABLES = AWS_ACCOUNT_DATA.fetch(AWS_ACCOUNT)


### PR DESCRIPTION
## What

We are now getting stuck into our epic for doing Paas-CF on AWS and our first story is to find a solution whereby we can override the default GDS values for domain names and email addresses in a way that does not displease the GDS folks.

This PR adds a function to the `Vagrantfile` that will attempt to get credentials from `paas-pass` or return a default if not found in `paas-pass`.

If we've done everything correctly, then this should have no impact on existing GDS workflow, but will make it easier for other non-GDS people to make their own deployments.

New values which can now be configured in paas-pass are as follows:

```
├── paas-cf
│   ├── dev-subnet-id.gpg
│   ├── dev-security-group.gpg
│   ├── ci-subnet-id.gpg
│   ├── ci-security-group.gpg
│   ├── staging-subnet-id.gpg
│   ├── staging-security-group.gpg
│   ├── prod-subnet-id.gpg
│   ├── prod-security-group.gpg
```

## How to review

Review changes to the `Vagrantfile`
Follow the normal deployment procedure

## Who can review

Anyone on the GDS team.