### PR TITLE
[#133751193] Fix BOSH manifest rendering without datadog

### DIFF
--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -79,10 +79,6 @@ jobs:
         user: hm
         password: (( grab secrets.bosh_hm_director_password ))
       resurrector_enabled: false
-      datadog_enabled: (( grab meta.datadog.enabled ))
-      datadog:
-          api_key: (( grab meta.datadog.api_key ))
-          application_key: (( grab meta.datadog.application_key ))
 
     agent:
       mbus: (( concat "nats://nats:" secrets.bosh_nats_password "@" terraform_outputs.bosh_fqdn ":4222" ))

--- a/manifests/bosh-manifest/extensions/datadog-agent.yml
+++ b/manifests/bosh-manifest/extensions/datadog-agent.yml
@@ -8,3 +8,8 @@ jobs:
     tags:
       bosh-job: bosh
       bosh-az: (( grab terraform_outputs.bosh_az_label ))
+    hm:
+      datadog_enabled: (( grab meta.datadog.enabled ))
+      datadog:
+          api_key: (( grab meta.datadog.api_key ))
+          application_key: (( grab meta.datadog.application_key ))


### PR DESCRIPTION
[#133751193 Enable datadog BOSH healthmonitor integration](https://www.pivotaltracker.com/story/show/133751193)

## What

In #607 we have introduced a "fixed" portion of hm config which references meta.datadog, but which is only added in datadog extension yml - which is not merged in when datadog is disabled. This then breaks rendering of manifest. Move datadog monitor config into extension file to fix this.

## How to review

Run generate-bosh-config with datadog enabled and with datadog disabled. It should work correctly in both cases.

## Who can review

not @mtekel