### PR TITLE
Make dashboard link to triggered alerts

### DIFF
--- a/tools/paas_dashboard/README.md
+++ b/tools/paas_dashboard/README.md
@@ -31,3 +31,10 @@ See [dashing.io](http://dashing.io) and the [smashing wiki](https://github.com/d
 
 We deploy our smashing app as part of the `create-bosh-cloudfoundry` pipeline.
 It should be available at https://paas-dasboard.cloudapps.digital
+
+### Running locally
+
+Obtain API and app keys from https://app.datadoghq.com/account/settings#api
+
+```bundle install
+ DD_API_KEY=<api key> DD_APP_KEY=<app key> bundle exec smashing start```

--- a/tools/paas_dashboard/dashboards/paas-overview.erb
+++ b/tools/paas_dashboard/dashboards/paas-overview.erb
@@ -8,17 +8,17 @@ $(function() {
 <div class="gridster">
   <ul>
     <li data-row="1" data-col="1" data-sizex="1" data-sizey="1">
-      <a href="https://app.datadoghq.com/monitors#manage?query=service:prod_monitors" target="_blank">
+      <a href="https://app.datadoghq.com/monitors#triggered?query=service:prod_monitors" target="_blank">
         <div data-title="Prod" data-id="prod_counts" data-view="Health"></div>
       </a>
     </li>
     <li data-row="2" data-col="1" data-sizex="1" data-sizey="1">
-      <a href="https://app.datadoghq.com/monitors#manage?query=service:staging_monitors" target="_blank">
+      <a href="https://app.datadoghq.com/monitors#triggered?query=service:staging_monitors" target="_blank">
         <div data-title="Staging" data-id="staging_counts" data-view="Health"></div>
       </a>
     </li>
     <li data-row="3" data-col="1" data-sizex="1" data-sizey="1">
-      <a href="https://app.datadoghq.com/monitors#manage?query=service:master_monitors" target="_blank">
+      <a href="https://app.datadoghq.com/monitors#triggered?query=service:master_monitors" target="_blank">
         <div data-title="CI" data-id="ci_counts" data-view="Health"></div>
       </a>
     </li>


### PR DESCRIPTION
## What

Link to triggered monitors, rather than the managed monitors, so I can quickly see a list of things making an environment not be green.

Add instructions for running the dashboard locally because I wanted to do that to make this change.

## How to review

- Follow the links and make sure they link to the right places
- Test the instructions for running locally

## Who can review

Not me