### PR TITLE
[#142302879] Reduce ginkgo nodes to 5

### DIFF
--- a/manifests/cf-manifest/manifest/900-cf-tests.yml
+++ b/manifests/cf-manifest/manifest/900-cf-tests.yml
@@ -23,7 +23,7 @@ properties:
     include_docker: true
     include_route_services: true
     artifacts_directory: "/var/vcap/sys/log/test_artifacts"
-    nodes: 10
+    nodes: 5
 
   smoke_tests:
     api: (( grab properties.acceptance_tests.api ))


### PR DESCRIPTION
## What

To be on a safe side with acceptance tests we have decided to reduce
ginkgo nodes to 5 to decrease the load on cells and reduce possibility
to lose logs.

## How to review

Sanity check

## Who can review

Not @combor