### PR TITLE
[#144269245] Increase timeout for availability-tests

### DIFF
--- a/platform-tests/src/availability/healthcheck_availability_during_deployment_test.go
+++ b/platform-tests/src/availability/healthcheck_availability_during_deployment_test.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	availabilityTestRate             = 10
-	availabilityTestMaxDuration      = 2 * time.Hour
+	availabilityTestMaxDuration      = 12 * time.Hour
 	availabilityTestMaxLatency       = 300 * time.Millisecond
 	availabilityTestMaxErrors        = 0
 	availabilitySuccessRateThreshold = 100.0


### PR DESCRIPTION
## What

CF upgrades that include stemcell changes can easily take longer than 2
hours to complete. When this happens, the `availability-tests` job in
Concourse will fail prematurely, and we will stop monitoring availability
for the remainder of the deployment until someone manually restarts it.

Ideally we'd have this wait for as long as the `cf-deploy` job is running;
the helper will stop the test as soon as the status changes to `succeeded`
or `failed`. But we *have* to give Ginkgo a timeout otherwise it will
default to 1s and we can't set polling interval without setting timeout. So
I've picked a reasonably high values of 12h instead.

## How to review

Code review only.

You don't have to make the deploy take 12 hours and wait for it to fail 😄 

## Who can review

Not @dcarley