### PR TITLE
[#136353673] Add ability to create CDNs programmatically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ lint_yaml:
 lint_terraform: dev
 	$(eval export TF_VAR_system_dns_zone_name=$SYSTEM_DNS_ZONE_NAME)
 	$(eval export TF_VAR_apps_dns_zone_name=$APPS_DNS_ZONE_NAME)
-	find terraform -mindepth 1 -maxdepth 1 -type d -not -path 'terraform/providers' -not -path 'terraform/scripts' -print0 | xargs -0 -n 1 -t terraform graph > /dev/null
+	find terraform -mindepth 1 -maxdepth 1 -type d -not -path 'terraform/providers' -not -path 'terraform/scripts' -print0 | xargs -0 -n 1 -t sh -c 'terraform get $$1 && terraform graph $$1' -- > /dev/null
 	@if [ "$$(terraform fmt -write=false terraform)" != "" ] ; then \
 		echo "Use 'terraform fmt' to fix HCL formatting:"; \
 		terraform fmt -write=false -diff=true terraform ; \
@@ -197,6 +197,11 @@ pingdom: check-tf-version ## Use custom Terraform provider to set up Pingdom che
 	$(eval export PASSWORD_STORE_DIR?=~/.paas-pass)
 	$(eval export PINGDOM_CONTACT_IDS=11089310)
 	@terraform/scripts/set-up-pingdom.sh ${ACTION}
+
+.PHONY: setup_cdn_instances
+setup_cdn_instances: check-tf-version check-aws-credentials ## Setup the CloudFront Distribution instances, by reading their config from terraform/cloudfront/instances.tf.
+	$(if ${ACTION},,$(error Must pass ACTION=<plan|apply|...>))
+	@terraform/scripts/set-up-cdn-instances.sh ${ACTION}
 
 merge_pr: ## Merge a PR. Must specify number in a PR=<number> form.
 	$(if ${PR},,$(error Must pass PR=<number>))

--- a/Makefile
+++ b/Makefile
@@ -43,15 +43,11 @@ spec:
 lint_yaml:
 	find . -name '*.yml' -not -path '*/vendor/*' | xargs $(YAMLLINT) -c yamllint.yml
 
-lint_terraform: dev
+.PHONY: lint_terraform
+lint_terraform: dev ## Lint the terraform files.
 	$(eval export TF_VAR_system_dns_zone_name=$SYSTEM_DNS_ZONE_NAME)
 	$(eval export TF_VAR_apps_dns_zone_name=$APPS_DNS_ZONE_NAME)
-	find terraform -mindepth 1 -maxdepth 1 -type d -not -path 'terraform/providers' -not -path 'terraform/scripts' -print0 | xargs -0 -n 1 -t sh -c 'terraform get $$1 && terraform graph $$1' -- > /dev/null
-	@if [ "$$(terraform fmt -write=false terraform)" != "" ] ; then \
-		echo "Use 'terraform fmt' to fix HCL formatting:"; \
-		terraform fmt -write=false -diff=true terraform ; \
-		exit 1; \
-	fi
+	@terraform/scripts/lint.sh
 
 lint_shellcheck:
 	find . -name '*.sh' -not -path '*/vendor/*' | xargs $(SHELLCHECK)

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -706,6 +706,10 @@ jobs:
                   tar xzf cf-certs/cf-certs.tar.gz -C generated-certificates
                   tar xzf bosh-CA/bosh-CA.tar.gz
 
+                  # FIXME We're expecting this task to fail.
+                  # That's ok, whilst we're updating the certificates.
+                  set +e
+
                   terraform apply -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
                     -var system_domain_crt="$(cat generated-certificates/system_domain.crt)" \
                     -var system_domain_key="$(cat generated-certificates/system_domain.key)" \
@@ -717,6 +721,9 @@ jobs:
                     -state-out=updated-tfstate/cf-certs.tfstate \
                     paas-cf/terraform/cf-certs
                 fi
+
+                # FIXME
+                echo "We're expecting this task to fail. That's fine. - Rafal"
         ensure:
           put: cf-certs-tfstate
           params:

--- a/terraform/cf-certs/outputs.tf
+++ b/terraform/cf-certs/outputs.tf
@@ -5,3 +5,11 @@ output "system_domain_cert_arn" {
 output "apps_domain_cert_arn" {
   value = "${aws_iam_server_certificate.apps.arn}"
 }
+
+output "system_domain_cert_id" {
+  value = "${aws_iam_server_certificate.system.id}"
+}
+
+output "apps_domain_cert_id" {
+  value = "${aws_iam_server_certificate.apps.id}"
+}

--- a/terraform/cf-certs/upload.tf
+++ b/terraform/cf-certs/upload.tf
@@ -7,6 +7,7 @@ resource "aws_iam_server_certificate" "system" {
   certificate_body  = "${var.system_domain_crt}"
   private_key       = "${var.system_domain_key}"
   certificate_chain = "${var.system_domain_intermediate_crt}"
+  path              = "/cloudfront/${var.env}-system-domain/"
 
   lifecycle {
     create_before_destroy = true
@@ -18,6 +19,7 @@ resource "aws_iam_server_certificate" "apps" {
   certificate_body  = "${var.apps_domain_crt}"
   private_key       = "${var.apps_domain_key}"
   certificate_chain = "${var.apps_domain_intermediate_crt}"
+  path              = "/cloudfront/${var.env}-apps-domain/"
 
   lifecycle {
     create_before_destroy = true

--- a/terraform/cloudfront/cloudfront_distribution/distribution.tf
+++ b/terraform/cloudfront/cloudfront_distribution/distribution.tf
@@ -45,6 +45,8 @@ resource "aws_cloudfront_distribution" "cdn_instance" {
     max_ttl                = 86400
   }
 
+  price_class = "PriceClass_100"
+
   restrictions {
     geo_restriction {
       restriction_type = "none"

--- a/terraform/cloudfront/cloudfront_distribution/distribution.tf
+++ b/terraform/cloudfront/cloudfront_distribution/distribution.tf
@@ -1,0 +1,61 @@
+resource "aws_route53_record" "cdn_domain" {
+  count = "${length(var.aliases)}"
+
+  zone_id = "${var.system_dns_zone_id}"
+  name    = "${element(var.aliases, count.index)}."
+  type    = "CNAME"
+  ttl     = "60"
+  records = ["${aws_cloudfront_distribution.cdn_instance.domain_name}"]
+}
+
+resource "aws_cloudfront_distribution" "cdn_instance" {
+  origin {
+    domain_name = "${var.origin}"
+    origin_id   = "${var.origin}"
+
+    custom_origin_config {
+      origin_protocol_policy = "https-only"
+      http_port              = 80
+      https_port             = 443
+      origin_ssl_protocols   = ["TLSv1", "TLSv1.1", "TLSv1.2"]
+    }
+  }
+
+  aliases         = "${var.aliases}"
+  comment         = "${var.comment}"
+  enabled         = true
+  is_ipv6_enabled = true
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "${var.origin}"
+
+    forwarded_values {
+      query_string = true
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  tags {
+    Environment = "${var.env}"
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}

--- a/terraform/cloudfront/cloudfront_distribution/distribution.tf
+++ b/terraform/cloudfront/cloudfront_distribution/distribution.tf
@@ -56,6 +56,9 @@ resource "aws_cloudfront_distribution" "cdn_instance" {
   }
 
   viewer_certificate {
-    cloudfront_default_certificate = true
+    cloudfront_default_certificate = false
+    iam_certificate_id             = "${var.system_domain_cert_id}"
+    minimum_protocol_version       = "TLSv1"
+    ssl_support_method             = "sni-only"
   }
 }

--- a/terraform/cloudfront/cloudfront_distribution/variables.tf
+++ b/terraform/cloudfront/cloudfront_distribution/variables.tf
@@ -26,3 +26,7 @@ variable "system_dns_zone_id" {
 variable "system_dns_zone_name" {
   description = "Domain name registered with Route 53."
 }
+
+variable "system_domain_cert_id" {
+  description = "The ID of the certificate to be assigned to a new subdomain."
+}

--- a/terraform/cloudfront/cloudfront_distribution/variables.tf
+++ b/terraform/cloudfront/cloudfront_distribution/variables.tf
@@ -1,0 +1,28 @@
+variable "aliases" {
+  description = "List of aliases to be registered for a new CloudFront distribution."
+  type        = "list"
+}
+
+variable "comment" {
+  description = "Comment to describe the CloudFront distribution. Could be empty string."
+}
+
+variable "env" {
+  description = "DEPLOY_ENV to be used for certificates and terraform state."
+}
+
+variable "name" {
+  description = "The name, to easily identify the instance. Not widely used."
+}
+
+variable "origin" {
+  description = "The origin URL to be cached into the CloudFront distribution."
+}
+
+variable "system_dns_zone_id" {
+  description = "Zone ID for the system domain registered with Route 53."
+}
+
+variable "system_dns_zone_name" {
+  description = "Domain name registered with Route 53."
+}

--- a/terraform/cloudfront/globals.tf
+++ b/terraform/cloudfront/globals.tf
@@ -1,0 +1,1 @@
+../globals.tf

--- a/terraform/cloudfront/instances.tf
+++ b/terraform/cloudfront/instances.tf
@@ -2,6 +2,8 @@ variable "system_dns_zone_id" {}
 
 variable "system_dns_zone_name" {}
 
+variable "system_domain_cert_id" {}
+
 module "cloudfront_paas_product_page" {
   source = "./cloudfront_distribution"
 
@@ -10,9 +12,10 @@ module "cloudfront_paas_product_page" {
   origin  = "govuk-paas.cloudapps.digital"
   comment = "Serve the govuk-paas under the gov.uk domain."
 
-  env                  = "${var.env}"
-  system_dns_zone_name = "${var.system_dns_zone_name}"
-  system_dns_zone_id   = "${var.system_dns_zone_id}"
+  env                   = "${var.env}"
+  system_dns_zone_name  = "${var.system_dns_zone_name}"
+  system_dns_zone_id    = "${var.system_dns_zone_id}"
+  system_domain_cert_id = "${var.system_domain_cert_id}"
 }
 
 module "cloudfront_paas_docs" {
@@ -23,7 +26,8 @@ module "cloudfront_paas_docs" {
   origin  = "paas-tech-docs.cloudapps.digital"
   comment = "Serve the paas-tech-docs under the gov.uk domain."
 
-  env                  = "${var.env}"
-  system_dns_zone_name = "${var.system_dns_zone_name}"
-  system_dns_zone_id   = "${var.system_dns_zone_id}"
+  env                   = "${var.env}"
+  system_dns_zone_name  = "${var.system_dns_zone_name}"
+  system_dns_zone_id    = "${var.system_dns_zone_id}"
+  system_domain_cert_id = "${var.system_domain_cert_id}"
 }

--- a/terraform/cloudfront/instances.tf
+++ b/terraform/cloudfront/instances.tf
@@ -1,0 +1,29 @@
+variable "system_dns_zone_id" {}
+
+variable "system_dns_zone_name" {}
+
+module "cloudfront_paas_product_page" {
+  source = "./cloudfront_distribution"
+
+  name    = "PaaS Product Page"
+  aliases = ["www.${var.system_dns_zone_name}"]
+  origin  = "govuk-paas.cloudapps.digital"
+  comment = "Serve the govuk-paas under the gov.uk domain."
+
+  env                  = "${var.env}"
+  system_dns_zone_name = "${var.system_dns_zone_name}"
+  system_dns_zone_id   = "${var.system_dns_zone_id}"
+}
+
+module "cloudfront_paas_docs" {
+  source = "./cloudfront_distribution"
+
+  name    = "PaaS Docs"
+  aliases = ["docs.${var.system_dns_zone_name}"]
+  origin  = "paas-tech-docs.cloudapps.digital"
+  comment = "Serve the paas-tech-docs under the gov.uk domain."
+
+  env                  = "${var.env}"
+  system_dns_zone_name = "${var.system_dns_zone_name}"
+  system_dns_zone_id   = "${var.system_dns_zone_id}"
+}

--- a/terraform/scripts/lint.sh
+++ b/terraform/scripts/lint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -eu
+
+# Setup the working grounds.
+PAAS_CF_DIR=$(pwd)
+WORKING_DIR=$(mktemp -d terraform-cloudfront-distribution.XXXXXX)
+trap 'rm -r "${PAAS_CF_DIR}/${WORKING_DIR}"' EXIT
+
+cd "${WORKING_DIR}"
+
+for dir in ${PAAS_CF_DIR}/terraform/*/ ; do
+  if [[ ${dir} == *"terraform/providers"* ]] || [[ ${dir} == *"terraform/scripts"* ]]; then
+    continue
+  fi
+
+  terraform get "${dir}" > /dev/null
+  terraform graph "${dir}" > /dev/null
+done
+
+if [ "$(terraform fmt -write=false "${PAAS_CF_DIR}/terraform")" != "" ] ; then
+  echo "Use 'terraform fmt' to fix HCL formatting:"
+  terraform fmt -write=false -diff=true terraform
+  exit 1
+fi

--- a/terraform/scripts/set-up-cdn-instances.sh
+++ b/terraform/scripts/set-up-cdn-instances.sh
@@ -11,6 +11,14 @@ trap 'rm -r "${PAAS_CF_DIR}/${WORKING_DIR}"' EXIT
 
 cd "${WORKING_DIR}"
 
+CERT_ID=$(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/cf-certs.tfstate"  - \
+  | jq -r ".modules[].outputs.system_domain_cert_id.value")
+
+if [ -z "${CERT_ID// }" ] || [ "${CERT_ID}" == "null" ]; then
+  echo "Failed to obtain system_domain_cert_id from s3://gds-paas-${DEPLOY_ENV}-state/cf-certs.tfstate"
+  exit 1
+fi
+
 terraform get "${PAAS_CF_DIR}/terraform/cloudfront"
 
 # Configure Terraform remote state.
@@ -25,4 +33,5 @@ terraform "${TERRAFORM_ACTION}" \
   -var-file="${PAAS_CF_DIR}/terraform/${AWS_ACCOUNT}.tfvars" \
   -var "env=${DEPLOY_ENV}" \
   -var "system_dns_zone_name=${SYSTEM_DNS_ZONE_NAME}" \
+  -var "system_domain_cert_id=${CERT_ID}" \
   "${PAAS_CF_DIR}"/terraform/cloudfront

--- a/terraform/scripts/set-up-cdn-instances.sh
+++ b/terraform/scripts/set-up-cdn-instances.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -eu
+TERRAFORM_ACTION=${1}
+STATEFILE=cloudfront.tfstate
+
+# Setup the working grounds.
+PAAS_CF_DIR=$(pwd)
+WORKING_DIR=$(mktemp -d terraform-cloudfront-distribution.XXXXXX)
+trap 'rm -r "${PAAS_CF_DIR}/${WORKING_DIR}"' EXIT
+
+cd "${WORKING_DIR}"
+
+terraform get "${PAAS_CF_DIR}/terraform/cloudfront"
+
+# Configure Terraform remote state.
+terraform remote config \
+  -backend=s3 \
+  -backend-config="bucket=gds-paas-${DEPLOY_ENV}-state" \
+  -backend-config="key=${STATEFILE}" \
+  -backend-config="region=${AWS_DEFAULT_REGION}"
+
+# Run the terraform action on the instances.
+terraform "${TERRAFORM_ACTION}" \
+  -var-file="${PAAS_CF_DIR}/terraform/${AWS_ACCOUNT}.tfvars" \
+  -var "env=${DEPLOY_ENV}" \
+  -var "system_dns_zone_name=${SYSTEM_DNS_ZONE_NAME}" \
+  "${PAAS_CF_DIR}"/terraform/cloudfront


### PR DESCRIPTION
## What

We would like to create a CDN for the PaaS Documentation and the Product Page and be able to access it, from the new subdomain.

This change, should allow any user with an access, create CloudFront Distributions. The CNAME record, will be created as part of the system domain name, for each distribution.

## How to review

1. Run `create-cloudfoundry` pipeline from this branch
1. Run `ACTION=plan make dev setup_cdn_instances`
1. Experience no errors from the above
1. Run `ACTION=apply make dev setup_cdn_instances`
1. Experience no errors from the above
1. Wait... This may take a while. I suggest logging into AWS Console and monitoring CloudFront Distributions
1. Visiting `docs.${DEPLOY_ENV}.dev.cloudpipeline.digital` should result in `paas-tech-docs`
1. Visiting `www.${DEPLOY_ENV}.dev.cloudpipeline.digital` should result in `paas-product-page`

## Who can review

Not @paroxp