### PR TITLE
Update spruce to v 1.8.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
 env:
   global:
     - TF_VERSION="0.8.5"
-    - SPRUCE_VERSION="1.5.0"
+    - SPRUCE_VERSION="1.8.9"
     - DEPLOY_ENV="travis"
 
 addons:


### PR DESCRIPTION
## What

As we use this version in the spruce container we need to synchronise
version in travis. This is a follow up to external PR: https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/90

## How to review

- check if travis tests have passed

## Who can review

Not @combor
