### PR TITLE
[#131975557] Add adhoc bosh ssh task to clean old rsyslog conf

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -2117,6 +2117,7 @@ jobs:
           - get: cf-secrets
             passed: ['cf-deploy']
           - get: bosh-CA
+          - get: bosh-secrets
 
       - task: retrieve-config
         config:
@@ -2149,55 +2150,56 @@ jobs:
                   echo export "${var_name}"=\"$(eval echo \$${var_name})\"
                 done > config/config.sh
 
-      - task: deploy-healthcheck
-        config:
-          platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/cf-cli
-          params:
-            DISABLE_HEALTHCHECK_DB: {{disable_healthcheck_db}}
-          inputs:
-            - name: paas-cf
-            - name: config
-            - name: bosh-CA
-          outputs:
-            - name: deployed-healthcheck
-          run:
-            path: sh
-            args:
-              - -e
-              - -u
-              - -c
-              - |
-                ./paas-cf/concourse/scripts/import_bosh_ca.sh
+      - aggregate:
+        - task: deploy-healthcheck
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/cf-cli
+            params:
+              DISABLE_HEALTHCHECK_DB: {{disable_healthcheck_db}}
+            inputs:
+              - name: paas-cf
+              - name: config
+              - name: bosh-CA
+            outputs:
+              - name: deployed-healthcheck
+            run:
+              path: sh
+              args:
+                - -e
+                - -u
+                - -c
+                - |
+                  ./paas-cf/concourse/scripts/import_bosh_ca.sh
 
-                . ./config/config.sh
-                echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
-                cf create-org testers
-                cf set-quota testers test_apps
-                cf create-space healthcheck -o testers
-                cf target -o testers -s healthcheck
-                BUILD_ROOT=$(pwd)
-                cd paas-cf/platform-tests/example-apps/healthcheck
-                cf push --no-start
-                if  [ "${DISABLE_HEALTHCHECK_DB:-}" != "true" ] ; then
-                  cf create-service postgres Free healthcheck-db
-                  while ! cf service healthcheck-db | grep -q 'Status: create succeeded'; do
-                    echo "Waiting for creation of service to complete..."
-                    sleep 30
-                  done
-                  cf bind-service healthcheck healthcheck-db
-                fi
+                  . ./config/config.sh
+                  echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
+                  cf create-org testers
+                  cf set-quota testers test_apps
+                  cf create-space healthcheck -o testers
+                  cf target -o testers -s healthcheck
+                  BUILD_ROOT=$(pwd)
+                  cd paas-cf/platform-tests/example-apps/healthcheck
+                  cf push --no-start
+                  if  [ "${DISABLE_HEALTHCHECK_DB:-}" != "true" ] ; then
+                    cf create-service postgres Free healthcheck-db
+                    while ! cf service healthcheck-db | grep -q 'Status: create succeeded'; do
+                      echo "Waiting for creation of service to complete..."
+                      sleep 30
+                    done
+                    cf bind-service healthcheck healthcheck-db
+                  fi
 
-                cf start healthcheck
-                cd $BUILD_ROOT
-                echo "yes" > deployed-healthcheck/healthcheck-deployed
-        on_success:
-          put: deployed-healthcheck
-          params:
-            file: deployed-healthcheck/healthcheck-deployed
+                  cf start healthcheck
+                  cd $BUILD_ROOT
+                  echo "yes" > deployed-healthcheck/healthcheck-deployed
+          on_success:
+            put: deployed-healthcheck
+            params:
+              file: deployed-healthcheck/healthcheck-deployed
 
   - name: smoke-tests
     serial_groups: [smoke-tests]

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -2151,6 +2151,32 @@ jobs:
                 done > config/config.sh
 
       - aggregate:
+        - task: bosh-adhoc
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/bosh-cli
+            inputs:
+              - name: paas-cf
+              - name: cf-manifest
+              - name: bosh-secrets
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  ./paas-cf/concourse/scripts/bosh_login.sh {{bosh_fqdn}} bosh-secrets/bosh-secrets.yml
+                  sed -e "s/^director_uuid:.*/director_uuid: $(bosh status --uuid)/" < cf-manifest/cf-manifest.yml > cf-manifest.yml
+                  bosh deployment cf-manifest.yml
+                  echo "Removing old /etc/rsyslog.d/00-syslog_forwarder.conf set by metron_agent from all jobs"
+                  for job in $(bosh vms | awk '/[a-z0-9_-]\/[0-9]/ { print $2 }'); do
+                    # shellcheck disable=SC2016
+                    bosh ssh "${job}" 'set -x ; if [ -f /etc/rsyslog.d/00-syslog_forwarder.conf ]; then sudo rm -f /etc/rsyslog.d/00-syslog_forwarder.conf; sudo service rsyslog restart; ls -l /etc/rsyslog.d; ps -fp $(pgrep rsyslogd); fi'
+                  done
+
         - task: deploy-healthcheck
           config:
             platform: linux


### PR DESCRIPTION
[#131975557 Alternate solution to configure syslog forwarding without metron agent](https://www.pivotaltracker.com/story/show/131975557)

What?
-----

In #561 and #585 we added some logic to remove the old rsyslog config created by metron_agent. But this solution did not work completely due some reason, and some VMs keeped the old file.

As it is quite slow and tedious the approach of creating an adhoc task to delete the file, we will use a concourse task that runs a `bosh ssh` on all the VMs.

This is simplier, quicker to develop and review, and easier to test and later remove. I also prevent unnecesary bosh deployments and restart of services after removing the task.

Currently this task will do bosh ssh on each VM, check if the file `/etc/rsyslog.d/00-syslog_forwarder.conf` is present, and if it is, remove it and restart rsyslogd.

This commit can be later reverted.

How to test
-----------

Fake the situation by dropping  this file on some VMs:

```
bosh ssh access/1 'sudo touch /etc/rsyslog.d/00-syslog_forwarder.conf'
bosh ssh api/1 'sudo touch /etc/rsyslog.d/00-syslog_forwarder.conf'
```

Apply this pipeline, and run the task

```
export DEPLOY_ENV=...
BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines
BRANCH=$(git rev-parse --abbrev-ref HEAD) JOB=post-deploy make dev run_job
```

You should see in the output of post-deploy/bosh-adhoc that the script is executed in all the VMs, and the ones that had the file did remove it and restart rsyslog.

Who?
---

Anyone but @keymon