### PR TITLE
[#136433665] DATADOG: monitor concourse disk

### DIFF
--- a/terraform/datadog/general.tf
+++ b/terraform/datadog/general.tf
@@ -4,7 +4,7 @@ resource "datadog_monitor" "disk-space" {
   message            = "${format("More than {{threshold}}%% disk used. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message = "There is still {{value}} % disk used. Check the VM!"
   notify_no_data     = false
-  query              = "${format("max(last_5m):max:system.disk.in_use{deploy_env:%s,!device:/dev/loop0,!device:tmpfs,!device:cgroup,!device:udev,!device:/var/vcap/data/root_log,!device:/var/vcap/data/root_tmp,!bosh-job:concourse} by {bosh-job,device,bosh-index} * 100 > 85", var.env)}"
+  query              = "${format("max(last_5m):max:system.disk.in_use{deploy_env:%s,!device:/dev/loop0,!device:tmpfs,!device:cgroup,!device:udev,!device:/var/vcap/data/root_log,!device:/var/vcap/data/root_tmp} by {bosh-job,device,bosh-index} * 100 > 85", var.env)}"
 
   thresholds {
     warning  = "75.0"


### PR DESCRIPTION
## What

We have previously removed concourse specific monitor in
b2f63b7f2befd0a1063c24cb5d44e3dc97d070b7 but forgot to remove condition to
exclude concourse from generic disk monitor. Remove that exclusion to cover
concourse disks as well

## How to review

Deploy. Check disk monitor covers concourse disks as well.

## Who can review

not @mtekel
