### PR TITLE
[#136435555] Add user to mailing list notification

### DIFF
--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -33,7 +33,15 @@ https://government-paas-developer-docs.readthedocs.io/en/latest/getting_started/
 Regards,
 Government PaaS team.
 '
+NOTIFICATION='
+As the account has been created now please remeber to update gov-uk-paas-announce
+mailing list. You can do that by inviting the user to the group by usng this URL:
 
+https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!managemembers/gov-uk-paas-announce/invite
+
+As a welcome message you can use the text from here:
+https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/gov-uk-paas-announce
+'
 
 ###########################################################################
 usage() {
@@ -183,6 +191,7 @@ send_mail() {
       --output text > /dev/null
 
     echo "An email has been sent to ${EMAIL} with their new credentials."
+    show_notification
   else
     echo "User was already present and has not been recreated. No mail sent."
   fi
@@ -198,6 +207,11 @@ emit_password() {
   else
     send_mail
   fi
+}
+
+show_notification() {
+    echo
+    info "${NOTIFICATION}"
 }
 
 TMP_OUTPUT="$(mktemp -t create-tenant-output.XXXXXX)"

--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -129,7 +129,7 @@ create_user() {
     cf delete-user "${EMAIL}" -f
   fi
 
-  if cf create-user "${EMAIL}" "${PASSWORD}" | tee "${TMP_OUTPUT}"; then
+  if cf create-user "${EMAIL}" "${PASSWORD}" 2>&1 | tee "${TMP_OUTPUT}"; then
     if ! grep -q "already exists" "${TMP_OUTPUT}"; then
       SEND_EMAIL=true
     fi


### PR DESCRIPTION
## What

As a part of improve incident communications story we've decided to
notify operator that every user should be a member of GOV.UK PaaS
Announce. As a first step before implementing automation for this task
we will would like to add notification that will be displayed after user
account was successfully created.

Also it includes a small fix to correctly detect if user account already exists. 

## How to review

- run it on your dev env and check if it notification is displayed and makes sense 

## Who can review

Not @combor
