### PR TITLE
Increase elasticsearch disk space in prod

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1349,6 +1349,7 @@ jobs:
                 ./paas-cf/manifests/cf-manifest/cloud-config/*.yml
                 ./terraform-outputs/*.yml
                 ./cf-secrets/cf-secrets.yml
+                ./paas-cf/manifests/cf-manifest/cloud-config/env-specific/{{cf_env_specific_manifest}}
             run:
               path: sh
               args:
@@ -1357,7 +1358,7 @@ jobs:
                 - |
                   echo "Generating cloud config..."
 
-                  ./paas-cf/manifests/shared/build_manifest.sh $MANIFEST_STUBS > cloud-config/cloud-config.yml
+                  eval ./paas-cf/manifests/shared/build_manifest.sh $MANIFEST_STUBS > cloud-config/cloud-config.yml
           on_success:
             put: cloud-config
             params:

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -1349,7 +1349,7 @@ jobs:
                 ./paas-cf/manifests/cf-manifest/cloud-config/*.yml
                 ./terraform-outputs/*.yml
                 ./cf-secrets/cf-secrets.yml
-                ./paas-cf/manifests/cf-manifest/cloud-config/env-specific/{{cf_env_specific_manifest}}
+                ./paas-cf/manifests/cf-manifest/env-specific/{{cf_env_specific_manifest}}
             run:
               path: sh
               args:
@@ -1391,7 +1391,7 @@ jobs:
                 ./paas-cf/manifests/shared/deployments/collectd.yml
                 ./paas-cf/manifests/shared/deployments/datadog-agent.yml
                 ./paas-cf/manifests/shared/deployments/syslog.yml
-                ./paas-cf/manifests/cf-manifest/manifest/env-specific/{{cf_env_specific_manifest}}
+                ./paas-cf/manifests/cf-manifest/env-specific/{{cf_env_specific_manifest}}
               AWS_ACCOUNT: {{aws_account}}
               ENABLE_DATADOG: {{enable_datadog}}
               DATADOG_API_KEY: {{datadog_api_key}}

--- a/manifests/cf-manifest/cloud-config/030-logsearch.yml
+++ b/manifests/cf-manifest/cloud-config/030-logsearch.yml
@@ -31,7 +31,7 @@ vm_types:
 
 disk_types:
   - name: elasticsearch_master
-    disk_size: 307200
+    disk_size: (( grab meta.elasticsearch_master.disk_size ))
     cloud_properties: {type: gp2}
   - name: queue
     disk_size: 102400

--- a/manifests/cf-manifest/cloud-config/env-specific/cf-default.yml
+++ b/manifests/cf-manifest/cloud-config/env-specific/cf-default.yml
@@ -1,0 +1,4 @@
+---
+meta:
+  elasticsearch_master:
+    disk_size: 307200

--- a/manifests/cf-manifest/cloud-config/env-specific/cf-prod.yml
+++ b/manifests/cf-manifest/cloud-config/env-specific/cf-prod.yml
@@ -1,0 +1,4 @@
+---
+meta:
+  elasticsearch_master:
+    disk_size: 377856

--- a/manifests/cf-manifest/env-specific/cf-default.yml
+++ b/manifests/cf-manifest/env-specific/cf-default.yml
@@ -1,0 +1,7 @@
+---
+meta:
+  cell:
+    instances: 2
+
+  elasticsearch_master:
+    disk_size: 307200

--- a/manifests/cf-manifest/env-specific/cf-prod.yml
+++ b/manifests/cf-manifest/env-specific/cf-prod.yml
@@ -1,0 +1,7 @@
+---
+meta:
+  cell:
+    instances: 9
+
+  elasticsearch_master:
+    disk_size: 377856

--- a/manifests/cf-manifest/manifest/env-specific/cf-default.yml
+++ b/manifests/cf-manifest/manifest/env-specific/cf-default.yml
@@ -1,4 +1,0 @@
----
-meta:
-  cell:
-    instances: 2

--- a/manifests/cf-manifest/manifest/env-specific/cf-prod.yml
+++ b/manifests/cf-manifest/manifest/env-specific/cf-prod.yml
@@ -1,4 +1,0 @@
----
-meta:
-  cell:
-    instances: 9

--- a/manifests/cf-manifest/spec/manifest/env_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/env_spec.rb
@@ -13,4 +13,15 @@ RSpec.describe "Environment specific configuration" do
 
     expect(default_cell_instances).to be < prod_cell_instances
   end
+
+  def get_disk_size(manifest, disk_name)
+    manifest["disk_types"].select { |j| j["name"] == disk_name }.first["disk_size"]
+  end
+
+  it "should specify a larger elasticseach disk size in production" do
+    default_es_disk_size = get_disk_size(default_manifest, "elasticsearch_master")
+    prod_es_disk_size = get_disk_size(prod_manifest, "elasticsearch_master")
+
+    expect(default_es_disk_size).to be < prod_es_disk_size
+  end
 end

--- a/manifests/cf-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/cf-manifest/spec/support/manifest_helpers.rb
@@ -71,6 +71,7 @@ private
         File.expand_path("../../../../shared/spec/fixtures/terraform/*.yml", __FILE__),
         File.expand_path("../../../../shared/spec/fixtures/cf-secrets.yml", __FILE__),
         File.expand_path("../../../../shared/spec/fixtures/cf-ssl-certificates.yml", __FILE__),
+        File.expand_path("../../../cloud-config/env-specific/cf-#{environment}.yml", __FILE__),
     ])
 
     # Deep freeze the object so that it's safe to use across multiple examples

--- a/manifests/cf-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/cf-manifest/spec/support/manifest_helpers.rb
@@ -57,7 +57,7 @@ private
         File.expand_path("../../../manifest/*.yml", __FILE__),
         File.expand_path("../../../manifest/data/*.yml", __FILE__),
         grafana_dashboards_manifest_path,
-        File.expand_path("../../../manifest/env-specific/cf-#{environment}.yml", __FILE__),
+        File.expand_path("../../../env-specific/cf-#{environment}.yml", __FILE__),
         File.expand_path("../../../../shared/deployments/datadog-agent.yml", __FILE__),
         File.expand_path("../../../stubs/datadog-nozzle.yml", __FILE__),
         File.expand_path("../../../../shared/spec/fixtures/terraform/*.yml", __FILE__),
@@ -71,7 +71,7 @@ private
         File.expand_path("../../../../shared/spec/fixtures/terraform/*.yml", __FILE__),
         File.expand_path("../../../../shared/spec/fixtures/cf-secrets.yml", __FILE__),
         File.expand_path("../../../../shared/spec/fixtures/cf-ssl-certificates.yml", __FILE__),
-        File.expand_path("../../../cloud-config/env-specific/cf-#{environment}.yml", __FILE__),
+        File.expand_path("../../../env-specific/cf-#{environment}.yml", __FILE__),
     ])
 
     # Deep freeze the object so that it's safe to use across multiple examples


### PR DESCRIPTION
## What

Rework of #652

I've increased the size of our elasticsearch persistent disks in prod because they are fairly steady at 80% full (we alert at 75% full). I think we'd prefer to be at something more like 65% full.

I originally planned to change it everywhere, but @keymon convinced me it would be worth saving money by only changing it in prod.

## How to review

Check I'm not adding an unreasonable amount of disk space.

Technical review (optional):

1. deploy this change and check that the size has not increased in your dev environment
1. create a temporary branch that is a copy of this one and switch your env to pull from it
1. add a commit to set `ENV_SPECIFIC_CF_MANIFEST=cf-prod.yml` in Makefile:101
1. deploy
1. check that `/var/vcap/store` on elasticsearch_master got bigger
1. Check that all your elasticsearch data didn't disappear

## Who can review

Anyone but @bleach
