### PR TITLE
[#135948443]  Pin cf-release with paas-cf from cf-deploy

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1048,6 +1048,12 @@ jobs:
     serial: true
     plan:
       - aggregate:
+          - get: cf-release
+            version:
+              ref: {{cf-release-version}}
+            params:
+              submodules:
+                - src/smoke-tests
           - get: pipeline-trigger
             passed: ['generate-cf-config']
             trigger: true
@@ -1156,6 +1162,7 @@ jobs:
             source:
               repository: governmentpaas/bosh-cli
           inputs:
+            - name: cf-release
             - name: paas-cf
             - name: cf-manifest
             - name: bosh-secrets
@@ -1756,11 +1763,10 @@ jobs:
             passed: ['post-deploy','availability-tests']
             trigger: true
           - get: cf-release
-            version:
-              ref: {{cf-release-version}}
             params:
               submodules:
                 - src/smoke-tests
+            passed: ['cf-deploy']
           - get: paas-cf
             passed: ['post-deploy','availability-tests']
           - get: cf-manifest
@@ -1797,11 +1803,10 @@ jobs:
             passed: ['post-deploy','availability-tests']
             trigger: true
           - get: cf-release
-            version:
-              ref: {{cf-release-version}}
             params:
               submodules:
                 - src/github.com/cloudfoundry/cf-acceptance-tests
+            passed: ['cf-deploy']
           - get: paas-cf
             passed: ['post-deploy','availability-tests']
           - get: cf-manifest
@@ -2285,6 +2290,7 @@ jobs:
           params:
             submodules:
               - src/smoke-tests
+          passed: ['cf-deploy']
         - get: paas-cf
           passed: ['cf-deploy']
         - get: cf-manifest

--- a/concourse/pipelines/failure-testing.yml
+++ b/concourse/pipelines/failure-testing.yml
@@ -100,6 +100,8 @@ jobs:
     plan:
       - aggregate:
           - get: cf-release
+            version:
+              ref: {{cf-release-version}}
             params:
               submodules:
                 - src/smoke-tests
@@ -150,6 +152,7 @@ jobs:
             params:
               submodules:
                 - src/smoke-tests
+            passed: ['cloud-controller']
           - get: paas-cf
           - get: cf-manifest
           - get: cf-secrets
@@ -197,6 +200,7 @@ jobs:
             params:
               submodules:
                 - src/smoke-tests
+            passed: ['nats']
           - get: paas-cf
           - get: cf-manifest
           - get: cf-secrets
@@ -244,6 +248,7 @@ jobs:
             params:
               submodules:
                 - src/smoke-tests
+            passed: ['router']
           - get: paas-cf
           - get: cf-manifest
           - get: cf-secrets
@@ -291,6 +296,7 @@ jobs:
             params:
               submodules:
                 - src/smoke-tests
+            passed: ['etcd']
           - get: paas-cf
           - get: cf-manifest
           - get: cf-secrets
@@ -338,6 +344,7 @@ jobs:
             params:
               submodules:
                 - src/smoke-tests
+            passed: ['consul']
           - get: paas-cf
           - get: cf-manifest
           - get: cf-secrets


### PR DESCRIPTION
[#135948443 Upgrade CF from v245 to v250](https://www.pivotaltracker.com/story/show/135948443)

What?
-----

 Pin cf-release with paas-cf from cf-deploy

Note: this commit is aligned with the change to pin the `get`
of cf-release in the commit 3f623b1

Although it is not directly being used by the cf-deploy job, we pin the
version of cf-release using the `get.version` syntax[1] in that job.
We must define it as a input to prevent the pipechecker from failing:

```
==  paas-cf/concourse/pipelines/create-cloudfoundry.yml  ==
WARNING * Unused Fetch: job='cf-deploy', resource='cf-release'
make: *** [lint_concourse] Error 20
```

With this commit we maintain the consistency of the deployed paas-cf with
the deployed version of cf-release using the `passed` tag based on the
version pulled during the cf-deploy task.

In the case of the fail-pipeline, we pull the cf-release toguether with
paas-cf.

[1] https://concourse.ci/get-step.html#get-version

Warnings
----------

Note: After merging this, the continous-smoke-test will stop working from the self-update pipelines until `cf-deploy` finishes. The reason is that until `cf-deploy` finishes there is no build which used `cf-release` as dependency.

This might trigger our monitoring if the time from auto-update pipelines to `cf-deploy` is more than 15m

How to review?
------------

Code review


Who?
----

Anyone but @keymon or @henrytk