### PR TITLE
[#133513945] Increase delay of clean_concourse plugin to 2s [ci skip]

### DIFF
--- a/misc/chrome_plugins/clean_concourse_pipeline/src/inject.user.js
+++ b/misc/chrome_plugins/clean_concourse_pipeline/src/inject.user.js
@@ -30,4 +30,4 @@ var readyStateCheckInterval = setInterval(function() {
         // Remove the padding because the top bar isn't there any more.
         element.style.paddingTop = "0";
     }
-}, 10);
+}, 2000);


### PR DESCRIPTION
[#133513945 Upgrade concourse 2.4.0](https://www.pivotaltracker.com/story/show/133513945)

What?
----

This plugin assumes that all the elements are present and the page
rendered after 10ms, and if not, it fails because it cannot find the
right DOM elements.

The new version of concourse 2.4.0 takes longer to completely render in
the dashboard screen, specially when we have 3 frames as we do. Because
that the script does not work in our dashboard.

In this commit we workaround this issue by delaying the execution of
the script much more longer, up to 2000ms or 2s.

A more elegant solution should be waiting/polling until all elements are
present and then apply the changes. But as this is a simple script for
our dashboards it is not so relevant.

How to test?
------------

I applied this to the dashboard. check that works. Check the code.

Dependencies
-----------

After merge, pull and checkout master in the dashboard, refresh the extensions
in chrome and refresh the build dashboard.

Who?
----

Anyone but @keymon