### PR TITLE
[#136189211] Increase number of CC workers to 3 per VM

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -190,7 +190,9 @@ properties:
       droplet_upload:
         timeout_in_seconds: ~
       generic:
-        number_of_workers: ~
+        number_of_workers: 3
+      local:
+        number_of_workers: 3
 
     app_events:
       cutoff_age_in_days: 31


### PR DESCRIPTION
[#136189211 Increase number of api workers ](https://www.pivotaltracker.com/story/show/136189211)

What?

Datadog is alerting about high number of jobs in the CF api queue[1] while  the tests run. It seems that after increase the paralelism #614 in the tests the load on the API increased.

Checking the CPU and load of the APIs, we found that currently the load on the CC worker VMs is:

 * api: ~50% CPU and ~0.5 load during tests
 *  api workers: ~25-30% CPU and ~0.3 load.

Currently we run:

 * api: 1 main process, 2 workers
 * api_worker: 1 workers

In this PR we increase this to:

 * api: 1 main process, 3 workers
 * api_worker: 3 workers

[1] https://app.datadoghq.com/event/event?id=3649877123650295918 both in CI as in staging.

How to review?
-------------

Check that the changes make sense.

Optionally: run the deployment and full acceptance test. You should enable the nozzle to get the metrics by setting ENABLE_DATADOG or removing the condition [here](https://github.com/alphagov/paas-cf/blob/c292aad01133c3cb79117e1aca4bbd11e22bcf1d/concourse/pipelines/create-bosh-cloudfoundry.yml#L1418-L1422)

The metric of cc queue size should be close to 0 during all the acceptance tests.

Who?
----

Anyone but @keymon