### PR TITLE
[#139361587]  Update rds-broker to fix bug in restore snapshot

### DIFF
--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -30,9 +30,9 @@ meta:
 
 releases:
   - name: rds-broker
-    version: 0.1.3
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.3.tgz
-    sha1: 99cb288048d1f5c394e663985e7a8c15c5b2617a
+    version: 0.1.4
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.4.tgz
+    sha1: 59d315079352308a2d2c66ae9058c3253b591b5b
 
 jobs:
   - name: rds_broker


### PR DESCRIPTION
[#139361587 rds-broker: Able to create a instance from the latest snapshot of other instance](https://www.pivotaltracker.com/n/projects/1275640/stories/139361587)

What?
----

Update the broker to get the changes implemeented in:

 - https://github.com/alphagov/paas-rds-broker/pull/36
 - https://github.com/alphagov/paas-rds-broker-boshrelease/pull/30


Update this PR once the other is merged.

Who?
---

Anyone but @keymon