### PR TITLE
Bump bbs database max_open_connections to 40

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -530,7 +530,7 @@ properties:
         db_port: 5432
         db_schema: bbs
         db_driver: postgres
-        max_open_connections: 20
+        max_open_connections: 40
       dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
       require_ssl: true
 


### PR DESCRIPTION
## What

If this is too low we risk triggering a deadlock in bbs due to a bug in
bbs itself. We believe the bug is the on fixed in
https://github.com/cloudfoundry/bbs/commit/b33de3b07ed47077b6afbb3ad1a8331cee4c8b85.
At the time of writing, this has not yet been released.

## How to review

Code review.

## Who can review

Anyone but myself.