### PR TITLE
[#138702349] TO DISCUSS: Fix flapping route53 alias with hardcoded zone id

### DIFF
--- a/terraform/cloudfoundry/dns-records.tf
+++ b/terraform/cloudfoundry/dns-records.tf
@@ -60,8 +60,15 @@ resource "aws_route53_record" "apps_apex" {
   type    = "A"
 
   alias {
-    name                   = "${aws_elb.cf_router.dns_name}"
-    zone_id                = "${aws_elb.cf_router.zone_id}"
+    name = "${aws_elb.cf_router.dns_name}."
+
+    # FIXME: Workaround for the issue described in
+    # https://github.com/hashicorp/terraform/issues/10007#issuecomment-281417653
+    # We would use a hardcoded zone_id rather than the one reported by
+    # the ELB terraform resource
+    # zone_id                = "${aws_elb.cf_router.zone_id}"
+    zone_id = "${lookup(var.elb_zone_ids, var.region)}"
+
     evaluate_target_health = true
   }
 }

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -145,6 +145,27 @@ variable "elb_account_ids" {
   }
 }
 
+# List of zone IDs used by ELBs in AWS
+# Provided by AWS in http://docs.aws.amazon.com/general/latest/gr/rande.html
+variable "elb_zone_ids" {
+  default = {
+    us-east-1      = "Z35SXDOTRQ7X7K"
+    us-east-2      = "Z3AADJGX6KTTL2"
+    us-west-1      = "Z368ELLRRE2KJ0"
+    us-west-2      = "Z1H1FL5HABSF5"
+    ca-central-1   = "ZQSVJUPU6J1EY"
+    ap-south-1     = "ZP97RAFLXTNZK"
+    ap-northeast-2 = "ZWKZPGTI48KDX"
+    ap-southeast-1 = "Z1LMS91P8CMLE5"
+    ap-southeast-2 = "Z1GM3OXH4ZPM65"
+    ap-northeast-1 = "Z14GRHDCWA56QT"
+    eu-central-1   = "Z215JYRZR1TBD5"
+    eu-west-1      = "Z32O12XQLNTSW2"
+    eu-west-2      = "ZHURV8PSTC4K8"
+    sa-east-1      = "Z2P70J7HTTTPLU"
+  }
+}
+
 variable "assets_prefix" {
   description = "Prefix for global assests like S3 buckets"
   default     = "gds-paas"


### PR DESCRIPTION
What?
----


It seems to be an issue in terraform [1] which makes the route53 alias
to flap changes. The solution for the time being is:

 1. Add a `.` in the domain reported by ELB
 2. Hardcode the zone id of the ELBs. (Z32O12XQLNTSW2 for eu-west-1)

We get the zone IDs from http://docs.aws.amazon.com/general/latest/gr/rande.html

How to test?
----------

This problem does not happen in dev :(

You can test it in CI, though. Or simply do a code review.

Who?
----

Anyone but @keymon