### PR TITLE
[#137700569] Set up Pingdom alerts to PagerDuty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,6 @@ manually_upload_certs: check-tf-version ## Manually upload to AWS the SSL certif
 pingdom: check-tf-version ## Use custom Terraform provider to set up Pingdom check
 	$(if ${ACTION},,$(error Must pass ACTION=<plan|apply|...>))
 	$(eval export PASSWORD_STORE_DIR?=~/.paas-pass)
-	$(eval export PINGDOM_CONTACT_IDS=11089310)
 	@terraform/scripts/set-up-pingdom.sh ${ACTION}
 
 .PHONY: setup_cdn_instances

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,6 @@ globals:
 
 .PHONY: dev
 dev: globals check-env-vars ## Set Environment to DEV
-	$(eval export MAKEFILE_ENV_TARGET=dev)
 	$(eval export AWS_ACCOUNT=dev)
 	$(eval export ENABLE_DESTROY=true)
 	$(eval export ENABLE_AUTODELETE=true)
@@ -102,7 +101,6 @@ dev: globals check-env-vars ## Set Environment to DEV
 
 .PHONY: ci
 ci: globals check-env-vars ## Set Environment to CI
-	$(eval export MAKEFILE_ENV_TARGET=ci)
 	$(eval export AWS_ACCOUNT=ci)
 	$(eval export ENABLE_AUTO_DEPLOY=true)
 	$(eval export TAG_PREFIX=staging-)
@@ -116,7 +114,6 @@ ci: globals check-env-vars ## Set Environment to CI
 
 .PHONY: staging
 staging: globals check-env-vars ## Set Environment to Staging
-	$(eval export MAKEFILE_ENV_TARGET=staging)
 	$(eval export AWS_ACCOUNT=staging)
 	$(eval export ENABLE_AUTO_DEPLOY=true)
 	$(eval export SKIP_UPLOAD_GENERATED_CERTS=true)
@@ -133,7 +130,6 @@ staging: globals check-env-vars ## Set Environment to Staging
 
 .PHONY: prod
 prod: globals check-env-vars ## Set Environment to Production
-	$(eval export MAKEFILE_ENV_TARGET=prod)
 	$(eval export AWS_ACCOUNT=prod)
 	$(eval export ENABLE_AUTO_DEPLOY=true)
 	$(eval export SKIP_UPLOAD_GENERATED_CERTS=true)

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -334,7 +334,7 @@ jobs:
           params:
             DEPLOY_ENV: {{deploy_env}}
             BRANCH: {{branch_name}}
-            MAKEFILE_ENV_TARGET: {{makefile_env_target}}
+            AWS_ACCOUNT: {{aws_account}}
             SELF_UPDATE_PIPELINE: {{self_update_pipeline}}
             PIPELINES_TO_UPDATE: {{pipeline_name}}
             BOSH_AZ: {{bosh_az}}

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -129,7 +129,7 @@ jobs:
           params:
             DEPLOY_ENV: {{deploy_env}}
             BRANCH: {{branch_name}}
-            MAKEFILE_ENV_TARGET: {{makefile_env_target}}
+            AWS_ACCOUNT: {{aws_account}}
             SELF_UPDATE_PIPELINE: {{self_update_pipeline}}
             PIPELINES_TO_UPDATE: {{pipeline_name}}
             ENABLE_DESTROY: {{enable_destroy}}

--- a/concourse/pipelines/failure-testing.yml
+++ b/concourse/pipelines/failure-testing.yml
@@ -86,7 +86,7 @@ jobs:
           params:
             DEPLOY_ENV: {{deploy_env}}
             BRANCH: {{branch_name}}
-            MAKEFILE_ENV_TARGET: {{makefile_env_target}}
+            AWS_ACCOUNT: {{aws_account}}
             SELF_UPDATE_PIPELINE: {{self_update_pipeline}}
             PIPELINES_TO_UPDATE: {{pipeline_name}}
           run:

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -88,7 +88,6 @@ generate_vars_file() {
 ---
 pipeline_name: ${pipeline_name}
 enable_destroy: ${ENABLE_DESTROY:-}
-makefile_env_target: ${MAKEFILE_ENV_TARGET:-dev}
 self_update_pipeline: ${SELF_UPDATE_PIPELINE:-true}
 skip_upload_generated_certs: ${SKIP_UPLOAD_GENERATED_CERTS:-false}
 aws_account: ${AWS_ACCOUNT:-dev}

--- a/concourse/scripts/self-update-pipeline.sh
+++ b/concourse/scripts/self-update-pipeline.sh
@@ -2,7 +2,7 @@
 #
 # Required variables are:
 # - DEPLOY_ENV
-# - MAKEFILE_ENV_TARGET
+# - AWS_ACCOUNT
 # - SELF_UPDATE_PIPELINE
 #
 # Optional variables:
@@ -22,5 +22,5 @@ if [ "${SELF_UPDATE_PIPELINE}" != "true" ]; then
 else
   echo "Self update pipeline is enabled. Updating. (set SELF_UPDATE_PIPELINE=false to disable)"
 
-  make -C ./paas-cf "${MAKEFILE_ENV_TARGET}" pipelines
+  make -C ./paas-cf "${AWS_ACCOUNT}" pipelines
 fi

--- a/terraform/ci.tfvars
+++ b/terraform/ci.tfvars
@@ -10,3 +10,4 @@ support_email="govpaas-alerting-ci@digital.cabinet-office.gov.uk"
 # Enabled/disabled resources
 # Disable datadog_monitor.total_routes_drop resource
 datadog_monitor_total_routes_drop_enabled = 0
+pingdom_contact_ids = [ 11089310, 11190300 ]

--- a/terraform/dev.tfvars
+++ b/terraform/dev.tfvars
@@ -6,3 +6,4 @@ cf_db_backup_retention_period = "0"
 cf_db_skip_final_snapshot = "true"
 cf_db_maintenance_window = "Mon:04:00-Mon:05:00"
 support_email="govpaas-alerting-dev@digital.cabinet-office.gov.uk"
+pingdom_contact_ids = [ 11089310 ]

--- a/terraform/pingdom/pingdom.tf
+++ b/terraform/pingdom/pingdom.tf
@@ -10,7 +10,9 @@ variable "apps_dns_zone_name" {}
 
 variable "env" {}
 
-variable "contact_ids" {}
+variable "pingdom_contact_ids" {
+  type = "list"
+}
 
 provider "pingdom" {
   user          = "${var.pingdom_user}"
@@ -30,7 +32,7 @@ resource "pingdom_check" "paas_http_healthcheck" {
   sendtoemail              = true
   sendnotificationwhendown = 2
   notifywhenbackup         = true
-  contactids               = ["${split(",", var.contact_ids)}"]
+  contactids               = ["${var.pingdom_contact_ids}"]
 }
 
 resource "pingdom_check" "paas_db_healthcheck" {
@@ -44,5 +46,5 @@ resource "pingdom_check" "paas_db_healthcheck" {
   sendtoemail              = true
   sendnotificationwhendown = 2
   notifywhenbackup         = true
-  contactids               = ["${split(",", var.contact_ids)}"]
+  contactids               = ["${var.pingdom_contact_ids}"]
 }

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -52,3 +52,4 @@ enable_cve_monitor=1
 
 # Enable the pagerduty notifications
 enable_pagerduty_notifications = 1
+pingdom_contact_ids = [ 11089310, 11189971 ]

--- a/terraform/scripts/set-up-pingdom.sh
+++ b/terraform/scripts/set-up-pingdom.sh
@@ -4,7 +4,7 @@ set -eu
 TERRAFORM_ACTION=${1}
 VERSION=0.2.2
 BINARY=terraform-provider-pingdom-tf-0.8.5-$(uname -s)-$(uname -m)
-STATEFILE=pingdom-${MAKEFILE_ENV_TARGET}.tfstate
+STATEFILE=pingdom-${AWS_ACCOUNT}.tfstate
 
 # Get Pingdom credentials
 export PASSWORD_STORE_DIR=~/.paas-pass

--- a/terraform/scripts/set-up-pingdom.sh
+++ b/terraform/scripts/set-up-pingdom.sh
@@ -34,8 +34,8 @@ terraform remote config \
 
 # Run Terraform Pingdom Provider
 terraform "${TERRAFORM_ACTION}" \
-	-var "env=${MAKEFILE_ENV_TARGET}" \
-	-var "contact_ids=\"${PINGDOM_CONTACT_IDS}\"" \
+	-var-file="${PAAS_CF_DIR}/terraform/${AWS_ACCOUNT}.tfvars" \
+	-var "env=${DEPLOY_ENV}" \
 	-var "pingdom_user=${PINGDOM_USER}" \
 	-var "pingdom_password=${PINGDOM_PASSWORD}" \
 	-var "pingdom_api_key=${PINGDOM_API_KEY}" \

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -16,3 +16,4 @@ support_email="govpaas-alerting-staging@digital.cabinet-office.gov.uk"
 # Enabled/disabled resources
 # Disable datadog_monitor.total_routes_drop resource
 datadog_monitor_total_routes_drop_enabled = 0
+pingdom_contact_ids = [ 11089310, 11190300 ]


### PR DESCRIPTION
## What

[Set up Pingdom alerts to PagerDuty](https://www.pivotaltracker.com/n/projects/1275640/stories/137700569)

New contacts in pingdom have been created which point to new services created in pagerduty for pingdom alerts - one for in-hours notifications only and one for 24/7. This PR configures pagerduty notifications for CI/Staging (in-hours) and prod (24/7).

## How to review

Locally edit dev tfvars file. Copy pingdom contact ids from ci/staging tfvars files. This will enable in-hours pager duty notifications for dev when you create pingdom checks.

Override in-hours schedule to your name. `ACTION=apply make dev pingdom`. Stop your healthcheck app. Wait. Get notified by pagerduty - the way you configured your notification options in PD. 

Don't forget to clean up the override in PD (it's in the right column of schedules interface) and testing pingdom checks: `ACTION=destroy make dev pingdom`

## Who can review

not @mtekel or @paroxp 
