### PR TITLE
[#136351753] Rotate BBS encryption key

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -495,10 +495,12 @@ properties:
       dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
 
     bbs:
-      active_key_label: keylabel1
+      active_key_label: key-2017-01
       encryption_keys:
         - label: keylabel1
           passphrase: "a secure passphrase"
+        - label: key-2017-01
+          passphrase: (( grab secrets.bbs_encryption_key ))
       ca_cert: (( grab meta.secrets.bbs_ca_cert ))
       server_cert: (( grab secrets.bbs_server_cert ))
       server_key: (( grab secrets.bbs_server_key ))

--- a/manifests/cf-manifest/scripts/generate-cf-secrets.rb
+++ b/manifests/cf-manifest/scripts/generate-cf-secrets.rb
@@ -37,6 +37,7 @@ generator = SecretGenerator.new(
   "rds_broker_state_encryption_key" => :simple,
   "ssh_proxy_host_key" => :ssh_key,
   "kibana_admin_password" => :simple,
+  "bbs_encryption_key" => :simple,
 )
 
 option_parser = OptionParser.new do |opts|

--- a/manifests/shared/spec/fixtures/cf-secrets.yml
+++ b/manifests/shared/spec/fixtures/cf-secrets.yml
@@ -59,6 +59,9 @@ secrets:
   # rds broker creds
   rds_broker_master_password_seed: RDS_BROKER_MASTER_PASSWORD_SEED
 
+  # bbs creds
+  bbs_encryption_key: BBS_ENCRYPTION_KEY
+
   ssh_proxy_host_key:
     private_key: |
       -----BEGIN RSA PRIVATE KEY-----


### PR DESCRIPTION
## What

This is the first step of BBS encryption key rotation. It replaces the hardcoded passphrase with generated one. Old pass is not removed as in this phase it will be used to decrypt already encrypted data. New one will be than used to re-encrypt everything and put back in ETCD. There will we a follow up PR to remove old pass after this change is deployed to all environments. 

## How to review

- code sanity check
- deploy and wait for acceptance tests to pass 

## Who can review

not @combor
