### PR TITLE
[#132736941] Layout Datadog dashboard vertically

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -2096,8 +2096,8 @@ jobs:
                   . ./config/config.sh
                   cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS} \
                     -o admin -s admin
-                  cf push --no-start -m 256M -b ruby_buildpack \
-                    -p paas-cf/tools/paas_dashboard paas-dashboard
+                  cd paas-cf/tools/paas_dashboard
+                  cf push --no-start paas-dashboard
                   echo Setting DD_API_KEY...
                   cf set-env paas-dashboard DD_API_KEY {{datadog_api_key}} > /dev/null
                   echo Setting DD_APP_KEY...

--- a/tools/paas_dashboard/Gemfile
+++ b/tools/paas_dashboard/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby '2.3.1'
+
 gem 'smashing'
 
 # js runtime for execjs to use

--- a/tools/paas_dashboard/Gemfile.lock
+++ b/tools/paas_dashboard/Gemfile.lock
@@ -71,5 +71,8 @@ DEPENDENCIES
   smashing
   therubyracer
 
+RUBY VERSION
+   ruby 2.3.1p112
+
 BUNDLED WITH
-   1.12.5
+   1.13.1

--- a/tools/paas_dashboard/Procfile
+++ b/tools/paas_dashboard/Procfile
@@ -1,1 +1,0 @@
-web: smashing start -e production -p $PORT

--- a/tools/paas_dashboard/dashboards/paas-overview.erb
+++ b/tools/paas_dashboard/dashboards/paas-overview.erb
@@ -1,7 +1,8 @@
 <script type='text/javascript'>
 $(function() {
-  Dashing.numColumns = 3
-  Dashing.widget_base_dimensions = [600, 500]
+  var rows = 3;
+  Dashing.numColumns = 1;
+  Dashing.widget_base_dimensions = [window.innerWidth - 20, (window.innerHeight - 10) / rows - 10];
 });
 </script>
 <div class="gridster">
@@ -11,12 +12,12 @@ $(function() {
         <div data-title="Prod" data-id="prod_counts" data-view="Health"></div>
       </a>
     </li>
-    <li data-row="1" data-col="2" data-sizex="1" data-sizey="1">
+    <li data-row="2" data-col="1" data-sizex="1" data-sizey="1">
       <a href="https://app.datadoghq.com/monitors#manage?query=service:staging_monitors" target="_blank">
         <div data-title="Staging" data-id="staging_counts" data-view="Health"></div>
       </a>
     </li>
-    <li data-row="1" data-col="3" data-sizex="1" data-sizey="1">
+    <li data-row="3" data-col="1" data-sizex="1" data-sizey="1">
       <a href="https://app.datadoghq.com/monitors#manage?query=service:master_monitors" target="_blank">
         <div data-title="CI" data-id="ci_counts" data-view="Health"></div>
       </a>

--- a/tools/paas_dashboard/manifest.yml
+++ b/tools/paas_dashboard/manifest.yml
@@ -1,0 +1,6 @@
+---
+applications:
+ - buildpack: ruby_buildpack
+   memory: 256M
+   instances: 1
+   command: "bundle exec smashing start -e production -p $PORT"

--- a/tools/paas_dashboard/widgets/health/health.html
+++ b/tools/paas_dashboard/widgets/health/health.html
@@ -6,20 +6,20 @@
         </div> <!-- /error -->
         <div data-hideif="status | equals 'error'"> <!-- no error -->
             <div data-hideif="criticals | equals 0" class="floated">
-                <div class="h3" data-bind="criticals"></div>
-                <div class="h4">
+                <h3 data-bind="criticals"></h3>
+                <h4>
                     critical<span data-hideif="criticals | equals 1">s</span>
-                </div>
+                </h4>
             </div>
 
             <div data-hideif="warnings | equals 0" class="floated">
-                <div class="h3" data-bind="warnings"></div>
-                <div class="h4">
+                <h3 data-bind="warnings"></h3>
+                <h4>
                     warning<span data-hideif="warnings | equals 1">s</span>
-                </div>
+                </h4>
             </div>
             <div data-showif="status | equals 'green'">
-                <div class="h3">&#10003;</div>
+                <h3>&#10003;</h3>
             </div>
             <p class="updated-at" data-bind="updatedAtMessage"></p>
         </div> <!-- /no error -->

--- a/tools/paas_dashboard/widgets/health/health.html
+++ b/tools/paas_dashboard/widgets/health/health.html
@@ -7,7 +7,7 @@
         <div data-hideif="status | equals 'error'"> <!-- no error -->
             <div data-hideif="criticals | equals 0" class="floated">
                 <div class="h3" data-bind="criticals"></div>
-                <div data-hideif="criticals | equals 0" class="h4">
+                <div class="h4">
                     critical<span data-hideif="criticals | equals 1">s</span>
                 </div>
             </div>

--- a/tools/paas_dashboard/widgets/health/health.scss
+++ b/tools/paas_dashboard/widgets/health/health.scss
@@ -75,22 +75,10 @@ $error: #5B0274;
       }
     }
 
-    div {
-      &.floated {
-        display: inline-block;
-        margin-left: 20px;
-        margin-right: 20px;
-      }
-
-      &.h3 {
-        font-size: 120px;
-        font-weight: bold;
-      }
-
-      &.h4 {
-        font-size: 50px;
-        text-transform: uppercase;
-      }
+    div.floated {
+      display: inline-block;
+      margin-left: 20px;
+      margin-right: 20px;
     }
   }
 }

--- a/tools/paas_dashboard/widgets/health/health.scss
+++ b/tools/paas_dashboard/widgets/health/health.scss
@@ -13,20 +13,20 @@ $error: #5B0274;
     bottom: 0;
     left: 0;
     right: 0;
-    padding-top: 25px;
+    padding-top: 5px;
 
 
     h1 {
-      font-size: 80px;
+      font-size: 7vh;
     }
 
     h3 {
-      font-size: 30px;
+      font-size: 7vh;
       font-weight: bold;
     }
 
     h4 {
-      font-size: 10px;
+      font-size: 3vh;
       font-weight: bold;
       text-transform: uppercase;
     }


### PR DESCRIPTION
## What

We want to use a vertical split view to show this dashboard on our big
 screens. This updates the Smashing Datadog dashboard to arrange the 3 boxes
vertically. It also updates the sizes to be dynamic based on the window
size. In order to get the fonts sized accordingly, I've had to use the
[viewport-percentage units](https://drafts.csswg.org/css-values/#viewport-relative-lengths). This is the best that's possible with pure
CSS, but they will need updating if we add/remove rows.

This also includes a couple of other small fixes/improvements. See individual commits for details.

## How to review

Push the dashboard to a CF instance.
* `cf login`, and target a suitable space.
* Push the app:
```sh
cd tools/paas_dashboard
cf push testing-dashboard --no-start
cf set-env testing-dashboard DD_APP_KEY "$(paas-pass datadog/dev/datadog_app_key)"
cf set-env testing-dashboard DD_API_KEY "$(paas-pass datadog/dev/datadog_api_key)"
cf start testing-dashboard
```
View the app URL in the browser (`https://testing-dashboard.${DEPLOY_ENV}.dev.cloudpipelineapps.digital`). Check it fills the screen.

Load this up in frame-splits using the large/small 2 column view available in my fork.  (Use the following replacing `DEPLOY_ENV`: `https://alext.github.io/frame-splits/index.html?title=&layout=2col-large-small&url%5B%5D=about%3Ablank&url%5B%5D=https%3A%2F%2Ftest-dashboard.DEPLOY_ENV.dev.cloudpipelineapps.digital%2Fpaas-overview&url%5B%5D=&url%5B%5D=`). Check it looks right at likely screen sizes.

Clean up the app:
```sh
cf delete -r testing-dashboard
```

## Who can review

Anyone but myself.