### PR TITLE
Enable cf tasks acceptance tests

### DIFF
--- a/manifests/cf-manifest/manifest/900-cf-tests.yml
+++ b/manifests/cf-manifest/manifest/900-cf-tests.yml
@@ -10,7 +10,7 @@ properties:
     backend: "diego"
     client_secret: (( grab secrets.uaa_clients_gorouter_secret ))
     skip_diego_unsupported_tests: true
-    include_tasks: false
+    include_tasks: true
     include_v3: false
     include_security_groups: true
     include_routing: true


### PR DESCRIPTION
## What
As of our upgrade to v251, we have announced support of cf tasks.
Do run acceptance tests to keep verifying that the functionality
still works correctly over time.

Note that the tests can still pass even if task_creation feature
flag is disabled as tests run with user that has admin privileges,
which can run tasks even if they are disabled.

## How to review

Run. Acceptance tests should pass.

## Who can review
not @mtekel