### PR TITLE
Add a static prefix 'p' to all generated passwords.

### DIFF
--- a/manifests/shared/lib/secret_generator.rb
+++ b/manifests/shared/lib/secret_generator.rb
@@ -3,11 +3,12 @@ require 'openssl'
 require 'digest/md5'
 
 class SecretGenerator
+  PASSWORD_PREFIX = 'p'.freeze
   PASSWORD_LENGTH = 18
 
   def self.random_password
     bytes = PASSWORD_LENGTH / 2
-    SecureRandom.hex(bytes)
+    PASSWORD_PREFIX + SecureRandom.hex(bytes)
   end
 
   def self.sha512_crypt(password, salt = nil)

--- a/manifests/shared/spec/secret_generator_spec.rb
+++ b/manifests/shared/spec/secret_generator_spec.rb
@@ -5,9 +5,14 @@ RSpec.describe SecretGenerator do
   SIMPLE_PASSWORD_REGEX = /\A[a-zA-Z0-9]+\z/
 
   describe "password generation" do
+    it "prefixes the password with a fixed character" do
+      pw = SecretGenerator.random_password
+      expect(pw).to start_with(SecretGenerator::PASSWORD_PREFIX)
+    end
+
     it "generates a passwords of the required length" do
       pw = SecretGenerator.random_password
-      expect(pw.size).to eq(SecretGenerator::PASSWORD_LENGTH)
+      expect(pw.size).to eq(SecretGenerator::PASSWORD_LENGTH + SecretGenerator::PASSWORD_PREFIX.size)
     end
 
     it "generates a different password each time" do


### PR DESCRIPTION
## What

We've run into yet another problem with how these passwords are being
represented in YAML. In this case, the password generated was a hex
string like '12345678e123'. The ruby YAML library output this unquoted.
The Go YAML library (as used in spruce) interpreted this as a number
with an exponent. After this has been through spruce, it comes out as
'.inf' (presumably because it gets stored in a float32 somewhere along
the way, and this value is larger than the max value that can fit in an
IEEE single precision floating point number). JSON doesn't allow
Infinity, so this causes an error in bosh when it tries to serialise the
manifest into its database.

Digging further, the YAML spec is unclear on how these are supposed to
be represented and matched. It says "These may be matched against a set
of regular expressions to provide automatic resolution of integers,
floats, timestamps, and similar types."[1]. There are a number of
recommended schemas specified for this in the spec[2], and it would seem
that the ruby and Go libraries are using different ones (probably the
JSON schema, and the Core schema respectively).

Having said all that, this PR aims to avoid all of this by adding a
static prefix to all generated passwords, thereby ensuring they're
interpreted as a string by everything.

[1]http://yaml.org/spec/1.2/spec.html#id2768011
[2]http://yaml.org/spec/1.2/spec.html#Schema

## How to review

Code review.

## Who can review

Anyone but myself.