### PR TITLE
[#131375099] Add monitors for the Cell rep and garden services

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -106,12 +106,6 @@ resources:
       tag_filter: {{cf_graphite_version}}
       branch: gds_master
 
-  - name: datadog-for-cloudfoundry-boshrelease
-    type: git
-    source:
-      uri: https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease.git
-      tag_filter: {{cf_datadog_for_cloudfoundry_version}}
-
   - name: os-conf-boshrelease
     type: git
     source:
@@ -1502,7 +1496,6 @@ jobs:
           - get: bosh-secrets
           - get: graphite-statsd-boshrelease
           - get: paas-haproxy-release
-          - get: datadog-for-cloudfoundry-boshrelease
           - get: os-conf-boshrelease
           - get: cf-secrets
             passed: ['generate-cf-config']
@@ -1551,7 +1544,6 @@ jobs:
               - name: paas-haproxy-release
               - name: os-conf-boshrelease
               - name: logsearch-for-cloudfoundry-boshrelease
-              - name: datadog-for-cloudfoundry-boshrelease
             run:
               path: sh
               args:
@@ -1575,10 +1567,6 @@ jobs:
                   ./paas-cf/concourse/scripts/git_check_tag.sh {{cf_logsearch_for_cloudfoundry_version}} logsearch-for-cloudfoundry-boshrelease
                   paas-cf/concourse/scripts/bosh_create_and_upload_release.rb logsearch-for-cloudfoundry \
                     {{cf_logsearch_for_cloudfoundry_version}} logsearch-for-cloudfoundry-boshrelease
-
-                  ./paas-cf/concourse/scripts/git_check_tag.sh {{cf_datadog_for_cloudfoundry_version}} datadog-for-cloudfoundry-boshrelease
-                  paas-cf/concourse/scripts/bosh_create_and_upload_release.rb datadog-for-cloudfoundry \
-                    {{cf_datadog_for_cloudfoundry_version}} datadog-for-cloudfoundry-boshrelease
 
         - task: get-and-upload-stemcell
           config:

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -32,7 +32,9 @@ releases:
   - name: paas-haproxy
     version: 0.0.5
   - name: datadog-for-cloudfoundry
-    version: "0.0.5"
+    version: 0.1.2
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.1.2.tgz
+    sha1: 481cf458f39984067144f281be28506ca738d029
 
 stemcells:
   - alias: default

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -334,6 +334,10 @@ jobs:
         release: diego
       - name: metron_agent
         release: cf
+      - name: datadog-rep
+        release: datadog-for-cloudfoundry
+      - name: datadog-garden
+        release: datadog-for-cloudfoundry
     instances: (( grab meta.cell.instances ))
     vm_type: cell
     stemcell: default

--- a/terraform/datadog/cell.tf
+++ b/terraform/datadog/cell.tf
@@ -19,3 +19,47 @@ resource "datadog_monitor" "cell-available-memory" {
     "job"        = "cell"
   }
 }
+
+resource "datadog_monitor" "rep_process_running" {
+  name                = "${format("%s Cell rep process running", var.env)}"
+  type                = "service check"
+  message             = "Cell rep process not running. Check router state."
+  escalation_message  = "Cell rep process still not running. Check router state."
+  notify_no_data      = false
+  require_full_window = true
+
+  query = "${format("'process.up'.over('bosh-deployment:%s','process:rep').last(4).count_by_status()", var.env)}"
+
+  thresholds {
+    ok       = 1
+    warning  = 2
+    critical = 3
+  }
+
+  tags {
+    "deployment" = "${var.env}"
+    "service"    = "${var.env}_monitors"
+    "job"        = "cell"
+  }
+}
+
+resource "datadog_monitor" "rep_healthy" {
+  name                = "${format("%s Cell rep healthy", var.env)}"
+  type                = "service check"
+  message             = "Large portion of Cell reps unhealthy. Check deployment state."
+  escalation_message  = "Large portion of Cell reps still unhealthy. Check deployment state."
+  no_data_timeframe   = "7"
+  require_full_window = true
+
+  query = "${format("'http.can_connect'.over('bosh-deployment:%s','instance:rep_service_endpoint').by('*').last(1).pct_by_status()", var.env)}"
+
+  thresholds {
+    critical = 50
+  }
+
+  tags {
+    "deployment" = "${var.env}"
+    "service"    = "${var.env}_monitors"
+    "job"        = "cell"
+  }
+}

--- a/terraform/datadog/cell.tf
+++ b/terraform/datadog/cell.tf
@@ -63,3 +63,47 @@ resource "datadog_monitor" "rep_healthy" {
     "job"        = "cell"
   }
 }
+
+resource "datadog_monitor" "garden_process_running" {
+  name                = "${format("%s Cell garden process running", var.env)}"
+  type                = "service check"
+  message             = "Cell garden process not running. Check router state."
+  escalation_message  = "Cell garden process still not running. Check router state."
+  notify_no_data      = false
+  require_full_window = true
+
+  query = "${format("'process.up'.over('bosh-deployment:%s','process:guardian').last(4).count_by_status()", var.env)}"
+
+  thresholds {
+    ok       = 1
+    warning  = 2
+    critical = 3
+  }
+
+  tags {
+    "deployment" = "${var.env}"
+    "service"    = "${var.env}_monitors"
+    "job"        = "cell"
+  }
+}
+
+resource "datadog_monitor" "garden_healthy" {
+  name                = "${format("%s Cell garden healthy", var.env)}"
+  type                = "service check"
+  message             = "Large portion of Cell garden unhealthy. Check deployment state."
+  escalation_message  = "Large portion of Cell garden still unhealthy. Check deployment state."
+  no_data_timeframe   = "7"
+  require_full_window = true
+
+  query = "${format("'http.can_connect'.over('bosh-deployment:%s','instance:garden_debug_endpoint').by('*').last(1).pct_by_status()", var.env)}"
+
+  thresholds {
+    critical = 50
+  }
+
+  tags {
+    "deployment" = "${var.env}"
+    "service"    = "${var.env}_monitors"
+    "job"        = "cell"
+  }
+}


### PR DESCRIPTION
[#131375099 Check health of cell components](https://www.pivotaltracker.com/story/show/131375099)

What?
----

We want to monitor the processes rep and garden in the cells. In https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/6 we added the required checks to the host:

In this PR we use the new datadog-for-cloudfoundry release (we switch to final tar releases) and configure the monitors:

 * Check if the processes rep and garden are running
 * check if the rep service endpoint is responding in > 50% of the hosts
 * Check if the garden debug endpoing is reponding in > 50% of the hosts.

Note that in the case of garden-runc the process is currently called guardian. Also, we only monitor the debug port of garden because the service socket is a unix socket that datadog does not currently support.

Dependencies
------------

https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/6 should be merged first.

https://github.com/alphagov/paas-release-ci/pull/3 should be merged, and the pipeline has to run and generate the final versions of datadog-for-cloudfoundry. The commits in this PR must be updated to reflect that.

How to test?
-----------

 1. Code check.
 2. Deploy everything with datadog enabled.
 3. Check that the monitors are present. You can try to stop some rep or garden processes to test.

Who?
---

Anyone but @keymon