### PR TITLE
[#121934253] Use blue-green-deploy plugin for healthcheck app

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1228,30 +1228,59 @@ jobs:
 
                 ls -l config/*
 
-      - task: create-admin-org-space
-        config:
-          platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/cf-cli
-          inputs:
-            - name: paas-cf
-            - name: config
-            - name: bosh-CA
-          run:
-            path: sh
-            args:
-              - -e
-              - -c
-              - |
-                ./paas-cf/concourse/scripts/import_bosh_ca.sh
-                . ./config/config.sh
-                echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
-                echo | cf create-org admin
-                cf create-space admin -o admin
-
       - aggregate:
+        - task: create-admin-org-space
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/cf-cli
+            inputs:
+              - name: paas-cf
+              - name: config
+              - name: bosh-CA
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  ./paas-cf/concourse/scripts/import_bosh_ca.sh
+                  . ./config/config.sh
+                  echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
+                  echo | cf create-org admin
+                  cf create-space admin -o admin
+
+        - task: register-rds-broker
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/cf-cli
+            inputs:
+              - name: paas-cf
+              - name: config
+              - name: bosh-CA
+            run:
+              path: sh
+              args:
+                - -e
+                - -u
+                - -c
+                - |
+                  ./paas-cf/concourse/scripts/import_bosh_ca.sh
+                  . ./config/config.sh
+                  echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
+
+                  if cf service-brokers | grep "rds-broker\s"; then
+                    cf update-service-broker rds-broker rds-broker $RDS_BROKER_PASS http://$RDS_BROKER_SERVER
+                  else
+                    cf create-service-broker rds-broker rds-broker $RDS_BROKER_PASS http://$RDS_BROKER_SERVER
+                  fi
+                  cf enable-service-access postgres
+
         - task: set-security-groups-from-manifest
           config:
             platform: linux
@@ -1305,6 +1334,7 @@ jobs:
 
                   ./paas-cf/concourse/scripts/set_quotas_from_manifest.rb cf-manifest/cf-manifest.yml
 
+      - aggregate:
         - task: sync-admin-users
           config:
             platform: linux
@@ -1337,35 +1367,6 @@ jobs:
                   cd paas-cf/scripts
                   bundle
                   bundle exec sync-admin-users.rb ${API_ENDPOINT} ../config/admin_users.yml "{{NEW_ACCOUNT_EMAIL_ADDRESS}}"
-
-        - task: register-rds-broker
-          config:
-            platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: governmentpaas/cf-cli
-            inputs:
-              - name: paas-cf
-              - name: config
-              - name: bosh-CA
-            run:
-              path: sh
-              args:
-                - -e
-                - -u
-                - -c
-                - |
-                  ./paas-cf/concourse/scripts/import_bosh_ca.sh
-                  . ./config/config.sh
-                  echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
-
-                  if cf service-brokers | grep "rds-broker\s"; then
-                    cf update-service-broker rds-broker rds-broker $RDS_BROKER_PASS http://$RDS_BROKER_SERVER
-                  else
-                    cf create-service-broker rds-broker rds-broker $RDS_BROKER_PASS http://$RDS_BROKER_SERVER
-                  fi
-                  cf enable-service-access postgres
 
         - task: deploy-graphite-nozzle
           config:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -10,7 +10,6 @@ groups:
       - cf-terraform
       - generate-cf-config
       - cf-deploy
-      - post-deploy
       - smoke-tests
       - acceptance-tests
       - custom-acceptance-tests
@@ -26,7 +25,6 @@ groups:
       - cf-terraform
       - generate-cf-config
       - cf-deploy
-      - post-deploy
       - smoke-tests
       - acceptance-tests
       - custom-acceptance-tests
@@ -1487,6 +1485,62 @@ jobs:
                   -d '{"transient":{"cluster.routing.allocation.enable":"all"}}' \
                   "${TF_VAR_logsearch_elastic_master_elb_dns_name}:9200/_cluster/settings"
 
+        - task: deploy-healthcheck
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/cf-cli
+            params:
+              DISABLE_HEALTHCHECK_DB: {{disable_healthcheck_db}}
+            inputs:
+              - name: paas-cf
+              - name: config
+              - name: bosh-CA
+            outputs:
+              - name: deployed-healthcheck
+            run:
+              path: sh
+              args:
+                - -e
+                - -u
+                - -c
+                - |
+                  ./paas-cf/concourse/scripts/import_bosh_ca.sh
+
+                  . ./config/config.sh
+                  echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
+                  cf create-org testers
+                  cf set-quota testers test_apps
+                  cf create-space healthcheck -o testers
+                  cf target -o testers -s healthcheck
+                  BUILD_ROOT=$(pwd)
+                  cd paas-cf/platform-tests/example-apps/healthcheck
+
+                  if  [ "${DISABLE_HEALTHCHECK_DB:-}" != "true" ] ; then
+                    cf create-service postgres Free healthcheck-db
+                    while ! cf service healthcheck-db | grep -q 'Status: create succeeded'; do
+                      echo "Waiting for creation of service to complete..."
+                      sleep 30
+                    done
+
+                    ruby -ryaml -e '
+                      manifest = YAML.load_file("manifest.yml")
+                      manifest["applications"].each { |app| app["services"] = ["healthcheck-db"] }
+                      File.write("manifest.yml", manifest.to_yaml)
+                    '
+                  fi
+
+                  cf blue-green-deploy healthcheck
+
+                  cd $BUILD_ROOT
+                  echo "yes" > deployed-healthcheck/healthcheck-deployed
+          on_success:
+            put: deployed-healthcheck
+            params:
+              file: deployed-healthcheck/healthcheck-deployed
+
         - task: run-bosh-cleanup
           config:
             platform: linux
@@ -1696,113 +1750,12 @@ jobs:
                   cf set-env rubbernecker PIVOTAL_PROJECT_ID ${PIVOTAL_PROJECT_ID}
                   cf start rubbernecker
 
-  - name: post-deploy
-    plan:
-      - aggregate:
-          - get: pipeline-trigger
-            passed: ['cf-deploy']
-            trigger: true
-          - get: paas-cf
-            passed: ['cf-deploy']
-          - get: cf-manifest
-            passed: ['cf-deploy']
-          - get: cf-secrets
-            passed: ['cf-deploy']
-          - get: bosh-CA
-
-      - task: retrieve-config
-        config:
-          platform: linux
-          inputs:
-            - name: paas-cf
-            - name: cf-secrets
-            - name: cf-manifest
-          outputs:
-            - name: config
-          params:
-          image_resource:
-            type: docker-image
-            source:
-              repository: ruby
-              tag: 2.2-slim
-          run:
-            path: sh
-            args:
-              - -e
-              - -c
-              - |
-                VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
-
-                CF_ADMIN=admin
-                CF_PASS=$($VAL_FROM_YAML secrets.uaa_admin_password cf-secrets/cf-secrets.yml)
-                API_ENDPOINT=$($VAL_FROM_YAML properties.cc.srv_api_uri cf-manifest/cf-manifest.yml)
-
-                for var_name in CF_ADMIN CF_PASS API_ENDPOINT; do
-                  echo export "${var_name}"=\"$(eval echo \$${var_name})\"
-                done > config/config.sh
-
-      - task: deploy-healthcheck
-        config:
-          platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/cf-cli
-          params:
-            DISABLE_HEALTHCHECK_DB: {{disable_healthcheck_db}}
-          inputs:
-            - name: paas-cf
-            - name: config
-            - name: bosh-CA
-          outputs:
-            - name: deployed-healthcheck
-          run:
-            path: sh
-            args:
-              - -e
-              - -u
-              - -c
-              - |
-                ./paas-cf/concourse/scripts/import_bosh_ca.sh
-
-                . ./config/config.sh
-                echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
-                cf create-org testers
-                cf set-quota testers test_apps
-                cf create-space healthcheck -o testers
-                cf target -o testers -s healthcheck
-                BUILD_ROOT=$(pwd)
-                cd paas-cf/platform-tests/example-apps/healthcheck
-
-                if  [ "${DISABLE_HEALTHCHECK_DB:-}" != "true" ] ; then
-                  cf create-service postgres Free healthcheck-db
-                  while ! cf service healthcheck-db | grep -q 'Status: create succeeded'; do
-                    echo "Waiting for creation of service to complete..."
-                    sleep 30
-                  done
-
-                  ruby -ryaml -e '
-                    manifest = YAML.load_file("manifest.yml")
-                    manifest["applications"].each { |app| app["services"] = ["healthcheck-db"] }
-                    File.write("manifest.yml", manifest.to_yaml)
-                  '
-                fi
-
-                cf blue-green-deploy healthcheck
-
-                cd $BUILD_ROOT
-                echo "yes" > deployed-healthcheck/healthcheck-deployed
-        on_success:
-          put: deployed-healthcheck
-          params:
-            file: deployed-healthcheck/healthcheck-deployed
-
   - name: smoke-tests
     serial_groups: [smoke-tests]
     plan:
       - aggregate:
           - get: pipeline-trigger
-            passed: ['post-deploy','availability-tests']
+            passed: ['cf-deploy','availability-tests']
             trigger: true
           - get: cf-release
             params:
@@ -1810,12 +1763,12 @@ jobs:
                 - src/smoke-tests
             passed: ['cf-deploy']
           - get: paas-cf
-            passed: ['post-deploy','availability-tests']
+            passed: ['cf-deploy','availability-tests']
           - get: cf-manifest
-            passed: ['post-deploy']
+            passed: ['cf-deploy']
           - get: bosh-CA
           - get: cf-secrets
-            passed: ['post-deploy']
+            passed: ['cf-deploy']
 
       - do:
         - task: create-temp-user
@@ -1842,7 +1795,7 @@ jobs:
     plan:
       - aggregate:
           - get: pipeline-trigger
-            passed: ['post-deploy','availability-tests']
+            passed: ['cf-deploy','availability-tests']
             trigger: true
           - get: cf-release
             params:
@@ -1850,12 +1803,12 @@ jobs:
                 - src/github.com/cloudfoundry/cf-acceptance-tests
             passed: ['cf-deploy']
           - get: paas-cf
-            passed: ['post-deploy','availability-tests']
+            passed: ['cf-deploy','availability-tests']
           - get: cf-manifest
-            passed: ['post-deploy']
+            passed: ['cf-deploy']
           - get: bosh-CA
           - get: cf-secrets
-            passed: ['post-deploy']
+            passed: ['cf-deploy']
 
       - do:
         - task: create-temp-user
@@ -1962,15 +1915,15 @@ jobs:
     plan:
       - aggregate:
           - get: pipeline-trigger
-            passed: ['post-deploy','availability-tests']
+            passed: ['cf-deploy','availability-tests']
             trigger: true
           - get: paas-cf
-            passed: ['post-deploy','availability-tests']
+            passed: ['cf-deploy','availability-tests']
           - get: cf-manifest
-            passed: ['post-deploy']
+            passed: ['cf-deploy']
           - get: bosh-CA
           - get: cf-secrets
-            passed: ['post-deploy']
+            passed: ['cf-deploy']
 
       - do:
         - task: create-temp-user
@@ -2005,10 +1958,10 @@ jobs:
     plan:
       - aggregate:
           - get: pipeline-trigger
-            passed: ['post-deploy','availability-tests']
+            passed: ['cf-deploy','availability-tests']
             trigger: true
           - get: paas-cf
-            passed: ['post-deploy','availability-tests']
+            passed: ['cf-deploy','availability-tests']
           - get: cf-manifest
           - get: bosh-secrets
       - task: test-bosh-cli

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1533,6 +1533,7 @@ jobs:
                   fi
 
                   cf blue-green-deploy healthcheck
+                  cf delete -f healthcheck-old
 
                   cd $BUILD_ROOT
                   echo "yes" > deployed-healthcheck/healthcheck-deployed

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1773,17 +1773,23 @@ jobs:
                 cf target -o testers -s healthcheck
                 BUILD_ROOT=$(pwd)
                 cd paas-cf/platform-tests/example-apps/healthcheck
-                cf push --no-start
+
                 if  [ "${DISABLE_HEALTHCHECK_DB:-}" != "true" ] ; then
                   cf create-service postgres Free healthcheck-db
                   while ! cf service healthcheck-db | grep -q 'Status: create succeeded'; do
                     echo "Waiting for creation of service to complete..."
                     sleep 30
                   done
-                  cf bind-service healthcheck healthcheck-db
+
+                  ruby -ryaml -e '
+                    manifest = YAML.load_file("manifest.yml")
+                    manifest["applications"].each { |app| app["services"] = ["healthcheck-db"] }
+                    File.write("manifest.yml", manifest.to_yaml)
+                  '
                 fi
 
-                cf start healthcheck
+                cf blue-green-deploy healthcheck
+
                 cd $BUILD_ROOT
                 echo "yes" > deployed-healthcheck/healthcheck-deployed
         on_success:


### PR DESCRIPTION
## What

This will ensure that there is no downtime when we deploy the healthcheck
app - which happens during every run of the pipeline. It will enable us to
merge the `post-deploy` job into `cf-deploy` because it will now be safe to
run in parallel with `availability-tests`.

Although it hasn't been a problem to date, it will also prevent us from
getting false-positive alerts from Pingdom (which monitors this app) and may
allow us to reduce the threshold for alerts.

## How to review

- see the individual commit messages for more information
- test without the healthcheck database
  - deploy from `master` to ensure that you have a running environment (not deleted overnight)
  - deploy the pipeline from a branch
  - run it all the way through
  - confirm that the availability-tests pass
- test with the healthcheck database
  - deploy from `master` to ensure that you have a running environment (not deleted overnight)
  - delete `DISABLE_HEALTHCHECK_DB` from your local `Makefile`
  - deploy the pipeline from a branch with `SELF_UPDATE_PIPELINE=false`
  - run it all the way through
  - confirm that the availability-tests pass
- **important before merging**
  - merge alphagov/paas-docker-cloudfoundry-tools#89 first
  - remove the "TMP" commit

## Who can review

Not @dcarley

Unfortunately I'm on holiday after today, so someone else may need to address any comments that arise.