### PR TITLE
[#139296467] Add redirection to add www to the system domain

### DIFF
--- a/terraform/cloudfront/cloudfront_redirect/distribution.tf
+++ b/terraform/cloudfront/cloudfront_redirect/distribution.tf
@@ -1,0 +1,152 @@
+variable "redirect_methods" {
+  default = ["GET", "HEAD"]
+}
+
+resource "aws_api_gateway_rest_api" "redirect_api_gw" {
+  name        = "${var.name}-redirect_api_gw"
+  description = "Basic redirect for ${var.name}"
+}
+
+resource "aws_api_gateway_method" "redirect_api_gw" {
+  count            = "${length(var.redirect_methods)}"
+  rest_api_id      = "${aws_api_gateway_rest_api.redirect_api_gw.id}"
+  resource_id      = "${aws_api_gateway_rest_api.redirect_api_gw.root_resource_id}"
+  http_method      = "${element(var.redirect_methods, count.index)}"
+  api_key_required = false
+  authorization    = "NONE"
+}
+
+resource "aws_api_gateway_integration" "redirect_api_gw" {
+  count                = "${length(var.redirect_methods)}"
+  rest_api_id          = "${aws_api_gateway_rest_api.redirect_api_gw.id}"
+  resource_id          = "${aws_api_gateway_rest_api.redirect_api_gw.root_resource_id}"
+  http_method          = "${element(aws_api_gateway_method.redirect_api_gw.*.http_method, count.index)}"
+  type                 = "MOCK"
+  passthrough_behavior = "WHEN_NO_MATCH"
+
+  request_templates = {
+    "application/json" = "{\"statusCode\": 200}"
+  }
+}
+
+resource "aws_api_gateway_method_response" "redirect_api_gw" {
+  count       = "${length(var.redirect_methods)}"
+  rest_api_id = "${aws_api_gateway_rest_api.redirect_api_gw.id}"
+  resource_id = "${aws_api_gateway_rest_api.redirect_api_gw.root_resource_id}"
+  http_method = "${element(aws_api_gateway_method.redirect_api_gw.*.http_method, count.index)}"
+  status_code = "301"
+
+  response_models = {
+    "application/json" = "Empty"
+  }
+
+  response_parameters = {
+    "method.response.header.Location"                  = true
+    "method.response.header.Strict-Transport-Security" = true
+  }
+}
+
+resource "aws_api_gateway_integration_response" "redirect_api_gw" {
+  count             = "${length(var.redirect_methods)}"
+  rest_api_id       = "${aws_api_gateway_rest_api.redirect_api_gw.id}"
+  resource_id       = "${aws_api_gateway_rest_api.redirect_api_gw.root_resource_id}"
+  http_method       = "${element(aws_api_gateway_method.redirect_api_gw.*.http_method, count.index)}"
+  status_code       = "${element(aws_api_gateway_method_response.redirect_api_gw.*.status_code, count.index)}"
+  selection_pattern = ""
+
+  response_parameters = {
+    "method.response.header.Location"                  = "'${var.redirect_target}'"
+    "method.response.header.Strict-Transport-Security" = "'max-age=10886400; includeSubDomains; preload'"
+  }
+}
+
+resource "aws_api_gateway_deployment" "redirect_api_gw" {
+  depends_on = [
+    "aws_api_gateway_integration.redirect_api_gw",
+    "aws_api_gateway_integration_response.redirect_api_gw",
+  ]
+
+  rest_api_id = "${aws_api_gateway_rest_api.redirect_api_gw.id}"
+  stage_name  = "redirect"
+
+  variables = {
+    # something in this resource needs to change to
+    # pick up changes to the `aws_api_gateway_method*`
+    # and `aws_api_gateway_integration*` resources,
+    # otherwise your changes won't be deployed
+    version = "0.0.1"
+  }
+}
+
+resource "aws_cloudfront_distribution" "simple_redirect" {
+  origin {
+    # TODO: Where can I get this name???
+    domain_name = "${aws_api_gateway_rest_api.redirect_api_gw.id}.execute-api.eu-west-1.amazonaws.com"
+    origin_path = "/redirect"
+    origin_id   = "redirect_api_gw"
+
+    custom_origin_config {
+      origin_protocol_policy = "https-only"
+      http_port              = 80
+      https_port             = 443
+      origin_ssl_protocols   = ["TLSv1", "TLSv1.1", "TLSv1.2"]
+    }
+  }
+
+  aliases         = "${var.aliases}"
+  comment         = "Redirection ${join(",", var.aliases)} to ${var.redirect_target}"
+  enabled         = true
+  is_ipv6_enabled = true
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "redirect_api_gw"
+
+    forwarded_values {
+      query_string = true
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 5
+    max_ttl                = 86400
+  }
+
+  price_class = "PriceClass_100"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  tags {
+    Environment = "${var.env}"
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = false
+    iam_certificate_id             = "${var.domain_cert_id}"
+    minimum_protocol_version       = "TLSv1"
+    ssl_support_method             = "sni-only"
+  }
+}
+
+resource "aws_route53_record" "redirect_domain" {
+  count = "${length(var.aliases)}"
+
+  zone_id = "${var.dns_zone_id}"
+  name    = "${element(var.aliases, count.index)}."
+  type    = "A"
+
+  alias {
+    name                   = "${aws_cloudfront_distribution.simple_redirect.domain_name}"
+    zone_id                = "${aws_cloudfront_distribution.simple_redirect.hosted_zone_id }"
+    evaluate_target_health = true
+  }
+}

--- a/terraform/cloudfront/cloudfront_redirect/variables.tf
+++ b/terraform/cloudfront/cloudfront_redirect/variables.tf
@@ -1,0 +1,24 @@
+variable "aliases" {
+  description = "List of aliases to be registered for a new CloudFront distribution."
+  type        = "list"
+}
+
+variable "env" {
+  description = "DEPLOY_ENV to be used for certificates and terraform state."
+}
+
+variable "name" {
+  description = "The name, to easily identify the instance. Not widely used."
+}
+
+variable "redirect_target" {
+  description = "Url to redirect to"
+}
+
+variable "dns_zone_id" {
+  description = "Zone ID for the system domain registered with Route 53."
+}
+
+variable "domain_cert_id" {
+  description = "The ID of the certificate to be assigned to a new subdomain."
+}

--- a/terraform/cloudfront/instances.tf
+++ b/terraform/cloudfront/instances.tf
@@ -31,3 +31,16 @@ module "cloudfront_paas_docs" {
   system_dns_zone_id    = "${var.system_dns_zone_id}"
   system_domain_cert_id = "${var.system_domain_cert_id}"
 }
+
+module "redirect_paas_product_page" {
+  source = "./cloudfront_redirect"
+
+  name = "${var.env}-paas-product-page"
+
+  aliases         = ["${var.system_dns_zone_name}"]
+  redirect_target = "https://www.${var.system_dns_zone_name}"
+
+  env            = "${var.env}"
+  dns_zone_id    = "${var.system_dns_zone_id}"
+  domain_cert_id = "${var.system_domain_cert_id}"
+}


### PR DESCRIPTION
[#139296467 Redirect from cloud.service.gov.uk (no www prefix)](https://www.pivotaltracker.com/story/show/139296467)

What?
-----

Set it up so that if users try to navigate to `cloud.service.gov.uk` in their browsers, they will be redirected to `https://www.cloud.service.gov.uk`

We use a configuration based on Cloudfront + API Gateway to redirect to the www.${apex} domain from the APEX system domain.

Limitation: Any other path will return a 403 error. In order to make API Gateway work with any path, we must use proxy mode and send the request to a Lambda function or similar.

Dependencies
------------

This supersedes the PRs https://github.com/alphagov/paas-cf/pull/791 and https://github.com/alphagov/paas-product-page/pull/2

How to review?
------------

 * Code review
 * Deploy from master with `make dev setup_cdn_instances ACTION=apply`, then check the difference checking out this branch and running `make dev setup_cdn_instances ACTION=plan`

You can deploy it by `make dev setup_cdn_instances ACTION=apply` again, and check that you are reaching the govuk product page when running `curl -v -I -k https://${DEPLOY_ENV}.dev.cloudpipeline.digital`

Note that cloudfront creation takes some minutes.

Who?
----

Anyone but @keymon