### PR TITLE
[#130660899] Add monitors for diego single-instance service locks and for etcd

### DIFF
--- a/terraform/datadog/auctioneer.tf
+++ b/terraform/datadog/auctioneer.tf
@@ -1,0 +1,23 @@
+resource "datadog_monitor" "auctioneer_lock_held_once" {
+  name                = "${format("%s auctioneer lock held exactly once (%s)", var.env, element(list("upper", "lower"), count.index))}"
+  type                = "query alert"
+  message             = "There is not exactly one auctioneer holding the lock."
+  escalation_message  = "There is still not exactly one auctioneer holding the lock."
+  notify_no_data      = false
+  require_full_window = true
+
+  count = 2
+
+  query = "${
+    format(
+      "min(last_5m):sum:cf.auctioneer.LockHeld.v1_locks_auctioneer_lock{deployment:%s}.fill(last, 60) %s",
+      var.env,
+      element(list("> 1", "< 1"), count.index)
+    )}"
+
+  thresholds {
+    critical = "1" # This value must match the threshold set in the query. Otherwise datadog API would fail obscurely
+  }
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:auctioneer"]
+}

--- a/terraform/datadog/auctioneer.tf
+++ b/terraform/datadog/auctioneer.tf
@@ -10,7 +10,8 @@ resource "datadog_monitor" "auctioneer_lock_held_once" {
 
   query = "${
     format(
-      "min(last_5m):sum:cf.auctioneer.LockHeld.v1_locks_auctioneer_lock{deployment:%s}.fill(last, 60) %s",
+      "%s(last_5m):sum:cf.auctioneer.LockHeld.v1_locks_auctioneer_lock{deployment:%s}.fill(last, 60) %s",
+      element(list("max", "min"), count.index),
       var.env,
       element(list("> 1", "< 1"), count.index)
     )}"

--- a/terraform/datadog/bbs.tf
+++ b/terraform/datadog/bbs.tf
@@ -1,0 +1,23 @@
+resource "datadog_monitor" "bbs_lock_held_once" {
+  name                = "${format("%s bbs lock held exactly once (%s)", var.env, element(list("upper", "lower"), count.index))}"
+  type                = "query alert"
+  message             = "There is not exactly one bbs holding the lock."
+  escalation_message  = "There is still not exactly one bbs holding the lock."
+  notify_no_data      = false
+  require_full_window = true
+
+  count = 2
+
+  query = "${
+    format(
+      "min(last_5m):sum:cf.bbs.LockHeld.v1_locks_bbs_lock{deployment:%s}.fill(last, 60) %s",
+      var.env,
+      element(list("> 1", "< 1"), count.index)
+    )}"
+
+  thresholds {
+    critical = "1" # This value must match the threshold set in the query. Otherwise datadog API would fail obscurely
+  }
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:bbs"]
+}

--- a/terraform/datadog/bbs.tf
+++ b/terraform/datadog/bbs.tf
@@ -10,7 +10,8 @@ resource "datadog_monitor" "bbs_lock_held_once" {
 
   query = "${
     format(
-      "min(last_5m):sum:cf.bbs.LockHeld.v1_locks_bbs_lock{deployment:%s}.fill(last, 60) %s",
+      "%s(last_5m):sum:cf.bbs.LockHeld.v1_locks_bbs_lock{deployment:%s}.fill(last, 60) %s",
+      element(list("max", "min"), count.index),
       var.env,
       element(list("> 1", "< 1"), count.index)
     )}"

--- a/terraform/datadog/etcd.tf
+++ b/terraform/datadog/etcd.tf
@@ -1,0 +1,23 @@
+resource "datadog_monitor" "etcd_one_leader" {
+  name                = "${format("%s etcd IsLeader count is exactly one (%s)", var.env, element(list("upper", "lower"), count.index))}"
+  type                = "query alert"
+  message             = "There is not exactly one etcd reporting IsLeader."
+  escalation_message  = "There is still not exactly one etcd reporting IsLeader."
+  notify_no_data      = false
+  require_full_window = true
+
+  count = 2
+
+  query = "${
+    format(
+      "min(last_5m):sum:cf.etcd.IsLeader{deployment:%s}.fill(last, 60) %s",
+      var.env,
+      element(list("> 1", "< 1"), count.index)
+    )}"
+
+  thresholds {
+    critical = "1"
+  }
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:etcd"]
+}

--- a/terraform/datadog/etcd.tf
+++ b/terraform/datadog/etcd.tf
@@ -10,7 +10,8 @@ resource "datadog_monitor" "etcd_one_leader" {
 
   query = "${
     format(
-      "min(last_5m):sum:cf.etcd.IsLeader{deployment:%s}.fill(last, 60) %s",
+      "%s(last_5m):sum:cf.etcd.IsLeader{deployment:%s}.fill(last, 60) %s",
+      element(list("max", "min"), count.index),
       var.env,
       element(list("> 1", "< 1"), count.index)
     )}"

--- a/terraform/datadog/nsync.tf
+++ b/terraform/datadog/nsync.tf
@@ -1,0 +1,23 @@
+resource "datadog_monitor" "nsync_bulker_lock_held_once" {
+  name                = "${format("%s nsync_bulker lock held exactly once (%s)", var.env, element(list("upper", "lower"), count.index))}"
+  type                = "query alert"
+  message             = "There is not exactly one nsync_bulker holding the lock."
+  escalation_message  = "There is still not exactly one nsync_bulker holding the lock."
+  notify_no_data      = false
+  require_full_window = true
+
+  count = 2
+
+  query = "${
+    format(
+      "min(last_5m):sum:cf.nsync_bulker.LockHeld.v1_locks_nsync_bulker_lock{deployment:%s}.fill(last, 60) %s",
+      var.env,
+      element(list("> 1", "< 1"), count.index)
+    )}"
+
+  thresholds {
+    critical = "1" # This value must match the threshold set in the query. Otherwise datadog API would fail obscurely
+  }
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:nsync_bulker"]
+}

--- a/terraform/datadog/nsync.tf
+++ b/terraform/datadog/nsync.tf
@@ -10,7 +10,8 @@ resource "datadog_monitor" "nsync_bulker_lock_held_once" {
 
   query = "${
     format(
-      "min(last_5m):sum:cf.nsync_bulker.LockHeld.v1_locks_nsync_bulker_lock{deployment:%s}.fill(last, 60) %s",
+      "%s(last_5m):sum:cf.nsync_bulker.LockHeld.v1_locks_nsync_bulker_lock{deployment:%s}.fill(last, 60) %s",
+      element(list("max", "min"), count.index),
       var.env,
       element(list("> 1", "< 1"), count.index)
     )}"

--- a/terraform/datadog/route-emitter.tf
+++ b/terraform/datadog/route-emitter.tf
@@ -63,7 +63,8 @@ resource "datadog_monitor" "route_emitter_lock_held_once" {
 
   query = "${
     format(
-      "min(last_5m):sum:cf.route_emitter.LockHeld.v1_locks_route_emitter_lock{deployment:%s}.fill(last, 60) %s",
+      "%s(last_5m):sum:cf.route_emitter.LockHeld.v1_locks_route_emitter_lock{deployment:%s}.fill(last, 60) %s",
+      element(list("max", "min"), count.index),
       var.env,
       element(list("> 1", "< 1"), count.index)
     )}"

--- a/terraform/datadog/route-emitter.tf
+++ b/terraform/datadog/route-emitter.tf
@@ -69,7 +69,7 @@ resource "datadog_monitor" "route_emitter_lock_held_once" {
     )}"
 
   thresholds {
-    critical = "${element(list("1", "1"), count.index)}"
+    critical = "1" # This value must match the threshold set in the query. Otherwise datadog API would fail obscurely
   }
 
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:route_emitter"]

--- a/terraform/datadog/tps.tf
+++ b/terraform/datadog/tps.tf
@@ -1,0 +1,23 @@
+resource "datadog_monitor" "tps_watcher_lock_held_once" {
+  name                = "${format("%s tps_watcher lock held exactly once (%s)", var.env, element(list("upper", "lower"), count.index))}"
+  type                = "query alert"
+  message             = "There is not exactly one tps_watcher holding the lock."
+  escalation_message  = "There is still not exactly one tps_watcher holding the lock."
+  notify_no_data      = false
+  require_full_window = true
+
+  count = 2
+
+  query = "${
+    format(
+      "min(last_5m):sum:cf.tps_watcher.LockHeld.v1_locks_tps_watcher_lock{deployment:%s}.fill(last, 60) %s",
+      var.env,
+      element(list("> 1", "< 1"), count.index)
+    )}"
+
+  thresholds {
+    critical = "1" # This value must match the threshold set in the query. Otherwise datadog API would fail obscurely
+  }
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:tps_watcher"]
+}

--- a/terraform/datadog/tps.tf
+++ b/terraform/datadog/tps.tf
@@ -10,7 +10,8 @@ resource "datadog_monitor" "tps_watcher_lock_held_once" {
 
   query = "${
     format(
-      "min(last_5m):sum:cf.tps_watcher.LockHeld.v1_locks_tps_watcher_lock{deployment:%s}.fill(last, 60) %s",
+      "%s(last_5m):sum:cf.tps_watcher.LockHeld.v1_locks_tps_watcher_lock{deployment:%s}.fill(zero, 60) %s",
+      element(list("max", "min"), count.index),
       var.env,
       element(list("> 1", "< 1"), count.index)
     )}"


### PR DESCRIPTION
[#130660899 Monitor that single instance services are single instance (forever alone)](https://www.pivotaltracker.com/story/show/130660899)

What?
----

We want to monitor all the single-instance services from Diego as we do with route-emitter in #662.

We will add monitors only for the services: bbs, nsync, tps and auctioneer, for the lock flag in consul.

We also add monitor the etcd flag `cf.etc.IsLeader`.

We finally improve the query a little bit by using max/min depending if we are checkign the upper or lower value. See commits.

How to review?
-------------

Code review

You can deploy the changes only in CI by doing:

```
cd paas-cf/terraform/datadog
mkdir tmp
cd tmp

ln -s ../auctioneer.tf ../bbs.tf ../datadog.tf ../etcd.tf ../nsync.tf ../tps.tf ../variables.tf .
terraform apply -var aws_account=ci  -var datadog_api_key=$(paas-pass datadog/dev/datadog_api_key) -var datadog_app_key=$(paas-pass datadog/dev/datadog_app_key) -var env=master

```

Remember to destroy later:

```
terraform destroy -var aws_account=ci  -var datadog_api_key=$(paas-pass datadog/dev/datadog_api_key) -var datadog_app_key=$(paas-pass datadog/dev/datadog_app_key) -var env=master
```

Who?
---

Anyone but @keymon