### PR TITLE
Include ADR017 threshold in show-cf-memory-usage task

### DIFF
--- a/scripts/show-cf-memory-usage.rb
+++ b/scripts/show-cf-memory-usage.rb
@@ -54,13 +54,3 @@ puts "Allocated routes: #{allocated_routes}"
 puts
 puts "Memory reserved by orgs: #{format_memory(orgs_reserved_memory)}"
 puts "Memory reserved by apps: #{format_memory(apps_reserved_memory)}"
-
-apps_used_memory = 0
-apps = JSON.load(`cf curl /v2/apps`)['resources']
-apps.each { |app|
-  apps_used_memory += app['entity']['memory'].to_i
-}
-
-puts
-puts "Memory actually used by apps: #{format_memory(apps_used_memory)}"
-puts

--- a/scripts/show-cf-memory-usage.rb
+++ b/scripts/show-cf-memory-usage.rb
@@ -44,12 +44,16 @@ orgs.each { |org|
   puts "Memory reserved by apps in org '#{org['entity']['name']}': #{org_apps_reserved_memory} MB"
 }
 
+def format_memory(amount)
+  "#{amount} MB (#{amount / 1024} GB)"
+end
+
 puts
 puts "Allocated services: #{allocated_services}"
 puts "Allocated routes: #{allocated_routes}"
 puts
-puts "Memory reserved by orgs: #{orgs_reserved_memory} MB (#{orgs_reserved_memory / 1024} GB)"
-puts "Memory reserved by apps: #{apps_reserved_memory} MB (#{apps_reserved_memory / 1024} GB)"
+puts "Memory reserved by orgs: #{format_memory(orgs_reserved_memory)}"
+puts "Memory reserved by apps: #{format_memory(apps_reserved_memory)}"
 
 apps_used_memory = 0
 apps = JSON.load(`cf curl /v2/apps`)['resources']
@@ -58,5 +62,5 @@ apps.each { |app|
 }
 
 puts
-puts "Memory actually used by apps: #{apps_used_memory} (#{apps_used_memory / 1024} GB)"
+puts "Memory actually used by apps: #{format_memory(apps_used_memory)}"
 puts

--- a/scripts/show-cf-memory-usage.rb
+++ b/scripts/show-cf-memory-usage.rb
@@ -44,6 +44,10 @@ orgs.each { |org|
   puts "Memory reserved by apps in org '#{org['entity']['name']}': #{org_apps_reserved_memory} MB"
 }
 
+# ADR017 requires capacity for 50% of orgs_reserved_memory in the case of a region failure.
+# So we require 50% * 3/2 when all 3 regions are running.
+required_cell_memory = (orgs_reserved_memory / 2) * 3 / 2
+
 def format_memory(amount)
   "#{amount} MB (#{amount / 1024} GB)"
 end
@@ -54,3 +58,5 @@ puts "Allocated routes: #{allocated_routes}"
 puts
 puts "Memory reserved by orgs: #{format_memory(orgs_reserved_memory)}"
 puts "Memory reserved by apps: #{format_memory(apps_reserved_memory)}"
+puts
+puts "Total cell memory required to meet ADR017: #{format_memory(required_cell_memory)}"


### PR DESCRIPTION
## What

In order to help decide whether we need to increase capacity when adding an org, this adds a line to the `show-cf-memory-usage` task to show the total cell memory required to meet the [ADR017](https://government-paas-team-manual.readthedocs.io/en/latest/architecture_decision_records/ADR017-cell-capacity-assignment/) requirement.

While working on this, I've removed the "Memory actually used by apps:" line because it was incorrect, and wasn't reporting what we thought it was. See the commit message for details.

## How to review

Code review
Run the task from this branch. Verify the new output makes sense and agrees with the ADR.

## Who can review

Anyone but myself.