### PR TITLE
Upgrade cells to new r4 instance type

### DIFF
--- a/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
+++ b/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
@@ -109,7 +109,7 @@ vm_types:
     network: cell
     env: (( grab meta.default_env ))
     cloud_properties:
-      instance_type: r3.xlarge
+      instance_type: r4.xlarge
       ephemeral_disk:
         size: 102400
         type: gp2


### PR DESCRIPTION
## What

Use new r4 instance type for cells instead of current r3.

We get:
* a bit more CPU performance
* faster memory and more cache (java apps seem to like this)
* quite faster network
* 20% cost savings

The cost savings are considerable as we run many of these VMs in prod and they are not the cheapest.
Total savings for all environments are ~$12K/year or 1k per month...

## How to review

Deploy. Check that availability tests pass during VM upgrade. If you are paranoid, run the acceptance and custom acceptance tests (adds 20 mins to review time).

## Who can review

not @mtekel