### PR TITLE
[#135953741] Fix terraform destroy bug

### DIFF
--- a/concourse/tasks/terraform_destroy_datadog.yml
+++ b/concourse/tasks/terraform_destroy_datadog.yml
@@ -25,6 +25,7 @@ run:
         terraform destroy -force \
           -state=datadog-tfstate/datadog.tfstate \
           -state-out=updated-datadog-tfstate/datadog.tfstate \
+          -var-file=paas-cf/terraform/${TF_VAR_aws_account}.tfvars \
         paas-cf/terraform/datadog
       else
         echo "Datadog disabled, skipping terraform run..."


### PR DESCRIPTION
## What

Story: [Configure schedules and escalation policies for PagerDuty](https://www.pivotaltracker.com/story/show/135953741)

In https://github.com/alphagov/paas-cf/pull/765 new variables were added to env.tfvars files and used in datadog terraform. The destroy task wasn't reading the env.tfvars files so the task was hanging.
The env.tfvars are now read in the destroy task.

## How to review
Run the destroy-cloudfoundry pipeline, it shouldn't hang at task datadog-TF-destroy
Should you want to keep your environment, you can comment the delete-deployment and pause the the terraform-desrtoy job.

## Who can review
Not me
