### PR TITLE
[#133106357] Switch rsyslog from RELP to TCP

### DIFF
--- a/manifests/cf-manifest/runtime-config/runtime-config-base.yml
+++ b/manifests/cf-manifest/runtime-config/runtime-config-base.yml
@@ -21,6 +21,6 @@ addons:
     properties:
       syslog:
         address: (( grab terraform_outputs.logsearch_ingestor_elb_dns_name ))
-        port: 2514
-        transport: 'relp'
+        port: 5514
+        transport: 'tcp'
         log_template: 'metron_agent'


### PR DESCRIPTION
## What
Story: [Fix rsyslog high cpu usage & getting stuck on restart](https://www.pivotaltracker.com/story/show/133106357)

There is an issue in our configuration when sending logs via RELP protocol from syslog to logstash via an ELB. If the ingestor is temporarily disconnected, the messages aren't logged anymore. Rsyslog tries to reconnect, opens many connections and consumes a lot of CPU.
We may investigate the root cause but in the meantime, we revert to the default TCP configuration because it doesn't show this behaviour.

## How to review
* Deploy
* SSH to `cell/0` for example
* Observe rsyslog is not connected to the ingestor ELB via RELP: `netstat -an | grep :2514`
* Observe rsyslog is connected to the ingestor ELB via TCP: `netstat -an | grep :5514`
* In AWS console, locate the ingestor ELB and remove the ingestor backends
* Observe rsyslog is disconnected: `netstat -an | grep :5514`
* Observe kibana doesn't show new logs
* Reconnect the ingestor backends
* Observe rsyslog reconnects automatically: `netstat -an | grep :5514`
* Observe kibana shows new logs

## Who can review
Not @paroxp or me
