### PR TITLE
[#134350583] Fix RDS Broker and syslog trusted advisor warnings

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1275,9 +1275,9 @@ jobs:
                   echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
 
                   if cf service-brokers | grep "rds-broker\s"; then
-                    cf update-service-broker rds-broker rds-broker $RDS_BROKER_PASS http://$RDS_BROKER_SERVER
+                    cf update-service-broker rds-broker rds-broker $RDS_BROKER_PASS https://$RDS_BROKER_SERVER
                   else
-                    cf create-service-broker rds-broker rds-broker $RDS_BROKER_PASS http://$RDS_BROKER_SERVER
+                    cf create-service-broker rds-broker rds-broker $RDS_BROKER_PASS https://$RDS_BROKER_SERVER
                   fi
                   cf enable-service-access postgres
 

--- a/manifests/cf-manifest/manifest/800-logsearch.yml
+++ b/manifests/cf-manifest/manifest/800-logsearch.yml
@@ -131,8 +131,6 @@ jobs:
   templates:
   - name: ingestor_syslog
     release: logsearch
-  - name: ingestor_relp
-    release: logsearch
   vm_type: ingestor
   stemcell: default
   instances: 1
@@ -152,8 +150,6 @@ jobs:
   azs: [z2]
   templates:
   - name: ingestor_syslog
-    release: logsearch
-  - name: ingestor_relp
     release: logsearch
   vm_type: ingestor
   stemcell: default

--- a/terraform/cloudfoundry/logsearch.tf
+++ b/terraform/cloudfoundry/logsearch.tf
@@ -23,13 +23,6 @@ resource "aws_elb" "logsearch_ingestor" {
     lb_port           = 5514
     lb_protocol       = "tcp"
   }
-
-  listener {
-    instance_port     = 2514
-    instance_protocol = "tcp"
-    lb_port           = 2514
-    lb_protocol       = "tcp"
-  }
 }
 
 resource "aws_elb" "logsearch_es_master" {
@@ -107,16 +100,6 @@ resource "aws_security_group" "logsearch_ingestor_elb" {
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    from_port = 2514
-    to_port   = 2514
-    protocol  = "tcp"
-
-    cidr_blocks = [
-      "${var.vpc_cidr}",
-    ]
   }
 
   ingress {

--- a/terraform/cloudfoundry/logsearch.tf
+++ b/terraform/cloudfoundry/logsearch.tf
@@ -7,6 +7,7 @@ resource "aws_elb" "logsearch_ingestor" {
 
   security_groups = [
     "${aws_security_group.logsearch_ingestor_elb.id}",
+    "${aws_security_group.logsearch_ingestor_elb_ssl.id}",
   ]
 
   health_check {
@@ -22,6 +23,14 @@ resource "aws_elb" "logsearch_ingestor" {
     instance_protocol = "tcp"
     lb_port           = 5514
     lb_protocol       = "tcp"
+  }
+
+  listener {
+    instance_port      = 5514
+    instance_protocol  = "tcp"
+    lb_port            = 6514
+    lb_protocol        = "ssl"
+    ssl_certificate_id = "${var.system_domain_cert_arn}"
   }
 }
 
@@ -114,6 +123,33 @@ resource "aws_security_group" "logsearch_ingestor_elb" {
 
   tags {
     Name = "${var.env}-logsearch-ingestor"
+  }
+}
+
+resource "aws_security_group" "logsearch_ingestor_elb_ssl" {
+  name        = "${var.env}-logsearch-ingestor-elb-ssl"
+  description = "Security group for web that allows TCP/6514 for logsearch ingestor"
+  vpc_id      = "${var.vpc_id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 6514
+    to_port   = 6514
+    protocol  = "tcp"
+
+    cidr_blocks = [
+      "${var.vpc_cidr}",
+    ]
+  }
+
+  tags {
+    Name = "${var.env}-logsearch-ingestor-ssl"
   }
 }
 

--- a/terraform/cloudfoundry/rds_broker.tf
+++ b/terraform/cloudfoundry/rds_broker.tf
@@ -20,6 +20,14 @@ resource "aws_elb" "rds_broker" {
     lb_port           = 80
     lb_protocol       = "http"
   }
+
+  listener {
+    instance_port      = 80
+    instance_protocol  = "http"
+    lb_port            = 443
+    lb_protocol        = "https"
+    ssl_certificate_id = "${var.system_domain_cert_arn}"
+  }
 }
 
 resource "aws_db_subnet_group" "rds_broker" {

--- a/terraform/cloudfoundry/security-groups.tf
+++ b/terraform/cloudfoundry/security-groups.tf
@@ -157,6 +157,16 @@ resource "aws_security_group" "service_brokers" {
     ]
   }
 
+  ingress {
+    from_port = 443
+    to_port   = 443
+    protocol  = "tcp"
+
+    security_groups = [
+      "${aws_security_group.cloud_controller.id}",
+    ]
+  }
+
   tags {
     Name = "${var.env}-service-brokers"
   }


### PR DESCRIPTION
## What

In order for our Trusted Advisor to report when and what we desire, we would like to fix some issues we're currently facing.

Two issues targeted in this PR are: 
- the RDS Broker could use HTTPS connection
- the logsearch-ingestor could use ssl connection

In order to prevent downtime, we're adding an extra listener, which then will be removed in another PR.

## How to review

This changes need to be applied in strict order to avoid downtime for log forwarding:

1. Review and apply this PR. It will create new secure ELB listeners for rds-broker and ingestor 
2. Review and apply ( on bootstrap ) https://github.com/alphagov/paas-bootstrap/pull/46. It will change bosh runtime config to point rsyslog to new listener and use SSL
3. Review and apply https://github.com/alphagov/paas-cf/pull/782. It will remove old rds-broker listenr and **implicitly trigger deployment of rsyslog with TLS**
4. Review and apply https://github.com/alphagov/paas-cf/pull/783. It will remove now unused ingestor ELB 

- Run `create-cloudfoundry` pipeline from this branch
- Expect it to go through without errors
- Check if you're receiving logs to your Kabana
- Visit [Trusted Advisor Security](https://console.aws.amazon.com/trustedadvisor/home?region=eu-west-1#/category/security) and make sure,  
`{DEPLOY_ENV}-logsearch-ingestor` and`{DEPLOY_ENV}-rds-broker` are not listed under ELB Listener Security

## Who can review

Neither, @combor nor @paroxp
