### PR TITLE
[#133855001] Avoid - and _ in generated passwords.

### DIFF
--- a/manifests/shared/lib/secret_generator.rb
+++ b/manifests/shared/lib/secret_generator.rb
@@ -3,11 +3,11 @@ require 'openssl'
 require 'digest/md5'
 
 class SecretGenerator
-  PASSWORD_LENGTH = 12
+  PASSWORD_LENGTH = 18
 
   def self.random_password
-    bytes = PASSWORD_LENGTH * 3 / 4
-    SecureRandom.urlsafe_base64(bytes)
+    bytes = PASSWORD_LENGTH / 2
+    SecureRandom.hex(bytes)
   end
 
   def self.sha512_crypt(password, salt = nil)

--- a/manifests/shared/spec/secret_generator_spec.rb
+++ b/manifests/shared/spec/secret_generator_spec.rb
@@ -2,7 +2,7 @@
 require 'secret_generator'
 
 RSpec.describe SecretGenerator do
-  SIMPLE_PASSWORD_REGEX = /\A[a-zA-Z0-9_-]+\z/
+  SIMPLE_PASSWORD_REGEX = /\A[a-zA-Z0-9]+\z/
 
   describe "password generation" do
     it "generates a passwords of the required length" do
@@ -17,7 +17,7 @@ RSpec.describe SecretGenerator do
         "Duplicate passwords generated (#{duplicated_passwords.join(',')} generated more than once)"
     end
 
-    it "only uses URL-safe characters" do
+    it "only uses alphanumeric characters" do
       10.times do
         expect(SecretGenerator.random_password).to match(SIMPLE_PASSWORD_REGEX)
       end


### PR DESCRIPTION
## What

We've recently hit an issue with a generated password that started with
a - tripping up one of the CLI tools we use (`cf create-service-broker`).

This therefore changes the password generation scheme we use to use hex
instead. It also increases the length from 12 to 18 chars so that the
generated passwords continue to represent the same number of random
bytes.

Note: because passwords are only generated when missing, this won't affect any existing passwords, only new ones.

## How to review

Code review.
Run the pipeline as far as generate-secrets.
* Existing passwords should be unchanged.
* New passwords should now be 18 chars of hex.

## Who can review

Not me.