### PR TITLE
 [#131876783] Use deploy_env instead of bosh-deployment

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2195,7 +2195,7 @@ jobs:
                           \"points\":[[$current_time, ${delta}]],
                           \"type\":\"gauge\",
                           \"tags\":[
-                            \"bosh-deployment:${ENV}\",
+                            \"deploy_env:${ENV}\",
                             \"pipeline_name:${PIPELINE_NAME}\",
                             \"aws_account:${AWS_ACCOUNT}\"
                           ]}

--- a/terraform/datadog/cell.tf
+++ b/terraform/datadog/cell.tf
@@ -4,7 +4,7 @@ resource "datadog_monitor" "cell-available-memory" {
   message            = "${format("Less than {{threshold}}%% memory free on cells. There is only {{value}} %% memory free on average on cells. Review if this is temporary or we really need to scale... @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "There is only {{value}} % memory free on average on cells. Check the deployment!"
   no_data_timeframe  = "7"
-  query              = "${format("avg(last_1m):avg:system.mem.pct_usable{bosh-job:cell,bosh-deployment:%s} * 100 < 50", var.env)}"
+  query              = "${format("avg(last_1m):avg:system.mem.pct_usable{bosh-job:cell,deploy_env:%s} * 100 < 50", var.env)}"
 
   thresholds {
     warning  = "55.0"
@@ -28,7 +28,7 @@ resource "datadog_monitor" "rep_process_running" {
   notify_no_data      = false
   require_full_window = true
 
-  query = "${format("'process.up'.over('bosh-deployment:%s','process:rep').last(4).count_by_status()", var.env)}"
+  query = "${format("'process.up'.over('deploy_env:%s','process:rep').last(4).count_by_status()", var.env)}"
 
   thresholds {
     ok       = 1
@@ -51,7 +51,7 @@ resource "datadog_monitor" "rep_healthy" {
   no_data_timeframe   = "7"
   require_full_window = true
 
-  query = "${format("'http.can_connect'.over('bosh-deployment:%s','instance:rep_service_endpoint').by('*').last(1).pct_by_status()", var.env)}"
+  query = "${format("'http.can_connect'.over('deploy_env:%s','instance:rep_service_endpoint').by('*').last(1).pct_by_status()", var.env)}"
 
   thresholds {
     critical = 50
@@ -72,7 +72,7 @@ resource "datadog_monitor" "garden_process_running" {
   notify_no_data      = false
   require_full_window = true
 
-  query = "${format("'process.up'.over('bosh-deployment:%s','process:guardian').last(4).count_by_status()", var.env)}"
+  query = "${format("'process.up'.over('deploy_env:%s','process:guardian').last(4).count_by_status()", var.env)}"
 
   thresholds {
     ok       = 1
@@ -95,7 +95,7 @@ resource "datadog_monitor" "garden_healthy" {
   no_data_timeframe   = "7"
   require_full_window = true
 
-  query = "${format("'http.can_connect'.over('bosh-deployment:%s','instance:garden_debug_endpoint').by('*').last(1).pct_by_status()", var.env)}"
+  query = "${format("'http.can_connect'.over('deploy_env:%s','instance:garden_debug_endpoint').by('*').last(1).pct_by_status()", var.env)}"
 
   thresholds {
     critical = 50

--- a/terraform/datadog/cloud_controller.tf
+++ b/terraform/datadog/cloud_controller.tf
@@ -6,7 +6,7 @@ resource "datadog_monitor" "cc_api_master_process_running" {
   notify_no_data      = false
   require_full_window = true
 
-  query = "${format("'process.up'.over('bosh-deployment:%s','process:cc_api_master').last(4).count_by_status()", var.env)}"
+  query = "${format("'process.up'.over('deploy_env:%s','process:cc_api_master').last(4).count_by_status()", var.env)}"
 
   thresholds {
     ok       = 1
@@ -29,7 +29,7 @@ resource "datadog_monitor" "cc_api_worker_process_running" {
   notify_no_data      = false
   require_full_window = true
 
-  query = "${format("'process.up'.over('bosh-deployment:%s','process:cc_api_worker').last(4).count_by_status()", var.env)}"
+  query = "${format("'process.up'.over('deploy_env:%s','process:cc_api_worker').last(4).count_by_status()", var.env)}"
 
   thresholds {
     ok       = 1
@@ -52,7 +52,7 @@ resource "datadog_monitor" "cc_api_healthy" {
   no_data_timeframe   = "7"
   require_full_window = true
 
-  query = "${format("'http.can_connect'.over('bosh-deployment:%s','instance:cc_endpoint').by('*').last(1).pct_by_status()", var.env)}"
+  query = "${format("'http.can_connect'.over('deploy_env:%s','instance:cc_endpoint').by('*').last(1).pct_by_status()", var.env)}"
 
   thresholds {
     critical = 50

--- a/terraform/datadog/concourse.tf
+++ b/terraform/datadog/concourse.tf
@@ -4,7 +4,7 @@ resource "datadog_monitor" "concourse-load" {
   message            = "${format("Concourse load is too high: {{value}}. Check VM health. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "Concourse load still too high: {{value}}."
   notify_no_data     = false
-  query              = "${format("avg(last_5m):avg:system.load.5{bosh-job:concourse,bosh-deployment:%s} > 200", var.env)}"
+  query              = "${format("avg(last_5m):avg:system.load.5{bosh-job:concourse,deploy_env:%s} > 200", var.env)}"
 
   thresholds {
     warning  = "150.0"
@@ -26,7 +26,7 @@ resource "datadog_monitor" "continuous-smoketests" {
   message            = "${format("Continuous smoketests too slow: {{value}} ms. Check concourse VM health. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "Continuous smoketests still too slow: {{value}} ms."
   no_data_timeframe  = "30"
-  query              = "${format("max(last_1m):avg:concourse.build.finished{job:continuous-smoke-tests,bosh-deployment:%s} > 1800000", var.env)}"
+  query              = "${format("max(last_1m):avg:concourse.build.finished{job:continuous-smoke-tests,deploy_env:%s} > 1800000", var.env)}"
 
   thresholds {
     warning  = "1200000.0"
@@ -52,7 +52,7 @@ resource "datadog_timeboard" "concourse-jobs" {
     viz   = "change"
 
     request {
-      q = "${format("avg:concourse.build.finished{bosh-deployment:%s} by {job}", var.env)}"
+      q = "${format("avg:concourse.build.finished{deploy_env:%s} by {job}", var.env)}"
     }
   }
 
@@ -61,7 +61,7 @@ resource "datadog_timeboard" "concourse-jobs" {
     viz   = "timeseries"
 
     request {
-      q = "${format("avg:concourse.pipeline_time{bosh-deployment:%s,pipeline_name:create-cloudfoundry}", var.env)}"
+      q = "${format("avg:concourse.pipeline_time{deploy_env:%s,pipeline_name:create-cloudfoundry}", var.env)}"
     }
   }
 
@@ -70,7 +70,7 @@ resource "datadog_timeboard" "concourse-jobs" {
     viz   = "timeseries"
 
     request {
-      q    = "${format("count_nonzero(avg:concourse.build.finished{build_status:failed,bosh-deployment:%s,job:continuous-smoke-tests})", var.env)}"
+      q    = "${format("count_nonzero(avg:concourse.build.finished{build_status:failed,deploy_env:%s,job:continuous-smoke-tests})", var.env)}"
       type = "bars"
 
       style {
@@ -79,7 +79,7 @@ resource "datadog_timeboard" "concourse-jobs" {
     }
 
     request {
-      q    = "${format("count_nonzero(avg:concourse.build.finished{build_status:succeeded,bosh-deployment:%s,job:continuous-smoke-tests})", var.env)}"
+      q    = "${format("count_nonzero(avg:concourse.build.finished{build_status:succeeded,deploy_env:%s,job:continuous-smoke-tests})", var.env)}"
       type = "bars"
 
       style {

--- a/terraform/datadog/consul.tf
+++ b/terraform/datadog/consul.tf
@@ -4,7 +4,7 @@ resource "datadog_monitor" "consul" {
   message            = "${format("Consul process not running on this host in environment {{host.environment}}. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "Consul process not running! Check VM state."
   notify_no_data     = false
-  query              = "${format("'process.up'.over('bosh-deployment:%s','process:consul').last(6).count_by_status()", var.env)}"
+  query              = "${format("'process.up'.over('deploy_env:%s','process:consul').last(6).count_by_status()", var.env)}"
 
   thresholds {
     ok       = 1
@@ -29,7 +29,7 @@ resource "datadog_monitor" "consul_connect_to_port" {
   no_data_timeframe   = "7"
   require_full_window = true
 
-  query = "${format("'tcp.can_connect'.over('bosh-deployment:%s','instance:consul_server').by('*').last(1).pct_by_status()", var.env)}"
+  query = "${format("'tcp.can_connect'.over('deploy_env:%s','instance:consul_server').by('*').last(1).pct_by_status()", var.env)}"
 
   thresholds {
     critical = 50

--- a/terraform/datadog/general.tf
+++ b/terraform/datadog/general.tf
@@ -4,7 +4,7 @@ resource "datadog_monitor" "disk-space" {
   message            = "${format("More than {{threshold}}%% disk used. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "There is still {{value}} % disk used. Check the VM!"
   no_data_timeframe  = "10"
-  query              = "${format("max(last_5m):max:system.disk.in_use{bosh-deployment:%s,!device:/dev/loop0,!device:tmpfs,!device:cgroup,!device:udev,!device:/var/vcap/data/root_log,!device:/var/vcap/data/root_tmp,!bosh-job:concourse} by {bosh-job,device,bosh-index} * 100 > 85", var.env)}"
+  query              = "${format("max(last_5m):max:system.disk.in_use{deploy_env:%s,!device:/dev/loop0,!device:tmpfs,!device:cgroup,!device:udev,!device:/var/vcap/data/root_log,!device:/var/vcap/data/root_tmp,!bosh-job:concourse} by {bosh-job,device,bosh-index} * 100 > 85", var.env)}"
 
   thresholds {
     warning  = "75.0"
@@ -26,7 +26,7 @@ resource "datadog_monitor" "concourse-disk-space" {
   message            = "${format("More than {{threshold}}%% disk used. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "There is still {{value}} % disk used. Check the VM!"
   no_data_timeframe  = "30"
-  query              = "${format("max(last_5m):max:system.disk.in_use{bosh-deployment:%s,!device:/dev/loop0,!device:tmpfs,!device:cgroup,!device:udev,!device:/var/vcap/data/root_log,!device:/var/vcap/data/root_tmp,bosh-job:concourse} by {bosh-job,device,bosh-index} * 100 > 97", var.env)}"
+  query              = "${format("max(last_5m):max:system.disk.in_use{deploy_env:%s,!device:/dev/loop0,!device:tmpfs,!device:cgroup,!device:udev,!device:/var/vcap/data/root_log,!device:/var/vcap/data/root_tmp,bosh-job:concourse} by {bosh-job,device,bosh-index} * 100 > 97", var.env)}"
 
   thresholds {
     warning  = "95.0"

--- a/terraform/datadog/nats.tf
+++ b/terraform/datadog/nats.tf
@@ -6,7 +6,7 @@ resource "datadog_monitor" "nats_process_running" {
   notify_no_data      = false
   require_full_window = true
 
-  query = "${format("'process.up'.over('bosh-deployment:%s','process:nats').last(4).count_by_status()", var.env)}"
+  query = "${format("'process.up'.over('deploy_env:%s','process:nats').last(4).count_by_status()", var.env)}"
 
   thresholds {
     ok       = 1
@@ -29,7 +29,7 @@ resource "datadog_monitor" "nats_stream_forwarded_process_running" {
   notify_no_data      = false
   require_full_window = true
 
-  query = "${format("'process.up'.over('bosh-deployment:%s','process:nats_stream_forwarder').last(4).count_by_status()", var.env)}"
+  query = "${format("'process.up'.over('deploy_env:%s','process:nats_stream_forwarder').last(4).count_by_status()", var.env)}"
 
   thresholds {
     ok       = 1
@@ -52,7 +52,7 @@ resource "datadog_monitor" "nats_service_open" {
   no_data_timeframe   = "7"
   require_full_window = true
 
-  query = "${format("'tcp.can_connect'.over('bosh-deployment:%s','instance:nats_server').by('*').last(1).pct_by_status()", var.env)}"
+  query = "${format("'tcp.can_connect'.over('deploy_env:%s','instance:nats_server').by('*').last(1).pct_by_status()", var.env)}"
 
   thresholds {
     critical = 50
@@ -73,7 +73,7 @@ resource "datadog_monitor" "nats_cluster_service_open" {
   no_data_timeframe   = "7"
   require_full_window = true
 
-  query = "${format("'tcp.can_connect'.over('bosh-deployment:%s','instance:nats_cluster').by('*').last(1).pct_by_status()", var.env)}"
+  query = "${format("'tcp.can_connect'.over('deploy_env:%s','instance:nats_cluster').by('*').last(1).pct_by_status()", var.env)}"
 
   thresholds {
     critical = 50

--- a/terraform/datadog/route-emitter.tf
+++ b/terraform/datadog/route-emitter.tf
@@ -6,7 +6,7 @@ resource "datadog_monitor" "route_emitter_process_running" {
   notify_no_data      = false
   require_full_window = true
 
-  query = "${format("'process.up'.over('bosh-deployment:%s','process:route-emitter').last(4).count_by_status()", var.env)}"
+  query = "${format("'process.up'.over('deploy_env:%s','process:route-emitter').last(4).count_by_status()", var.env)}"
 
   thresholds {
     ok       = 1
@@ -29,7 +29,7 @@ resource "datadog_monitor" "route_emitter_healthy" {
   no_data_timeframe   = "7"
   require_full_window = true
 
-  query = "${format("'http.can_connect'.over('bosh-deployment:%s','instance:route_emitter_debug_endpoint').by('*').last(1).pct_by_status()", var.env)}"
+  query = "${format("'http.can_connect'.over('deploy_env:%s','instance:route_emitter_debug_endpoint').by('*').last(1).pct_by_status()", var.env)}"
 
   thresholds {
     critical = 50
@@ -50,7 +50,7 @@ resource "datadog_monitor" "route_emitter_consul_lock" {
   no_data_timeframe   = "7"
   require_full_window = true
 
-  query = "${format("'http.can_connect'.over('bosh-deployment:%s','instance:route_emitter_consul_lock').by('*').last(1).pct_by_status()", var.env)}"
+  query = "${format("'http.can_connect'.over('deploy_env:%s','instance:route_emitter_consul_lock').by('*').last(1).pct_by_status()", var.env)}"
 
   thresholds {
     critical = 100

--- a/terraform/datadog/router.tf
+++ b/terraform/datadog/router.tf
@@ -124,7 +124,7 @@ resource "datadog_monitor" "gorouter_process_running" {
   notify_no_data      = false
   require_full_window = true
 
-  query = "${format("'process.up'.over('bosh-deployment:%s','process:gorouter').last(4).count_by_status()", var.env)}"
+  query = "${format("'process.up'.over('deploy_env:%s','process:gorouter').last(4).count_by_status()", var.env)}"
 
   thresholds {
     ok       = 1
@@ -147,7 +147,7 @@ resource "datadog_monitor" "gorouter_healthy" {
   no_data_timeframe   = "7"
   require_full_window = true
 
-  query = "${format("'http.can_connect'.over('bosh-deployment:%s','instance:gorouter','url:http://localhost:80/').by('*').last(1).pct_by_status()", var.env)}"
+  query = "${format("'http.can_connect'.over('deploy_env:%s','instance:gorouter','url:http://localhost:80/').by('*').last(1).pct_by_status()", var.env)}"
 
   thresholds {
     critical = 50


### PR DESCRIPTION
[#131876783 Migrate paas-cf to paas-bootstrap](https://www.pivotaltracker.com/story/show/131876783)

What?
----

With the migration to paas-bootstrap we want to manage multiple deployments from the same bosh. That prevents us from using bosh-deployment tag to uniquely identify the environment.

We added instead the tag deploy_env which identifies the environment.

In this commit we stop using the bosh-deployment tag, and we use deploy_env.

The metrics from the datadog agent will have the tag from the changes done in [1] and the concourse ones from [2]

[1] https://github.com/alphagov/paas-cf/pull/696y
[2] https://github.com/alphagov/paas-bootstrap/pull/8


Dependencies
------------

It is convenient that https://github.com/alphagov/paas-cf/pull/696 has been deployed some time before in all environments.

Remove the temporary commit before merge.

How to test this?
----------------

Code review. 

You can test it with the metrics from CI thx to the temporary commit which allows define a different name for the monitors. Run this, changing `env2` as needed:

```
terraform apply \
  -var datadog_api_key=$(paas-pass datadog/dev/datadog_api_key) \
  -var datadog_app_key=$(paas-pass datadog/dev/datadog_app_key) \
  -var aws_account=ci  \
  -var env2=hector \
  -var env=master  \ 
  -var-file ../ci.tfvars
```

Who?
---

Anyone but @keymon