### PR TITLE
[#131876783] Remove migration code from migration paas-cf to paas-bootstrap

### DIFF
--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -208,14 +208,6 @@ if $FLY_CMD -t "${FLY_TARGET}" pipelines | grep -q create-bosh-cloudfoundry; the
     --new-name create-cloudfoundry
 fi
 
-# FIXME: Remove this once it's been removed everywhere.
-if $FLY_CMD -t "${FLY_TARGET}" pipelines | grep -q destroy-microbosh; then
-  $FLY_CMD -t "${FLY_TARGET}" \
-    destroy-pipeline \
-    --pipeline destroy-microbosh \
-    --non-interactive
-fi
-
 for p in $pipelines_to_update; do
   update_pipeline "$p"
 done

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -200,14 +200,6 @@ pipeline_name="test"
 generate_vars_file > /dev/null # Check for missing vars
 pipeline_name=
 
-# FIXME: Remove this once it's been renamed everywhere.
-if $FLY_CMD -t "${FLY_TARGET}" pipelines | grep -q create-bosh-cloudfoundry; then
-  $FLY_CMD -t "${FLY_TARGET}" \
-    rename-pipeline \
-    --old-name create-bosh-cloudfoundry \
-    --new-name create-cloudfoundry
-fi
-
 for p in $pipelines_to_update; do
   update_pipeline "$p"
 done


### PR DESCRIPTION
[#131876783 Migrate paas-cf to paas-bootstrap](https://www.pivotaltracker.com/story/show/131876783)

What?
-----

After #688 has been applied in all the environments, we can revert all the code used for the migration.

How to review?
-------------

Code review should be enough.

Who?
----

Anyone but @keymon or @alext