### PR TITLE
Raise CC error alert threshold

### DIFF
--- a/terraform/datadog/cloud_controller.tf
+++ b/terraform/datadog/cloud_controller.tf
@@ -77,7 +77,7 @@ resource "datadog_monitor" "cc_log_count_error_increase" {
   escalation_message  = "Amount of logged errors in Cloud Controller API still growing considerably, check the API health."
   require_full_window = false
 
-  query = "${format("change(max(last_1m),last_30m):sum:cf.cc.log_count.error{deployment:%s}.rollup(avg, 30) > 5", var.env)}"
+  query = "${format("change(max(last_1m),last_30m):sum:cf.cc.log_count.error{deployment:%s}.rollup(avg, 30) > 30", var.env)}"
 
   thresholds {
     warning  = "3"


### PR DESCRIPTION
## What

This is triggered during almost every deploy due to what appears to be a bug in cloud controller. This raises it to require around 5% of the requests-per-minute to be errors.

## How to review

Code review.