### PR TITLE
[#133748125] make target to restart concourse and clear volumes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,10 @@ tunnel: check-env-vars ## SSH tunnel to internal IPs
 stop-tunnel: check-env-vars ## Stop SSH tunnel
 	@./scripts/ssh.sh tunnel stop
 
+shake_concourse_volumes: check-env-vars ## Restarts concourse services and workers and clears the volumes
+	@./scripts/ssh.sh scp concourse/scripts/shake_concourse_volumes.sh /tmp/
+	@./scripts/ssh.sh ssh bash -i /tmp/shake_concourse_volumes.sh
+
 show-cf-memory-usage: ## Show the memory usage of the current CF cluster
 	$(eval export API_ENDPOINT=https://api.${SYSTEM_DNS_ZONE_NAME})
 	@./scripts/show-cf-memory-usage.rb

--- a/Makefile
+++ b/Makefile
@@ -215,15 +215,15 @@ run_job: check-env-vars ## Unbind paas-cf of $JOB in create-bosh-cloudfoundry pi
 ssh_bosh: check-env-vars ## SSH to the bosh server
 	@./scripts/ssh_bosh.sh
 
-ssh_concourse: check-env-vars ## SSH to the concourse server
-	@./scripts/ssh.sh
+ssh_concourse: check-env-vars ## SSH to the concourse server. Set SSH_CMD to pass a command to execute.
+	@./scripts/ssh.sh ssh ${SSH_CMD}
 
 tunnel: check-env-vars ## SSH tunnel to internal IPs
 	$(if ${TUNNEL},,$(error Must pass TUNNEL=SRC_PORT:HOST:DST_PORT))
-	@./scripts/ssh.sh ${TUNNEL}
+	@./scripts/ssh.sh tunnel ${TUNNEL}
 
 stop-tunnel: check-env-vars ## Stop SSH tunnel
-	@./scripts/ssh.sh stop
+	@./scripts/ssh.sh tunnel stop
 
 show-cf-memory-usage: ## Show the memory usage of the current CF cluster
 	$(eval export API_ENDPOINT=https://api.${SYSTEM_DNS_ZONE_NAME})

--- a/concourse/scripts/shake_concourse_volumes.sh
+++ b/concourse/scripts/shake_concourse_volumes.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+cat <<"EOF"
+
+This operation will restart concourse and dropping all the volumes...
+
+                 ,-.
+       _,.      /  /          ,--.!,
+      ; \____,-==-._  )    __/   -*-
+      //_    `----' {+>  ,d08b.  '|`
+      `  `'--/  /-'`(    0088MM
+            /  /         `9MMP'       BLOW THAT CONCOURSE!!!
+      dew   `='       hjm
+                               via http://ascii.co.uk/art/plane
+                               and http://ascii.co.uk/art/bomb
+
+EOF
+
+set -e
+
+sudo -v -p "Type sudo password to continue: "
+
+echo "Stopping all the concourse services..."
+for i in atc beacon tsa baggageclaim garden ; do
+   sudo -i /var/vcap/bosh/bin/monit stop $i;
+done
+sleep 10
+
+echo -n "Killing all runc containers..."
+sudo pkill -f runc # Be sure that all containers are stopped
+while pgrep -f runc; do
+   sleep 1
+   echo .
+done
+echo
+
+echo "Flushing all iptables rules from previus containers..."
+sudo iptables -F
+sudo iptables -X
+sudo iptables -t nat -F
+sudo iptables -t nat -X
+
+echo "Deleting all baggageclaim volumes and garden data"
+if grep -q /var/vcap/data/baggageclaim/volumes /proc/mounts; then
+   sudo umount -fl /var/vcap/data/baggageclaim/volumes
+fi
+if grep -q /var/vcap/data/garden/graph /proc/mounts; then
+   sudo umount -fl /var/vcap/data/garden/graph
+fi
+if sudo losetup -a | grep -q /dev/loop0; then
+   sudo losetup -d /dev/loop0
+fi
+if sudo losetup -a | grep -q /dev/loop1; then
+   sudo losetup -d /dev/loop1
+fi
+sudo rm -rf /var/vcap/data/garden /var/vcap/data/baggageclaim/volumes.img
+
+echo "Dropping volume, containers and images references from concourse DB..."
+# Remove all the tables related to containers
+sudo /var/vcap/packages/postgresql_9.3/bin/psql -U atc -h 127.0.0.1 <<EOF
+delete from volumes;
+delete from image_resource_versions;
+delete from containers;
+EOF
+
+echo "Starting the concourse services again..."
+for i in atc beacon tsa baggageclaim garden ; do
+   sudo -i /var/vcap/bosh/bin/monit start $i;
+done

--- a/scripts/ssh.sh
+++ b/scripts/ssh.sh
@@ -1,10 +1,37 @@
 #!/bin/bash
 
 set -euo pipefail
-TUNNEL=${1:-}
+SCRIPT=$0
+
 SOCKET_DIR=~/.ssh
 SOCKET_DEF=%r@%h:%p
 SOCKET=$SOCKET_DIR/$SOCKET_DEF
+
+usage() {
+  if [ ! -z "${1:-}" ]; then
+    echo "$@"
+    echo
+  fi
+  cat <<EOF
+Usage:
+
+  $SCRIPT <action> [-- action_params]
+
+SSH/SCP to concourse.
+
+actions:
+  ssh [command]     (default) SSH to concourse.
+                    Optionally run the provided command
+
+  scp <from> <to>   Copy 'from' local file to 'to' remote location.
+
+  tunnel <tunnel>   Configure a TCP ssh tunnel for the given port
+                    Syntax: <local_port>:<remote_ip>:<remote_port>
+
+                    Use 'tunnel stop' to stop the tunnel.
+
+EOF
+}
 
 download_key() {
   key=/tmp/concourse_id_rsa.$RANDOM
@@ -21,11 +48,19 @@ ssh_concourse() {
     ruby -ryaml -e 'puts "Sudo password is " + YAML.load(STDIN)["secrets"]["concourse_vcap_password_orig"]'
   echo
 
-  ssh -i $key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=60 \
-    vcap@"$CONCOURSE_IP"
+  # shellcheck disable=SC2029
+  ssh -t -i $key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=60 \
+    vcap@"$CONCOURSE_IP" "$@"
+}
+
+scp_concourse() {
+  # shellcheck disable=SC2029
+  scp -i $key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=60 \
+    "$1" vcap@"$CONCOURSE_IP":"$2"
 }
 
 create_tunnel() {
+  TUNNEL=$1
   echo "Creating tunnel at socket $(print_socket) to ${TUNNEL}"
   ssh -i $key -fNTM -o ControlPath=${SOCKET} -o "ExitOnForwardFailure yes" \
     -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=60 \
@@ -38,15 +73,42 @@ stop_tunnel() {
 }
 
 print_socket() {
-  echo -n $SOCKET_DIR/vcap@"${CONCOURSE_IP}"
+  echo -n "$SOCKET_DIR/vcap@${CONCOURSE_IP}"
 }
 
-download_key
 
-if [[ -z "${TUNNEL}" ]]; then
-  ssh_concourse
-elif [[ "${TUNNEL}" != "stop" ]]; then
-  create_tunnel
-else
-  stop_tunnel
-fi
+case ${1:-} in
+  ssh|"")
+    shift || true
+    download_key
+    ssh_concourse "$@"
+    ;;
+  scp)
+    shift
+    if [ "$#" -ne 2 ]; then
+      usage "Wrong number of arguments for scp"
+    fi
+    download_key
+    scp_concourse "$1" "$2"
+    ;;
+  tunnel)
+    shift
+    case "$1" in
+      ?*:?*:?*)
+        download_key
+        create_tunnel "$1"
+        ;;
+      stop)
+        download_key
+        stop_tunnel
+        ;;
+      *)
+        usage "Invalid format for the tunnel option: '$1'"
+        ;;
+    esac
+    ;;
+  *)
+    usage "Unknown action '$1'"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
[#133748125  Automate execution of clear volumes procedure of concourse](https://www.pivotaltracker.com/story/show/133748125)

What?
----

We want to automate the procedure to restart and clear all the volumes in concourse. We run this often enough to automate it.

For several versions of concourse, we had multiple problems mostly related to baggageclaim volumes[1][2][3][4]

The development team in concourse says being working on it and refactoring the logic related to volume management.

Meanwhile the problem is not completely fixed, we found that the procedure commented here: https://github.com/concourse/concourse/issues/565#issuecomment-237845601 helps a lot. Basically it will:
 * stop concourse services and workers.
 * kill all containers.
 * clear container network.
 * clean up the volumes and images in disk.
 * remove the images and volumes references in concourse DB.
 * restart concourse.

The concourse team insisted that this is not a supported procedure and that the bugs must be fixed, but it did work for us several times and we consider it is a fair workaround until concourse fixes the issues.

[1] https://github.com/concourse/concourse/issues/565
[2] https://github.com/concourse/concourse/issues/737
[3] https://github.com/concourse/concourse/issues/682
[4] https://github.com/concourse/concourse/issues/507

How to test?
------------

Run `make shake_concourse_volumes DEPLOY_ENV=...`. All the concourse service will be restarted. Check that it still works.

Double check that `make ssh_concourse DEPLOY_ENV=...` and `make ssh_concourse DEPLOY_ENV=... SSH_CMD="ls /"` work

Who?
----

Anyone but @keymon