### PR TITLE
WIP: [#136027405] Script to workaround SSO redirect_uri bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,3 +234,6 @@ shake_concourse_volumes: check-env ## Restarts concourse services and workers an
 show-cf-memory-usage: ## Show the memory usage of the current CF cluster
 	$(eval export API_ENDPOINT=https://api.${SYSTEM_DNS_ZONE_NAME})
 	@./scripts/show-cf-memory-usage.rb
+
+fix_sso_url: check-env
+	@./scripts/fix_sso_url.rb

--- a/scripts/fix_sso_url.rb
+++ b/scripts/fix_sso_url.rb
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+# Temporary workaround for:
+# - https://github.com/cloudfoundry/uaa/issues/562
+# - https://github.com/cloudfoundry/uaa/pull/575
+
+require 'uri'
+
+REDIRECT_HOSTNAME = "login.#{ENV.fetch('SYSTEM_DNS_ZONE_NAME')}".freeze
+
+puts "Paste URL:"
+url = URI.parse(gets.chomp)
+
+query = Hash[URI.decode_www_form(url.query)]
+redirect_url = URI.parse(query.fetch('redirect_uri'))
+redirect_url.path = "/#{redirect_url.host}#{redirect_url.path}"
+redirect_url.host = REDIRECT_HOSTNAME
+query['redirect_uri'] = redirect_url
+url.query = URI.encode_www_form(query)
+
+puts
+puts "Corrected URL:"
+puts url


### PR DESCRIPTION
## What

Paste the broken URL and click on the corrected URL:

    ➜  paas-cf git:(bugfix/136027405-fix_sso_url_script) ✗ make dev fix_sso_url
    Paste URL:
    https://accounts.google.com/o/oauth2/v2/auth?client_id=REDACTED.apps.googleusercontent.com&response_type=code&redirect_uri=https%3A%2F%2Flogin%2Fcallback%2Fgoogle&scope=openid+email&nonce=REDACTED

    Corrected URL:
    https://accounts.google.com/o/oauth2/v2/auth?client_id=REDACTED.apps.googleusercontent.com&response_type=code&redirect_uri=https%3A%2F%2Flogin.dcarley.dev.cloudpipeline.digital%2Flogin%2Fcallback%2Fgoogle&scope=openid+email&nonce=REDACTED

## How to review

I used this myself while reviewing #851 because I found modifying the URL by hand was cumbersome. If it's useful to anyone else when I'll write tests and remove the WIP label. If it's not then I'll close the PR after a week or so.

1. Run it as shown above
1. Feedback whether it's useful

## Who can review

Not @dcarley
