### PR TITLE
Upgrade to concourse 2.4.0

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -22,8 +22,8 @@ resource_pools:
   - name: concourse
     network: concourse
     stemcell:
-      url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3263.5
-      sha1: a4a3b387ee81cd0e1b73debffc39f0907b80f9c6
+      url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3263.8
+      sha1: 95ecc2709ac62f21d0a1c6cac023585c3919b825
     cloud_properties:
       instance_type: m4.large
       availability_zone: (( grab terraform_outputs.zone0 ))

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -6,8 +6,8 @@ name: (( grab meta.environment ))
 
 releases:
   - name: concourse
-    url: https://bosh.io/d/github.com/concourse/concourse?v=2.2.1
-    sha1: 879d5cb45d12f173ff4c7912c7c7cdcd3e18c442
+    url: https://bosh.io/d/github.com/concourse/concourse?v=2.4.0
+    sha1: 8eb1e707594b47adc7bfa10c89fe17524caf8461
   - name: garden-runc
     url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=0.8.0
     sha1: 20e98ea84c8f4426bba00bbca17d931e27d3c07d


### PR DESCRIPTION
[#133513945 Upgrade concourse 2.4.0](https://www.pivotaltracker.com/story/show/133513945)

What?
-----

We want to upgrade concourse to keep the latest version for support and because they claim if fixes issues managing volumes.

No changes in the config but some additional features and bugfixes.

To highlight:

>   feature
>
> Baggageclaim will now be more durable to corrupt volumes. Previously
> a borked metadata file would effectively wedge the Baggageclaim API,
> making the worker unrecoverable. You would see an error like "failed
> to list volumes" in your builds. Baggageclaim will now pretend these
> volumes don't exist in the API, and reap them from the disk.

[1] https://concourse.ci/downloads.html#v240


I also use the same version of stemcell than CF and bosh.

How to test?
-----------

Deploy concourse as explained in the README. Use it for a while.

Who?
----

Anyone but @keymon