### PR TITLE
[#136052751] Adjust UAA ELB timeout

### DIFF
--- a/terraform/cloudfoundry/elbs.tf
+++ b/terraform/cloudfoundry/elbs.tf
@@ -45,7 +45,7 @@ resource "aws_lb_ssl_negotiation_policy" "cf_cc" {
 resource "aws_elb" "cf_uaa" {
   name                      = "${var.env}-cf-uaa"
   subnets                   = ["${split(",", var.infra_subnet_ids)}"]
-  idle_timeout              = "${var.elb_idle_timeout}"
+  idle_timeout              = 19
   cross_zone_load_balancing = "true"
 
   security_groups = [


### PR DESCRIPTION
## What

Story: [#136052751 Reduce ELB idle timeout (to reduce 504 errors)](https://www.pivotaltracker.com/story/show/136052751)

From time to time requests fail on the UAA ELB with a 504 error. In most cases this was caused by an unhealthy backend, but some cases were not explained. This was investigated in [#123760561](https://www.pivotaltracker.com/story/show/123760561) and the AWS support ticket 1861267451 was raised.

The problem may happen when ELB maintains connections to the backend because the backend uses HTTP keepalive, and the idle timeout on the ELB is higher than the backend keepalive timeout. This is explained in:
https://hardwarehacks.org/blogs/devops/2015/12/29/1451416941200.html

We have reasonable understanding of what is going on on UAA: the ELB backend here is tomcat, configured with a 20s keepalive timeout. The risk is probably low on UAA as requests should never take a long time, we change the ELB idle timeout to 19s in hope the ELB terminates the
connection instead of the backend.

This will be monitored over a period of time to check if things improve.

## How to review
Code review

## Who can review
Not @henrytk or me