### PR TITLE
[#135224045] Disable RDS auto minor version upgrade

### DIFF
--- a/terraform/bosh/rds.tf
+++ b/terraform/bosh/rds.tf
@@ -36,23 +36,24 @@ resource "aws_db_parameter_group" "default" {
 }
 
 resource "aws_db_instance" "bosh" {
-  identifier                = "${var.env}-bosh"
-  name                      = "bosh"
-  allocated_storage         = 5
-  storage_type              = "gp2"
-  engine                    = "postgres"
-  engine_version            = "9.4.5"
-  instance_class            = "db.t2.medium"
-  username                  = "dbadmin"
-  password                  = "${var.secrets_bosh_postgres_password}"
-  db_subnet_group_name      = "${aws_db_subnet_group.bosh_rds.name}"
-  parameter_group_name      = "${aws_db_parameter_group.default.id}"
-  backup_window             = "01:00-02:00"
-  maintenance_window        = "Thu:03:00-Thu:04:00"
-  multi_az                  = "${var.bosh_db_multi_az}"
-  backup_retention_period   = "${var.bosh_db_backup_retention_period}"
-  final_snapshot_identifier = "${var.env}-bosh-rds-final-snapshot"
-  skip_final_snapshot       = "${var.bosh_db_skip_final_snapshot}"
+  identifier                 = "${var.env}-bosh"
+  name                       = "bosh"
+  allocated_storage          = 5
+  storage_type               = "gp2"
+  engine                     = "postgres"
+  engine_version             = "9.4.5"
+  instance_class             = "db.t2.medium"
+  username                   = "dbadmin"
+  password                   = "${var.secrets_bosh_postgres_password}"
+  db_subnet_group_name       = "${aws_db_subnet_group.bosh_rds.name}"
+  parameter_group_name       = "${aws_db_parameter_group.default.id}"
+  backup_window              = "01:00-02:00"
+  maintenance_window         = "Thu:03:00-Thu:04:00"
+  multi_az                   = "${var.bosh_db_multi_az}"
+  backup_retention_period    = "${var.bosh_db_backup_retention_period}"
+  final_snapshot_identifier  = "${var.env}-bosh-rds-final-snapshot"
+  skip_final_snapshot        = "${var.bosh_db_skip_final_snapshot}"
+  auto_minor_version_upgrade = false
 
   vpc_security_group_ids = ["${aws_security_group.bosh_rds.id}"]
 

--- a/terraform/cloudfoundry/cf_rds.tf
+++ b/terraform/cloudfoundry/cf_rds.tf
@@ -52,14 +52,15 @@ resource "aws_db_instance" "cf" {
   db_subnet_group_name = "${aws_db_subnet_group.cf_rds.name}"
   parameter_group_name = "${aws_db_parameter_group.cf.id}"
 
-  storage_type              = "gp2"
-  backup_window             = "02:00-03:00"
-  maintenance_window        = "Thu:04:00-Thu:05:00"
-  multi_az                  = "${var.cf_db_multi_az}"
-  backup_retention_period   = "${var.cf_db_backup_retention_period}"
-  final_snapshot_identifier = "${var.env}-cf-rds-final-snapshot"
-  skip_final_snapshot       = "${var.cf_db_skip_final_snapshot}"
-  vpc_security_group_ids    = ["${aws_security_group.cf_rds.id}"]
+  storage_type               = "gp2"
+  backup_window              = "02:00-03:00"
+  maintenance_window         = "Thu:04:00-Thu:05:00"
+  multi_az                   = "${var.cf_db_multi_az}"
+  backup_retention_period    = "${var.cf_db_backup_retention_period}"
+  final_snapshot_identifier  = "${var.env}-cf-rds-final-snapshot"
+  skip_final_snapshot        = "${var.cf_db_skip_final_snapshot}"
+  vpc_security_group_ids     = ["${aws_security_group.cf_rds.id}"]
+  auto_minor_version_upgrade = false
 
   tags {
     Name = "${var.env}-cf"


### PR DESCRIPTION
## What
Story: [Upgrade RDS instance versions](https://www.pivotaltracker.com/story/show/135224045)

We are not sure how the next upgrade will impact us and we are planning a major upgrade anyway in #135224045. This removes the unknown for now and we will decide if we want to re-enable it or not in that story.

## How to review
* Deploy
* Check in the AWS console that the setting `Auto Minor Version Upgrade` is set to `No` for both BOSH and CF RDS instances

## Who can review
Anyone but me
