### PR TITLE
[#SUPPORT] Plot summarised app requests rate

### DIFF
--- a/manifests/cf-manifest/grafana/user-impact.json
+++ b/manifests/cf-manifest/grafana/user-impact.json
@@ -15,7 +15,9 @@
       "height": "150px",
       "panels": [
         {
-          "aliasColors": {},
+          "aliasColors": {
+            "5xx": "#BF1B00"
+          },
           "bars": false,
           "datasource": "graphite",
           "editable": true,
@@ -33,13 +35,13 @@
           "isNew": true,
           "legend": {
             "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "max": false,
+            "avg": true,
+            "current": true,
+            "max": true,
             "min": false,
             "show": true,
             "total": false,
-            "values": false
+            "values": true
           },
           "lines": true,
           "linewidth": 2,
@@ -49,7 +51,16 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [],
+          "seriesOverrides": [
+            {
+              "alias": "4xx",
+              "yaxis": 1
+            },
+            {
+              "alias": "5xx",
+              "yaxis": 1
+            }
+          ],
           "span": 6,
           "stack": false,
           "steppedLine": false,
@@ -57,17 +68,19 @@
             {
               "hide": false,
               "refId": "A",
-              "target": "alias(sumSeries(stats.counters.cfstats.router.*.ops.responses.rate), 'Total')",
+              "target": "alias(scaleToSeconds(summarize(sumSeries(stats.counters.cfstats.router.*.ops.responses.count), '1m', 'sum', true), 1), 'Total')",
               "textEditor": false
             },
             {
-              "refId": "B",
-              "target": "aliasByNode(sumSeries(stats.counters.cfstats.router.*.ops.responses.4xx.rate), -2)",
+              "hide": false,
+              "refId": "E",
+              "target": "alias(scaleToSeconds(summarize(sumSeries(stats.counters.cfstats.router.*.ops.responses.5xx.count), '1m', 'sum', true), 1), '5xx')",
               "textEditor": false
             },
             {
-              "refId": "C",
-              "target": "aliasByNode(sumSeries(stats.counters.cfstats.router.*.ops.responses.5xx.rate), -2)",
+              "hide": false,
+              "refId": "D",
+              "target": "alias(scaleToSeconds(summarize(sumSeries(stats.counters.cfstats.router.*.ops.responses.4xx.count), '1m', 'sum', true), 1), '4xx')",
               "textEditor": false
             }
           ],
@@ -100,7 +113,8 @@
               "min": 0,
               "show": true
             }
-          ]
+          ],
+          "decimals": null
         },
         {
           "aliasColors": {},

--- a/manifests/cf-manifest/grafana/user-impact.json
+++ b/manifests/cf-manifest/grafana/user-impact.json
@@ -117,7 +117,10 @@
           "decimals": null
         },
         {
-          "aliasColors": {},
+          "aliasColors": {
+            "5xx": "#BF1B00",
+            "Max": "#2F575E"
+          },
           "bars": false,
           "datasource": "graphite",
           "editable": true,
@@ -156,23 +159,28 @@
           "targets": [
             {
               "refId": "A",
-              "target": "alias(sumSeries(scaleToSeconds(nonNegativeDerivative(stats.gauges.cfstats.api.*.ops.cc.http_status.*), 1)), 'Total')",
+              "target": "alias(scaleToSeconds(summarize(sumSeries(nonNegativeDerivative(stats.gauges.cfstats.api.*.ops.cc.http_status.*)), '5m', 'sum', true), 1), 'Rate')",
+              "textEditor": false
+            },
+            {
+              "refId": "D",
+              "target": "alias(summarize(scaleToSeconds(sumSeries(nonNegativeDerivative(stats.gauges.cfstats.api.*.ops.cc.http_status.*)), 1), '5m', 'max', true), 'Max')",
               "textEditor": false
             },
             {
               "refId": "B",
-              "target": "aliasByNode(sumSeries(scaleToSeconds(nonNegativeDerivative(stats.gauges.cfstats.api.*.ops.cc.http_status.4XX), 1)), -1)",
+              "target": "alias(summarize(scaleToSeconds(sumSeries(nonNegativeDerivative(stats.gauges.cfstats.api.*.ops.cc.http_status.4XX)), 1), '5s', 'sum', true), 'max 4xx')",
               "textEditor": false
             },
             {
               "refId": "C",
-              "target": "aliasByNode(sumSeries(scaleToSeconds(nonNegativeDerivative(stats.gauges.cfstats.api.*.ops.cc.http_status.5XX), 1)), -1)",
-              "textEditor": true
+              "target": "alias(summarize(scaleToSeconds(sumSeries(nonNegativeDerivative(stats.gauges.cfstats.api.*.ops.cc.http_status.5XX)), 1), '5s', 'sum', true), 'max 5xx')",
+              "textEditor": false
             }
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "API requests/sec",
+          "title": "API requests/sec in 5m window",
           "tooltip": {
             "msResolution": true,
             "shared": true,


### PR DESCRIPTION
What?
----

In the grafana dashboard we plot the tenant's app and CC requests rate and 4xx and 5xx rate, so we can understand the normal traffic rate and spot rise in errors.

The metric is generated with a resolution of 10s, but we plot a total of 12 hours. Because that the graph is really spiky and noisy.

A solution would summarise the metric in a 1 minute window, creating a more smooth and easy to read metric.

In the case of app requests, to do so, we use the count of requests instead of the rate. We sum the values from all the gorouters, and then summarise in 1m window using sum. Finally we scale to seconds, as the metric is reported every 10s.

Screenshoot before
-----------------
![screenshot from 2016-12-20 13 47 55](https://cloud.githubusercontent.com/assets/280032/21352782/02b0f88a-c6bb-11e6-8316-343589e04e45.png)

and
![screenshot from 2016-12-20 14 30 17](https://cloud.githubusercontent.com/assets/280032/21354497/480e5696-c6c2-11e6-8ffa-db38fc33768d.png)


Screenshoot after
----------------

![screenshot from 2016-12-20 13 48 22](https://cloud.githubusercontent.com/assets/280032/21352792/0d5043c2-c6bb-11e6-913a-bc24fff5a308.png)

and 

![screenshot from 2016-12-20 14 38 10](https://cloud.githubusercontent.com/assets/280032/21354513/54b61c3a-c6c2-11e6-9b01-34b4a999aadc.png)


How to test
-----------

Go to any grafana and import the file `manifests/cf-manifest/grafana/user-impact.json` as dashboard (click on the grafana logo > Dashboards > Import).

Who?
---

Anyone but @keymon