### PR TITLE
[#142400337] Extend cf ssh tests to 10GB

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -566,6 +566,7 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/cf-cli
+                tag: cf_cli_6.26
             run:
               path: sh
               args:
@@ -616,6 +617,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/cf-acceptance-tests
+              tag: cf_cli_6.26
           inputs:
             - name: paas-cf
             - name: pipeline-trigger
@@ -1295,6 +1297,7 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/cf-cli
+                tag: cf_cli_6.26
             inputs:
               - name: paas-cf
               - name: config
@@ -1318,6 +1321,7 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/cf-cli
+                tag: cf_cli_6.26
             inputs:
               - name: paas-cf
               - name: config
@@ -1353,6 +1357,7 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/cf-cli
+                tag: cf_cli_6.26
             run:
               path: sh
               args:
@@ -1379,6 +1384,7 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/cf-cli
+                tag: cf_cli_6.26
             run:
               path: sh
               args:
@@ -1405,6 +1411,7 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/cf-cli
+                tag: cf_cli_6.26
             run:
               path: sh
               args:
@@ -1427,6 +1434,7 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/cf-cli
+                tag: cf_cli_6.26
             params:
               TEST_HEAVY_LOAD: {{test_heavy_load}}
             inputs:
@@ -1532,6 +1540,7 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/cf-cli
+                tag: cf_cli_6.26
             run:
               path: sh
               args:
@@ -1644,6 +1653,7 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/cf-cli
+                tag: cf_cli_6.26
             params:
               DISABLE_HEALTHCHECK_DB: {{disable_healthcheck_db}}
             inputs:
@@ -1806,6 +1816,7 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/cf-cli
+                tag: cf_cli_6.26
             inputs:
               - name: paas-cf
               - name: config
@@ -1841,6 +1852,7 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/cf-cli
+                tag: cf_cli_6.26
             inputs:
               - name: paas-cf
               - name: config
@@ -1953,6 +1965,7 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/cf-acceptance-tests
+                tag: cf_cli_6.26
             params:
               DISABLE_CF_ACCEPTANCE_TESTS: {{disable_cf_acceptance_tests}}
             inputs:
@@ -2112,6 +2125,7 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/cf-acceptance-tests
+                tag: cf_cli_6.26
             inputs:
               - name: paas-cf
               - name: test-config

--- a/concourse/tasks/custom-acceptance-tests-run.yml
+++ b/concourse/tasks/custom-acceptance-tests-run.yml
@@ -4,6 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/cf-acceptance-tests
+    tag: cf_cli_6.26
 inputs:
   - name: paas-cf
   - name: test-config

--- a/concourse/tasks/smoke-tests-run.yml
+++ b/concourse/tasks/smoke-tests-run.yml
@@ -4,6 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/cf-acceptance-tests
+    tag: cf_cli_6.26
 inputs:
   - name: paas-cf
   - name: cf-release

--- a/platform-tests/src/acceptance/cf_ssh_test.go
+++ b/platform-tests/src/acceptance/cf_ssh_test.go
@@ -39,9 +39,7 @@ var _ = Describe("CF SSH", func() {
 	})
 
 	It("allows uploading a large payload via standard ssh client", func() {
-		// FIXME: Increase to 10GB once the following issue is solved:
-		// https://github.com/cloudfoundry/cli/issues/1098
-		const payloadSize = 1*GIGABYTE + 900*MEGABYTE
+		const payloadSize = 10 * GIGABYTE
 		timeout := 600
 		appName := generator.PrefixedRandomName("CATS-APP-")
 		Expect(cf.Cf(

--- a/platform-tests/upstream/run_acceptance_tests.sh
+++ b/platform-tests/upstream/run_acceptance_tests.sh
@@ -30,6 +30,15 @@ for i in $(seq $SLEEPTIME 1); do echo -ne "$i"'\r'; sleep 1; done; echo
 
 cd "${CF_GOPATH}/cf-acceptance-tests"
 
+# FIXME: Remove this once we've upgraded to CF 257+
+if [ "$(git rev-parse HEAD)" != "8fcde18d9b514fcf695f10049880aabe32910eb5" ]; then
+  echo "Unexpected revision of acceptance tests repo. Check FIXME in ${BASH_SOURCE[0]}"
+  exit 1
+fi
+# Checkout SHA of merge with updates for cf-cli 6.26
+# This is the only change from the existing commit.
+git checkout 407abdc
+
 echo "Starting acceptace tests"
 ./bin/test \
   -keepGoing \

--- a/platform-tests/upstream/run_smoke_tests.sh
+++ b/platform-tests/upstream/run_smoke_tests.sh
@@ -17,5 +17,14 @@ ln -s "$(pwd)/artifacts" /tmp/artifacts
 
 cd "${CF_GOPATH}/cf-smoke-tests"
 
+# FIXME: Remove this once we've upgraded to CF 257+
+if [ "$(git rev-parse HEAD)" != "fd86457abc905ead9e4215a24eee0dc8d2189c12" ]; then
+  echo "Unexpected revision of smoke tests repo. Check FIXME in ${BASH_SOURCE[0]}"
+  exit 1
+fi
+# Checkout SHA of merge of https://github.com/cloudfoundry/cf-smoke-tests/pull/28
+# This is the only change from the existing commit.
+git checkout 20b5a25d
+
 echo "Starting smoke tests"
 ./bin/test -keepGoing


### PR DESCRIPTION
## What

Now that the CF CLI issue has been fixed (with version 6.26) this test
can be increased.

## How to review

Deploy from this branch and verify that the tests pass.

Note: alphagov/paas-docker-cloudfoundry-tools#92 must not be merged until this has been deployed to production.

## Who can review

Anyone but myself.