### PR TITLE
[#144447591] Add a doppler server in AZ 3

### DIFF
--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -327,9 +327,9 @@ jobs:
       - name: cf
 
   - name: doppler
-    azs: [z1, z2]
+    azs: [z1, z2, z3]
     templates: (( grab meta.loggregator_templates ))
-    instances: 2
+    instances: 3
     vm_type: medium
     stemcell: default
     networks:


### PR DESCRIPTION
# What

Story: [Add a doppler for availability zone 3](https://www.pivotaltracker.com/story/show/144447591)

We currently have only 2 dopplers and no doppler in zone 3. Metron connects primarily to the same zone so metron agents in zone 3 show this error message:

```
2017/04/27 13:38:14 Failed to lookup hostport: lookup z3.doppler.service.cf.internal on 127.0.0.1:53: no such host
```

As we are suffering from loggregator performance issues, it makes sense to add a doppler in z3

## How to review
Code review

## Who can review
Not me