### PR TITLE
[#139706089] Enable route services

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -171,6 +171,7 @@ properties:
       user: router_user
       password: (( grab secrets.router_password ))
     drain_wait: 15
+    route_services_secret: (( grab secrets.route_services_secret ))
 
   cc:
     jobs:

--- a/manifests/cf-manifest/manifest/900-cf-tests.yml
+++ b/manifests/cf-manifest/manifest/900-cf-tests.yml
@@ -20,7 +20,7 @@ properties:
     include_operator: true
     include_services: true
     include_diego_ssh: true
-    include_route_services: false
+    include_route_services: true
     artifacts_directory: "/var/vcap/sys/log/test_artifacts"
     nodes: 10
 

--- a/manifests/cf-manifest/scripts/generate-cf-secrets.rb
+++ b/manifests/cf-manifest/scripts/generate-cf-secrets.rb
@@ -14,6 +14,7 @@ generator = SecretGenerator.new(
   "bulk_api_password" => :simple,
   "nats_password" => :simple,
   "router_password" => :simple,
+  "route_services_secret" => :simple,
   "uaa_batch_password" => :simple,
   "uaa_admin_password" => :simple,
   "test_user_password" => :simple,

--- a/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
@@ -180,4 +180,12 @@ RSpec.describe "base properties" do
       end
     end
   end
+
+  describe "router" do
+    subject(:router) { properties.fetch("router") }
+
+    it "sets route_services_secret" do
+      expect(router["route_services_secret"]).not_to be_empty
+    end
+  end
 end


### PR DESCRIPTION
## What

This will enable tenants to add an authentication layer in front of an app without having to modify the app itself.

## How to review

- Deploy from this branch
- Push the [cf_basic_auth_route_service](https://github.com/alext/cf_basic_auth_route_service) app to CF (setting the AUTH_USERNAME,  AUTH_PASSWORD and SKIP_SSL_VALIDATION env vars).
- Define a user-provided-service for it:
```
cf create-user-provided-service my-auth -r https://basic-auth-route-service.${DEPLOY_ENV}.dev.cloudpipelineapps.digital
```
- Bind it to the route for an app:
```
cf bind-route-service ${DEPLOY_ENV}.dev.cloudpipelineapps.digital my-auth --hostname my-app-route
```
- Check if your app has basic auth now
## Who can review

Not @combor