### PR TITLE
[#130020741] Password rotation pipeline 

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -41,6 +41,7 @@ groups:
       - bump-patch-version
       - pipeline-check-lock
       - pipeline-release-lock
+      - reset-cloudfoundry-passwords
   - name: tests
     jobs:
       - availability-tests
@@ -2221,6 +2222,37 @@ jobs:
       - put: pipeline-pool
         params:
           release: pipeline-pool
+
+  - name: reset-cloudfoundry-passwords
+    plan:
+      - get: cf-secrets
+      - get: paas-cf
+      - task: reset-passwords
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/spruce
+          inputs:
+            - name: paas-cf
+            - name: cf-secrets
+          outputs:
+            - name: modified-secrets
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                spruce merge \
+                  cf-secrets/cf-secrets.yml \
+                  paas-cf/concourse/resources/cf-secrets-deleter.yml \
+                  > modified-secrets/cf-secrets.yml
+        on_success:
+          put: cf-secrets
+          params:
+            file: modified-secrets/cf-secrets.yml
 
   - name: generate-git-keys
     plan:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -42,6 +42,7 @@ groups:
       - pipeline-check-lock
       - pipeline-release-lock
       - reset-cloudfoundry-passwords
+      - reset-concourse-keys
       - reset-bosh-passwords
   - name: tests
     jobs:
@@ -2254,6 +2255,9 @@ jobs:
           put: cf-secrets
           params:
             file: modified-secrets/cf-secrets.yml
+
+  - name: reset-concourse-keys
+    plan:
       - task: clear-ssh-keys
         config:
           platform: linux
@@ -2276,6 +2280,7 @@ jobs:
                 if aws s3 ls s3://${BUCKET}/concourse_id_rsa.pub > /dev/null; then
                   aws s3 rm s3://${BUCKET}/concourse_id_rsa.pub
                 fi
+                echo "Done"
 
   - name: reset-bosh-passwords
     plan:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -42,6 +42,7 @@ groups:
       - pipeline-check-lock
       - pipeline-release-lock
       - reset-cloudfoundry-passwords
+      - reset-bosh-passwords
   - name: tests
     jobs:
       - availability-tests
@@ -2275,6 +2276,61 @@ jobs:
                 if aws s3 ls s3://${BUCKET}/concourse_id_rsa.pub > /dev/null; then
                   aws s3 rm s3://${BUCKET}/concourse_id_rsa.pub
                 fi
+
+  - name: reset-bosh-passwords
+    plan:
+      - get: bosh-secrets
+      - get: paas-cf
+      - task: reset-passwords
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/spruce
+          inputs:
+            - name: paas-cf
+            - name: bosh-secrets
+          outputs:
+            - name: modified-secrets
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+
+                spruce merge \
+                  bosh-secrets/bosh-secrets.yml \
+                  paas-cf/concourse/resources/bosh-secrets-deleter.yml \
+                  > modified-secrets/bosh-secrets.yml
+        on_success:
+          put: bosh-secrets
+          params:
+            file: modified-secrets/bosh-secrets.yml
+      - task: clear-ssh-keys
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/awscli
+          params:
+            AWS_DEFAULT_REGION: {{aws_region}}
+            BUCKET: {{state_bucket}}
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                if aws s3 ls s3://${BUCKET}/bosh_id_rsa > /dev/null; then
+                  aws s3 rm s3://${BUCKET}/bosh_id_rsa
+                fi
+                if aws s3 ls s3://${BUCKET}/bosh_id_rsa.pub > /dev/null; then
+                  aws s3 rm s3://${BUCKET}/bosh_id_rsa.pub
+                fi
+                echo "Done"
 
   - name: generate-git-keys
     plan:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2253,6 +2253,28 @@ jobs:
           put: cf-secrets
           params:
             file: modified-secrets/cf-secrets.yml
+      - task: clear-ssh-keys
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/awscli
+          params:
+            AWS_DEFAULT_REGION: {{aws_region}}
+            BUCKET: {{state_bucket}}
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                if aws s3 ls s3://${BUCKET}/concourse_id_rsa > /dev/null; then
+                  aws s3 rm s3://${BUCKET}/concourse_id_rsa
+                fi
+                if aws s3 ls s3://${BUCKET}/concourse_id_rsa.pub > /dev/null; then
+                  aws s3 rm s3://${BUCKET}/concourse_id_rsa.pub
+                fi
 
   - name: generate-git-keys
     plan:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2258,6 +2258,7 @@ jobs:
 
   - name: reset-concourse-keys
     plan:
+      - get: paas-cf
       - task: clear-ssh-keys
         config:
           platform: linux
@@ -2265,6 +2266,8 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/awscli
+          inputs:
+            - name: paas-cf
           params:
             AWS_DEFAULT_REGION: {{aws_region}}
             BUCKET: {{state_bucket}}

--- a/concourse/resources/bosh-secrets-deleter.yml
+++ b/concourse/resources/bosh-secrets-deleter.yml
@@ -1,0 +1,9 @@
+---
+secrets:
+  bosh_postgres_password: null
+  bosh_registry_password: null
+  bosh_redis_password: null
+  bosh_hm_director_password: null
+  bosh_admin_password: null
+  bosh_vcap_password_orig: null
+  bosh_vcap_password: null

--- a/concourse/resources/cf-secrets-deleter.yml
+++ b/concourse/resources/cf-secrets-deleter.yml
@@ -1,0 +1,17 @@
+---
+secrets:
+  staging_upload_password: null
+  bulk_api_password: null
+  uaa_batch_password: null
+  uaa_admin_password: null
+  uaa_admin_client_secret: null
+  uaa_cc_client_secret: null
+  uaa_cc_routing_secret: null
+  uaa_clients_login_secret: null
+  uaa_clients_notifications_secret: null
+  uaa_clients_doppler_secret: null
+  uaa_clients_cloud_controller_username_lookup_secret: null
+  uaa_clients_gorouter_secret: null
+  uaa_clients_ssh_proxy_secret: null
+  uaa_clients_firehose_password: null
+  grafana_admin_password: null


### PR DESCRIPTION
## What

This is a first batch of changes to implement password rotation pipelines.

There are two of them in the `operator` group. 

- reset cloudfoundry passwords - rotates all but grafana password
- reset bosh passwords - rotates all but NATS password

Grafana changes will come in a next PR as we decided to improve grafana release to implement password rotation via deployment manifest.

We found rotation of NATS particularly difficult so we agreed to put it out of scope. See https://www.pivotaltracker.com/n/projects/1275640/stories/127339659 for more details.   

## How to review
- deploy your `create` pipeline
- run `reset-cloudfoundry-passwords` and again `create` pipeline to test if creds are rotated
- run `reset-bosh-passwords` and next `bootstrap` pipeline to test bosh creds rotation 

## Who can review

Not @combor
