### PR TITLE
[#119089085] Stop graphite nozzle sg cleanup

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1398,10 +1398,6 @@ jobs:
                   cf create-security-group graphite-nozzle graphite-nozzle.json
                   cf bind-security-group graphite-nozzle admin admin
 
-                  #FIXME: remove after applied to prod
-                  cf unbind-staging-security-group graphite-nozzle
-                  cf unbind-running-security-group graphite-nozzle
-
                   cd graphite-nozzle
 
                   echo "web: graphite-nozzle" > Procfile


### PR DESCRIPTION
## What

After #727 is merged and applied, we no longer need to keep unbinding the graphite nozzle sg. This PR fixes that.

## How to review

Checkout, make dev pipelines, run cf-deploy job, observe that graphite-nozzle group is no longer being removed from global running and staging SGs.

## Who can review

not @mtekel