### PR TITLE
[pipecleaner] Don't assume dummy variables are safe.

### DIFF
--- a/concourse/scripts/pipecleaner.py
+++ b/concourse/scripts/pipecleaner.py
@@ -57,7 +57,9 @@ class Pipecleaner(object):
                 script += "set " + switch + "\n"
 
         for name, value in variables.iteritems():
-            script += "export " + name + "='DUMMY'\n"
+            # Include $(date) so that shellcheck doesn't assume these variables have safe contents
+            script += name + "=\"DUMMY-$(date)\"\n"
+            script += "export " + name + "\n"
 
         script += args[-1]
 


### PR DESCRIPTION
## What

When shellchecking scripts in the pipelines, pipecleaner inserts dummy
`export` statements for each of the `PARAMS` from the pipeline to prevent
shellcheck complaining about undefined variables. Because these were set
to the static string 'DUMMY', shellcheck wouldn't complain if they were
used unquoted in the scripts because it assumed their value was safe.
Inserting a call to `date` in these prevents shellcheck from assuming
they're safe.

## How to review

Code review.

## Who can review

Anyone but myself.