### PR TITLE
Add script to handle cf admin login in dev.

### DIFF
--- a/scripts/cf_admin_login_dev.sh
+++ b/scripts/cf_admin_login_dev.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+# shellcheck disable=SC1090
+source "${SCRIPT_DIR}/common.sh"
+check_aws_account_used dev
+
+API_URL="https://api.${DEPLOY_ENV}.dev.cloudpipeline.digital"
+
+# shellcheck disable=SC2091
+$("${SCRIPT_DIR}/show-cf-secrets.sh" uaa_admin_password)
+
+cf api "$API_URL" --skip-ssl-validation
+cf login -u admin -p "${UAA_ADMIN_PASSWORD}"


### PR DESCRIPTION
## What

In development we need to login as the cf admin user, which has an
autogenerated password which needs to be pulled out of the state bucket.
This script simplifies this process.

This is deliberately restricted to operate on dev only because we
should be using our individual user accounts in other environments.

## How to review

* Verify that the script correctly logs you into a dev CF deployment.
* Verify that it fails with a helpful error when using AWS keys for a different account.

## Who can review

Anyone but myself.