### PR TITLE
[#126126973] Tooling to use STS tokens once we enforce MFA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,8 +172,8 @@ bootstrap-destroy: ## Destroy bootstrap
 bosh-cli: ## Create interactive connnection to BOSH container
 	concourse/scripts/bosh-cli.sh
 
-.PHONY: pipelines check-aws-credentials
-pipelines: ## Upload pipelines to Concourse
+.PHONY: pipelines
+pipelines: check-aws-credentials ## Upload pipelines to Concourse
 	concourse/scripts/pipelines-bosh-cloudfoundry.sh
 
 .PHONY: showenv

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ check-env-vars:
 check-tf-version:
 	@./terraform/scripts/ensure_terraform_version.sh $(MIN_TERRAFORM_VERSION)
 
+check-aws-credentials:
+	@./scripts/validate_aws_credentials.sh
+
 test: spec lint_yaml lint_terraform lint_shellcheck lint_concourse lint_ruby lint_posix_newlines ## Run linting tests
 
 spec:
@@ -169,12 +172,12 @@ bootstrap-destroy: ## Destroy bootstrap
 bosh-cli: ## Create interactive connnection to BOSH container
 	concourse/scripts/bosh-cli.sh
 
-.PHONY: pipelines
+.PHONY: pipelines check-aws-credentials
 pipelines: ## Upload pipelines to Concourse
 	concourse/scripts/pipelines-bosh-cloudfoundry.sh
 
 .PHONY: showenv
-showenv: ## Display environment information
+showenv: check-aws-credentials ## Display environment information
 	$(eval export TARGET_CONCOURSE=deployer)
 	@concourse/scripts/environment.sh
 	@scripts/show-cf-secrets.sh grafana_admin_password kibana_admin_password uaa_admin_password
@@ -183,7 +186,7 @@ showenv: ## Display environment information
 		--query 'Reservations[].Instances[].PublicIpAddress' --output text)
 
 .PHONY: upload-datadog-secrets
-upload-datadog-secrets: check-env-vars ## Decrypt and upload Datadog credentials to S3
+upload-datadog-secrets: check-env-vars check-aws-credentials ## Decrypt and upload Datadog credentials to S3
 	$(eval export DATADOG_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
 	$(if ${AWS_ACCOUNT},,$(error Must set environment to ci/staging/prod))
 	$(if ${DATADOG_PASSWORD_STORE_DIR},,$(error Must pass DATADOG_PASSWORD_STORE_DIR=<path_to_password_store>))
@@ -192,7 +195,7 @@ upload-datadog-secrets: check-env-vars ## Decrypt and upload Datadog credentials
 
 .PHONY: manually_upload_certs
 CERT_PASSWORD_STORE_DIR?=~/.paas-pass-high
-manually_upload_certs: check-tf-version ## Manually upload to AWS the SSL certificates for public facing endpoints
+manually_upload_certs: check-tf-version check-aws-credentials ## Manually upload to AWS the SSL certificates for public facing endpoints
 	$(if ${ACTION},,$(error Must pass ACTION=<plan|apply|...>))
 	# check password store and if varables are accesible
 	$(if ${CERT_PASSWORD_STORE_DIR},,$(error Must pass CERT_PASSWORD_STORE_DIR=<path_to_password_store>))
@@ -200,7 +203,7 @@ manually_upload_certs: check-tf-version ## Manually upload to AWS the SSL certif
 	@terraform/scripts/manually-upload-certs.sh ${ACTION}
 
 .PHONY: pingdom
-pingdom: check-tf-version ## Use custom Terraform provider to set up Pingdom check
+pingdom: check-tf-version check-aws-credentials ## Use custom Terraform provider to set up Pingdom check
 	$(if ${ACTION},,$(error Must pass ACTION=<plan|apply|...>))
 	$(eval export PASSWORD_STORE_DIR?=~/.paas-pass)
 	$(eval export PINGDOM_CONTACT_IDS=11089310)
@@ -219,20 +222,20 @@ run_job: check-env-vars ## Unbind paas-cf of $JOB in create-bosh-cloudfoundry pi
 	$(if ${JOB},,$(error Must pass JOB=<name>))
 	./concourse/scripts/run_job.sh ${JOB}
 
-ssh_bosh: check-env-vars ## SSH to the bosh server
+ssh_bosh: check-env-vars check-aws-credentials ## SSH to the bosh server
 	@./scripts/ssh_bosh.sh
 
-ssh_concourse: check-env-vars ## SSH to the concourse server. Set SSH_CMD to pass a command to execute.
+ssh_concourse: check-env-vars check-aws-credentials ## SSH to the concourse server. Set SSH_CMD to pass a command to execute.
 	@./scripts/ssh.sh ssh ${SSH_CMD}
 
-tunnel: check-env-vars ## SSH tunnel to internal IPs
+tunnel: check-env-vars check-aws-credentials ## SSH tunnel to internal IPs
 	$(if ${TUNNEL},,$(error Must pass TUNNEL=SRC_PORT:HOST:DST_PORT))
 	@./scripts/ssh.sh tunnel ${TUNNEL}
 
-stop-tunnel: check-env-vars ## Stop SSH tunnel
+stop-tunnel: check-env-vars check-aws-credentials ## Stop SSH tunnel
 	@./scripts/ssh.sh tunnel stop
 
-shake_concourse_volumes: check-env-vars ## Restarts concourse services and workers and clears the volumes
+shake_concourse_volumes: check-env-vars check-aws-credentials ## Restarts concourse services and workers and clears the volumes
 	@./scripts/ssh.sh scp concourse/scripts/shake_concourse_volumes.sh /tmp/
 	@./scripts/ssh.sh ssh bash -i /tmp/shake_concourse_volumes.sh
 

--- a/scripts/create_sts_token.sh
+++ b/scripts/create_sts_token.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 
 ensure_env_vars() {
   if [ -z "${DEPLOY_ENV}" ] || [ -z "${AWS_ACCOUNT}" ] || [ -z "${AWS_ACCESS_KEY_ID}" ] || [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
-    echo "Must set DEPLOY_ENV, AWS_ACCOUNT, AWS_ACCOUNT, AWS_SECRET_ACCESS_KEY"
+    echo "Must set DEPLOY_ENV, AWS_ACCOUNT, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY"
     exit 1
   fi
 

--- a/scripts/create_sts_token.sh
+++ b/scripts/create_sts_token.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -eo pipefail
+
+ensure_env_vars() {
+  if [ -z "${DEPLOY_ENV}" ] || [ -z "${AWS_ACCOUNT}" ] || [ -z "${AWS_ACCESS_KEY_ID}" ] || [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
+    echo "Must set DEPLOY_ENV, AWS_ACCOUNT, AWS_ACCOUNT, AWS_SECRET_ACCESS_KEY"
+    exit 1
+  fi
+
+  if ! [[ "${AWS_ACCOUNT:-}" =~ ^(dev|ci|staging|prod)$ ]]; then
+    echo "You must set AWS_ACCOUNT with one of: dev|ci|staging|prod"
+    exit 1
+  fi
+
+  STS_TOKEN_DURATION="${STS_TOKEN_DURATION:-43200}"
+  STS_TOKEN_DIRECTORY="${STS_TOKEN_DIRECTORY:-${HOME}/.aws_sts_tokens}"
+
+  STS_TOKEN_STALESNESS_THRESHOLD=600
+  TOKEN_FILE="${STS_TOKEN_DIRECTORY}/${AWS_ACCOUNT}_${DEPLOY_ENV}.sh"
+  unset AWS_SESSION_TOKEN
+}
+
+ensure_token_dir() {
+  if [ ! -d "${STS_TOKEN_DIRECTORY}" ]; then
+      mkdir "${STS_TOKEN_DIRECTORY}"
+  fi
+}
+
+delete_stale_tokens() {
+  # we can't use last modified time since we want the duration to be configurable
+
+  now=$(date +%s)
+  token_files=$(find "${STS_TOKEN_DIRECTORY}" -name "*_*.sh" -type f)
+
+  for f in $token_files; do
+    expire_time=$(head -1 "${f}" | cut -d ":" -f 2)
+    if [ "${expire_time}" -lt "${now}" ]; then
+      rm "${f}"
+    fi
+  done
+}
+
+generate_new_token() {
+  expires=$(($(date +%s) + STS_TOKEN_DURATION - STS_TOKEN_STALESNESS_THRESHOLD))
+  echo "# EXPIRES:${expires}" > "${TOKEN_FILE}"
+  chmod 600 "${TOKEN_FILE}"
+  trap 'rm ${TOKEN_FILE}' ERR
+
+  read -r -p "Enter MFA code for ${AWS_ACCOUNT}: " mfa_token
+
+  user_arn=$(aws sts get-caller-identity --query Arn --output text)
+  token_arn=${user_arn/:user/:mfa}
+
+  aws sts get-session-token \
+    --serial-number "${token_arn}" \
+    --duration-seconds "${STS_TOKEN_DURATION}" \
+    --output text \
+    --query "[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken]" \
+    --token-code "${mfa_token}" | \
+      awk '{ print "export AWS_ACCESS_KEY_ID=\"" $1 "\"\n" "export AWS_SECRET_ACCESS_KEY=\"" $2 "\"\n" "export AWS_SESSION_TOKEN=\"" $3 "\"" }' >> "${TOKEN_FILE}"
+}
+
+ensure_env_vars
+ensure_token_dir
+delete_stale_tokens
+
+if [ ! -e "${TOKEN_FILE}" ]; then
+  generate_new_token
+fi

--- a/scripts/validate_aws_credentials.sh
+++ b/scripts/validate_aws_credentials.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+if [ -z "$AWS_SESSION_TOKEN" ]; then
+  echo "No temporary AWS credentials found, please run create_sts_token.sh"
+  exit 255;
+fi
+
+aws iam get-user > /dev/null 2>&1
+if [[ $? != 0 ]]; then
+  echo "Current AWS credentials are invalid, please refresh them using create_sts_token.sh"
+  exit 255;
+fi


### PR DESCRIPTION
## What

In [another PR](https://github.gds/government-paas/aws-account-wide-terraform/pull/68) we enforce users to have MFA enabled using an IAM policy that blocks all access to AWS if a token has not been registered. Because regular AWS keys are not MFA'd, any request made using them will be blocked by the policy.

The solution to this is to move to [security tokens](http://docs.aws.amazon.com/STS/latest/APIReference/Welcome.html) which are MFA'd, and are issued using the regular AWS keys. These tokens are time-limited with a maximum lifetime of 36 hours, however we set the expiry to 12 hours so they last a working day.

This PR introduces tooling that both checks you have valid keys before running Make tasks, and tooling to issue & cache tokens.

We acknowledge that the interaction with this tooling may not be perfect yet, however we would like to see how people use it before integrating it more deeply or adding more magic ✨.

It is suggested that developers create bash aliases to both create and source the correct credentials for an environment. Such as:

    alias fetch_token="${PAAS_CF_DIR}/scripts/create_sts_token.sh" && \
        source "${HOME}/.aws_sts_tokens/${AWS_ACCOUNT}_${DEPLOY_ENV}.sh"

## How to review

1. Run `make showenv` and observe that you are warned about not having credentials.
2. Run `./scripts/create_sts_token.sh` to create an STS token in `~/.aws_sts_tokens/`.
3. Run `source ~/.aws_sts_tokens/$AWS_ACCOUNT_$DEPLOY_ENV.sh` (Assuming you have `AWS_ACCOUNT` set to `dev` or similar).
4. Run `make showenv` and observe it working using the temporary credentials.
5. Optionally wait 12 hours and try `make showenv` again, then observe a notice telling you your credentials are now invalid.

## Who can review
Preferably not @benhyland or @jonty.