### PR TITLE
[#130195859] Enable versioning for CF blobstore buckets

### DIFF
--- a/terraform/cloudfoundry/buckets.tf
+++ b/terraform/cloudfoundry/buckets.tf
@@ -1,25 +1,25 @@
 resource "aws_s3_bucket" "droplets-s3" {
-    bucket = "${var.env}-cf-droplets"
-    acl = "private"
-    force_destroy = "true"
+  bucket = "${var.env}-cf-droplets"
+  acl = "private"
+  force_destroy = "true"
 }
 
 resource "aws_s3_bucket" "buildpacks-s3" {
-    bucket = "${var.env}-cf-buildpacks"
-    acl = "private"
-    force_destroy = "true"
+  bucket = "${var.env}-cf-buildpacks"
+  acl = "private"
+  force_destroy = "true"
 }
 
 resource "aws_s3_bucket" "packages-s3" {
-    bucket = "${var.env}-cf-packages"
-    acl = "private"
-    force_destroy = "true"
+  bucket = "${var.env}-cf-packages"
+  acl = "private"
+  force_destroy = "true"
 }
 
 resource "aws_s3_bucket" "resources-s3" {
-    bucket = "${var.env}-cf-resources"
-    acl = "private"
-    force_destroy = "true"
+  bucket = "${var.env}-cf-resources"
+  acl = "private"
+  force_destroy = "true"
 }
 
 resource "aws_s3_bucket" "test-artifacts" {

--- a/terraform/cloudfoundry/buckets.tf
+++ b/terraform/cloudfoundry/buckets.tf
@@ -2,24 +2,36 @@ resource "aws_s3_bucket" "droplets-s3" {
   bucket = "${var.env}-cf-droplets"
   acl = "private"
   force_destroy = "true"
+  versioning {
+    enabled = true
+  }
 }
 
 resource "aws_s3_bucket" "buildpacks-s3" {
   bucket = "${var.env}-cf-buildpacks"
   acl = "private"
   force_destroy = "true"
+  versioning {
+    enabled = true
+  }
 }
 
 resource "aws_s3_bucket" "packages-s3" {
   bucket = "${var.env}-cf-packages"
   acl = "private"
   force_destroy = "true"
+  versioning {
+    enabled = true
+  }
 }
 
 resource "aws_s3_bucket" "resources-s3" {
   bucket = "${var.env}-cf-resources"
   acl = "private"
   force_destroy = "true"
+  versioning {
+    enabled = true
+  }
 }
 
 resource "aws_s3_bucket" "test-artifacts" {

--- a/terraform/cloudfoundry/buckets.tf
+++ b/terraform/cloudfoundry/buckets.tf
@@ -5,6 +5,18 @@ resource "aws_s3_bucket" "droplets-s3" {
   versioning {
     enabled = true
   }
+  lifecycle_rule {
+    id = "Expire old previous versions"
+    enabled = true
+    prefix = ""
+    noncurrent_version_expiration {
+      days = 36
+    }
+    expiration {
+      expired_object_delete_marker = true
+    }
+    abort_incomplete_multipart_upload_days = "3"
+  }
 }
 
 resource "aws_s3_bucket" "buildpacks-s3" {
@@ -13,6 +25,18 @@ resource "aws_s3_bucket" "buildpacks-s3" {
   force_destroy = "true"
   versioning {
     enabled = true
+  }
+  lifecycle_rule { 
+    id = "Expire old previous versions"
+    enabled = true
+    prefix = ""
+    noncurrent_version_expiration {
+      days = 36
+    }
+    expiration {
+      expired_object_delete_marker = true
+    }
+    abort_incomplete_multipart_upload_days = "3"
   }
 }
 
@@ -23,6 +47,18 @@ resource "aws_s3_bucket" "packages-s3" {
   versioning {
     enabled = true
   }
+  lifecycle_rule { 
+    id = "Expire old previous versions"
+    enabled = true
+    prefix = ""
+    noncurrent_version_expiration {
+      days = 36
+    }
+    expiration {
+      expired_object_delete_marker = true
+    }
+    abort_incomplete_multipart_upload_days = "3"
+  }
 }
 
 resource "aws_s3_bucket" "resources-s3" {
@@ -31,6 +67,18 @@ resource "aws_s3_bucket" "resources-s3" {
   force_destroy = "true"
   versioning {
     enabled = true
+  }
+  lifecycle_rule { 
+    id = "Expire old previous versions"
+    enabled = true
+    prefix = ""
+    noncurrent_version_expiration {
+      days = 36
+    }
+    expiration {
+      expired_object_delete_marker = true
+    }
+    abort_incomplete_multipart_upload_days = "3"
   }
 }
 


### PR DESCRIPTION
## What

As a requirement for being able to [restore blobstore buckets to a point-in-time](https://www.pivotaltracker.com/n/projects/1275640/stories/130195859) and to be able to enable replication later, we need to enable bucket versioning. We also add a lifecycle that mirrors backup settings for the CC DB.

## How to review

Run `cf-terraform` job, e.g. `JOB=cf-terraform make dev run_job`.

* If you had existing environment, then verify that the job applies changes to the blobstore buckets.
* If you deployed from scratch from this branch, verify that the job doesn't apply any changes.

Finally, verify directly in S3 that the versioning and lifecycle are configured for blobstore buckets.

## Who can review

not @mtekel or @combor 
