### PR TITLE
[#136340183] Change tracker token management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,9 @@ upload-datadog-secrets: check-env-vars ## Decrypt and upload Datadog credentials
 	$(if $(wildcard ${DATADOG_PASSWORD_STORE_DIR}),,$(error Password store ${DATADOG_PASSWORD_STORE_DIR} does not exist))
 	@scripts/upload-datadog-secrets.sh
 
+upload-tracker-token: check-env-vars ## Decrypt and upload Pivotal tracker API token to S3
+	pass pivotal/tracker_token | aws s3 cp - "s3://${DEPLOY_ENV}-state/tracker_token"
+
 .PHONY: manually_upload_certs
 CERT_PASSWORD_STORE_DIR?=~/.paas-pass-high
 manually_upload_certs: check-tf-version ## Manually upload to AWS the SSL certificates for public facing endpoints

--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -305,13 +305,6 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-rubbernecker
 
-  - name: tracker_token
-    type: s3-iam
-    source:
-      bucket: {{state_bucket}}
-      region_name: {{aws_region}}
-      versioned_file: tracker_token
-
 jobs:
   - name: pipeline-lock
     serial: true
@@ -1494,7 +1487,6 @@ jobs:
           - get: datadog-tfstate
           - get: paas-roadmap
           - get: paas-rubbernecker
-          - get: tracker_token
 
       - aggregate:
         - task: extract-cf-terraform-outputs
@@ -2081,10 +2073,10 @@ jobs:
               - name: config
               - name: bosh-CA
               - name: paas-rubbernecker
-              - name: tracker_token
             params:
               DEPLOY_RUBBERNECKER: {{deploy_rubbernecker}}
               PIVOTAL_PROJECT_ID: {{pivotal_project_id}}
+              TRACKER_TOKEN: {{tracker_token}}
             run:
               path: sh
               args:
@@ -2102,8 +2094,7 @@ jobs:
 
                   cf push --no-start -p paas-rubbernecker -f paas-rubbernecker/manifest.yml
                   echo Setting PIVOTAL_API_KEY...
-                  cf set-env rubbernecker PIVOTAL_API_KEY $(cat tracker_token/tracker_token) \
-                    > /dev/null
+                  cf set-env rubbernecker PIVOTAL_API_KEY ${TRACKER_TOKEN} > /dev/null
                   echo Setting PIVOTAL_PROJECT_ID...
                   cf set-env rubbernecker PIVOTAL_PROJECT_ID ${PIVOTAL_PROJECT_ID}
                   cf start rubbernecker


### PR DESCRIPTION
## What

Story: [Productionnecker](https://www.pivotaltracker.com/story/show/136340183)

The previous behaviour broke in production as the token was never
uploaded to the bucket and the deploy rubbernecker task would wait
forever.
We now use the same approach as for the datadog secrets: the token is
uploaded manually via a make command then retrieved and set as a
pipeline parameter.


## How to review

* Code review or:
* Standard deploy. It shouldn't deploy rubbernecker
* Upload pivotal tracker token: `make dev upload-tracker-token`
* Deploy with `DEPLOY_RUBBERNECKER=true`. It should deploy it.

## Who can review
Not me