### PR TITLE
[#141948375] Split Consul client and server checks 

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -26,9 +26,9 @@ releases:
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/paas-haproxy-0.1.3.tgz
     sha1: 732ceb817afe33ee117b85a202d87f6f5c3dd760
   - name: datadog-for-cloudfoundry
-    version: 0.1.14
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.1.14.tgz
-    sha1: 555b7dc5c7a98540bee81b80db72584f68d4ab79
+    version: 0.1.15
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.1.15.tgz
+    sha1: 8270937b7519fa15d58d80810a62ccc2badb90a2
   - name: ipsec
     version: 0.1.2
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/ipsec-0.1.2.tgz

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -37,7 +37,7 @@ meta:
     release: (( grab meta.release.name ))
   - name: staticfile-buildpack
     release: (( grab meta.release.name ))
-  - name: datadog-consul
+  - name: datadog-consul-agent-client
     release: datadog-for-cloudfoundry
   - name: datadog-cc
     release: datadog-for-cloudfoundry
@@ -51,7 +51,7 @@ meta:
     consumes: {nats: nil}
   - name: metron_agent
     release: (( grab meta.release.name ))
-  - name: datadog-consul
+  - name: datadog-consul-agent-client
     release: datadog-for-cloudfoundry
   - name: datadog-cc-worker
     release: datadog-for-cloudfoundry
@@ -60,7 +60,9 @@ meta:
   - name: consul_agent
     release: (( grab meta.release.name ))
     consumes: {consul: nil}
-  - name: datadog-consul
+  - name: datadog-consul-agent-server
+    release: datadog-for-cloudfoundry
+  - name: datadog-consul-agent-client
     release: datadog-for-cloudfoundry
   - name: metron_agent
     release: (( grab meta.release.name ))
@@ -69,7 +71,7 @@ meta:
   - name: consul_agent
     release: (( grab meta.release.name ))
     consumes: {consul: nil}
-  - name: datadog-consul
+  - name: datadog-consul-agent-client
     release: datadog-for-cloudfoundry
   - name: etcd
     release: (( grab meta.release.name ))
@@ -82,7 +84,7 @@ meta:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
     consumes: {consul: nil}
-  - name: datadog-consul
+  - name: datadog-consul-agent-client
     release: datadog-for-cloudfoundry
   - name: doppler
     release: (( grab meta.release.name ))
@@ -95,7 +97,7 @@ meta:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
     consumes: {consul: nil}
-  - name: datadog-consul
+  - name: datadog-consul-agent-client
     release: datadog-for-cloudfoundry
   - name: loggregator_trafficcontroller
     release: (( grab meta.release.name ))
@@ -106,7 +108,7 @@ meta:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
     consumes: {consul: nil}
-  - name: datadog-consul
+  - name: datadog-consul-agent-client
     release: datadog-for-cloudfoundry
   - name: nats
     consumes: {nats: nil}
@@ -122,7 +124,7 @@ meta:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
     consumes: {consul: nil}
-  - name: datadog-consul
+  - name: datadog-consul-agent-client
     release: datadog-for-cloudfoundry
   - name: gorouter
     release: (( grab meta.release.name ))
@@ -142,7 +144,7 @@ meta:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
     consumes: {consul: nil}
-  - name: datadog-consul
+  - name: datadog-consul-agent-client
     release: datadog-for-cloudfoundry
   - name: uaa
     release: (( grab meta.release.name ))
@@ -210,7 +212,7 @@ jobs:
     templates:
       - name: consul_agent
         release: cf
-      - name: datadog-consul
+      - name: datadog-consul-agent-client
         release: datadog-for-cloudfoundry
       - name: datadog-bbs
         release: datadog-for-cloudfoundry
@@ -337,7 +339,7 @@ jobs:
     templates:
       - name: consul_agent
         release: cf
-      - name: datadog-consul
+      - name: datadog-consul-agent-client
         release: datadog-for-cloudfoundry
       - name: auctioneer
         release: diego
@@ -356,7 +358,7 @@ jobs:
     templates:
       - name: consul_agent
         release: cf
-      - name: datadog-consul
+      - name: datadog-consul-agent-client
         release: datadog-for-cloudfoundry
       - name: rep
         release: diego
@@ -392,7 +394,7 @@ jobs:
     templates:
       - name: consul_agent
         release: cf
-      - name: datadog-consul
+      - name: datadog-consul-agent-client
         release: datadog-for-cloudfoundry
       - name: stager
         release: cf
@@ -417,7 +419,7 @@ jobs:
     templates:
       - name: consul_agent
         release: cf
-      - name: datadog-consul
+      - name: datadog-consul-agent-client
         release: datadog-for-cloudfoundry
       - name: route_emitter
         release: diego
@@ -438,7 +440,7 @@ jobs:
     templates:
       - name: consul_agent
         release: cf
-      - name: datadog-consul
+      - name: datadog-consul-agent-client
         release: datadog-for-cloudfoundry
       - name: ssh_proxy
         release: diego


### PR DESCRIPTION
## What

Currently we run the Consul server checks on all VMs, because the datadog-consul job in the datadog-for-cloudfoundry release couples the two together. They have been split into datadog-consul-agent-client and datadog-consul-agent-server jobs in the release as part of https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/18. We leave the client checks on all VMs, but only include the server check for the VMs which are part of the Consul cluster.

## How to review

First, this pull request must be merged: https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/18 is being reviewed. Once that is done the temporary commit should be replaced with one that points to the final release. The commits may or may not be squashed together, I am not fussy.

The other pull request should involve reviewing that the new release actually puts the right configuration files in the right places, so I will leave it up to the reviewer to decide whether code review is sufficient here.

## Who can review

Anyone but me.
