### PR TITLE
[#142854167] Remove deprecated metron_agent properties

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -140,9 +140,6 @@ properties:
 
   metron_agent:
     deployment: (( grab meta.environment ))
-    preferred_protocol: ~
-    enable_buffer: ~
-    buffer_size: ~
     dropsonde_incoming_port: (( grab properties.loggregator.dropsonde_incoming_port ))
 
   metron_endpoint:


### PR DESCRIPTION
## What

Those properties were deprecated some time ago and are not present in
v79 of metron spec:
https://github.com/cloudfoundry/loggregator/blob/v79/jobs/metron_agent/spec
Cleaning them as leftovers.

OK, I lied. This is actually just an excuse to deploy https://github.com/alphagov/paas-graphite-nozzle/pull/5 as we don't have any other trigger mechanism at the moment. 

## How to review

Sanity check

## Who can review

Not @combor
