### PR TITLE
Attempt not to record 'No data'

### DIFF
--- a/terraform/datadog/cve-notifier.tf
+++ b/terraform/datadog/cve-notifier.tf
@@ -27,6 +27,7 @@ resource "datadog_monitor" "cve-notifier-reporter" {
   message           = "${format("New CVE has been found on https://pivotal.io/security @%s", var.support_email)}"
   no_data_timeframe = "180"
   query             = "events('priority:all tags:service:pivotal').rollup('count').last('1h') >= 1"
+  notify_no_data    = false
 
   thresholds {
     ok       = "1"


### PR DESCRIPTION
## What

We don't really need, the status of this monitor going to "No data". Although, in this case, this status is good, we would like to avoid it being recorded. If the status changes to "No data", our dashboard will turn orange for production, which may cause confusion.

## How to review

**This has not been tested by me** and in order to test it properly, it would need to stay live for couple of hours/days, to establish if the monitor status is switching to "No data".

  - Push pipelines from this branch with `ENABLE_DATADOG=true` and `ENABLE_CVE_NOTIFIER=true` set
  - Check if new monitor has been created
  - Wait a while, and see if the status of the monitor turns into "No data"

## Who can review

Anyone but @paroxp