### PR TITLE
[#122026001] Ensure that personal data is deleted as described in our policy 

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -2396,6 +2396,8 @@ jobs:
           file: paas-cf/concourse/tasks/custom-acceptance-tests-run.yml
           params:
             DISABLE_CUSTOM_ACCEPTANCE_TESTS: {{disable_custom_acceptance_tests}}
+            DEPLOY_ENV: {{deploy_env}}
+            AWS_REGION: {{aws_region}}
 
           ensure:
             task: upload-test-artifacts

--- a/manifests/cf-manifest/manifest/800-logsearch.yml
+++ b/manifests/cf-manifest/manifest/800-logsearch.yml
@@ -181,6 +181,8 @@ properties:
       elasticsearch:
         data_hosts: (( grab properties.elasticsearch.master_hosts ))
   curator:
+    purge_logs:
+      retention_period: 30
     elasticsearch:
       host: (( grab terraform_outputs.logsearch_elastic_master_elb_dns_name ))
   elasticsearch:

--- a/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
@@ -65,6 +65,30 @@ RSpec.describe "base properties" do
 
       it { is_expected.to include("resource_directory_key" => "#{terraform_fixture(:environment)}-cf-resources") }
     end
+
+    describe "app_events" do
+      subject(:app_events) { cc.fetch("app_events") }
+
+      it { is_expected.to include("cutoff_age_in_days" => 31), "Retention period should be same as specified in Privacy Policy" }
+    end
+
+    describe "app_usage_events" do
+      subject(:app_usage_events) { cc.fetch("app_usage_events") }
+
+      it { is_expected.to include("cutoff_age_in_days" => 31), "Retention period should be same as specified in Privacy Policy" }
+    end
+
+    describe "service_usage_events" do
+      subject(:service_usage_events) { cc.fetch("service_usage_events") }
+
+      it { is_expected.to include("cutoff_age_in_days" => 31), "Retention period should be same as specified in Privacy Policy" }
+    end
+
+    describe "audit_events" do
+      subject(:audit_events) { cc.fetch("audit_events") }
+
+      it { is_expected.to include("cutoff_age_in_days" => 31), "Retention period should be same as specified in Privacy Policy" }
+    end
   end
 
   describe "login" do

--- a/manifests/cf-manifest/spec/manifest/logsearch_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/logsearch_spec.rb
@@ -1,0 +1,12 @@
+
+RSpec.describe "Logsearch properties" do
+  let(:manifest) { manifest_with_defaults }
+  let(:properties) { manifest.fetch("properties") }
+
+  describe "curator job" do
+    it "contains purge_logs.retention_period. Retention period should not be changed without updating Privacy Policy." do
+      defs = properties.fetch("curator").fetch("purge_logs")
+      expect(defs.fetch("retention_period")).to eq(30)
+    end
+  end
+end

--- a/platform-tests/src/acceptance/s3_retention_test.go
+++ b/platform-tests/src/acceptance/s3_retention_test.go
@@ -1,0 +1,42 @@
+package acceptance_test
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func GetConfigFromEnvironment(varName string) string {
+	configValue := os.Getenv(varName)
+	ExpectWithOffset(1, configValue).NotTo(BeEmpty(), "Environment variable $%s is not set", varName)
+	return configValue
+}
+
+var _ = Describe("S3 logs bucket", func() {
+	const (
+		expectedRetention = 30
+	)
+
+	It("should have retention period set to "+strconv.Itoa(expectedRetention)+" days", func() {
+		sess, err := session.NewSession()
+		Expect(err).NotTo(HaveOccurred())
+
+		svc := s3.New(sess)
+		bucket := "gds-paas-" + GetConfigFromEnvironment("DEPLOY_ENV") + "-elb-access-log"
+		getBucketInput := &s3.GetBucketLifecycleConfigurationInput{
+			Bucket: aws.String(bucket),
+		}
+
+		req, resp := svc.GetBucketLifecycleConfigurationRequest(getBucketInput)
+
+		err = req.Send()
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(*resp.Rules[0].Expiration.Days).To(BeNumerically("==", expectedRetention))
+	})
+})


### PR DESCRIPTION
## What

We want to be sure that when a user stops using the service, their personal data is removed, and that any records of their actions/personal data in logs is automatically (programmatically) purged to facilitate a maximum 2-year retention period.

This PR adds tests around our retention period settings to ensure that when we change them such changes are reflected in our Privacy Policy document. 

## How to review

Run the pipelene and check if deployment is no-op and all tests pass. 

## Who can review

not @combor or @keymon 
