### PR TITLE
[#143868179] Deploy walking skeleton of Compose service broker

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1485,41 +1485,14 @@ jobs:
 
                   cp ./paas-cf/config/service-brokers/compose/catalog.json ./paas-compose-broker/
                   cd paas-compose-broker/
-                  cf push --no-start
-                  cf set-env compose-broker LOG_LEVEL DEBUG
-                  cf set-env compose-broker USERNAME compose-broker
-                  cf set-env compose-broker PASSWORD "$COMPOSE_BROKER_PASS"
+                  ruby -ryaml -e "
+                    manifest = YAML.load_file('manifest.yml')
+                    env = { 'env' => {'LOG_LEVEL' => 'DEBUG' , 'USERNAME' => 'compose-broker', 'PASSWORD' => '${COMPOSE_BROKER_PASS}'} }
+                    manifest['applications'].each { |app| app.merge!(env) }
+                    File.write('manifest.yml', manifest.to_yaml)
+                  "
                   cf blue-green-deploy compose-broker
-
-        - task: register-compose-broker
-          config:
-            platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: governmentpaas/cf-cli
-            inputs:
-              - name: paas-cf
-              - name: config
-              - name: bosh-CA
-            params:
-              APPS_DNS_ZONE_NAME: {{apps_dns_zone_name}}
-            run:
-              path: sh
-              args:
-                - -e
-                - -u
-                - -c
-                - |
-                  ./paas-cf/concourse/scripts/import_bosh_ca.sh
-                  . ./config/config.sh
-                  echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
-
-                  if cf service-brokers | grep "compose-broker\s"; then
-                    cf update-service-broker compose-broker compose-broker "$COMPOSE_BROKER_PASS" "https://compose-broker.${APPS_DNS_ZONE_NAME}"
-                  else
-                    cf create-service-broker compose-broker compose-broker "$COMPOSE_BROKER_PASS" "https://compose-broker.${APPS_DNS_ZONE_NAME}"
-                  fi
+                  cf delete -f compose-broker-old
 
         - task: deploy-simulated-load-application
           config:
@@ -1685,62 +1658,6 @@ jobs:
 
                   ../paas-cf/concourse/scripts/cf_push_on_git_change.sh graphite-nozzle
 
-        - task: update-kibana-timezone
-          config:
-            platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: ruby
-                tag: 2.2-slim
-            params:
-              SYSTEM_DNS_ZONE_NAME: {{system_dns_zone_name}}
-              DEPLOY_ENV: {{deploy_env}}
-            inputs:
-            - name: paas-cf
-            - name: cf-tfstate
-            run:
-              path: sh
-              args:
-              - -e
-              - -c
-              - |
-                SCRIPT_DIR="./paas-cf/concourse/scripts"
-
-                ruby "${SCRIPT_DIR}/extract_terraform_state_to_yaml.rb" \
-                  < cf-tfstate/cf.tfstate \
-                  > cf-tfstate.yaml
-
-                export ES_HOST
-                ES_HOST=$(ruby "${SCRIPT_DIR}/val_from_yaml.rb" terraform_outputs.logsearch_elastic_master_elb_dns_name cf-tfstate.yaml)
-                export ES_PORT="9200"
-                ruby "${SCRIPT_DIR}/kibana_set_utc.rb"
-
-        - task: enable-elasticsearch-shard-reallocation
-          config:
-            platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: governmentpaas/curl-ssl
-                tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
-            inputs:
-            - name: paas-cf
-            - name: cf-terraform-outputs
-            run:
-              path: sh
-              args:
-              - -e
-              - -c
-              - |
-                export TF_VAR_logsearch_elastic_master_elb_dns_name
-                . cf-terraform-outputs/cf.tfstate.sh
-
-                curl -s \
-                  -X PUT \
-                  -d '{"transient":{"cluster.routing.allocation.enable":"all"}}' \
-                  "${TF_VAR_logsearch_elastic_master_elb_dns_name}:9200/_cluster/settings"
-
         - task: deploy-healthcheck
           config:
             platform: linux
@@ -1819,6 +1736,94 @@ jobs:
                   ./paas-cf/concourse/scripts/bosh_login.sh {{bosh_fqdn}} bosh-secrets/bosh-secrets.yml
 
                   bosh cleanup --all
+
+      - aggregate:
+        - task: register-compose-broker
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/cf-cli
+                tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+            inputs:
+              - name: paas-cf
+              - name: config
+              - name: bosh-CA
+            params:
+              APPS_DNS_ZONE_NAME: {{apps_dns_zone_name}}
+            run:
+              path: sh
+              args:
+                - -e
+                - -u
+                - -c
+                - |
+                  ./paas-cf/concourse/scripts/import_bosh_ca.sh
+                  . ./config/config.sh
+                  echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
+
+                  if cf service-brokers | grep "compose-broker\s"; then
+                    cf update-service-broker compose-broker compose-broker "$COMPOSE_BROKER_PASS" "https://compose-broker.${APPS_DNS_ZONE_NAME}"
+                  else
+                    cf create-service-broker compose-broker compose-broker "$COMPOSE_BROKER_PASS" "https://compose-broker.${APPS_DNS_ZONE_NAME}"
+                  fi
+
+        - task: update-kibana-timezone
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: ruby
+                tag: 2.2-slim
+            params:
+              SYSTEM_DNS_ZONE_NAME: {{system_dns_zone_name}}
+              DEPLOY_ENV: {{deploy_env}}
+            inputs:
+            - name: paas-cf
+            - name: cf-tfstate
+            run:
+              path: sh
+              args:
+              - -e
+              - -c
+              - |
+                SCRIPT_DIR="./paas-cf/concourse/scripts"
+
+                ruby "${SCRIPT_DIR}/extract_terraform_state_to_yaml.rb" \
+                  < cf-tfstate/cf.tfstate \
+                  > cf-tfstate.yaml
+
+                export ES_HOST
+                ES_HOST=$(ruby "${SCRIPT_DIR}/val_from_yaml.rb" terraform_outputs.logsearch_elastic_master_elb_dns_name cf-tfstate.yaml)
+                export ES_PORT="9200"
+                ruby "${SCRIPT_DIR}/kibana_set_utc.rb"
+
+        - task: enable-elasticsearch-shard-reallocation
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/curl-ssl
+                tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+            inputs:
+            - name: paas-cf
+            - name: cf-terraform-outputs
+            run:
+              path: sh
+              args:
+              - -e
+              - -c
+              - |
+                export TF_VAR_logsearch_elastic_master_elb_dns_name
+                . cf-terraform-outputs/cf.tfstate.sh
+
+                curl -s \
+                  -X PUT \
+                  -d '{"transient":{"cluster.routing.allocation.enable":"all"}}' \
+                  "${TF_VAR_logsearch_elastic_master_elb_dns_name}:9200/_cluster/settings"
 
         - do:
           - task: datadog-terraform-apply

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -249,6 +249,11 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-rubbernecker
 
+  - name: paas-compose-broker
+    type: git
+    source:
+      uri: https://github.com/alphagov/paas-compose-broker
+
 jobs:
   - name: pipeline-lock
     serial: true
@@ -1116,6 +1121,7 @@ jobs:
           - get: graphite-nozzle
           - get: datadog-tfstate
           - get: paas-rubbernecker
+          - get: paas-compose-broker
 
       - aggregate:
         - task: extract-cf-terraform-outputs
@@ -1269,8 +1275,9 @@ jobs:
                 RDS_BROKER_PASS=$($VAL_FROM_YAML secrets.rds_broker_admin_password cf-secrets/cf-secrets.yml)
                 CDN_BROKER_SERVER=$($VAL_FROM_YAML terraform_outputs.cdn_broker_elb_dns_name cf-terraform-outputs.yml)
                 CDN_BROKER_PASS=$($VAL_FROM_YAML secrets.cdn_broker_admin_password cf-secrets/cf-secrets.yml)
+                COMPOSE_BROKER_PASS=$($VAL_FROM_YAML secrets.compose_broker_admin_password cf-secrets/cf-secrets.yml)
 
-                for var_name in CF_ADMIN CF_PASS FIREHOSE_USER FIREHOSE_PASS API_ENDPOINT UAA_ENDPOINT DOPPLER_ENDPOINT GRAPHITE_SERVER RDS_BROKER_SERVER RDS_BROKER_PASS CDN_BROKER_SERVER CDN_BROKER_PASS; do
+                for var_name in CF_ADMIN CF_PASS FIREHOSE_USER FIREHOSE_PASS API_ENDPOINT UAA_ENDPOINT DOPPLER_ENDPOINT GRAPHITE_SERVER RDS_BROKER_SERVER RDS_BROKER_PASS CDN_BROKER_SERVER CDN_BROKER_PASS COMPOSE_BROKER_PASS; do
                   echo export "${var_name}"=\"$(eval echo \$${var_name})\"
                 done > config/config.sh
 
@@ -1280,7 +1287,7 @@ jobs:
                 ls -l config/*
 
       - aggregate:
-        - task: create-admin-org-space
+        - task: create-orgs
           config:
             platform: linux
             image_resource:
@@ -1303,6 +1310,9 @@ jobs:
                   echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
                   echo | cf create-org admin
                   cf create-space admin -o admin
+                  cf create-org service-brokers
+                  cf set-quota service-brokers small
+                  cf create-space compose -o service-brokers
 
         - task: register-rds-broker
           config:
@@ -1447,6 +1457,70 @@ jobs:
                   cf enable-feature-flag diego_docker
 
       - aggregate:
+        - task: deploy-compose-service-broker
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/cf-cli
+                tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+            inputs:
+              - name: paas-cf
+              - name: paas-compose-broker
+              - name: config
+              - name: bosh-CA
+            run:
+              path: sh
+              args:
+                - -e
+                - -u
+                - -c
+                - |
+                  ./paas-cf/concourse/scripts/import_bosh_ca.sh
+
+                  . ./config/config.sh
+                  echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
+                  cf target -o service-brokers -s compose
+
+                  cp ./paas-cf/config/service-brokers/compose/catalog.json ./paas-compose-broker/
+                  cd paas-compose-broker/
+                  cf push --no-start
+                  cf set-env compose-broker LOG_LEVEL DEBUG
+                  cf set-env compose-broker USERNAME compose-broker
+                  cf set-env compose-broker PASSWORD "$COMPOSE_BROKER_PASS"
+                  cf blue-green-deploy compose-broker
+
+        - task: register-compose-broker
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/cf-cli
+            inputs:
+              - name: paas-cf
+              - name: config
+              - name: bosh-CA
+            params:
+              APPS_DNS_ZONE_NAME: {{apps_dns_zone_name}}
+            run:
+              path: sh
+              args:
+                - -e
+                - -u
+                - -c
+                - |
+                  ./paas-cf/concourse/scripts/import_bosh_ca.sh
+                  . ./config/config.sh
+                  echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
+
+                  if cf service-brokers | grep "compose-broker\s"; then
+                    cf update-service-broker compose-broker compose-broker "$COMPOSE_BROKER_PASS" "https://compose-broker.${APPS_DNS_ZONE_NAME}"
+                  else
+                    cf create-service-broker compose-broker compose-broker "$COMPOSE_BROKER_PASS" "https://compose-broker.${APPS_DNS_ZONE_NAME}"
+                  fi
+
         - task: deploy-simulated-load-application
           config:
             platform: linux

--- a/concourse/resources/cf-secrets-keep.yml
+++ b/concourse/resources/cf-secrets-keep.yml
@@ -10,6 +10,7 @@ keep:
   rds_broker_state_encryption_key: (( grab secrets.rds_broker_state_encryption_key ))
   cdn_broker_admin_password: (( grab secrets.cdn_broker_admin_password ))
   cdn_db_master_password: (( grab secrets.cdn_db_master_password ))
+  compose_broker_admin_password: (( grab secrets.compose_broker_admin_password ))
   route_services_secret: (( grab secrets.route_services_secret ))
   ssh_proxy_host_key: (( grab secrets.ssh_proxy_host_key ))
   uaa_clients_cc_service_dashboards_password: (( grab secrets.uaa_clients_cc_service_dashboards_password ))

--- a/config/service-brokers/compose/catalog.json
+++ b/config/service-brokers/compose/catalog.json
@@ -1,0 +1,43 @@
+{
+   "services":[
+      {
+      "id":"76066f82-5388-48c8-9daf-044cf7b432f2",
+         "name":"mongo",
+         "description":"Compose MongoDB instance",
+         "requires":[],
+         "tags":[
+            "mongo",
+            "compose"
+         ],
+         "metadata":{
+            "displayName":"mongo",
+            "imageUrl":"https://webassets.mongodb.com/_com_assets/cms/MongoDB-Logo-5c3a7405a85675366beb3a5ec4c032348c390b3f142f5e6dddf1d78e2df5cb5c.png",
+            "longDescription":"Compose MongoDB instance",
+            "providerDisplayName":"GOV.UK PaaS",
+            "documentationUrl":"https://compose.com/mongodb",
+            "supportUrl":"https://www.cloud.service.gov.uk/support.html"
+         },
+         "plans":[
+            {
+               "id":"6c09a422-5f0e-4c8e-9c2d-92710b594589",
+               "name":"Mongo small",
+               "description":"Small plan",
+               "metadata":{
+                  "bullets":[
+                     "1 unit"
+                  ],
+                  "costs":[
+                     {
+                        "amount":{
+                           "GBP":1
+                        },
+                        "unit":"MONTHLY"
+                    }
+                  ],
+                  "displayName":"Mongo small"
+	       }
+	    }
+         ]
+      }
+   ]
+}

--- a/manifests/cf-manifest/scripts/generate-cf-secrets.rb
+++ b/manifests/cf-manifest/scripts/generate-cf-secrets.rb
@@ -40,6 +40,7 @@ generator = SecretGenerator.new(
   "rds_broker_state_encryption_key" => :simple,
   "cdn_broker_admin_password" => :simple,
   "cdn_db_master_password" => :simple,
+  "compose_broker_admin_password" => :simple,
   "ssh_proxy_host_key" => :ssh_key,
   "kibana_admin_password" => :simple,
   "bbs_encryption_key" => :simple,

--- a/platform-tests/src/acceptance/compose_broker_test.go
+++ b/platform-tests/src/acceptance/compose_broker_test.go
@@ -1,0 +1,22 @@
+package acceptance_test
+
+import (
+	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("ComposeBroker", func() {
+
+	const (
+		serviceName = "mongo"
+	)
+
+	It("is registered in the marketplace", func() {
+		marketplace := cf.Cf("marketplace").Wait(DEFAULT_TIMEOUT)
+		Expect(marketplace).To(Exit(0))
+		Expect(marketplace).To(Say(serviceName))
+	})
+})

--- a/platform-tests/src/acceptance/init_test.go
+++ b/platform-tests/src/acceptance/init_test.go
@@ -8,7 +8,10 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
 
+	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
 )
 
@@ -58,6 +61,13 @@ func TestSuite(t *testing.T) {
 
 	BeforeSuite(func() {
 		environment.Setup()
+		// FIXME this should be removed once the broker is generally available.
+		org := context.RegularUserContext().Org
+		cf.AsUser(context.AdminUserContext(), context.ShortTimeout(), func() {
+			enableServiceAccess := cf.Cf("enable-service-access", "mongo", "-o", org).Wait(DEFAULT_TIMEOUT)
+			Expect(enableServiceAccess).To(Exit(0))
+			Expect(enableServiceAccess).To(Say("OK"))
+		})
 	})
 
 	AfterSuite(func() {


### PR DESCRIPTION
## What

https://www.pivotaltracker.com/story/show/143868179

We want to deploy the Compose service broker as an application on the platform.

## How to review

Preferably review in conjunction with https://github.com/alphagov/paas-compose-broker/pull/1

Deploy from this branch and make sure all of the tests passed. The tests haven't been changed, but the ordering of tasks in the CF deploy has.

The broker is a 'walking skeleton', so doesn't need to actually provision anything. Its 'correct' behaviour is to error when actually performing all operations except the _Services_ endpoint for returning the catalog.

Example of checking it serves the catalog:

```
curl -k -u compose-broker:$PASSWORD_FROM_CF_SECRETS https://compose-broker.${DEPLOY_ENV}.dev.cloudpipelineapps.digital/v2/catalog
```

### Before merging ⚠️ 

Review and merge https://github.com/alphagov/paas-compose-broker/pull/1 and then remove the temporary commit on this branch.

## Who can review

Anyone but me or @combor 
