### PR TITLE
[#135948443] Increase BBS DB max_connections to 150.

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -530,7 +530,7 @@ properties:
         db_port: 5432
         db_schema: bbs
         db_driver: postgres
-        max_open_connections: 40
+        max_open_connections: 150
       dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
       require_ssl: true
 


### PR DESCRIPTION
## What

We previously bumped this to 40 in 5b77529 to avoid triggering a
deadlock in bbs caused by [1]. This has proved insufficient as are still
seeing occasional deadlocks. Even with the limit set to 150, I've still
managed to trigger the deadlock in a dev environment by rapidly scaling
an app up to a large number of instances (`cf scale debug-app -i 400`
for example). It's still worth increasing the limit though as it will
reduce the likelyhood of these occurrences.

The RDS instance has max_connections set to 198, so setting the limit
for bbs to 150 still leaves headroom for the other components that use
this instance. We've observed the other components (cloudcontroller and
uaa) typically using c. 30 connections.

[1]https://github.com/cloudfoundry/bbs/commit/b33de3b07ed47077b6afbb3ad1a8331cee4c8b85

## How to review

Code review.
You could test this in a dev environment, or trust me ;-)

## Who can review

Anyone but myself.