### PR TITLE
Upgrade CF to stemcell 3263.12

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -37,7 +37,7 @@ releases:
 stemcells:
   - alias: default
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3263.8"
+    version: "3263.12"
 
 update:
   canaries: 0


### PR DESCRIPTION
## What

Upgrade CF to fix USN-3151-2

We're applying it first to the CF installation, which is at greater risk of being exploited, given it has local users.

https://www.cloudfoundry.org/usn-3151-2/
https://www.ubuntu.com/usn/usn-3151-2/

## How to review

We agreed at standup that we will only code review and apply directly to CI.

Check that #649 has been merged first to unblock the pipeline.

## Who can review

Anyone but @bleach

