### PR TITLE
[#132331007] Document how to rotate the manually uploaded certs.

### DIFF
--- a/manifests/cf-manifest/scripts/generate-cf-certs.sh
+++ b/manifests/cf-manifest/scripts/generate-cf-certs.sh
@@ -38,8 +38,6 @@ for cert_entry in ${CERTS_TO_GENERATE}; do
   if [ -f "${CERTS_DIR}/${cn}.crt" ]; then
     echo "Certificate ${cn} is already generated, skipping."
   else
-    # shellcheck disable=SC2086
-    # We don't need/want to quote the domains bit (fixed in newer shellcheck versions)
     certstrap request-cert --passphrase "" --common-name "${cn}" ${domains:+--domain "${domains}"}
     certstrap sign --CA "${CA_NAME}" --passphrase "" "${cn}"
     mv "out/${cn}.key" "${CERTS_DIR}/"


### PR DESCRIPTION
## What

This process is somewhat gnarly due to limitations in terraform and the
way we've had to split things up.

Having said that, it's still valuable to have this documented until we
can come up with another approach (possibly not using terraform for this
specific bit).

This PR also includes the removal of a shellcheck disable that's no longer needed now that we've upgraded shellcheck.

## How to review

Read the new docs, and verify they make sense.

Verify Travis passes.

## Who can review

Anyone buy @henrytk or myself.