### PR TITLE
Change user facing email address in user scripts

### DIFF
--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -9,7 +9,7 @@ source "${SCRIPT_DIR}/common.sh"
 ###########################################################################
 # Defaults
 DEFAULT_SPACE=sandbox
-FROM_ADDRESS='the-multi-cloud-paas-team@digital.cabinet-office.gov.uk'
+FROM_ADDRESS='gov-uk-paas-support@digital.cabinet-office.gov.uk'
 # shellcheck disable=SC2016
 SUBJECT='Welcome to the Government PaaS'
 # shellcheck disable=SC2016,SC1078

--- a/scripts/rotate-user-password.sh
+++ b/scripts/rotate-user-password.sh
@@ -6,7 +6,7 @@ SCRIPT=$(basename "$0")
 # shellcheck disable=SC1090
 source "${SCRIPT_DIR}/common.sh"
 
-FROM_ADDRESS='the-multi-cloud-paas-team@digital.cabinet-office.gov.uk'
+FROM_ADDRESS='gov-uk-paas-support@digital.cabinet-office.gov.uk'
 SUBJECT='Government PaaS Password Reset Request'
 # shellcheck disable=SC2016
 MESSAGE='Hello,


### PR DESCRIPTION
## What

When we create a user or rotate their password, we want to send email from
the support address, so that when they respond, it goes to support and there
is someone to deal with it.

## How to review

You can try creating users or rotating some passwords. Either create a dummy user or you can even rotate your own PW. **NEVER rotate PWs of other people** unless requested! Or you can trust me. You can also check that the support address is now verified: `aws ses get-identity-verification-attributes --identities gov-uk-paas-support@digital.cabinet-office.gov.uk`

## Who can review

not @mtekel
