### PR TITLE
[#121483833] Upload test artifacts skips when there is none

### DIFF
--- a/concourse/tasks/upload-test-artifacts.yml
+++ b/concourse/tasks/upload-test-artifacts.yml
@@ -13,6 +13,11 @@ run:
     - -e
     - -c
     - |
+      if [ "$(find artifacts -type f | wc -l)" -eq 0 ]; then
+        echo "No test artifacts generated. Skipping."
+        exit 0
+      fi
+
       echo "Archiving test artifacts..."
       RAND=$(hexdump -n 2 -e '/2 "%u"' /dev/urandom)
       ARTIFACT_NAME="test-artifact-$(date '+%Y-%m-%d-%H-%M-%S')-$RAND.tgz"
@@ -22,4 +27,3 @@ run:
 
       echo "To fetch the artifact from the bucket run:"
       echo aws s3 cp s3://"${TEST_ARTIFACTS_BUCKET}/${ARTIFACT_NAME}" /tmp/
-


### PR DESCRIPTION
[#121483833 - Capture api calls made in pipeline tests](https://www.pivotaltracker.com/story/show/121483833)

What?
-----

In #582 we added logic to "Capture API calls during pipeline tests"

But in the upload tests artifacts task, the tar command would fail if the previous tests did not generate any test artifacts with the api calls:

    Archiving test artifacts...
    tar: *: No such file or directory
    tar: error exit delayed from previous errors

This can happen if the acceptance tests are disabled, like in staging&prod. e.g: https://deployer.staging.cloudpipeline.digital/teams/main/pipelines/create-bosh-cloudfoundry/jobs/acceptance-tests/builds/279

To avoid that, we add some logic to skip the upload if there are no file in the artifacts directory.

How to test?
-----------

Run the acceptance-tests job with DISABLE_CF_ACCEPTANCE_TESTS=true

```
export DEPLOY_ENV=...
DISABLE_CF_ACCEPTANCE_TESTS=true SELF_UPDATE_PIPELINE=false   BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines
BRANCH=$(git rev-parse --abbrev-ref HEAD) JOB=acceptance-tests make dev run_job DEPLOY_ENV=hector
```

It should skip the upload.

You can add a `touch artifacts/foo && exit 0` to `run-tests` to check that it still uploads.

Who?
---

Anyone but @keymon