### PR TITLE
Prepare for aws credentials validation

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -339,6 +339,7 @@ jobs:
             SELF_UPDATE_PIPELINE: {{self_update_pipeline}}
             PIPELINES_TO_UPDATE: {{pipeline_name}}
             BOSH_AZ: {{bosh_az}}
+            SKIP_AWS_CREDENTIAL_VALIDATION: true
           run:
             path: ./paas-cf/concourse/scripts/self-update-pipeline.sh
       - put: pipeline-trigger


### PR DESCRIPTION

## What

We want to have different behavior of AWS credentials check based on if the
script runs inside concourse pipeline, which is a server that uses IAM role
and when it runs on the command line in your laptops, in which case we use
STS tokens + temporary credentials. In order to introduce this logic, we
need to first add variable in self-update-pipelines where we store the
information for the script to not do STS related credentials check, but skip
them instead.

This is a pre-quel to #798

## How to review

Check that it makes sense in the context of #798

## Who can review

not @mtekel
that can't review, because they worked on it.
