### PR TITLE
[#135207089] Use java offline buildpack

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -301,9 +301,7 @@ properties:
         total_routes: 1000
     default_quota_definition: default
 
-    user_buildpacks: []
-    system_buildpacks: (( grab properties.cc.default_buildpacks ))
-    default_buildpacks:
+    install_buildpacks:
       - name: staticfile_buildpack
         package: staticfile-buildpack
       - name: java_buildpack
@@ -320,8 +318,6 @@ properties:
         package: php-buildpack
       - name: binary_buildpack
         package: binary-buildpack
-
-    install_buildpacks: (( grab properties.cc.system_buildpacks properties.cc.user_buildpacks ))
 
     stacks: ~
 

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -307,7 +307,7 @@ properties:
       - name: staticfile_buildpack
         package: staticfile-buildpack
       - name: java_buildpack
-        package: buildpack_java
+        package: buildpack_java_offline
       - name: ruby_buildpack
         package: ruby-buildpack
       - name: nodejs_buildpack

--- a/manifests/cf-manifest/manifest/900-cf-tests.yml
+++ b/manifests/cf-manifest/manifest/900-cf-tests.yml
@@ -13,7 +13,7 @@ properties:
     include_v3: false
     include_security_groups: true
     include_routing: true
-    skip_regex: 'routing.API|allows\spreviously-blocked\sip|Adding\sa\swildcard\sroute\sto\sa\sdomain|forwards\sapp\smessages\sto\sregistered\ssyslog\sdrains|uses\sa\sbuildpack\sfrom\sa\sgit\surl|when\sapp\shas\smultiple\sports\smapped|transparently\sproxies\sboth\sreserved\scharacters\sand\sunsafe\scharacters'
+    skip_regex: 'routing.API|allows\spreviously-blocked\sip|Adding\sa\swildcard\sroute\sto\sa\sdomain|forwards\sapp\smessages\sto\sregistered\ssyslog\sdrains|uses\sa\sbuildpack\sfrom\sa\sgit\surl|when\sapp\shas\smultiple\sports\smapped'
     include_internet_dependent: true
     include_logging: true
     include_operator: true


### PR DESCRIPTION
What?
-----

The acceptance tests started failing due the java-buildpack using a newer minor version for tomcat (from 8.0.38 to 8.0.39), which changed the behaviour with special chars in the request. See #624 for details.

In this PR we want to use the java-offline-buildpack, which pins all the versions of the dependencies instead of allowing minor upgrades. This will allow us to better control the upgrades.

The commit will enable again the test.

We also simplify the buildpack a little bit.

How to test?
------------

 * Code review
 * The pipeline should pass. Trust us, let it run in CI ;)

Who?
---
Anyone but @keymon or @combor