### PR TITLE
[Support] Whitelist notify IPs

### DIFF
--- a/terraform/bosh-lite/bosh-lite_security_groups.tf
+++ b/terraform/bosh-lite/bosh-lite_security_groups.tf
@@ -14,14 +14,14 @@ resource "aws_security_group" "bosh_lite_office" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["${compact(concat(split(",", var.admin_cidrs)))}"]
+    cidr_blocks = ["${compact(concat(var.admin_cidrs))}"]
   }
 
   ingress {
     from_port   = 25555
     to_port     = 25555
     protocol    = "tcp"
-    cidr_blocks = ["${compact(concat(split(",", var.admin_cidrs)))}"]
+    cidr_blocks = ["${compact(concat(var.admin_cidrs))}"]
   }
 
   tags {

--- a/terraform/cloudfoundry/logsearch.tf
+++ b/terraform/cloudfoundry/logsearch.tf
@@ -179,7 +179,7 @@ resource "aws_security_group" "logsearch_elb" {
     protocol  = "tcp"
 
     cidr_blocks = [
-      "${compact(split(",", var.admin_cidrs))}",
+      "${compact(var.admin_cidrs)}",
     ]
   }
 

--- a/terraform/cloudfoundry/security-groups.tf
+++ b/terraform/cloudfoundry/security-groups.tf
@@ -26,8 +26,8 @@ resource "aws_security_group" "cf_api_elb" {
     protocol  = "tcp"
 
     cidr_blocks = [
-      "${compact(split(",", var.admin_cidrs))}",
-      "${compact(split(",", var.tenant_cidrs))}",
+      "${compact(var.admin_cidrs)}",
+      "${compact(var.tenant_cidrs)}",
       "${var.concourse_elastic_ip}/32",
       "${formatlist("%s/32", aws_eip.cf.*.public_ip)}",
     ]
@@ -56,7 +56,7 @@ resource "aws_security_group" "metrics_elb" {
     protocol  = "tcp"
 
     cidr_blocks = [
-      "${compact(split(",", var.admin_cidrs))}",
+      "${compact(var.admin_cidrs)}",
     ]
   }
 
@@ -66,7 +66,7 @@ resource "aws_security_group" "metrics_elb" {
     protocol  = "tcp"
 
     cidr_blocks = [
-      "${compact(split(",", var.admin_cidrs))}",
+      "${compact(var.admin_cidrs)}",
     ]
   }
 
@@ -93,9 +93,9 @@ resource "aws_security_group" "web" {
     protocol  = "tcp"
 
     cidr_blocks = [
-      "${compact(split(",", var.admin_cidrs))}",
-      "${compact(split(",", var.tenant_cidrs))}",
-      "${compact(split(",", var.web_access_cidrs))}",
+      "${compact(var.admin_cidrs)}",
+      "${compact(var.tenant_cidrs)}",
+      "${compact(var.web_access_cidrs)}",
       "${var.concourse_elastic_ip}/32",
       "${formatlist("%s/32", aws_eip.cf.*.public_ip)}",
     ]
@@ -124,8 +124,8 @@ resource "aws_security_group" "sshproxy" {
     protocol  = "tcp"
 
     cidr_blocks = [
-      "${compact(split(",", var.admin_cidrs))}",
-      "${compact(split(",", var.tenant_cidrs))}",
+      "${compact(var.admin_cidrs)}",
+      "${compact(var.tenant_cidrs)}",
       "${var.concourse_elastic_ip}/32",
     ]
   }

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -98,20 +98,25 @@ variable "microbosh_static_private_ip" {
 
 /* Operators will mainly be from the office. See https://sites.google.com/a/digital.cabinet-office.gov.uk/gds-internal-it/news/aviationhouse-sourceipaddresses for details. */
 variable "admin_cidrs" {
-  description = "CSV of CIDR addresses with access to operator/admin endpoints"
-  default     = "80.194.77.90/32,80.194.77.100/32,85.133.67.244/32"
+  description = "List of CIDR addresses with access to operator/admin endpoints"
+
+  default = [
+    "80.194.77.90/32",
+    "80.194.77.100/32",
+    "85.133.67.244/32",
+  ]
 }
 
 /* Note: This is overridden in prod.tfvars to allow specific tenant access */
 variable "tenant_cidrs" {
-  description = "CSV of CIDR addresses of tenants with access to CloudFoundry API"
-  default     = ""
+  description = "List of CIDR addresses of tenants with access to CloudFoundry API"
+  default     = []
 }
 
 /* Note: This is overridden in prod.tfvars to allow world access */
 variable "web_access_cidrs" {
-  description = "CSV of CIDR addresses with access to "
-  default     = ""
+  description = "List of CIDR addresses with access to "
+  default     = []
 }
 
 # See https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-policy-table.html

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -35,6 +35,13 @@ tenant_cidrs = [
   "52.214.76.50/32",
   # GOV.UK Pay CI node
   "52.210.67.64/32",
+  # GOV.UK Notify egress IPs (for metrics gathering)
+  "52.209.11.109/32",
+  "52.212.153.196/32",
+  "52.19.155.10/32",
+  "52.213.138.76/32",
+  "52.213.151.67/32",
+  "52.208.47.129/32",
 ]
 bosh_db_backup_retention_period = "35"
 bosh_db_skip_final_snapshot = "false"

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -6,8 +6,36 @@ bosh_db_multi_az = "true"
 cf_db_backup_retention_period = "35"
 cf_db_skip_final_snapshot = "false"
 cf_db_maintenance_window = "Thu:04:00-Thu:05:00"
-web_access_cidrs = "0.0.0.0/0"
-tenant_cidrs = "52.19.165.178/32,52.49.20.243/32,52.18.106.146/32,52.212.106.102/32,37.26.93.212/32,80.194.77.64/26,84.93.121.196/32,195.171.79.218/32,25.8.49.225/32,25.8.49.187/32,52.214.41.17/32,52.214.76.50/32,52.210.67.64/32"
+web_access_cidrs = [
+  "0.0.0.0/0",
+]
+tenant_cidrs = [
+  # BitZesty (trade-tarrif)
+  "52.19.165.178/32",
+  # DIT
+  "52.49.20.243/32",
+  # HMPO trial
+  "52.18.106.146/32",
+  # Usability Jenkins EIP
+  "52.212.106.102/32",
+  # Verify Jenkins server
+  "37.26.93.212/32",
+  # Shockley
+  "80.194.77.64/26",
+  # DWP carers trial
+  "84.93.121.196/32",
+  # DBS team
+  "195.171.79.218/32",
+  # MOD PaaS Trial
+  "25.8.49.225/32",
+  "25.8.49.187/32",
+  # GOV.UK Notify Jenkins server
+  "52.214.41.17/32",
+  # Accessing Government Services team Jenkins server
+  "52.214.76.50/32",
+  # GOV.UK Pay CI node
+  "52.210.67.64/32",
+]
 bosh_db_backup_retention_period = "35"
 bosh_db_skip_final_snapshot = "false"
 support_email="gov-uk-paas-support@digital.cabinet-office.gov.uk"

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -6,7 +6,9 @@ bosh_db_multi_az = "true"
 cf_db_backup_retention_period = "35"
 cf_db_skip_final_snapshot = "false"
 cf_db_maintenance_window = "Wed:04:00-Wed:05:00"
-web_access_cidrs = "0.0.0.0/0"
+web_access_cidrs = [
+  "0.0.0.0/0",
+]
 bosh_db_backup_retention_period = "35"
 bosh_db_skip_final_snapshot = "false"
 support_email="govpaas-alerting-staging@digital.cabinet-office.gov.uk"


### PR DESCRIPTION
## What

Add Notify's egress IPs to the API whitelist so they can gather metrics (Deskpro #3271).

I've taken the opportunity to refactor our CIDR lists to use terraform arrays (thanks to suggestion from @keymon), which makes them much clearer.

## How to review

Code review - verify that the updated list contains the same data as the original list + the 6 new notify IPs.
I've added a `[TMP]` commit to ease testing the new syntax in dev. Deploy to dev and verify that the security group rules look correct.

Remove the `[TMP]` commit before merging.

## Who can review

Anyone but myself.
