### PR TITLE
Allow apostrophes in tenant email addresses

### DIFF
--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -85,7 +85,7 @@ check_params_and_environment() {
     abort_usage "Email must be defined"
   fi
 
-  local email_expr="^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}$"
+  local email_expr="^[A-Za-z0-9._%+-\']+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}$"
   if ! [[ "${EMAIL}" =~ ${email_expr} ]]; then
     abort "You must specify a valid email"
   fi
@@ -176,7 +176,7 @@ send_mail() {
     "
 
     aws ses send-email \
-      --destination "ToAddresses=${EMAIL}" \
+      --destination "{ \"ToAddresses\": [\"${EMAIL}\"] }" \
       --message "${MESSAGE_JSON}"\
       --from "${FROM_ADDRESS}"  \
       --region eu-west-1 \

--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -85,7 +85,7 @@ check_params_and_environment() {
     abort_usage "Email must be defined"
   fi
 
-  local email_expr="^[A-Za-z0-9._%+-\']+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}$"
+  local email_expr="^[A-Za-z0-9._%+\'-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}$"
   if ! [[ "${EMAIL}" =~ ${email_expr} ]]; then
     abort "You must specify a valid email"
   fi


### PR DESCRIPTION
## What

When creating a user with the email address firstname.o'lastname@domain
this script would previously report that the email address was invalid.

Since I wanted to create such a user I needed to make the script accept email addresses with apostrophes in them.

## How to review

Ask a friendly colleague with an apostrophe in their email address if they mind getting a bunch of emails and test against your development environment.

## Who can review

Anyone but @bleach
