### PR TITLE
[#131876783] Add deploy_env as a tag for datadog

### DIFF
--- a/manifests/cf-manifest/spec/runtime-config/shared_config_spec.rb
+++ b/manifests/cf-manifest/spec/runtime-config/shared_config_spec.rb
@@ -14,9 +14,15 @@ RSpec.describe "Runtime config" do
       expect(datadog_addon.fetch("properties").fetch("use_dogstatsd")).to eq false
     end
 
-    it "with some tags like aws_account" do
+    it "adds aws_account as a tag to datadog" do
       expect(datadog_addon.fetch("properties").fetch("tags")).not_to be_nil
       expect(datadog_addon.fetch("properties").fetch("tags").fetch("aws_account")).to eq(ENV["AWS_ACCOUNT"])
+    end
+
+    it "adds deploy_env from the terraform environment as a tag to datadog" do
+      expect(datadog_addon.fetch("properties").fetch("tags")).not_to be_nil
+      terraform_environment = terraform_fixture("environment")
+      expect(datadog_addon.fetch("properties").fetch("tags").fetch("deploy_env")).to eq(terraform_environment)
     end
   end
 

--- a/manifests/shared/deployments/datadog-agent.yml
+++ b/manifests/shared/deployments/datadog-agent.yml
@@ -14,3 +14,4 @@ meta:
     include_bosh_tags: true
     tags:
       aws_account: (( grab $AWS_ACCOUNT ))
+      deploy_env: (( grab terraform_outputs.environment ))


### PR DESCRIPTION
[#131876783 Migrate paas-cf to paas-bootstrap](https://www.pivotaltracker.com/story/show/131876783)

What?
----

We have the plan to split the different deployments (concourse, CF, etc), using the same bosh. This means that we cannot identify each specific environment base on the bosh-deployment tag, as we were doing previously because it was set with the value $DEPLOY_ENV.

Specifically, when migrating to paas-bootstrap, the the deployment of concourse is "concourse" for all the environments. Because that we cannot identify the concourse VM per environment and the monitor do not work anymore.

To solve this, we add the tag `deploy_env`. This will allow us to filter by deploy_env without relying on the bosh   deployment name.

More info: https://github.com/alphagov/paas-bootstrap/commit/f2b277fd92496c51b6ad26741221156c9a83bdf3

How to test?
------------

You can do code check, and check that the tests make sense.

Who?
----

Anyone but @keymon or @alext