### PR TITLE
[SUPPORT] Change parser VM type to medium

### DIFF
--- a/manifests/cf-manifest/manifest/800-logsearch.yml
+++ b/manifests/cf-manifest/manifest/800-logsearch.yml
@@ -34,7 +34,7 @@ jobs:
     release: logsearch
   - name: logsearch-for-cloudfoundry-filters
     release: logsearch-for-cloudfoundry
-  vm_type: small
+  vm_type: medium
   stemcell: default
   instances: 1
   networks:
@@ -54,7 +54,7 @@ jobs:
     release: logsearch
   - name: logsearch-for-cloudfoundry-filters
     release: logsearch-for-cloudfoundry
-  vm_type: small
+  vm_type: medium
   stemcell: default
   instances: 1
   networks:


### PR DESCRIPTION
## What
Due to huge volume of logs to parse we went out of cpu credits on
parser VMs. This slowed down logstash considerably and resulted in
almost no log ingestion to elasticsearch.  To avoid such situation in
the future we would like to use a VM type that is not burstable.

medium type is EC2 m3.medium VM. 

## How to review

Deploy and check if you are getting logs in Elasticsearch ( by checking in Kibana )

## Who can review

Not @combor
