### PR TITLE
Fix mistaken args in user research cleanup script

### DIFF
--- a/scripts/reset-org.py
+++ b/scripts/reset-org.py
@@ -36,8 +36,6 @@ class OrgReset(object):
         self.user = self.parse_current_user(self.run(['cf', 'target']))
 
     def delete_org(self):
-        # require org to be deleted in advance? have this check for org and and advise, so we don't use the `-f` flag
-        # Prompt for confirmtaion...
         self.run_with_retry(['cf', 'delete-org', self.org, '-f'], 20, lambda err:
             'one or more resources within could not be deleted' in err.output
         )

--- a/scripts/reset-user-testing.sh
+++ b/scripts/reset-user-testing.sh
@@ -13,12 +13,13 @@ check_logged_in_cf api.cloud.service.gov.uk
 "${SCRIPT_DIR}"/reset-org.py \
 	-o paas_user_research \
 	-s sandbox \
-	-u holly.challenger+1@digital.cabinet-office.gov.uk \
-	-u holly.challenger+2@digital.cabinet-office.gov.uk \
-	-u holly.challenger+3@digital.cabinet-office.gov.uk \
-	-u holly.challenger+4@digital.cabinet-office.gov.uk \
-	-u holly.challenger+5@digital.cabinet-office.gov.uk \
-	-u holly.challenger+6@digital.cabinet-office.gov.uk \
+	-u \
+	holly.challenger+1@digital.cabinet-office.gov.uk \
+	holly.challenger+2@digital.cabinet-office.gov.uk \
+	holly.challenger+3@digital.cabinet-office.gov.uk \
+	holly.challenger+4@digital.cabinet-office.gov.uk \
+	holly.challenger+5@digital.cabinet-office.gov.uk \
+	holly.challenger+6@digital.cabinet-office.gov.uk \
 	--org-managers \
 	--space-managers \
 	--space-developers \


### PR DESCRIPTION
We'd switched on some `nargs=*` for argparse without correcting the
wrapping bash script.

Presumably this is the first time we ran the org cleanup via that
script in its current form, since the last user research session went OK.

Review by @henrytk 