### PR TITLE
[#144035107] Upgrade CF to version 257

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -6,17 +6,17 @@ director_uuid: ~
 
 releases:
   - name: cf
-    version: "256"
-    url: https://bosh.io/d/github.com/cloudfoundry/cf-release?v=256
-    sha1: 7eb583eb6dd08dfce8858d891b2571aebeb6b52c
+    version: "257"
+    url: https://bosh.io/d/github.com/cloudfoundry/cf-release?v=257
+    sha1: d25c454f551017196a5aa4690d80fd261561ac49
   - name: diego
-    version: 1.12.0
-    url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=1.12.0
-    sha1: 6fe4073431ac2dcb7072493fae0f6c22f780e8a2
+    version: 1.13.0
+    url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=1.13.0
+    sha1: e067f76ea02e2c88a16d56d7cce5a7a44f254762
   - name: garden-runc
-    version: 1.4.0
-    url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.4.0
-    sha1: 1d6020e761806d7f355ceda06c889c582b47dc32
+    version: 1.5.0
+    url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.5.0
+    sha1: c86150d54162e80597cfa2959137014c41512bbf
   - name: cflinuxfs2
     version: 1.117.0
     url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.117.0

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -662,6 +662,8 @@ properties:
   garden:
     network_mtu: 1500
     log_level: error
+    # to be removed after upgrade of Diago to 1.14
+    cleanup_process_dirs_on_wait: true
   racoon:
     certificate_authority_cert: (( grab secrets.ipsec_ca_cert ))
     certificate_authority_private_key: (( grab secrets.ipsec_ca_key ))

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -454,14 +454,14 @@ properties:
         authorized-grant-types: client_credentials
         secret: (( grab secrets.uaa_cc_routing_secret ))
       gorouter:
-        authorities: routing.routes.read
+        authorities: routing.routes.read, routing.router_groups.read
         authorized-grant-types: client_credentials,refresh_token
         secret: (( grab secrets.uaa_clients_gorouter_secret ))
       tcp_emitter:
         authorities: routing.routes.write,routing.routes.read
         authorized-grant-types: client_credentials,refresh_token
       tcp_router:
-        authorities: routing.routes.read
+        authorities: routing.routes.read, routing.router_groups.read
         authorized-grant-types: client_credentials,refresh_token
       ssh-proxy:
         authorized-grant-types: authorization_code

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -597,6 +597,10 @@ properties:
   capi:
     cc_uploader:
       dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
+      mutual_tls:
+        ca_cert: (( grab secrets.bosh_ca_cert ))
+        server_cert: (( grab secrets.cc_server_cert ))
+        server_key: (( grab secrets.cc_server_key ))
       cc:
         base_url: (( grab properties.cc.srv_api_uri ))
         basic_auth_password: (( grab properties.cc.internal_api_password ))

--- a/platform-tests/upstream/run_acceptance_tests.sh
+++ b/platform-tests/upstream/run_acceptance_tests.sh
@@ -30,15 +30,6 @@ for i in $(seq $SLEEPTIME 1); do echo -ne "$i"'\r'; sleep 1; done; echo
 
 cd "${CF_GOPATH}/cf-acceptance-tests"
 
-# FIXME: Remove this once we've upgraded to CF 257+
-if [ "$(git rev-parse HEAD)" != "8fcde18d9b514fcf695f10049880aabe32910eb5" ]; then
-  echo "Unexpected revision of acceptance tests repo. Check FIXME in ${BASH_SOURCE[0]}"
-  exit 1
-fi
-# Checkout SHA of merge with updates for cf-cli 6.26
-# This is the only change from the existing commit.
-git checkout 407abdc
-
 echo "Starting acceptace tests"
 ./bin/test \
   -keepGoing \

--- a/platform-tests/upstream/run_smoke_tests.sh
+++ b/platform-tests/upstream/run_smoke_tests.sh
@@ -17,14 +17,5 @@ ln -s "$(pwd)/artifacts" /tmp/artifacts
 
 cd "${CF_GOPATH}/cf-smoke-tests"
 
-# FIXME: Remove this once we've upgraded to CF 257+
-if [ "$(git rev-parse HEAD)" != "fd86457abc905ead9e4215a24eee0dc8d2189c12" ]; then
-  echo "Unexpected revision of smoke tests repo. Check FIXME in ${BASH_SOURCE[0]}"
-  exit 1
-fi
-# Checkout SHA of merge of https://github.com/cloudfoundry/cf-smoke-tests/pull/28
-# This is the only change from the existing commit.
-git checkout 20b5a25d
-
 echo "Starting smoke tests"
 ./bin/test -keepGoing


### PR DESCRIPTION
## What

Story: [Upgrade CF to version >= 257](https://www.pivotaltracker.com/story/show/144035107)

Deploys upgraded Cloud Foundry (257). This also includes an upgrade to Diago (1.13.0) and Garden-Runc (1.5.0).
No upgrades to stemcels or buildpacks are required for this release.

This PR keeps the patched version of UAA in and also reverts the large file transfer SSH test workaround.

## How to review

1. Code review
2. Deploy from the branch
3. Rotate credentials - don't need to go out of `dev` environment

## Who can review
Not @paroxp or me
