### PR TITLE
[support] Double graphite EBS IOPs

### DIFF
--- a/manifests/cf-manifest/cloud-config/040-graphite.yml
+++ b/manifests/cf-manifest/cloud-config/040-graphite.yml
@@ -1,7 +1,7 @@
 ---
 disk_types:
   - name: graphite_data
-    disk_size: 204800
+    disk_size: 409600
     cloud_properties: {type: gp2}
 
 vm_types:


### PR DESCRIPTION
### What
Graphite is currently IOPs starved. Current volume is 200GB, which
guarantees 600 IOPs only. This is not enough, as we are having more
apps, hosts and other sources of metrics in prod. IO starvation leads
to not all metrics being always written to disk, which leaves gaps in
graphs. Also, display of our user impact dashboard is affected, as there
is not enough IO available to retrieve all the stats in time, which leaves
blank graphs in grafana.

Double IOPs to 1200 by doubling size of the volume. This is still cheaper
than switching to provisioned IOPs, which at 1200 IO and 40GB only size is
more than twice the cost. The actual data usage is currently at 14GB...

## How to review

Code review. You can apply to your environment - you should see graphite disk being upgraded. Upgrade should preserve all the historical data.

## Who can review

not @mtekel
