### PR TITLE
Travis: set +e after each before_install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,24 +22,29 @@ before_install:
     export PATH=~/bin:$PATH
   - |
     echo "Fetching shellcheck"
+    set -e
     wget -O ~/bin/shellcheck https://github.com/alphagov/paas-cf/releases/download/shellcheck_binary_0.4.4/shellcheck_linux_amd64
     chmod +x ~/bin/shellcheck
+    set +e
   - |
     echo "Fetching Terraform"
     set -e
     wget https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip
     unzip -o terraform_${TF_VERSION}_linux_amd64.zip -d ~/bin
     rm terraform_${TF_VERSION}_linux_amd64.zip
+    set +e
   - |
     echo "Fetching Terraform pingdom provider"
     set -e
     wget -O ~/bin/terraform-provider-pingdom "https://github.com/alphagov/paas-terraform-provider-pingdom/releases/download/0.2.2/terraform-provider-pingdom-tf-${TF_VERSION}-$(uname -s)-$(uname -m)"
     chmod +x ~/bin/terraform-provider-pingdom
+    set +e
   - |
     echo "Fetching Spruce"
     set -e
     wget https://github.com/geofffranks/spruce/releases/download/v${SPRUCE_VERSION}/spruce-linux-amd64
     mv spruce-linux-amd64 ~/bin/spruce && chmod +x ~/bin/spruce
+    set +e
   - pip install --user yamllint
   - cd scripts && BUNDLE_GEMFILE=Gemfile bundle install --jobs=3 --retry=3 --deployment && cd ..
 


### PR DESCRIPTION
## What

We added `set -e` before each `before_install` block in c1a5aa0 to make the
build fail fast if it was unable to install any of the dependencies.

There appears to have been a change to Travis today that now causes the
build to fail if `set -e` is used in `before_install`. From some previous
issues it looks like it causes it to be set globally for all of Travis's own
scripts that run within the build and has never been fully supported:

- https://github.com/travis-ci/travis-ci/issues/3586#issuecomment-274585174
- https://github.com/travis-ci/travis-ci/issues/891#issuecomment-32318632

We would still like the build to fail fast if it's unable to install the
dependencies. So it seems that the compromise is to unset it after each
command block until the following feature is implemented:

- https://github.com/travis-ci/travis-ci/issues/1066

## How to review

- review the code changes
- confirm that the Travis build now passes

## Who can review

Not @dcarley