### PR TITLE
[#139196683] Monitor BBS health

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -26,9 +26,9 @@ releases:
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/paas-haproxy-0.1.3.tgz
     sha1: 732ceb817afe33ee117b85a202d87f6f5c3dd760
   - name: datadog-for-cloudfoundry
-    version: 0.1.7
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.1.7.tgz
-    sha1: 3bdfdbd98cac6e9452b80788229e83cddf9549d3
+    version: 0.1.13
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.1.13.tgz
+    sha1: b5846e6bb476ac76725ceac62ef5d512de6b46dd
   - name: ipsec
     version: 0.1.1
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/ipsec-0.1.1.tgz

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -207,6 +207,8 @@ jobs:
         release: cf
       - name: datadog-consul
         release: datadog-for-cloudfoundry
+      - name: datadog-bbs
+        release: datadog-for-cloudfoundry
       - name: bbs
         release: diego
       - name: cfdot

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -224,6 +224,9 @@ jobs:
       - name: cf
     update:
       serial: true
+    properties:
+      bbs:
+          url: (( concat "https://" meta.bbs.api_location "/v1/actual_lrp_groups/list" ))
 
   - name: uaa
     azs: [z1, z2]

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -7,6 +7,8 @@ meta:
   secrets:
     consul_ca_cert: (( grab secrets.bosh_ca_cert ))
     bbs_ca_cert: (( grab secrets.bosh_ca_cert ))
+  bbs:
+    api_location: bbs.service.cf.internal:8889
 
   consul_servers: (( grab jobs.consul.networks.cf.static_ips ))
 
@@ -493,7 +495,7 @@ properties:
         use_ssl: (( grab properties.diego.bbs.require_ssl ))
     auctioneer:
       bbs:
-        api_location: bbs.service.cf.internal:8889
+        api_location: (( grab meta.bbs.api_location ))
         ca_cert: (( grab meta.secrets.bbs_ca_cert ))
         client_cert: (( grab secrets.bbs_client_cert  ))
         client_key: (( grab secrets.bbs_client_key  ))
@@ -533,7 +535,7 @@ properties:
     rep:
       dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
       bbs:
-        api_location: bbs.service.cf.internal:8889
+        api_location: (( grab meta.bbs.api_location ))
         ca_cert: (( grab meta.secrets.bbs_ca_cert ))
         client_cert: (( grab secrets.bbs_client_cert ))
         client_key: (( grab secrets.bbs_client_key ))
@@ -544,7 +546,7 @@ properties:
     route_emitter:
       dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
       bbs:
-        api_location: bbs.service.cf.internal:8889
+        api_location: (( grab meta.bbs.api_location ))
         ca_cert: (( grab meta.secrets.bbs_ca_cert ))
         client_cert: (( grab secrets.bbs_client_cert ))
         client_key: (( grab secrets.bbs_client_key ))
@@ -558,7 +560,7 @@ properties:
     ssh_proxy:
       dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
       bbs:
-        api_location: bbs.service.cf.internal:8889
+        api_location: (( grab meta.bbs.api_location ))
         ca_cert: (( grab meta.secrets.bbs_ca_cert ))
         client_cert: (( grab secrets.bbs_client_cert ))
         client_key: (( grab secrets.bbs_client_key ))
@@ -582,7 +584,7 @@ properties:
     nsync:
       dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
       bbs:
-        api_location: bbs.service.cf.internal:8889
+        api_location: (( grab meta.bbs.api_location ))
         ca_cert: (( grab meta.secrets.bbs_ca_cert ))
         client_cert: (( grab secrets.bbs_client_cert  ))
         client_key: (( grab secrets.bbs_client_key  ))
@@ -597,7 +599,7 @@ properties:
     stager:
       dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
       bbs:
-        api_location: bbs.service.cf.internal:8889
+        api_location: (( grab meta.bbs.api_location ))
         ca_cert: (( grab meta.secrets.bbs_ca_cert ))
         client_cert: (( grab secrets.bbs_client_cert ))
         client_key: (( grab secrets.bbs_client_key ))
@@ -616,7 +618,7 @@ properties:
         staging_upload_user: (( grab properties.cc.staging_upload_user ))
         staging_upload_password: (( grab properties.cc.staging_upload_password ))
       bbs:
-        api_location: bbs.service.cf.internal:8889
+        api_location: (( grab meta.bbs.api_location ))
         ca_cert: (( grab meta.secrets.bbs_ca_cert ))
         client_cert: (( grab secrets.bbs_client_cert ))
         client_key: (( grab secrets.bbs_client_key ))

--- a/terraform/datadog/bbs.tf
+++ b/terraform/datadog/bbs.tf
@@ -22,3 +22,20 @@ resource "datadog_monitor" "bbs_lock_held_once" {
 
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:bbs"]
 }
+
+resource "datadog_monitor" "bbs_healthy" {
+  name                = "${format("%s bbs healthy", var.env)}"
+  type                = "query alert"
+  message             = "${format("BBS health check failed. Check BBS status immediately. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
+  escalation_message  = "BBS health check still failing. Check BBS status immediately."
+  notify_no_data      = true
+  require_full_window = false
+
+  query = "${format("min(last_1m):min:cf.bbs.Healthy{bosh-deployment:%s} < 1", var.env)}"
+
+  thresholds {
+    critical = "1"
+  }
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:bbs"]
+}


### PR DESCRIPTION
## What

This is set of PRs to deploy BBS monitoring solution. It adds new `cf.bbs.Healthy` and `cf.bbs.ResponseTime` metrics. 

It consists of:
- https://github.com/alphagov/paas-bootstrap/pull/55 - WHICH MUST BE DEPLOYED FIRST
- https://github.com/alphagov/paas-datadog-bbs-integration/pull/1 - Provides BBS check and tests.
- https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/13 - Integrates BBS check into BOSH release and provides default config
- https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/13 - Implements new mechanism to copy custom checks into datadog agent directory
- This PR

## How to review

- deploy from this branch and check if `cf.bbs.Healthy` and `cf.bbs.ResponseTime` are available in DD for your env. Check if monitor works
- Review and merge https://github.com/alphagov/paas-datadog-bbs-integration/pull/1
- update git submodule in  https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/13 to point to master branch of `alphagov/paas-datadog-bbs-integration`
- Merge https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/13 - this will trigger final build for `paas-datadog-for-cloudfoundry-boshrelease`
- Once https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/13 is merged, replace TMP commit with final build of the release.

## Who can review

not @mtekel or @combor
