### PR TITLE
[#141315433] Monitor CPU credits for t2 instances

### DIFF
--- a/terraform/datadog/aws.tf
+++ b/terraform/datadog/aws.tf
@@ -1,0 +1,16 @@
+resource "datadog_monitor" "ec2-cpu-credits" {
+  name           = "${format("%s EC2 CPU credits", var.env)}"
+  type           = "query alert"
+  message        = "${format("Instance is {{#is_warning}}low on{{/is_warning}}{{#is_alert}}out of{{/is_alert}} on CPU credits and may perform badly. See: https://government-paas-team-manual.readthedocs.io/en/latest/support/responding_to_alerts/#cpu-credits @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
+  notify_no_data = false
+  query          = "${format("avg(last_30m):avg:aws.ec2.cpucredit_balance{deploy_env:%s} by {bosh-job,bosh-index} <= 1", var.env)}"
+
+  thresholds {
+    warning  = "20"
+    critical = "1"
+  }
+
+  require_full_window = true
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:all"]
+}


### PR DESCRIPTION
## What

AWS t2 instance types have burstable CPU performance. They accumulate
"credits" when not doing anything and then can consume the credits when they
want to do CPU intensive work. When the credits run out, the instance will
not be able to do CPU intensive work and will slow down. We want to know
when this happens because it is normally correlates to another problem/alert
and may indicate that we need to change the instance type in future.

There's a lot more information about the implementation in the commit message.

## How to review

ℹ️  This PR depends on alphagov/paas-team-manual#111 ℹ️ 

⚠️  I've included a WIP commit that makes this easier to test, so you don't need to deploy all of the DataDog features and it uses the metrics from CI where we have the integrations enabled. You **must** rebase this commit out and delete the monitors before merging ⚠️ 

The steps to test this are:

1. Deploy the pipeline from this branch to your dev environment
1. Run the pipeline (`cf-deploy` will apply the changes)
1. View the two new monitors in DataDog (search for "CPU credits"): https://app.datadoghq.com/monitors#manage
1. Cause a VM in CI to exhaust it's credits. This can take a while, so I suggest the smallest VM possible, e.g. `rds_broker/1`:
    1. Get a BOSH shell in CI: `make ci bosh_cli`
    1. SSH to the VM: `bosh ssh rds_broker/1`
    1. Install `stress` to stress the CPU: `sudo apt-get update && sudo apt-get install -y stress`
    1. Run it indefinitely: `stress --cpu 10`
    1. I found that I needed to background the process and run `top` to prevent the session from timing out, but you could choose to use `screen`/`tmux` instead.
    1. Watch the CPU credits go down in DataDog and eventually trigger the monitor.
    1. Restore the VM to normal when you're done, either with `apt-get remove` or `bosh recreate`.
1. I haven't tested the RDS monitor because we no longer have any instances for CF that are t2. I'm confident that it will work the same, but if you want to you can test it by using `cf create-service postgres Free <name>` and somehow making RDS consume lots of CPU

## Who can review

Not @dcarley