### PR TITLE
[#135801295] Upgrade stemcell for BOSH and Concourse

### DIFF
--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -154,8 +154,8 @@ resource_pools:
 - name: bosh
   network: private
   stemcell:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3263.8
-    sha1: 95ecc2709ac62f21d0a1c6cac023585c3919b825
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3263.12
+    sha1: b2e8ea8415dca3ab5826a39dcbe4ef760bcc7b05
   cloud_properties:
     instance_type: t2.medium
     ephemeral_disk: {size: 40000, type: gp2}

--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -22,8 +22,8 @@ releases:
 # bosh-init container must also be updated so that the cached CPI compile
 # will be used.
 - name: bosh-aws-cpi
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=60
-  sha1: 8e40a9ff892204007889037f094a1b0d23777058
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=62
+  sha1: f36967927ceae09e5663a41fdda199edfe649dc6
 
 jobs:
 - name: bosh

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -15,8 +15,8 @@ releases:
   # bosh-init container must also be updated so that the cached CPI compile
   # will be used.
   - name: bosh-aws-cpi
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=60
-    sha1: 8e40a9ff892204007889037f094a1b0d23777058
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=62
+    sha1: f36967927ceae09e5663a41fdda199edfe649dc6
 
 resource_pools:
   - name: concourse

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -22,8 +22,8 @@ resource_pools:
   - name: concourse
     network: concourse
     stemcell:
-      url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3263.8
-      sha1: 95ecc2709ac62f21d0a1c6cac023585c3919b825
+      url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3263.12
+      sha1: b2e8ea8415dca3ab5826a39dcbe4ef760bcc7b05
     cloud_properties:
       instance_type: m4.xlarge
       availability_zone: (( grab terraform_outputs.zone0 ))


### PR DESCRIPTION
## What

[Apply USN-3151-2 everywhere](https://www.pivotaltracker.com/n/projects/1275640/stories/135801295).

To apply the security fix, we need to upgrade stemcell used by concourse and BOSH. We have decided to upgrade to the same version as CF uses currently.

## How to review

Apply. You can either watch (and trust) the output from bosh-init, which should say `Uploading stemcell 'bosh-aws-xen-hvm-ubuntu-trusty-go_agent/3263.12'...` or ssh to bosh/concourse (`make dev ssh_bosh`/`make dev ssh_concourse`) and watch logs of bosh agent, which reports which stemcell it thinks the VM is running - and trust this information. Logs are located in `/var/vcap/bosh/logs` and it should look like `[App] 2016/12/09 11:35:15 INFO - Running on stemcell version '3263.12' (git: 41edff6464246431d6440b2446bb9cc5f872167f+)`

## Who can review

not @mtekel
