### PR TITLE
[#115429827] Enable basic auth for kibana

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,8 +177,7 @@ pipelines: ## Upload pipelines to Concourse
 showenv: ## Display environment information
 	$(eval export TARGET_CONCOURSE=deployer)
 	@concourse/scripts/environment.sh
-	@echo export GRAFANA_PASSWORD=$$(aws s3 cp "s3://${DEPLOY_ENV}-state/cf-secrets.yml" - | \
-		ruby -ryaml -e 'puts YAML.load(STDIN)["secrets"]["grafana_admin_password"]')
+	@scripts/show-cf-secrets.sh grafana_admin_password kibana_admin_password
 	@echo export CONCOURSE_IP=$$(aws ec2 describe-instances \
 		--filters 'Name=tag:Name,Values=concourse/0' "Name=key-name,Values=${DEPLOY_ENV}_concourse_key_pair" \
 		--query 'Reservations[].Instances[].PublicIpAddress' --output text)

--- a/manifests/cf-manifest/manifest/800-logsearch.yml
+++ b/manifests/cf-manifest/manifest/800-logsearch.yml
@@ -121,6 +121,8 @@ jobs:
   templates:
   - name: kibana
     release: logsearch
+  - name: haproxy
+    release: logsearch
   vm_type: kibana
   stemcell: default
   instances: 1
@@ -188,6 +190,14 @@ properties:
     elasticsearch:
       host: (( grab terraform_outputs.logsearch_elastic_master_elb_dns_name ))
       port: 9200
+  haproxy:
+    kibana:
+      auth:
+        username: admin
+        password: (( grab secrets.kibana_admin_password ))
+      backend_servers: ["localhost"]
+      backend_port: 5601
+      inbound_port: 5602
   elasticsearch_config:
     elasticsearch:
       host: (( grab terraform_outputs.logsearch_elastic_master_elb_dns_name ))

--- a/manifests/cf-manifest/scripts/generate-cf-secrets.rb
+++ b/manifests/cf-manifest/scripts/generate-cf-secrets.rb
@@ -35,6 +35,7 @@ generator = SecretGenerator.new(
   "rds_broker_master_password_seed" => :simple,
   "rds_broker_state_encryption_key" => :simple,
   "ssh_proxy_host_key" => :ssh_key,
+  "kibana_admin_password" => :simple,
 )
 
 option_parser = OptionParser.new do |opts|

--- a/manifests/shared/spec/fixtures/cf-secrets.yml
+++ b/manifests/shared/spec/fixtures/cf-secrets.yml
@@ -48,6 +48,9 @@ secrets:
   # grafana creds
   grafana_admin_password: GRAFANA_ADMIN_PASSWORD
 
+  # kibana creds
+  kibana_admin_password: KIBANA_ADMIN_PASSWORD
+
   # rds broker creds
   rds_broker_admin_password: RDS_BROKER_ADMIN_PASSWORD
   rds_broker_state_encryption_key: RDS_BROKER_STATE_ENCRYPTION_KEY

--- a/scripts/show-cf-secrets.sh
+++ b/scripts/show-cf-secrets.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+requested_secrets=( "$@" )
+
+raw_secrets="$(aws s3 cp "s3://${DEPLOY_ENV}-state/cf-secrets.yml" -)"
+
+for secret in "${requested_secrets[@]}"; do
+  value=$(echo "${raw_secrets}" | grep "${secret}" | cut -d ':' -f 2 | tr -d ' ')
+  key="${secret^^}"
+  echo "export ${key}=${value}"
+done

--- a/terraform/cloudfoundry/logsearch_elb.tf
+++ b/terraform/cloudfoundry/logsearch_elb.tf
@@ -70,7 +70,7 @@ resource "aws_elb" "logsearch_kibana" {
   ]
 
   health_check {
-    target              = "TCP:5601"
+    target              = "TCP:5602"
     interval            = "${var.health_check_interval}"
     timeout             = "${var.health_check_timeout}"
     healthy_threshold   = "${var.health_check_healthy}"
@@ -78,7 +78,7 @@ resource "aws_elb" "logsearch_kibana" {
   }
 
   listener {
-    instance_port      = 5601
+    instance_port      = 5602
     instance_protocol  = "tcp"
     lb_port            = 443
     lb_protocol        = "ssl"


### PR DESCRIPTION
## What

https://www.pivotaltracker.com/story/show/115429827

Use HAProxy from the logsearch release to put http basic auth in front of Kibana.

## How to review

- Deploy the branch
- Run `make dev showenv`, notice that `KIBANA_ADMIN_PASSWORD` is shown
- Visit the logsearch URL
- Verify that http basic auth is required, and that the creds `admin`/`<KIBANA_ADMIN_PASSWORD>` give access

## Who can review

not @benhyland
