### PR TITLE
[#136351753] Remove hardcoded BBS pass

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -497,8 +497,6 @@ properties:
     bbs:
       active_key_label: key-2017-01
       encryption_keys:
-        - label: keylabel1
-          passphrase: "a secure passphrase"
         - label: key-2017-01
           passphrase: (( grab secrets.bbs_encryption_key ))
       ca_cert: (( grab meta.secrets.bbs_ca_cert ))


### PR DESCRIPTION
## What

This is follow up to https://github.com/alphagov/paas-cf/pull/710 which has to be applied first to all environments. 

Hardcoded BBS pass phrase can be now removed from cf-manifest as we use generated one.  

More details in: https://www.pivotaltracker.com/story/show/136351753

## How to review

- code sanity check
- run pipeline and wait for acceptance tests to pass.

## Who can review

Not @combor
