### PR TITLE
[#144269245] Re-enable IPsec pt1: use

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -662,5 +662,4 @@ properties:
     certificate_authority_cert: (( grab secrets.ipsec_ca_cert ))
     certificate_authority_private_key: (( grab secrets.ipsec_ca_key ))
     verify_certificate: "on"
-    level: require
-    disabled: true
+    level: use


### PR DESCRIPTION
## What

This is a partial revert of f400a1e once the MTU fix in bde67c5 has been
deployed to production. We need to bring IPsec back in `use` mode initially
and then later switch to `require` mode, as described in:

- https://github.com/SAP/ipsec-release#activating-ipsec-without-downtime

## How to review

1. Confirm that #884 and #887 have been deployed to production 🐝  🐝  🐝 
1. Deploy from `master` to your dev environment
1. Deploy from this branch to your dev environment
1. Confirm that `availability-tests` pass, meaning that the change caused no downtime for applications

## Who can review

Not @dcarley