### PR TITLE
Increase elasticsearch data storage

### DIFF
--- a/manifests/cf-manifest/cloud-config/030-logsearch.yml
+++ b/manifests/cf-manifest/cloud-config/030-logsearch.yml
@@ -31,7 +31,7 @@ vm_types:
 
 disk_types:
   - name: elasticsearch_master
-    disk_size: 307200
+    disk_size: 377856
     cloud_properties: {type: gp2}
   - name: queue
     disk_size: 102400


### PR DESCRIPTION
## What

I've increased the size of our elasticsearch persistent disks because they are fairly steady at 80% full (we alert at 75% full). I think we'd prefer to be at something more like 65% full.

## How to review

Check I'm not adding an unreasonable amount of disk space.

Technical review (optional):

1. `df -h /var/vcap/store` on `elasticsearch_master/0` (and 1 and 2 if you are very thorough)
1. deploy this change
1. Repeat step 1 and verify that the size has increased
1. Check that all your elasticsearch data didn't disappear

## Who can review

Anyone but @bleach