### PR TITLE
[#135953741] Fix terraform destroy bug #2

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1538,6 +1538,7 @@ jobs:
                       terraform destroy -force \
                          -state=datadog-tfstate/datadog.tfstate \
                          -state-out=updated-tfstate/datadog.tfstate \
+                         -var-file=paas-cf/terraform/${TF_VAR_aws_account}.tfvars \
                          paas-cf/terraform/datadog
                       exit 0
                     fi


### PR DESCRIPTION
## What

Same problem as in 5693f800ea6190271a27dc0b0d382932ecbef39b but now in
create pipeline.

New variables were added to env.tfvars files and used in datadog
terraform. The destroy task wasn't reading the env.tfvars files so the
task was hanging.
The env.tfvars are now read in the destroy task.

## How to review

Upload you datadog keys but set `ENABLE_DATADOG` to false. The `datadog-terraform-apply` task in `cf-deploy` job should not hang. 

## Who can review

Not @combor
