### PR TITLE
[#139196683] Use deploy_env tag in bbs monitor definition

### DIFF
--- a/terraform/datadog/bbs.tf
+++ b/terraform/datadog/bbs.tf
@@ -31,7 +31,7 @@ resource "datadog_monitor" "bbs_healthy" {
   notify_no_data      = true
   require_full_window = false
 
-  query = "${format("min(last_1m):min:cf.bbs.Healthy{bosh-deployment:%s} < 1", var.env)}"
+  query = "${format("min(last_1m):min:cf.bbs.Healthy{deploy_env:%s} < 1", var.env)}"
 
   thresholds {
     critical = "1"


### PR DESCRIPTION
## What

Before the tag didn't seem to be available on the metric (probably because of issues fixed by https://github.com/alphagov/paas-datadog-agent-boshrelease/pull/10).

The tag is now present, so we can use like we do in all other monitors.

## How to review

Deploy. See TF apply change to monitor. Check the monitor - the state should not change. Stop your dev bbs servers to trigger the monitor to verify it still works.

## Who can review

not @mtekel