### PR TITLE
[#142318777] CF upgrade to v256

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2004,23 +2004,6 @@ jobs:
                 - -e
                 - -c
                 - |
-                  # FIXME: Remove this once
-                  # https://github.com/cloudfoundry/cf-acceptance-tests/pull/188 has been merged
-                  # and we use the new version.
-                  (
-                    cd  cf-release/src/github.com/cloudfoundry/cf-acceptance-tests/
-                    expected_commit_hash="b3f4485c8fb874b5c6be969c916f6b8a5922c0bc"
-                    current_commit_hash="$(git log --pretty=format:'%H' -n 1)"
-                    if [ "${expected_commit_hash}" != "${current_commit_hash}" ]; then
-                      echo "ERROR: Current commit for cf-acceptance-test is different than expected one: ${expected_commit_hash} != ${current_commit_hash}"
-                      echo "Double check if we still need to pull our branch"
-                      exit 1
-                    fi
-                    git remote add alphagov https://github.com/alphagov/paas-cf-acceptance-tests.git
-                    git fetch alphagov
-                    git checkout fix_v3_helper_doppler
-                  )
-
                   ./paas-cf/concourse/scripts/import_bosh_ca.sh
                   mkdir -p /var/vcap/sys
                   ln -s $(pwd)/artifacts /var/vcap/sys/log

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2018,6 +2018,9 @@ jobs:
                     SLEEPTIME=90
                     echo "Sleeping for ${SLEEPTIME} seconds..."
                     for i in $(seq $SLEEPTIME); do echo -ne "$i"'\r'; sleep 1; done; echo
+                    # FIXME. Should be removed after solving:
+                    # https://github.com/cloudfoundry/cf-release/issues/1188
+                    sed -i '/install-plugin/d' /var/vcap/jobs/acceptance-tests/bin/run
                     /var/vcap/jobs/acceptance-tests/bin/run
                   fi
 

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -6,21 +6,21 @@ director_uuid: ~
 
 releases:
   - name: cf
-    version: "253"
-    url: https://bosh.io/d/github.com/cloudfoundry/cf-release?v=253
-    sha1: 8e0ea926929bdb1ff16a366e2154d017c637a137
+    version: "256"
+    url: https://bosh.io/d/github.com/cloudfoundry/cf-release?v=256
+    sha1: 7eb583eb6dd08dfce8858d891b2571aebeb6b52c
   - name: diego
-    version: 1.8.1
-    url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=1.8.1
-    sha1: a8c9fdecf59a1fceb2837ac0cfbde6a939427adb
+    version: 1.12.0
+    url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=1.12.0
+    sha1: 6fe4073431ac2dcb7072493fae0f6c22f780e8a2
   - name: garden-runc
-    version: 1.2.0
-    url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.2.0
-    sha1: 37d46f41d187dbd90e1bf0748fa5c1fb60870bff
+    version: 1.4.0
+    url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.4.0
+    sha1: 1d6020e761806d7f355ceda06c889c582b47dc32
   - name: cflinuxfs2-rootfs
-    version: 1.53.0
-    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-rootfs-release?v=1.53.0
-    sha1: 93950d5d2071fdb395b7b1c958b8abddb8fdcfa0
+    version: 1.60.0
+    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-rootfs-release?v=1.60.0
+    sha1: 12b7e2473d0f4e9edc90bc3da873f51e70ede942
   - name: paas-haproxy
     version: 0.1.3
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/paas-haproxy-0.1.3.tgz
@@ -41,7 +41,7 @@ releases:
 stemcells:
   - alias: default
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3363.12"
+    version: "3363.19"
 
 update:
   canaries: 0

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -13,10 +13,6 @@ releases:
     version: 1.8.1
     url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=1.8.1
     sha1: a8c9fdecf59a1fceb2837ac0cfbde6a939427adb
-  - name: diego-patched
-    version: 1.8.1
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/diego-patched-1.8.1.tgz
-    sha1: 26f7599cfe41db8ecd335f19d7c8337cd2ac20e2
   - name: garden-runc
     version: 1.2.0
     url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.2.0

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -37,6 +37,14 @@ releases:
     version: 1.11.7
     url: https://github.com/cloudfoundry-community/nginx-release/releases/download/v1.11.7/nginx-1.11.7.tgz
     sha1: 133bb2260411b197924fff08d4cbd923cc8ec7eb
+    #FIXME: using a patched UAA release due to CVEs:
+    # https://www.cloudfoundry.org/cve-2017-4972/
+    # https://www.cloudfoundry.org/cve-2017-4973/
+    # Remove once CF is upgraded to >= v257
+  - name: uaa
+    version: "30"
+    url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=30
+    sha1: 90b034c0d9a8282a47d0409e561ffb1b9abf626b
 
 stemcells:
   - alias: default

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -75,6 +75,7 @@ meta:
     release: datadog-for-cloudfoundry
   - name: etcd
     release: (( grab meta.release.name ))
+    consumes: {etcd: nil}
   - name: etcd_metrics_server
     release: (( grab meta.release.name ))
   - name: metron_agent
@@ -101,6 +102,7 @@ meta:
     release: datadog-for-cloudfoundry
   - name: loggregator_trafficcontroller
     release: (( grab meta.release.name ))
+    consumes: {doppler: nil}
   - name: metron_agent
     release: (( grab meta.release.name ))
 

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -149,7 +149,11 @@ meta:
   - name: datadog-consul-agent-client
     release: datadog-for-cloudfoundry
   - name: uaa
-    release: (( grab meta.release.name ))
+    #FIXME: using a patched UAA release due to CVEs:
+    # https://www.cloudfoundry.org/cve-2017-4972/
+    # https://www.cloudfoundry.org/cve-2017-4973/
+    # Remove once CF is upgraded to >= v257
+    release: uaa
   - name: metron_agent
     release: (( grab meta.release.name ))
   - name: statsd_injector

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -480,11 +480,11 @@ jobs:
       - name: datadog-consul-agent-client
         release: datadog-for-cloudfoundry
       - name: ssh_proxy
-        release: diego-patched
+        release: diego
       - name: metron_agent
         release: cf
       - name: file_server
-        release: diego-patched
+        release: diego
       - name: cfdot
         release: diego
     instances: 2

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -598,6 +598,9 @@ properties:
         basic_auth_password: (( grab properties.cc.internal_api_password ))
         staging_upload_user: (( grab properties.cc.staging_upload_user ))
         staging_upload_password: (( grab properties.cc.staging_upload_password ))
+        ca_cert: (( grab secrets.bosh_ca_cert ))
+        client_cert: (( grab secrets.cc_client_cert ))
+        client_key: (( grab secrets.cc_client_key ))
 
     nsync:
       dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -560,6 +560,10 @@ properties:
         require_ssl: true
       preloaded_rootfses:
         - "cflinuxfs2:/var/vcap/packages/cflinuxfs2/rootfs"
+      tls:
+        ca_cert: (( grab secrets.bosh_ca_cert ))
+        cert: (( grab secrets.cc_client_cert ))
+        key: (( grab secrets.cc_client_key ))
 
     route_emitter:
       dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))


### PR DESCRIPTION
# What

Story: [Upgrade CF to version >= 254](https://www.pivotaltracker.com/story/show/142318777)

Upgrade to CF v256. Includes:
* diego-release: v1.12.0
* garden-runc-release: v1.4.0
* cflinuxfs2-rootfs release v1.60.0
* stemcell 3363.19 (latest)
* Upgrade UAA to v30 to cover latest CVEs

Revert of FIXME commits

# How to review
* Deploy on top of deployment based on master
* Check all tests pass
* Consult guidance in [the team manual](https://government-paas-team-manual.readthedocs.io/en/latest/guides/upgrading_CF,_bosh_and_stemcells/) for a list of other things to check.

# Who can review

Not me or @saliceti 
