### PR TITLE
[bugfix] platform-tests: canhazip.com -> icanhazip.com

### DIFF
--- a/platform-tests/src/acceptance/http_forwarded_for_test.go
+++ b/platform-tests/src/acceptance/http_forwarded_for_test.go
@@ -19,7 +19,7 @@ import (
 
 var _ = Describe("X-Forwarded headers", func() {
 	const (
-		egressURL   = "https://canhazip.com/"
+		egressURL   = "https://icanhazip.com/"
 		fakeProxyIP = "1.2.3.4"
 	)
 


### PR DESCRIPTION
## What

The test for XFF headers started failing this morning because the egress IP
returned by `canhazip.com` didn't match what the app was reporting:

    X-Forwarded headers
    /tmp/build/3151afb2/paas-cf/platform-tests/src/acceptance/http_forwarded_for_test.go:71
      should append real egress IP to existing X-Forwarded-For request header
    [It]
      /tmp/build/3151afb2/paas-cf/platform-tests/src/acceptance/http_forwarded_for_test.go:70

      Expected
          <[]string | len:3, cap:3>: ["1.2.3.4", "52.51.7.62", "127.0.0.1"]
      to consist of
          <[]interface {} | len:3, cap:3>: ["1.2.3.4", "162.158.38.21", "127.0.0.1"]

      /tmp/build/3151afb2/paas-cf/platform-tests/src/acceptance/http_forwarded_for_test.go:69

It looks like `canhazip.com` is broken as of this morning; it's returning an
IP that belongs to CloudFlare instead of the IP of the client you're
accessing it with. While debugging this, I noticed that we're not actually
using the service that I had intended to in ba9582b. The addition of one
character means that it should now work again:

    ➜  paas-cf git:(bugfix/egress_ip_test_failing) ✗ curl https://canhazip.com/
    141.101.98.207
    ➜  paas-cf git:(bugfix/egress_ip_test_failing) ✗ curl https://icanhazip.com/
    80.194.77.100

Hector has noted that we could make this test more reliable in the future by
storing the EIPs of the NAT Gateways that we create in Terraform, either in
DNS or S3. But we don't need to do it right now.

## How to review

A code review is probably sufficient. I'd like to note though that I **have not** tested this in my own development environment, because it's still in the process of deploying.

## Who can review

Not @dcarley