### PR TITLE
[#138486833] Terraform update to 0.8.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 2.2.6
 env:
   global:
-    - TF_VERSION="0.7.10"
+    - TF_VERSION="0.8.5"
     - SPRUCE_VERSION="1.5.0"
     - DEPLOY_ENV="travis"
 

--- a/terraform/datadog/bosh-jobs.tf
+++ b/terraform/datadog/bosh-jobs.tf
@@ -44,9 +44,5 @@ resource "datadog_monitor" "job_healthy" {
     warning  = "${element(null_resource.parsed_job_instances.*.triggers.warning, count.index)}"
   }
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "${element(null_resource.parsed_job_instances.*.triggers.job_name, count.index)}"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:${element(null_resource.parsed_job_instances.*.triggers.job_name, count.index)}"]
 }

--- a/terraform/datadog/cell.tf
+++ b/terraform/datadog/cell.tf
@@ -13,11 +13,7 @@ resource "datadog_monitor" "cell-available-memory" {
 
   require_full_window = true
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "cell"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:cell"]
 }
 
 resource "datadog_monitor" "rep_process_running" {
@@ -36,11 +32,7 @@ resource "datadog_monitor" "rep_process_running" {
     critical = 3
   }
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "cell"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:cell"]
 }
 
 resource "datadog_monitor" "rep_healthy" {
@@ -57,11 +49,7 @@ resource "datadog_monitor" "rep_healthy" {
     critical = 50
   }
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "cell"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:cell"]
 }
 
 resource "datadog_monitor" "garden_process_running" {
@@ -80,9 +68,5 @@ resource "datadog_monitor" "garden_process_running" {
     critical = 3
   }
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "cell"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:cell"]
 }

--- a/terraform/datadog/cloud_controller.tf
+++ b/terraform/datadog/cloud_controller.tf
@@ -14,11 +14,7 @@ resource "datadog_monitor" "cc_api_master_process_running" {
     critical = 3
   }
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "api"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:api"]
 }
 
 resource "datadog_monitor" "cc_api_worker_process_running" {
@@ -37,11 +33,7 @@ resource "datadog_monitor" "cc_api_worker_process_running" {
     critical = 3
   }
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "api"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:api"]
 }
 
 resource "datadog_monitor" "cc_api_healthy" {
@@ -58,11 +50,7 @@ resource "datadog_monitor" "cc_api_healthy" {
     critical = 50
   }
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "api"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:api"]
 }
 
 resource "datadog_monitor" "cc_failed_job_count_total_increase" {
@@ -79,11 +67,7 @@ resource "datadog_monitor" "cc_failed_job_count_total_increase" {
     critical = "5"
   }
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "api"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:api"]
 }
 
 resource "datadog_monitor" "cc_log_count_error_increase" {
@@ -100,11 +84,7 @@ resource "datadog_monitor" "cc_log_count_error_increase" {
     critical = "5"
   }
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "api"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:api"]
 }
 
 resource "datadog_monitor" "cc_job_queue_length" {
@@ -121,9 +101,5 @@ resource "datadog_monitor" "cc_job_queue_length" {
     critical = "25"
   }
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "api"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:api"]
 }

--- a/terraform/datadog/concourse.tf
+++ b/terraform/datadog/concourse.tf
@@ -13,11 +13,7 @@ resource "datadog_monitor" "concourse-load" {
 
   require_full_window = true
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "concourse"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:concourse"]
 }
 
 resource "datadog_monitor" "continuous-smoketests" {
@@ -35,11 +31,7 @@ resource "datadog_monitor" "continuous-smoketests" {
 
   require_full_window = false
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "concourse"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:concourse"]
 }
 
 resource "datadog_timeboard" "concourse-jobs" {

--- a/terraform/datadog/consul.tf
+++ b/terraform/datadog/consul.tf
@@ -14,11 +14,7 @@ resource "datadog_monitor" "consul" {
 
   require_full_window = true
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "consul"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:consul"]
 }
 
 resource "datadog_monitor" "consul_connect_to_port" {
@@ -35,9 +31,5 @@ resource "datadog_monitor" "consul_connect_to_port" {
     critical = 50
   }
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "consul"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:consul"]
 }

--- a/terraform/datadog/cve.tf
+++ b/terraform/datadog/cve.tf
@@ -12,8 +12,5 @@ resource "datadog_monitor" "cve-reporter" {
     critical = "1"
   }
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors"]
 }

--- a/terraform/datadog/general.tf
+++ b/terraform/datadog/general.tf
@@ -13,9 +13,5 @@ resource "datadog_monitor" "disk-space" {
 
   require_full_window = true
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "all"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:all"]
 }

--- a/terraform/datadog/ipsec.tf
+++ b/terraform/datadog/ipsec.tf
@@ -14,9 +14,5 @@ resource "datadog_monitor" "ipsec_daemon_running" {
     critical = 2
   }
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "all"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:all"]
 }

--- a/terraform/datadog/nats.tf
+++ b/terraform/datadog/nats.tf
@@ -14,11 +14,7 @@ resource "datadog_monitor" "nats_process_running" {
     critical = 3
   }
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "nats"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:nats"]
 }
 
 resource "datadog_monitor" "nats_stream_forwarded_process_running" {
@@ -37,11 +33,7 @@ resource "datadog_monitor" "nats_stream_forwarded_process_running" {
     critical = 3
   }
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "nats"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:nats"]
 }
 
 resource "datadog_monitor" "nats_service_open" {
@@ -58,11 +50,7 @@ resource "datadog_monitor" "nats_service_open" {
     critical = 50
   }
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "nats"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:nats"]
 }
 
 resource "datadog_monitor" "nats_cluster_service_open" {
@@ -79,9 +67,5 @@ resource "datadog_monitor" "nats_cluster_service_open" {
     critical = 50
   }
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "nats"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:nats"]
 }

--- a/terraform/datadog/route-emitter.tf
+++ b/terraform/datadog/route-emitter.tf
@@ -14,11 +14,7 @@ resource "datadog_monitor" "route_emitter_process_running" {
     critical = 3
   }
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "route_emitter"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:route_emitter"]
 }
 
 resource "datadog_monitor" "route_emitter_healthy" {
@@ -35,11 +31,7 @@ resource "datadog_monitor" "route_emitter_healthy" {
     critical = 50
   }
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "route_emitter"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:route_emitter"]
 }
 
 resource "datadog_monitor" "route_emitter_consul_lock" {
@@ -56,11 +48,7 @@ resource "datadog_monitor" "route_emitter_consul_lock" {
     critical = 100
   }
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "route_emitter"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:route_emitter"]
 }
 
 resource "datadog_monitor" "route_emitter_lock_held_once" {
@@ -84,9 +72,5 @@ resource "datadog_monitor" "route_emitter_lock_held_once" {
     critical = "${element(list("1", "1"), count.index)}"
   }
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "route_emitter"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:route_emitter"]
 }

--- a/terraform/datadog/router.tf
+++ b/terraform/datadog/router.tf
@@ -59,11 +59,7 @@ resource "datadog_monitor" "route_update_latency" {
     critical = "45000.0"
   }
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "router"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:router"]
 }
 
 variable "datadog_monitor_total_routes_drop_enabled" {
@@ -90,11 +86,7 @@ resource "datadog_monitor" "total_routes_drop" {
     critical = "-33.0"
   }
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "router"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:router"]
 }
 
 resource "datadog_monitor" "total_routes_discrepancy" {
@@ -109,11 +101,7 @@ resource "datadog_monitor" "total_routes_discrepancy" {
 
   thresholds {}
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "router"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:router"]
 }
 
 resource "datadog_monitor" "gorouter_process_running" {
@@ -132,11 +120,7 @@ resource "datadog_monitor" "gorouter_process_running" {
     critical = 3
   }
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "router"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:router"]
 }
 
 resource "datadog_monitor" "gorouter_healthy" {
@@ -153,9 +137,5 @@ resource "datadog_monitor" "gorouter_healthy" {
     critical = 50
   }
 
-  tags {
-    "deployment" = "${var.env}"
-    "service"    = "${var.env}_monitors"
-    "job"        = "router"
-  }
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:router"]
 }


### PR DESCRIPTION
## What

This is terraform update to fix the "diffs didn't match during apply" error.

Also, it includes a commit to change formatting of datadog tags that has been introduced in v 0.8.5 of terraform ( hashicorp/terraform@d06138d )
Tags are now required to be a list in a form of: `tags = ["foo:bar", "baz"]`


## How to review

- Run from this branch to test https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/86
- See also https://github.com/alphagov/paas-bootstrap/pull/44 for a similar change in paas-bootstrap.
- After merging https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/86, wait for the build to complete in Docker Hub before removing TMP commit and merging this.

## Who can review

Not @alext or @combor