### PR TITLE
[WIP] Cache ruby and python deps in travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ addons:
 cache:
   bundler: true
   pip: true
-  apt: true
   directories:
     - $HOME/.cache/pip
     - $HOME/.rvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ cache:
   directories:
     - $HOME/.cache/pip
     - $HOME/.rvm
+    - $HOME/gopath
+    - $HOME/vendor/bundle
 
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ cache:
   apt: true
   directories:
     - $HOME/.cache/pip
+    - $HOME/.rvm
 
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ cache:
   bundler: true
   pip: true
   apt: true
+  directories:
+    - $HOME/.cache/pip
 
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ addons:
       - git
       - gnupg
 
+cache:
+  bundler: true
+  pip: true
+
 before_install:
   - |
     mkdir ~/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ addons:
 cache:
   bundler: true
   pip: true
+  apt: true
 
 before_install:
   - |


### PR DESCRIPTION
This PR is to discuss/poke [caching dependencies in travis](https://docs.travis-ci.com/user/caching/) builds to both speed them up and make them more reliable.

Currently it (might):
* Cache python dependencies using travis' built in support for pip
* Cache ruby dependencies using travis' built in support for bundler

It could also:
* Cache things installed in the ~/bin directory if we added some simple checks to the `before_install` sections: https://github.com/alphagov/paas-cf/blob/master/.travis.yml#L19
* Cache all the things built in the `GOPATH`

Thoughts? Criticisms? Prophecies?