### PR TITLE
[#137701781] Set up smoke test alerts to PagerDuty using datadog

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,7 @@ gem 'bosh_cli'
 gem 'webmock', "~> 1.24"
 gem 'govuk-lint', "~> 1.2.1"
 gem 'json-minify', '~> 0.0.2'
+
+group :datadog do
+  gem 'dogapi'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
+    dogapi (1.24.0)
+      multi_json
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
@@ -106,7 +108,11 @@ PLATFORMS
 
 DEPENDENCIES
   bosh_cli
+  dogapi
   govuk-lint (~> 1.2.1)
   json-minify (~> 0.0.2)
   rspec (~> 3.3)
   webmock (~> 1.24)
+
+BUNDLED WITH
+   1.13.2

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1507,53 +1507,89 @@ jobs:
 
                   bosh cleanup --all
 
-        - task: datadog-terraform-apply
-          config:
-            platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: governmentpaas/terraform
-            inputs:
-              - name: datadog-tfstate
-              - name: paas-cf
-              - name: config
-            outputs:
-              - name: updated-tfstate
-            params:
-              TF_VAR_env: {{deploy_env}}
-              TF_VAR_datadog_api_key: {{datadog_api_key}}
-              TF_VAR_datadog_app_key: {{datadog_app_key}}
-              TF_VAR_aws_account: {{aws_account}}
-              ENABLE_DATADOG: {{enable_datadog}}
-            run:
-              path: sh
-              args:
-                - -e
-                - -c
-                - |
-                  if [ -n "${TF_VAR_datadog_api_key}" ] && [ -n "${TF_VAR_datadog_app_key}" ] && [ "${ENABLE_DATADOG}" = "false" ]; then
-                    echo "Datadog disabled but keys present, running check cleanup..."
-                    terraform destroy -force \
-                       -state=datadog-tfstate/datadog.tfstate \
-                       -state-out=updated-tfstate/datadog.tfstate \
-                       paas-cf/terraform/datadog
-                    exit 0
-                  fi
+        - do:
+          - task: datadog-terraform-apply
+            config:
+              platform: linux
+              image_resource:
+                type: docker-image
+                source:
+                  repository: governmentpaas/terraform
+              inputs:
+                - name: datadog-tfstate
+                - name: paas-cf
+                - name: config
+              outputs:
+                - name: updated-tfstate
+              params:
+                TF_VAR_env: {{deploy_env}}
+                TF_VAR_datadog_api_key: {{datadog_api_key}}
+                TF_VAR_datadog_app_key: {{datadog_app_key}}
+                TF_VAR_aws_account: {{aws_account}}
+                ENABLE_DATADOG: {{enable_datadog}}
+              run:
+                path: sh
+                args:
+                  - -e
+                  - -c
+                  - |
+                    if [ -n "${TF_VAR_datadog_api_key}" ] && [ -n "${TF_VAR_datadog_app_key}" ] && [ "${ENABLE_DATADOG}" = "false" ]; then
+                      echo "Datadog disabled but keys present, running check cleanup..."
+                      terraform destroy -force \
+                         -state=datadog-tfstate/datadog.tfstate \
+                         -state-out=updated-tfstate/datadog.tfstate \
+                         paas-cf/terraform/datadog
+                      exit 0
+                    fi
 
-                  if [ "${ENABLE_DATADOG}" = "true" ]; then
-                    terraform apply \
-                      -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
-                      -state=datadog-tfstate/datadog.tfstate -state-out=updated-tfstate/datadog.tfstate \
-                      -var-file=config/job_instances.tfvars paas-cf/terraform/datadog
-                  else
-                    echo "Datadog disabled, skipping terraform run..."
-                    cp datadog-tfstate/datadog.tfstate updated-tfstate/datadog.tfstate
-                  fi
-          ensure:
-            put: datadog-tfstate
-            params:
-              file: updated-tfstate/datadog.tfstate
+                    if [ "${ENABLE_DATADOG}" = "true" ]; then
+                      terraform apply \
+                        -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
+                        -state=datadog-tfstate/datadog.tfstate -state-out=updated-tfstate/datadog.tfstate \
+                        -var-file=config/job_instances.tfvars paas-cf/terraform/datadog
+                    else
+                      echo "Datadog disabled, skipping terraform run..."
+                      cp datadog-tfstate/datadog.tfstate updated-tfstate/datadog.tfstate
+                    fi
+            ensure:
+              put: datadog-tfstate
+              params:
+                file: updated-tfstate/datadog.tfstate
+
+          - task: datadog-apply-attributes
+            config:
+              platform: linux
+              image_resource:
+                type: docker-image
+                source:
+                  repository: ruby
+                  tag: 2.2-alpine
+              inputs:
+                - name: datadog-tfstate
+                - name: paas-cf
+              params:
+                TF_VAR_env: {{deploy_env}}
+                TF_VAR_datadog_api_key: {{datadog_api_key}}
+                TF_VAR_datadog_app_key: {{datadog_app_key}}
+                TF_VAR_aws_account: {{aws_account}}
+                ENABLE_DATADOG: {{enable_datadog}}
+              run:
+                path: sh
+                args:
+                  - -e
+                  - -c
+                  - |
+                    # FIXME: Remove this task when https://github.com/zorkian/go-datadog-api/issues/56 is fixed
+                    if [ "${ENABLE_DATADOG}" = "true" ]; then
+                      BUNDLE_GEMFILE=paas-cf/Gemfile bundle install --without=default
+                      echo "Applying require_full_window atributes for monitors that set it to false..."
+                      echo
+                      paas-cf/concourse/scripts/update_monitor_options.rb < datadog-tfstate/datadog.tfstate
+                      echo
+                      echo "Done"
+                    else
+                      echo "Datadog disabled, skipping attribute applying..."
+                    fi
 
         - task: deploy-paas-dashboard
           config:

--- a/concourse/scripts/update_monitor_options.rb
+++ b/concourse/scripts/update_monitor_options.rb
@@ -1,0 +1,54 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require 'dogapi'
+
+tfstate = JSON.load($stdin)
+
+def to_boolean(str)
+  str == 'true'
+end
+
+def find_monitors(tfstate)
+  monitor_ids = Hash.new
+  tfstate['modules'][0]['resources'].each do |_, name|
+    attributes = Hash.new
+    if name["type"] == "datadog_monitor"
+      name["primary"]["attributes"].each do |attribute, value|
+        # Optimise for require_full_window attribute only as others have sane defaults
+        if attribute == "require_full_window" && value == "false"
+          attributes[attribute] = to_boolean(value)
+        end
+      end
+      if attributes != {}
+        monitor_ids[name["primary"]["id"]] = attributes
+      end
+    end
+  end
+  monitor_ids
+end
+
+def update_monitors(monitor_ids, api_client)
+  monitor_ids.each do |id, tfstate_options|
+    resp, monitor = api_client.get_monitor(id)
+    if resp != "200"
+      abort("Get monitor failed. Got response: #{resp}. Error message: #{monitor}")
+    end
+    options = monitor["options"]
+    options.merge!(tfstate_options)
+    query = monitor["query"]
+    resp, body = api_client.update_monitor(id, query, options: options)
+    if resp != "200"
+      abort("Update failed. Got response: #{resp}. Error message: #{body}")
+    end
+    puts "Updated monitor #{id} with attributes #{options}"
+  end
+  nil
+end
+
+api_key = ENV['TF_VAR_datadog_api_key']
+app_key = ENV['TF_VAR_datadog_app_key']
+api_host = ARGV[0]
+dog = Dogapi::Client.new(api_key, app_key, nil, nil, nil, nil, api_host)
+monitor_ids = find_monitors(tfstate)
+update_monitors(monitor_ids, dog)

--- a/concourse/scripts/update_monitor_options_test.go
+++ b/concourse/scripts/update_monitor_options_test.go
@@ -1,0 +1,260 @@
+package scripts_test
+
+import (
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+	"github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("UpdateDataDogMonitor", func() {
+
+	var (
+		cmdInput               string
+		requireFullWindowFalse = `
+{
+    "version": 3,
+    "terraform_version": "0.7.3",
+    "serial": 5,
+    "lineage": "bfa4e77c-4e4e-462e-92a9-dba07be0f409",
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {},
+			"resources": {
+				"datadog_monitor.continuous-smoketests-failures": {
+					"type": "datadog_monitor",
+					"depends_on": [],
+					"primary": {
+						"id": "1",
+						"attributes": {
+							"escalation_message": "Test",
+							"id": "1",
+							"message": "Test",
+							"name": "Fake monitor",
+							"notify_no_data": "false",
+							"query": "fake_query",
+							"require_full_window": "false",
+							"tags.%": "2",
+							"tags.deployment": "fake_tag",
+							"tags.service": "fake_monitors",
+							"thresholds.%": "1",
+							"thresholds.critical": "3",
+							"type": "metric alert"
+						},
+						"meta": {},
+						"tainted": false
+					},
+					"deposed": [],
+					"provider": ""
+				}
+			},
+			"depends_on": []
+		}
+	]
+}
+			`
+		requireFullWindowTrue = `
+{
+    "version": 3,
+    "terraform_version": "0.7.3",
+    "serial": 5,
+    "lineage": "bfa4e77c-4e4e-462e-92a9-dba07be0f409",
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {},
+			"resources": {
+				"datadog_monitor.continuous-smoketests-failures": {
+					"type": "datadog_monitor",
+					"depends_on": [],
+					"primary": {
+						"id": "1",
+						"attributes": {
+							"escalation_message": "Test",
+							"id": "1",
+							"message": "Test",
+							"name": "Fake monitor",
+							"notify_no_data": "false",
+							"query": "fake_query",
+							"require_full_window": "true",
+							"tags.%": "2",
+							"tags.deployment": "fake_tag",
+							"tags.service": "fake_monitors",
+							"thresholds.%": "1",
+							"thresholds.critical": "3",
+							"type": "metric alert"
+						},
+						"meta": {},
+						"tainted": false
+					},
+					"deposed": [],
+					"provider": ""
+				}
+			},
+			"depends_on": []
+		}
+	]
+}
+			`
+		session *gexec.Session
+		server  *ghttp.Server
+
+		respJsonPut = []byte(`{
+  "tags": [
+    "deployment:fake",
+    "service:fake"
+  ],
+  "deleted": null,
+  "query": "fake query",
+  "message": "fake message",
+  "id": 1,
+  "multi": false,
+  "name": "concourse continuous smoketests failures",
+  "created": "1970-00-00T00:00:01.000000+00:00",
+  "created_at": 1,
+  "creator": {
+    "id": 1,
+    "handle": "fake.email@fake.com",
+    "name": "Mr Fake",
+    "email": "fake.email.@fake.com"
+  },
+  "org_id": 1,
+  "modified": "1970-00-00T00:00:02.000000+00:00",
+  "state": {
+    "groups": {}
+  },
+  "overall_state": "No Data",
+  "type": "query alert",
+  "options": {
+    "notify_audit": false,
+    "locked": false,
+    "silenced": {},
+    "thresholds": {
+      "critical": 3
+    },
+    "require_full_window": false,
+    "new_host_delay": 300,
+    "notify_no_data": false,
+    "escalation_message": "Smoke test failures"
+  }
+}`)
+
+		respJsonGet = []byte(`{
+  "tags": [
+    "deployment:fake",
+    "service:fake"
+  ],
+  "deleted": null,
+  "query": "fake query",
+  "message": "fake message",
+  "id": 1,
+  "multi": false,
+  "name": "concourse continuous smoketests failures",
+  "created": "1970-00-00T00:00:01.000000+00:00",
+  "created_at": 1,
+  "creator": {
+    "id": 1,
+    "handle": "fake.email@fake.com",
+    "name": "Mr Fake",
+    "email": "fake.email.@fake.com"
+  },
+  "org_id": 1,
+  "modified": "1970-00-00T00:00:02.000000+00:00",
+  "state": {
+    "groups": {}
+  },
+  "overall_state": "No Data",
+  "type": "query alert",
+  "options": {
+    "notify_audit": false,
+    "locked": false,
+    "silenced": {},
+    "thresholds": {
+      "critical": 3
+    },
+    "new_host_delay": 300,
+    "notify_no_data": false,
+    "escalation_message": "Smoke test failures"
+  }
+}`)
+	)
+
+	BeforeEach(func() {
+		server = ghttp.NewServer()
+	})
+
+	AfterEach(func() {
+		server.Close()
+	})
+
+	JustBeforeEach(func() {
+		os.Setenv("TF_VAR_datadog_api_key", "aaaaaaaaaaaaa")
+		os.Setenv("TF_VAR_datadog_app_key", "bbbbbbbbbbbbb")
+		command := exec.Command("bundle", "exec", "./update_monitor_options.rb", server.URL())
+		command.Stdin = strings.NewReader(cmdInput)
+
+		var err error
+		session, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Context("when the require_full_window option is set to false", func() {
+		BeforeEach(func() {
+			cmdInput = requireFullWindowFalse
+			server.RouteToHandler("GET", "/api/v1/monitor/1", ghttp.RespondWith(http.StatusOK, respJsonGet))
+			server.RouteToHandler("PUT", "/api/v1/monitor/1", ghttp.RespondWith(http.StatusOK, respJsonPut))
+		})
+
+		It("updates the monitor and preserves all options", func() {
+			Eventually(session).Should(gexec.Exit(0))
+			Expect(session.Out).To(gbytes.Say("Updated monitor 1 with attributes {\"notify_audit\"=>false, \"locked\"=>false, \"silenced\"=>{}, \"thresholds\"=>{\"critical\"=>3}, \"new_host_delay\"=>300, \"notify_no_data\"=>false, \"escalation_message\"=>\"Smoke test failures\", \"require_full_window\"=>false}\n"))
+		})
+	})
+
+	Context("when the require_full_window option is set to true", func() {
+		BeforeEach(func() {
+			cmdInput = requireFullWindowTrue
+			server.RouteToHandler("GET", "/api/v1/monitor/1", ghttp.RespondWith(http.StatusOK, respJsonGet))
+			server.RouteToHandler("PUT", "/api/v1/monitor/1", ghttp.RespondWith(http.StatusOK, respJsonPut))
+		})
+
+		It("doesn't update the monitor", func() {
+			Eventually(session).Should(gexec.Exit(0))
+			Expect(session.Out.Contents()).To(BeEmpty())
+		})
+	})
+
+	Context("when API responds with non 200 code to GET monitor", func() {
+		BeforeEach(func() {
+			cmdInput = requireFullWindowFalse
+			server.RouteToHandler("GET", "/api/v1/monitor/1", ghttp.RespondWith(http.StatusInternalServerError, nil))
+		})
+
+		It("exits with non 0 code", func() {
+			Eventually(session).Should(gexec.Exit(1))
+		})
+	})
+	Context("when API responds with non 200 code to PUT monitor", func() {
+		BeforeEach(func() {
+			cmdInput = requireFullWindowFalse
+			server.RouteToHandler("GET", "/api/v1/monitor/1", ghttp.RespondWith(http.StatusOK, respJsonGet))
+			server.RouteToHandler("PUT", "/api/v1/monitor/1", ghttp.RespondWith(http.StatusInternalServerError, nil))
+		})
+
+		It("exits with non 0 code", func() {
+			Eventually(session).Should(gexec.Exit(1))
+		})
+	})
+})

--- a/terraform/datadog/concourse.tf
+++ b/terraform/datadog/concourse.tf
@@ -34,6 +34,42 @@ resource "datadog_monitor" "continuous-smoketests" {
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:concourse"]
 }
 
+resource "datadog_monitor" "continuous-smoketests-failures" {
+  count              = "${var.enable_pagerduty_notifications}"
+  name               = "${format("%s concourse continuous smoketests failures", var.env)}"
+  type               = "query alert"
+  escalation_message = "Smoke test failures"
+  no_data_timeframe  = "15"
+  query              = "${format("sum(last_15m):count_nonzero(avg:concourse.build.finished{build_status:failed,deploy_env:%s,job:continuous-smoke-tests}) >= 3", var.env)}"
+
+  message = <<EOF
+  {{#is_alert}}
+    The `continuous-smoke-tests` have been failing for a while now.
+
+    We need to investigate.
+
+    Notify: @pagerduty-Datadog
+  {{/is_alert}}
+
+  {{#is_no_data}}
+    The `continuous-smoke-tests` have not reported any metrics for a while.
+
+    We need to investigate.
+
+    Notify: @pagerduty-Datadog_no_data
+  {{/is_no_data}}
+EOF
+
+  require_full_window = false
+  notify_no_data      = true
+
+  thresholds {
+    critical = "3"
+  }
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors"]
+}
+
 resource "datadog_timeboard" "concourse-jobs" {
   title       = "${format("%s job runtime difference", var.env) }"
   description = "vs previous hour"

--- a/terraform/datadog/variables.tf
+++ b/terraform/datadog/variables.tf
@@ -12,3 +12,8 @@ variable "enable_cve_monitor" {
   description = "Enable CVE monitor: 1 to enable, 0 to disable"
   default     = 0
 }
+
+variable "enable_pagerduty_notifications" {
+  description = "Selector to enable/disable the pagerduty notifications."
+  default     = 0
+}

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -47,3 +47,6 @@ bosh_db_backup_retention_period = "35"
 bosh_db_skip_final_snapshot = "false"
 support_email="gov-uk-paas-support@digital.cabinet-office.gov.uk"
 enable_cve_monitor=1
+
+# Enable the pagerduty notifications
+enable_pagerduty_notifications = 1


### PR DESCRIPTION
## What

[Set up smoke test alerts to PagerDuty using datadog](https://www.pivotaltracker.com/n/projects/1275640/stories/137701781)

Create a monitor that notifies via pagerduty if >= 3 continuous smoke tests failures in 15m or no_data for 15m.

## How to review

Deploy with datadog enabled. Put yourself on [schedule](https://gds-paas.pagerduty.com/schedules#PEQKA3V) in pagerduty. Run continuous smoke tests. Make them fail 3 times in 15 min window (you can e.g. stop cloud controllers). You should get notification based on the preferences you set-up in PagerDuty. Stop running tests for 15 mins - you should get no_data notification. Note that if you test out of "office hours (9 - 17oo), then this will be marked as low priority and based on your notification settings you might not be notified. Before merging, remove temp commit 57346d2.

## Who can review

not @mtekel or @paroxp or @combor 
