### PR TITLE
Correct failover when not logged into CF CLI

### DIFF
--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -89,6 +89,10 @@ check_params_and_environment() {
     abort_usage "Org must be defined"
   fi
 
+  if ! cf orgs >/dev/null 2>&1; then
+    abort "You need to be logged into CF CLI"
+  fi
+
   if ! aws ses get-send-quota >/dev/null 2>&1; then
     abort "You must have AWS cli installed and configured with valid credentials. Test it with: aws ses get-send-quota"
   fi


### PR DESCRIPTION
## What

We've ran into an issue, where the script failed with the message requesting correct AWS credentials, whilst not being logged in.

In order to avoid the confusion, we've placed an extra check just before the AWS check which should failover nicely.

## How to review

Attempt to run the script, whilst being logged out.

## Who can review

Not @paroxp