### PR TITLE
[#122026001] Remove Privacy Policy info from tests

### DIFF
--- a/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
@@ -69,25 +69,25 @@ RSpec.describe "base properties" do
     describe "app_events" do
       subject(:app_events) { cc.fetch("app_events") }
 
-      it { is_expected.to include("cutoff_age_in_days" => 31), "Retention period should be same as specified in Privacy Policy" }
+      it { is_expected.to include("cutoff_age_in_days" => 31), "We expect retention period for data to be 31 days." }
     end
 
     describe "app_usage_events" do
       subject(:app_usage_events) { cc.fetch("app_usage_events") }
 
-      it { is_expected.to include("cutoff_age_in_days" => 31), "Retention period should be same as specified in Privacy Policy" }
+      it { is_expected.to include("cutoff_age_in_days" => 31), "We expect retention period for data to be 31 days." }
     end
 
     describe "service_usage_events" do
       subject(:service_usage_events) { cc.fetch("service_usage_events") }
 
-      it { is_expected.to include("cutoff_age_in_days" => 31), "Retention period should be same as specified in Privacy Policy" }
+      it { is_expected.to include("cutoff_age_in_days" => 31), "We expect retention period for data to be 31 days." }
     end
 
     describe "audit_events" do
       subject(:audit_events) { cc.fetch("audit_events") }
 
-      it { is_expected.to include("cutoff_age_in_days" => 31), "Retention period should be same as specified in Privacy Policy" }
+      it { is_expected.to include("cutoff_age_in_days" => 31), "We expect retention period for data to be 31 days." }
     end
   end
 

--- a/manifests/cf-manifest/spec/manifest/logsearch_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/logsearch_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Logsearch properties" do
   let(:properties) { manifest.fetch("properties") }
 
   describe "curator job" do
-    it "contains purge_logs.retention_period. Retention period should not be changed without updating Privacy Policy." do
+    it "contains purge_logs.retention_period. We expect retention period to be 30 days." do
       defs = properties.fetch("curator").fetch("purge_logs")
       expect(defs.fetch("retention_period")).to eq(30)
     end


### PR DESCRIPTION
## What

This is follow up for: https://www.pivotaltracker.com/story/show/122026001/comments/157906483

As we agreed that we are not going to mention our current retention
period in Privacy Policy it would be confusing to leave such info in
tests. Instead tests mention that we expect to have retention period set
to N days.

## How to review

Check if changes are sane. This should be no-op deployment so we can leave it for CI Concourse to test. 

## Who can review

not @combor

