### PR TITLE
[#135948443] Lose ends in upgrade to cf-release v250

### DIFF
--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -10,6 +10,8 @@ meta:
     release: (( grab meta.consul_templates.consul_agent.release ))
   - name: cloud_controller_ng
     release: (( grab meta.release.name ))
+  - name: metron_agent
+    release: (( grab meta.release.name ))
   - name: statsd-injector
     release: (( grab meta.release.name ))
   - name: java-buildpack
@@ -53,6 +55,8 @@ meta:
   - name: datadog-consul
     release: datadog-for-cloudfoundry
   - name: cloud_controller_clock
+    release: (( grab meta.release.name ))
+  - name: metron_agent
     release: (( grab meta.release.name ))
 
   consul_templates:

--- a/terraform/datadog/cell.tf
+++ b/terraform/datadog/cell.tf
@@ -86,24 +86,3 @@ resource "datadog_monitor" "garden_process_running" {
     "job"        = "cell"
   }
 }
-
-resource "datadog_monitor" "garden_healthy" {
-  name                = "${format("%s Cell garden healthy", var.env)}"
-  type                = "service check"
-  message             = "Large portion of Cell garden unhealthy. Check deployment state."
-  escalation_message  = "Large portion of Cell garden still unhealthy. Check deployment state."
-  no_data_timeframe   = "7"
-  require_full_window = true
-
-  query = "${format("'http.can_connect'.over('deploy_env:%s','instance:garden_debug_endpoint').by('*').last(1).pct_by_status()", var.env)}"
-
-  thresholds {
-    critical = 50
-  }
-
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "cell"
-  }
-}


### PR DESCRIPTION
[#135948443 Upgrade CF from v245 to v250](https://www.pivotaltracker.com/story/show/135948443)

What?
----

Fix some lose ends in the CF upgrade. We did not spot them until reaching CI because we did not test the integration with datadog :(.

So far this PR will:
 * Restore metron_agent in CC vms
 * Remove an obsolete monitor for garden


How to review?
-------------

Code review should be enough.

Dependencies
------------

We will do another PR in datadog-for-cloudfoundry to remove the check on the debug endpoint of garden

Who?
---

Anyone but @keymon