### PR TITLE
[#143153295] Configure Nginx to block UAA endpoints

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -37,6 +37,10 @@ releases:
     version: 0.1.2
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/ipsec-0.1.2.tgz
     sha1: b9799935c22965443f3ddfc9ccdacd9c2cccfa5f
+  - name: nginx
+    version: 1.11.7
+    url: https://github.com/cloudfoundry-community/nginx-release/releases/download/v1.11.7/nginx-1.11.7.tgz
+    sha1: 133bb2260411b197924fff08d4cbd923cc8ec7eb
 
 stemcells:
   - alias: default

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -265,7 +265,11 @@ jobs:
             server 127.0.0.1:8080;
           }
           server {
-            listen 8090;
+            listen 9443;
+            ssl on;
+            ssl_certificate_key /var/vcap/jobs/nginx/etc/ssl.key.pem;
+            ssl_certificate  /var/vcap/jobs/nginx/etc/ssl_chained.crt.pem;
+
             location / {
               rewrite ^/create_account(.do)?$ /create_account_disabled break;
               rewrite ^/forgot_password(.do)?$ /create_account_disabled break;
@@ -278,6 +282,8 @@ jobs:
             }
           }
         }
+      ssl_key: (( grab secrets.uaa_internal_key ))
+      ssl_chained_cert: (( grab secrets.uaa_internal_cert ))
       consul:
         agent:
           services:

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -152,6 +152,8 @@ meta:
     release: (( grab meta.release.name ))
   - name: statsd_injector
     release: (( grab meta.release.name ))
+  - name: nginx
+    release: nginx
 
 jobs:
   - name: consul
@@ -247,6 +249,35 @@ jobs:
     networks:
       - name: cf
     properties:
+      nginx_conf: |
+        worker_processes  2;
+        error_log syslog:server=127.0.0.1 info;
+        events {
+          worker_connections  1024;
+        }
+        http {
+          include /var/vcap/packages/nginx/conf/mime.types;
+          access_log syslog:server=127.0.0.1 combined;
+          sendfile on;
+          keepalive_timeout 20s;
+          upstream uaa {
+            keepalive 10;
+            server 127.0.0.1:8080;
+          }
+          server {
+            listen 8090;
+            location / {
+              rewrite ^/create_account(.do)?$ /create_account_disabled break;
+              rewrite ^/forgot_password(.do)?$ /create_account_disabled break;
+
+              proxy_pass http://uaa;
+              proxy_set_header Host $host;
+              proxy_set_header X-Forwarded-For $remote_addr;
+              proxy_http_version 1.1;
+              proxy_set_header Connection "";
+            }
+          }
+        }
       consul:
         agent:
           services:

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -368,6 +368,7 @@ properties:
       serviceProviderCertificate: ((grab secrets.saml_cert))
     enabled: true
     brand: oss
+    self_service_links_enabled: "false"
     links:
       passwd: (( concat "https://login." properties.system_domain "/forgot_password" ))
       signup: (( concat "https://login." properties.system_domain "/create_account" ))


### PR DESCRIPTION
## What

Story: [Block UAA create_account endpoints](https://www.pivotaltracker.com/story/show/143153295)

Deploy Nginx that will be used in front of UAA to block particular endpoints. The traffic is not routed to it yet. This will be done in PR https://github.com/alphagov/paas-cf/pull/873 to avoid downtime.

Also disable the self service links.

## How to review
* Deploy
* Open https://login.colin2017.dev.cloudpipeline.digital.  Check the links "Create account" "Reset password" are absent
* SSH to UAA
* Check Nginx proxies successfully to UAA:

```
curl -i --resolve login.colin2017.dev.cloudpipeline.digital:127.0.0.1 https://login.colin2017.dev.cloudpipeline.digital:9443/login -k
```
* Check the endpoints create_account, create_account.do and forgot_password.do return 404:

```
curl -i --resolve login.colin2017.dev.cloudpipeline.digital:127.0.0.1 https://login.colin2017.dev.cloudpipeline.digital:9443/create_account -k
```

## Who can review
Not @combor or me
