### PR TITLE
[#142302879] Increase default number of cells

### DIFF
--- a/manifests/cf-manifest/manifest/env-specific/cf-default.yml
+++ b/manifests/cf-manifest/manifest/env-specific/cf-default.yml
@@ -1,4 +1,4 @@
 ---
 meta:
   cell:
-    instances: 2
+    instances: 3


### PR DESCRIPTION
## What

Due to performance problems during acceptance tests execution we decided
to increase number of cells on CI and STAGING environments to cope with
the load and allow tests to finish undisrupted. During
investigation with Pivotal we have discovered that metron is dropping
messages and UDP packed are being dropped by kernel as the load on cells
was extremely high.

## How to review

Sanity check

## Who can review

Not @combor