### PR TITLE
[#136189211] Revert "Merge pull request #674 Increase number of CC workers to 3 per VM"

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -190,9 +190,7 @@ properties:
       droplet_upload:
         timeout_in_seconds: ~
       generic:
-        number_of_workers: 3
-      local:
-        number_of_workers: 3
+        number_of_workers: ~
 
     app_events:
       cutoff_age_in_days: 31


### PR DESCRIPTION
Revert PR #674 as it did not reduce the number of jobs in the queue.

We will try to change the monitor instead.

This reverts commit b14f8f523dce125e06a13f08e32f77867736aee0, reversing
changes made to b40bde8017fc5d17839feb3a1dcd61146babe0d1.