### PR TITLE
[#132736941] Increase memory allocated to paas-dashboard

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -2096,7 +2096,7 @@ jobs:
                   . ./config/config.sh
                   cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS} \
                     -o admin -s admin
-                  cf push --no-start -m 100M -b ruby_buildpack \
+                  cf push --no-start -m 256M -b ruby_buildpack \
                     -p paas-cf/tools/paas_dashboard paas-dashboard
                   echo Setting DD_API_KEY...
                   cf set-env paas-dashboard DD_API_KEY {{datadog_api_key}} > /dev/null


### PR DESCRIPTION
## What
Story: [Create Dashboard based on Datadog Monitoring](https://www.pivotaltracker.com/story/show/132736941)

When deployed to production the paas-dashboard app was crashing as it uses slightly more memory than the allocated 100MB.
We increase it to 256MB to avoid this.

## How to review

* Deploy with `ENABLE_PAAS_DASHBOARD=true`
* Check the app `paas-dashboard` in org admin space admin has 256MB allocated

## Who can review
Not me
