### PR TITLE
[#136783629] Send router ELB traffic to HAProxy SSL port #2

### DIFF
--- a/terraform/cloudfoundry/router_elb.tf
+++ b/terraform/cloudfoundry/router_elb.tf
@@ -27,8 +27,8 @@ resource "aws_elb" "cf_router" {
   }
 
   listener {
-    instance_port      = 81
-    instance_protocol  = "tcp"
+    instance_port      = 443
+    instance_protocol  = "ssl"
     lb_port            = 443
     lb_protocol        = "ssl"
     ssl_certificate_id = "${var.apps_domain_cert_arn}"
@@ -48,5 +48,5 @@ resource "aws_lb_ssl_negotiation_policy" "cf_router" {
 
 resource "aws_proxy_protocol_policy" "http_haproxy" {
   load_balancer  = "${aws_elb.cf_router.name}"
-  instance_ports = ["81"]
+  instance_ports = ["443"]
 }


### PR DESCRIPTION
## What

Story: [How do encrypt traffic between the elb and gorouter using haproxy](https://www.pivotaltracker.com/story/show/136783629)

As part of DIT onboarding, we want to encrypt all communications.

This PR follows https://github.com/alphagov/paas-cf/pull/713 and changes the backend port on the ELB to use this HAProxy SSL port.

## How to review
* Rebase `136783629_enable_ssl_haproxy_2` on `136783629_enable_ssl_haproxy` branch in a temporary branch
* Deploy from the temporary branch
* Make sure there is no unencrypted traffic between ELB and HAProxy (port 443)
* Make sure all tests pass

## Before merging
* Merge https://github.com/alphagov/paas-cf/pull/713
* Rebase `136783629_enable_ssl_haproxy_2` on `master`
* Merge

## Who can review
Not @keymon or me
