### PR TITLE
Don't require DEPLOY_ENV in create_sts_token.sh

### DIFF
--- a/scripts/create_sts_token.sh
+++ b/scripts/create_sts_token.sh
@@ -3,8 +3,8 @@
 set -eo pipefail
 
 ensure_env_vars() {
-  if [ -z "${DEPLOY_ENV}" ] || [ -z "${AWS_ACCOUNT}" ] || [ -z "${AWS_ACCESS_KEY_ID}" ] || [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
-    echo "Must set DEPLOY_ENV, AWS_ACCOUNT, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY"
+  if [ -z "${AWS_ACCOUNT}" ] || [ -z "${AWS_ACCESS_KEY_ID}" ] || [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
+    echo "Must set AWS_ACCOUNT, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY"
     exit 1
   fi
 
@@ -17,7 +17,7 @@ ensure_env_vars() {
   STS_TOKEN_DIRECTORY="${STS_TOKEN_DIRECTORY:-${HOME}/.aws_sts_tokens}"
 
   STS_TOKEN_STALESNESS_THRESHOLD=600
-  TOKEN_FILE="${STS_TOKEN_DIRECTORY}/${AWS_ACCOUNT}_${DEPLOY_ENV}.sh"
+  TOKEN_FILE="${STS_TOKEN_DIRECTORY}/${AWS_ACCOUNT}.sh"
   unset AWS_SESSION_TOKEN
 }
 
@@ -31,7 +31,7 @@ delete_stale_tokens() {
   # we can't use last modified time since we want the duration to be configurable
 
   now=$(date +%s)
-  token_files=$(find "${STS_TOKEN_DIRECTORY}" -name "*_*.sh" -type f)
+  token_files=$(find "${STS_TOKEN_DIRECTORY}" -name "*.sh" -type f)
 
   for f in $token_files; do
     expire_time=$(head -1 "${f}" | cut -d ":" -f 2)

--- a/scripts/create_sts_token.sh
+++ b/scripts/create_sts_token.sh
@@ -42,15 +42,15 @@ delete_stale_tokens() {
 }
 
 generate_new_token() {
-  expires=$(($(date +%s) + STS_TOKEN_DURATION - STS_TOKEN_STALESNESS_THRESHOLD))
-  echo "# EXPIRES:${expires}" > "${TOKEN_FILE}"
-  chmod 600 "${TOKEN_FILE}"
-  trap 'rm ${TOKEN_FILE}' ERR
-
   read -r -p "Enter MFA code for ${AWS_ACCOUNT}: " mfa_token
 
   user_arn=$(aws sts get-caller-identity --query Arn --output text)
   token_arn=${user_arn/:user/:mfa}
+
+  expires=$(($(date +%s) + STS_TOKEN_DURATION - STS_TOKEN_STALESNESS_THRESHOLD))
+  echo "# EXPIRES:${expires}" > "${TOKEN_FILE}"
+  chmod 600 "${TOKEN_FILE}"
+  trap 'rm ${TOKEN_FILE}' ERR
 
   aws sts get-session-token \
     --serial-number "${token_arn}" \


### PR DESCRIPTION
## What

There's nothing about the generated credentials that is specific to a given
`DEPLOY_ENV`, so there's no need to base the generated files on it.
Additionally, `DEPLOY_ENV` doesn't make sense in contexts that are wider
than a given deployment (eg account-wide terraform). This therefore removes
the use of `DEPLOY_ENV` from the script.

A second commit also improves the error handling (a Ctrl-C would leave an incomplete token file behind).

## How to review

Code review. Verify that the script still works.
Verify that the corresponding documentation change (https://github.com/alphagov/paas-team-manual/pull/85) also is correct.

## Who can review

Anyone but myself.