### PR TITLE
[#141476575] Increase prod cell count to 12.

### DIFF
--- a/manifests/cf-manifest/manifest/env-specific/cf-prod.yml
+++ b/manifests/cf-manifest/manifest/env-specific/cf-prod.yml
@@ -1,4 +1,4 @@
 ---
 meta:
   cell:
-    instances: 9
+    instances: 12


### PR DESCRIPTION
## What

We're currently exceeding the limit defined in [ADR017](https://government-paas-team-manual.readthedocs.io/en/latest/architecture_decision_records/ADR017-cell-capacity-assignment/). With 9 cells,
the total memory provided is 269G. The amount we need depends on
whether we include the Smoke tests and acceptance tests. The numbers are
as follows:

- Not including smoke tests: 268G
- Including smoke tests: 276G
- Including smoke tests and custom acc tests: 291G

Given the smoke tests are running continually, this usage should be
included in the total, hence the need to increase the cell count.

## How to review

Code review.

## Who can review

Anyone but myself.