### PR TITLE
Bugfix: add elasticsearch_master disk size for CI

### DIFF
--- a/manifests/cf-manifest/env-specific/cf-ci.yml
+++ b/manifests/cf-manifest/env-specific/cf-ci.yml
@@ -2,3 +2,5 @@
 meta:
   cell:
     instances: 6
+  elasticsearch_master:
+    disk_size: 307200


### PR DESCRIPTION
## What

The story to change disk sizes in production clashed with the addition
of our first CI-specific manifest configuration. The CI manifest config
file was moved, but the elasticsearch_master disk configuration was
not added. This adds it.

## How to review

See https://github.com/alphagov/paas-cf/pull/858

Code review should be sufficient.

## Who can review

@paroxp preferably.
