### PR TITLE
[#SUPPORT] Add the Host header to the HAProxy logs

### DIFF
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -93,12 +93,6 @@ resources:
       tag_filter: {{paas_cf_tag_filter}}
       commit_verification_key_ids: {{gpg_ids}}
 
-  - name: paas-haproxy-release
-    type: git
-    source:
-      uri: https://github.com/alphagov/paas-haproxy-release.git
-      tag_filter: {{cf-paas-haproxy-release-version}}
-
   - name: graphite-statsd-boshrelease
     type: git
     source:
@@ -1488,7 +1482,6 @@ jobs:
             passed: ['generate-cf-config']
           - get: bosh-secrets
           - get: graphite-statsd-boshrelease
-          - get: paas-haproxy-release
           - get: os-conf-boshrelease
           - get: cf-secrets
             passed: ['generate-cf-config']
@@ -1533,7 +1526,6 @@ jobs:
               - name: paas-cf
               - name: bosh-secrets
               - name: graphite-statsd-boshrelease
-              - name: paas-haproxy-release
               - name: os-conf-boshrelease
             run:
               path: sh
@@ -1546,10 +1538,6 @@ jobs:
                   ./paas-cf/concourse/scripts/git_check_tag.sh {{cf_graphite_version}} graphite-statsd-boshrelease
                   paas-cf/concourse/scripts/bosh_create_and_upload_release.rb graphite \
                     {{cf_graphite_version}} graphite-statsd-boshrelease
-
-                  ./paas-cf/concourse/scripts/git_check_tag.sh {{cf-paas-haproxy-release-version}} paas-haproxy-release
-                  paas-cf/concourse/scripts/bosh_create_and_upload_release.rb paas-haproxy \
-                    {{cf-paas-haproxy-release-version}} paas-haproxy-release
 
                   ./paas-cf/concourse/scripts/git_check_tag.sh {{cf_os_conf_version}} os-conf-boshrelease
                   paas-cf/concourse/scripts/bosh_create_and_upload_release.rb os-conf \

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -42,7 +42,6 @@ prepare_environment() {
 
   cf_manifest_dir="${SCRIPT_DIR}/../../manifests/cf-manifest/manifest"
   cf_release_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.cf.version "${cf_manifest_dir}/000-base-cf-deployment.yml")
-  cf_paas_haproxy_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.paas-haproxy.version "${cf_manifest_dir}/000-base-cf-deployment.yml")
   cf_graphite_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.graphite.version "${cf_manifest_dir}/040-graphite.yml")
   cf_os_conf_version=$("${SCRIPT_DIR}"/val_from_yaml.rb releases.os-conf.version "${cf_manifest_dir}/../runtime-config/runtime-config-base.yml")
 
@@ -84,7 +83,6 @@ branch_name: ${BRANCH:-master}
 aws_region: ${AWS_DEFAULT_REGION}
 debug: ${DEBUG:-}
 cf-release-version: v${cf_release_version}
-cf-paas-haproxy-release-version: ${cf_paas_haproxy_version}
 cf_graphite_version: ${cf_graphite_version}
 cf_os_conf_version: ${cf_os_conf_version}
 cf_env_specific_manifest: ${ENV_SPECIFIC_CF_MANIFEST}

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -30,7 +30,9 @@ releases:
     url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-rootfs-release?v=1.43.0
     sha1: 587c61d39a525245934f97396ec6d5dd1c97bf79
   - name: paas-haproxy
-    version: 0.0.5
+    version: 0.1.1
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/paas-haproxy-0.1.1.tgz
+    sha1: 50cb6f378a3f6af9d78a55ba5b449f15e227d778
   - name: datadog-for-cloudfoundry
     version: 0.1.4
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.1.4.tgz

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -30,9 +30,9 @@ releases:
     url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-rootfs-release?v=1.43.0
     sha1: 587c61d39a525245934f97396ec6d5dd1c97bf79
   - name: paas-haproxy
-    version: 0.1.1
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/paas-haproxy-0.1.1.tgz
-    sha1: 50cb6f378a3f6af9d78a55ba5b449f15e227d778
+    version: 0.1.2
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/paas-haproxy-0.1.2.tgz
+    sha1: 73fc08b2c7a27caf5d88c9c70f26dcf0ba60bf66
   - name: datadog-for-cloudfoundry
     version: 0.1.4
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.1.4.tgz


### PR DESCRIPTION
Currently we capture the access log of the HAProxy in front of our gorouters.

Today I was troubleshooting some spike in the request latency, and I wanted to check the access log from the HAProxy in logsearch. But I found out that I could not correlate the requests with the applications because the log messages do not include the Host header.

That is valuable information, but in order to identify for which application each request is, we need to log the Host header.

We will use the paas-haproxy bosh release PR in https://github.com/alphagov/paas-haproxy-release/pull/7

We also migrate this bosh release to the PR based builds (see https://www.pivotaltracker.com/story/show/132745311)

Dependencies
-----------

Depends on https://github.com/alphagov/paas-haproxy-release/pull/7 which should be merged first and the relevant commit updated in this PR.

But both can be tested together.

How to review?
--------------

 1. Deploy this.
 2. Access any app `curl -k https://healthcheck.hector.dev.cloudpipelineapps.digital`
 3. go to your logsearch and check that the haproxy logs have a new field: `haproxy.captured_request_headers == healthcheck.hector.dev.cloudpipelineappseapps.digital`

Who?
---

Anyone but @keymon