### PR TITLE
[#126126973] Remove concourse password gpg decrypt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,6 @@ ci: globals check-env-vars ## Set Environment to CI
 	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS=${ALERT_EMAIL_ADDRESS})
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-default.yml)
 	$(eval export ENABLE_DATADOG=true)
-	$(eval export DECRYPT_CONCOURSE_ATC_PASSWORD=ci_deployments/master)
 	@true
 
 .PHONY: staging
@@ -134,7 +133,6 @@ staging: globals check-env-vars ## Set Environment to Staging
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-default.yml)
 	$(eval export DISABLE_CF_ACCEPTANCE_TESTS=true)
 	$(eval export ENABLE_DATADOG=true)
-	$(eval export DECRYPT_CONCOURSE_ATC_PASSWORD=staging_deployment)
 	@true
 
 .PHONY: prod
@@ -151,7 +149,6 @@ prod: globals check-env-vars ## Set Environment to Production
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-prod.yml)
 	$(eval export DISABLE_CF_ACCEPTANCE_TESTS=true)
 	$(eval export ENABLE_DATADOG=true)
-	$(eval export DECRYPT_CONCOURSE_ATC_PASSWORD=prod_deployment)
 	$(eval export DEPLOY_ROADMAP=true)
 	$(eval export ENABLE_PAAS_DASHBOARD=true)
 	$(eval export DEPLOY_RUBBERNECKER=true)

--- a/concourse/scripts/environment.sh
+++ b/concourse/scripts/environment.sh
@@ -32,11 +32,7 @@ esac
 
 CONCOURSE_ATC_USER=${CONCOURSE_ATC_USER:-admin}
 if [ -z "${CONCOURSE_ATC_PASSWORD:-}" ]; then
-  if [ -n "${DECRYPT_CONCOURSE_ATC_PASSWORD:-}" ]; then
-    CONCOURSE_ATC_PASSWORD=$(pass "${DECRYPT_CONCOURSE_ATC_PASSWORD}/concourse_password")
-  else
-    CONCOURSE_ATC_PASSWORD=$(concourse/scripts/val_from_yaml.rb secrets.concourse_atc_password <(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/concourse-secrets.yml" -))
-  fi
+  CONCOURSE_ATC_PASSWORD=$(concourse/scripts/val_from_yaml.rb secrets.concourse_atc_password <(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/concourse-secrets.yml" -))
 fi
 
 cat <<EOF


### PR DESCRIPTION
## What

Story: [Ensure all AWS IAM accounts have MFA enabled](https://www.pivotaltracker.com/story/show/126126973)

The concourse password is now stored exclusively in S3. We shouldn't try
to read it from GPG anymore.


## How to review
Code review

## Who can review
Not me