### PR TITLE
Update accidental dev datadog boshrelease pointer.

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -34,9 +34,9 @@ releases:
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/paas-haproxy-0.1.2.tgz
     sha1: 73fc08b2c7a27caf5d88c9c70f26dcf0ba60bf66
   - name: datadog-for-cloudfoundry
-    version: 0.0.1483718504
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.0.1483718504.tgz
-    sha1: 8ddc55b0e4f7fd483ce83c984affc8f9edf47646
+    version: 0.1.6
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.1.6.tgz
+    sha1: 639f123a36869fcb23aaefafd8133a508b20befd
   - name: ipsec
     version: 0.1.1
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/ipsec-0.1.1.tgz


### PR DESCRIPTION
## What

8e06c54 should not have been merged to master as it points to a development release. This commit updates it to point to the final datadog boshrelease.

## How to review

Check the release URL is valid & hash is correct, if you must.

## Who can review

Not @jonty.
