### PR TITLE
[#142042903] Fix no_data in failed job and error count monitors

### DIFF
--- a/terraform/datadog/cloud_controller.tf
+++ b/terraform/datadog/cloud_controller.tf
@@ -60,7 +60,7 @@ resource "datadog_monitor" "cc_failed_job_count_total_increase" {
   escalation_message  = "Amount of failed jobs in Cloud Controller API still growing considerably, check the API health."
   require_full_window = false
 
-  query = "${format("change(max(last_1m),last_30m):max:cf.cc.failed_job_count.total{deployment:%s} > 5", var.env)}"
+  query = "${format("change(max(last_1m),last_30m):max:cf.cc.failed_job_count.total{deployment:%s}.rollup(avg, 30) > 5", var.env)}"
 
   thresholds {
     warning  = "3"
@@ -77,7 +77,7 @@ resource "datadog_monitor" "cc_log_count_error_increase" {
   escalation_message  = "Amount of logged errors in Cloud Controller API still growing considerably, check the API health."
   require_full_window = false
 
-  query = "${format("change(max(last_1m),last_30m):sum:cf.cc.log_count.error{deployment:%s} > 5", var.env)}"
+  query = "${format("change(max(last_1m),last_30m):sum:cf.cc.log_count.error{deployment:%s}.rollup(avg, 30) > 5", var.env)}"
 
   thresholds {
     warning  = "3"


### PR DESCRIPTION
## What
Apply rollup function, because, as responded by DataDog support:

>The issue on the initial monitors was that during evaluation, the timeshift
that necessarily operates on a change monitor, couldn't find datapoints that
were there if the datapoints were not submitted at the exact timeshift
timestamp of the monitor:

>    Let's say the timeshift was looking for a datapoint at 8:34:25 am , and
you had one at 8:34:23 and one at 8:34:29, you'd artificially get a no data
result.

>Appending the rollup(avg,30) function is correcting that in the way that it
will average the points buckets over a 30 sec timeframe, so you'd always
have data.

## How to review

Apply to your DD enabled environment. Observe monitors being updated. Observe monitors not having no_data issues any more (give it few hours - but change should be visible very soon given how much no_data there is on the monitors before fix).

## Who can review

not @mtekel
