### PR TITLE
[#133036569] Set ELB security policies (take 2)

### DIFF
--- a/terraform/cloudfoundry/cf_api_elb.tf
+++ b/terraform/cloudfoundry/cf_api_elb.tf
@@ -31,6 +31,17 @@ resource "aws_elb" "cf_cc" {
   }
 }
 
+resource "aws_lb_ssl_negotiation_policy" "cf_cc" {
+  name          = "paas-${var.default_elb_security_policy}"
+  load_balancer = "${aws_elb.cf_cc.id}"
+  lb_port       = 443
+
+  attribute {
+    name  = "Reference-Security-Policy"
+    value = "${var.default_elb_security_policy}"
+  }
+}
+
 resource "aws_elb" "cf_uaa" {
   name                      = "${var.env}-cf-uaa"
   subnets                   = ["${split(",", var.infra_subnet_ids)}"]
@@ -61,6 +72,17 @@ resource "aws_elb" "cf_uaa" {
     lb_port            = 443
     lb_protocol        = "https"
     ssl_certificate_id = "${var.system_domain_cert_arn}"
+  }
+}
+
+resource "aws_lb_ssl_negotiation_policy" "cf_uaa" {
+  name          = "paas-${var.default_elb_security_policy}"
+  load_balancer = "${aws_elb.cf_uaa.id}"
+  lb_port       = 443
+
+  attribute {
+    name  = "Reference-Security-Policy"
+    value = "${var.default_elb_security_policy}"
   }
 }
 
@@ -97,6 +119,17 @@ resource "aws_elb" "cf_loggregator" {
   }
 }
 
+resource "aws_lb_ssl_negotiation_policy" "cf_loggregator" {
+  name          = "paas-${var.default_elb_security_policy}"
+  load_balancer = "${aws_elb.cf_loggregator.id}"
+  lb_port       = 443
+
+  attribute {
+    name  = "Reference-Security-Policy"
+    value = "${var.default_elb_security_policy}"
+  }
+}
+
 resource "aws_elb" "cf_doppler" {
   name                      = "${var.env}-cf-doppler"
   subnets                   = ["${split(",", var.infra_subnet_ids)}"]
@@ -127,5 +160,16 @@ resource "aws_elb" "cf_doppler" {
     lb_port            = 443
     lb_protocol        = "ssl"
     ssl_certificate_id = "${var.system_domain_cert_arn}"
+  }
+}
+
+resource "aws_lb_ssl_negotiation_policy" "cf_doppler" {
+  name          = "paas-${var.default_elb_security_policy}"
+  load_balancer = "${aws_elb.cf_doppler.id}"
+  lb_port       = 443
+
+  attribute {
+    name  = "Reference-Security-Policy"
+    value = "${var.default_elb_security_policy}"
   }
 }

--- a/terraform/cloudfoundry/logsearch_elb.tf
+++ b/terraform/cloudfoundry/logsearch_elb.tf
@@ -85,3 +85,14 @@ resource "aws_elb" "logsearch_kibana" {
     ssl_certificate_id = "${var.system_domain_cert_arn}"
   }
 }
+
+resource "aws_lb_ssl_negotiation_policy" "logsearch_kibana" {
+  name          = "paas-${var.default_elb_security_policy}"
+  load_balancer = "${aws_elb.logsearch_kibana.id}"
+  lb_port       = 443
+
+  attribute {
+    name  = "Reference-Security-Policy"
+    value = "${var.default_elb_security_policy}"
+  }
+}

--- a/terraform/cloudfoundry/metrics_elb.tf
+++ b/terraform/cloudfoundry/metrics_elb.tf
@@ -32,3 +32,25 @@ resource "aws_elb" "metrics" {
     ssl_certificate_id = "${var.system_domain_cert_arn}"
   }
 }
+
+resource "aws_lb_ssl_negotiation_policy" "metrics_443" {
+  name          = "paas-${var.default_elb_security_policy}"
+  load_balancer = "${aws_elb.metrics.id}"
+  lb_port       = 443
+
+  attribute {
+    name  = "Reference-Security-Policy"
+    value = "${var.default_elb_security_policy}"
+  }
+}
+
+resource "aws_lb_ssl_negotiation_policy" "metrics_3001" {
+  name          = "paas-${var.default_elb_security_policy}"
+  load_balancer = "${aws_elb.metrics.id}"
+  lb_port       = 3001
+
+  attribute {
+    name  = "Reference-Security-Policy"
+    value = "${var.default_elb_security_policy}"
+  }
+}

--- a/terraform/cloudfoundry/router_elb.tf
+++ b/terraform/cloudfoundry/router_elb.tf
@@ -35,6 +35,17 @@ resource "aws_elb" "cf_router" {
   }
 }
 
+resource "aws_lb_ssl_negotiation_policy" "cf_router" {
+  name          = "paas-${var.default_elb_security_policy}"
+  load_balancer = "${aws_elb.cf_router.id}"
+  lb_port       = 443
+
+  attribute {
+    name  = "Reference-Security-Policy"
+    value = "${var.default_elb_security_policy}"
+  }
+}
+
 resource "aws_proxy_protocol_policy" "http_haproxy" {
   load_balancer  = "${aws_elb.cf_router.name}"
   instance_ports = ["81"]

--- a/terraform/concourse/elb.tf
+++ b/terraform/concourse/elb.tf
@@ -35,6 +35,17 @@ resource "aws_elb" "concourse" {
   }
 }
 
+resource "aws_lb_ssl_negotiation_policy" "concourse" {
+  name          = "paas-${var.default_elb_security_policy}"
+  load_balancer = "${aws_elb.concourse.id}"
+  lb_port       = 443
+
+  attribute {
+    name  = "Reference-Security-Policy"
+    value = "${var.default_elb_security_policy}"
+  }
+}
+
 resource "aws_security_group" "concourse-elb" {
   name        = "${var.env}-concourse-elb"
   description = "Concourse ELB security group"

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -119,6 +119,12 @@ variable "web_access_cidrs" {
   default     = ""
 }
 
+# See https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-policy-table.html
+variable "default_elb_security_policy" {
+  description = "Which Security policy to use for ELBs. This controls things like available SSL protocols/ciphers."
+  default     = "ELBSecurityPolicy-2016-08"
+}
+
 # List of Elastic Load Balancing Account ID to configure ELB access log policies
 # Provided by AWS in http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/enable-access-logs.html
 variable "elb_account_ids" {


### PR DESCRIPTION
## What

The default behaviour if this is unspecified is for the ELBs to get the
AWS default security policy at the time that the ELB is created. This
has led to our long-lived deployments having an older security policy,
which raises warnings in Trusted Advisor etc.

This therefore updates all ELBs that terminate SSL to use the latest
built-in AWS policy (2016-08).

We previously attempted this in #647, but had to revert. This was due
to a misunderstanding about how these policies work. An ELB has one or
more policies defined for it. Each SSL listener then has one of these
policies attached to it. The previous commit failed because we were
attempting to attach a policy to the listeners that didn't exist on the
ELB.

## How to review

To test this properly, it's necessary to have an ELB configured with an old policy (and with no new policies attached at all):
* Deploy from master as far as cf-terraform
* In the web UI, change the SSL policy for one of the ELBs to an old policy (Using the "change" link for the Ciphers in the listener properties).
* Delete the now unused policy from the elb (substitute cf-router if changing a different one):
    `aws elb delete-load-balancer-policy --load-balancer-name ${DEPLOY_ENV}-cf-router --policy-name ELBSecurityPolicy-2016-08`

Now deploy from this branch (again as far as cf-terraform).
Verify that the ELB has had it's policy updated to the current one (it may be necessary to refresh the web UI before the change is visible).

## Who can review

Anyone but myself.