### PR TITLE
[#141777063] Tests for VPC peering config generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ spec:
 		bundle exec rspec
 	cd platform-tests/bosh-template-renderer &&\
 		bundle exec rspec
+	cd terraform/scripts &&\
+		go test
 
 lint_yaml:
 	find . -name '*.yml' -not -path '*/vendor/*' | xargs $(YAMLLINT) -c yamllint.yml

--- a/terraform/scripts/generate_vpc_peering_manifest.rb
+++ b/terraform/scripts/generate_vpc_peering_manifest.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 require "rubygems"
 require "json"
 require "yaml"

--- a/terraform/scripts/generate_vpc_peering_test.go
+++ b/terraform/scripts/generate_vpc_peering_test.go
@@ -1,0 +1,188 @@
+package scripts_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+var _ = Describe("VPC peering", func() {
+	var examplePeerConfig = map[string]string{
+		"peer_name":   "cheese",
+		"account_id":  "123cheese",
+		"vpc_id":      "vpc123cheese",
+		"subnet_cidr": "0.0.0.0/32",
+	}
+
+	var files []string
+
+	BeforeEach(func() {
+		files, _ = filepath.Glob("../*.vpc_peering.json")
+	})
+
+	Context("config files", func() {
+		It("have all required values", func() {
+			for _, filename := range files {
+				file, _ := ioutil.ReadFile(filename)
+
+				var peers []map[string]string
+				err := json.Unmarshal([]byte(file), &peers)
+				Expect(err).To(BeNil(), "Config file: %s", filename)
+
+				for _, peer := range peers {
+					for k, _ := range examplePeerConfig {
+						Expect(peer).To(HaveKeyWithValue(k, Not(BeEmpty())), "Config %s missing %s", filename, k)
+					}
+				}
+			}
+		})
+
+		It("do not have intersecting CIDRs", func() {
+			for _, filename := range files {
+				file, _ := ioutil.ReadFile(filename)
+
+				var peers []map[string]string
+				err := json.Unmarshal([]byte(file), &peers)
+				Expect(err).To(BeNil(), "Config file: %s", filename)
+
+				var nets []*net.IPNet
+				for _, peer := range peers {
+					_, net, err := net.ParseCIDR(peer["subnet_cidr"])
+					Expect(err).To(BeNil(), "Config file: %s", filename)
+
+					for _, othernet := range nets {
+						intersection := (net.Contains(othernet.IP) || othernet.Contains(net.IP))
+						Expect(intersection).To(Equal(false), "%s has intersecting CIDRs: %s, %s", filename, net, othernet)
+					}
+					nets = append(nets, net)
+				}
+			}
+		})
+	})
+
+	Context("tfvar output", func() {
+		It("can be generated", func() {
+			for _, filename := range files {
+				command := exec.Command("./generate_vpc_peering_tfvars.rb", filename)
+				var out bytes.Buffer
+				command.Stdout = &out
+				err := command.Run()
+				Expect(err).To(BeNil(), "Config file: %s", filename)
+				Expect(out.String()).ToNot(BeEmpty(), "Config file: %s", filename)
+			}
+		})
+
+		It("is empty with no environment config", func() {
+			command := exec.Command("./generate_vpc_peering_tfvars.rb", "cheese")
+			var out bytes.Buffer
+			command.Stdout = &out
+			err := command.Run()
+			Expect(err).To(BeNil())
+			Expect(out.String()).To(BeEmpty())
+		})
+
+		It("crashes when not given a config", func() {
+			command := exec.Command("./generate_vpc_peering_tfvars.rb")
+			err := command.Run()
+			Expect(err).ToNot(BeNil())
+		})
+
+		It("crashes when a field is missing", func() {
+			for field, _ := range examplePeerConfig {
+				var config = map[string]string{}
+				for k, v := range examplePeerConfig {
+					if k == field {
+						continue
+					}
+					config[k] = v
+				}
+
+				file, err := ioutil.TempFile(os.TempDir(), "vpcpeer")
+				Expect(err).To(BeNil())
+
+				defer os.Remove(file.Name())
+
+				data, _ := json.Marshal(config)
+				err = ioutil.WriteFile(file.Name(), data, 0644)
+				Expect(err).To(BeNil())
+
+				command := exec.Command("./generate_vpc_peering_tfvars.rb", file.Name())
+				var out bytes.Buffer
+				command.Stdout = &out
+				err = command.Run()
+				Expect(err).ToNot(BeNil(), "Missing field: %s", field)
+			}
+		})
+	})
+
+	Context("manifest output", func() {
+		It("can be generated", func() {
+			for _, filename := range files {
+				command := exec.Command("./generate_vpc_peering_manifest.rb", filename)
+				var out bytes.Buffer
+				command.Stdout = &out
+				err := command.Run()
+				Expect(err).To(BeNil(), "Config file: %s", filename)
+				Expect(out.String()).ToNot(BeEmpty(), "Config file: %s", filename)
+				Expect(out.String()).ToNot(Equal(`---
+properties:
+  cc:
+    security_group_definitions: []
+`), "Config file: %s", filename)
+			}
+		})
+
+		It("has empty manifest with no environment config", func() {
+			command := exec.Command("./generate_vpc_peering_manifest.rb", "cheese")
+			var out bytes.Buffer
+			command.Stdout = &out
+			err := command.Run()
+			Expect(err).To(BeNil())
+			Expect(out.String()).To(Equal(`---
+properties:
+  cc:
+    security_group_definitions: []
+`))
+		})
+
+		It("crashes when not given a config", func() {
+			command := exec.Command("./generate_vpc_peering_manifest.rb")
+			err := command.Run()
+			Expect(err).ToNot(BeNil())
+		})
+
+		It("crashes when a field is missing", func() {
+			for field, _ := range examplePeerConfig {
+				var config = map[string]string{}
+				for k, v := range examplePeerConfig {
+					if k == field {
+						continue
+					}
+					config[k] = v
+				}
+
+				file, err := ioutil.TempFile(os.TempDir(), "vpcpeer")
+				Expect(err).To(BeNil())
+
+				defer os.Remove(file.Name())
+
+				data, _ := json.Marshal(config)
+				err = ioutil.WriteFile(file.Name(), data, 0644)
+				Expect(err).To(BeNil())
+
+				command := exec.Command("./generate_vpc_peering_manifest.rb", file.Name())
+				var out bytes.Buffer
+				command.Stdout = &out
+				err = command.Run()
+				Expect(err).ToNot(BeNil(), "Missing field: %s", field)
+			}
+		})
+	})
+})

--- a/terraform/scripts/generate_vpc_peering_tfvars.rb
+++ b/terraform/scripts/generate_vpc_peering_tfvars.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 require "rubygems"
 require "json"
 

--- a/terraform/scripts/scripts_suite_test.go
+++ b/terraform/scripts/scripts_suite_test.go
@@ -1,0 +1,13 @@
+package scripts_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestScripts(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Scripts Suite")
+}


### PR DESCRIPTION
## What

These tests are mostly designed to spot incorrect .json VPC peer configurations, but they also minimally validate that the generators are working as expected.

## How to review

* Code review.
* Run the tests.
* Twiddle the `prod.vpc_peering.json` until each of them breaks, or create a new one that is interestingly broken.

## Who can review

Not @jonty.