### PR TITLE
Allow override values in reset-user-testing.sh

### DIFF
--- a/scripts/reset-user-testing.sh
+++ b/scripts/reset-user-testing.sh
@@ -4,30 +4,34 @@ set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
+TARGET_EMAIL_USER=${TARGET_EMAIL_USER:-holly.challenger}
+TARGET_ENVIRONMENT=${TARGET_ENVIRONMENT:-prod}
+TARGET_ENVIRONMENT_API=${TARGET_ENVIRONMENT_API:-api.cloud.service.gov.uk}
+
 # shellcheck disable=SC1090
 source "${SCRIPT_DIR}/common.sh"
 
-check_aws_account_used prod
-check_logged_in_cf api.cloud.service.gov.uk
+check_aws_account_used "${TARGET_ENVIRONMENT}"
+check_logged_in_cf "${TARGET_ENVIRONMENT_API}"
 
 "${SCRIPT_DIR}"/reset-org.py \
 	-o paas_user_research \
 	-s sandbox \
 	-u \
-	holly.challenger+1@digital.cabinet-office.gov.uk \
-	holly.challenger+2@digital.cabinet-office.gov.uk \
-	holly.challenger+3@digital.cabinet-office.gov.uk \
-	holly.challenger+4@digital.cabinet-office.gov.uk \
-	holly.challenger+5@digital.cabinet-office.gov.uk \
-	holly.challenger+6@digital.cabinet-office.gov.uk \
+	"${TARGET_EMAIL_USER}+1@digital.cabinet-office.gov.uk" \
+	"${TARGET_EMAIL_USER}+2@digital.cabinet-office.gov.uk" \
+	"${TARGET_EMAIL_USER}+3@digital.cabinet-office.gov.uk" \
+	"${TARGET_EMAIL_USER}+4@digital.cabinet-office.gov.uk" \
+	"${TARGET_EMAIL_USER}+5@digital.cabinet-office.gov.uk" \
+	"${TARGET_EMAIL_USER}+6@digital.cabinet-office.gov.uk" \
 	--org-managers \
 	--space-managers \
 	--space-developers \
 	--quota small
 
-"${SCRIPT_DIR}"/rotate-user-password.sh -e prod -u holly.challenger+1@digital.cabinet-office.gov.uk
-"${SCRIPT_DIR}"/rotate-user-password.sh -e prod -u holly.challenger+2@digital.cabinet-office.gov.uk
-"${SCRIPT_DIR}"/rotate-user-password.sh -e prod -u holly.challenger+3@digital.cabinet-office.gov.uk
-"${SCRIPT_DIR}"/rotate-user-password.sh -e prod -u holly.challenger+4@digital.cabinet-office.gov.uk
-"${SCRIPT_DIR}"/rotate-user-password.sh -e prod -u holly.challenger+5@digital.cabinet-office.gov.uk
-"${SCRIPT_DIR}"/rotate-user-password.sh -e prod -u holly.challenger+6@digital.cabinet-office.gov.uk
+"${SCRIPT_DIR}"/rotate-user-password.sh -e "${TARGET_ENVIRONMENT}" -u "${TARGET_EMAIL_USER}+1@digital.cabinet-office.gov.uk"
+"${SCRIPT_DIR}"/rotate-user-password.sh -e "${TARGET_ENVIRONMENT}" -u "${TARGET_EMAIL_USER}+2@digital.cabinet-office.gov.uk"
+"${SCRIPT_DIR}"/rotate-user-password.sh -e "${TARGET_ENVIRONMENT}" -u "${TARGET_EMAIL_USER}+3@digital.cabinet-office.gov.uk"
+"${SCRIPT_DIR}"/rotate-user-password.sh -e "${TARGET_ENVIRONMENT}" -u "${TARGET_EMAIL_USER}+4@digital.cabinet-office.gov.uk"
+"${SCRIPT_DIR}"/rotate-user-password.sh -e "${TARGET_ENVIRONMENT}" -u "${TARGET_EMAIL_USER}+5@digital.cabinet-office.gov.uk"
+"${SCRIPT_DIR}"/rotate-user-password.sh -e "${TARGET_ENVIRONMENT}" -u "${TARGET_EMAIL_USER}+6@digital.cabinet-office.gov.uk"


### PR DESCRIPTION
**Note:** Re-opened based on https://github.com/alphagov/paas-cf/pull/665 from @keymon , which was targeted against a branch which no longer exists.

Allow override the hardcoded values, so at least is easier to run this script in a development environment without issues.

For example:

    for i in `seq 1 6`; do ./scripts/create-user.sh -o paas_user_research -e hector.rivas.gandara+$i@digital.cabinet-office.gov.uk; done
    DEPLOY_ENV=hector TARGET_EMAIL_USER=hector.rivas.gandara TARGET_ENVIRONMENT=dev TARGET_ENVIRONMENT_API=api.hector.dev.cloudpipeline.digital scripts/reset-user-testing.sh
