### PR TITLE
[#Support] Remove duplicate IP from whitelist

### DIFF
--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -79,7 +79,6 @@ tenant_cidrs = [
   # DIT Services
   "81.128.182.170/32",
   "52.56.227.174/32",
-  "52.49.20.243/32",
 ]
 bosh_db_backup_retention_period = "35"
 bosh_db_skip_final_snapshot = "false"


### PR DESCRIPTION
## What

The duplicated IP caused live incident on PaaS. Terraform failed with:
```
Error applying plan:

3 error(s) occurred:

* aws_security_group.cf_api_elb: Error authorizing security group ingress rules: InvalidParameterValue: The same permission must not appear multiple times
	status code: 400, request id: e39509db-3715-490f-a53f-3ce751fdd17e
* aws_security_group.sshproxy: Error authorizing security group ingress rules: InvalidParameterValue: The same permission must not appear multiple times
	status code: 400, request id: 7ce7dce5-1c3b-43f6-a659-3901c62f50e4
* aws_security_group.web: Error authorizing security group ingress rules: InvalidParameterValue: The same permission must not appear multiple times
	status code: 400, request id: 15047c12-7eee-482c-95d8-421c4ffaabe9
```
It left the security group in a state where all traffic was blocked.

## How to review

This command should return no results:
```
egrep '\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b' terraform/prod.tfvars  | sort | uniq -c  | awk '$1 != 1 {print $0}'
```

## Who can review

Not me
