### PR TITLE
[#131802383] Make sure we require the IPSec at all times

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -618,4 +618,4 @@ properties:
     certificate_authority_cert: (( grab secrets.ipsec_ca_cert ))
     certificate_authority_private_key: (( grab secrets.ipsec_ca_key ))
     verify_certificate: "on"
-    level: use
+    level: require


### PR DESCRIPTION
## What

Great! It looks like IPSec has been deployed in `ci`, `staging` and `prod`, right?

As a follow up to #684, we'd like to require the use of IPSec between the enabled nodes.

In the previous PR, IPSec level has been set to `use`, which means we can avoid any downtime. It is recommended to be set to `require`, hence this PR.

Level `require`, forces the traffic to use IPSec but it also drops any connection not using it.

## How to review

- **Make sure you're happy with the IPSec being already successfully deployed to all the environments.**

## Who can review

Anyone but @combor or @paroxp
