### PR TITLE
[#126115903] Remove user that ran create-user script from organisation

### DIFF
--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -130,6 +130,11 @@ create_org_space() {
   cf unset-org-role "${admin_user}" "${ORG}" OrgManager
   cf unset-space-role "${admin_user}" "${ORG}" "${DEFAULT_SPACE}" SpaceManager
   cf unset-space-role "${admin_user}" "${ORG}" "${DEFAULT_SPACE}" SpaceDeveloper
+
+  # Even after losing all the roles, user is still present in the list of all users of an org
+  # FIXME: remove this fix for https://github.com/cloudfoundry/cli/issues/781 is deployed
+  guid=$(cf org "${ORG}" --guid)
+  cf curl -X DELETE "/v2/organizations/${guid}/users" -d "{\"username\": \"${admin_user}\"}"
 }
 
 create_user() {

--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -134,7 +134,11 @@ create_org_space() {
 
 create_user() {
   if [[ "${RESET_USER}" == "true" ]]; then
-    cf delete-user "${EMAIL}" -f
+    if cf delete-user "${EMAIL}" -f 2>&1 | tee "${TMP_OUTPUT}"; then
+      if grep -q "does not exist" "${TMP_OUTPUT}"; then
+        abort "Trying to reset password for non-existing user. Is someone trying to trick you into getting an account?"
+      fi
+    fi
   fi
 
   if cf create-user "${EMAIL}" "${PASSWORD}" 2>&1 | tee "${TMP_OUTPUT}"; then


### PR DESCRIPTION
## What
[Remove user that ran create-user script from organisation](https://www.pivotaltracker.com/n/projects/1275640/stories/126115903)
Also check if user exists for reset password.

## How to review

* Reset pw: try to reset password of an user that doesn't exist, e.g. `/scripts/create-user.sh -r -e dummy@user.org -o admin`
* User cleanup: create a dummy user in some test org and then list all the users in that org. You should not be among the list:
```
/scripts/create-user.sh -e dummy@user.org -o dummy-org
cf org-users -a dummy-org
```

## Who can review
not @mtekel
