### PR TITLE
[#134350583] Cleanup of rds listener 

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1275,9 +1275,9 @@ jobs:
                   echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
 
                   if cf service-brokers | grep "rds-broker\s"; then
-                    cf update-service-broker rds-broker rds-broker $RDS_BROKER_PASS http://$RDS_BROKER_SERVER
+                    cf update-service-broker rds-broker rds-broker $RDS_BROKER_PASS https://$RDS_BROKER_SERVER
                   else
-                    cf create-service-broker rds-broker rds-broker $RDS_BROKER_PASS http://$RDS_BROKER_SERVER
+                    cf create-service-broker rds-broker rds-broker $RDS_BROKER_PASS https://$RDS_BROKER_SERVER
                   fi
                   cf enable-service-access postgres
 

--- a/manifests/cf-manifest/manifest/800-logsearch.yml
+++ b/manifests/cf-manifest/manifest/800-logsearch.yml
@@ -131,8 +131,6 @@ jobs:
   templates:
   - name: ingestor_syslog
     release: logsearch
-  - name: ingestor_relp
-    release: logsearch
   vm_type: ingestor
   stemcell: default
   instances: 1
@@ -152,8 +150,6 @@ jobs:
   azs: [z2]
   templates:
   - name: ingestor_syslog
-    release: logsearch
-  - name: ingestor_relp
     release: logsearch
   vm_type: ingestor
   stemcell: default

--- a/terraform/cloudfoundry/logsearch.tf
+++ b/terraform/cloudfoundry/logsearch.tf
@@ -23,13 +23,6 @@ resource "aws_elb" "logsearch_ingestor" {
     lb_port           = 5514
     lb_protocol       = "tcp"
   }
-
-  listener {
-    instance_port     = 2514
-    instance_protocol = "tcp"
-    lb_port           = 2514
-    lb_protocol       = "tcp"
-  }
 }
 
 resource "aws_elb" "logsearch_es_master" {
@@ -107,16 +100,6 @@ resource "aws_security_group" "logsearch_ingestor_elb" {
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    from_port = 2514
-    to_port   = 2514
-    protocol  = "tcp"
-
-    cidr_blocks = [
-      "${var.vpc_cidr}",
-    ]
   }
 
   ingress {

--- a/terraform/cloudfoundry/logsearch.tf
+++ b/terraform/cloudfoundry/logsearch.tf
@@ -7,6 +7,7 @@ resource "aws_elb" "logsearch_ingestor" {
 
   security_groups = [
     "${aws_security_group.logsearch_ingestor_elb.id}",
+    "${aws_security_group.logsearch_ingestor_elb_ssl.id}",
   ]
 
   health_check {
@@ -22,6 +23,14 @@ resource "aws_elb" "logsearch_ingestor" {
     instance_protocol = "tcp"
     lb_port           = 5514
     lb_protocol       = "tcp"
+  }
+
+  listener {
+    instance_port      = 5514
+    instance_protocol  = "tcp"
+    lb_port            = 6514
+    lb_protocol        = "ssl"
+    ssl_certificate_id = "${var.system_domain_cert_arn}"
   }
 }
 
@@ -114,6 +123,33 @@ resource "aws_security_group" "logsearch_ingestor_elb" {
 
   tags {
     Name = "${var.env}-logsearch-ingestor"
+  }
+}
+
+resource "aws_security_group" "logsearch_ingestor_elb_ssl" {
+  name        = "${var.env}-logsearch-ingestor-elb-ssl"
+  description = "Security group for web that allows TCP/6514 for logsearch ingestor"
+  vpc_id      = "${var.vpc_id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 6514
+    to_port   = 6514
+    protocol  = "tcp"
+
+    cidr_blocks = [
+      "${var.vpc_cidr}",
+    ]
+  }
+
+  tags {
+    Name = "${var.env}-logsearch-ingestor-ssl"
   }
 }
 

--- a/terraform/cloudfoundry/rds_broker.tf
+++ b/terraform/cloudfoundry/rds_broker.tf
@@ -20,6 +20,14 @@ resource "aws_elb" "rds_broker" {
     lb_port           = 80
     lb_protocol       = "http"
   }
+
+  listener {
+    instance_port      = 80
+    instance_protocol  = "http"
+    lb_port            = 443
+    lb_protocol        = "https"
+    ssl_certificate_id = "${var.system_domain_cert_arn}"
+  }
 }
 
 resource "aws_db_subnet_group" "rds_broker" {

--- a/terraform/cloudfoundry/rds_broker.tf
+++ b/terraform/cloudfoundry/rds_broker.tf
@@ -15,13 +15,6 @@ resource "aws_elb" "rds_broker" {
   }
 
   listener {
-    instance_port     = 80
-    instance_protocol = "http"
-    lb_port           = 80
-    lb_protocol       = "http"
-  }
-
-  listener {
     instance_port      = 80
     instance_protocol  = "http"
     lb_port            = 443

--- a/terraform/cloudfoundry/security-groups.tf
+++ b/terraform/cloudfoundry/security-groups.tf
@@ -157,6 +157,16 @@ resource "aws_security_group" "service_brokers" {
     ]
   }
 
+  ingress {
+    from_port = 443
+    to_port   = 443
+    protocol  = "tcp"
+
+    security_groups = [
+      "${aws_security_group.cloud_controller.id}",
+    ]
+  }
+
   tags {
     Name = "${var.env}-service-brokers"
   }

--- a/terraform/cloudfoundry/security-groups.tf
+++ b/terraform/cloudfoundry/security-groups.tf
@@ -148,16 +148,6 @@ resource "aws_security_group" "service_brokers" {
   }
 
   ingress {
-    from_port = 80
-    to_port   = 80
-    protocol  = "tcp"
-
-    security_groups = [
-      "${aws_security_group.cloud_controller.id}",
-    ]
-  }
-
-  ingress {
     from_port = 443
     to_port   = 443
     protocol  = "tcp"


### PR DESCRIPTION
## What

This needs to be rebased after https://github.com/alphagov/paas-cf/pull/776 is merged.

As we have moved to https for cloud controller to rds broker
communication we can now remove old listener and related security rule.

## How to review

This needs to be applied after https://github.com/alphagov/paas-cf/pull/776. Check the sequence in the master PR.

Run deployment from this branch and make sure you still can interact with rds-broker. For instance execute `cf create-service` command.

## Who can review
Not @paroxp or @combor
