### PR TITLE
Fix admin users login with OpenID connect 

### DIFF
--- a/manifests/cf-manifest/stubs/oauth.yml
+++ b/manifests/cf-manifest/stubs/oauth.yml
@@ -6,6 +6,7 @@ properties:
           type: oidc1.0
           authUrl: https://accounts.google.com/o/oauth2/v2/auth
           tokenUrl: https://www.googleapis.com/oauth2/v4/token
+          tokenKeyUrl: https://www.googleapis.com/oauth2/v3/certs
           issuer: https://accounts.google.com
           redirectUrl: (( concat "https://login." properties.system_domain "/uaa" ))
           scopes:

--- a/scripts/lib/mail_credentials_helper.rb
+++ b/scripts/lib/mail_credentials_helper.rb
@@ -44,7 +44,7 @@ A CF admin user has been created for you with the following details:
 
 You can log in by executing:
 
-  cf login -a #{api_url} -u #{user.fetch(:username)} --sso
+  cf login -a #{api_url} --sso
 
 Regards,
 The Government PaaS Team.

--- a/terraform/cloudfoundry/elbs.tf
+++ b/terraform/cloudfoundry/elbs.tf
@@ -86,6 +86,13 @@ resource "aws_lb_ssl_negotiation_policy" "cf_uaa" {
   }
 }
 
+resource "aws_app_cookie_stickiness_policy" "cf_uaa" {
+  name          = "cf-uaa"
+  load_balancer = "${aws_elb.cf_uaa.id}"
+  lb_port       = 443
+  cookie_name   = "JSESSIONID"
+}
+
 resource "aws_elb" "cf_loggregator" {
   name                      = "${var.env}-cf-loggregator"
   subnets                   = ["${split(",", var.infra_subnet_ids)}"]


### PR DESCRIPTION
## What

Fix some problems that we found after merging the original PR

### Unable to validate google JWT signatures

CF v253 introduced a UAA change that appears to require a new `tokenKeyUrl` property to be set to allow Google's signatures to be validated. A [bug](https://github.com/cloudfoundry/uaa/issues/565) exists for this upstream.

### Passcode issuance requires sticky sessions

The user visits login.domain/passcode to get a one-time code to use in the CLI, they then get redirected to /login, visit google to login and then return to access the passcode page.

This requires sticky sessions to be enabled on the UAA load balancer because the the URL that a user was intending to visit is saved in a server side session and there does not seem to be a way of sharing the sessions between UAA instances.

The expectation from the UAA team seems be to that it will be deployed behind gorouter, which automatically uses sticky sessions when it sees a `JSESSIONID` cookie. https://docs.cloudfoundry.org/concepts/http-routing.html 

We switched away from gorouter load balancing of UAA (and all CF endpoints) in #196 

In order to fix this, an ELB stickiness policy has been defined, based on the UAA JSESSIONID cookie. I don't believe this will have any effect on most of our requests through the ELB, as most of them will be from the CLI.

## How to review

- Ensure that your environment creates admin users:
```
export NEW_ACCOUNT_EMAIL_ADDRESS='the-multi-cloud-paas-team+dev@digital.cabinet-office.gov.uk'
make dev pipelines
```
- [optional] Out of politeness you may add a temporary commit to remove your colleagues from `config/admin_users.yml` to ensure they don't receive confusing emails
- Ensure you have pulled `paas-pass` / credentials recently and run `make dev upload-google-oauth-secrets`
- Add `https://login.$DEPLOY_ENV.dev.cloudpipeline.digital/login/callback/google` to the list of _Authorised redirect URIs_ for dev in the [Google API developer console](https://console.developers.google.com/apis/credentials?project=govuk-paas)
- Deploy this branch
- Check your email, including your spam folder for an email saying an account has been set up
- Follow the workaround instructions [here](https://github.com/alphagov/paas-team-manual/blob/d551300451c4c6cc43106ab5248006b07e80b2c2/docs/guides/cf_admin_users.md) to login, working around a UAA bug

## Who can review

Anyone but me.
