### PR TITLE
Add script and pipeline task for cf-psql

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,9 @@ prod: globals ## Set Environment to Production
 bosh-cli: check-env ## Create interactive connnection to BOSH container
 	concourse/scripts/bosh-cli.sh
 
+cf-psql: check-env ## Create interactive connnection to the CF RDS instance
+	concourse/scripts/cf-psql.sh
+
 .PHONY: pipelines
 pipelines: check-env ## Upload pipelines to Concourse
 	concourse/scripts/pipelines-cloudfoundry.sh

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2476,3 +2476,74 @@ jobs:
               uuid=$(bosh status --uuid)
               sed -e "s/^director_uuid:.*$/director_uuid: ${uuid}/" cf-manifest/cf-manifest.yml > cf-manifest-with-uuid.yml
               bosh deployment ./cf-manifest-with-uuid.yml
+
+  - name: cf-psql
+    plan:
+      - aggregate:
+          - get: paas-cf
+          - get: cf-tfstate
+          - get: cf-secrets
+      - task: extract-terraform-variables
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: ruby
+              tag: 2.2-slim
+          inputs:
+            - name: paas-cf
+            - name: cf-secrets
+          outputs:
+            - name: terraform-variables
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                ruby paas-cf/concourse/scripts/extract_tf_vars_from_yaml.rb \
+                < cf-secrets/cf-secrets.yml > terraform-variables/cf-secrets.tfvars.sh
+      - task: extract-cf-terraform-outputs
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: ruby
+              tag: 2.2-slim
+          inputs:
+            - name: paas-cf
+            - name: cf-tfstate
+          outputs:
+            - name: cf-terraform-outputs
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                SCPATH="./paas-cf/concourse/scripts"
+                SCFILE="extract_tf_vars_from_terraform_state.rb"
+                $SCPATH/$SCFILE < cf-tfstate/cf.tfstate > cf-terraform-outputs/cf.tfstate.sh
+      - task: run-cf-psql
+        config:
+          platform: linux
+          image: docker:///governmentpaas/psql
+          inputs:
+            - name: paas-cf
+            - name: terraform-variables
+            - name: cf-terraform-outputs
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                . terraform-variables/cf-secrets.tfvars.sh
+                . cf-terraform-outputs/cf.tfstate.sh
+
+                cat <<EOF > ./psql_adm.sh
+                export PGPASSWORD="${TF_VAR_secrets_cf_db_readonly_password:?}"
+                psql -h "${TF_VAR_cf_db_address:?}" -U u_readonly postgres
+                EOF

--- a/concourse/scripts/cf-psql.sh
+++ b/concourse/scripts/cf-psql.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+export TARGET_CONCOURSE=deployer
+# shellcheck disable=SC2091
+$("${SCRIPT_DIR}/environment.sh")
+"${SCRIPT_DIR}/fly_sync_and_login.sh"
+
+OUTPUT_FILE=$(mktemp -t bosh-cli.XXXXXX)
+trap 'rm -f "${OUTPUT_FILE}"' EXIT
+
+$FLY_CMD -t "${FLY_TARGET}" trigger-job -j create-cloudfoundry/cf-psql -w | tee "${OUTPUT_FILE}"
+
+BUILD_NUMBER=$(awk '/started create-cloudfoundry\/cf-psql/ { print $3 }' "${OUTPUT_FILE}" | tr -d '#')
+
+$FLY_CMD -t "${FLY_TARGET}" intercept -j create-cloudfoundry/cf-psql -b "${BUILD_NUMBER}" \
+   -s run-cf-psql sh ./psql_adm.sh

--- a/manifests/cf-manifest/scripts/create-cf-dbs.sh
+++ b/manifests/cf-manifest/scripts/create-cf-dbs.sh
@@ -6,6 +6,7 @@ export PGPASSWORD=${TF_VAR_secrets_cf_db_master_password:?}
 api_pass=${TF_VAR_secrets_cf_db_api_password:?}
 uaa_pass=${TF_VAR_secrets_cf_db_uaa_password:?}
 bbs_pass=${TF_VAR_secrets_cf_db_bbs_password:?}
+readonly_pass=${TF_VAR_secrets_cf_db_readonly_password:?}
 db_address=${TF_VAR_cf_db_address:?}
 
 # See: https://github.com/koalaman/shellcheck/wiki/SC2086#exceptions
@@ -22,10 +23,23 @@ psql_adm -d postgres -c "SELECT rolname FROM pg_roles WHERE rolname = 'uaa'" \
 psql_adm -d postgres -c "SELECT rolname FROM pg_roles WHERE rolname = 'bbs'" \
   | grep -q 'bbs' || psql_adm -d postgres -c "CREATE USER bbs WITH ROLE dbadmin"
 
+psql_adm -d postgres -c "SELECT rolname FROM pg_roles WHERE rolname = 'u_readonly'" \
+  | grep -q 'u_readonly' || psql_adm -d postgres -c "CREATE USER u_readonly"
+
 # Always update passwords
 psql_adm -d postgres -c "ALTER USER api WITH PASSWORD '${api_pass}'"
 psql_adm -d postgres -c "ALTER USER uaa WITH PASSWORD '${uaa_pass}'"
 psql_adm -d postgres -c "ALTER USER bbs WITH PASSWORD '${bbs_pass}'"
+psql_adm -d postgres -c "ALTER USER u_readonly WITH PASSWORD '${readonly_pass}'"
+
+psql_adm -d postgres <<'EOF'
+CREATE OR REPLACE FUNCTION pg_stat_allusers()
+RETURNS setof pg_stat_activity
+LANGUAGE sql SECURITY DEFINER
+AS $function$
+  SELECT * FROM pg_stat_activity;
+$function$
+EOF
 
 for db in api uaa bbs; do
 
@@ -37,5 +51,13 @@ for db in api uaa bbs; do
   for ext in citext pgcrypto pg_stat_statements; do
     psql_adm -d "${db}" -c "CREATE EXTENSION IF NOT EXISTS ${ext}"
   done
+
+  psql_adm -d postgres -c "GRANT CONNECT ON DATABASE ${db} TO u_readonly"
+
+  psql -h "${db_address}" -U dbadmin -d "${db}" -c "GRANT USAGE ON SCHEMA public TO u_readonly"
+  psql -h "${db_address}" -U dbadmin -d "${db}" -c "GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO u_readonly"
+  psql -h "${db_address}" -U dbadmin -d "${db}" -c "GRANT SELECT ON ALL TABLES IN SCHEMA public to u_readonly"
+  psql -h "${db_address}" -U dbadmin -d "${db}" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO u_readonly"
+  psql -h "${db_address}" -U dbadmin -d "${db}" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON SEQUENCES TO u_readonly"
 
 done

--- a/manifests/cf-manifest/scripts/generate-cf-secrets.rb
+++ b/manifests/cf-manifest/scripts/generate-cf-secrets.rb
@@ -7,6 +7,7 @@ require File.expand_path("../../../shared/lib/secret_generator", __FILE__)
 generator = SecretGenerator.new(
   "vcap_password" => :sha512_crypted,
   "cf_db_master_password" => :simple,
+  "cf_db_readonly_password" => :simple,
   "cf_db_api_password" => :simple,
   "cf_db_uaa_password" => :simple,
   "cf_db_bbs_password" => :simple,


### PR DESCRIPTION
## What

I started writing this when I was on support. This could be useful to debug RDS.

Allows to open a psql shell on the CF RDS instance.
    
For security reasons, the connection is made with a specially crafted readonly user.
    
A funcion `pg_stat_allusers()` is created as a replacement for view `pg_stat_activity`. It is the same, with elevated privilege.

## How to review

* Deploy
* Run: `DEPLOY_ENV=XXX make dev cf-psql`
* Check you can connect to any database
* Check you can run select on any table
* Connect to `postgres` database (default). Check that `select * from pg_stat_activity;` doesn't show you the queries, but `select * from pg_stat_allusers();` does
* Check you can't delete, insert, update the data, delete database, etc

## Who can review
Not me