### PR TITLE
[#144269245] Temporarily disable IPsec

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -662,3 +662,4 @@ properties:
     certificate_authority_private_key: (( grab secrets.ipsec_ca_key ))
     verify_certificate: "on"
     level: require
+    disabled: true


### PR DESCRIPTION
## What

Yesterday we manually turned this off on the cells and routers in response
to an incident. We want to codify this change, so that we can unblock other
deployments, and then the correct fix will follow soon after.

When IPsec is re-enabled we will need to change the level to `use` and then
do a subsequent deployment with `require`.

## How to review

These steps simulate CI and staging:

1. Deploy [dora](https://github.com/cloudfoundry/cf-acceptance-tests/tree/master/assets/dora) to your environment
1. Confirm that querying dora for `/largetext/10` hangs
1. Deploy from branch
1. Confirm that querying dora for `/largetext/10` works

You can simulate production, where IPsec has been disabled, by doing this first and then the steps above:

1. `make dev bosh-cli`
1. `for i in router/0 router/1 cell/0 cell/1 cell/2; do bosh ssh $i -- /var/vcap/bosh/bin/monit stop racoon`

I've tested both in dev. I'll leave it up to the reviewer to choose what they do.

## Who can review

Not @dcarley