### PR TITLE
[#119089085] Private graphite SG

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1396,8 +1396,7 @@ jobs:
                   ]
                   EOF
                   cf create-security-group graphite-nozzle graphite-nozzle.json
-                  cf bind-staging-security-group graphite-nozzle
-                  cf bind-running-security-group graphite-nozzle
+                  cf bind-security-group graphite-nozzle admin admin
 
                   cd graphite-nozzle
 

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1398,6 +1398,10 @@ jobs:
                   cf create-security-group graphite-nozzle graphite-nozzle.json
                   cf bind-security-group graphite-nozzle admin admin
 
+                  #FIXME: remove after applied to prod
+                  cf unbind-staging-security-group graphite-nozzle
+                  cf unbind-running-security-group graphite-nozzle
+
                   cd graphite-nozzle
 
                   echo "web: graphite-nozzle" > Procfile


### PR DESCRIPTION
## What

[Restrict graphite access to the graphite-nozzle app only](https://www.pivotaltracker.com/n/projects/1275640/stories/119089085)

Make graphite nozzle SG available only to admin/admin org/space, where the graphite nozzle lives.

## How to review

Checkout branch. Make dev pipelines. If you are on recent master, just run cf-deploy job: `JOB=cf-deploy make dev run_job`. Observe graphite-nozzle SG being added only to admin/admin org/space and removed from globals. Run the job again to confirm it's idempotent. Confirm you still get CF metrics by e.g. going to graphite or grafana and viewing any cf metric.

Create a test user `cf create-user test testtest`. Make them admin of e.g. testers. Log in as this user. Verify that you can't see graphite-nozzle SG.

## Who can review

not @mtekel
