### PR TITLE
Fix generate-git-keys task

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2267,7 +2267,7 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: governmentpaas/awscli
+              repository: governmentpaas/git-ssh
           platform: linux
           outputs:
           - name: generated-git-keys


### PR DESCRIPTION
## What

Fix generate-git-keys task

ssh-keygen is present in the git-ssh container. We use that in other tasks
that also need ssh-keygen. Use this image instead of awscli, which was
missing ssh-keygen.

## How to review

Task generate-git-keys should work now. This is in 'operator' tab. Without this PR, it fails with `sh: ssh-keygen: not found`

## Who can review

not @mtekel
