### PR TITLE
Fix the counters on window with certain width

### DIFF
--- a/tools/paas_dashboard/widgets/health/health.scss
+++ b/tools/paas_dashboard/widgets/health/health.scss
@@ -6,6 +6,8 @@ $warning: #F25F00;
 $failure: #AF0900;
 $error: #5B0274;
 
+$small: 34em;
+
 
 .widget-health {
   li {
@@ -22,14 +24,22 @@ $error: #5B0274;
     }
 
     h3 {
-      font-size: 7vh;
+      font-size: 5vh;
       font-weight: bold;
+
+      @media screen and (min-width: $small) {
+        font-size: 7vh;
+      }
     }
 
     h4 {
-      font-size: 3vh;
+      font-size: 2.5vh;
       font-weight: bold;
       text-transform: uppercase;
+
+      @media screen and (min-width: $small) {
+        font-size: 3vh;
+      }
     }
 
     p &.updated-at {
@@ -88,8 +98,21 @@ $error: #5B0274;
 
     div.floated {
       display: inline-block;
-      margin-left: 20px;
-      margin-right: 20px;
+      margin-left: 10px;
+      margin-right: 10px;
+
+      @media screen and (min-width: $small) {
+        margin-left: 20px;
+        margin-right: 20px;
+      }
+
+      &:first-of-type {
+        margin-left: 0;
+      }
+
+      &:last-of-type {
+        margin-right: 0;
+      }
     }
   }
 }


### PR DESCRIPTION
## What

Now that we have a third counter available, we may meet the case where all three will need to be displayed on the dashboard. This will cause some layout disturbances and could be fixed by making the counters smaller on a window below 544 pixels wide.

## How to review

1. Run the dashboard locally
2. ~Cause many DataDog monitors to fail on one of our environments~ or remove `data-hideif="X | equals 0"` from `widgets/health/health.html` lines `9`, `15` and `21`
3. Check the behaviour on different window widths - You need to refresh every time you set a new window width

## Who can review

Not @paroxp