### PR TITLE
[#136433665] Don't alert on no_data for disk check

### DIFF
--- a/terraform/datadog/general.tf
+++ b/terraform/datadog/general.tf
@@ -19,25 +19,3 @@ resource "datadog_monitor" "disk-space" {
     "job"        = "all"
   }
 }
-
-resource "datadog_monitor" "concourse-disk-space" {
-  name               = "${format("%s concourse disk space", var.env)}"
-  type               = "query alert"
-  message            = "${format("More than {{threshold}}%% disk used. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message = "There is still {{value}} % disk used. Check the VM!"
-  no_data_timeframe  = "30"
-  query              = "${format("max(last_5m):max:system.disk.in_use{deploy_env:%s,!device:/dev/loop0,!device:tmpfs,!device:cgroup,!device:udev,!device:/var/vcap/data/root_log,!device:/var/vcap/data/root_tmp,bosh-job:concourse} by {bosh-job,device,bosh-index} * 100 > 97", var.env)}"
-
-  thresholds {
-    warning  = "95.0"
-    critical = "97.0"
-  }
-
-  require_full_window = true
-
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "concourse"
-  }
-}


### PR DESCRIPTION
## What

[Don't email no_data notifications for disk monitor](https://www.pivotaltracker.com/n/projects/1275640/stories/136433665)

## How to review

Deploy with datadog enabled. Stop datadog agent (forwarder is enough) and check that you get no emails. Or you can trust the code. Worst case scenario is that we'll still get spam, which is not a change from current situation.

## Who can review

not @mtekel
