### PR TITLE
[#137700569] Fix self-update pipelines

### DIFF
--- a/concourse/scripts/self-update-pipeline.sh
+++ b/concourse/scripts/self-update-pipeline.sh
@@ -9,6 +9,9 @@
 # - BRANCH
 # - PIPELINES_TO_UPDATE
 
+# FIXME: Remove after switched to AWS_ACCOUNT
+AWS_ACCOUNT=${AWS_ACCOUNT:-$MAKEFILE_ENV_TARGET}
+
 set -u
 set -e
 


### PR DESCRIPTION
## What

We removed MAKEFILE_ENV_TARGET and replaced it with AWS_ACCOUNT, but that
one is only available _after_ successfull self update. Fix the script to
take the old variable still.

## How to review

Try to run self update pipelines job. It should succeed.

## Who can review

not @mtekel
