### PR TITLE
[Support] Fix literal not terminated

### DIFF
--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -79,7 +79,7 @@ tenant_cidrs = [
   # DIT Services
   "81.128.182.170/32",
   "52.56.227.174/32",
-  "52.49.20.243/32,
+  "52.49.20.243/32",
 ]
 bosh_db_backup_retention_period = "35"
 bosh_db_skip_final_snapshot = "false"


### PR DESCRIPTION
## What

Lack of quotation made Terraform to fail miserably crying about
```
invalid value "paas-cf/terraform/prod.tfvars" for flag -var-file: Error
parsing paas-cf/terraform/prod.tfvars: At 82:20: literal not terminated
```

## How to review

Sanity check

## Who can review

Not me
