### PR TITLE
WIP: [#134345035] Do not notify "No Data" for CC log error monitor

### DIFF
--- a/terraform/datadog/cloud_controller.tf
+++ b/terraform/datadog/cloud_controller.tf
@@ -92,6 +92,7 @@ resource "datadog_monitor" "cc_log_count_error_increase" {
   message             = "Amount of logged errors in Cloud Controller API grew considerably, check the API health."
   escalation_message  = "Amount of logged errors in Cloud Controller API still growing considerably, check the API health."
   require_full_window = false
+  notify_no_data      = false
 
   query = "${format("change(max(last_1m),last_30m):sum:cf.cc.log_count.error{deployment:%s} > 5", var.env)}"
 


### PR DESCRIPTION
[#134345035 Monitor cloud controller job](https://www.pivotaltracker.com/story/show/134345035)

What?
-----

In the monitor added in #655 we alert when there is no data after
2 minutes (the default).

But this metric is not generated if no log entries are produced, so it
might happen that we get No Data alerts in periods of no activity,
specially in CI or staging.

How to review?
------------

We need to first discuss: https://github.com/alphagov/paas-cf/pull/645#issuecomment-265200333

Who?
---

Anyone but @keymon