### PR TITLE
Use CF_PUSH_TIMEOUT for any `cf push` or `cf start` in our tests.

### DIFF
--- a/platform-tests/src/acceptance/http_closed_test.go
+++ b/platform-tests/src/acceptance/http_closed_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Http client", func() {
 			"-p", "../../example-apps/static-app",
 			"-d", config.AppsDomain,
 		).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
-		Expect(cf.Cf("start", appName).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
+		Expect(cf.Cf("start", appName).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 
 		uri := appName + "." + config.AppsDomain + ":80"
 		_, err := net.DialTimeout("tcp", uri, CONNECTION_TIMEOUT)

--- a/platform-tests/src/acceptance/rds_broker_test.go
+++ b/platform-tests/src/acceptance/rds_broker_test.go
@@ -117,7 +117,7 @@ var _ = Describe("RDS broker", func() {
 			Expect(cf.Cf("stop", appName).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
 			Expect(cf.Cf("unbind-service", appName, dbInstanceName).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
 			Expect(cf.Cf("bind-service", appName, dbInstanceName).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
-			Expect(cf.Cf("start", appName).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
+			Expect(cf.Cf("start", appName).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 
 			resp, err = httpClient.Get(helpers.AppUri(appName, "/db/permissions-check?phase=test"))
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
# What

Currently we run several tests in parallel, and the load might make the operation last longer, so the test fails due timeout. It already happened several times in our CI environment

We use in most cases CF_PUSH_TIMEOUT (2m) for `cf push` or `cf start` currently 2m, instead of `DEFAULT_TIMEOUT` (30s) in the rest of operations.

In this PR we apply it to all the cases.

# How to review?

Double check that makes sense. I think it is quite safe to merge.

# Who?

Anyone but @keymon
