### PR TITLE
[#136353673] Reduce the default TTL for CloudFront instances

### DIFF
--- a/terraform/cloudfront/cloudfront_distribution/distribution.tf
+++ b/terraform/cloudfront/cloudfront_distribution/distribution.tf
@@ -41,7 +41,7 @@ resource "aws_cloudfront_distribution" "cdn_instance" {
 
     viewer_protocol_policy = "redirect-to-https"
     min_ttl                = 0
-    default_ttl            = 3600
+    default_ttl            = 5
     max_ttl                = 86400
   }
 


### PR DESCRIPTION
## What

We have decided, it may be unreasonable to have a 60 minute delay, before CloudFront is going to check for the changes.

This has been justified with the scenario: During user testing lab, we may want to quickly run an update on the docs and expect it to appear fairly quickly online, for the users to look up.

This has been changed to 5s as agreed with Ben, @dcarley, @alext and @mtekel. It may be worth, keeping an eye on this change.

## How to review

Code review, should be sufficient test.

After the change is applied, the manual `ACTION=apply make prod setup_cdn_instances` will need to be ran.

## Who can review

Anyone but @paroxp.