### PR TITLE
[#135953741] Datadog pagerduty integration

### DIFF
--- a/terraform/ci.tfvars
+++ b/terraform/ci.tfvars
@@ -10,4 +10,8 @@ support_email="govpaas-alerting-ci@digital.cabinet-office.gov.uk"
 # Enabled/disabled resources
 # Disable datadog_monitor.total_routes_drop resource
 datadog_monitor_total_routes_drop_enabled = 0
+
 pingdom_contact_ids = [ 11089310, 11190300 ]
+
+datadog_notification_24x7 = "@pagerduty-datadog-in-hours"
+datadog_notification_in_hours = "@pagerduty-datadog-in-hours"

--- a/terraform/datadog/variables.tf
+++ b/terraform/datadog/variables.tf
@@ -17,3 +17,11 @@ variable "enable_pagerduty_notifications" {
   description = "Selector to enable/disable the pagerduty notifications."
   default     = 0
 }
+
+variable "datadog_notification_24x7" {
+  description = "Datadog notification for 24x7 alerts: empty string for no notification, email address (start with @) or pagerduty service name (start with @)"
+}
+
+variable "datadog_notification_in_hours" {
+  description = "Datadog notification for in hours alerts: empty string for no notification, email address (start with @) or pagerduty service name (start with @)"
+}

--- a/terraform/dev.tfvars
+++ b/terraform/dev.tfvars
@@ -7,3 +7,5 @@ cf_db_skip_final_snapshot = "true"
 cf_db_maintenance_window = "Mon:04:00-Mon:05:00"
 support_email="govpaas-alerting-dev@digital.cabinet-office.gov.uk"
 pingdom_contact_ids = [ 11089310 ]
+datadog_notification_24x7 = "@govpaas-alerting-dev@digital.cabinet-office.gov.uk"
+datadog_notification_in_hours = "@govpaas-alerting-dev@digital.cabinet-office.gov.uk"

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -55,3 +55,6 @@ enable_cve_monitor=1
 # Enable the pagerduty notifications
 enable_pagerduty_notifications = 1
 pingdom_contact_ids = [ 11089310, 11189971 ]
+
+datadog_notification_24x7 = "@pagerduty-datadog-24x7"
+datadog_notification_in_hours = "@pagerduty-datadog-in-hours"

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -17,3 +17,6 @@ support_email="govpaas-alerting-staging@digital.cabinet-office.gov.uk"
 # Disable datadog_monitor.total_routes_drop resource
 datadog_monitor_total_routes_drop_enabled = 0
 pingdom_contact_ids = [ 11089310, 11190300 ]
+
+datadog_notification_24x7 = "@pagerduty-datadog-in-hours"
+datadog_notification_in_hours = "@pagerduty-datadog-in-hours"


### PR DESCRIPTION
## What
Stories:

* [Configure schedules and escalation policies for PagerDuty](https://www.pivotaltracker.com/story/show/135953741)
* [Send smoke test and Pingdom alerts from CI and staging to the in-hours support person using PagerDuty](https://www.pivotaltracker.com/story/show/139005729)

Create explicit variables for alerting in and out of hours. They can be set differently for each environment. We currently set email notification for dev, in hours pagerduty only in ci and staging, in hours and out of hours pagerduty in production.

## How to review
* There is a "[TEMP]" commit to create datadog monitors even if you don't have datadog enabled
* Apply to your environment, the monitors should be created
* Change values in `dev.tfvars`, the notifications should change
* You can double check the pagerduty service notifications correspond to real services configured in the integration

## Before merging
* Remove the "[TEMP]" commit

## Who can review
Not me
