### PR TITLE
[support] Omit silenced monitors from DataDog dashboard

### DIFF
--- a/tools/paas_dashboard/jobs/datadog.rb
+++ b/tools/paas_dashboard/jobs/datadog.rb
@@ -38,7 +38,9 @@ def get_and_emit_data_for_env(service_tag:, data_id_prefix:)
 end
 
 def get_monitor_results(service_tag)
-  dog.get_all_monitors[1].select { |monitor| monitor['tags'].include?(service_tag) }
+  dog.get_all_monitors[1].select { |monitor|
+    monitor['tags'].include?(service_tag) && monitor['options']['silenced'].empty?
+  }
 end
 
 def get_counts(results)


### PR DESCRIPTION
## What

I'm using the "mute for N hours" button in DataDog to silence some alerts
that we know are currently false-positives. I'd like them to be omitted from
the dashboard so that I can concentrate on real alerts.

I had to look at the [API docs][0] to implement this. It seems that
`options.silenced` will contain a hash of `scope: timestamp` when a monitor
is muted/silenced. I'm omitting the monitor if the hash contains *anything*
because:

- I don't think the scope matters because the dashboard currently collapses
  triggered monitors of the same type, e.g. it tells us we have one warning
  if two hosts have alerts for disk space.
- I don't think we need to compare the timestamp because the `silenced` will
  be removed from the API results when the mute period expires.

[0]: http://docs.datadoghq.com/api/#monitor-get-all

## How to review

1. Checkout the branch: `git checkout dashboard_omit_silenced`
1. Change to the dashboard directory: `cd tools/paas_dashboard`
1. Install the dependencies: `bundle install`
1. Run the dashboard using keys from [government-paas/credentials](https://github.gds/government-paas/credentials):
```
DD_API_KEY=$(PASSWORD_STORE_DIR=~/.paas-pass pass datadog/dev/datadog_api_key) \
DD_APP_KEY=$(PASSWORD_STORE_DIR=~/.paas-pass pass datadog/dev/datadog_app_key) \
bundle exec smashing start
```
1. View the dashboard at http://localhost:3030/paas-overview and confirm that it doesn't show the alerts that are currently muted in production (you might need to confirm if they are still muted depending on when the PR is reviewed).
1. Figure out how ordered list with codeblocks work in Markdown.

## Who can review

Not @dcarley