### PR TITLE
[#136550911] Reintroduce CVE monitor

### DIFF
--- a/terraform/datadog/cve.tf
+++ b/terraform/datadog/cve.tf
@@ -1,0 +1,19 @@
+resource "datadog_monitor" "cve-reporter" {
+  count = "${var.enable_cve_monitor}"
+
+  name    = "${format("%s New CVE Reported", var.env)}"
+  type    = "event alert"
+  message = "${format("{{#is_alert}}Check https://government-paas-team-manual.readthedocs.io/en/latest/team/responding_to_security_issues/ for instructions @%s{{/is_alert}}", var.support_email)}"
+  query   = "events('sources:feed priority:all status:info tags:cve,service:pivotal').rollup('count').last('5m') >= 1"
+
+  thresholds {
+    ok       = "1"
+    warning  = "1"
+    critical = "1"
+  }
+
+  tags {
+    "deployment" = "${var.env}"
+    "service"    = "${var.env}_monitors"
+  }
+}

--- a/terraform/datadog/variables.tf
+++ b/terraform/datadog/variables.tf
@@ -7,3 +7,8 @@ variable "support_email" {
   description = "DeskPro email address"
   default     = "govpaas-alerting-dev@digital.cabinet-office.gov.uk"
 }
+
+variable "enable_cve_monitor" {
+  description = "Enable CVE monitor: 1 to enable, 0 to disable"
+  default     = 0
+}

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -10,3 +10,4 @@ tenant_cidrs = "52.19.165.178/32,52.49.20.243/32,52.18.106.146/32,52.212.106.102
 bosh_db_backup_retention_period = "35"
 bosh_db_skip_final_snapshot = "false"
 support_email="gov-uk-paas-support@digital.cabinet-office.gov.uk"
+enable_cve_monitor=1


### PR DESCRIPTION
## What
Story: [Review & improve CF CVE notifications](https://www.pivotaltracker.com/story/show/136550911)

Reintroduce the datadog CVE monitor, based on the RSS feed from cloudfoundry.

## How to review
This branch has `[TEMP]` commits to help with review. Update if required and delete after testing.
* Update email in commit `[TEMP] Send to test email address`
* Deploy (no need to enable datadog)
* Send a test event:

```
$ export DD_API_KEY=$(gov-pass datadog/dev/datadog_api_key)
$ curl  -X POST -H "Content-type: application/json" \
-d '{
      "title": "CVE-2016-1234: Cloud Foundry is not so secure",
      "text": "Bla bla bla bla bla",
      "priority": "normal",
      "tags": ["service:pivotal"],
      "alert_type": "info",
      "source_type_name": "feed"
  }' \
"https://app.datadoghq.com/api/v1/events?api_key=${DD_API_KEY}"
```
* Take note of the event id
* An event should be created in datadog
* The monitor `New CVE Reported` should trigger after 1 min
* You should receive an email
* The monitor `New CVE Reported` should resolve after 5 min
* You should NOT receive a new email
* Delete the event:

```
$ export DD_API_KEY=$(gov-pass datadog/dev/datadog_api_key)
$ export DD_APP_KEY=$(gov-pass datadog/dev/datadog_app_key)
$ export event_id=1234567890
$ curl -X DELETE "https://app.datadoghq.com/api/v1/events/${event_id}?api_key=${DD_API_KEY}&application_key=${DD_APP_KEY}"
```
* Deploy from master to clear the monitors

## Before merging
Delete the `[TEMP]` commits

## Who can review
Not me
