### PR TITLE
[#133036569] Revert "Specify ELB security policy for all ELBs"

### DIFF
--- a/terraform/cloudfoundry/cf_api_elb.tf
+++ b/terraform/cloudfoundry/cf_api_elb.tf
@@ -31,15 +31,6 @@ resource "aws_elb" "cf_cc" {
   }
 }
 
-resource "aws_load_balancer_listener_policy" "cf_cc_listener_policies_443" {
-  load_balancer_name = "${aws_elb.cf_cc.name}"
-  load_balancer_port = 443
-
-  policy_names = [
-    "${var.default_elb_security_policy}",
-  ]
-}
-
 resource "aws_elb" "cf_uaa" {
   name                      = "${var.env}-cf-uaa"
   subnets                   = ["${split(",", var.infra_subnet_ids)}"]
@@ -71,15 +62,6 @@ resource "aws_elb" "cf_uaa" {
     lb_protocol        = "https"
     ssl_certificate_id = "${var.system_domain_cert_arn}"
   }
-}
-
-resource "aws_load_balancer_listener_policy" "cf_uaa_listener_policies_443" {
-  load_balancer_name = "${aws_elb.cf_uaa.name}"
-  load_balancer_port = 443
-
-  policy_names = [
-    "${var.default_elb_security_policy}",
-  ]
 }
 
 resource "aws_elb" "cf_loggregator" {
@@ -115,15 +97,6 @@ resource "aws_elb" "cf_loggregator" {
   }
 }
 
-resource "aws_load_balancer_listener_policy" "cf_loggregator_listener_policies_443" {
-  load_balancer_name = "${aws_elb.cf_loggregator.name}"
-  load_balancer_port = 443
-
-  policy_names = [
-    "${var.default_elb_security_policy}",
-  ]
-}
-
 resource "aws_elb" "cf_doppler" {
   name                      = "${var.env}-cf-doppler"
   subnets                   = ["${split(",", var.infra_subnet_ids)}"]
@@ -155,13 +128,4 @@ resource "aws_elb" "cf_doppler" {
     lb_protocol        = "ssl"
     ssl_certificate_id = "${var.system_domain_cert_arn}"
   }
-}
-
-resource "aws_load_balancer_listener_policy" "cf_doppler_listener_policies_443" {
-  load_balancer_name = "${aws_elb.cf_doppler.name}"
-  load_balancer_port = 443
-
-  policy_names = [
-    "${var.default_elb_security_policy}",
-  ]
 }

--- a/terraform/cloudfoundry/logsearch_elb.tf
+++ b/terraform/cloudfoundry/logsearch_elb.tf
@@ -85,12 +85,3 @@ resource "aws_elb" "logsearch_kibana" {
     ssl_certificate_id = "${var.system_domain_cert_arn}"
   }
 }
-
-resource "aws_load_balancer_listener_policy" "logsearch_kibana_listener_policies_443" {
-  load_balancer_name = "${aws_elb.logsearch_kibana.name}"
-  load_balancer_port = 443
-
-  policy_names = [
-    "${var.default_elb_security_policy}",
-  ]
-}

--- a/terraform/cloudfoundry/metrics_elb.tf
+++ b/terraform/cloudfoundry/metrics_elb.tf
@@ -32,21 +32,3 @@ resource "aws_elb" "metrics" {
     ssl_certificate_id = "${var.system_domain_cert_arn}"
   }
 }
-
-resource "aws_load_balancer_listener_policy" "metrics_listener_policies_443" {
-  load_balancer_name = "${aws_elb.metrics.name}"
-  load_balancer_port = 443
-
-  policy_names = [
-    "${var.default_elb_security_policy}",
-  ]
-}
-
-resource "aws_load_balancer_listener_policy" "metrics_listener_policies_3001" {
-  load_balancer_name = "${aws_elb.metrics.name}"
-  load_balancer_port = 3001
-
-  policy_names = [
-    "${var.default_elb_security_policy}",
-  ]
-}

--- a/terraform/cloudfoundry/router_elb.tf
+++ b/terraform/cloudfoundry/router_elb.tf
@@ -35,15 +35,6 @@ resource "aws_elb" "cf_router" {
   }
 }
 
-resource "aws_load_balancer_listener_policy" "cf_router_listener_policies_443" {
-  load_balancer_name = "${aws_elb.cf_router.name}"
-  load_balancer_port = 443
-
-  policy_names = [
-    "${var.default_elb_security_policy}",
-  ]
-}
-
 resource "aws_proxy_protocol_policy" "http_haproxy" {
   load_balancer  = "${aws_elb.cf_router.name}"
   instance_ports = ["81"]

--- a/terraform/concourse/elb.tf
+++ b/terraform/concourse/elb.tf
@@ -35,15 +35,6 @@ resource "aws_elb" "concourse" {
   }
 }
 
-resource "aws_load_balancer_listener_policy" "concourse_listener_policies_443" {
-  load_balancer_name = "${aws_elb.concourse.name}"
-  load_balancer_port = 443
-
-  policy_names = [
-    "${var.default_elb_security_policy}",
-  ]
-}
-
 resource "aws_security_group" "concourse-elb" {
   name        = "${var.env}-concourse-elb"
   description = "Concourse ELB security group"

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -119,12 +119,6 @@ variable "web_access_cidrs" {
   default     = ""
 }
 
-/* See https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-policy-table.html */
-variable "default_elb_security_policy" {
-  description = "Which Security policy to use for ELBs. This controls things like available SSL protocols/ciphers."
-  default     = "ELBSecurityPolicy-2016-08"
-}
-
 # List of Elastic Load Balancing Account ID to configure ELB access log policies
 # Provided by AWS in http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/enable-access-logs.html
 variable "elb_account_ids" {


### PR DESCRIPTION
## What

This has thrown errors for ELBs created prior to the change because the
policy needs to be attached to the ELB before it can be added to a
listener.

This reverts commit 2e96ba43717342b508de302f4515c2568704c282 (PR #647)

## How to review

Verify that this does indeed revert the mentioned PR.

## Who can review

Anyone but myself.