### PR TITLE
[#134345035] Add Cloud Controller process checks and monitors

### DIFF
--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -46,7 +46,6 @@ prepare_environment() {
   cf_graphite_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.graphite.version "${cf_manifest_dir}/040-graphite.yml")
   cf_os_conf_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.os-conf.version "${cf_manifest_dir}/../runtime-config/runtime-config-base.yml")
   cf_logsearch_for_cloudfoundry_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.logsearch-for-cloudfoundry.version "${cf_manifest_dir}/800-logsearch.yml")
-  cf_datadog_for_cloudfoundry_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.datadog-for-cloudfoundry.version "${cf_manifest_dir}/000-base-cf-deployment.yml")
 
   if [ "${SKIP_COMMIT_VERIFICATION:-}" = "true" ] ; then
     gpg_ids="[]"
@@ -88,7 +87,6 @@ debug: ${DEBUG:-}
 cf-release-version: v${cf_release_version}
 cf-paas-haproxy-release-version: ${cf_paas_haproxy_version}
 cf_graphite_version: ${cf_graphite_version}
-cf_datadog_for_cloudfoundry_version: ${cf_datadog_for_cloudfoundry_version}
 cf_os_conf_version: ${cf_os_conf_version}
 cf_logsearch_for_cloudfoundry_version: ${cf_logsearch_for_cloudfoundry_version}
 cf_env_specific_manifest: ${ENV_SPECIFIC_CF_MANIFEST}

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -32,9 +32,10 @@ releases:
   - name: paas-haproxy
     version: 0.0.5
   - name: datadog-for-cloudfoundry
-    version: 0.1.2
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.1.2.tgz
-    sha1: 481cf458f39984067144f281be28506ca738d029
+    version: 0.1.4
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.1.4.tgz
+    sha1: 763edf6e79b36bdb3b3cd41d1b8b203fb14b5505
+
 
 stemcells:
   - alias: default

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -8,8 +8,6 @@ meta:
   api_templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
-  - name: datadog-consul
-    release: datadog-for-cloudfoundry
   - name: cloud_controller_ng
     release: capi
   - name: metron_agent
@@ -34,16 +32,22 @@ meta:
     release: (( grab meta.release.name ))
   - name: staticfile-buildpack
     release: (( grab meta.release.name ))
+  - name: datadog-consul
+    release: datadog-for-cloudfoundry
+  - name: datadog-cc
+    release: datadog-for-cloudfoundry
 
   api_worker_templates:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
-  - name: datadog-consul
-    release: datadog-for-cloudfoundry
   - name: cloud_controller_worker
     release: capi
   - name: metron_agent
     release: (( grab meta.release.name ))
+  - name: datadog-consul
+    release: datadog-for-cloudfoundry
+  - name: datadog-cc-worker
+    release: datadog-for-cloudfoundry
 
   clock_templates:
   - name: consul_agent

--- a/terraform/datadog/cloud_controller.tf
+++ b/terraform/datadog/cloud_controller.tf
@@ -64,3 +64,66 @@ resource "datadog_monitor" "cc_api_healthy" {
     "job"        = "api"
   }
 }
+
+resource "datadog_monitor" "cc_failed_job_count_total_increase" {
+  name                = "${format("%s Cloud Controller API failed job count", var.env)}"
+  type                = "query alert"
+  message             = "Amount of failed jobs in Cloud Controller API grew considerably, check the API health."
+  escalation_message  = "Amount of failed jobs in Cloud Controller API still growing considerably, check the API health."
+  require_full_window = false
+
+  query = "${format("change(max(last_1m),last_30m):max:cf.cc.failed_job_count.total{deployment:%s} > 5", var.env)}"
+
+  thresholds {
+    warning  = "3"
+    critical = "5"
+  }
+
+  tags {
+    "deployment" = "${var.env}"
+    "service"    = "${var.env}_monitors"
+    "job"        = "api"
+  }
+}
+
+resource "datadog_monitor" "cc_log_count_error_increase" {
+  name                = "${format("%s Cloud Controller API log error count", var.env)}"
+  type                = "query alert"
+  message             = "Amount of logged errors in Cloud Controller API grew considerably, check the API health."
+  escalation_message  = "Amount of logged errors in Cloud Controller API still growing considerably, check the API health."
+  require_full_window = false
+
+  query = "${format("change(max(last_1m),last_30m):sum:cf.cc.log_count.error{deployment:%s} > 5", var.env)}"
+
+  thresholds {
+    warning  = "3"
+    critical = "5"
+  }
+
+  tags {
+    "deployment" = "${var.env}"
+    "service"    = "${var.env}_monitors"
+    "job"        = "api"
+  }
+}
+
+resource "datadog_monitor" "cc_job_queue_length" {
+  name                = "${format("%s Cloud Controller API job queue length", var.env)}"
+  type                = "query alert"
+  message             = "Job queue in Cloud Controller API grew considerably, check the API health."
+  escalation_message  = "Job queue in Cloud Controller API still too big, check the API health."
+  require_full_window = false
+
+  query = "${format("max(last_30m):max:cf.cc.job_queue_length.total{deployment:%s} > 10", var.env)}"
+
+  thresholds {
+    warning  = "6"
+    critical = "10"
+  }
+
+  tags {
+    "deployment" = "${var.env}"
+    "service"    = "${var.env}_monitors"
+    "job"        = "api"
+  }
+}

--- a/terraform/datadog/cloud_controller.tf
+++ b/terraform/datadog/cloud_controller.tf
@@ -1,0 +1,66 @@
+resource "datadog_monitor" "cc_api_master_process_running" {
+  name                = "${format("%s Cloud Controller API master process running", var.env)}"
+  type                = "service check"
+  message             = "Cloud Controller API master process is not running. Check deployment state."
+  escalation_message  = "Cloud Controller API master process is still not running. Check deployment state."
+  notify_no_data      = false
+  require_full_window = true
+
+  query = "${format("'process.up'.over('bosh-deployment:%s','process:cc_api_master').last(4).count_by_status()", var.env)}"
+
+  thresholds {
+    ok       = 1
+    warning  = 2
+    critical = 3
+  }
+
+  tags {
+    "deployment" = "${var.env}"
+    "service"    = "${var.env}_monitors"
+    "job"        = "api"
+  }
+}
+
+resource "datadog_monitor" "cc_api_worker_process_running" {
+  name                = "${format("%s Cloud Controller API worker process running", var.env)}"
+  type                = "service check"
+  message             = "Cloud Controller API worker process is not running. Check deployment state."
+  escalation_message  = "Cloud Controller API worker process is still not running. Check deployment state."
+  notify_no_data      = false
+  require_full_window = true
+
+  query = "${format("'process.up'.over('bosh-deployment:%s','process:cc_api_worker').last(4).count_by_status()", var.env)}"
+
+  thresholds {
+    ok       = 1
+    warning  = 2
+    critical = 3
+  }
+
+  tags {
+    "deployment" = "${var.env}"
+    "service"    = "${var.env}_monitors"
+    "job"        = "api"
+  }
+}
+
+resource "datadog_monitor" "cc_api_healthy" {
+  name                = "${format("%s Cloud Controller API healthy", var.env)}"
+  type                = "service check"
+  message             = "Large portion of Cloud Controller API master unhealthy. Check deployment state."
+  escalation_message  = "Large portion of Cloud Controller API master still unhealthy. Check deployment state."
+  no_data_timeframe   = "7"
+  require_full_window = true
+
+  query = "${format("'http.can_connect'.over('bosh-deployment:%s','instance:cc_endpoint').by('*').last(1).pct_by_status()", var.env)}"
+
+  thresholds {
+    critical = 50
+  }
+
+  tags {
+    "deployment" = "${var.env}"
+    "service"    = "${var.env}_monitors"
+    "job"        = "api"
+  }
+}


### PR DESCRIPTION
[#134345035 Monitor cloud controller job](https://www.pivotaltracker.com/story/show/134345035)

What?
-----

We want to monitor elementary health metrics of the cloud controller to help us diagnose the issues and warn us in advance if there are problems with platform. This story is about monitoring on the VM directly, there are other stories to monitor API on high level (e.g. externally).

This PR uses the feature from https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/7 to implement datadog monitors for the Cloud Controller API main process and workers and the CC HTTP endpoint.


We add some monitors for the Cloud Controller metrics from the CF datadog
nozzle:

 * `cf.cc.failed_job_count.total`: alert if there were an increase of more than 5 errors in the last 30m.

 * `cf.cc.log_count.error`: In a similar way, alert if there is an increase of more than 5 errors in the last 30m.

  From the docs:
  > Number of log messages of severity “error.” Error is the most severe level. It is used for failures and during error handling. Most errors can be found under this log level, eg. failed unbinding a service, failed to cancel a task, Diego app crashed error, staging completion errors, staging errors, and resource not found. The count resets when the Cloud Controller process is restarted. Emitted every 30 seconds per VM.

 * `cf.cc.job_queue_length.total`: warning when is > 6, alert >10. This can detect high load in the APIs or slowness in any component of the platform when deploying.

Dependencies?
-------------

This depends on https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/7. Once merged, the relevant commit must be updated in this PR.

There is a TEMPORARY commit in this  PR for testing. Remove it before merge.

How to review?
------------

I added a TEMPORARY commit to this branch that will:
 * Install datadog agent on the Cloud Controller VMs, without needing reinstall all the environment with DATADOG_ENABLED.
 * Enable the datadog nozzle
 * Includes a directory with the new monitors to test in terraform.

So to review:

 1. Deploy as usual with the datadog credentials in the S3 bucket. it is NOT required to have `DATADOG_ENABLED`
 2. apply the monitors manually:

```
cd terraform/datadog/tmp_check_cc_monitors/ && terraform apply -var datadog_api_key=$(paas-pass datadog/dev/datadog_api_key) -var datadog_app_key=$(paas-pass datadog/dev/datadog_app_key) -var aws_account=dev  -var env=hector
```

You can simply check if the monitors makes sense, but if you want to trigger then:
 * Stop API cloudcontroler and the workers and check alerts from the process & HTTP monitors.
 * Stop the rds-broker and try to create instances. It will increase the error count.
 * Stop several CC workers and try to push several apps at the same time.

 Note: I was not able to make it increase the failed jobs counter.

 Who?
 ----

 Anyone but @keymon