### PR TITLE
WIP: [#131722515] Output certificate ID and change path of certs to `/cloudfront/*` to be able to use them with cloudfront

### DIFF
--- a/terraform/cf-certs/outputs.tf
+++ b/terraform/cf-certs/outputs.tf
@@ -2,6 +2,14 @@ output "system_domain_cert_arn" {
   value = "${aws_iam_server_certificate.system.arn}"
 }
 
+output "system_domain_cert_id" {
+  value = "${aws_iam_server_certificate.system.id}"
+}
+
 output "apps_domain_cert_arn" {
   value = "${aws_iam_server_certificate.apps.arn}"
+}
+
+output "apps_domain_cert_id" {
+  value = "${aws_iam_server_certificate.apps.id}"
 }

--- a/terraform/cf-certs/upload.tf
+++ b/terraform/cf-certs/upload.tf
@@ -7,6 +7,7 @@ resource "aws_iam_server_certificate" "system" {
   certificate_body  = "${var.system_domain_crt}"
   private_key       = "${var.system_domain_key}"
   certificate_chain = "${var.system_domain_intermediate_crt}"
+  path              = "/cloudfront/system"
 
   lifecycle {
     create_before_destroy = true
@@ -18,6 +19,7 @@ resource "aws_iam_server_certificate" "apps" {
   certificate_body  = "${var.apps_domain_crt}"
   private_key       = "${var.apps_domain_key}"
   certificate_chain = "${var.apps_domain_intermediate_crt}"
+  path              = "/cloudfront/apps"
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
[#131722515 SPIKE: ability to ban IP ranges from CF endpoint access](https://www.pivotaltracker.com/story/show/131722515)

What?
-----

If we want to use AWS CloudFront with certificates uploaded to IAM, we must be able to get the ID of the certificate, and [these certificates must be set with a `path` with value `/cloudfront/something`](https://www.terraform.io/docs/providers/aws/r/iam_server_certificate.html#path).

This PR implements both cases, enabling us to use cloudfront in the future.

How to review?
--------------

Apply the deployment. everything should be working. Terraform output for certs should report the changes.

Who?
---

Anyone but @keymon