### PR TITLE
[#134579301] UAA failed login monitors

### DIFF
--- a/terraform/datadog/uaa.tf
+++ b/terraform/datadog/uaa.tf
@@ -1,0 +1,23 @@
+resource "datadog_monitor" "user_not_found" {
+  name    = "${format("%s UAA - Failed login: user not found", var.env)}"
+  type    = "query alert"
+  message = "${format("Anomalous levels of authentication attempts with a user name that does not exist. See https://government-paas-team-manual.readthedocs.io/en/latest/support/responding_to_alerts/. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
+
+  query = "${format("avg(last_30m):anomalies(sum:cf.uaa.audit_service.user_not_found_count{deployment:%s}, 'agile', 2, direction='above') >= 0.5", var.env)}"
+
+  require_full_window = true
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:uaa"]
+}
+
+resource "datadog_monitor" "login_with_wrong_password" {
+  name    = "${format("%s UAA - Failed login: wrong password", var.env)}"
+  type    = "query alert"
+  message = "${format("Anomalous levels of authentication attempts with an existing user name and wrong password. See https://government-paas-team-manual.readthedocs.io/en/latest/support/responding_to_alerts/ @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
+
+  query = "${format("avg(last_30m):anomalies(sum:cf.uaa.audit_service.user_authentication_failure_count{deployment:%s}, 'agile', 2, direction='above') >= 0.5", var.env)}"
+
+  require_full_window = true
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:uaa"]
+}


### PR DESCRIPTION
## What

Story: [Create alerts for anomalous UAA behaviour](https://www.pivotaltracker.com/story/show/134579301)

Add 2 monitors based on UAA failed login metrics.

## How to review

The monitors require 2 weeks of data, it is recommended to test in CI by creating the monitors and testing login there.

### Setup

```
$ export TF_VAR_env=master
$ export TF_VAR_datadog_api_key=$(gov-pass datadog/dev/datadog_api_key)
$ export TF_VAR_datadog_app_key=$(gov-pass datadog/dev/datadog_app_key)
$ cd terraform/datadog
$ terraform apply -var-file=../ci.tfvars -target=datadog_monitor.login_with_wrong_password -target=datadog_monitor.user_not_found
```

### Test

Make many failed login attempts, watch the monitor fail and recover. You can tweak the threshold and time to make it fail faster.

#### Wrong username

```
$ while true; do echo "" | cf login -a https://api.master.ci.cloudpipeline.digital --skip-ssl-validation -u admin$i -p ababa; i=$((i+1)); sleep 1; done
```

### Wrong password

Run a few times:

```
$ cf login -a https://api.master.ci.cloudpipeline.digital --skip-ssl-validation -u admin -p ababa
```

The UAA will lock the account for that user, so you can try again with another user.

### Destroy

```
$ terraform destroy -var-file=../ci.tfvars -target=datadog_monitor.login_with_wrong_password -target=datadog_monitor.user_not_found
```

## Who can review
Not me
