### PR TITLE
[#144269245] Increase `go test` timeout for availability-tests

### DIFF
--- a/platform-tests/src/availability/run_tests.sh
+++ b/platform-tests/src/availability/run_tests.sh
@@ -2,5 +2,5 @@
 
 set -eu
 
-go test -timeout 130m -ginkgo.v
+go test -timeout 12h -ginkgo.v
 


### PR DESCRIPTION
## What

We increased the timeout of the long running `Eventually` block of the
`availability-tests` in 510471b but overlooked that we also have to provide
a timeout to `go test`.

I considered adding a comment to point people at one-or-the-other but it
seems unlikely that we'll need to change these values again.

## How to review

Code review.

## Who can review

Not @dcarley