### PR TITLE
[#139361587] Update rds-broker to support restore from latest snapshot

### DIFF
--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -30,9 +30,9 @@ meta:
 
 releases:
   - name: rds-broker
-    version: 0.1.2
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.2.tgz
-    sha1: f111152713d00d884d4d9bdb28f96778d3016e50
+    version: 0.1.3
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.3.tgz
+    sha1: 99cb288048d1f5c394e663985e7a8c15c5b2617a
 
 jobs:
   - name: rds_broker


### PR DESCRIPTION
[#139361587 rds-broker: Able to create a instance from the latest snapshot of other instance](https://www.pivotaltracker.com/story/show/139361587)

## What?

We want to provide the user logic to be able to restore the latest snapshot of any existing service instance.

We implemented that feature in https://github.com/alphagov/paas-rds-broker/pull/35

It adds an additional parameter to be passed during provisioning: `restore_from_latest_snapshot_of`. The user must pass the GUID of an existing postgres service, which can find out using `cf service mydb --guid`.


# Dependencies 

This PR depends on https://github.com/alphagov/paas-rds-broker/pull/35 and https://github.com/alphagov/paas-rds-broker-boshrelease/pull/29

You can test this PR by itself, but once all 3 have been reviewed, you must merge and update the others in the right order:
 1. Review and merge: https://github.com/alphagov/paas-rds-broker/pull/35
 2. Update submodule after merging paas-rds-broker and merge  https://github.com/alphagov/paas-rds-broker-boshrelease/pull/29

Once merged, you must update the rds-broker-boshrelease to point to the final release created in https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/rds-broker?groups=main

# How to review

You can deploy this PR and check that feature works:

```
# Create an instance
cf create-service postgres Free mydb

# ... wait for it to be created ;)
cf service mydb

# Get the service GUID
service_guid=$(cf service henrys-cool-db --guid)

# Trigger a snapshot of it. We use aws cli because we still do not have the right feature for this
aws --region eu-west-1 rds create-db-snapshot --db-instance-identifier rdsbroker-$service_guid --db-snapshot-identifier rdsbroker-$service_guid-$(date +%Y-%m-%d-%H-%M)

# Wait to finish the snapshot
aws --region eu-west-1 rds describe-db-instances --db-instance-identifier rdsbroker-$service_guid --query DBInstances[].DBInstanceStatus --output text
backing-up

# Now, trigger the restore:

cf create-service postgres Free mydb-restore -c "{\"restore_from_latest_snapshot_of\": \"${service_guid}\"}"


```

You can optionally stop one of the RDS brokers and go to the other to check the logs:

```
make dev bosh-cli DEPLOY_ENV=...

# Stop one broker
bosh ssh rds_broker/1 sudo /var/vcap/bosh/bin/monit stop rds-broker

# go to the other
bosh ssh rds_broker/0
sudo su -
less /var/vcap/sys/log/rds-broker/rds-broker.stdout.log  

# You can also use veritas to see the logs
cd /tmp
wget https://github.com/pivotal-cf-experimental/veritas/releases/download/latest/veritas
chmod +x veritas
./veritas chug /var/vcap/sys/log/rds-broker/rds-broker.stdout.log  | less -R -S
```

# Who

Anyone but @keymon, @henrytk or @jonty
