### PR TITLE
[#144441123] Reduce false alarms due to etcd monitor

### DIFF
--- a/terraform/datadog/etcd.tf
+++ b/terraform/datadog/etcd.tf
@@ -10,8 +10,8 @@ resource "datadog_monitor" "etcd_one_leader" {
 
   query = "${
     format(
-      "%s(last_5m):sum:cf.etcd.IsLeader{deployment:%s}.fill(last, 60) %s",
-      element(list("max", "min"), count.index),
+      "%s(last_1m):sum:cf.etcd.IsLeader{deployment:%s}.fill(last, 60) %s",
+      element(list("min", "max"), count.index),
       var.env,
       element(list("> 1", "< 1"), count.index)
     )}"


### PR DESCRIPTION
## What

Story: [Make etcd leader monitor less sensitive](https://www.pivotaltracker.com/story/show/144441123)

The "etcd IsLeader count is exactly one" monitor is triggered every time
the leader count is different than one. However, this happens frequently
for a few seconds because of deployments or normal etcd re-elections and
this creates a lot of false alarms.

Now it will alarm if the count is continuously different than 1 on a 1
minute period. This is a short interval but this metric arrives every
20-30s so this should be enough.

## How to review

* Reproducing etcd election issue is tricky. I suggest code review and:
* Run from paas-cf:

```
TF_VAR_env=<env> TF_VAR_datadog_app_key=$(paas-pass datadog/dev/datadog_app_key) TF_VAR_datadog_api_key=$(paas-pass datadog/dev/datadog_api_key) terraform apply -var-file=terraform/dev.tfvars -target=datadog_monitor.etcd_one_leader terraform/datadog
```
* Compare monitors with prod for example and observe "at leat one" is replaced by "at all times"
* Run the same command with "destroy" to clean up the monitors

## Who can review
Not me
