### PR TITLE
[#136340183] Rubbernecker fake token fix

### DIFF
--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -32,8 +32,14 @@ get_git_concourse_pool_clone_full_url_ssh() {
 }
 
 upload_tracker_token() {
-  echo "Uploading Pivotal tracker token..."
-  pass pivotal/tracker_token | aws s3 cp - "s3://${state_bucket}/tracker_token"
+  if [ "${DEPLOY_RUBBERNECKER:-}" = "true" ]; then
+    echo "Uploading Pivotal tracker token..."
+    pass pivotal/tracker_token | aws s3 cp - "s3://${state_bucket}/tracker_token"
+  else
+    echo "Uploading empty Pivotal tracker token..."
+    echo "no token" | aws s3 cp - "s3://${state_bucket}/tracker_token"
+  fi
+
 }
 
 prepare_environment() {
@@ -70,9 +76,7 @@ prepare_environment() {
 
   export EXPOSE_PIPELINE=1
 
-  if [ "${DEPLOY_RUBBERNECKER:-}" = "true" ]; then
-    upload_tracker_token
-  fi
+  upload_tracker_token
 
 }
 


### PR DESCRIPTION
## What
We upload the Pivotal tracker API token to S3 when we deploy
rubbernecker. But when we don't deploy it, the pipeline would wait
forever for a token even if we don't need it.

This quick fix uploads a fake token.

## How to review
Code review

## Who can review
Not me
