### PR TITLE
[#130821719] User research org cleanup script

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -35,3 +35,28 @@ generate_password() {
     abort "Failure generating password"
   fi
 }
+
+check_aws_account_used() {
+  required_account="${1}"
+  account_alias=$(aws iam list-account-aliases | grep gov-paas | tr -d '" ')
+
+  if [[ "${account_alias}" != "gov-paas-${required_account}" ]]; then
+    echo "Required AWS account is ${required_account}, but your aws-cli is using keys for ${account_alias}"
+    exit 1
+  fi
+}
+
+check_logged_in_cf() {
+  required_api_endpoint="${1}"
+  api_result=$(cf api)
+  if ! [[ "${api_result}" =~ ${required_api_endpoint} ]]; then
+    echo "Required cf api endpoint is ${required_api_endpoint}, but your cf reports '${api_result}'"
+    exit 1
+  fi
+
+  logged_in_pattern="Not logged in"
+  if [[ $(cf target) =~ ${logged_in_pattern} ]]; then
+    echo "Not logged in. Please 'cf login' and retry."
+    exit 1
+  fi
+}

--- a/scripts/reset-org.py
+++ b/scripts/reset-org.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+
+import argparse
+import re
+import subprocess
+import sys
+import time
+
+class SubprocessException(Exception):
+    pass
+
+class OrgReset(object):
+    def __init__(self, org, initial_space, org_managers, users, users_are_org_managers, users_are_space_managers, users_are_space_developers, org_quota):
+        self.org = org
+        self.initial_space = initial_space
+        self.org_managers = org_managers
+        self.users = users
+        self.users_are_org_managers = users_are_org_managers
+        self.users_are_space_managers = users_are_space_managers
+        self.users_are_space_developers = users_are_space_developers
+        self.org_quota = org_quota
+
+    def confirm(self):
+        if not self.confirm_user_input('Are you sure you want to delete org %s? (y/n): ' % self.org):
+            sys.exit("'No future change is possible.' (phew, not deleted)")
+
+    def confirm_user_input(self, question):
+        response = raw_input(question)
+        return response == "y"
+
+    def whoami(self):
+        self.user = self.parse_current_user(self.run(['cf', 'target']))
+
+    def delete_org(self):
+        # require org to be deleted in advance? have this check for org and and advise, so we don't use the `-f` flag
+        # Prompt for confirmtaion...
+        self.run_with_retry(['cf', 'delete-org', self.org, '-f'], 20, lambda err:
+            'one or more resources within could not be deleted' in err.output
+        )
+
+    def create_org(self):
+        self.run(['cf', 'create-org', self.org])
+        self.run(['cf', 'unset-org-role', self.user, self.org, 'OrgManager'])
+        if self.org_quota:
+            self.run(['cf', 'set-quota', self.org, self.org_quota])
+
+    def create_space(self):
+        self.run(['cf', 'create-space', self.initial_space, '-o', self.org])
+        self.run(['cf', 'unset-space-role', self.user, self.org, self.initial_space, 'SpaceManager'])
+        self.run(['cf', 'unset-space-role', self.user, self.org, self.initial_space, 'SpaceDeveloper'])
+
+    def set_roles(self):
+        for org_manager in self.org_managers:
+            self.run(['cf', 'set-org-role', org_manager, self.org, 'OrgManager'])
+
+        for user in self.users:
+            if self.users_are_org_managers:
+                self.run(['cf', 'set-org-role', user, self.org, 'OrgManager'])
+            if self.users_are_space_managers:
+                self.run(['cf', 'set-space-role', user, self.org, self.initial_space, 'SpaceManager'])
+            if self.users_are_space_developers:
+                self.run(['cf', 'set-space-role', user, self.org, self.initial_space, 'SpaceDeveloper'])
+
+    def run(self, command):
+        print 'Running \'%s\'' % ' '.join(command)
+        try:
+            output = subprocess.check_output(command)
+            print output
+            return output
+        except subprocess.CalledProcessError as err:
+            raise SubprocessException('Aborting: \'%s\' failed with exit code %d\n%s' % (err.cmd, err.returncode, err.output))
+
+    def run_with_retry(self, command, retry_count, retry_func):
+        print 'Running with retry \'%s\'' % ' '.join(command)
+        try:
+            output = subprocess.check_output(command)
+            print output
+            return output
+        except subprocess.CalledProcessError as err:
+            if retry_func(err):
+                print err.output
+                retry_count -= 1
+                if retry_count <= 0:
+                    raise SubprocessException('Timed out retrying \'%s\'' % ' '.join(command))
+
+                print 'Sleeping for 30 secs before retrying'
+                time.sleep(30)
+                return self.run_with_retry(command, retry_count, retry_func)
+            else:
+                raise SubprocessException('Aborting: \'%s\' failed with exit code %d\n%s' % (err.cmd, err.returncode, err.output))
+
+    def parse_current_user(self, target_output):
+        match = re.search(r'User:\s+(\S+)', target_output)
+        return match.group(1)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-o', metavar='ORG_NAME', help='Which org to wipe and recreate', required=True)
+    parser.add_argument('-s', metavar='INITIAL_SPACE', help='Initial space to create (default is sandbox)', default='sandbox')
+    parser.add_argument('-m', metavar='ORG_MANAGER_EMAIL', help='Emails of users who will manage the new org', nargs='*', default=[])
+    parser.add_argument('-u', metavar='USER_EMAIL', help='Emails of team members to add to the org', nargs='*', default=[])
+    parser.add_argument('--org-managers', help='Add the OrgManager role for the listed team members', action='store_true', default=False)
+    parser.add_argument('--space-managers', help='Add the SpaceManager role for the listed team members in the initial space', action='store_true', default=False)
+    parser.add_argument('--space-developers', help='Add the SpaceDeveloper role for the listed team members in the initial space', action='store_true', default=False)
+    parser.add_argument('--quota', help='Name of the org quota to use')
+
+    args = parser.parse_args()
+
+    org_reset = OrgReset(args.o, args.s, args.m, args.u, args.org_managers, args.space_managers, args.space_developers, args.quota)
+    org_reset.confirm()
+    org_reset.whoami()
+    org_reset.delete_org()
+    org_reset.create_org()
+    org_reset.create_space()
+    org_reset.set_roles()

--- a/scripts/reset-org.py
+++ b/scripts/reset-org.py
@@ -6,6 +6,10 @@ import subprocess
 import sys
 import time
 
+# python2 compatibility
+try: input = raw_input
+except NameError: pass
+
 class SubprocessException(Exception):
     pass
 
@@ -25,7 +29,7 @@ class OrgReset(object):
             sys.exit("'No future change is possible.' (phew, not deleted)")
 
     def confirm_user_input(self, question):
-        response = raw_input(question)
+        response = input(question)
         return response == "y"
 
     def whoami(self):
@@ -62,28 +66,28 @@ class OrgReset(object):
                 self.run(['cf', 'set-space-role', user, self.org, self.initial_space, 'SpaceDeveloper'])
 
     def run(self, command):
-        print 'Running \'%s\'' % ' '.join(command)
+        print('Running \'%s\'' % ' '.join(command))
         try:
             output = subprocess.check_output(command)
-            print output
+            print(output)
             return output
         except subprocess.CalledProcessError as err:
             raise SubprocessException('Aborting: \'%s\' failed with exit code %d\n%s' % (err.cmd, err.returncode, err.output))
 
     def run_with_retry(self, command, retry_count, retry_func):
-        print 'Running with retry \'%s\'' % ' '.join(command)
+        print('Running with retry \'%s\'' % ' '.join(command))
         try:
             output = subprocess.check_output(command)
-            print output
+            print(output)
             return output
         except subprocess.CalledProcessError as err:
             if retry_func(err):
-                print err.output
+                print(err.output)
                 retry_count -= 1
                 if retry_count <= 0:
                     raise SubprocessException('Timed out retrying \'%s\'' % ' '.join(command))
 
-                print 'Sleeping for 30 secs before retrying'
+                print('Sleeping for 30 secs before retrying')
                 time.sleep(30)
                 return self.run_with_retry(command, retry_count, retry_func)
             else:

--- a/scripts/reset-user-testing.sh
+++ b/scripts/reset-user-testing.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+# shellcheck disable=SC1090
+source "${SCRIPT_DIR}/common.sh"
+
+check_aws_account_used prod
+check_logged_in_cf api.cloud.service.gov.uk
+
+"${SCRIPT_DIR}"/reset-org.py \
+	-o paas_user_research \
+	-s sandbox \
+	-u holly.challenger+1@digital.cabinet-office.gov.uk \
+	-u holly.challenger+2@digital.cabinet-office.gov.uk \
+	-u holly.challenger+3@digital.cabinet-office.gov.uk \
+	-u holly.challenger+4@digital.cabinet-office.gov.uk \
+	-u holly.challenger+5@digital.cabinet-office.gov.uk \
+	-u holly.challenger+6@digital.cabinet-office.gov.uk \
+	--org-managers \
+	--space-managers \
+	--space-developers \
+	--quota small
+
+"${SCRIPT_DIR}"/rotate-user-password.sh -e prod -u holly.challenger+1@digital.cabinet-office.gov.uk
+"${SCRIPT_DIR}"/rotate-user-password.sh -e prod -u holly.challenger+2@digital.cabinet-office.gov.uk
+"${SCRIPT_DIR}"/rotate-user-password.sh -e prod -u holly.challenger+3@digital.cabinet-office.gov.uk
+"${SCRIPT_DIR}"/rotate-user-password.sh -e prod -u holly.challenger+4@digital.cabinet-office.gov.uk
+"${SCRIPT_DIR}"/rotate-user-password.sh -e prod -u holly.challenger+5@digital.cabinet-office.gov.uk
+"${SCRIPT_DIR}"/rotate-user-password.sh -e prod -u holly.challenger+6@digital.cabinet-office.gov.uk

--- a/scripts/rotate-user-password.sh
+++ b/scripts/rotate-user-password.sh
@@ -29,7 +29,7 @@ usage() {
 
 Usage:
 
-  ./$SCRIPT -e \$ENV -u \$USERNAME
+  ./$SCRIPT -e \$ENV -u \$USERNAME [--no-email]
 
 Example:
 
@@ -38,6 +38,7 @@ Example:
 Description:
 
   This script will generate a new password for an existing user, change their password to the newly generated one, and then email them the password.
+  To print the password instead of emailing, supply the '--no-email' flag (useful for development)
 
 Requirements:
 
@@ -58,21 +59,25 @@ fi
 while [[ $# -gt 1 ]]
 do
 key="$1"
+shift
 
 case $key in
   -e|--env)
-  ENVIRONMENT="$2"
-  shift # past argument
+  ENVIRONMENT="$1"
+  shift
   ;;
   -u|--username)
-  USERNAME="$2"
+  USERNAME="$1"
+  shift
+  ;;
+  --no-email)
+  NO_EMAIL="true"
   ;;
   *)
   echo "You have passed an unknown option: $key" >&2
   usage
   ;;
 esac
-shift # past argument or value
 done
 
 check_environment() {
@@ -185,6 +190,18 @@ send_mail() {
   echo
 }
 
+print_password() {
+  success "${USERNAME} has had their password changed to '${PASSWORD}'."
+}
+
+emit_password() {
+  if [ "${NO_EMAIL:-}" = "true" ]; then
+    print_password
+  else
+    send_mail
+  fi
+}
+
 delete_token() {
   info "Deleting your uaac token..."
   uaac token delete
@@ -200,5 +217,5 @@ set_uaac_target
 set_uaac_context
 generate_password
 change_password
-send_mail
+emit_password
 delete_token


### PR DESCRIPTION
[#130821719 Automate reset of User Research organisation after Lab Session](https://www.pivotaltracker.com/story/show/130821719)

## What

Introduce a script to wipe and recreate the `paas_user_research` org
and to reset the passwords of the user testing users.

This will be run manually after each user research session, to ensure that the next session starts with a clean environment.

See https://www.pivotaltracker.com/story/show/130821719 and https://github.com/alphagov/paas-team-manual/pull/75

## How to review

Either:
- review code and story summary and trust us that it works, or
- create an org in dev with some apps, services, and users, and run the script with appropriate modifications to see it for yourself, or
- ask @benhyland or @alext for a walkthrough

## Who can review

Anyone but @benhyland and @alext 
