### PR TITLE
[#141315433] Unset require_full_window for CPU credit monitors

### DIFF
--- a/terraform/datadog/aws.tf
+++ b/terraform/datadog/aws.tf
@@ -10,7 +10,7 @@ resource "datadog_monitor" "ec2-cpu-credits" {
     critical = "1"
   }
 
-  require_full_window = true
+  require_full_window = false
 
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:all"]
 }
@@ -27,7 +27,7 @@ resource "datadog_monitor" "rds-cpu-credits" {
     critical = "1"
   }
 
-  require_full_window = true
+  require_full_window = false
 
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:all"]
 }


### PR DESCRIPTION
## What

The RDS monitor added in d8cfb6d is reporting "no data" in CI despite being
able to find metrics. This might be because the RDS metrics have a
resolution of 5mins compared to 2-3mins for EC2 metrics. We tested disabling
`require_full_window` and the monitor changed to "ok" state.

Although it's seemingly not affected at the moment, I'm applying the same to
the EC2 monitor to be safe. This still seems better than increasing the
window as described in 1f33b77. The other option would be to set "delay
evaluation" but that doesn't seem possible using the Terraform provider or
API.

## How to review

Code review and check the state of CI after merging.

## Who can review

Ideally @Jonty or @saliceti 