### PR TITLE
[support] show-cf-memory-usage: Link to memory graph

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,6 +236,6 @@ shake_concourse_volumes: check-env ## Restarts concourse services and workers an
 	@./scripts/ssh.sh scp concourse/scripts/shake_concourse_volumes.sh /tmp/
 	@./scripts/ssh.sh ssh bash -i /tmp/shake_concourse_volumes.sh
 
-show-cf-memory-usage: ## Show the memory usage of the current CF cluster
+show-cf-memory-usage: check-env ## Show the memory usage of the current CF cluster
 	$(eval export API_ENDPOINT=https://api.${SYSTEM_DNS_ZONE_NAME})
 	@./scripts/show-cf-memory-usage.rb

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ DEPLOY_ENV_VALID_LENGTH=$(shell if [ $$(printf "%s" $(DEPLOY_ENV) | wc -c) -gt $
 DEPLOY_ENV_VALID_CHARS=$(shell if echo $(DEPLOY_ENV) | grep -q '^[a-zA-Z0-9-]*$$'; then echo "OK"; else echo ""; fi)
 
 check-env:
+	$(if ${RAN_MAKE_ENV_TARGET},,$(error Must run an environment target, e.g. `make dev $(MAKECMDGOALS)`))
 	$(if ${DEPLOY_ENV},,$(error Must pass DEPLOY_ENV=<name>))
 	$(if ${DEPLOY_ENV_VALID_LENGTH},,$(error Sorry, DEPLOY_ENV ($(DEPLOY_ENV)) has a max length of $(DEPLOY_ENV_MAX_LENGTH), otherwise derived names will be too long))
 	$(if ${DEPLOY_ENV_VALID_CHARS},,$(error Sorry, DEPLOY_ENV ($(DEPLOY_ENV)) must use only alphanumeric chars and hyphens, otherwise derived names will be malformatted))
@@ -91,6 +92,7 @@ dev: globals ## Set Environment to DEV
 	$(eval export CONCOURSE_AUTH_DURATION=48h)
 	$(eval export DISABLE_PIPELINE_LOCKING=true)
 	$(eval export TEST_HEAVY_LOAD=true)
+	$(eval export RAN_MAKE_ENV_TARGET=true)
 	@true
 
 .PHONY: ci
@@ -106,6 +108,7 @@ ci: globals ## Set Environment to CI
 	$(eval export ENABLE_DATADOG=true)
 	$(eval export DEPLOY_ENV=master)
 	$(eval export TEST_HEAVY_LOAD=true)
+	$(eval export RAN_MAKE_ENV_TARGET=true)
 	@true
 
 .PHONY: staging
@@ -124,6 +127,7 @@ staging: globals ## Set Environment to Staging
 	$(eval export ENABLE_DATADOG=true)
 	$(eval export DEPLOY_ENV=staging)
 	$(eval export TEST_HEAVY_LOAD=true)
+	$(eval export RAN_MAKE_ENV_TARGET=true)
 	@true
 
 .PHONY: prod
@@ -142,6 +146,7 @@ prod: globals ## Set Environment to Production
 	$(eval export ENABLE_PAAS_DASHBOARD=true)
 	$(eval export DEPLOY_RUBBERNECKER=true)
 	$(eval export DEPLOY_ENV=prod)
+	$(eval export RAN_MAKE_ENV_TARGET=true)
 	@true
 
 .PHONY: bosh-cli

--- a/scripts/show-cf-memory-usage.rb
+++ b/scripts/show-cf-memory-usage.rb
@@ -1,6 +1,14 @@
 #!/usr/bin/env ruby
 
 require 'json'
+require 'uri'
+
+datadog_url = URI("https://app.datadoghq.com/metric/explorer")
+datadog_url.query = URI.encode_www_form(
+  exp_agg: "sum",
+  exp_metric: "system.mem.total",
+  exp_scope: "bosh-job:cell,bosh-deployment:#{ENV.fetch('DEPLOY_ENV')}",
+)
 
 config_path = File.expand_path('~/.cf/config.json')
 if File.exist?(config_path)
@@ -76,3 +84,4 @@ puts "Memory reserved by orgs: #{format_memory(orgs_reserved_memory)}"
 puts "Memory reserved by apps: #{format_memory(apps_reserved_memory)}"
 puts
 puts "Total cell memory required to meet ADR017: #{format_memory(required_cell_memory)}"
+puts "Compare this against: #{datadog_url}"


### PR DESCRIPTION
## What

Make it easier for people to know what they should compare the "memory
required" number against. I've previously run the script but not verified
whether we are meeting ADR017 because it was too much effort to look.

The link shows a sum of all cells by environment. I was going to hardcode it
to `bosh-deployment:prod` since that's the environment that we most often
add orgs and cells to, but the script can be used against any environment.

## How to review

1. Checkout the branch
1. Run `make show-cf-memory-usage`
1. Click the link and verify that it shows useful information

## Who can review

Not @dcarley