### PR TITLE
[#130020741] Update grafana to v 4.1.2

### DIFF
--- a/manifests/cf-manifest/manifest/040-graphite.yml
+++ b/manifests/cf-manifest/manifest/040-graphite.yml
@@ -15,9 +15,9 @@ releases:
   url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/graphite-0.1.1.tgz
   sha1: 7ce15711ae9afc04ccf152bab3f7de9b234f7c4f
 - name: grafana
-  version: 5
-  url: https://bosh.io/d/github.com/vito/grafana-boshrelease?v=5
-  sha1: 0edd89d7b383a2556a79f6688f576aa4b6f33bc2
+  version: 0.1.2
+  url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/grafana-0.1.2.tgz
+  sha1: 483ee4a07d683c94014efede103dd93cb92cd883
 
 jobs:
 - name: graphite


### PR DESCRIPTION
## What

This is a follow up to https://github.com/alphagov/paas-cf/pull/789 that updates Grafana to v 4.1.2 to make use of newly provided `grafana-cli` admin command.
The `grafana-cli admin` allows to change admin user password via cli.
This will let us to set new password in the manifest and rotate it during deployment.

## How to review

**This is master PR for set of PRs related to grafana update. PRs need to be merged in the sequence listed below**:
- https://github.gds/government-paas/aws-account-wide-terraform/pull/83
- https://github.com/alphagov/paas-release-ci/pull/12
- https://github.com/alphagov/paas-grafana-boshrelease/pull/1
- this PR

## Who can review

Not @combor
