### PR TITLE
[#136725001] Add plans with Storage Encryption enabled

### DIFF
--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -6,6 +6,7 @@ meta:
       storage_type: "gp2"
       auto_minor_version_upgrade: true
       multi_az: false
+      storage_encrypted: false
       publicly_accessible: false
       copy_tags_to_snapshot: true
       skip_final_snapshot: false
@@ -151,6 +152,24 @@ jobs:
                     inject: (( inject meta.rds_broker.medium_postgres_rds_properties ))
                     multi_az: true
 
+                - id: "8d50ccc5-707c-4306-be8f-f59a158eb736"
+                  name: "M-HA-enc-dedicated-9.5"
+                  description: "20GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.large."
+                  free: false
+                  metadata:
+                    costs:
+                      - amount:
+                          usd: 0.402
+                        unit: "HOUR"
+                    bullets:
+                      - "Dedicated Postgres 9.5 server"
+                      - "Storage Encrypted"
+                      - "AWS RDS"
+                  rds_properties:
+                    inject: (( inject meta.rds_broker.medium_postgres_rds_properties ))
+                    multi_az: true
+                    storage_encrypted: true
+
                 - id: "238a1328-4f77-4b70-9bd9-2cdbbfb999c8"
                   name: "L-dedicated-9.5"
                   description: "20GB Storage, Dedicated Instance, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.2xlarge."
@@ -181,6 +200,24 @@ jobs:
                   rds_properties:
                     inject: (( inject meta.rds_broker.large_postgres_rds_properties ))
                     multi_az: true
+
+                - id: "620055b3-fe7c-46fc-87ad-c7d8f4fe7f34"
+                  name: "L-HA-enc-dedicated-9.5"
+                  description: "20GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.2xlarge."
+                  free: false
+                  metadata:
+                    costs:
+                      - amount:
+                          usd: 1.612
+                        unit: "HOUR"
+                    bullets:
+                      - "Dedicated Postgres 9.5 server"
+                      - "Storage Encrypted"
+                      - "AWS RDS"
+                  rds_properties:
+                    inject: (( inject meta.rds_broker.large_postgres_rds_properties ))
+                    multi_az: true
+                    storage_encrypted: true
 properties:
   cc:
     security_group_definitions:

--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -29,9 +29,9 @@ meta:
 
 releases:
   - name: rds-broker
-    version: 0.1.1
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.1.tgz
-    sha1: 7c5261a2946c14c7beea5ce7129315c1a447613e
+    version: 0.1.2
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.2.tgz
+    sha1: f111152713d00d884d4d9bdb28f96778d3016e50
 
 jobs:
   - name: rds_broker

--- a/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "RDS broker properties" do
 
       it "contains only specific plans" do
         pg_plan_names = pg_plans.map { |p| p["name"] }
-        expect(pg_plan_names).to contain_exactly("Free", "S-dedicated-9.5", "S-HA-dedicated-9.5", "M-dedicated-9.5", "M-HA-dedicated-9.5", "L-dedicated-9.5", "L-HA-dedicated-9.5")
+        expect(pg_plan_names).to contain_exactly("Free", "S-dedicated-9.5", "S-HA-dedicated-9.5", "M-dedicated-9.5", "M-HA-dedicated-9.5", "M-HA-enc-dedicated-9.5", "L-dedicated-9.5", "L-HA-dedicated-9.5", "L-HA-enc-dedicated-9.5")
       end
 
       describe "plan rds_properties" do
@@ -167,71 +167,99 @@ RSpec.describe "RDS broker properties" do
           it { expect(rds_properties).to include("multi_az" => false) }
         end
 
+        shared_examples "Encryption disabled plans" do
+          let(:rds_properties) { subject.fetch("rds_properties") }
+          it { expect(rds_properties).to include("storage_encrypted" => false) }
+        end
+
+        shared_examples "Encryption enabled plans" do
+          let(:rds_properties) { subject.fetch("rds_properties") }
+          it { expect(rds_properties).to include("storage_encrypted" => true) }
+        end
+
         describe "S-dedicated-9.5" do
-          let(:plan) { pg_plans.find { |p| p["name"] == "S-dedicated-9.5" } }
-          subject { plan }
+          subject { pg_plans.find { |p| p["name"] == "S-dedicated-9.5" } }
 
           it_behaves_like "small sized postgres plans"
           it_behaves_like "backup enabled plans"
           it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption disabled plans"
         end
 
         describe "S-HA-dedicated-9.5" do
-          let(:plan) { pg_plans.find { |p| p["name"] == "S-HA-dedicated-9.5" } }
-          subject { plan }
+          subject { pg_plans.find { |p| p["name"] == "S-HA-dedicated-9.5" } }
 
           it_behaves_like "small sized postgres plans"
           it_behaves_like "backup enabled plans"
           it_behaves_like "HA plans"
+          it_behaves_like "Encryption disabled plans"
         end
 
         describe "M-dedicated-9.5" do
-          let(:plan) { pg_plans.find { |p| p["name"] == "M-dedicated-9.5" } }
-          subject { plan }
+          subject { pg_plans.find { |p| p["name"] == "M-dedicated-9.5" } }
 
           it_behaves_like "medium sized postgres plans"
           it_behaves_like "backup enabled plans"
           it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption disabled plans"
         end
 
         describe "M-HA-dedicated-9.5" do
-          let(:plan) { pg_plans.find { |p| p["name"] == "M-HA-dedicated-9.5" } }
-          subject { plan }
+          subject { pg_plans.find { |p| p["name"] == "M-HA-dedicated-9.5" } }
 
           it_behaves_like "medium sized postgres plans"
           it_behaves_like "backup enabled plans"
           it_behaves_like "HA plans"
+          it_behaves_like "Encryption disabled plans"
+        end
+
+        describe "M-HA-enc-dedicated-9.5" do
+          subject { pg_plans.find { |p| p["name"] == "M-HA-enc-dedicated-9.5" } }
+
+          it_behaves_like "medium sized postgres plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "HA plans"
+          it_behaves_like "Encryption enabled plans"
         end
 
         describe "L-dedicated-9.5" do
-          let(:plan) { pg_plans.find { |p| p["name"] == "L-dedicated-9.5" } }
-          subject { plan }
+          subject { pg_plans.find { |p| p["name"] == "L-dedicated-9.5" } }
 
           it_behaves_like "large sized postgres plans"
           it_behaves_like "backup enabled plans"
           it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption disabled plans"
         end
 
         describe "L-HA-dedicated-9.5" do
-          let(:plan) { pg_plans.find { |p| p["name"] == "L-HA-dedicated-9.5" } }
-          subject { plan }
+          subject { pg_plans.find { |p| p["name"] == "L-HA-dedicated-9.5" } }
 
           it_behaves_like "large sized postgres plans"
           it_behaves_like "backup enabled plans"
           it_behaves_like "HA plans"
+          it_behaves_like "Encryption disabled plans"
+        end
+
+        describe "L-HA-enc-dedicated-9.5" do
+          subject { pg_plans.find { |p| p["name"] == "L-HA-enc-dedicated-9.5" } }
+
+          it_behaves_like "large sized postgres plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "HA plans"
+          it_behaves_like "Encryption enabled plans"
         end
 
         describe "free plan" do
-          let(:plan) { pg_plans.find { |p| p["name"] == "Free" } }
-          subject { plan }
+          subject { pg_plans.find { |p| p["name"] == "Free" } }
 
           it "is marked as free" do
-            expect(plan.fetch("free")).to eq(true)
+            expect(subject.fetch("free")).to eq(true)
           end
 
           it_behaves_like "free sized postgres plans"
           it_behaves_like "backup disabled plans"
           it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption disabled plans"
         end
       end
     end

--- a/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
@@ -105,6 +105,15 @@ RSpec.describe "RDS broker properties" do
           it { expect(rds_properties).to include("db_instance_class" => "db.t2.micro") }
         end
 
+        shared_examples "small sized postgres plans" do
+          it_behaves_like "all postgres plans"
+
+          let(:rds_properties) { subject.fetch("rds_properties") }
+
+          it { expect(rds_properties).to include("allocated_storage" => 20) }
+          it { expect(rds_properties).to include("db_instance_class" => "db.t2.small") }
+        end
+
         shared_examples "medium sized postgres plans" do
           it_behaves_like "all postgres plans"
 
@@ -112,6 +121,15 @@ RSpec.describe "RDS broker properties" do
 
           it { expect(rds_properties).to include("allocated_storage" => 20) }
           it { expect(rds_properties).to include("db_instance_class" => "db.m4.large") }
+        end
+
+        shared_examples "large sized postgres plans" do
+          it_behaves_like "all postgres plans"
+
+          let(:rds_properties) { subject.fetch("rds_properties") }
+
+          it { expect(rds_properties).to include("allocated_storage" => 20) }
+          it { expect(rds_properties).to include("db_instance_class" => "db.m4.2xlarge") }
         end
 
         shared_examples "backup enabled plans" do
@@ -149,6 +167,24 @@ RSpec.describe "RDS broker properties" do
           it { expect(rds_properties).to include("multi_az" => false) }
         end
 
+        describe "S-dedicated-9.5" do
+          let(:plan) { pg_plans.find { |p| p["name"] == "S-dedicated-9.5" } }
+          subject { plan }
+
+          it_behaves_like "small sized postgres plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "non-HA plans"
+        end
+
+        describe "S-HA-dedicated-9.5" do
+          let(:plan) { pg_plans.find { |p| p["name"] == "S-HA-dedicated-9.5" } }
+          subject { plan }
+
+          it_behaves_like "small sized postgres plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "HA plans"
+        end
+
         describe "M-dedicated-9.5" do
           let(:plan) { pg_plans.find { |p| p["name"] == "M-dedicated-9.5" } }
           subject { plan }
@@ -163,6 +199,24 @@ RSpec.describe "RDS broker properties" do
           subject { plan }
 
           it_behaves_like "medium sized postgres plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "HA plans"
+        end
+
+        describe "L-dedicated-9.5" do
+          let(:plan) { pg_plans.find { |p| p["name"] == "L-dedicated-9.5" } }
+          subject { plan }
+
+          it_behaves_like "large sized postgres plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "non-HA plans"
+        end
+
+        describe "L-HA-dedicated-9.5" do
+          let(:plan) { pg_plans.find { |p| p["name"] == "L-HA-dedicated-9.5" } }
+          subject { plan }
+
+          it_behaves_like "large sized postgres plans"
           it_behaves_like "backup enabled plans"
           it_behaves_like "HA plans"
         end

--- a/platform-tests/src/acceptance/rds_broker_test.go
+++ b/platform-tests/src/acceptance/rds_broker_test.go
@@ -91,15 +91,15 @@ var _ = Describe("RDS broker", func() {
 			pollForRDSDeletionCompletion(dbInstanceName)
 		})
 
-		It("can connect to the DB instance from the app", func() {
-			By("Sending request to DB Healthcheck app")
+		It("binds a DB instance to the Healthcheck app that matches our criteria", func() {
+			By("allowing connections from the Healthcheck app")
 			resp, err := httpClient.Get(helpers.AppUri(appName, "/db"))
 			Expect(err).NotTo(HaveOccurred())
 			body, err := ioutil.ReadAll(resp.Body)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(200), "Got %d response from healthcheck app. Response body:\n%s\n", resp.StatusCode, string(body))
 
-			By("Sending request to DB Healthcheck app without TLS")
+			By("disallowing connections from the Healthcheck app without TLS")
 			resp, err = httpClient.Get(helpers.AppUri(appName, "/db?ssl=false"))
 			Expect(err).NotTo(HaveOccurred())
 			body, err = ioutil.ReadAll(resp.Body)
@@ -107,7 +107,7 @@ var _ = Describe("RDS broker", func() {
 			Expect(resp.StatusCode).NotTo(Equal(200), "Got %d response from healthcheck app. Response body:\n%s\n", resp.StatusCode, string(body))
 			Expect(body).To(MatchRegexp("no pg_hba.conf entry for .* SSL off"), "Connection without TLS did not report a TLS error")
 
-			By("Testing permissions after unbind and rebind")
+			By("keeping the right permissions after unbind and rebind")
 			resp, err = httpClient.Get(helpers.AppUri(appName, "/db/permissions-check?phase=setup"))
 			Expect(err).NotTo(HaveOccurred())
 			body, err = ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
[#136725001 Enable at rest encryption for broker created RDS DB instances](https://www.pivotaltracker.com/n/projects/1275640/stories/136725001)

What?
-----

We want provide the option of provision DBs with Storage Encription enabled. This is a requirement for DIT onboarding.

At rest encryption has been mentioned as a good thing to turn on by our AWS account manager.

As explained in the ADR: https://github.com/alphagov/paas-team-manual/pull/88 , we decided to provide additional explicit plans with Encryption enabled, and keep the old ones. We will add logic in the broker to prevent updates between plans with or without encryption. We only add to the HA plans, as removing plans later is painful.

In this PR we add two plans based on the Medium and Large HA plans.

We upgrade the RDS broker to ensure that it is not possible update between plans with/without encryption. We check that the manifest defined plans enable/disable the encryption as expected.

Dependencies
------------

 - Related: https://github.com/alphagov/paas-team-manual/pull/88
 - Must be merged first and this PR updated: https://github.com/alphagov/paas-rds-broker/pull/34 https://github.com/alphagov/paas-rds-broker-boshrelease/pull/28

How to review
---------

 - Code review
 - Travis should pass
 - Create a DB in a encrypted and other in un-encrypted plans.
 - Check the settings in aws RDS.
 - Try to update between plans with/without: should fail
 - Try to update within plans with and without: should work

Who?
----

Anyone but @keymon