### PR TITLE
[#139179971] Pin the version of cf-acceptance-tests container

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1926,6 +1926,7 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/cf-acceptance-tests
+                tag: cf_6_21_1
             params:
               DISABLE_CF_ACCEPTANCE_TESTS: {{disable_cf_acceptance_tests}}
             inputs:


### PR DESCRIPTION
[#139179971 Upgrade CF to >= v252](https://www.pivotaltracker.com/story/show/139179971)

What?
-----

We are experimenting failures[1] running the acceptance tests after
upgrading the cf client to 6.25.0 [2]

In this commit we use a tagged container with the previous version
v6.21.1. [3][4] We must revert this after merging [5]

[1] https://deployer.master.ci.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/acceptance-tests/builds/472
[2] https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/91
[3] https://github.com/alphagov/paas-docker-cloudfoundry-tools/tree/cf_6_21_1
[4] https://hub.docker.com/r/governmentpaas/cf-acceptance-tests/builds/bm4heywjrlwtjazox8sqazk/
[5] https://github.com/alphagov/paas-cf/pull/829

Dependencies
---------------

Add a revert to https://github.com/alphagov/paas-cf/pull/829 once this is merged.

How to review?
------------

Code review. Maybe you can run one time the pipeline and check that the acceptance tests pass (I didn't, I don't have an env deployed right now ;))

Who?
----

Anyone but @keymon