### PR TITLE
Prevent datadog deployment with missing keys

### DIFF
--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -56,7 +56,16 @@ prepare_environment() {
 
   download_git_id_rsa
   get_git_concourse_pool_clone_full_url_ssh
-  get_datadog_secrets
+
+  if [ "${ENABLE_DATADOG}" = "true" ] ; then
+    get_datadog_secrets
+
+    # shellcheck disable=SC2154
+    if [ -z "${datadog_api_key+x}" ] || [ -z "${datadog_app_key+x}" ] ; then
+      echo "Datadog enabled but could not retrieve api or app key. Did you do run \`make dev upload-datadog-secrets\`?"
+      exit 1
+    fi
+  fi
 
   export EXPOSE_PIPELINE=1
 }


### PR DESCRIPTION
## What

When you set "ENABLE_DATADOG" to true, you declare your intention to deploy monitoring. For that to work, you also have to have datadog keys available in your bucket (done with `make upload-datadog-secrets`). If you forgot about this, everything will work fine and deploy. Except no metrics will be
sent. So you have to investigate, figure out and then deploy everything again. Which can take couple of hours at least...

Stop deployment when datadog is enabled, but no keys are retrievable.

This has happened to me once and to @henrytk at least once as well. And it took half day to fix. Let's add this check so that we don't lose any more time.

## How to review

1. With `datadog-secrets.yml` missing in your bucket, try `ENABLE_DATADOG=true make dev pipelines`. It should fail with 
```
Datadog enabled but could not retrieve api or app key. Did you do run `make dev upload-datadog-secrets`?
make: *** [pipelines] Error 1
```
2. Do `make dev upload-datadog-secrets`. Run `ENABLE_DATADOG=true make dev pipelines` again. It should work correctly and upload pipeline which contains datadog app and api keys.

## Who can review

not @mtekel