### PR TITLE
Fix link to paas-dashboard

### DIFF
--- a/tools/paas_dashboard/README.md
+++ b/tools/paas_dashboard/README.md
@@ -30,7 +30,7 @@ See [dashing.io](http://dashing.io) and the [smashing wiki](https://github.com/d
 ### Our deployment
 
 We deploy our smashing app as part of the `create-bosh-cloudfoundry` pipeline.
-It should be available at https://paas-dasboard.cloudapps.digital
+It should be available [here](https://paas-dashboard.cloudapps.digital)
 
 ### Running locally
 


### PR DESCRIPTION
Small typo in the link to the paas dashboard. Also changed it to a link
so when viewing in web interface it is clickable