### PR TITLE
[#137698283] CF manifest tests cleanup

### DIFF
--- a/manifests/cf-manifest/spec/cloud-config/compilation_spec.rb
+++ b/manifests/cf-manifest/spec/cloud-config/compilation_spec.rb
@@ -1,18 +1,16 @@
 
 RSpec.describe "compilation" do
-  let(:manifest) { manifest_with_defaults }
-
   it "is defined" do
-    expect(manifest["compilation"]).not_to be_empty
+    expect(cloud_config["compilation"]).not_to be_empty
   end
 
   it "references an existing AZ" do
-    az_list = manifest["azs"].map { |az| az["name"] }
-    expect(az_list).to include(manifest["compilation"]["az"])
+    az_list = cloud_config["azs"].map { |az| az["name"] }
+    expect(az_list).to include(cloud_config["compilation"]["az"])
   end
 
   it "references an existing vm_type" do
-    vm_type_list = manifest["vm_types"].map { |az| az["name"] }
-    expect(vm_type_list).to include(manifest["compilation"]["vm_type"])
+    vm_type_list = cloud_config["vm_types"].map { |az| az["name"] }
+    expect(vm_type_list).to include(cloud_config["compilation"]["vm_type"])
   end
 end

--- a/manifests/cf-manifest/spec/cloud-config/networks_spec.rb
+++ b/manifests/cf-manifest/spec/cloud-config/networks_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "networks" do
     router
   ).freeze
 
-  let(:networks) { manifest_with_defaults.fetch("networks") }
+  let(:networks) { cloud_config.fetch("networks") }
 
   CF_NETWORK_NAMES.each do |net_name|
     describe "#{net_name} network" do

--- a/manifests/cf-manifest/spec/cloud-config/vm_types_spec.rb
+++ b/manifests/cf-manifest/spec/cloud-config/vm_types_spec.rb
@@ -1,6 +1,6 @@
 
 RSpec.describe "vm_types" do
-  let(:vm_types) { manifest_with_defaults.fetch("vm_types") }
+  let(:vm_types) { cloud_config.fetch("vm_types") }
 
   describe "the router pool" do
     let(:pool) { vm_types.find { |p| p["name"] == "router" } }

--- a/manifests/cf-manifest/spec/manifest/secret_generation_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/secret_generation_spec.rb
@@ -2,30 +2,12 @@ require 'tempfile'
 
 RSpec.describe "secret generation" do
   describe "generate-cf-secrets" do
-    let(:script) {
-      File.expand_path("../../../scripts/generate-cf-secrets.rb", __FILE__)
-    }
-
     specify "it should produce lint-free YAML" do
-      yaml, error, status = Open3.capture3(script)
-      expect(status).to be_success, "script exited #{status.exitstatus}, stderr:\n#{error}"
-      expect(yaml).to_not be_empty
-
-      tempfile = Tempfile.new('yamllint')
-      begin
-        tempfile.write(yaml)
-        tempfile.close
-
-        output, status = Open3.capture2e(
-          [
-            'yamllint',
-            '-c', File.expand_path("../../../../../yamllint.yml", __FILE__),
-            tempfile.path,
-          ].join(' ')
-        )
-      ensure
-        tempfile.unlink
-      end
+      output, status = Open3.capture2e(*[
+        'yamllint',
+        '-c', File.expand_path("../../../../../yamllint.yml", __FILE__),
+        cf_secrets_file,
+      ])
 
       expect(status).to be_success, "yamllint exited #{status.exitstatus}, output:\n#{output}"
       expect(output).to be_empty


### PR DESCRIPTION
## What

This is a follow-up to #724:

Now that we're generating the secrets for the tests, there's no need to separately generate them for the yaml lint check.

I've taken the opportunity to separate the cloud-config from the manifest in the tests to make it clearer what comes from where.

## How to review

Code review. Verify tests pass in travis.

## Who can review

Anyone but myself.