### PR TITLE
[#131975557] Fix rsyslog log forwarding and parsing

### DIFF
--- a/manifests/cf-manifest/runtime-config/runtime-config-base.yml
+++ b/manifests/cf-manifest/runtime-config/runtime-config-base.yml
@@ -27,3 +27,6 @@ addons:
     jobs:
     - name: cleanup_syslog_forwarding
       release: os-conf
+      properties:
+        syslog_daemon_config: # Note: property also used by metron_agent in main manifest
+          enable: false

--- a/manifests/cf-manifest/runtime-config/runtime-config-base.yml
+++ b/manifests/cf-manifest/runtime-config/runtime-config-base.yml
@@ -23,6 +23,7 @@ addons:
         address: (( grab terraform_outputs.logsearch_ingestor_elb_dns_name ))
         port: 2514
         transport: 'relp'
+        log_template: 'metron_agent'
   - name: syslog_cleanup
     jobs:
     - name: cleanup_syslog_forwarding

--- a/manifests/shared/deployments/syslog.yml
+++ b/manifests/shared/deployments/syslog.yml
@@ -1,6 +1,6 @@
 ---
 releases:
   - name: syslog
-    version: "7"
-    url: https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=7
-    sha1: 7aca1a3633f12cc5ce760812959e62b6e51b8641
+    version: "7+gds1"
+    url: https://github.com/alphagov/paas-syslog-release/releases/download/v7-gds1/syslog-7.gds1.tgz
+    sha1: 13e2d7082b128ca59824529dc348ad96568be348


### PR DESCRIPTION
[#131975557 Alternate solution to configure syslog forwarding without metron agent](https://www.pivotaltracker.com/story/show/131975557)

What?
-----

After merging #570 and #561, we have broken the log forwarding to logsearch.

See the story and commits for details.

We fix the issues in this PR

Dependencies
------------

https://github.com/alphagov/paas-syslog-release/pull/1 should be merged first, the code tagged, a new release built and the commit in this PR updated.

Both can be tested together.

How to review?
--------------

 * Deploy.
 * Check that the logs are being sent to loggregator and parsed properly
 * Check that in the VMs:
    * the `/etc/rsyslog.d/rsyslog.conf` using the template format with `[job=jobname index=X]`
    * the `/var/vcap/jobs/cleanup_syslog_forwarding/bin/cleanup_syslog_forwarding_ctl` script contains the code `# Cleanup metron_agent's rsyslog config, if present` and the file `/etc/rsyslog.d/00-syslog_forwarder.conf` is not there anymore.

Who?
----

Anyone but @keymon