### PR TITLE
[#140395801] Reduce false positives for out-of-hours support

### DIFF
--- a/terraform/datadog/concourse.tf
+++ b/terraform/datadog/concourse.tf
@@ -19,7 +19,7 @@ resource "datadog_monitor" "concourse-load" {
 resource "datadog_monitor" "continuous-smoketests" {
   name               = "${format("%s concourse continuous smoketests runtime", var.env)}"
   type               = "query alert"
-  message            = "${format("Continuous smoketests too slow: {{value}} ms. Check concourse VM health. %s{{#is_no_data}}The continuous smoke tests  have not reported any metrics for a while. Check concourse status. %s {{/is_no_data}}", var.datadog_notification_24x7, var.datadog_notification_in_hours)}"
+  message            = "${format("Continuous smoketests too slow: {{value}} ms. Check concourse VM health. {{#is_alert}}%s{{/is_alert}} {{#is_warning}}%s{{/is_warning}} {{#is_no_data}}The continuous smoke tests have not reported any metrics for a while. Check concourse status. %s{{/is_no_data}}", var.datadog_notification_24x7, var.datadog_notification_in_hours, var.datadog_notification_24x7)}"
   escalation_message = "Continuous smoketests still too slow: {{value}} ms."
   no_data_timeframe  = "20"
   query              = "${format("max(last_1m):avg:concourse.build.finished{job:continuous-smoke-tests,deploy_env:%s} > 1200000", var.env)}"


### PR DESCRIPTION
## What

[#140395801](https://www.pivotaltracker.com/story/show/140395801)

We received notifications out-of-hours for smoke tests running for 12 minutes. We were not expecting to receive notifications for breaching the warning threshold. This adds [message template variables](http://docs.datadoghq.com/monitoring/#message-template-variables) which alert to the 24x7 endpoint for critical alerts, and the in-hours endpoint for warnings. We also alert out-of-hours for no-data, because we need assurance the smoke tests are actually running.

## How to review

I have already done the bootstrapping of Concourse and deploying, both with Datadog enabled, in order to test this sends notifications under the right circumstances (alert, warning, and no-data), so I don't blame you if you don't want to repeat that whole process. Perhaps a code review would be sufficient, and check I haven't missed anything.

## Who can review

Anyone but me or @timmow
