### PR TITLE
Prepare for aws credentials validation 2

### DIFF
--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -133,6 +133,7 @@ jobs:
             SELF_UPDATE_PIPELINE: {{self_update_pipeline}}
             PIPELINES_TO_UPDATE: {{pipeline_name}}
             ENABLE_DESTROY: {{enable_destroy}}
+            SKIP_AWS_CREDENTIAL_VALIDATION: true
           run:
             path: ./paas-cf/concourse/scripts/self-update-pipeline.sh
       - put: pipeline-trigger

--- a/concourse/pipelines/failure-testing.yml
+++ b/concourse/pipelines/failure-testing.yml
@@ -89,6 +89,7 @@ jobs:
             AWS_ACCOUNT: {{aws_account}}
             SELF_UPDATE_PIPELINE: {{self_update_pipeline}}
             PIPELINES_TO_UPDATE: {{pipeline_name}}
+            SKIP_AWS_CREDENTIAL_VALIDATION: true
           run:
             path: ./paas-cf/concourse/scripts/self-update-pipeline.sh
       - put: pipeline-trigger


### PR DESCRIPTION
## What

Failure testing and destroy pipelines also call self update. Add the
SKIP_AWS_CREDENTIAL_VALIDATION flag there as well.

This is a requirement for #798

## How to review

Check that it makes sense in context of #798

## Who can review

not @mtekel