### PR TITLE
[#140834345] Enable docker image support 

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1331,6 +1331,32 @@ jobs:
 
                   ./paas-cf/concourse/scripts/set_quotas_from_manifest.rb cf-manifest/cf-manifest.yml
 
+        - task: enable-diego_docker-feature-flag
+          config:
+            platform: linux
+            inputs:
+              - name: paas-cf
+              - name: bosh-CA
+              - name: config
+            params:
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/cf-cli
+            run:
+              path: sh
+              args:
+                - -e
+                - -u
+                - -c
+                - |
+                  ./paas-cf/concourse/scripts/import_bosh_ca.sh
+                  . ./config/config.sh
+
+                  echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}"
+
+                  cf enable-feature-flag diego_docker
+
       - aggregate:
         - task: deploy-simulated-load-application
           config:

--- a/manifests/cf-manifest/manifest/900-cf-tests.yml
+++ b/manifests/cf-manifest/manifest/900-cf-tests.yml
@@ -20,6 +20,7 @@ properties:
     include_operator: true
     include_services: true
     include_diego_ssh: true
+    include_docker: true
     include_route_services: true
     artifacts_directory: "/var/vcap/sys/log/test_artifacts"
     nodes: 10


### PR DESCRIPTION
## What

[Turn on Docker support as experimental](https://www.pivotaltracker.com/n/projects/1275640/stories/140834345)

## How to review

1. Check that diego_docker feature is disabled: `cf feature-flags`
2. Deploy. Acceptance tests should pass.
3. Check that diego_docker feature is enabled.
4. Disable feature by hand: `cf disable-feature-flag diego_docker`.
5. Run acceptance tests. They should fail.

## Who can review

not @mtekel
