### PR TITLE
[#127792523] Enable SSH for CF

### DIFF
--- a/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
+++ b/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
@@ -104,16 +104,6 @@ vm_types:
         - (( grab terraform_outputs.cf_router_elb_name ))
 
 # Diego below
-  - name: access
-    network: cf
-    env: (( grab meta.default_env ))
-    cloud_properties:
-      instance_type: m3.medium
-      ephemeral_disk:
-        size: 10240
-        type: gp2
-      elbs:
-        - (( grab terraform_outputs.cf_ssh_proxy_elb_name ))
 
   - name: cell
     network: cell

--- a/manifests/cf-manifest/cloud-config/021-cf-vm-extensions.yml
+++ b/manifests/cf-manifest/cloud-config/021-cf-vm-extensions.yml
@@ -1,0 +1,8 @@
+---
+
+vm_extensions:
+
+  - name: ssh_proxy_elb
+    cloud_properties:
+      elbs:
+        - (( grab terraform_outputs.cf_ssh_proxy_elb_name ))

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -400,7 +400,9 @@ jobs:
       - name: cfdot
         release: diego
     instances: 2
-    vm_type: access
+    vm_type: medium
+    vm_extensions:
+      - ssh_proxy_elb
     stemcell: default
     networks:
       - name: cf

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -400,7 +400,7 @@ jobs:
       - name: cfdot
         release: diego
     instances: 2
-    vm_type: medium
+    vm_type: small
     vm_extensions:
       - ssh_proxy_elb
     stemcell: default

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -489,7 +489,7 @@ properties:
         autoapprove: true
         override: true
         redirect-uri: /login
-        scope: openid,cloud_controller.read,cloud_controller.write
+        scope: openid,cloud_controller.read,cloud_controller.write,cloud_controller.admin
         secret: (( grab secrets.uaa_clients_ssh_proxy_secret ))
       graphite-nozzle:
         access-token-validity: 1209600

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -203,7 +203,7 @@ properties:
 
     users_can_select_backend: true
     default_to_diego_backend: true
-    allow_app_ssh_access: false
+    allow_app_ssh_access: true
     default_app_memory: 1024
     default_app_disk_in_mb: 1024
     maximum_app_disk_in_mb: 2048

--- a/manifests/cf-manifest/manifest/900-cf-tests.yml
+++ b/manifests/cf-manifest/manifest/900-cf-tests.yml
@@ -18,6 +18,7 @@ properties:
     include_logging: true
     include_operator: true
     include_services: true
+    include_diego_ssh: true
     include_route_services: false
     artifacts_directory: "/var/vcap/sys/log/test_artifacts"
     nodes: 10

--- a/platform-tests/src/acceptance/cf_ssh_test.go
+++ b/platform-tests/src/acceptance/cf_ssh_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 var _ = Describe("CF SSH", func() {
-	It("should be disabled", func() {
+	It("should be enabled", func() {
 		appName := generator.PrefixedRandomName("CATS-APP-")
 		Expect(cf.Cf(
 			"push", appName,
@@ -21,7 +21,7 @@ var _ = Describe("CF SSH", func() {
 			"-m", "64M",
 		).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 		cfSSH := cf.Cf("ssh", appName, "-c", "uptime").Wait(DEFAULT_TIMEOUT)
-		Expect(cfSSH).NotTo(Exit(0))
-		Expect(cfSSH).To(Say("Error opening SSH connection:"))
+		Expect(cfSSH).To(Exit(0))
+		Expect(cfSSH).To(Say("load average:"))
 	})
 })


### PR DESCRIPTION
## What

We'd like to enable the ssh functionality for our CF. The flag has been switched, and the tests are being corrected.

This also enables the upstream ssh tests in cf-acceptance-tests.

We've updated the `ssh-proxy oauth` config to match docs. This looks to have changed in newer releases since this was initially implemented. This scope is what the [documentation](http://docs.cloudfoundry.org/running/config-ssh.html#cf-manifest) says should be set.

We use `vm_extensions` to specify `access` VM ELB. This avoids the need to have an extra vm_type just to add the VMs to an ELB.

We make the `access` use a small VM. It's only proxying SSH connections, so doesn't need to be very big. Some crude load testing shows that this VM size is plenty (we managed to get a peak load average or 0.2)

## How to review

  - Run the pipeline from this branch
  - Create/Push an app
  - Attempt to `cf ssh` into it (You may need to have `SpaceDeveloper` role set)
  - **Optional**: If you've got app already:
    - Establish if you can SSH
    - If not, run `cf enable-ssh`
    - Retry ssh'ing.

## Who can review

Neither @alext nor @paroxp
