### PR TITLE
[#136353673] Revert "Allow the pipeline to fail"

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -706,10 +706,6 @@ jobs:
                   tar xzf cf-certs/cf-certs.tar.gz -C generated-certificates
                   tar xzf bosh-CA/bosh-CA.tar.gz
 
-                  # FIXME We're expecting this task to fail.
-                  # That's ok, whilst we're updating the certificates.
-                  set +e
-
                   terraform apply -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
                     -var system_domain_crt="$(cat generated-certificates/system_domain.crt)" \
                     -var system_domain_key="$(cat generated-certificates/system_domain.key)" \
@@ -721,9 +717,6 @@ jobs:
                     -state-out=updated-tfstate/cf-certs.tfstate \
                     paas-cf/terraform/cf-certs
                 fi
-
-                # FIXME
-                echo "We're expecting this task to fail. That's fine. - Rafal"
         ensure:
           put: cf-certs-tfstate
           params:


### PR DESCRIPTION
## What

The certs have now been updated, and the old ones cleaned up in all
long-lived environments, so this is no longer needed.

This reverts commit 5fa517c5aabc46289ff7af4a43c7f29c2c14ae9f.

## How to review

Code review. 

## Who can review

Anyone but myself or @paroxp.