### PR TITLE
Fix showenv on old bash, and include uaa_admin_password

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ pipelines: ## Upload pipelines to Concourse
 showenv: ## Display environment information
 	$(eval export TARGET_CONCOURSE=deployer)
 	@concourse/scripts/environment.sh
-	@scripts/show-cf-secrets.sh grafana_admin_password kibana_admin_password
+	@scripts/show-cf-secrets.sh grafana_admin_password kibana_admin_password uaa_admin_password
 	@echo export CONCOURSE_IP=$$(aws ec2 describe-instances \
 		--filters 'Name=tag:Name,Values=concourse/0' "Name=key-name,Values=${DEPLOY_ENV}_concourse_key_pair" \
 		--query 'Reservations[].Instances[].PublicIpAddress' --output text)

--- a/scripts/show-cf-secrets.sh
+++ b/scripts/show-cf-secrets.sh
@@ -6,6 +6,6 @@ raw_secrets="$(aws s3 cp "s3://${DEPLOY_ENV}-state/cf-secrets.yml" -)"
 
 for secret in "${requested_secrets[@]}"; do
   value=$(echo "${raw_secrets}" | grep "${secret}" | cut -d ':' -f 2 | tr -d ' ')
-  key="${secret^^}"
+  key=$(echo "${secret}" | tr '[:lower:]' '[:upper:]')
   echo "export ${key}=${value}"
 done


### PR DESCRIPTION
## What

The `^^` uppercasing variable substitution is only available in bash 4+.
OS X still ships with bash 3.2. Changing this to use `tr` is less elegant,
but more portable.

This PR also adds `uaa_admin_password` to the list of variables returned.
This is used to login to dev deployments, and so is useful to have present here.

## How to review

Verify that `make dev showenv` works without error.

## Who can review

Anyone running bash 3.2.