### PR TITLE
[#134551329] Parallelise acceptance tests

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -2332,7 +2332,7 @@ jobs:
             outputs:
               - name: artifacts
             run:
-              path: sh
+              path: bash
               args:
                 - -e
                 - -c
@@ -2348,6 +2348,9 @@ jobs:
                   if  [ "${DISABLE_CF_ACCEPTANCE_TESTS:-}" = "true" ]; then
                     echo "WARNING: The acceptance tests have been disabled. Unset DISABLE_CF_ACCEPTANCE_TESTS when uploading the pipelines to enable them. You can still hijack this container to run them manually, but you must update the admin user in ./test-config/config.json."
                   else
+                    SLEEPTIME=90
+                    echo "Sleeping for ${SLEEPTIME} seconds..."
+                    for i in $(seq $SLEEPTIME); do echo -ne "$i"'\r'; sleep 1; done; echo
                     /var/vcap/jobs/acceptance-tests/bin/run
                   fi
 

--- a/manifests/cf-manifest/manifest/900-cf-tests.yml
+++ b/manifests/cf-manifest/manifest/900-cf-tests.yml
@@ -20,6 +20,7 @@ properties:
     include_services: true
     include_route_services: false
     artifacts_directory: "/var/vcap/sys/log/test_artifacts"
+    nodes: 10
 
   smoke_tests:
     api: (( grab properties.acceptance_tests.api ))

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -25,7 +25,7 @@ resource_pools:
       url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3263.8
       sha1: 95ecc2709ac62f21d0a1c6cac023585c3919b825
     cloud_properties:
-      instance_type: m4.large
+      instance_type: m4.xlarge
       availability_zone: (( grab terraform_outputs.zone0 ))
       iam_instance_profile: deployer-concourse
       elbs:


### PR DESCRIPTION
## What

We want to speed up acceptance tests by enabling higher parallelisation.
The most stable configuration with huge reduction of tests run time was achieved with m4.xlarge VM type and 10 test nodes. Also we introduce 90 sec sleep time for `acceptance-tests` to spread initial load over time. Such config allows us to finish all tests suites in ~20 mins.

All test results and more reasoning: https://www.pivotaltracker.com/story/show/134551329 

## How to review

Read, run bootstrap to re-provision concourse and run the CF deploy pipeline twice.
Second run of `acceptance-tests` should take ~20min.  

## Who can review

Not @saliceti or @combor
