### PR TITLE
Fix make ci showenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,13 +98,13 @@ ci: globals ## Set Environment to CI
 	$(eval export AWS_ACCOUNT=ci)
 	$(eval export ENABLE_AUTO_DEPLOY=true)
 	$(eval export TAG_PREFIX=staging-)
+	$(eval export DEPLOY_ENV=master)
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.ci.cloudpipeline.digital)
 	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.ci.cloudpipelineapps.digital)
 	$(eval export ALERT_EMAIL_ADDRESS=the-multi-cloud-paas-team+ci@digital.cabinet-office.gov.uk)
 	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS=${ALERT_EMAIL_ADDRESS})
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-default.yml)
 	$(eval export ENABLE_DATADOG=true)
-	$(eval export DEPLOY_ENV=master)
 	$(eval export TEST_HEAVY_LOAD=true)
 	@true
 


### PR DESCRIPTION
## What

DEPLOY_ENV was defined only after SYSTEM_DNS_ZONE_NAME, which meant that had
empty environment name. Move DEPLOY_ENV definition before
SYSTEM_DNS_ZONE_NAME, so that it is defined correctly.

## How to review

Check that URLs contain `master` when you do `make ci showenv`.

## Who can review

not @mtekel
