### PR TITLE
[#136353551] Allow our own build Concourse to push apps

### DIFF
--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -55,6 +55,8 @@ tenant_cidrs = [
   # Tenant egress for story #140308141
   "185.40.8.212/32",
   "86.188.177.234/32",
+  # Our own build Concourse in CI
+  "52.213.245.135/32",
 ]
 bosh_db_backup_retention_period = "35"
 bosh_db_skip_final_snapshot = "false"


### PR DESCRIPTION
## What

[#136353551](https://www.pivotaltracker.com/story/show/136353551)

We are going to use the build Concourse in CI to automatically push
apps, such as the tech docs, to our production platform. We need
to allow it to communicate with the API until the API is opened up
to the public. The IP is an Elastic IP, so it will be stable over
time.

## How to review

Check the IP of the build Concourse in CI matches the one provided in this pull request.
You can try adding a similar patch to your dev.tfvars and see if it deploys, but that may be overkill.

## Who can review

Anyone but me or @saliceti 
