### PR TITLE
Remove aws cred check from pipelines make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ bosh-cli: ## Create interactive connnection to BOSH container
 	concourse/scripts/bosh-cli.sh
 
 .PHONY: pipelines
-pipelines: check-aws-credentials ## Upload pipelines to Concourse
+pipelines: ## Upload pipelines to Concourse
 	concourse/scripts/pipelines-bosh-cloudfoundry.sh
 
 .PHONY: showenv


### PR DESCRIPTION
This check is useful in dev, but breaks permanent envs since
self-update-pipelines runs the make target directly.

We can figure out how to gracefully run this check in dev only
some other time.