### PR TITLE
[#139361587] rds-broker with bugfix getting latest snapshot

### DIFF
--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -30,9 +30,9 @@ meta:
 
 releases:
   - name: rds-broker
-    version: 0.1.6
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.6.tgz
-    sha1: 68b663941988948d51299042f7bd8fa3d73060da
+    version: 0.1.7
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.7.tgz
+    sha1: 5dbbe4c468027d2df7188bed282a4623c3acf9e6
 
 jobs:
   - name: rds_broker


### PR DESCRIPTION
[#139361587 rds-broker: Able to create a instance from the latest snapshot of other instance](https://www.pivotaltracker.com/story/show/139361587)

What?
----

We were using the wrong field to short the snapshots of an instance. We   should use `SnapshotCreateTime`, not `InstanceCreateTime` that is the date of the creation of the instance.

Because this, we are actually restoring the oldest because AWS API seems to return ordered by from oldest to newest.

How to review?
------------

Review with https://github.com/alphagov/paas-rds-broker/pull/40 and https://github.com/alphagov/paas-rds-broker-boshrelease/pull/34

You can review following the steps described in https://github.com/alphagov/paas-cf/pull/784, but creating 2x snapshots instead of one.
Then check that the Tag "Restored Snapshot From" of the restored instance is the latest snapshot.

Who?
---

Anyone but @keymon

See https://github.com/alphagov/paas-rds-broker/pull/40