### PR TITLE
[#126126973] Fixes for require mfa

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,33 +192,6 @@ updating pipelines, or you'll get strange terraform errors during cf-terraform.
 ENABLE_DATADOG=true make dev pipelines
 ```
 
-## Sharing your Bootstrap Concourse
-
-If you need to share access to your *Bootstrap Concourse* with a colleague
-then you will need to reproduce some of the work that Vagrant does.
-
-Add their SSH public key:
-
-```
-cd vagrant
-echo "ssh-rsa AAAA... user" | \
-   vagrant ssh -- tee -a .ssh/authorized_keys
-```
-
-Learn the public IP of your *Bootstrap Concourse* run:
-
-```
-cd vagrant
-vagrant ssh-config
-```
-
-They will then need to manually create the SSH tunnel that is normally
-handled by `vagrant/deploy.sh`:
-
-```
-ssh ubuntu@<bootstrap_concourse_ip> -L 8080:127.0.0.1:8080 -fN
-```
-
 ## Using the bosh cli and `bosh ssh`
 
 There's a Makefile target that starts an interactive session on the deployer concourse
@@ -256,31 +229,15 @@ bosh server before opening the ssh session.
 
 ## Concourse credentials
 
-By default, the environment setup script generates the concourse ATC password
-for the admin user, based on the AWS credentials, the environment name and the
-application name. If the `CONCOURSE_ATC_PASSWORD` environment variable is set,
-this will be used instead. These credentials are output by all of the pipeline
-deployment tasks.
-
-These credentials will also be used by the *Deployer Concourse*.
-
-If necessary, the concourse password can be found in the `basic_auth_password`
-property of `concourse-manifest.yml` in the state bucket.
-
-You can also learn the credentials from the `atc` process arguments:
-
- 1. SSH to the Concourse server:
-    * For *Bootstrap Concourse*: `cd vagrant && vagrant ssh`
-    * [For *Deployer Concourse*](#ssh-to-deployer-concourse-and-microbosh)
- 2. Get the password from `atc` arguments: `ps -fea | sed -n 's/.*--basic-auth[-]password \([^ ]*\).*/\1/p'`
+By default, the environment setup script retrieves the admin user password set
+in paas-bootstrap and stored in S3 in the `concourse-secrets.yml` file. If the
+`CONCOURSE_ATC_PASSWORD` environment variable is set, this will be used instead.
+These credentials are output by all of the pipeline deployment tasks.
 
 ## Overnight deletion of environments
 
 In order to avoid unnecessary costs in AWS, there is some logic to
 stop environments and VMs at night:
-
- * **Bootstrap Concourse**: The `self-terminate` pipeline
-   will be triggered every night to terminate the *Bootstrap Concourse*.
 
  * **Cloud Foundry deployment**: The `autodelete-cloudfoundry` pipeline
    will be triggered every night to delete the specific deployment.

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -123,13 +123,6 @@ resources:
       region_name: {{aws_region}}
       versioned_file: bosh-CA.tar.gz
 
-  - name: concourse-manifest
-    type: s3-iam
-    source:
-      bucket: {{state_bucket}}
-      region_name: {{aws_region}}
-      versioned_file: concourse-manifest.yml
-
   - name: ssh-private-key
     type: s3-iam
     source:
@@ -267,7 +260,6 @@ jobs:
         - get: paas-cf
           trigger: {{auto_deploy}}
         - get: git-ssh-private-key
-        - get: concourse-manifest
       - task: init-pipeline-pool
         config:
           platform: linux
@@ -339,7 +331,6 @@ jobs:
               repository: governmentpaas/self-update-pipelines
           inputs:
             - name: paas-cf
-            - name: concourse-manifest
           params:
             DEPLOY_ENV: {{deploy_env}}
             BRANCH: {{branch_name}}
@@ -585,7 +576,6 @@ jobs:
           - get: paas-cf
             passed: ['generate-secrets']
           - get: bosh-CA
-          - get: concourse-manifest
       - task: run-tests
         config:
           platform: linux
@@ -596,7 +586,6 @@ jobs:
           inputs:
             - name: paas-cf
             - name: pipeline-trigger
-            - name: concourse-manifest
             - name: bosh-CA
             - name: deployed-healthcheck
           params:
@@ -606,6 +595,7 @@ jobs:
             CONCOURSE_ATC_USERNAME: admin
             DEPLOY_ENV: {{deploy_env}}
             BRANCH: {{branch_name}}
+            CONCOURSE_ATC_PASSWORD: {{concourse_atc_password}}
           run:
             path: sh
             args:
@@ -620,8 +610,6 @@ jobs:
 
                 ./paas-cf/concourse/scripts/import_bosh_ca.sh
 
-                export CONCOURSE_ATC_PASSWORD
-                CONCOURSE_ATC_PASSWORD=$(awk '/basic_auth_password/ { print $2 }' concourse-manifest/concourse-manifest.yml | tr -d '"')
                 export CONCOURSE_ATC_URL
                 CONCOURSE_ATC_URL=https://deployer.${SYSTEM_DNS_ZONE_NAME}
                 export PIPELINE_TRIGGER_VERSION
@@ -1980,7 +1968,6 @@ jobs:
             trigger: true
           - get: paas-cf
             passed: ['post-deploy','availability-tests']
-          - get: concourse-manifest
           - get: cf-manifest
           - get: bosh-secrets
       - task: test-bosh-cli
@@ -1994,18 +1981,15 @@ jobs:
           params:
             SYSTEM_DNS_ZONE_NAME: {{system_dns_zone_name}}
             DEPLOY_ENV: {{deploy_env}}
+            CONCOURSE_ATC_PASSWORD: {{concourse_atc_password}}
           inputs:
           - name: paas-cf
-          - name: concourse-manifest
           run:
             path: sh
             args:
             - -e
             - -c
             - |
-              VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
-              CONCOURSE_ATC_PASSWORD=$("$VAL_FROM_YAML" jobs.concourse.templates.atc.properties.basic_auth_password concourse-manifest/concourse-manifest.yml)
-              export CONCOURSE_ATC_PASSWORD
               echo Looking for non running VMs
               ./paas-cf/concourse/scripts/bosh-cli.sh bosh status
       - task: test-bosh-vms

--- a/concourse/scripts/environment.sh
+++ b/concourse/scripts/environment.sh
@@ -5,10 +5,6 @@ set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 PROJECT_DIR=$(cd "${SCRIPT_DIR}/../.." && pwd)
 
-hashed_password() {
-  echo "$1" | shasum -a 256 | base64 | head -c 32
-}
-
 DEPLOY_ENV=${1:-${DEPLOY_ENV:-}}
 if [ -z "${DEPLOY_ENV}" ]; then
   echo "Must specify DEPLOY_ENV as \$1 or environment variable" 1>&2
@@ -39,7 +35,7 @@ if [ -z "${CONCOURSE_ATC_PASSWORD:-}" ]; then
   if [ -n "${DECRYPT_CONCOURSE_ATC_PASSWORD:-}" ]; then
     CONCOURSE_ATC_PASSWORD=$(pass "${DECRYPT_CONCOURSE_ATC_PASSWORD}/concourse_password")
   else
-    CONCOURSE_ATC_PASSWORD=$(hashed_password "${AWS_SECRET_ACCESS_KEY}:${DEPLOY_ENV}:atc")
+    CONCOURSE_ATC_PASSWORD=$(concourse/scripts/val_from_yaml.rb secrets.concourse_atc_password <(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/concourse-secrets.yml" -))
   fi
 fi
 

--- a/concourse/scripts/pipelines-bosh-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-bosh-cloudfoundry.sh
@@ -124,6 +124,7 @@ deploy_roadmap: ${DEPLOY_ROADMAP:-false}
 deploy_rubbernecker: ${DEPLOY_RUBBERNECKER:-false}
 tracker_token: ${tracker_token:-}
 pivotal_project_id: ${PIVOTAL_PROJECT_ID:-1275640}
+concourse_atc_password: ${CONCOURSE_ATC_PASSWORD}
 EOF
   echo -e "pipeline_lock_git_private_key: |\n  ${git_id_rsa//$'\n'/$'\n'  }"
 }

--- a/concourse/scripts/self-update-pipeline.sh
+++ b/concourse/scripts/self-update-pipeline.sh
@@ -12,8 +12,8 @@
 set -u
 set -e
 
-if [ ! -d "./paas-cf" ] || [ ! -f "concourse-manifest/concourse-manifest.yml" ]; then
-  echo "Resources paas-cf and concourse-manifest must be checkout"
+if [ ! -d "./paas-cf" ]; then
+  echo "Resource paas-cf must be checkout"
   exit 1
 fi
 
@@ -21,10 +21,6 @@ if [ "${SELF_UPDATE_PIPELINE}" != "true" ]; then
   echo "Self update pipeline is disabled. Skipping. (set SELF_UPDATE_PIPELINE=true to enable)"
 else
   echo "Self update pipeline is enabled. Updating. (set SELF_UPDATE_PIPELINE=false to disable)"
-
-  VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
-  CONCOURSE_ATC_PASSWORD=$("$VAL_FROM_YAML" jobs.concourse.templates.atc.properties.basic_auth_password concourse-manifest/concourse-manifest.yml)
-  export CONCOURSE_ATC_PASSWORD
 
   make -C ./paas-cf "${MAKEFILE_ENV_TARGET}" pipelines
 fi


### PR DESCRIPTION
## What

Story: [Ensure all AWS IAM accounts have MFA enabled](https://www.pivotaltracker.com/story/show/126126973)

This PR brings adjustments required to be compliant with changes introduced in https://github.com/alphagov/paas-bootstrap/pull/16. It changes the way how CONCOURSE_ATC_PASSWORD is fetched. Now we get it from `concourse-sectrets.yml` from S3 bucket. Also, it unifies the way we get ATC password in create CF pipeline ( where possible )

## How to review

- make sure `make dev showenv` displays correct ATC password
- run pipeline to check if all jobs are OK

## Who can review

Not @combor or @saliceti 

You can review it now and don't have to wait for https://github.com/alphagov/paas-bootstrap/pull/16 to be merged. 
