### PR TITLE
[#141300765] Increase CF DB instance type 

### DIFF
--- a/terraform/cloudfoundry/cf_rds.tf
+++ b/terraform/cloudfoundry/cf_rds.tf
@@ -40,7 +40,7 @@ resource "aws_db_instance" "cf" {
   allocated_storage    = 10
   engine               = "postgres"
   engine_version       = "9.5.4"
-  instance_class       = "db.t2.small"
+  instance_class       = "db.m3.medium"
   username             = "dbadmin"
   password             = "${var.secrets_cf_db_master_password}"
   db_subnet_group_name = "${aws_db_subnet_group.cf_rds.name}"


### PR DESCRIPTION
What?
------

We ran out of CPU credits in the CF RDS instance because of unexpectedly
high CPU usage. This caused CPU usage to be capped at 20% and it made
the system slow. We noticed most CPU was consumed by cloud controller
workers. They constantly poll the DB for new jobs to execute. We reduced
the number by reverting [1]

We change the instance type to a type that is not credit based.

[1]  https://github.com/alphagov/paas-cf/pull/817

How to review?
--------------

Code review

After merge
-----------

We suggest that the change is done manually with "apply immediatelly" in prod. We have already tested that the upgrade with no impact for the end user, as RDS will be upgraded in a HA way, but we want to babysit the upgrade anyway.

Who?
----

Anyone but @keymon