### PR TITLE
[#143151443] Reset unused accounts

### DIFF
--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -39,15 +39,6 @@ PS Some departmental email systems will check links in inbound emails as part of
 their virus protection. This may have invalidated your one-time link. If this is
 the case please contact support to set your password another way.
 '
-NOTIFICATION='
-As the account has been created now please remeber to update gov-uk-paas-announce
-mailing list. You can do that by inviting the user to the group by usng this URL:
-
-https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!managemembers/gov-uk-paas-announce/invite
-
-As a welcome message you can use the text from here:
-https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/gov-uk-paas-announce
-'
 
 ###########################################################################
 usage() {
@@ -103,10 +94,6 @@ check_params_and_environment() {
     abort "You must specify a valid email"
   fi
 
-  if [ -z "${ORG:-}" ]; then
-    abort_usage "Org must be defined"
-  fi
-
   if ! jq -V >/dev/null 2>&1; then
     abort "You need to have jq installed"
   fi
@@ -119,24 +106,6 @@ check_params_and_environment() {
     abort "You must have AWS cli installed and configured with valid credentials. Test it with: aws ses get-send-quota"
   fi
 
-}
-
-create_org_space() {
-  cf create-org "${ORG}"
-  cf create-space "${DEFAULT_SPACE}" -o "${ORG}"
-
-  # cf create-{org|space} has the side-effect of giving roles in the org/space
-  # to the user making the request. We don't want this, so have to undo it.
-  local admin_user
-  admin_user=$(cf target | awk '/User:/ { print $2}')
-  cf unset-org-role "${admin_user}" "${ORG}" OrgManager
-  cf unset-space-role "${admin_user}" "${ORG}" "${DEFAULT_SPACE}" SpaceManager
-  cf unset-space-role "${admin_user}" "${ORG}" "${DEFAULT_SPACE}" SpaceDeveloper
-
-  # Even after losing all the roles, user is still present in the list of all users of an org
-  # FIXME: remove this fix for https://github.com/cloudfoundry/cli/issues/781 is deployed
-  guid=$(cf org "${ORG}" --guid)
-  cf curl -X DELETE "/v2/organizations/${guid}/users" -d "{\"username\": \"${admin_user}\"}"
 }
 
 create_user() {
@@ -205,14 +174,6 @@ create_user() {
   fi
 }
 
-set_user_roles() {
-  if [[ "${ORG_MANAGER}" == "true" ]]; then
-    cf set-org-role "${EMAIL}" "${ORG}" OrgManager
-    cf set-space-role "${EMAIL}" "${ORG}" "${DEFAULT_SPACE}" SpaceManager
-  fi
-  cf set-space-role "${EMAIL}" "${ORG}" "${DEFAULT_SPACE}" SpaceDeveloper
-}
-
 # Expand variables from subject, escaping quotes
 get_subject() {
   eval "echo ${SUBJECT}" | \
@@ -249,7 +210,6 @@ send_mail() {
     --output text > /dev/null
 
   echo "An email has been sent to ${EMAIL} with their new credentials."
-  show_notification
 }
 
 print_invite() {
@@ -266,11 +226,6 @@ emit_invite() {
   else
     echo "No new users created. Use -r to force new invites for existing users."
   fi
-}
-
-show_notification() {
-    echo
-    info "${NOTIFICATION}"
 }
 
 TMP_OUTPUT="$(mktemp -t create-tenant-output.XXXXXX)"
@@ -311,7 +266,5 @@ done
 load_colors
 check_params_and_environment
 
-create_org_space
 create_user
-set_user_roles
 emit_invite

--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -11,17 +11,25 @@ source "${SCRIPT_DIR}/common.sh"
 DEFAULT_SPACE=sandbox
 FROM_ADDRESS='gov-uk-paas-support@digital.cabinet-office.gov.uk'
 # shellcheck disable=SC2016
-SUBJECT='Welcome to GOV.UK PaaS'
+SUBJECT='Your GOV.UK PaaS account'
 # shellcheck disable=SC2016,SC1078
 MESSAGE='Hello,
 
-Your account for GOV.UK PaaS is ready:
+We'"'"'ve noticed that you have not yet reset the password for your GOV.UK PaaS
+account since it was first created.
 
- - username: ${EMAIL}
- - organisation: ${ORG}
+To keep your account secure, please follow this link to activate it and set
+a new password: ${INVITE_URL}
 
-Please use this link to activate your account and set a password. The link will only work once:
-${INVITE_URL}
+This link will only work once.
+
+If you do not activate your account within 7 days it will automatically be
+locked. If you wish to reactivate it after this time, please email us at
+gov-uk-paas-support@digital.cabinet-office.gov.uk
+
+If you’ve not yet signed up to our mailing list to receive important
+notifications about GOV.UK PaaS, please do so here:
+https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/gov-uk-paas-announce
 
 You can find advice about choosing a password:
 https://docs.cloud.service.gov.uk/#choosing-passwords
@@ -33,11 +41,12 @@ You can find our privacy policy here:
 https://docs.cloud.service.gov.uk/#privacy-policy
 
 Regards,
-Government PaaS team.
+GOV.UK PaaS team
 
-PS Some departmental email systems will check links in inbound emails as part of
-their virus protection. This may have invalidated your one-time link. If this is
-the case please contact support to set your password another way.
+PS Some departmental email systems will check links in inbound emails as
+part of their virus protection. This may have invalidated your one-time
+link. If this is the case please contact support to set your password
+another way.
 '
 
 ###########################################################################

--- a/scripts/list_uaa_users.rb
+++ b/scripts/list_uaa_users.rb
@@ -15,7 +15,7 @@ require 'uaa'
 target=ENV.fetch("TARGET")
 token=ENV.fetch("TOKEN")
 options = {}
-options[:skip_ssl_validation] = ENV.fetch("SKIP_SSL_VALIDATION") == "true"
+options[:skip_ssl_validation] = ENV.fetch("SKIP_SSL_VALIDATION", "false") == "true"
 
 uaac = CF::UAA::Scim.new(target, token, options)
 

--- a/scripts/list_uaa_users.rb
+++ b/scripts/list_uaa_users.rb
@@ -1,0 +1,53 @@
+#!/usr/bin/env ruby
+
+# Configuration
+# export TARGET="https://uaa.<SYSTEM DOMAIN>"
+# export UAA_CLIENT_USERNAME=admin
+# export UAA_CLIENT_PASSWORD=xxx # uaa_admin_client_secret
+# export SKIP_SSL_VALIDATION=true
+
+# Uncomment and edit queries below
+
+# Run within paas-cf/scripts
+# ./force_user_reset_password.rb | sort -f
+
+require './lib/uaa_sync_admin_users.rb'
+
+target=ENV.fetch("TARGET")
+admin_user=ENV.fetch("UAA_CLIENT_USERNAME")
+admin_password=ENV.fetch("UAA_CLIENT_PASSWORD")
+options = {}
+options[:skip_ssl_validation] = ENV.fetch("SKIP_SSL_VALIDATION") == "true"
+
+uaa_sync_admin_users = UaaSyncAdminUsers.new(target, admin_user, admin_password, options)
+uaa_sync_admin_users.request_token
+
+# doesn't work :(
+# query = { filter: "previouslogontime pr" }
+# query = { attributes: "userName previouslogontime" }
+
+# All users
+query = { }
+# 1 user
+# query = { filter: "userName eq 'colin-test'"}
+users = uaa_sync_admin_users.ua.all_pages(:user, query)
+
+users.each{ |u|
+  # Users who never changed password
+  if Time.parse(u['passwordlastmodified']).to_i == Time.parse(u['meta']['created']).to_i and u["origin"] == "uaa"
+    puts "#{u['username']}"
+  end
+
+  # Users who logged in at least twice
+  # puts "#{u['username']}" if u.has_key?('previouslogontime') and u["origin"] == "uaa"
+
+  # Users who logged in at least once
+  # puts "#{u['username']}" if u.has_key?('lastlogontime') and u["origin"] == "uaa"
+
+  # Users who never logged in
+  # puts "#{u['username']}" if !u.has_key?('lastlogontime') and u["origin"] == "uaa"
+
+  # All users
+  # puts "#{u['username']} previous: #{u['previouslogontime']} last: #{u['lastlogontime']}"
+  # pp u
+}

--- a/scripts/list_uaa_users.rb
+++ b/scripts/list_uaa_users.rb
@@ -2,8 +2,7 @@
 
 # Configuration
 # export TARGET="https://uaa.<SYSTEM DOMAIN>"
-# export UAA_CLIENT_USERNAME=admin
-# export UAA_CLIENT_PASSWORD=xxx # uaa_admin_client_secret
+# export TOKEN=$(cf oauth-token)
 # export SKIP_SSL_VALIDATION=true
 
 # Uncomment and edit queries below
@@ -11,16 +10,14 @@
 # Run within paas-cf/scripts
 # ./force_user_reset_password.rb | sort -f
 
-require './lib/uaa_sync_admin_users.rb'
+require 'uaa'
 
 target=ENV.fetch("TARGET")
-admin_user=ENV.fetch("UAA_CLIENT_USERNAME")
-admin_password=ENV.fetch("UAA_CLIENT_PASSWORD")
+token=ENV.fetch("TOKEN")
 options = {}
 options[:skip_ssl_validation] = ENV.fetch("SKIP_SSL_VALIDATION") == "true"
 
-uaa_sync_admin_users = UaaSyncAdminUsers.new(target, admin_user, admin_password, options)
-uaa_sync_admin_users.request_token
+uaac = CF::UAA::Scim.new(target, token, options)
 
 # doesn't work :(
 # query = { filter: "previouslogontime pr" }
@@ -30,7 +27,7 @@ uaa_sync_admin_users.request_token
 query = { }
 # 1 user
 # query = { filter: "userName eq 'colin-test'"}
-users = uaa_sync_admin_users.ua.all_pages(:user, query)
+users = uaac.all_pages(:user, query)
 
 users.each{ |u|
   # Users who never changed password

--- a/scripts/list_uaa_users.rb
+++ b/scripts/list_uaa_users.rb
@@ -30,9 +30,26 @@ query = { }
 users = uaac.all_pages(:user, query)
 
 users.each{ |u|
+  # Ignore users created by tests in the pipeline
+  next if u.fetch('username').start_with?(
+    "CATS-USER-",
+    "custom-acceptance-test-user-",
+    "smoketest-user-",
+    "cont-smoketest-user-",
+  )
+
+  # Ignore SSO users
+  next if u.fetch('origin') != "uaa"
+
+  # Ignore users with outstanding invites
+  next if u.fetch('verified') == false
+
+  # Ignore locked users
+  next if u.fetch('active') == false
+
   # Users who never changed password
-  if Time.parse(u['passwordlastmodified']).to_i == Time.parse(u['meta']['created']).to_i and u["origin"] == "uaa"
-    puts "#{u['username']}"
+  if Time.parse(u.fetch('passwordlastmodified')).to_i == Time.parse(u.fetch('meta').fetch('created')).to_i
+    puts "#{u.fetch('username')}"
   end
 
   # Users who logged in at least twice


### PR DESCRIPTION
## What

Reset passwords for users that have never changed their password and still have their plaintext credentials stored in email.

## How to review

🐝  This PR contains code that you need to use but should **not** be merged 🐝 

Optional: if you want to test this in development:

1. Checkout an old copy of the `create-user.sh` script before we used invites:

        git checkout 201c5f8b3b686f9245faa450758269a95ae8276a~1

1. Create some users and make a note of their passwords:

        ./create-user.sh -o govuk-paas --no-email -e <YOUR_NAME>+1@digital.cabinet-office.gov.uk
        ./create-user.sh -o govuk-paas --no-email -e <YOUR_NAME>+2@digital.cabinet-office.gov.uk
        ./create-user.sh -o govuk-paas --no-email -e <YOUR_NAME>+3@digital.cabinet-office.gov.uk

1. Login with one of the users but do not change the password
1. Login with another of the users and change the password

Generate a list of users to reset:

1. Checkout branch:

        git fetch && git checkout bugfix/143151443-reset_unused_accounts

1. Change to scripts dir:

        cd scripts

1. Install dependencies:

        bundle install
        
1. Login to the environment that you want to target, either dev or prod:

        cf login …

1. Get list of users (you'll need to use `SKIP_SSL_VALIDATION=true` for dev):

        TARGET=$(cf curl /v2/info | jq -r .token_endpoint) \
        TOKEN=$(cf oauth-token) \
        bundle exec ./list_uaa_users.rb | tee users

1. Review the list of users for sanity.

1. Send a new invite to each user:

        while read user; do
            ./create-user.sh -r -e "$user"
        done < users

1. Close this PR.

## Who can review

Not @dcarley