### PR TITLE
Read datadog secrets even when datadog is disabled

### DIFF
--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -56,10 +56,9 @@ prepare_environment() {
 
   download_git_id_rsa
   get_git_concourse_pool_clone_full_url_ssh
+  get_datadog_secrets
 
   if [ "${ENABLE_DATADOG}" = "true" ] ; then
-    get_datadog_secrets
-
     # shellcheck disable=SC2154
     if [ -z "${datadog_api_key+x}" ] || [ -z "${datadog_app_key+x}" ] ; then
       echo "Datadog enabled but could not retrieve api or app key. Did you do run \`make dev upload-datadog-secrets\`?"


### PR DESCRIPTION
## What

https://github.com/alphagov/paas-cf/pull/608 was played allowed verification of datadog keys when 
datadog is enabled. However, there was a problem as we wouldn't be able to delete datadog resources when we decide to disable datadog.

This now reads keys all the time, allowing deletion.

## How to review
* code review should be fine
* else: build an environment with datadog enabled, rebuild with datadog disabled. It should delete what was created in datadog

## Who can review
Anyone but me
