### PR TITLE
[#130188061] Fix aws-broker download URL

### DIFF
--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -30,7 +30,7 @@ meta:
 releases:
   - name: aws-broker
     version: 0.0.12
-    url: https://github.com/alphagov/paas-aws-broker-boshrelease/releases/download/0.0.12/aws-broker-0.0.12.tgz
+    url: https://github.com/alphagov/paas-rds-broker-boshrelease/releases/download/0.0.12/aws-broker-0.0.12.tgz
     sha1: 5de975ce69085df22870fc695986fc4331a37881
 
 jobs:


### PR DESCRIPTION
## What

In https://github.com/alphagov/paas-rds-broker-boshrelease/pull/16 we
renamed the broker boshrelease from aws-broker to rds-broker. As part of
this we also renamed the github repo. This should not have been a
problem because Github [automatically sets up redirects](https://help.github.com/articles/renaming-a-repository/) when you do
this. However, these redirects are a 301 Moved Permanently redirect,
and the bosh director only currently follows 302 redirects (see https://github.com/cloudfoundry/bosh/pull/1523 for
details)

## How to review

It should be enough to verify that downloading from the new URL does not involve any 301 redirects, and that the resulting file has the correct SHA1 sum.

## Who can review

Anyone but myself.