### PR TITLE
[#144763021] Bump stemcell and cflinux2 rootfs to fix USNs

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -17,10 +17,10 @@ releases:
     version: 1.4.0
     url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.4.0
     sha1: 1d6020e761806d7f355ceda06c889c582b47dc32
-  - name: cflinuxfs2-rootfs
+  - name: cflinuxfs2
     version: 1.117.0
-    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-rootfs-release?v=1.117.0
-    sha1: 0b2c0b5c34bd9b17ac18aaba13ff9ce275849e22
+    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.117.0
+    sha1: 2491396518e151679c2337b4a421d9f5248c1aac
   - name: paas-haproxy
     version: 0.1.3
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/paas-haproxy-0.1.3.tgz

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -50,7 +50,7 @@ releases:
 stemcells:
   - alias: default
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3363.19"
+    version: "3363.20"
 
 update:
   canaries: 0

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -18,9 +18,9 @@ releases:
     url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.4.0
     sha1: 1d6020e761806d7f355ceda06c889c582b47dc32
   - name: cflinuxfs2-rootfs
-    version: 1.60.0
-    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-rootfs-release?v=1.60.0
-    sha1: 12b7e2473d0f4e9edc90bc3da873f51e70ede942
+    version: 1.117.0
+    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-rootfs-release?v=1.117.0
+    sha1: 0b2c0b5c34bd9b17ac18aaba13ff9ce275849e22
   - name: paas-haproxy
     version: 0.1.3
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/paas-haproxy-0.1.3.tgz

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -408,7 +408,7 @@ jobs:
       - name: garden
         release: garden-runc
       - name: cflinuxfs2-rootfs-setup
-        release: cflinuxfs2-rootfs
+        release: cflinuxfs2
       - name: cfdot
         release: diego
       - name: metron_agent


### PR DESCRIPTION
## What

This updates the stemcell to the latest in the series to pick up fixes for some USNs (see commit for details).

It also updates cflinux2-rootfs for the same reason (again see commit for details)

I've taken this opportunity to switch to the renamed boshrelease for cflinux2. This was [announced on cf-dev](https://lists.cloudfoundry.org/archives/list/cf-dev@lists.cloudfoundry.org/thread/XEX6Z2YMTYSPK3I6RQE6TQILKQESUDCB/), and the current release is deprecated, and will be discontinued at some point.

## How to review

Deploy from this branch and verify all works.

## Who can review

Not me.