### PR TITLE
[#135948443] Fix name of java buildpack.

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -316,7 +316,7 @@ properties:
       - name: staticfile_buildpack
         package: staticfile-buildpack
       - name: java_buildpack
-        package: buildpack_java_offline
+        package: java-offline-buildpack
       - name: ruby_buildpack
         package: ruby-buildpack
       - name: nodejs_buildpack

--- a/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
@@ -166,4 +166,18 @@ RSpec.describe "base properties" do
       end
     end
   end
+
+  describe "buildpacks" do
+    let(:api_job) { manifest_with_defaults.fetch("jobs").find { |j| j.fetch("name") == "api" } }
+    let(:api_template_names) { api_job.fetch("templates").map { |t| t.fetch("name") } }
+
+    let(:install_buildpacks_property) { properties.fetch("cc").fetch("install_buildpacks") }
+
+    it "install_buildpacks reference packages that exist" do
+      install_buildpacks_property.each do |pack|
+        expect(api_template_names).to include(pack.fetch("package")),
+          "install_buildpacks entry #{pack.fetch('name')} references non-existent package #{pack.fetch('package')}"
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What

The package was renamed in CF v246[1]. This omission wasn't an obvious
problem for existing deployments because the buildpack had already been
uploaded, however for a clean deployment the java buildpack would be
missing. For existing deployments it means that the buildpack wouldn't have
been updated from the previous version.

[1]https://github.com/cloudfoundry/cf-release/commit/72222a8

## How to review

Do a fresh deploy from master and verify that the java buildpack is present.

## Who can review

Anyone but myself or @combor 