### PR TITLE
[#SUPPORT] Only enable routes drop monitor in dev and prod

### DIFF
--- a/terraform/ci.tfvars
+++ b/terraform/ci.tfvars
@@ -5,3 +5,7 @@ cf_db_multi_az = "false"
 cf_db_backup_retention_period = "0"
 cf_db_skip_final_snapshot = "true"
 support_email="govpaas-alerting-ci@digital.cabinet-office.gov.uk"
+
+# Enabled/disabled resources
+# Disable datadog_monitor.total_routes_drop resource
+datadog_monitor_total_routes_drop_enabled = 0

--- a/terraform/datadog/router.tf
+++ b/terraform/datadog/router.tf
@@ -66,6 +66,12 @@ resource "datadog_monitor" "route_update_latency" {
   }
 }
 
+variable "datadog_monitor_total_routes_drop_enabled" {
+  description = "Selector to enable/disable the named resource"
+
+  default = 1
+}
+
 resource "datadog_monitor" "total_routes_drop" {
   name                = "${format("%s total routes difference", var.env)}"
   type                = "query alert"
@@ -73,6 +79,9 @@ resource "datadog_monitor" "total_routes_drop" {
   escalation_message  = "Total routes still dropping quickly. Check the deployment."
   no_data_timeframe   = "7"
   require_full_window = true
+
+  # Conditionally enable this resource based on var.aws_account.
+  count = "${var.datadog_monitor_total_routes_drop_enabled}"
 
   query = "${format("pct_change(avg(last_1m),last_30m):avg:cf.gorouter.total_routes{deployment:%s,job:router} < -33", var.env)}"
 

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -9,3 +9,7 @@ web_access_cidrs = "0.0.0.0/0"
 bosh_db_backup_retention_period = "35"
 bosh_db_skip_final_snapshot = "false"
 support_email="govpaas-alerting-staging@digital.cabinet-office.gov.uk"
+
+# Enabled/disabled resources
+# Disable datadog_monitor.total_routes_drop resource
+datadog_monitor_total_routes_drop_enabled = 0


### PR DESCRIPTION
What?
-----

The `router_routes_drop` monitor get easily triggered when running the tests in environments with little routes, like ci or staging.

We do not need to monitor this on those environments, but it is still useful in prod. We can also keep it in dev for testing/development.

> Note: as we add `count`, it will actually recreate the monitor in prod, because the ID changes (add a .0 suffix). That is fine and expected.

How to test?
------------

You can apply these monitors in dev like this:

```
PAAS_CF_DIR=$(pwd)
mkdir /tmp/testing_tf
cd /tmp/testing_tf
ln -s ${PAAS_CF_DIR}/terraform/datadog/{datadog.tf,variables.tf,router.tf} .

terraform apply -var datadog_api_key=$(paas-pass datadog/dev/datadog_api_key) -var datadog_app_key=$(paas-pass datadog/dev/datadog_app_key) -var aws_account=dev  -var env=hector -var-file  ${PAAS_CF_DIR}/terraform/dev.tfvars
```

You will see that it creates the monitor.

Now run with a different vars file:

```
terraform apply -var datadog_api_key=$(paas-pass datadog/dev/datadog_api_key) -var datadog_app_key=$(paas-pass datadog/dev/datadog_app_key) -var aws_account=dev  -var env=hector -var-file  ${PAAS_CF_DIR}/terraform/ci.tfvars
```

It will destroy the old monitor.

Remember do `terraform destroy`

Who?
---

Anyone but @keymon