### PR TITLE
[#136783629] SSL between router ELB and HAProxy

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -30,9 +30,9 @@ releases:
     url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-rootfs-release?v=1.43.0
     sha1: 587c61d39a525245934f97396ec6d5dd1c97bf79
   - name: paas-haproxy
-    version: 0.1.2
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/paas-haproxy-0.1.2.tgz
-    sha1: 73fc08b2c7a27caf5d88c9c70f26dcf0ba60bf66
+    version: 0.1.3
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/paas-haproxy-0.1.3.tgz
+    sha1: 732ceb817afe33ee117b85a202d87f6f5c3dd760
   - name: datadog-for-cloudfoundry
     version: 0.1.6
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.1.6.tgz

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -159,6 +159,7 @@ properties:
       capture response header strict-transport-security len 128
       http-response add-header Strict-Transport-Security max-age=31536000;\ includeSubDomains;\ preload unless { capture.res.hdr(0) -m found }
     enable_healthcheck_frontend: true
+    ssl_pem: (( concat secrets.router_internal_cert secrets.router_internal_key ))
 
   router:
     enable_ssl: false


### PR DESCRIPTION
## What

Story: [How do encrypt traffic between the elb and gorouter using haproxy](https://www.pivotaltracker.com/story/show/136783629)

As part of DIT onboarding, we want to encrypt all communications. This PR enables SSL on HAProxy.
The following PR https://github.com/alphagov/paas-cf/pull/715 will change the backend port on the ELB to use this SSL port. It was separated in 2 PRs to create minimal downtime.

Depends on https://github.com/alphagov/paas-haproxy-release/pull/8

## How to review
* Deploy
* Make sure all tests pass

## Before merging
* Merge https://github.com/alphagov/paas-haproxy-release/pull/8
* Copy the output from the `build-final-release` job at https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/paas-haproxy
* Update commit `[TEMP] Use haproxy release with SSL` with the final release
* Merge

## Who can review
Not @keymon or me
