### PR TITLE
[support] dashboard: Separate no data alerts from warnings

### DIFF
--- a/tools/paas_dashboard/widgets/health/health.coffee
+++ b/tools/paas_dashboard/widgets/health/health.coffee
@@ -8,10 +8,15 @@ class Dashing.Health extends Dashing.Widget
   onData: (data) ->
 
     status = switch
-      when not (data.hasOwnProperty('warnings') and data.hasOwnProperty('criticals')) then 'error'
+      when not (
+        data.hasOwnProperty('warnings') and
+        data.hasOwnProperty('criticals') and
+        data.hasOwnProperty('unknowns')
+      ) then 'error'
       when data.hasOwnProperty('error') then 'error'
       when @get('criticals') > 0 then 'red'
       when @get('warnings') > 0 then 'yellow'
+      when @get('unknowns') > 0 then 'grey'
       else 'green'
 
     @set 'status', status
@@ -19,4 +24,4 @@ class Dashing.Health extends Dashing.Widget
     if status is 'error'
       if not data.hasOwnProperty('error')
         # Error condition because of a missing field
-        @set 'error', 'Data provided without "warnings" and "criticals" fields.'
+        @set 'error', 'Data provided without "warnings", "criticals", and "unknown" fields.'

--- a/tools/paas_dashboard/widgets/health/health.html
+++ b/tools/paas_dashboard/widgets/health/health.html
@@ -12,11 +12,16 @@
                     critical<span data-hideif="criticals | equals 1">s</span>
                 </h4>
             </div>
-
             <div data-hideif="warnings | equals 0" class="floated">
                 <h3 data-bind="warnings"></h3>
                 <h4>
                     warning<span data-hideif="warnings | equals 1">s</span>
+                </h4>
+            </div>
+            <div data-hideif="unknowns | equals 0" class="floated">
+                <h3 data-bind="unknowns"></h3>
+                <h4>
+                    unknown<span data-hideif="unknowns | equals 1">s</span>
                 </h4>
             </div>
             <div data-showif="status | equals 'green'">

--- a/tools/paas_dashboard/widgets/health/health.scss
+++ b/tools/paas_dashboard/widgets/health/health.scss
@@ -1,6 +1,7 @@
 $background: #444;
 $text: #fff;
 $success: #0E8F00;
+$unknown: #9B9B9B;
 $warning: #F25F00;
 $failure: #AF0900;
 $error: #5B0274;
@@ -41,6 +42,16 @@ $error: #5B0274;
       p {
         &.updated-at {
           color: lighten($success, 20%);
+        }
+      }
+    }
+
+    &.grey {
+      background-color: $unknown;
+
+      p {
+        &.updated-at {
+          color: lighten($unknown, 60%);
         }
       }
     }


### PR DESCRIPTION
## What

A "no data" alert isn't necessarily as serious as a "warning". They normally
indicate that the monitoring isn't working correctly, which may be hiding
more serious problems, but aren't the same as a known alert.

I choose "unknown" as the dashboard label because "no data" could possibly
be confused with the dashboard no updating from the DataDog API.

This is particularly of interest to me at the moment while I'm on support
because we're investigating a problem with a handful of monitors that are
reporting "no data". I have been muting the affected monitors and dc41a8e
prevents them from showing on the dashboard, but because they come and go I
haven't been able to mute all of them, and I'm still getting distracted from
real alerts.

## How to review

1. Checkout the branch: `git checkout support/dashboard_unknowns`
1. Change to the dashboard directory: `cd tools/paas_dashboard`
1. Install the dependencies: `bundle install`
1. Run the dashboard using keys from [government-paas/credentials](https://github.gds/government-paas/credentials):

        DD_API_KEY=$(PASSWORD_STORE_DIR=~/.paas-pass pass datadog/dev/datadog_api_key) \
        DD_APP_KEY=$(PASSWORD_STORE_DIR=~/.paas-pass pass datadog/dev/datadog_app_key) \
        bundle exec smashing start

1. View the dashboard at http://localhost:3030/paas-overview and confirm that it shows "unknown" alerts. The background will be grey when there are no other kinds of alerts. I'll leave the alerts in CI unmuted so that you can test this.

## Who can review

Not @dcarley