### PR TITLE
[#141785699] Fix ssh upload

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -13,6 +13,10 @@ releases:
     version: 1.8.1
     url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=1.8.1
     sha1: a8c9fdecf59a1fceb2837ac0cfbde6a939427adb
+  - name: diego-patched
+    version: 1.8.1
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/diego-patched-1.8.1.tgz
+    sha1: 26f7599cfe41db8ecd335f19d7c8337cd2ac20e2
   - name: garden-runc
     version: 1.2.0
     url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.2.0

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -441,11 +441,11 @@ jobs:
       - name: datadog-consul
         release: datadog-for-cloudfoundry
       - name: ssh_proxy
-        release: diego
+        release: diego-patched
       - name: metron_agent
         release: cf
       - name: file_server
-        release: diego
+        release: diego-patched
       - name: cfdot
         release: diego
     instances: 2

--- a/platform-tests/src/acceptance/cf_ssh_test.go
+++ b/platform-tests/src/acceptance/cf_ssh_test.go
@@ -1,12 +1,25 @@
 package acceptance_test
 
 import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
 	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/generator"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gbytes"
 	. "github.com/onsi/gomega/gexec"
+)
+
+const (
+	BYTE     = int64(1)
+	KILOBYTE = 1024 * BYTE
+	MEGABYTE = 1024 * KILOBYTE
+	GIGABYTE = 1024 * MEGABYTE
+	TERABYTE = 1024 * GIGABYTE
 )
 
 var _ = Describe("CF SSH", func() {
@@ -23,5 +36,41 @@ var _ = Describe("CF SSH", func() {
 		cfSSH := cf.Cf("ssh", appName, "-c", "uptime").Wait(DEFAULT_TIMEOUT)
 		Expect(cfSSH).To(Exit(0))
 		Expect(cfSSH).To(Say("load average:"))
+	})
+
+	It("allows uploading a large payload via standard ssh client", func() {
+		// FIXME: Increase to 10GB once the following issue is solved:
+		// https://github.com/cloudfoundry/cli/issues/1098
+		const payloadSize = 1*GIGABYTE + 900*MEGABYTE
+		timeout := 600
+		appName := generator.PrefixedRandomName("CATS-APP-")
+		Expect(cf.Cf(
+			"push", appName,
+			"-b", config.StaticFileBuildpackName,
+			"-p", "../../example-apps/static-app",
+			"-d", config.AppsDomain,
+			"-i", "1",
+			"-m", "64M",
+		).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+
+		cfSSHCommand := exec.Command("/usr/bin/cf", "ssh", appName, "-c", "cat > /dev/null")
+		sshStdin, err := cfSSHCommand.StdinPipe()
+		Expect(err).NotTo(HaveOccurred())
+
+		file, err := os.Open("/dev/zero")
+		Expect(err).NotTo(HaveOccurred())
+		defer file.Close()
+
+		session, err := Start(cfSSHCommand, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+
+		copied, err := io.CopyN(sshStdin, file, payloadSize)
+		Expect(err).NotTo(HaveOccurred())
+		fmt.Fprintf(GinkgoWriter, "Successfully copied %d bytes", copied)
+		sshStdin.Close()
+
+		Expect(copied).To(Equal(payloadSize))
+		session.Wait(timeout)
+		Expect(session).To(Exit(0))
 	})
 })


### PR DESCRIPTION
## What
Story: [Resolve issues with large database imports](https://www.pivotaltracker.com/story/show/141785699)

Fix the issue reported by Notify that prevents them to upload more than 1GB data via ssh. The issue was reported here: https://github.com/cloudfoundry/diego-ssh/issues/31
A PR was raised upstream to update the crypto library globally in diego-release: https://github.com/cloudfoundry/diego-release/pull/288
For our issue we only need to update the ssh_proxy and file_server jobs.
An acceptance test covers uploads 1.9GB to cover the fix we've made. Another issue prevents us from uploading more than 2GB via `cf` command line: https://github.com/cloudfoundry/cli/issues/1098

We should increase the limit when it's fixed.

## How to review
* Install [pv](https://linux.die.net/man/1/pv)
* Test ssh against a vanilla environment. This should fail:

```
$ dd if=/dev/zero count=1040 bs=1024k | pv | cf ssh healthcheck -c "cat > /dev/null"
```
* Deploy
* Restage the healthcheck app
* Test again, it should work now
* Check it fails above 1GB

## Who can review

Not me