### PR TITLE
[#141315433] Monitor RDS instances for CPU credits

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1740,25 +1740,11 @@ jobs:
                   - -e
                   - -c
                   - |
-                    if [ -n "${TF_VAR_datadog_api_key}" ] && [ -n "${TF_VAR_datadog_app_key}" ] && [ "${ENABLE_DATADOG}" = "false" ]; then
-                      echo "Datadog disabled but keys present, running check cleanup..."
-                      terraform destroy -force \
-                         -state=datadog-tfstate/datadog.tfstate \
-                         -state-out=updated-tfstate/datadog.tfstate \
-                         -var-file=paas-cf/terraform/${TF_VAR_aws_account}.tfvars \
-                         paas-cf/terraform/datadog
-                      exit 0
-                    fi
-
-                    if [ "${ENABLE_DATADOG}" = "true" ]; then
                       terraform apply \
+                        -target datadog_monitor.rds-cpu-credits \
                         -var-file=paas-cf/terraform/{{aws_account}}.tfvars \
                         -state=datadog-tfstate/datadog.tfstate -state-out=updated-tfstate/datadog.tfstate \
                         -var-file=config/job_instances.tfvars paas-cf/terraform/datadog
-                    else
-                      echo "Datadog disabled, skipping terraform run..."
-                      cp datadog-tfstate/datadog.tfstate updated-tfstate/datadog.tfstate
-                    fi
             ensure:
               put: datadog-tfstate
               params:

--- a/terraform/cloudfoundry/cf_rds.tf
+++ b/terraform/cloudfoundry/cf_rds.tf
@@ -57,7 +57,8 @@ resource "aws_db_instance" "cf" {
   auto_minor_version_upgrade = false
 
   tags {
-    Name = "${var.env}-cf"
+    Name       = "${var.env}-cf"
+    deploy_env = "${var.env}"
   }
 }
 

--- a/terraform/datadog/aws.tf
+++ b/terraform/datadog/aws.tf
@@ -20,7 +20,7 @@ resource "datadog_monitor" "rds-cpu-credits" {
   type           = "query alert"
   message        = "${format("Instance is {{#is_warning}}low on{{/is_warning}}{{#is_alert}}out of{{/is_alert}} CPU credits and may perform badly. See: %s#cpu-credits @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_documentation_url, var.aws_account)}"
   notify_no_data = false
-  query          = "${format("avg(last_30m):avg:aws.rds.cpucredit_balance{deploy_env:%s,!created_by:aws_rds_service_broker} by {dbinstanceidentifier} <= 1", var.env)}"
+  query          = "${format("avg(last_30m):avg:aws.rds.cpucredit_balance{deploy_env:%s,!created_by:aws_rds_service_broker} by {dbinstanceidentifier} <= 1", "master")}"
 
   thresholds {
     warning  = "20"

--- a/terraform/datadog/aws.tf
+++ b/terraform/datadog/aws.tf
@@ -14,3 +14,20 @@ resource "datadog_monitor" "ec2-cpu-credits" {
 
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:all"]
 }
+
+resource "datadog_monitor" "rds-cpu-credits" {
+  name           = "${format("%s RDS CPU credits", var.env)}"
+  type           = "query alert"
+  message        = "${format("Instance is {{#is_warning}}low on{{/is_warning}}{{#is_alert}}out of{{/is_alert}} CPU credits and may perform badly. See: %s#cpu-credits @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_documentation_url, var.aws_account)}"
+  notify_no_data = false
+  query          = "${format("avg(last_30m):avg:aws.rds.cpucredit_balance{deploy_env:%s,!created_by:aws_rds_service_broker} by {dbinstanceidentifier} <= 1", var.env)}"
+
+  thresholds {
+    warning  = "20"
+    critical = "1"
+  }
+
+  require_full_window = true
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:all"]
+}

--- a/terraform/datadog/aws.tf
+++ b/terraform/datadog/aws.tf
@@ -1,7 +1,7 @@
 resource "datadog_monitor" "ec2-cpu-credits" {
   name           = "${format("%s EC2 CPU credits", var.env)}"
   type           = "query alert"
-  message        = "${format("Instance is {{#is_warning}}low on{{/is_warning}}{{#is_alert}}out of{{/is_alert}} on CPU credits and may perform badly. See: https://government-paas-team-manual.readthedocs.io/en/latest/support/responding_to_alerts/#cpu-credits @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
+  message        = "${format("Instance is {{#is_warning}}low on{{/is_warning}}{{#is_alert}}out of{{/is_alert}} CPU credits and may perform badly. See: https://government-paas-team-manual.readthedocs.io/en/latest/support/responding_to_alerts/#cpu-credits @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   notify_no_data = false
   query          = "${format("avg(last_30m):avg:aws.ec2.cpucredit_balance{deploy_env:%s} by {bosh-job,bosh-index} <= 1", var.env)}"
 

--- a/terraform/datadog/aws.tf
+++ b/terraform/datadog/aws.tf
@@ -1,7 +1,7 @@
 resource "datadog_monitor" "ec2-cpu-credits" {
   name           = "${format("%s EC2 CPU credits", var.env)}"
   type           = "query alert"
-  message        = "${format("Instance is {{#is_warning}}low on{{/is_warning}}{{#is_alert}}out of{{/is_alert}} CPU credits and may perform badly. See: https://government-paas-team-manual.readthedocs.io/en/latest/support/responding_to_alerts/#cpu-credits @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
+  message        = "${format("Instance is {{#is_warning}}low on{{/is_warning}}{{#is_alert}}out of{{/is_alert}} CPU credits and may perform badly. See: %s#cpu-credits @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_documentation_url, var.aws_account)}"
   notify_no_data = false
   query          = "${format("avg(last_30m):avg:aws.ec2.cpucredit_balance{deploy_env:%s} by {bosh-job,bosh-index} <= 1", var.env)}"
 

--- a/terraform/datadog/uaa.tf
+++ b/terraform/datadog/uaa.tf
@@ -1,7 +1,7 @@
 resource "datadog_monitor" "user_not_found" {
   name    = "${format("%s UAA - Failed login: user not found", var.env)}"
   type    = "query alert"
-  message = "${format("Anomalous levels of authentication attempts with a user name that does not exist. See https://government-paas-team-manual.readthedocs.io/en/latest/support/responding_to_alerts/. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
+  message = "${format("Anomalous levels of authentication attempts with a user name that does not exist. See %s#failed-logins @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_documentation_url, var.aws_account)}"
 
   query = "${format("avg(last_30m):anomalies(sum:cf.uaa.audit_service.user_not_found_count{deployment:%s}, 'agile', 2, direction='above') >= 0.5", var.env)}"
 
@@ -13,7 +13,7 @@ resource "datadog_monitor" "user_not_found" {
 resource "datadog_monitor" "login_with_wrong_password" {
   name    = "${format("%s UAA - Failed login: wrong password", var.env)}"
   type    = "query alert"
-  message = "${format("Anomalous levels of authentication attempts with an existing user name and wrong password. See https://government-paas-team-manual.readthedocs.io/en/latest/support/responding_to_alerts/ @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
+  message = "${format("Anomalous levels of authentication attempts with an existing user name and wrong password. See %s#failed-logins @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_documentation_url, var.aws_account)}"
 
   query = "${format("avg(last_30m):anomalies(sum:cf.uaa.audit_service.user_authentication_failure_count{deployment:%s}, 'agile', 2, direction='above') >= 0.5", var.env)}"
 

--- a/terraform/datadog/variables.tf
+++ b/terraform/datadog/variables.tf
@@ -25,3 +25,8 @@ variable "datadog_notification_24x7" {
 variable "datadog_notification_in_hours" {
   description = "Datadog notification for in hours alerts: empty string for no notification, email address (start with @) or pagerduty service name (start with @)"
 }
+
+variable "datadog_documentation_url" {
+  description = "URL that documents how to respond to specific DataDog alerts. Anchors can be appended to refer to specific alerts."
+  default     = "https://government-paas-team-manual.readthedocs.io/en/latest/support/responding_to_alerts/"
+}


### PR DESCRIPTION
## What

Similar to 1f33b77 for EC2 instances. I omitted this from the first PR
because I thought we didn't have any RDS t2 instances, but BOSH has been
since alphagov/paas-bootstrap@043f3dd.

The use of the `deploy_env` tag depends on alphagov/paas-bootstrap#59

I've used `dbinstanceidentifier` as the group `by` because it's a mandatory
attribute for RDS instances, unlike `dbname` (Terraform's `name` attribute)
or `name` (which comes from a standard AWS tag).

The `!created_by:aws_rds_service_broker` will prevent us from ever being
warned about the performance of tenant database instances which aren't
relevant to the health of our platform. The filter isn't strictly necessary
at the moment because they aren't tagged with `deploy_env`, but it's
possible that they could be in the future.

## How to review

This is even more difficult to test than the last PR 🐼  

1. Review, merge, and deploy alphagov/paas-bootstrap#59 first
1. Upload secrets: `make dev upload-datadog-secrets`
1. Deploy this branch to your dev environment. 
1. Have a look in DataDog for a monitor called "RDS CPU credits" which is tagged with your dev environment but uses data from CI. Confirm that the query is correct by observing a single metric line for BOSH.
1. I **have not** tested triggering the monitor by exhausting the RDS instance credits. It's going to be tricky to do and disruptive to CI. Based on the previous PR I'm reasonably confident that it will work, but please test it or talk to me if you're unsure.
1. Manually delete the monitor in DataDog
1. ⚠️  Remove the WIP commit before merging ⚠️ 
1. Merge

## Who can review

Not @dcarley