### PR TITLE
[#134267945] Error handling for smashing dashboard

### DIFF
--- a/tools/paas_dashboard/widgets/health/health.html
+++ b/tools/paas_dashboard/widgets/health/health.html
@@ -3,6 +3,7 @@
         <h1 class="title" data-bind="title"></h1>
         <div data-showif="status | equals 'error'"> <!-- error -->
             <span class="h4" data-bind="error">Error</span>
+            <p class="updated-at" data-bind="updatedAtMessage"></p>
         </div> <!-- /error -->
         <div data-hideif="status | equals 'error'"> <!-- no error -->
             <div data-hideif="criticals | equals 0" class="floated">


### PR DESCRIPTION
## What

https://www.pivotaltracker.com/story/show/134267945

We want to handle the situatoin where our dashboard gets an error from the datadog api,
but still displays green on the dashboard.

We will
- display the last recorded event, rather than setting all error counts to 0
- after 15mins of not being able to see good data, display an error condition

We set the `silent` flag false on the dogapi client, so that it throws
an error we can handle when it can't get a good response from datadog.

We handle that error by testing whether the last good event is stale
- if it is, we emit an error, if not, we display the old data for a
while in case the error is transient.

## How to review

Start the dashboard locally, see the readme for how.
Wait 20secs, stop the dashboard.
Observe recent events appear in the local history.yml file.

Change the app key so dd should reject the api requests, start the dashboard again.
Observe the recent events are still displayed.

Wait 15 mins or change the threshold in the `jobs/datadog.rb` file.
Start the dashboard again, still with the bad app key.
Observe that an error condition is displayed on the dashboard and the history file
is updated with the error when the dashboard is stopped.

Correct the app key and start the dashboard again.
Observe that the error condition is no longer displayed and the history file is
updated when the dashboard is stopped.

Or, trust us :)

## Who can review

Not @benhyland or @mtekel 

