### PR TITLE
[#136100681] Remove ETCD configuration for BBS

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -506,10 +506,10 @@ properties:
       auctioneer:
         api_url: http://auctioneer.service.cf.internal:9016
       etcd:
-        machines: [(( grab properties.etcd.advertise_urls_dns_suffix ))]
-        ca_cert: (( grab meta.secrets.consul_ca_cert ))
-        client_cert: (( grab secrets.consul_agent_cert ))
-        client_key: (( grab secrets.consul_agent_key ))
+        machines: []
+        ca_cert: ""
+        client_cert: ""
+        client_key: ""
         require_ssl: false
       sql:
         db_connection_string: (( concat "postgres://bbs:" secrets.cf_db_bbs_password "@" terraform_outputs.cf_db_address ":5432/bbs" ))


### PR DESCRIPTION
⚠️  Depends on PR https://github.com/alphagov/paas-cf/pull/721 ⚠️ 

# What

Story: [Migrate Diego to use a Relational Datastore](https://www.pivotaltracker.com/story/show/136100681)

BBS has now migrated to postgres, we don't need ETCD anymore.

# How to review
* After https://github.com/alphagov/paas-cf/pull/721 is merged, rebase this branch on master
* Deploy from master
* Make sure all tests pass

# Who can review
Not @combor or me
