### PR TITLE
Remove the API whitelist

### DIFF
--- a/terraform/cloudfoundry/security-groups.tf
+++ b/terraform/cloudfoundry/security-groups.tf
@@ -27,7 +27,7 @@ resource "aws_security_group" "cf_api_elb" {
 
     cidr_blocks = [
       "${compact(var.admin_cidrs)}",
-      "${compact(var.tenant_cidrs)}",
+      "${compact(var.api_access_cidrs)}",
       "${var.concourse_elastic_ip}/32",
       "${formatlist("%s/32", aws_eip.cf.*.public_ip)}",
     ]
@@ -94,7 +94,6 @@ resource "aws_security_group" "web" {
 
     cidr_blocks = [
       "${compact(var.admin_cidrs)}",
-      "${compact(var.tenant_cidrs)}",
       "${compact(var.web_access_cidrs)}",
       "${var.concourse_elastic_ip}/32",
       "${formatlist("%s/32", aws_eip.cf.*.public_ip)}",
@@ -125,7 +124,7 @@ resource "aws_security_group" "sshproxy" {
 
     cidr_blocks = [
       "${compact(var.admin_cidrs)}",
-      "${compact(var.tenant_cidrs)}",
+      "${compact(var.api_access_cidrs)}",
       "${var.concourse_elastic_ip}/32",
     ]
   }

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -107,15 +107,15 @@ variable "admin_cidrs" {
   ]
 }
 
-/* Note: This is overridden in prod.tfvars to allow specific tenant access */
-variable "tenant_cidrs" {
-  description = "List of CIDR addresses of tenants with access to CloudFoundry API"
+/* Note: This is overridden in prod.tfvars to allow world access */
+variable "api_access_cidrs" {
+  description = "List of CIDR addresses with access to CloudFoundry API"
   default     = []
 }
 
 /* Note: This is overridden in prod.tfvars to allow world access */
 variable "web_access_cidrs" {
-  description = "List of CIDR addresses with access to "
+  description = "List of CIDR addresses with access to CloudFoundry web interfaces"
   default     = []
 }
 

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -9,76 +9,8 @@ cf_db_maintenance_window = "Thu:07:00-Thu:08:00"
 web_access_cidrs = [
   "0.0.0.0/0",
 ]
-tenant_cidrs = [
-  # BitZesty (trade-tarrif)
-  "52.19.165.178/32",
-  # DIT
-  "52.49.20.243/32",
-  "81.149.93.91/32",
-  # HMPO trial
-  "52.18.106.146/32",
-  # Usability Jenkins EIP
-  "52.212.106.102/32",
-  # Verify Jenkins server
-  "37.26.93.212/32",
-  # Shockley
-  "80.194.77.64/26",
-  # DWP carers trial
-  "84.93.121.196/32",
-  # DBS team
-  "195.171.79.218/32",
-  # MOD PaaS Trial
-  "25.8.49.225/32",
-  "25.8.49.187/32",
-  # GOV.UK Notify Jenkins server
-  "52.214.41.17/32",
-  # Accessing Government Services team Jenkins server
-  "52.214.76.50/32",
-  # GOV.UK Pay CI node
-  "34.251.16.209/32",
-  # GOV.UK Notify egress IPs (for metrics gathering)
-  "52.209.11.109/32",
-  "52.212.153.196/32",
-  "52.19.155.10/32",
-  "52.213.138.76/32",
-  "52.213.151.67/32",
-  "52.208.47.129/32",
-  # Cabinet office trial
-  "85.133.79.201/32",
-  # Parliamentary web services trial
-  "82.35.29.203/32",
-  # Digital Marketplace Jenkins
-  "52.18.174.104/32",
-  # DWP Bereavement Payment Support
-  "194.73.212.3/32",
-  # MOJ Digital and Technology
-  "81.134.202.29/32",
-  # Tenant egress for story #140308141
-  "185.40.8.212/32",
-  "86.188.177.234/32",
-  # Our own build Concourse in CI
-  "52.213.245.135/32",
-  # mod-dbs-trial org
-  "82.6.141.121/32",
-  "31.122.47.191/32",
-  # Innovision/DIT Horizon
-  "87.224.83.58/32",
-  # Notify NAT IPs to export data to paas
-  "52.18.54.222/32",
-  "52.208.148.20/32",
-  "52.208.3.206/32",
-  # BEIS platform team
-  "193.240.203.38/32",
-  "52.56.227.113/32",
-  # DWP Carer's Allowance
-  "194.159.238.241/32",
-  "212.250.23.69/32",
-  "212.250.43.3/32",
-  # DWP Overseas Healthcare Service Trial
-  "217.33.141.90/32",
-  # DIT Services
-  "81.128.182.170/32",
-  "52.56.227.174/32",
+api_access_cidrs = [
+  "0.0.0.0/0",
 ]
 bosh_db_backup_retention_period = "35"
 bosh_db_skip_final_snapshot = "false"


### PR DESCRIPTION
## What

🐝 🐝 **THIS CAN BE REVIEWED, BUT DO NOT MERGE IT UNTIL AFTER EASTER WEEKEND**🐝🐝 

This duplicates the way we have set up access for `web_access_cidrs` for the API, removing the current set of whitelisted addresses and replacing it with 0.0.0.0/0. It also renames the configuration variable from `tenant_cidrs` to `api_access_cidrs` in order to bring it in line with `web_access_cidrs` and make the new purpose clearer.

I have not completely removed the whitelisting code because we still require the ability to toggle access between dev/prod, and I think that renaming things to make them clearer makes the .tfvars configuration easier to understand.

## How to review

🐝 🐝**THIS CAN BE REVIEWED, BUT DO NOT MERGE IT UNTIL AFTER EASTER WEEKEND**🐝 🐝  

Copy the `api_access_cidrs` block from `prod.tfvars` to your `dev.tfvars`. Deploy. Check you can hit the API when you're routed via an IP address that was previously not on the whitelist.

Please do not merge this until after the easter weekend, but you can review it at will.