### PR TITLE
 [#135948443] Revert pinning of CATS container

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -619,7 +619,6 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/cf-acceptance-tests
-              tag: steal-upstream-cats-image
           inputs:
             - name: paas-cf
             - name: pipeline-trigger
@@ -1871,7 +1870,6 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/cf-acceptance-tests
-                tag: steal-upstream-cats-image
             params:
               DISABLE_CF_ACCEPTANCE_TESTS: {{disable_cf_acceptance_tests}}
             inputs:
@@ -2044,7 +2042,6 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/cf-acceptance-tests
-                tag: steal-upstream-cats-image
             inputs:
               - name: paas-cf
               - name: test-config

--- a/concourse/tasks/custom-acceptance-tests-run.yml
+++ b/concourse/tasks/custom-acceptance-tests-run.yml
@@ -4,7 +4,6 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/cf-acceptance-tests
-    tag: steal-upstream-cats-image
 inputs:
   - name: paas-cf
   - name: test-config

--- a/concourse/tasks/smoke-tests-run.yml
+++ b/concourse/tasks/smoke-tests-run.yml
@@ -4,7 +4,6 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/cf-acceptance-tests
-    tag: steal-upstream-cats-image
 inputs:
   - name: paas-cf
   - name: cf-release


### PR DESCRIPTION
## What

We don't pin our container versions, so in https://github.com/alphagov/paas-cf/pull/735 we had to merge a temporary commit to avoid breaking deployments in our persistent environments when https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/83 gets merged.

## How to review

Merge order:

* https://github.com/alphagov/paas-cf/pull/735 and wait until it is deployed in all environments.
* https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/83
* rebase and merge this pull request.

Review by pinning the latest cf-acceptance-tests and running the pipeline, but you shouldn't have to if you have high confidence the thing pinned in https://github.com/alphagov/paas-cf/pull/735 is the same thing as currently on paas-docker-cloudfoundry-tools master (in Docker Hub).

## Who can review

Anyone but me or @keymon 
