### PR TITLE
[#135224045] Cleanup FIXMEs from CF RDS upgrade.

### DIFF
--- a/terraform/cloudfoundry/cf_rds.tf
+++ b/terraform/cloudfoundry/cf_rds.tf
@@ -29,19 +29,6 @@ resource "aws_security_group" "cf_rds" {
   }
 }
 
-# FIXME: Remove this once the upgrade to 9.5 has applied everywhere.
-resource "aws_db_parameter_group" "cf" {
-  name        = "${var.env}-cf"
-  family      = "postgres9.4"
-  description = "RDS CF Postgres parameter group"
-
-  parameter {
-    apply_method = "pending-reboot"
-    name         = "max_connections"
-    value        = "500"
-  }
-}
-
 resource "aws_db_parameter_group" "cf_pg_9_5" {
   name        = "${var.env}-pg95-cf"
   family      = "postgres9.5"
@@ -68,9 +55,6 @@ resource "aws_db_instance" "cf" {
   skip_final_snapshot        = "${var.cf_db_skip_final_snapshot}"
   vpc_security_group_ids     = ["${aws_security_group.cf_rds.id}"]
   auto_minor_version_upgrade = false
-
-  # FIXME: Remove this once the upgrade to 9.5 has applied everywhere.
-  allow_major_version_upgrade = true
 
   tags {
     Name = "${var.env}-cf"


### PR DESCRIPTION
🚨  **DO NOT MERGE** until the upgrade has applied to all environments - production is scheduled to be applied between 4-5am on Thursday 26th, and any pending dev environments will be applied the following Monday (30th)

## What

The parameter group had to be left in place from the upgrade (#734)
because the upgrade wasn't applied immediately, instead it was applied
in the defined maintenance window for the instance.

Now that the upgrade has been applied, the old parameter group can be
removed.

Similarly, we no longer need to set allow_major_version_upgrade because
the upgrade has completed.

## How to review

Code review.
Verify these changes apply cleanly to a deployed environment.

## Before merging

Verify the upgrade has applied to all environments.

## Who can review

Anyone but myself.
