### PR TITLE
[#139296467] Add bare domain of product page to cloudfront

### DIFF
--- a/terraform/cloudfront/cloudfront_distribution/distribution.tf
+++ b/terraform/cloudfront/cloudfront_distribution/distribution.tf
@@ -3,9 +3,13 @@ resource "aws_route53_record" "cdn_domain" {
 
   zone_id = "${var.system_dns_zone_id}"
   name    = "${element(var.aliases, count.index)}."
-  type    = "CNAME"
-  ttl     = "60"
-  records = ["${aws_cloudfront_distribution.cdn_instance.domain_name}"]
+  type    = "A"
+
+  alias {
+    name                   = "${aws_cloudfront_distribution.cdn_instance.domain_name}"
+    zone_id                = "${aws_cloudfront_distribution.cdn_instance.hosted_zone_id}"
+    evaluate_target_health = true
+  }
 }
 
 resource "aws_cloudfront_distribution" "cdn_instance" {

--- a/terraform/cloudfront/instances.tf
+++ b/terraform/cloudfront/instances.tf
@@ -8,7 +8,7 @@ module "cloudfront_paas_product_page" {
   source = "./cloudfront_distribution"
 
   name    = "PaaS Product Page"
-  aliases = ["www.${var.system_dns_zone_name}"]
+  aliases = ["www.${var.system_dns_zone_name}", "${var.system_dns_zone_name}"]
   origin  = "govuk-paas.cloudapps.digital"
   comment = "Serve the govuk-paas under the gov.uk domain."
 


### PR DESCRIPTION
[#139296467 Redirect from cloud.service.gov.uk (no www prefix)](https://www.pivotaltracker.com/story/show/139296467)

What?
-----

Set it up so that if users try to navigate to `cloud.service.gov.uk` in their browsers, they will be redirected to `https://www.cloud.service.gov.uk`

We added logic to the product page to redirect to the page with the www prefix in [1]. Here we map the domain in cloudfront.

[1] https://github.com/alphagov/paas-product-page/pull/2

How to review?
------------

 * Code review
 * Deploy from master with `make dev setup_cdn_instances ACTION=apply`, then check the difference checking out this branch and running `make dev setup_cdn_instances ACTION=plan`

You can deploy it by `make dev setup_cdn_instances ACTION=apply` again, and check that you are reaching the govuk product page when running `curl -v -I -k https://${DEPLOY_ENV}.dev.cloudpipeline.digital`

Dependencies
-----------

https://github.com/alphagov/paas-product-page/pull/2 should be merged first and deployed to prod.


Who?
----

Anyone but @keymon