### PR TITLE
[#133751193] Enable datadog BOSH healthmonitor integration and add some monitors on healthy metric]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
   - 2.2.3
 env:
   global:
-    - TF_VERSION="0.7.3"
+    - TF_VERSION="0.7.10"
     - SPRUCE_VERSION="1.5.0"
     - DEPLOY_ENV="travis"
 

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -980,6 +980,7 @@ jobs:
           params:
             AWS_ACCOUNT: {{aws_account}}
             DATADOG_API_KEY: {{datadog_api_key}}
+            DATADOG_APP_KEY: {{datadog_app_key}}
             ENABLE_DATADOG: {{enable_datadog}}
             BOSH_MANIFEST_STUBS: |
               ./paas-cf/manifests/bosh-manifest/bosh-manifest.yml

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1660,10 +1660,10 @@ jobs:
                 bosh deployment updated-cf-manifest/cf-manifest.yml
                 bosh update runtime-config runtime-config/runtime-config.yml
                 bosh -n deploy
+
       - put: cf-manifest
         params:
           file: updated-cf-manifest/cf-manifest.yml
-
 
       - task: retrieve-config
         config:
@@ -1707,6 +1707,11 @@ jobs:
                 for var_name in CF_ADMIN CF_PASS FIREHOSE_USER FIREHOSE_PASS API_ENDPOINT UAA_ENDPOINT DOPPLER_ENDPOINT GRAPHITE_SERVER RDS_BROKER_SERVER RDS_BROKER_PASS; do
                   echo export "${var_name}"=\"$(eval echo \$${var_name})\"
                 done > config/config.sh
+
+                paas-cf/scripts/job_instances.rb cf-manifest/cf-manifest.yml \
+                  > config/job_instances.tfvars
+
+                ls -l config/*
 
       - task: create-admin-org-space
         config:
@@ -1996,6 +2001,7 @@ jobs:
             inputs:
               - name: datadog-tfstate
               - name: paas-cf
+              - name: config
             outputs:
               - name: updated-tfstate
             params:
@@ -2022,7 +2028,8 @@ jobs:
 
                   if [ "${ENABLE_DATADOG}" = "true" ]; then
                     [ "${ENABLE_CVE_NOTIFIER}" = "true" ] && export TF_VAR_enable_cve_notifier=1
-                    terraform apply -state=datadog-tfstate/datadog.tfstate -state-out=updated-tfstate/datadog.tfstate paas-cf/terraform/datadog
+                    terraform apply -state=datadog-tfstate/datadog.tfstate -state-out=updated-tfstate/datadog.tfstate \
+                      -var-file=config/job_instances.tfvars paas-cf/terraform/datadog
                   else
                     echo "Datadog disabled, skipping terraform run..."
                     cp datadog-tfstate/datadog.tfstate updated-tfstate/datadog.tfstate

--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -79,6 +79,10 @@ jobs:
         user: hm
         password: (( grab secrets.bosh_hm_director_password ))
       resurrector_enabled: false
+      datadog_enabled: (( grab meta.datadog.enabled ))
+      datadog:
+          api_key: (( grab meta.datadog.api_key ))
+          application_key: (( grab meta.datadog.application_key ))
 
     agent:
       mbus: (( concat "nats://nats:" secrets.bosh_nats_password "@" terraform_outputs.bosh_fqdn ":4222" ))

--- a/manifests/bosh-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/bosh-manifest/spec/support/manifest_helpers.rb
@@ -17,6 +17,7 @@ private
   def load_default_manifest
     ENV["AWS_ACCOUNT"] = "dev"
     ENV["DATADOG_API_KEY"] = "abcd1234"
+    ENV["ENABLE_DATADOG"] = "true"
 
     output, error, status = Open3.capture3(
       [

--- a/manifests/cf-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/cf-manifest/spec/support/manifest_helpers.rb
@@ -24,6 +24,7 @@ private
   def fake_env_vars
     ENV["AWS_ACCOUNT"] = "dev"
     ENV["DATADOG_API_KEY"] = "abcd1234"
+    ENV["ENABLE_DATADOG"] = "true"
   end
 
   def render(arg_list)

--- a/manifests/concourse-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/concourse-manifest/spec/support/manifest_helpers.rb
@@ -18,6 +18,7 @@ private
     ENV["AWS_ACCOUNT"] = "dev"
     ENV["DATADOG_API_KEY"] = "abcd1234"
     ENV["CONCOURSE_AUTH_DURATION"] = "5m"
+    ENV["ENABLE_DATADOG"] = "true"
     output, error, status = Open3.capture3(
       [
         File.expand_path("../../../../shared/build_manifest.sh", __FILE__),

--- a/manifests/shared/deployments/datadog-agent.yml
+++ b/manifests/shared/deployments/datadog-agent.yml
@@ -7,7 +7,9 @@ releases:
 
 meta:
   datadog:
+    enabled: (( grab $ENABLE_DATADOG ))
     api_key: (( grab $DATADOG_API_KEY || "undefined" ))
+    application_key: (( grab $DATADOG_APP_KEY || "undefined" ))
     use_dogstatsd: false
     include_bosh_tags: true
     tags:

--- a/scripts/job_instances.rb
+++ b/scripts/job_instances.rb
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+
+require File.expand_path("../lib/job_instances_lib", __FILE__)
+
+manifest_path = ARGV[0]
+manifest = File.read(manifest_path)
+
+puts JobInstances.generate manifest

--- a/scripts/lib/job_instances_lib.rb
+++ b/scripts/lib/job_instances_lib.rb
@@ -1,0 +1,21 @@
+require 'yaml'
+
+class JobInstances
+  def self.generate(manifest_yaml)
+    manifest = YAML.load(manifest_yaml)
+    return "" unless manifest
+
+    jobs = YAML.load(manifest_yaml)['jobs']
+    jobs_list = Array.new
+
+    if jobs
+      jobs.each do |job|
+        if job['instances'] > 0
+          jobs_list << "\"#{job['name']}:#{job['instances']}\""
+        end
+      end
+    end
+
+    "job_instances = [ #{jobs_list.join(', ')} ]"
+  end
+end

--- a/scripts/spec/job_instances_spec.rb
+++ b/scripts/spec/job_instances_spec.rb
@@ -1,0 +1,41 @@
+require 'job_instances_lib'
+
+RSpec.describe JobInstances do
+  it "generates an empty string when the manifest is empty" do
+    manifest = ""
+    tfvars = JobInstances.generate manifest
+    expect(tfvars).to be_empty
+  end
+
+  it "generates an empty list when there is no job" do
+    manifest = %{
+      jobs:
+    }
+    tfvars = JobInstances.generate manifest
+    expect(tfvars).to eq("job_instances = [  ]")
+  end
+
+  it "ignores a job with 0 instance" do
+    manifest = %{
+      jobs:
+      - name: consul
+        instances: 0
+    }
+    tfvars = JobInstances.generate manifest
+    expect(tfvars).to eq("job_instances = [  ]")
+  end
+
+  it "generates a list when there are several jobs" do
+    manifest = %{
+      jobs:
+        - name: consul
+          instances: 3
+        - name: nats
+          instances: 2
+        - name: etcd
+          instances: 3
+    }
+    tfvars = JobInstances.generate manifest
+    expect(tfvars).to eq("job_instances = [ \"consul:3\", \"nats:2\", \"etcd:3\" ]")
+  end
+end

--- a/terraform/datadog/bosh-jobs.tf
+++ b/terraform/datadog/bosh-jobs.tf
@@ -1,0 +1,52 @@
+resource "null_resource" "parsed_job_instances" {
+  count = "${length(var.job_instances)}"
+
+  triggers {
+    job_name = "${element(split(":", element(var.job_instances, count.index)), 0)}"
+    warning  = "${element(split(":", element(var.job_instances, count.index)), 1) - 1}"
+    critical = "${element(split(":", element(var.job_instances, count.index)), 1) - 2}"
+  }
+}
+
+resource "datadog_monitor" "job_healthy" {
+  count = "${length(var.job_instances)}"
+
+  name = "${format(
+    "%s %s bosh job is healthy",
+    var.env,
+    element(null_resource.parsed_job_instances.*.triggers.job_name, count.index)
+  )}"
+
+  type = "metric alert"
+
+  message = "${format(
+    "%s bosh job has too many unhealthy instances",
+    element(null_resource.parsed_job_instances.*.triggers.job_name, count.index)
+  )}"
+
+  escalation_message = "${format(
+    "%s bosh job has still too many unhealthy instances",
+    element(null_resource.parsed_job_instances.*.triggers.job_name, count.index)
+  )}"
+
+  no_data_timeframe   = "30"
+  require_full_window = true
+
+  query = "${format(
+    "avg(last_5m):sum:bosh.healthmonitor.system.healthy{deployment:%s,job:%s} <= %s",
+    var.env,
+    element(null_resource.parsed_job_instances.*.triggers.job_name, count.index),
+    element(null_resource.parsed_job_instances.*.triggers.critical, count.index)
+  )}"
+
+  thresholds {
+    critical = "${element(null_resource.parsed_job_instances.*.triggers.critical, count.index)}"
+    warning  = "${element(null_resource.parsed_job_instances.*.triggers.warning, count.index)}"
+  }
+
+  tags {
+    "deployment" = "${var.env}"
+    "service"    = "${var.env}_monitors"
+    "job"        = "${element(null_resource.parsed_job_instances.*.triggers.job_name, count.index)}"
+  }
+}

--- a/terraform/datadog/variables.tf
+++ b/terraform/datadog/variables.tf
@@ -2,3 +2,8 @@ variable "enable_cve_notifier" {
   description = "Enable CVE notifier. 1 to enable, 0 to disable."
   default     = 0
 }
+
+variable "job_instances" {
+  description = "List of pairs <job_name>:<job_count> of expected bosh job instance count"
+  default     = []
+}


### PR DESCRIPTION
[#133751193 Enable datadog BOSH healthmonitor integration](https://www.pivotaltracker.com/story/show/133751193)

NOTE: This is WIP because we are not sure about the cost of adding the metrics in datadog.

What?
----

[The BOSH health monitor runs on the director VM and receives heartbeats every minute from all bosh agents via the Bosh NATS bus](https://bosh.io/docs/monitoring.html). The heartbeats contain system metrics (CPU, Memory, load, etc) and if all the monit services are running on the VM `bosh.healthmonitor.system.healthy` .

We are mainly interested in this `bosh.healthmonitor.system.healthy` metric, and we will ignore the other metrics that are already being sent by the datadog agents on each VM.

[Bosh health_manager can be configured to send the metrics to datadog](https://github.com/cloudfoundry/bosh/blob/master/release/jobs/health_monitor/spec#L185-L194).

We will create datadog monitors each job/vm defined in the manifest using Terraform. The monitor will alert based on the threshold of the sum of `bosh.healthmonitor.system.healthy` metric for each job type. We set `warning` if we loose one instance and `critical` if we loose 2.

Jobs with only one instance are not supposed to be critical, we will receive only a warning. We do not monitor jobs with 0 instances in the manifest.

During deployment, if a VM is replaced we will receive a temporary warning, as the services get restarted. It makes sense as redundancy is reduced.

If bosh or NATS are redeployed, we will not get metrics at all. The monitors will alert with `No data` after 30 min, to cover the time to redeploy bosh.

Dependencies
------------

Merge https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/77

How to review?
-------------

Redeploy everything with datadog enabled:
```
ENABLE_DATADOG=true  BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines DEPLOY_ENV=...
```

Check that the monitors are working and defined.

Who?
----

Anyone but @keymon or @saliceti