### PR TITLE
[#133247209] Datadog: don't false alarm during deployment

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -42,6 +42,6 @@ stemcells:
 update:
   canaries: 0
   max_in_flight: 1
-  canary_watch_time: 30000-600000
-  update_watch_time: 5000-600000
+  canary_watch_time: 30000-420000
+  update_watch_time: 5000-420000
   serial: false

--- a/terraform/datadog/cell.tf
+++ b/terraform/datadog/cell.tf
@@ -3,7 +3,7 @@ resource "datadog_monitor" "cell-available-memory" {
   type               = "query alert"
   message            = "${format("Less than {{threshold}}%% memory free on cells. There is only {{value}} %% memory free on average on cells. Review if this is temporary or we really need to scale... @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "There is only {{value}} % memory free on average on cells. Check the deployment!"
-  no_data_timeframe  = "5"
+  no_data_timeframe  = "7"
   query              = "${format("avg(last_1m):avg:system.mem.pct_usable{bosh-job:cell,bosh-deployment:%s} * 100 < 50", var.env)}"
 
   thresholds {

--- a/terraform/datadog/consul.tf
+++ b/terraform/datadog/consul.tf
@@ -3,7 +3,7 @@ resource "datadog_monitor" "consul" {
   type               = "service check"
   message            = "${format("Missing consul hosts in environment {{host.environment}}. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "Missing consul hosts! Check VM state."
-  no_data_timeframe  = "2"
+  no_data_timeframe  = "7"
   query              = "${format("'process.up'.over('bosh-deployment:%s','process:consul').last(6).count_by_status()", var.env)}"
 
   thresholds {
@@ -26,7 +26,7 @@ resource "datadog_monitor" "consul_connect_to_port" {
   type                = "service check"
   message             = "Large portion of consul service are not accepting connections. Check deployment state."
   escalation_message  = "Large portion of consul service are still not accepting connections. Check deployment state."
-  no_data_timeframe   = "5"
+  no_data_timeframe   = "7"
   require_full_window = true
 
   query = "${format("'tcp.can_connect'.over('bosh-deployment:%s','instance:consul_server').by('*').last(1).pct_by_status()", var.env)}"

--- a/terraform/datadog/consul.tf
+++ b/terraform/datadog/consul.tf
@@ -3,7 +3,7 @@ resource "datadog_monitor" "consul" {
   type               = "service check"
   message            = "${format("Consul process not running on this host in environment {{host.environment}}. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "Consul process not running! Check VM state."
-  no_data_timeframe  = "7"
+  notify_no_data     = false
   query              = "${format("'process.up'.over('bosh-deployment:%s','process:consul').last(6).count_by_status()", var.env)}"
 
   thresholds {

--- a/terraform/datadog/consul.tf
+++ b/terraform/datadog/consul.tf
@@ -1,8 +1,8 @@
 resource "datadog_monitor" "consul" {
-  name               = "${format("%s Consul hosts", var.env)}"
+  name               = "${format("%s Consul process running", var.env)}"
   type               = "service check"
-  message            = "${format("Missing consul hosts in environment {{host.environment}}. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message = "Missing consul hosts! Check VM state."
+  message            = "${format("Consul process not running on this host in environment {{host.environment}}. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
+  escalation_message = "Consul process not running! Check VM state."
   no_data_timeframe  = "7"
   query              = "${format("'process.up'.over('bosh-deployment:%s','process:consul').last(6).count_by_status()", var.env)}"
 

--- a/terraform/datadog/general.tf
+++ b/terraform/datadog/general.tf
@@ -25,7 +25,7 @@ resource "datadog_monitor" "concourse-disk-space" {
   type               = "query alert"
   message            = "${format("More than {{threshold}}%% disk used. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "There is still {{value}} % disk used. Check the VM!"
-  no_data_timeframe  = "7"
+  no_data_timeframe  = "30"
   query              = "${format("max(last_5m):max:system.disk.in_use{bosh-deployment:%s,!device:/dev/loop0,!device:tmpfs,!device:cgroup,!device:udev,!device:/var/vcap/data/root_log,!device:/var/vcap/data/root_tmp,bosh-job:concourse} by {bosh-job,device,bosh-index} * 100 > 97", var.env)}"
 
   thresholds {

--- a/terraform/datadog/general.tf
+++ b/terraform/datadog/general.tf
@@ -3,7 +3,7 @@ resource "datadog_monitor" "disk-space" {
   type               = "query alert"
   message            = "${format("More than {{threshold}}%% disk used. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "There is still {{value}} % disk used. Check the VM!"
-  no_data_timeframe  = "5"
+  no_data_timeframe  = "7"
   query              = "${format("max(last_5m):max:system.disk.in_use{bosh-deployment:%s,!device:/dev/loop0,!device:tmpfs,!device:cgroup,!device:udev,!device:/var/vcap/data/root_log,!device:/var/vcap/data/root_tmp,!bosh-job:concourse} by {bosh-job,device,bosh-index} * 100 > 85", var.env)}"
 
   thresholds {
@@ -25,7 +25,7 @@ resource "datadog_monitor" "concourse-disk-space" {
   type               = "query alert"
   message            = "${format("More than {{threshold}}%% disk used. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "There is still {{value}} % disk used. Check the VM!"
-  no_data_timeframe  = "5"
+  no_data_timeframe  = "7"
   query              = "${format("max(last_5m):max:system.disk.in_use{bosh-deployment:%s,!device:/dev/loop0,!device:tmpfs,!device:cgroup,!device:udev,!device:/var/vcap/data/root_log,!device:/var/vcap/data/root_tmp,bosh-job:concourse} by {bosh-job,device,bosh-index} * 100 > 97", var.env)}"
 
   thresholds {

--- a/terraform/datadog/general.tf
+++ b/terraform/datadog/general.tf
@@ -3,7 +3,7 @@ resource "datadog_monitor" "disk-space" {
   type               = "query alert"
   message            = "${format("More than {{threshold}}%% disk used. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "There is still {{value}} % disk used. Check the VM!"
-  no_data_timeframe  = "7"
+  no_data_timeframe  = "10"
   query              = "${format("max(last_5m):max:system.disk.in_use{bosh-deployment:%s,!device:/dev/loop0,!device:tmpfs,!device:cgroup,!device:udev,!device:/var/vcap/data/root_log,!device:/var/vcap/data/root_tmp,!bosh-job:concourse} by {bosh-job,device,bosh-index} * 100 > 85", var.env)}"
 
   thresholds {

--- a/terraform/datadog/nats.tf
+++ b/terraform/datadog/nats.tf
@@ -1,26 +1,3 @@
-resource "datadog_monitor" "nats" {
-  name               = "${format("%s NATS hosts", var.env)}"
-  type               = "service check"
-  message            = "${format("Missing nats hosts in environment {{host.environment}}. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message = "Missing nats hosts! Check VM state."
-  no_data_timeframe  = "7"
-  query              = "${format("'datadog.agent.up'.over('bosh-deployment:%s','bosh-job:nats').by('*').last(1).pct_by_status()", var.env)}"
-
-  thresholds {
-    ok       = 0
-    warning  = 0
-    critical = 10
-  }
-
-  require_full_window = true
-
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "nats"
-  }
-}
-
 resource "datadog_monitor" "nats_process_running" {
   name                = "${format("%s NATS process running", var.env)}"
   type                = "service check"

--- a/terraform/datadog/nats.tf
+++ b/terraform/datadog/nats.tf
@@ -3,7 +3,7 @@ resource "datadog_monitor" "nats" {
   type               = "service check"
   message            = "${format("Missing nats hosts in environment {{host.environment}}. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "Missing nats hosts! Check VM state."
-  no_data_timeframe  = "2"
+  no_data_timeframe  = "7"
   query              = "${format("'datadog.agent.up'.over('bosh-deployment:%s','bosh-job:nats').by('*').last(1).pct_by_status()", var.env)}"
 
   thresholds {
@@ -26,7 +26,7 @@ resource "datadog_monitor" "nats_process_running" {
   type                = "service check"
   message             = "nats process not running. Check nats state."
   escalation_message  = "nats process still not running. Check nats state."
-  no_data_timeframe   = "5"
+  no_data_timeframe   = "7"
   require_full_window = true
 
   query = "${format("'process.up'.over('bosh-deployment:%s','process:nats').last(4).count_by_status()", var.env)}"
@@ -49,7 +49,7 @@ resource "datadog_monitor" "nats_stream_forwarded_process_running" {
   type                = "service check"
   message             = "NATS stream forwarder process not running. Check nats state."
   escalation_message  = "NATS stream forwarder process still not running. Check NATS state."
-  no_data_timeframe   = "5"
+  no_data_timeframe   = "7"
   require_full_window = true
 
   query = "${format("'process.up'.over('bosh-deployment:%s','process:nats_stream_forwarder').last(4).count_by_status()", var.env)}"
@@ -72,7 +72,7 @@ resource "datadog_monitor" "nats_service_open" {
   type                = "service check"
   message             = "Large portion of NATS service are not accepting connections. Check deployment state."
   escalation_message  = "Large portion of NATS service are still not accepting connections. Check deployment state."
-  no_data_timeframe   = "5"
+  no_data_timeframe   = "7"
   require_full_window = true
 
   query = "${format("'tcp.can_connect'.over('bosh-deployment:%s','instance:nats_server').by('*').last(1).pct_by_status()", var.env)}"
@@ -93,7 +93,7 @@ resource "datadog_monitor" "nats_cluster_service_open" {
   type                = "service check"
   message             = "Large portion of NATS cluster service are not accepting connections. Check deployment state."
   escalation_message  = "Large portion of NATS cluster service are still not accepting connections. Check deployment state."
-  no_data_timeframe   = "5"
+  no_data_timeframe   = "7"
   require_full_window = true
 
   query = "${format("'tcp.can_connect'.over('bosh-deployment:%s','instance:nats_cluster').by('*').last(1).pct_by_status()", var.env)}"

--- a/terraform/datadog/nats.tf
+++ b/terraform/datadog/nats.tf
@@ -3,7 +3,7 @@ resource "datadog_monitor" "nats_process_running" {
   type                = "service check"
   message             = "nats process not running. Check nats state."
   escalation_message  = "nats process still not running. Check nats state."
-  no_data_timeframe   = "7"
+  notify_no_data      = false
   require_full_window = true
 
   query = "${format("'process.up'.over('bosh-deployment:%s','process:nats').last(4).count_by_status()", var.env)}"
@@ -26,7 +26,7 @@ resource "datadog_monitor" "nats_stream_forwarded_process_running" {
   type                = "service check"
   message             = "NATS stream forwarder process not running. Check nats state."
   escalation_message  = "NATS stream forwarder process still not running. Check NATS state."
-  no_data_timeframe   = "7"
+  notify_no_data      = false
   require_full_window = true
 
   query = "${format("'process.up'.over('bosh-deployment:%s','process:nats_stream_forwarder').last(4).count_by_status()", var.env)}"

--- a/terraform/datadog/router.tf
+++ b/terraform/datadog/router.tf
@@ -44,29 +44,6 @@ resource "datadog_timeboard" "gorouter" {
   }
 }
 
-resource "datadog_monitor" "router" {
-  name               = "${format("%s router hosts", var.env)}"
-  type               = "service check"
-  message            = "${format("Missing router hosts in environment {{host.environment}}. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message = "Missing router hosts! Check VM state."
-  no_data_timeframe  = "7"
-  query              = "${format("'datadog.agent.up'.over('bosh-deployment:%s','bosh-job:router').by('*').last(1).pct_by_status()", var.env)}"
-
-  thresholds {
-    ok       = 0
-    warning  = 0
-    critical = 10
-  }
-
-  require_full_window = true
-
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "router"
-  }
-}
-
 resource "datadog_monitor" "route_update_latency" {
   name                = "${format("%s route update latency", var.env)}"
   type                = "metric alert"

--- a/terraform/datadog/router.tf
+++ b/terraform/datadog/router.tf
@@ -112,7 +112,7 @@ resource "datadog_monitor" "gorouter_process_running" {
   type                = "service check"
   message             = "gorouter process not running. Check router state."
   escalation_message  = "gorouter process still not running. Check router state."
-  no_data_timeframe   = "7"
+  notify_no_data      = false
   require_full_window = true
 
   query = "${format("'process.up'.over('bosh-deployment:%s','process:gorouter').last(4).count_by_status()", var.env)}"

--- a/terraform/datadog/router.tf
+++ b/terraform/datadog/router.tf
@@ -49,7 +49,7 @@ resource "datadog_monitor" "router" {
   type               = "service check"
   message            = "${format("Missing router hosts in environment {{host.environment}}. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "Missing router hosts! Check VM state."
-  no_data_timeframe  = "2"
+  no_data_timeframe  = "7"
   query              = "${format("'datadog.agent.up'.over('bosh-deployment:%s','bosh-job:router').by('*').last(1).pct_by_status()", var.env)}"
 
   thresholds {
@@ -72,7 +72,7 @@ resource "datadog_monitor" "route_update_latency" {
   type                = "metric alert"
   message             = "Route update latency too high, possibly serving stale routes."
   escalation_message  = "Route update latency still too high. Check the deployment."
-  no_data_timeframe   = "5"
+  no_data_timeframe   = "7"
   require_full_window = true
 
   query = "${format("max(last_1m):avg:cf.gorouter.ms_since_last_registry_update{deployment:%s,job:router} by {ip} > 45000", var.env)}"
@@ -94,7 +94,7 @@ resource "datadog_monitor" "total_routes_drop" {
   type                = "query alert"
   message             = "Amount of the routes has decreased considerably, check deployment status."
   escalation_message  = "Total routes still dropping quickly. Check the deployment."
-  no_data_timeframe   = "5"
+  no_data_timeframe   = "7"
   require_full_window = true
 
   query = "${format("pct_change(avg(last_1m),last_30m):avg:cf.gorouter.total_routes{deployment:%s,job:router} < -33", var.env)}"
@@ -116,7 +116,7 @@ resource "datadog_monitor" "total_routes_discrepancy" {
   type                = "query alert"
   message             = "Discrepancy in the amount of routes on routers. Check deployment status."
   escalation_message  = "Routers still have considerably different amount of total routes!"
-  no_data_timeframe   = "5"
+  no_data_timeframe   = "7"
   require_full_window = true
 
   query = "${format("avg(last_5m):outliers(avg:cf.gorouter.total_routes{deployment:%s,job:router} by {ip}, 'dbscan', 3.0) > 0", var.env)}"
@@ -135,7 +135,7 @@ resource "datadog_monitor" "gorouter_process_running" {
   type                = "service check"
   message             = "gorouter process not running. Check router state."
   escalation_message  = "gorouter process still not running. Check router state."
-  no_data_timeframe   = "5"
+  no_data_timeframe   = "7"
   require_full_window = true
 
   query = "${format("'process.up'.over('bosh-deployment:%s','process:gorouter').last(4).count_by_status()", var.env)}"
@@ -158,7 +158,7 @@ resource "datadog_monitor" "gorouter_healthy" {
   type                = "service check"
   message             = "Large portion of gorouters unhealthy. Check deployment state."
   escalation_message  = "Large portion of gorouters still unhealthy. Check deployment state."
-  no_data_timeframe   = "5"
+  no_data_timeframe   = "7"
   require_full_window = true
 
   query = "${format("'http.can_connect'.over('bosh-deployment:%s','instance:gorouter','url:http://localhost:80/').by('*').last(1).pct_by_status()", var.env)}"


### PR DESCRIPTION
## What

[Datadog: don't false alarm during deployment](https://www.pivotaltracker.com/n/projects/1275640/stories/133247209)
Reconfigure datadog checks so that we don't get false positives (alerts, no_data notifications) during BOSH deployments (when you e.g. rotate a stemcell).

## How to review

Deploy environment with datadog enabled. Apply this branch. Then bump stemcell (e.g. change the number to 3263.10 in `manifests/cf-manifest/manifest/000-base-cf-deployment.yml` - you'll need to commit. To test that, create a branch from this branch and commit there, or you can add a temporary commit into this branch). Apply. There should be no false positive alerts.

Note that we have tested stemcell bump (to 3236.10) several times during development, with passing acceptance and custom acceptance tests. I think we could leave the stemcell bump a part of this branch, as the reviewer will have to test it as well. And then it becomes tested by both developer and reviewer, so no reason to drop it and do upgrade in separate story.

## Who can review

not @mtekel or @henrytk 
