### PR TITLE
[#131375807] Add Route Emitter process and metrics checks and monitors

### DIFF
--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -386,6 +386,8 @@ jobs:
         release: diego
       - name: metron_agent
         release: cf
+      - name: datadog-route-emitter
+        release: datadog-for-cloudfoundry
     instances: 2
     vm_type: medium
     stemcell: default

--- a/terraform/datadog/route-emitter.tf
+++ b/terraform/datadog/route-emitter.tf
@@ -1,0 +1,64 @@
+resource "datadog_monitor" "route_emitter_process_running" {
+  name                = "${format("%s route-emitter process running", var.env)}"
+  type                = "service check"
+  message             = "route-emitter process not running. Check router state."
+  escalation_message  = "route-emitter rep process still not running. Check router state."
+  notify_no_data      = false
+  require_full_window = true
+
+  query = "${format("'process.up'.over('bosh-deployment:%s','process:route-emitter').last(4).count_by_status()", var.env)}"
+
+  thresholds {
+    ok       = 1
+    warning  = 2
+    critical = 3
+  }
+
+  tags {
+    "deployment" = "${var.env}"
+    "service"    = "${var.env}_monitors"
+    "job"        = "route_emitter"
+  }
+}
+
+resource "datadog_monitor" "route_emitter_healthy" {
+  name                = "${format("%s route-emitter healthy", var.env)}"
+  type                = "service check"
+  message             = "Large portion of route-emitter unhealthy. Check deployment state."
+  escalation_message  = "Large portion of route-emitter still unhealthy. Check deployment state."
+  no_data_timeframe   = "7"
+  require_full_window = true
+
+  query = "${format("'http.can_connect'.over('bosh-deployment:%s','instance:route_emitter_debug_endpoint').by('*').last(1).pct_by_status()", var.env)}"
+
+  thresholds {
+    critical = 50
+  }
+
+  tags {
+    "deployment" = "${var.env}"
+    "service"    = "${var.env}_monitors"
+    "job"        = "route_emitter"
+  }
+}
+
+resource "datadog_monitor" "route_emitter_consul_lock" {
+  name                = "${format("%s route-emitter consul lock", var.env)}"
+  type                = "service check"
+  message             = "route-emitter consul lock not present in any VM. Check route-emitter state."
+  escalation_message  = "route-emitter consul lock still not present in any VM. Check route-emitter state."
+  no_data_timeframe   = "7"
+  require_full_window = true
+
+  query = "${format("'http.can_connect'.over('bosh-deployment:%s','instance:route_emitter_consul_lock').by('*').last(1).pct_by_status()", var.env)}"
+
+  thresholds {
+    critical = 100
+  }
+
+  tags {
+    "deployment" = "${var.env}"
+    "service"    = "${var.env}_monitors"
+    "job"        = "route_emitter"
+  }
+}


### PR DESCRIPTION
[#131375807 Check health of route emitter component](https://www.pivotaltracker.com/story/show/131375807)

What?
----

We want to monitor the route_emitter as we do with other processes.


There are also [several metrics from the CF Datadog nozzle](https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/8). After testing we decided to monitor:

 * The process is running
 * The process opens the debug port.
 * The consul lock is held:
   * Local check in each route_emitter, querying http://localhost:8500/v1/kv/v1/locks/route_emitter_lock
   * The metric sent by CF Nozzle: `cf.route_emitter.LockHeld.v1-locks-route_emitter_lock`
 * ~~The gorouter and the route_emitter total routes match~~
   * ~~We need to take into account LRPs that are not running. They are in route-emitter but not in gorouter.~~
   * Note: I actually decided to drop this monitor as explained in https://github.com/alphagov/paas-cf/pull/662#issuecomment-266715172

 * ~~The route-emitter is still getting new routes from the Registered and Unregistered events in BBS, and the bulk route sync. To do so, we check if the related metrics are being updated.~~

Dependencies
-----------

This PR depends on https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/8 which must be reviewed and merged first. After that, the commit referring to `datadog-for-cloudfoundry` bosh-release must be updated with the new final release details.

There is a WIP commit in this PR for testing purposes, which should be deleted before merge.

How to review?
--------------

I added a TEMPORARY commit to this branch that will:

 * Install datadog agent on the route-emitter VMs, without needing reinstall all the environment with DATADOG_ENABLED.
 * Enable the datadog CF nozzle
 * Includes a directory with the new monitors to test in terraform.


So to review:

 * Deploy as usual with the datadog credentials in the S3 bucket. it is NOT required to have DATADOG_ENABLED
 * apply the monitors manually:
   `cd terraform/datadog/tmp_check_cc_monitors/ && terraform apply -var datadog_api_key=$(paas-pass datadog/dev/datadog_api_key) -var datadog_app_key=$(paas-pass datadog/dev/datadog_app_key) -var aws_account=dev  -var env=hector`



To test the monitors:

 * You can simply check if the monitors makes sense.
 * If you want to trigger then:
   * stop & start route_emitter, consul, etc.
   * go to the nats boxes, and block the route_emitter with iptables.
   * go to the route_emitter boxes and block access to BBS. That would stop the routes from being updated. (e.g. `iptables -A OUTPUT -p tcp --destination-port 8889 -j DROP`, clear it with `iptables -F OUTPUT`)

Who?
---

Anyone but @keymon