### PR TITLE
Set garden log_level to error

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -655,3 +655,6 @@ properties:
       traffic_controller_url: (( grab properties.loggregator.traffic_controller_url ))
   cflinuxfs2-rootfs:
     trusted_certs: (( grab meta.ca_certs.aws_rds_combined_ca_bundle ))
+
+  garden:
+    log_level: error


### PR DESCRIPTION
## What

The elastic search disk capacity has recently ben increased (https://github.com/alphagov/paas-cf/pull/627) but this is not enough as the quantity of logs always increases little by little. Now the disk space used on elastic search VMs is around 75% and causes frequent warnings.

Garden currently is set to default `info` log level. This includes a lot of debug like messages and this represents more than half the total quantity of logs.
By setting `error` we will reduce drastically the quantity of logs emitted.

## How to review
- Check in kibana that there is a lot of logs emitted by garden and their relative usefulness
- Deploy with the branch
- Check garden logs are now minimal

## Who can review
Anyone but me

