### PR TITLE
Silence no data monitors

### DIFF
--- a/terraform/datadog/cloud_controller.tf
+++ b/terraform/datadog/cloud_controller.tf
@@ -67,7 +67,7 @@ resource "datadog_monitor" "cc_failed_job_count_total_increase" {
     critical = "5"
   }
 
-  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:api"]
+  tags = ["deployment:${var.env}", "job:api"]
 }
 
 resource "datadog_monitor" "cc_log_count_error_increase" {
@@ -84,7 +84,7 @@ resource "datadog_monitor" "cc_log_count_error_increase" {
     critical = "5"
   }
 
-  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:api"]
+  tags = ["deployment:${var.env}", "job:api"]
 }
 
 resource "datadog_monitor" "cc_job_queue_length" {

--- a/terraform/datadog/cloud_controller.tf
+++ b/terraform/datadog/cloud_controller.tf
@@ -56,7 +56,7 @@ resource "datadog_monitor" "cc_api_healthy" {
 resource "datadog_monitor" "cc_failed_job_count_total_increase" {
   name                = "${format("%s Cloud Controller API failed job count", var.env)}"
   type                = "query alert"
-  message             = "Amount of failed jobs in Cloud Controller API grew considerably, check the API health."
+  message             = "${format("Amount of failed jobs in Cloud Controller API grew considerably, check the API health. {{#is_alert}}%s{{/is_alert}}", var.datadog_notification_in_hours)}"
   escalation_message  = "Amount of failed jobs in Cloud Controller API still growing considerably, check the API health."
   require_full_window = false
 
@@ -73,7 +73,7 @@ resource "datadog_monitor" "cc_failed_job_count_total_increase" {
 resource "datadog_monitor" "cc_log_count_error_increase" {
   name                = "${format("%s Cloud Controller API log error count", var.env)}"
   type                = "query alert"
-  message             = "Amount of logged errors in Cloud Controller API grew considerably, check the API health."
+  message             = "${format("Amount of logged errors in Cloud Controller API grew considerably, check the API health. {{#is_alert}}%s{{/is_alert}}", var.datadog_notification_in_hours)}"
   escalation_message  = "Amount of logged errors in Cloud Controller API still growing considerably, check the API health."
   require_full_window = false
 


### PR DESCRIPTION
## What

The cloud controller monitors based on metric change are most of the time in "No data" state even if the metric is sent every 30s. Datadog has confirmed it's a bug and is currently investigating.

They show as warnings on the dashboard. This is distracting and may hide real issues.

To work around the problem, we replace the dashboard visual notification by in hours pagerduty alerting.

## How to review

You can enable the monitors without deploying the everything by running only the teraform bit. This can be achieved by a command such as (replace appropriately):

```
export TF_VAR_aws_account=dev
export TF_VAR_datadog_api_key=$(gov-pass datadog/dev/datadog_api_key)
export TF_VAR_datadog_app_key=$(gov-pass datadog/dev/datadog_app_key)
export TF_VAR_datadog_notification_24x7=colin.saliceti@digital.cabinet-office.gov.uk
export TF_VAR_datadog_notification_in_hours=colin.saliceti@digital.cabinet-office.gov.uk
export TF_VAR_env=colin2017
terraform apply -target=datadog_monitor.cc_failed_job_count_total_increase -target=datadog_monitor.cc_log_count_error_increase
```

## Who can review
Not me