### PR TITLE
[#144269245] Re-enable IPsec pt2: require

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -662,4 +662,4 @@ properties:
     certificate_authority_cert: (( grab secrets.ipsec_ca_cert ))
     certificate_authority_private_key: (( grab secrets.ipsec_ca_key ))
     verify_certificate: "on"
-    level: use
+    level: require


### PR DESCRIPTION
## What

Once `use` mode has been deployed to production we can switch back to
`require` mode without downtime, as described in:

- https://github.com/SAP/ipsec-release#activating-ipsec-without-downtime

## How to review

🐝  🐝  🐝 
TBC. Needs rebasing after #888 has been deployed to production.
🐝  🐝  🐝 

1. Confirm that #888 have been deployed to production 🐝  🐝  🐝 
1. Deploy from `master` to your dev environment
1. Deploy from this branch to your dev environment
1. Confirm that `availability-tests` pass, meaning that the change caused no downtime for applications

## Who can review

Not @dcarley