### PR TITLE
[#SUPPORT] CC queue length monitors the avg in last 30m

### DIFF
--- a/terraform/datadog/cloud_controller.tf
+++ b/terraform/datadog/cloud_controller.tf
@@ -114,10 +114,10 @@ resource "datadog_monitor" "cc_job_queue_length" {
   escalation_message  = "Job queue in Cloud Controller API still too big, check the API health."
   require_full_window = false
 
-  query = "${format("max(last_30m):max:cf.cc.job_queue_length.total{deployment:%s} > 10", var.env)}"
+  query = "${format("avg(last_30m):max:cf.cc.job_queue_length.total{deployment:%s} > 10", var.env)}"
 
   thresholds {
-    warning  = "6"
+    warning  = "7"
     critical = "10"
   }
 


### PR DESCRIPTION
What?
----

Since we increased the number of jobs in parallel in the tests in #614, the CC queue length monitor gets triggered often, specially in CI and staging.

But that monitor is too sensitive, as it gets triggered if any value in the last 30 minutes is more that 6 or 10. We change this to alert when the average on the last 30 minutes, making the monitor resilient to spikes. We will still detect if jobs get stuck for too long.

I also increase the warning to 7 because some of the lastest runs of acceptance tests in CI got an average in 30m above 6.

How to review?
----------

Check that makes sense. Optionally follow the steps in #677 to test only the monitors.

Who?
----

Anyone but @keymon