### PR TITLE
[docs] Change self-update instructions for DataDog in dev

### DIFF
--- a/doc/datadog.md
+++ b/doc/datadog.md
@@ -21,9 +21,9 @@ make <ENV> upload-datadog-secrets
 make dev upload-datadog-secrets
 ```
 
-2. If you have auto-update pipelines disabled
+2. Deploy the pipeline with self-update disabled
 ```
-ENABLE_DATADOG=true make dev pipelines
+ENABLE_DATADOG=true SELF_UPDATE_PIPELINE=false make dev pipelines
 ```
 
 3. Re-run your pipelines

--- a/doc/datadog.md
+++ b/doc/datadog.md
@@ -17,36 +17,37 @@ make <ENV> upload-datadog-secrets
 ### Example for testing in a dev environment with standard dev API/application keys
 1. Upload the dev keys to your state bucket
 
-```
-make dev upload-datadog-secrets
-```
+  ```
+  make dev upload-datadog-secrets
+  ```
 
-2. Deploy the pipeline with self-update disabled
-```
-ENABLE_DATADOG=true SELF_UPDATE_PIPELINE=false make dev pipelines
-```
+1. Deploy the pipeline with self-update disabled
 
-3. Re-run your pipelines
+  ```
+  ENABLE_DATADOG=true SELF_UPDATE_PIPELINE=false make dev pipelines
+  ```
+
+1. Re-run your pipelines
 
 ### Example for testing in a dev environment with new API/application keys
 
 1. Switch to a test password store dir
 
-```
-export DATADOG_PASSWORD_STORE_DIR="tmp/datadog-password-store"
-```
+  ```
+  export DATADOG_PASSWORD_STORE_DIR="tmp/datadog-password-store"
+  ```
 
-2. Insert your test datadog keys
+1. Insert your test datadog keys
 
-```
-pass insert datadog/dev/datadog_api_key
-pass insert datadog/dev/datadog_app_key
-```
+  ```
+  pass insert datadog/dev/datadog_api_key
+  pass insert datadog/dev/datadog_app_key
+  ```
 
-3. Upload the new keys to your state bucket
+1. Upload the new keys to your state bucket
 
-```
-ENABLE_DATADOG=true make dev upload-datadog-secrets
-```
+  ```
+  ENABLE_DATADOG=true make dev upload-datadog-secrets
+  ```
 
-4. Re-run your pipelines
+1. Re-run your pipelines


### PR DESCRIPTION
## What

Replace the sentence, which says what to do if you have self-update
pipelines disabled but not what to do if you don't, with a command to
also disable self-update pipelines.

Because I copied the command without reading the preceding sentence, so
self-update pipeline overwrote my changes and I was left momentarily
confused.

## How to review

Text review only should be sufficient.

## Who can review

Not @dcarley