### PR TITLE
[#144269245] Set MTU for Garden containers back to 1500 and add test

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2049,6 +2049,10 @@ jobs:
           - get: bosh-CA
           - get: cf-secrets
             passed: ['cf-deploy']
+          - get: cf-release
+            params:
+              submodules:
+                - src/github.com/cloudfoundry/cf-acceptance-tests
 
       - do:
         - task: create-temp-user

--- a/concourse/pipelines/failure-testing.yml
+++ b/concourse/pipelines/failure-testing.yml
@@ -397,6 +397,11 @@ jobs:
           - get: pipeline-trigger
             passed: ['init']
             trigger: true
+          - get: cf-release
+            params:
+              submodules:
+                - src/github.com/cloudfoundry/cf-acceptance-tests
+
       - task: get-instance-id
         file: paas-cf/concourse/tasks/get-instance-id.yml
         params:

--- a/concourse/tasks/custom-acceptance-tests-run.yml
+++ b/concourse/tasks/custom-acceptance-tests-run.yml
@@ -8,6 +8,7 @@ inputs:
   - name: paas-cf
   - name: test-config
   - name: bosh-CA
+  - name: cf-release
 outputs:
   - name: artifacts
 run:

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -656,6 +656,7 @@ properties:
     trusted_certs: (( grab meta.ca_certs.aws_rds_combined_ca_bundle ))
 
   garden:
+    network_mtu: 1500
     log_level: error
   racoon:
     certificate_authority_cert: (( grab secrets.ipsec_ca_cert ))

--- a/platform-tests/src/acceptance/response_size_test.go
+++ b/platform-tests/src/acceptance/response_size_test.go
@@ -1,0 +1,42 @@
+package acceptance_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+
+	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
+	"github.com/cloudfoundry-incubator/cf-test-helpers/generator"
+	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
+)
+
+var _ = Describe("Apps response size", func() {
+	var appName string
+
+	BeforeEach(func() {
+		appName = generator.PrefixedRandomName("CATS-APP-DORA-")
+		Expect(cf.Cf(
+			"push", appName,
+			"-b", config.RubyBuildpackName,
+			"-p", "../../../../cf-release/src/github.com/cloudfoundry/cf-acceptance-tests/assets/dora",
+			"-d", config.AppsDomain,
+			"-i", "1",
+			"-m", "256M",
+		).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+	})
+
+	It("should serve request and response bodies of increasing sizes", func() {
+		for responsekB := 1; responsekB <= 200; responsekB += 10 {
+			By(fmt.Sprintf("response size of %d kB", responsekB))
+			response := helpers.CurlAppWithTimeout(
+				appName,
+				fmt.Sprintf("/largetext/%d", responsekB),
+				5*time.Second,
+			)
+			Expect(response).To(HaveLen(responsekB * int(KILOBYTE)))
+		}
+	})
+})


### PR DESCRIPTION
## What

garden-runc 1.3.0, which was included by the CF upgrade in 46019be, changed
the MTU of Guardian containers to match the host's external network
interface instead of always being 1500:

- cloudfoundry/guardian@af8d612
- cloudfoundry/garden-runc-release@a9b22fd

For our cells on AWS this meant a change from 1500 to 9001:

- http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/network_mtu.html#jumbo_frame_instances

This didn't work well with IPsec, which we use to secure web traffic between
the routers and cells. Requests which generated responses larger than approx
9000 bytes were too large after the IPsec headers were added and never made
it back to the router.

It might have been nice to set this to a value a *bit* smaller than 9000, to
allow for the IPsec overhead, but we can't guarantee the MTU value of the
host interface because it gets set by AWS.

Ideally PMTU should mean that we wouldn't have to do this. We think that the
ICMP unreachable messages might not be getting back to the container (or
host?) correctly. It might be that we can revert this commit in future after
some more investigation.

Includes an acceptance test that: 

Check that requests don't hang when the HTTP response is large (up to
200kB). This should prevent regressions of the MTU problem described in the
preceding commit.

## How to review

🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 
**This must not be deployed before #884 but it should be safe if they are deployed at the same time**
🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝 🐝

1. Code review
1. Deploy
1. Confirm that `availability-tests` pass meaning that containers were migrated correctly
1. Confirm that `custom-acceptance-tests` pass meaning that larger response sizes work

## Who can review

Not @saliceti or @dcarley