### PR TITLE
[#142066597] VPC peering

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -811,8 +811,13 @@ jobs:
                 mkdir generated-certificates
                 tar xzf cf-certs/cf-certs.tar.gz -C generated-certificates
 
+                # FIXME: remove this once it's run everywhere.
+                wget -O tf_aws_route_migrator https://github.com/alext/tf_aws_route_migrator/releases/download/0.0.1/tf_aws_route_migrator_linux_amd64
+                chmod +x tf_aws_route_migrator
+                ./tf_aws_route_migrator < cf-tfstate/cf.tfstate > migrated-cf.tfstate
+
                 terraform apply -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
-                  -state=cf-tfstate/cf.tfstate -state-out=updated-tfstate/cf.tfstate paas-cf/terraform/cloudfoundry
+                  -state=migrated-cf.tfstate -state-out=updated-tfstate/cf.tfstate paas-cf/terraform/cloudfoundry
         ensure:
           put: cf-tfstate
           params:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -775,6 +775,30 @@ jobs:
                 < cf-certs-tfstate/cf-certs.tfstate > terraform-variables/cf-certs.tfvars.sh
                 ruby paas-cf/concourse/scripts/extract_tf_vars_from_yaml.rb \
                 < cf-secrets/cf-secrets.yml > terraform-variables/cf-secrets.tfvars.sh
+
+      - task: generate-peer-tfvars
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: ruby
+              tag: 2.2-slim
+          inputs:
+            - name: paas-cf
+          outputs:
+            - name: vpc-peering-tfvars
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                ruby paas-cf/terraform/scripts/generate_vpc_peering_tfvars.rb paas-cf/terraform/{{aws_account}}.vpc_peering.json \
+                > vpc-peering-tfvars/vpc-peers.tfvars
+
+                cat vpc-peering-tfvars/vpc-peers.tfvars
+
       - task: terraform-apply
         config:
           platform: linux
@@ -788,6 +812,7 @@ jobs:
             - name: cf-tfstate
             - name: cf-certs
             - name: pingdom-probes-ips
+            - name: vpc-peering-tfvars
           outputs:
             - name: updated-tfstate
           params:
@@ -817,6 +842,7 @@ jobs:
                 ./tf_aws_route_migrator < cf-tfstate/cf.tfstate > migrated-cf.tfstate
 
                 terraform apply -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
+                  -var-file=vpc-peering-tfvars/vpc-peers.tfvars \
                   -state=migrated-cf.tfstate -state-out=updated-tfstate/cf.tfstate paas-cf/terraform/cloudfoundry
         ensure:
           put: cf-tfstate
@@ -941,6 +967,29 @@ jobs:
                   ${CF_MANIFEST_DIR}/scripts/grafana-dashboards-manifest.rb ${CF_MANIFEST_DIR}/grafana \
                     > grafana-dashboards-manifest/grafana-dashboards-manifest.yml
 
+      - task: generate-peer-manifest
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: ruby
+              tag: 2.2-slim
+          inputs:
+            - name: paas-cf
+          outputs:
+            - name: vpc-peering-manifest
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                ruby paas-cf/terraform/scripts/generate_vpc_peering_manifest.rb paas-cf/terraform/{{aws_account}}.vpc_peering.json \
+                > vpc-peering-manifest/vpc-peers.yml
+
+                cat vpc-peering-manifest/vpc-peers.yml
+
       - aggregate:
         - task: generate-cloud-config
           config:
@@ -991,6 +1040,7 @@ jobs:
               - name: bosh-CA
               - name: ipsec-CA
               - name: grafana-dashboards-manifest
+              - name: vpc-peering-manifest
             outputs:
               - name: cf-manifest
             params:
@@ -1002,6 +1052,7 @@ jobs:
                 ./certs/*.yml
                 ./grafana-dashboards-manifest/grafana-dashboards-manifest.yml
                 ./paas-cf/manifests/cf-manifest/env-specific/{{cf_env_specific_manifest}}
+                ./vpc-peering-manifest/*.yml
               AWS_ACCOUNT: {{aws_account}}
               ENABLE_DATADOG: {{enable_datadog}}
               DATADOG_API_KEY: {{datadog_api_key}}

--- a/terraform/cloudfoundry/nat.tf
+++ b/terraform/cloudfoundry/nat.tf
@@ -12,11 +12,13 @@ resource "aws_nat_gateway" "cf" {
 resource "aws_route_table" "internet" {
   vpc_id = "${var.vpc_id}"
   count  = "${var.zone_count}"
+}
 
-  route {
-    cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = "${element(aws_nat_gateway.cf.*.id, count.index)}"
-  }
+resource "aws_route" "internet" {
+  count                  = "${var.zone_count}"
+  route_table_id         = "${element(aws_route_table.internet.*.id, count.index)}"
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = "${element(aws_nat_gateway.cf.*.id, count.index)}"
 }
 
 resource "aws_route_table_association" "internet" {

--- a/terraform/cloudfoundry/vpc_peering.tf
+++ b/terraform/cloudfoundry/vpc_peering.tf
@@ -1,0 +1,27 @@
+resource "aws_vpc_peering_connection" "vpc_peer" {
+  count         = "${length(var.peer_vpc_ids)}"
+  peer_owner_id = "${element(var.peer_account_ids, count.index)}"
+  peer_vpc_id   = "${element(var.peer_vpc_ids, count.index)}"
+  vpc_id        = "${var.vpc_id}"
+}
+
+resource "aws_route" "vpc_peer_route_0" {
+  count                     = "${length(var.peer_vpc_ids)}"
+  route_table_id            = "${aws_route_table.internet.0.id}"
+  destination_cidr_block    = "${element(var.peer_cidrs, count.index)}"
+  vpc_peering_connection_id = "${element(aws_vpc_peering_connection.vpc_peer.*.id, count.index)}"
+}
+
+resource "aws_route" "vpc_peer_route_1" {
+  count                     = "${length(var.peer_vpc_ids)}"
+  route_table_id            = "${aws_route_table.internet.1.id}"
+  destination_cidr_block    = "${element(var.peer_cidrs, count.index)}"
+  vpc_peering_connection_id = "${element(aws_vpc_peering_connection.vpc_peer.*.id, count.index)}"
+}
+
+resource "aws_route" "vpc_peer_route_2" {
+  count                     = "${length(var.peer_vpc_ids)}"
+  route_table_id            = "${aws_route_table.internet.2.id}"
+  destination_cidr_block    = "${element(var.peer_cidrs, count.index)}"
+  vpc_peering_connection_id = "${element(aws_vpc_peering_connection.vpc_peer.*.id, count.index)}"
+}

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -149,3 +149,23 @@ variable "assets_prefix" {
   description = "Prefix for global assests like S3 buckets"
   default     = "gds-paas"
 }
+
+variable "peer_names" {
+  description = "The name of the peer"
+  default     = []
+}
+
+variable "peer_account_ids" {
+  description = "The account ID's that contains the VPC to peer with"
+  default     = []
+}
+
+variable "peer_vpc_ids" {
+  description = "The VPC to peer with"
+  default     = []
+}
+
+variable "peer_cidrs" {
+  description = "The CIDR of the VPC to peer with"
+  default     = []
+}

--- a/terraform/prod.vpc_peering.json
+++ b/terraform/prod.vpc_peering.json
@@ -1,0 +1,8 @@
+[
+    {
+        "peer_name": "dit",
+        "account_id": "513071381340",
+        "vpc_id": "vpc-4b0c122f",
+        "subnet_cidr": "172.16.1.0/24"
+    }
+]

--- a/terraform/scripts/generate_vpc_peering_manifest.rb
+++ b/terraform/scripts/generate_vpc_peering_manifest.rb
@@ -1,0 +1,29 @@
+require "rubygems"
+require "json"
+require "yaml"
+
+security_groups = Array.new
+
+if File.file?(ARGV[0])
+  peers = JSON.parse(File.read(ARGV[0]))
+  peers.each do |peer|
+    group = {
+      "name" => "vpc_peer_" + peer["peer_name"],
+      "rules" => [{
+          "protocol" => "all",
+          "destination" => peer["subnet_cidr"],
+      }]
+    }
+    security_groups.push(group)
+  end
+end
+
+manifest = {
+  "properties" => {
+    "cc" => {
+      "security_group_definitions" => security_groups
+    }
+  }
+}
+
+puts manifest.to_yaml

--- a/terraform/scripts/generate_vpc_peering_tfvars.rb
+++ b/terraform/scripts/generate_vpc_peering_tfvars.rb
@@ -1,0 +1,22 @@
+require "rubygems"
+require "json"
+
+names = Array.new
+vpc_ids = Array.new
+account_ids = Array.new
+cidrs = Array.new
+
+if File.file?(ARGV[0])
+  peers = JSON.parse(File.read(ARGV[0]))
+  peers.each do |peer|
+    names.push(peer["peer_name"])
+    vpc_ids.push(peer["vpc_id"])
+    account_ids.push(peer["account_id"])
+    cidrs.push(peer["subnet_cidr"])
+  end
+
+  printf "peer_names = %s\n", names
+  printf "peer_vpc_ids = %s\n", vpc_ids
+  printf "peer_account_ids = %s\n", account_ids
+  printf "peer_cidrs = %s\n", cidrs
+end


### PR DESCRIPTION
## What

This introduces VPC peering infrastructure to allow tenants access to their own VPC so they can expose services we don't have as brokers to their applications.

This also introduces the live configuration for DIT's VPC peering. Once this has been merged and deployed they should be notified that they need to accept the peering request and add the route.

It does this by having a per-environment json definition of the VPCs to peer with, along with who they belong to and what ranges to route. This json definition is then parsed during the pipeline and both a `tfvars` file is generated so that the VPC peering can be established & routing configured, and a CF manifest file is generated to configure a CF security group that can be bound to an organisation.

The workflow is as follows:

* We give a tenant a CIDR in the 172 range
* A tenant creates a VPC using this range, then gives us their account ID & VPC ID
* We add this information to our `prod.vpc_peering.json` file and deploy to production
* We bind the newly generated security group to the tenants organisations
* The tenant accepts the VPC peering request
* The tenant creates a route directing all 10.0.0.0/16 traffic to the new vpc peering
* Tenants now have access to their VPC in the orgs that are bound

## How to review

Peering requests between VPC's in the same account work the same way as peering requests between accounts, so for simplicity you can simply test in dev.

I have left a test peering VPC configured in dev, along with a deployed elasticache node in it. Please delete these when you are done testing. The VPC is `vpc-911a03f5`, and the redis instance is `peering-test.p9lva7.0001.euw1.cache.amazonaws.com`.

Create & commit `paas-cf/terraform/dev.vpc_peering.json` with the following contents in your dev env:
```
[
    {
        "peer_name": "peering_test",
        "account_id": "595665891067",
        "vpc_id": "vpc-911a03f5",
        "subnet_cidr": "172.16.1.0/24"
    }
]
```

Deploy.

Either deploy an application, or `cf ssh` to a container in the org you'll be testing with and `nc peering-test.p9lva7.0001.euw1.cache.amazonaws.com 6379`. It should fail to connect.

Bind the newly created security group `vpc_peer_peering_test` to an org, and `cf restart` the application you're testing with to have the group take effect.

Repeat the previous test, and `nc` should now connect.

## After deploy

Once this has been merged and deployed DIT should be notified that they need to accept the peering request and add the route. We also need to bind the group to their org.

## Who can review

Not @jonty.
