### PR TITLE
[#143153295] Point UAA ELB to Nginx

### DIFF
--- a/platform-tests/src/acceptance/account_management_test.go
+++ b/platform-tests/src/acceptance/account_management_test.go
@@ -1,0 +1,113 @@
+package acceptance_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
+	"github.com/cloudfoundry-incubator/cf-test-helpers/generator"
+)
+
+var _ = Describe("AccountManagement", func() {
+	const email = "the-multi-cloud-paas-team+account-test@digital.cabinet-office.gov.uk"
+
+	var (
+		params   url.Values
+		password string
+		authURL  *url.URL
+	)
+
+	BeforeEach(func() {
+		params = url.Values{}
+		params.Set("client_id", "")
+		params.Set("redirect_uri", "")
+
+		password = generator.PrefixedRandomName("CATS-PASSWORD-")
+
+		infoCommand := cf.Cf("curl", "/v2/info")
+		Expect(infoCommand.Wait(DEFAULT_TIMEOUT)).To(Exit(0))
+
+		var infoResp struct {
+			AuthorizationEndpoint string `json:"authorization_endpoint"`
+		}
+
+		err := json.Unmarshal(infoCommand.Buffer().Contents(), &infoResp)
+		Expect(err).NotTo(HaveOccurred())
+
+		authURL, err = url.Parse(infoResp.AuthorizationEndpoint)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Describe("login server /create_account endpoint", func() {
+		It("should not allow access to the create account page", func() {
+			createAccountURL := authURL
+			createAccountURL.Path = "/create_account"
+
+			resp, err := httpClient.Get(createAccountURL.String())
+			Expect(err).NotTo(HaveOccurred())
+
+			defer resp.Body.Close()
+			body, err := ioutil.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound), "wrong status code, body:\n\n %s", body)
+			Expect(body).To(ContainSubstring("Something went amiss"))
+		})
+
+		It("should not allow anonymous users to create accounts", func() {
+			createAccountURL := authURL
+			createAccountURL.Path = "/create_account.do"
+
+			params.Set("email", email)
+			params.Set("password", password)
+			params.Set("password_confirmation", password)
+
+			resp, err := httpClient.PostForm(createAccountURL.String(), params)
+			Expect(err).NotTo(HaveOccurred())
+
+			defer resp.Body.Close()
+			body, err := ioutil.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound), "wrong status code, body:\n\n %s", body)
+			Expect(body).To(ContainSubstring("Something went amiss"))
+		})
+	})
+
+	Describe("login server /forgot_password endpoint", func() {
+		It("should not allow anonymous users to initiate password resets", func() {
+			resetPasswordURL := authURL
+			resetPasswordURL.Path = "/forgot_password.do"
+
+			params.Set("email", email)
+
+			resp, err := httpClient.PostForm(resetPasswordURL.String(), params)
+			Expect(err).NotTo(HaveOccurred())
+
+			defer resp.Body.Close()
+			body, err := ioutil.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound), "wrong status code, body:\n\n %s", body)
+			Expect(body).To(ContainSubstring("Something went amiss"))
+		})
+		It("should not allow anonymous users to initiate password resets page", func() {
+			resetPasswordURL := authURL
+			resetPasswordURL.Path = "/forgot_password"
+
+			params.Set("email", email)
+
+			resp, err := httpClient.Get(resetPasswordURL.String())
+			Expect(err).NotTo(HaveOccurred())
+
+			defer resp.Body.Close()
+			body, err := ioutil.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound), "wrong status code, body:\n\n %s", body)
+			Expect(body).To(ContainSubstring("Something went amiss"))
+		})
+	})
+})

--- a/terraform/cloudfoundry/elbs.tf
+++ b/terraform/cloudfoundry/elbs.tf
@@ -59,7 +59,7 @@ resource "aws_elb" "cf_uaa" {
   }
 
   health_check {
-    target              = "HTTP:8080/healthz"
+    target              = "HTTPS:9443/healthz"
     interval            = "${var.health_check_interval}"
     timeout             = "${var.health_check_timeout}"
     healthy_threshold   = "${var.health_check_healthy}"
@@ -67,8 +67,8 @@ resource "aws_elb" "cf_uaa" {
   }
 
   listener {
-    instance_port      = 8080
-    instance_protocol  = "http"
+    instance_port      = 9443
+    instance_protocol  = "https"
     lb_port            = 443
     lb_protocol        = "https"
     ssl_certificate_id = "${var.system_domain_cert_arn}"


### PR DESCRIPTION
## What

Story: https://www.pivotaltracker.com/story/show/134175741
Depends on: https://github.com/alphagov/paas-cf/pull/874 

Rebase this branch on master after above PR is merged.  

Following the change that introduced Nginx in front of UAA to block
create_account endpoints this points external ELB to Nginx proxy and
enables SSL between them.

## How to review

Deploy and check if acceptance-tests pass

## Who can review

Not @saliceti or @combor 
