### PR TITLE
[#130660899] Upgrade datadog-for-cloudfoundry to enable consul integration and check for consul leader

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -26,9 +26,9 @@ releases:
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/paas-haproxy-0.1.3.tgz
     sha1: 732ceb817afe33ee117b85a202d87f6f5c3dd760
   - name: datadog-for-cloudfoundry
-    version: 0.1.6
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.1.6.tgz
-    sha1: 639f123a36869fcb23aaefafd8133a508b20befd
+    version: 0.1.7
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.1.7.tgz
+    sha1: 3bdfdbd98cac6e9452b80788229e83cddf9549d3
   - name: ipsec
     version: 0.1.1
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/ipsec-0.1.1.tgz

--- a/terraform/datadog/consul.tf
+++ b/terraform/datadog/consul.tf
@@ -33,3 +33,20 @@ resource "datadog_monitor" "consul_connect_to_port" {
 
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:consul"]
 }
+
+resource "datadog_monitor" "consul_has_leader" {
+  name                = "${format("%s consul cluster has at least one leader", var.env)}"
+  type                = "service check"
+  message             = "No consul cluster servers are repoted as leader"
+  escalation_message  = "Still no consul cluster servers are repoted as leader. Check deployment state."
+  no_data_timeframe   = "7"
+  require_full_window = true
+
+  query = "${format("'http.can_connect'.over('deploy_env:%s','instance:consul_is_leader').by('*').last(1).pct_by_status()", var.env)}"
+
+  thresholds {
+    critical = 100
+  }
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:consul"]
+}


### PR DESCRIPTION
[#130660899 Monitor that single instance services are single instance (forever alone)](https://www.pivotaltracker.com/story/show/130660899)

What?
-----

We want to be able to start monitoring consul in datadog
 *  get events from the leader election in datadog so that we can correlate incidents.
 * monitor if there is a leader

In https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/12 we enable datadog integration.

This commit upgrades this release so the integration would start working.

> **Note**: Initially we wanted to add a monitor to check that there is exactly one leader elected, but the consul integration does not offer any good metric for that. Instead we added a check and a monitor to check that there is at least one leader.

Dependencies
------------

Merge this first:  https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/12

Change the release data after build.

remove the tmp commit that enables datadog in consul

How to review?
------------

Deploy this branch. It enables datadog for only the consul nodes.

You will see a new metrics: consul.peer and events about leaders being elected.

You can stop all the consul agents, the monitor will trigger. It won't recover until you start at least 2x consul.

Check  https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/12

Who?
----

Anyone but @keymon