### PR TITLE
[#138486833] Revert "TMP - test terraform update"

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -682,7 +682,6 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
-              tag: update_terraform
           inputs:
             - name: paas-cf
             - name: cf-certs-tfstate
@@ -786,7 +785,6 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
-              tag: update_terraform
           inputs:
             - name: terraform-variables
             - name: paas-cf
@@ -1516,7 +1514,6 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/terraform
-                tag: update_terraform
             inputs:
               - name: datadog-tfstate
               - name: paas-cf

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -262,7 +262,6 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
-              tag: update_terraform
           inputs:
             - name: terraform-variables
             - name: paas-cf
@@ -305,7 +304,6 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
-              tag: update_terraform
           inputs:
             - name: paas-cf
             - name: cf-certs-tfstate


### PR DESCRIPTION
This reverts commit d7501a5d42c67562582962f930f12089c6da7f8a. added in #744

Strangely the commit was included because github did not detect the
changes from the `git push --force` and the `make merge_pr` got the
previous commit from the API.

We noticed that in https://status.github.com/ mean hook was too high
in that moment, 7.8s

We should wait before running merge_pr after a git push -f