### PR TITLE
[#133741599] Revert "Add adhoc bosh ssh task to clean old rsyslog conf"

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -2117,7 +2117,6 @@ jobs:
           - get: cf-secrets
             passed: ['cf-deploy']
           - get: bosh-CA
-          - get: bosh-secrets
 
       - task: retrieve-config
         config:
@@ -2150,82 +2149,55 @@ jobs:
                   echo export "${var_name}"=\"$(eval echo \$${var_name})\"
                 done > config/config.sh
 
-      - aggregate:
-        - task: bosh-adhoc
-          config:
-            platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: governmentpaas/bosh-cli
-            inputs:
-              - name: paas-cf
-              - name: cf-manifest
-              - name: bosh-secrets
-            run:
-              path: sh
-              args:
-                - -e
-                - -c
-                - |
-                  ./paas-cf/concourse/scripts/bosh_login.sh {{bosh_fqdn}} bosh-secrets/bosh-secrets.yml
-                  sed -e "s/^director_uuid:.*/director_uuid: $(bosh status --uuid)/" < cf-manifest/cf-manifest.yml > cf-manifest.yml
-                  bosh deployment cf-manifest.yml
-                  echo "Removing old /etc/rsyslog.d/00-syslog_forwarder.conf set by metron_agent from all jobs"
-                  for job in $(bosh vms | awk '/[a-z0-9_-]\/[0-9]/ { print $2 }'); do
-                    # shellcheck disable=SC2016
-                    bosh ssh "${job}" 'set -x ; if [ -f /etc/rsyslog.d/00-syslog_forwarder.conf ]; then sudo rm -f /etc/rsyslog.d/00-syslog_forwarder.conf; sudo service rsyslog restart; ls -l /etc/rsyslog.d; ps -fp $(pgrep rsyslogd); fi'
+      - task: deploy-healthcheck
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/cf-cli
+          params:
+            DISABLE_HEALTHCHECK_DB: {{disable_healthcheck_db}}
+          inputs:
+            - name: paas-cf
+            - name: config
+            - name: bosh-CA
+          outputs:
+            - name: deployed-healthcheck
+          run:
+            path: sh
+            args:
+              - -e
+              - -u
+              - -c
+              - |
+                ./paas-cf/concourse/scripts/import_bosh_ca.sh
+
+                . ./config/config.sh
+                echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
+                cf create-org testers
+                cf set-quota testers test_apps
+                cf create-space healthcheck -o testers
+                cf target -o testers -s healthcheck
+                BUILD_ROOT=$(pwd)
+                cd paas-cf/platform-tests/example-apps/healthcheck
+                cf push --no-start
+                if  [ "${DISABLE_HEALTHCHECK_DB:-}" != "true" ] ; then
+                  cf create-service postgres Free healthcheck-db
+                  while ! cf service healthcheck-db | grep -q 'Status: create succeeded'; do
+                    echo "Waiting for creation of service to complete..."
+                    sleep 30
                   done
+                  cf bind-service healthcheck healthcheck-db
+                fi
 
-        - task: deploy-healthcheck
-          config:
-            platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: governmentpaas/cf-cli
-            params:
-              DISABLE_HEALTHCHECK_DB: {{disable_healthcheck_db}}
-            inputs:
-              - name: paas-cf
-              - name: config
-              - name: bosh-CA
-            outputs:
-              - name: deployed-healthcheck
-            run:
-              path: sh
-              args:
-                - -e
-                - -u
-                - -c
-                - |
-                  ./paas-cf/concourse/scripts/import_bosh_ca.sh
-
-                  . ./config/config.sh
-                  echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
-                  cf create-org testers
-                  cf set-quota testers test_apps
-                  cf create-space healthcheck -o testers
-                  cf target -o testers -s healthcheck
-                  BUILD_ROOT=$(pwd)
-                  cd paas-cf/platform-tests/example-apps/healthcheck
-                  cf push --no-start
-                  if  [ "${DISABLE_HEALTHCHECK_DB:-}" != "true" ] ; then
-                    cf create-service postgres Free healthcheck-db
-                    while ! cf service healthcheck-db | grep -q 'Status: create succeeded'; do
-                      echo "Waiting for creation of service to complete..."
-                      sleep 30
-                    done
-                    cf bind-service healthcheck healthcheck-db
-                  fi
-
-                  cf start healthcheck
-                  cd $BUILD_ROOT
-                  echo "yes" > deployed-healthcheck/healthcheck-deployed
-          on_success:
-            put: deployed-healthcheck
-            params:
-              file: deployed-healthcheck/healthcheck-deployed
+                cf start healthcheck
+                cd $BUILD_ROOT
+                echo "yes" > deployed-healthcheck/healthcheck-deployed
+        on_success:
+          put: deployed-healthcheck
+          params:
+            file: deployed-healthcheck/healthcheck-deployed
 
   - name: smoke-tests
     serial_groups: [smoke-tests]


### PR DESCRIPTION
[#133741599 Remove syslog cleanup job](https://www.pivotaltracker.com/story/show/133741599)

Dependencies
------------------

Wait for #598 to be deployed in prod!

What?
-----

Continuation of #593

We added an adhoc task to remove a spurios rsyslog config from the metron_agent.

The previous approach from #561 and 561cb6b to add a addon to remove
the rsyslog config file created by metron_agent did not work.

This reverts commit 82c8fc8743fe6145561bab96d1a60045a7f9ecde. The job has run in all the environments, deleting the undesired config and restarting rsyslog.


How to review?
---------------

check that makes sense

Who?
----

Anyone but @keymon