### PR TITLE
[#139291295] fix lint_terraform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,6 @@ before_install:
     rm terraform_${TF_VERSION}_linux_amd64.zip
     set +e
   - |
-    echo "Fetching Terraform pingdom provider"
-    set -e
-    wget -O ~/bin/terraform-provider-pingdom "https://github.com/alphagov/paas-terraform-provider-pingdom/releases/download/0.2.2/terraform-provider-pingdom-tf-${TF_VERSION}-$(uname -s)-$(uname -m)"
-    chmod +x ~/bin/terraform-provider-pingdom
-    set +e
-  - |
     echo "Fetching Spruce"
     set -e
     wget https://github.com/geofffranks/spruce/releases/download/v${SPRUCE_VERSION}/spruce-linux-amd64

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ lint_yaml:
 lint_terraform: check-tf-version dev ## Lint the terraform files.
 	$(eval export TF_VAR_system_dns_zone_name=$SYSTEM_DNS_ZONE_NAME)
 	$(eval export TF_VAR_apps_dns_zone_name=$APPS_DNS_ZONE_NAME)
+	$(eval export TF_VERSION=$(MIN_TERRAFORM_VERSION))
 	@terraform/scripts/lint.sh
 
 lint_shellcheck:

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ lint_yaml:
 	find . -name '*.yml' -not -path '*/vendor/*' | xargs $(YAMLLINT) -c yamllint.yml
 
 .PHONY: lint_terraform
-lint_terraform: dev ## Lint the terraform files.
+lint_terraform: check-tf-version dev ## Lint the terraform files.
 	$(eval export TF_VAR_system_dns_zone_name=$SYSTEM_DNS_ZONE_NAME)
 	$(eval export TF_VAR_apps_dns_zone_name=$APPS_DNS_ZONE_NAME)
 	@terraform/scripts/lint.sh

--- a/terraform/scripts/lint.sh
+++ b/terraform/scripts/lint.sh
@@ -4,7 +4,7 @@ set -eu
 
 # Setup the working grounds.
 PAAS_CF_DIR=$(pwd)
-WORKING_DIR=$(mktemp -d terraform-cloudfront-distribution.XXXXXX)
+WORKING_DIR=$(mktemp -d terraform-lint.XXXXXX)
 trap 'rm -r "${PAAS_CF_DIR}/${WORKING_DIR}"' EXIT
 
 cd "${WORKING_DIR}"

--- a/terraform/scripts/lint.sh
+++ b/terraform/scripts/lint.sh
@@ -20,6 +20,6 @@ done
 
 if [ "$(terraform fmt -write=false "${PAAS_CF_DIR}/terraform")" != "" ] ; then
   echo "Use 'terraform fmt' to fix HCL formatting:"
-  terraform fmt -write=false -diff=true terraform
+  terraform fmt -write=false -diff=true "${PAAS_CF_DIR}/terraform"
   exit 1
 fi

--- a/terraform/scripts/lint.sh
+++ b/terraform/scripts/lint.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
 set -eu
+RELEASE=0.2.2
+BINARY=terraform-provider-pingdom-tf-${TF_VERSION}-$(uname -s)-$(uname -m)
 
 # Setup the working grounds.
 PAAS_CF_DIR=$(pwd)
 WORKING_DIR=$(mktemp -d terraform-lint.XXXXXX)
 trap 'rm -r "${PAAS_CF_DIR}/${WORKING_DIR}"' EXIT
+
+wget "https://github.com/alphagov/paas-terraform-provider-pingdom/releases/download/${RELEASE}/${BINARY}" \
+  -O "${WORKING_DIR}"/terraform-provider-pingdom
+chmod +x "${WORKING_DIR}"/terraform-provider-pingdom
 
 cd "${WORKING_DIR}"
 


### PR DESCRIPTION
## What

[Fix `make lint_terraform`](https://www.pivotaltracker.com/n/projects/1275640/stories/139291295)

We now have TF 0.8.5 and a new version of provider built for this TF. Use that for lint checks.

## How to review

`make lint_terraform` should succeed.

## Who can review

not @mtekel or @saliceti 