### PR TITLE
[#142066597] Extract aws_route terraform resources

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -811,8 +811,13 @@ jobs:
                 mkdir generated-certificates
                 tar xzf cf-certs/cf-certs.tar.gz -C generated-certificates
 
+                # FIXME: remove this once it's run everywhere.
+                wget -O tf_aws_route_migrator https://github.com/alext/tf_aws_route_migrator/releases/download/0.0.1/tf_aws_route_migrator_linux_amd64
+                chmod +x tf_aws_route_migrator
+                ./tf_aws_route_migrator < cf-tfstate/cf.tfstate > migrated-cf.tfstate
+
                 terraform apply -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
-                  -state=cf-tfstate/cf.tfstate -state-out=updated-tfstate/cf.tfstate paas-cf/terraform/cloudfoundry
+                  -state=migrated-cf.tfstate -state-out=updated-tfstate/cf.tfstate paas-cf/terraform/cloudfoundry
         ensure:
           put: cf-tfstate
           params:

--- a/terraform/cloudfoundry/nat.tf
+++ b/terraform/cloudfoundry/nat.tf
@@ -12,11 +12,13 @@ resource "aws_nat_gateway" "cf" {
 resource "aws_route_table" "internet" {
   vpc_id = "${var.vpc_id}"
   count  = "${var.zone_count}"
+}
 
-  route {
-    cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = "${element(aws_nat_gateway.cf.*.id, count.index)}"
-  }
+resource "aws_route" "internet" {
+  count                  = "${var.zone_count}"
+  route_table_id         = "${element(aws_route_table.internet.*.id, count.index)}"
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = "${element(aws_nat_gateway.cf.*.id, count.index)}"
 }
 
 resource "aws_route_table_association" "internet" {


### PR DESCRIPTION
## What

Use `aws_route` resources for the `internet` route table 

Terraform doesn't allow mixing routes defined inline in an
`aws_route_table` resource with separate `aws_route` resources[1]. We
need to start using the latter to add routes for the VPC peering, so we
need to migrate this.

This is non-straightforward because if we remove the inline `route`
statement, terraform won't remove the routes, which means that when it
attempts to create the replacement `aws_route` resource, it gets a
conflict. This is solved by modifying the tfstate file before
running terraform.

[1]https://www.terraform.io/docs/providers/aws/r/route_table.html

**Note:** depending on timings, we may include this in the VPC peering PR on Monday, but this would still benefit from a separate review.

## How to review

Run this branch, and verify that the cf-terraform change is a no-op.
Run it a second time to verify that the migration step only happens once, and that it's still a no-op.

## Who can review

Anyone but myself or @Jonty 