### PR TITLE
[#142066597] Revert "Modify cf.tfstate to extract aws_route resources."

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -836,14 +836,9 @@ jobs:
                 mkdir generated-certificates
                 tar xzf cf-certs/cf-certs.tar.gz -C generated-certificates
 
-                # FIXME: remove this once it's run everywhere.
-                wget -O tf_aws_route_migrator https://github.com/alext/tf_aws_route_migrator/releases/download/0.0.1/tf_aws_route_migrator_linux_amd64
-                chmod +x tf_aws_route_migrator
-                ./tf_aws_route_migrator < cf-tfstate/cf.tfstate > migrated-cf.tfstate
-
                 terraform apply -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
                   -var-file=vpc-peering-tfvars/vpc-peers.tfvars \
-                  -state=migrated-cf.tfstate -state-out=updated-tfstate/cf.tfstate paas-cf/terraform/cloudfoundry
+                  -state=cf-tfstate/cf.tfstate -state-out=updated-tfstate/cf.tfstate paas-cf/terraform/cloudfoundry
         ensure:
           put: cf-tfstate
           params:


### PR DESCRIPTION
## What

This was added as part of #861 to allow migrating to a separate `aws_route` resource. Now that this has been applied in all environments, it can be reverted.

This reverts commit d35d69bf5ecb7af92d5b3d8b16f6a5ba3a5b8abf.

## How to review

Code review - verify that it does indeed revert the above commit.

## Who can review

Anyone but myself.