### PR TITLE
[#SUPPORT] Plot summarised router response times

### DIFF
--- a/manifests/cf-manifest/grafana/user-impact.json
+++ b/manifests/cf-manifest/grafana/user-impact.json
@@ -196,7 +196,9 @@
       "height": "250px",
       "panels": [
         {
-          "aliasColors": {},
+          "aliasColors": {
+            "count": "#CCA300"
+          },
           "bars": false,
           "datasource": "graphite",
           "editable": true,
@@ -206,22 +208,26 @@
             "threshold1": null,
             "threshold1Color": "rgba(216, 200, 27, 0.27)",
             "threshold2": null,
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            "threshold2Color": "rgba(234, 112, 112, 0.22)",
+            "thresholdLine": false
           },
           "height": "250",
           "id": 4,
           "isNew": true,
           "legend": {
             "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
+            "current": true,
+            "max": true,
+            "min": true,
             "show": true,
             "total": false,
-            "values": false
+            "values": true,
+            "alignAsTable": false,
+            "rightSide": false,
+            "sideWidth": null
           },
           "lines": true,
-          "linewidth": 2,
+          "linewidth": 1,
           "links": [],
           "nullPointMode": "null",
           "percentage": false,
@@ -235,14 +241,27 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode(stats.timers.cfstats.router.*.http.responsetimes.http.upper_90, 4)"
+              "target": "alias(summarize(maxSeries(stats.timers.cfstats.router.*.http.responsetimes.http.upper), '1m', 'max', false), 'upper')"
+            },
+            {
+              "refId": "C",
+              "target": "alias(summarize(maxSeries(stats.timers.cfstats.router.*.http.responsetimes.http.upper_90), '1m', 'max', false), '90 percentile')",
+              "textEditor": false
+            },
+            {
+              "refId": "D",
+              "target": "alias(summarize(maxSeries(stats.timers.cfstats.router.*.http.responsetimes.http.mean_90), '1m', 'max', false), '90 avg')"
+            },
+            {
+              "refId": "E",
+              "target": "alias(summarize(maxSeries(stats.timers.cfstats.router.*.http.responsetimes.http.median), '1m', 'max', false), 'median')"
             }
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Router 90th percentile response times",
+          "title": "Router response times",
           "tooltip": {
-            "msResolution": false,
+            "msResolution": true,
             "shared": true,
             "value_type": "cumulative"
           },
@@ -254,9 +273,9 @@
             {
               "format": "ms",
               "label": null,
-              "logBase": 1,
+              "logBase": 10,
               "max": null,
-              "min": 0,
+              "min": 10,
               "show": true
             },
             {
@@ -267,7 +286,8 @@
               "min": 0,
               "show": true
             }
-          ]
+          ],
+          "decimals": 0
         },
         {
           "aliasColors": {},


### PR DESCRIPTION
What?
-----

In the grafana dashboard we plot the 90 percentile of the both routers, so we can spot deviations in the response time.

But that graph has several problems that make it not useful:
 * The metric is calculated and generated every 10 seconds, but we plot a total of 12 hours. The graph is really spiky and noisy.
 * Sometimes there are very little requests and some really slow but expected requests happen, that appear in the graph. For instance, the /events in a dashing dashboard which takes 900s. As we plot linearly, that causes the graph to get out of scale.
 * We don't plot the maximum request time, only 90 percentile.

In this commit we propose the following changes:

 * summarise all routers using max. The intention of the graph is highlight an issue, if one router is misbehaving, we can go and spot
   it later.

 * summarise all the values as the "max" of 1 minute window. That will make the graph be far less noisy, and we won't miss any issue as we use
   max.

 * Use Log scale to plot the response time. This way we can plot together high values (max) and average values.
   Our area of interest, 10ms - 2000ms gets the maximum resolution.  Also set minimum to 10ms.

 * Plot the Max, 90 percentile, mean 90 and median, so we get an idea of the distribution of the response times.

 * We also change some colors and labels, add info of max, min and avg values, etc.

Screenshot Before the changes
---------------------------
Before the changes, useless due having little metrics at night and a request was 15m:

![screenshot from 2016-12-20 11 56 01](https://cloud.githubusercontent.com/assets/280032/21349744/79f3d7d8-c6ab-11e6-95b5-52667223ece7.png)

So in this other I changed the window to latest 6h. Note that for 12h is even more noisy.
![screenshot from 2016-12-20 11 56 19](https://cloud.githubusercontent.com/assets/280032/21349767/9c58be42-c6ab-11e6-90c1-132da54b446c.png)

Screenshot after the changes
-------

This one is the same than the first image above. You can tell the outsiders, the median, average, etc.

![screenshot from 2016-12-20 11 32 21](https://cloud.githubusercontent.com/assets/280032/21349129/282224a8-c6a8-11e6-947c-61c7bf831d61.png)

> Note, I removed the side labels in the code,

How to test?
-----------

Go to any grafana and import the file `manifests/cf-manifest/grafana/user-impact.json` as dashboard (click on the grafana logo > Dashboards > Import).

Who?
----

Anyone but @keymon