### PR TITLE
[#136504507] Upgrade stemcells to 3263.14

### DIFF
--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -154,8 +154,8 @@ resource_pools:
 - name: bosh
   network: private
   stemcell:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3263.12
-    sha1: b2e8ea8415dca3ab5826a39dcbe4ef760bcc7b05
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3263.14
+    sha1: cc3377af8c0bf31d069b32d74ab01ab470b31c7a
   cloud_properties:
     instance_type: t2.medium
     ephemeral_disk: {size: 40000, type: gp2}

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -42,7 +42,7 @@ releases:
 stemcells:
   - alias: default
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3263.12"
+    version: "3263.14"
 
 update:
   canaries: 0

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -22,8 +22,8 @@ resource_pools:
   - name: concourse
     network: concourse
     stemcell:
-      url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3263.12
-      sha1: b2e8ea8415dca3ab5826a39dcbe4ef760bcc7b05
+      url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3263.14
+      sha1: cc3377af8c0bf31d069b32d74ab01ab470b31c7a
     cloud_properties:
       instance_type: m4.xlarge
       availability_zone: (( grab terraform_outputs.zone0 ))


### PR DESCRIPTION
What 
----

[Response to USN-3156-1](https://www.pivotaltracker.com/story/show/136504507)

This contains a fix for [USN-3156-1][1]. The fix was present in the
3263.13 stemcell release, but there seems to be no reason not to update
to the latest stemcell

[1] https://www.ubuntu.com/usn/usn-3156-1/

How to review
-------------

 * Check that the change makes sense (urls, hash)
 * redeploy concourse and redeploy the environment and check that the changes apply and acceptance tests pass

Who can review
-------------

Anyone but me