### PR TITLE
Prevent failures by pinning autodelete to master

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -15,7 +15,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-cf.git
-      branch: {{branch_name}}
+      branch: master
       tag_filter: {{paas_cf_tag_filter}}
       commit_verification_key_ids: {{gpg_ids}}
 


### PR DESCRIPTION
## What

Autodelete will often fail if the environment was deployed from a branch that has been merged, meaning the remote branch no longer exists. This pins the autodelete branch to master to avoid this.

90% of the time the branch is now part of master and the operations carried out are quite simple, so this should cause no problems.

## How to review

Code review.

## Who can review

Anyone!