### PR TITLE
[#support] Replace rotate-user-password with create-user.sh -r

### DIFF
--- a/scripts/reset-org.py
+++ b/scripts/reset-org.py
@@ -92,7 +92,7 @@ class OrgReset(object):
                 raise SubprocessException('Aborting: \'%s\' failed with exit code %d\n%s' % (err.cmd, err.returncode, err.output))
 
     def parse_current_user(self, target_output):
-        match = re.search(r'User:\s+(\S+)', target_output)
+        match = re.search(r'[Uu]ser:\s+(\S+)', target_output)
         return match.group(1)
 
 

--- a/scripts/reset-user-testing.sh
+++ b/scripts/reset-user-testing.sh
@@ -29,9 +29,9 @@ check_logged_in_cf "${TARGET_ENVIRONMENT_API}"
 	--space-developers \
 	--quota small
 
-"${SCRIPT_DIR}"/rotate-user-password.sh -e "${TARGET_ENVIRONMENT}" -u "${TARGET_EMAIL_USER}+1@digital.cabinet-office.gov.uk"
-"${SCRIPT_DIR}"/rotate-user-password.sh -e "${TARGET_ENVIRONMENT}" -u "${TARGET_EMAIL_USER}+2@digital.cabinet-office.gov.uk"
-"${SCRIPT_DIR}"/rotate-user-password.sh -e "${TARGET_ENVIRONMENT}" -u "${TARGET_EMAIL_USER}+3@digital.cabinet-office.gov.uk"
-"${SCRIPT_DIR}"/rotate-user-password.sh -e "${TARGET_ENVIRONMENT}" -u "${TARGET_EMAIL_USER}+4@digital.cabinet-office.gov.uk"
-"${SCRIPT_DIR}"/rotate-user-password.sh -e "${TARGET_ENVIRONMENT}" -u "${TARGET_EMAIL_USER}+5@digital.cabinet-office.gov.uk"
-"${SCRIPT_DIR}"/rotate-user-password.sh -e "${TARGET_ENVIRONMENT}" -u "${TARGET_EMAIL_USER}+6@digital.cabinet-office.gov.uk"
+"${SCRIPT_DIR}"/create-user.sh -r -m -o paas_user_research -e "${TARGET_EMAIL_USER}+1@digital.cabinet-office.gov.uk"
+"${SCRIPT_DIR}"/create-user.sh -r -m -o paas_user_research -e "${TARGET_EMAIL_USER}+2@digital.cabinet-office.gov.uk"
+"${SCRIPT_DIR}"/create-user.sh -r -m -o paas_user_research -e "${TARGET_EMAIL_USER}+3@digital.cabinet-office.gov.uk"
+"${SCRIPT_DIR}"/create-user.sh -r -m -o paas_user_research -e "${TARGET_EMAIL_USER}+4@digital.cabinet-office.gov.uk"
+"${SCRIPT_DIR}"/create-user.sh -r -m -o paas_user_research -e "${TARGET_EMAIL_USER}+5@digital.cabinet-office.gov.uk"
+"${SCRIPT_DIR}"/create-user.sh -r -m -o paas_user_research -e "${TARGET_EMAIL_USER}+6@digital.cabinet-office.gov.uk"


### PR DESCRIPTION
## What

As `rotate-user-password.sh` has been deprecated in https://github.com/alphagov/paas-cf/commit/ab676558e78bffe476b555dbf20623e4be109904 we need to use `create-user.sh -r` instead.

## How to review

Sanity check.

## Who can review

Not me
