### PR TITLE
[#136100681] Add Postgres DB for BBS

### DIFF
--- a/manifests/cf-manifest/cloud-config/021-cf-vm-extensions.yml
+++ b/manifests/cf-manifest/cloud-config/021-cf-vm-extensions.yml
@@ -6,3 +6,9 @@ vm_extensions:
     cloud_properties:
       elbs:
         - (( grab terraform_outputs.cf_ssh_proxy_elb_name ))
+
+  - name: cf_rds_client
+    cloud_properties:
+      security_groups:
+        - (( grab terraform_outputs.default_security_group ))
+        - (( grab terraform_outputs.cf_rds_client_security_group ))

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -220,6 +220,8 @@ jobs:
       - name: cf
     update:
       serial: true
+    vm_extensions:
+      - cf_rds_client
 
   - name: uaa
     azs: [z1, z2]

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -511,6 +511,9 @@ properties:
         client_cert: (( grab secrets.consul_agent_cert ))
         client_key: (( grab secrets.consul_agent_key ))
         require_ssl: false
+      sql:
+        db_connection_string: (( concat "postgres://bbs:" secrets.cf_db_bbs_password "@" terraform_outputs.cf_db_address ":5432/bbs" ))
+        db_driver: postgres
       dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
       require_ssl: true
 

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -514,6 +514,7 @@ properties:
       sql:
         db_connection_string: (( concat "postgres://bbs:" secrets.cf_db_bbs_password "@" terraform_outputs.cf_db_address ":5432/bbs" ))
         db_driver: postgres
+        max_open_connections: 20
       dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
       require_ssl: true
 

--- a/manifests/cf-manifest/scripts/create-cf-dbs.sh
+++ b/manifests/cf-manifest/scripts/create-cf-dbs.sh
@@ -5,6 +5,7 @@ set -e
 export PGPASSWORD=${TF_VAR_secrets_cf_db_master_password:?}
 api_pass=${TF_VAR_secrets_cf_db_api_password:?}
 uaa_pass=${TF_VAR_secrets_cf_db_uaa_password:?}
+bbs_pass=${TF_VAR_secrets_cf_db_bbs_password:?}
 db_address=${TF_VAR_cf_db_address:?}
 
 # See: https://github.com/koalaman/shellcheck/wiki/SC2086#exceptions
@@ -18,11 +19,15 @@ psql_adm -d postgres -c "SELECT rolname FROM pg_roles WHERE rolname = 'api'" \
 psql_adm -d postgres -c "SELECT rolname FROM pg_roles WHERE rolname = 'uaa'" \
   | grep -q 'uaa' || psql_adm -d postgres -c "CREATE USER uaa WITH ROLE dbadmin"
 
+psql_adm -d postgres -c "SELECT rolname FROM pg_roles WHERE rolname = 'bbs'" \
+  | grep -q 'bbs' || psql_adm -d postgres -c "CREATE USER bbs WITH ROLE dbadmin"
+
 # Always update passwords
 psql_adm -d postgres -c "ALTER USER api WITH PASSWORD '${api_pass}'"
 psql_adm -d postgres -c "ALTER USER uaa WITH PASSWORD '${uaa_pass}'"
+psql_adm -d postgres -c "ALTER USER bbs WITH PASSWORD '${bbs_pass}'"
 
-for db in api uaa; do
+for db in api uaa bbs; do
 
   # Create database
   psql_adm -d postgres -l | grep -q " ${db} " || \

--- a/manifests/cf-manifest/scripts/generate-cf-secrets.rb
+++ b/manifests/cf-manifest/scripts/generate-cf-secrets.rb
@@ -9,6 +9,7 @@ generator = SecretGenerator.new(
   "cf_db_master_password" => :simple,
   "cf_db_api_password" => :simple,
   "cf_db_uaa_password" => :simple,
+  "cf_db_bbs_password" => :simple,
   "staging_upload_password" => :simple,
   "bulk_api_password" => :simple,
   "nats_password" => :simple,


### PR DESCRIPTION
# What

Story: [Migrate Diego to use a Relational Datastore](https://www.pivotaltracker.com/story/show/136100681)

Create a new RDS DB for BBS and configure BBS to use it.

Triggers the data from ETCD to be migrated to the DB.

# How to review
* Deploy from master
* Deploy from the branch
* The migration takes a few minutes when the database VM is being updated
* Check for `bbs.migration-manager.finished-migrations` in BBS log. If you use logsearch, look for `migrations`.
* Check for lrps in BBS DB ([see comment](https://github.com/alphagov/paas-cf/pull/721#issuecomment-273091264) on where to run this from):
`psql -d bbs -h "${db_address}" -U bbs -W -c 'select * from actual_lrps '`
* Check via `cfdot` by `bosh ssh database/0` and running `source /var/vcap/jobs/cfdot/bin/setup && cfdot desired-lrps`
* Check all tests pass

# Who can review
Not @combor or me