### PR TITLE
[#139003315] Test subsequent deployments while under big load

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ dev: globals check-env-vars ## Set Environment to DEV
 	$(eval export ENABLE_DATADOG ?= false)
 	$(eval export CONCOURSE_AUTH_DURATION=48h)
 	$(eval export DISABLE_PIPELINE_LOCKING=true)
+	$(eval export TEST_HEAVY_LOAD=true)
 	@true
 
 .PHONY: ci
@@ -112,6 +113,7 @@ ci: globals check-env-vars ## Set Environment to CI
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-default.yml)
 	$(eval export ENABLE_DATADOG=true)
 	$(eval export DEPLOY_ENV=master)
+	$(eval export TEST_HEAVY_LOAD=true)
 	@true
 
 .PHONY: staging
@@ -129,6 +131,7 @@ staging: globals check-env-vars ## Set Environment to Staging
 	$(eval export DISABLE_CF_ACCEPTANCE_TESTS=true)
 	$(eval export ENABLE_DATADOG=true)
 	$(eval export DEPLOY_ENV=staging)
+	$(eval export TEST_HEAVY_LOAD=true)
 	@true
 
 .PHONY: prod

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1338,6 +1338,72 @@ jobs:
                   ./paas-cf/concourse/scripts/set_quotas_from_manifest.rb cf-manifest/cf-manifest.yml
 
       - aggregate:
+        - task: deploy-simulated-load-application
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/cf-cli
+            params:
+              TEST_HEAVY_LOAD: {{test_heavy_load}}
+            inputs:
+              - name: paas-cf
+              - name: config
+              - name: bosh-CA
+            run:
+              path: sh
+              args:
+                - -e
+                - -u
+                - -c
+                - |
+                  if [ "${TEST_HEAVY_LOAD:-}" != "true" ] ; then
+                    echo Heavy load test has been disabled. Skipping...
+                    exit 0
+                  fi
+
+                  ./paas-cf/concourse/scripts/import_bosh_ca.sh
+
+                  . ./config/config.sh
+                  echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
+                  cf create-org heavy-testers
+                  cf set-quota heavy-testers medium
+                  cf create-space test-application -o heavy-testers
+                  cf target -o heavy-testers -s test-application
+
+                  cd paas-cf/platform-tests/example-apps/healthcheck
+                  cf push simulated-load -i 180
+
+                  timeout=300
+                  deadline=$(($(date +%s) + timeout))
+
+                  checkInstances() {
+                    instances=$(cf app simulated-load | awk '/instances: / { print $2 }')
+                    RUNNING=$(echo "${instances}" | awk -F / '{ print $1 }')
+                    EXPECTED=$(echo "${instances}" | awk -F / '{ print $2 }')
+
+                    if [ "${RUNNING}" -lt "${EXPECTED}" ]; then
+                      return "1";
+                    fi
+
+                    return "0";
+                  }
+
+                  while [ "$(checkInstances && echo $?)" -eq "1" ]; do
+                    sleep 5
+                    echo "Retrying $((timeout - (deadline - $(date +%s))))s..."
+
+                    if [ "$(date +%s)" -gt ${deadline} ] ; then
+                      echo "We're expecting ${EXPECTED} number of instance(s) to run."
+                      echo "Only ${RUNNING} instance(s) running..."
+
+                      exit 1
+                    fi
+                  done
+
+                  echo Done!
+
         - task: sync-admin-users
           config:
             platform: linux

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -109,6 +109,7 @@ git_concourse_pool_clone_full_url_ssh: ${git_concourse_pool_clone_full_url_ssh}
 ALERT_EMAIL_ADDRESS: ${ALERT_EMAIL_ADDRESS:-}
 NEW_ACCOUNT_EMAIL_ADDRESS: ${NEW_ACCOUNT_EMAIL_ADDRESS:-}
 disable_healthcheck_db: ${DISABLE_HEALTHCHECK_DB:-}
+test_heavy_load: ${TEST_HEAVY_LOAD:-false}
 bosh_az: ${bosh_az}
 bosh_manifest_state: bosh-manifest-state-${bosh_az}.json
 bosh_fqdn: bosh.${SYSTEM_DNS_ZONE_NAME}

--- a/platform-tests/example-apps/healthcheck/manifest.yml
+++ b/platform-tests/example-apps/healthcheck/manifest.yml
@@ -2,6 +2,7 @@
 applications:
  - name: healthcheck
    memory: 64M
+   disk_quota: 100M
    instances: 2
    command: "./bin/healthcheck"
    buildpack: go_buildpack


### PR DESCRIPTION
## What

Prior to our BBS incident, we'd like to test against a large number of instances running to establish if our deployment is unaffected.

We would like to test that the subsequent deployments still work when there are many app instances running.

## How to review

- Review the code
- Run `make dev pipelines` from this branch
- Run `create-cloudfoundry` pipeline
- Expect it to succeed

**Optionally**
- Create separate branch
- Modify the `platform-tests/example-apps/healthcheck/manifest.yml` and remove the `disk_quota` or set it to `1G`
- Run `make dev pipelines` from new branch
- Run `create-cloudfoundry` pipeline
- Expect it to fail

## Who can review

Not @paroxp
