### PR TITLE
Switch documentation URL's to the new docs

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -19,7 +19,7 @@ properties:
   app_ssh:
     host_key_fingerprint: (( grab secrets.ssh_proxy_host_key.public_fingerprint ))
 
-  support_address: "https://government-paas-developer-docs.readthedocs.io/"
+  support_address: "https://docs.cloud.service.gov.uk"
   description: null
   ssl:
     skip_cert_verify: false

--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -23,12 +23,12 @@ Your organisation is \"${ORG}\" and your login and password are:
  - password: ${PASSWORD}
 
 To get started, look at our Quick Setup Guide:
-https://government-paas-developer-docs.readthedocs.io/en/latest/getting_started/quick_setup_guide/
+https://docs.cloud.service.gov.uk/#quick-setup-guide
 
 You should make sure to change your password, as explained in the Quick Setup Guide.
 
 You can find our privacy policy here:
-https://government-paas-developer-docs.readthedocs.io/en/latest/getting_started/privacy/
+https://docs.cloud.service.gov.uk/#privacy-policy
 
 Regards,
 Government PaaS team.

--- a/scripts/rotate-user-password.sh
+++ b/scripts/rotate-user-password.sh
@@ -16,7 +16,7 @@ We have received a request to reset the password associated with this email addr
 Your new password is: ${PASSWORD}
 
 For guidance on logging in and changing your password you can visit:
-https://government-paas-developer-docs.readthedocs.io/en/latest/getting_started/quick_setup_guide/#setting-up-the-command-line
+https://docs.cloud.service.gov.uk/#setting-up-the-command-line
 
 You should make sure to change your password, as explained in the documentation in the above link.
 


### PR DESCRIPTION
## What

We've moved our documentation off Readthedocs and onto the PaaS, this updates the documentation links in the API and in emails we send to tenants.

## How to review

Check the new links refer to the same documentation as the old links, but on the new server.

## Who can review

Anyone!