### PR TITLE
Fix issues created by displaying grafana PW

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,10 +176,12 @@ pipelines: ## Upload pipelines to Concourse
 .PHONY: showenv
 showenv: ## Display environment information
 	$(eval export TARGET_CONCOURSE=deployer)
-	@echo CONCOURSE_IP=$$(aws ec2 describe-instances \
+	@concourse/scripts/environment.sh
+	@echo export GRAFANA_PASSWORD=$$(aws s3 cp "s3://${DEPLOY_ENV}-state/cf-secrets.yml" - | \
+		ruby -ryaml -e 'puts YAML.load(STDIN)["secrets"]["grafana_admin_password"]')
+	@echo export CONCOURSE_IP=$$(aws ec2 describe-instances \
 		--filters 'Name=tag:Name,Values=concourse/0' "Name=key-name,Values=${DEPLOY_ENV}_concourse_key_pair" \
 		--query 'Reservations[].Instances[].PublicIpAddress' --output text)
-	@concourse/scripts/environment.sh
 
 .PHONY: upload-datadog-secrets
 upload-datadog-secrets: check-env-vars ## Decrypt and upload Datadog credentials to S3

--- a/concourse/scripts/environment.sh
+++ b/concourse/scripts/environment.sh
@@ -43,13 +43,6 @@ if [ -z "${CONCOURSE_ATC_PASSWORD:-}" ]; then
   fi
 fi
 
-if [ -n "${DECRYPT_CONCOURSE_ATC_PASSWORD:-}" ]; then
-  GRAFANA_PASSWORD=$(pass "${DECRYPT_CONCOURSE_ATC_PASSWORD}/grafana_admin_password")
-else
-  GRAFANA_PASSWORD=$(aws s3 cp "s3://${DEPLOY_ENV}-state/cf-secrets.yml" - | \
-                     ruby -ryaml -e 'puts YAML.load(STDIN)["secrets"]["grafana_admin_password"]')
-fi
-
 cat <<EOF
 export AWS_ACCOUNT=${AWS_ACCOUNT}
 export DEPLOY_ENV=${DEPLOY_ENV}
@@ -61,6 +54,5 @@ export FLY_TARGET=${FLY_TARGET}
 export API_ENDPOINT=https://api.${SYSTEM_DNS_ZONE_NAME}
 export LOGSEARCH_URL=https://logsearch.${SYSTEM_DNS_ZONE_NAME}
 export GRAFANA_URL=https://metrics.${SYSTEM_DNS_ZONE_NAME}
-export GRAFANA_PASSWORD=${GRAFANA_PASSWORD}
 export GRAPHITE_URL=https://metrics.${SYSTEM_DNS_ZONE_NAME}:3001
 EOF


### PR DESCRIPTION
## What

We do call the environment script in our pipeline and we run it in a container that does not have 'aws' tool installed - or even keys configured. Add same condition that we use for ATC password and adjust the relevant task in the pipeline to skip trying to retrieve grafana password

## How to review

Run bosh-cli tests task and make sure it passes.

## Who can review

not @mtekel