### PR TITLE
[support] Change default quota from 2G to 5G memory

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -279,7 +279,7 @@ properties:
       cdn: ~
     quota_definitions:
       default:
-        memory_limit: 2048
+        memory_limit: 5120
         total_services: 10
         non_basic_services_allowed: false
         total_routes: 1000


### PR DESCRIPTION
## What

Registers requested a quota change to their "trial" organisation because
they have hit the memory limit of the `default` quota by using a handful of
Rails applications each with two instances of 256M (which doesn't seem
unreasonable):

- https://gaap.deskpro.com/agent/#app.tickets,inbox:agent,t.o:4199,vis:7

Following a discussion with @alext, @jollery, and @bleach, we agreed that it
would be cheaper (in terms of total potential cost to us) to give "trial"
orgs more memory on the `default` quota rather than move them to the `small`
quota which allows for paid service plans.

I'm in favour of modifying the existing quota rather than introducing
another quota for "trial" users, because it requires less effort now to deploy
and less effort in the future to determine which quota an org should be
created with or later request a switch to.

Alex confirmed that we don't need to add an existing cells to support this
change:

> I could probably answer that for you with a quick hack to the memory-usage report.
> Looks good, we’d need 337Gb to meet our defined limit, and we currently have 359Gb

## How to review

Code review should be sufficient because we've changed quotas using this mechanism before.

## Who can review

Not @dcarley