### PR TITLE
WIP: [#133741599] Remove the cleanup_syslog_forwarding addon

### DIFF
--- a/manifests/cf-manifest/runtime-config/runtime-config-base.yml
+++ b/manifests/cf-manifest/runtime-config/runtime-config-base.yml
@@ -24,10 +24,3 @@ addons:
         port: 2514
         transport: 'relp'
         log_template: 'metron_agent'
-  - name: syslog_cleanup
-    jobs:
-    - name: cleanup_syslog_forwarding
-      release: os-conf
-      properties:
-        syslog_daemon_config: # Note: property also used by metron_agent in main manifest
-          enable: false


### PR DESCRIPTION
[#133741599 Remove syslog cleanup job](https://www.pivotaltracker.com/story/show/133741599)
[#131975557 Alternate solution to configure syslog forwarding without metron agent](https://www.pivotaltracker.com/story/show/131975557)

What?
-----

in #561 and 561cb6b we had to add a addon to remove the rsyslog config
file created by metron_agent.

The change has been deployed in all the environments, so we can remove
this cleanup job.

How to review
-----------

Check that makes sense.

Who?
---

Anyone but @keymon