### PR TITLE
[#130821719] Fix create_user.sh with the --no-email flag

### DIFF
--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -189,7 +189,7 @@ send_mail() {
 }
 
 print_password() {
-  success "${EMAIL} has had their password changed to '${PASSWORD}'."
+  success "${EMAIL} has had their password changed to ${PASSWORD}"
 }
 
 emit_password() {

--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -189,7 +189,7 @@ send_mail() {
 }
 
 print_password() {
-  success "${USERNAME} has had their password changed to '${PASSWORD}'."
+  success "${EMAIL} has had their password changed to '${PASSWORD}'."
 }
 
 emit_password() {

--- a/scripts/rotate-user-password.sh
+++ b/scripts/rotate-user-password.sh
@@ -191,7 +191,7 @@ send_mail() {
 }
 
 print_password() {
-  success "${USERNAME} has had their password changed to '${PASSWORD}'."
+  success "${USERNAME} has had their password changed to ${PASSWORD}"
 }
 
 emit_password() {


### PR DESCRIPTION
## What

This was a copy/paste error from the rotate-user-password.sh script,
which uses USERNAME instead of EMAIL.

This also updates the printing of password to avoid any possible confusion around quotes and .

## How to review

Test that you can create users in a dev deployment using the `--no-email` flag. eg:
```sh
./scripts/create_user.sh -o foo -e foo@example.com --no-email
```

## Who can review

Anyone but myself.