### PR TITLE
Revert "Increase number of CC workers to 3 per VM"

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -192,9 +192,7 @@ properties:
       droplet_upload:
         timeout_in_seconds: ~
       generic:
-        number_of_workers: 3
-      local:
-        number_of_workers: 3
+        number_of_workers: ~
 
     app_events:
       cutoff_age_in_days: 31


### PR DESCRIPTION
## What

This reverts commit c292aad01133c3cb79117e1aca4bbd11e22bcf1d.

The workers are constantly polling the RDS CC DB. This causes significant CPU usage and we have run out of credits. The impact is that services connecting to the databases in that instance are
slower (api, uaa, bbs). This has already been reported by some users.

We now revert to the default. This is safe as this commit hadn't made an improvement.

## How to review
Code review

## Who can review
Not me
