### PR TITLE
[#139666419] Whitelist DWP Bereavement Payment Support IP

### DIFF
--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -48,6 +48,8 @@ tenant_cidrs = [
   "82.35.29.203/32",
   # Digital Marketplace Jenkins
   "52.18.174.104/32",
+  # DWP Bereavement Payment Support
+  "194.73.212.3/32",
 ]
 bosh_db_backup_retention_period = "35"
 bosh_db_skip_final_snapshot = "false"


### PR DESCRIPTION
## What
[Create  DWP Bereavement Payment Support Org and Users](https://www.pivotaltracker.com/n/projects/1275640/stories/139666419)

Whitelist DWP Bereavement Payment Support IP so that they can connect an operate their dwp-bereavementpaymentsupport org.

## How to review

Check that the whitelisted IP matches the one in the story. Check that it belongs to DWP (tip: use `whois`).

## Who can review

not @mtekel
