### PR TITLE
[#136052751] Revert to default idle timeout on CC ELB

### DIFF
--- a/terraform/cloudfoundry/elbs.tf
+++ b/terraform/cloudfoundry/elbs.tf
@@ -1,7 +1,6 @@
 resource "aws_elb" "cf_cc" {
   name                      = "${var.env}-cf-cc"
   subnets                   = ["${split(",", var.infra_subnet_ids)}"]
-  idle_timeout              = "${var.elb_idle_timeout}"
   cross_zone_load_balancing = "true"
 
   security_groups = [


### PR DESCRIPTION
## What

Story: [Reduce ELB idle timeout (to reduce 504 errors)](https://www.pivotaltracker.com/story/show/136052751)

This was originally set on the router ELB and copied ever since to all ELBs. See:
https://github.com/gds-attic/paas-alpha-cf-terraform/commit/4a7191d4330a59e7676c8ae3c449f0b2cfd84c3e

This might be the cause of 504 errors we see from time to time on the CC ELB. Since the CC Nginx has a keepalive_timeout set to 75s, the ELB should have a lower idle timeout. Reverting to default will set it to 60s.

See commit 51f443f2c3a9828687d7ade0693eb7a3ebea72ca for details.

## How to review
Deploy, tests should pass. Pay attention to 504 errors on the CC ELB.

## Who can review
Not @henrytk or me