### PR TITLE
[#136027405] Fix dev oauth property

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -998,6 +998,7 @@ jobs:
               AWS_ACCOUNT: {{aws_account}}
               ENABLE_DATADOG: {{enable_datadog}}
               DATADOG_API_KEY: {{datadog_api_key}}
+              DISABLE_USER_CREATION: {{disable_user_creation}}
               OAUTH_CLIENT_ID: {{oauth_client_id}}
               OAUTH_CLIENT_SECRET: {{oauth_client_secret}}
             run:
@@ -1032,6 +1033,11 @@ jobs:
                   if [ "${ENABLE_DATADOG}" = "true" ] ; then
                      MANIFEST_STUBS="${MANIFEST_STUBS}
                                     ./paas-cf/manifests/cf-manifest/stubs/datadog-nozzle.yml"
+                  fi
+
+                  if [ "${DISABLE_USER_CREATION}" = "false" ] ; then
+                     MANIFEST_STUBS="${MANIFEST_STUBS}
+                                    ./paas-cf/manifests/cf-manifest/stubs/oauth.yml"
                   fi
 
                   # FIXME: Remove eval after https://github.com/concourse/concourse/issues/360

--- a/concourse/scripts/lib/google-oauth.sh
+++ b/concourse/scripts/lib/google-oauth.sh
@@ -7,7 +7,8 @@ get_google_oauth_secrets() {
   secrets_uri="s3://${state_bucket}/google-oauth-secrets.yml"
   export oauth_client_id
   export oauth_client_secret
-  if aws s3 ls "${secrets_uri}" > /dev/null ; then
+  secrets_size=$(aws s3 ls "${secrets_uri}" | awk '{print $3}')
+  if [ "${secrets_size}" != 0 ] && [ -n "${secrets_size}" ]  ; then
     secrets_file=$(mktemp -t google-oauth-secrets.XXXXXX)
 
     aws s3 cp "${secrets_uri}" "${secrets_file}"

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -374,25 +374,7 @@ properties:
     links:
       passwd: (( concat "https://login." properties.system_domain "/forgot_password" ))
       signup: (( concat "https://login." properties.system_domain "/create_account" ))
-    oauth:
-      providers:
-        google:
-          type: oidc1.0
-          authUrl: https://accounts.google.com/o/oauth2/v2/auth
-          tokenUrl: https://www.googleapis.com/oauth2/v4/token
-          issuer: https://accounts.google.com
-          redirectUrl: (( concat "https://login." properties.system_domain "/uaa" ))
-          scopes:
-            - openid
-            - email
-          linkText: Login with Google
-          showLinkText: true
-          addShadowUserOnLogin: false
-          relyingPartyId: (( grab $OAUTH_CLIENT_ID ))
-          relyingPartySecret: (( grab $OAUTH_CLIENT_SECRET ))
-          skipSslValidation: false
-          attributeMappings:
-            user_name: email
+
   uaa:
     url: (( concat "https://uaa." properties.system_domain ))
     issuer: (( grab properties.uaa.url ))

--- a/manifests/cf-manifest/stubs/oauth.yml
+++ b/manifests/cf-manifest/stubs/oauth.yml
@@ -1,0 +1,21 @@
+properties:
+  login:
+    oauth:
+      providers:
+        google:
+          type: oidc1.0
+          authUrl: https://accounts.google.com/o/oauth2/v2/auth
+          tokenUrl: https://www.googleapis.com/oauth2/v4/token
+          issuer: https://accounts.google.com
+          redirectUrl: (( concat "https://login." properties.system_domain "/uaa" ))
+          scopes:
+            - openid
+            - email
+          linkText: Login with Google
+          showLinkText: true
+          addShadowUserOnLogin: false
+          relyingPartyId: (( grab $OAUTH_CLIENT_ID ))
+          relyingPartySecret: (( grab $OAUTH_CLIENT_SECRET ))
+          skipSslValidation: false
+          attributeMappings:
+            user_name: email


### PR DESCRIPTION
## What

This implements a condition that checks if creation of admin users is
enabled and adds one more stub to the spruce command.

Oauth config has been moved to separate file to include it only when we
want to create admins.

## How to review

Deploy on dev and check if it finishes OK

## Who can review

Not @combor
