### PR TITLE
[Support] Fix create-user to work with cf-cli 6.26

### DIFF
--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -128,7 +128,7 @@ create_org_space() {
   # cf create-{org|space} has the side-effect of giving roles in the org/space
   # to the user making the request. We don't want this, so have to undo it.
   local admin_user
-  admin_user=$(cf target | awk '/User:/ { print $2}')
+  admin_user=$(cf target | awk 'tolower($0)~/user:/ { print $2}')
   cf unset-org-role "${admin_user}" "${ORG}" OrgManager
   cf unset-space-role "${admin_user}" "${ORG}" "${DEFAULT_SPACE}" SpaceManager
   cf unset-space-role "${admin_user}" "${ORG}" "${DEFAULT_SPACE}" SpaceDeveloper


### PR DESCRIPTION
## What

With version 6.26 of the cli, the output from `cf target` has changed
slightly. The fieldname is now "user" (lowercase) instead of "User".
This was breaking the script.

Instead of just changing this, I've used the `tolower` awk function (as
described [here](https://unix.stackexchange.com/questions/273624/case-insensitive-search-in-awk)) so that it remains compatible with older versions of
the CLI.

## How to review

Run the script against a dev environment with both version 6.25 and 6.26 of the cf cli (the `--no-email` flag is probably useful for this).

## Who can review

Anyone but myself.