### PR TITLE
Change dev bootstrap AZ to avoid capacity issues.

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -6,19 +6,19 @@ Vagrant.require_version ">= 1.8.0"
 AWS_ACCOUNT = ENV.fetch("AWS_ACCOUNT", "dev")
 AWS_ACCOUNT_DATA = {
   "dev" => {
-    subnet_id: "subnet-d55defe8", # us-east-1e in default VPC, 172.31.32.0/20 range
+    subnet_id: "subnet-d55defe8", # us-east-1e in default VPC
     security_group: "sg-99e0c0e0", # "Bootstrap Concourse" security group
   },
   "ci" => {
-    subnet_id: "subnet-68bb7e30", # us-east-1a in default VPC, 172.31.16.0/20 range
+    subnet_id: "subnet-68bb7e30", # us-east-1a in default VPC
     security_group: "sg-23e1c15a", # "Bootstrap Concourse" security group
   },
   "staging" => {
-    subnet_id: "subnet-9034fbc8", # us-east-1c in default VPC, 172.31.16.0/20 range
+    subnet_id: "subnet-9034fbc8", # us-east-1c in default VPC
     security_group: "sg-87e1c1fe", # "Bootstrap Concourse" security group
   },
   "prod" => {
-    subnet_id: "subnet-bc34fbe4", # us-east-1a in default VPC, 172.31.16.0/20 range
+    subnet_id: "subnet-bc34fbe4", # us-east-1a in default VPC
     security_group: "sg-14e2c26d", # "Bootstrap Concourse" security group
   },
 }.freeze

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -6,7 +6,7 @@ Vagrant.require_version ">= 1.8.0"
 AWS_ACCOUNT = ENV.fetch("AWS_ACCOUNT", "dev")
 AWS_ACCOUNT_DATA = {
   "dev" => {
-    subnet_id: "subnet-d55defe8", # us-east-1e in default VPC
+    subnet_id: "subnet-c417d3b2", # us-east-1b in default VPC
     security_group: "sg-99e0c0e0", # "Bootstrap Concourse" security group
   },
   "ci" => {


### PR DESCRIPTION
## What

We've been running into the following error fairly regularly when
creating bootstrap instances:

```
InsufficientInstanceCapacity => We currently do not have sufficient
m3.large capacity in the Availability Zone you requested (us-east-1e).
Our system will be working on provisioning additional capacity. You can
currently get m3.large capacity by not specifying an Availability Zone
in your request or choosing us-east-1b, us-east-1c, us-east-1a.
```

Using a different AZ (which is determined by the subnet being used)
normally avoids this, which suggests that the capacity problems are
limited to a single AZ.

This PR also removes the IP ranges from the comments, as they're not useful.

## How to review

Spin up a bootstrap concourse in dev. Verify this works without issue.

I don't think it'll be possible to know for sure whether this solves the issue without running it for a while.

## Who can review

Anyone but myself.