### PR TITLE
[#141423205] Don't skip SSL validation for concourse.

### DIFF
--- a/concourse/scripts/fly_sync_and_login.sh
+++ b/concourse/scripts/fly_sync_and_login.sh
@@ -10,12 +10,12 @@ set -euo pipefail
 
 FLY_CMD_URL="${CONCOURSE_URL}/api/v1/cli?arch=amd64&platform=$(uname | tr '[:upper:]' '[:lower:]')"
 echo "Downloading fly command..."
-curl "$FLY_CMD_URL" -# -L -f -k -z "$FLY_CMD" -o "$FLY_CMD" -u "${CONCOURSE_ATC_USER}:${CONCOURSE_ATC_PASSWORD}"
+curl "$FLY_CMD_URL" -# -L -f -z "$FLY_CMD" -o "$FLY_CMD" -u "${CONCOURSE_ATC_USER}:${CONCOURSE_ATC_PASSWORD}"
 chmod +x "$FLY_CMD"
 
 echo "Doing fly login"
 echo -e "${CONCOURSE_ATC_USER}\n${CONCOURSE_ATC_PASSWORD}" | \
-  $FLY_CMD -t "${FLY_TARGET}" login -k --concourse-url "${CONCOURSE_URL}"
+  $FLY_CMD -t "${FLY_TARGET}" login --concourse-url "${CONCOURSE_URL}"
 
 echo "Doing fly sync"
   $FLY_CMD -t "${FLY_TARGET}" sync


### PR DESCRIPTION
## What

Now that we have signed certs for the deployer concourse it's no longer
necessary to skip SSL validation when accessing it.

## How to review

Run `make dev pipelines` from this branch and verify that it works.  Run the pipeline from this branch and verify that the self-update-pipelines step works.

Optionally, if you have a concourse that hasn't been updated to use a real cert, verify that this command fails.

🚨  Note: This should not be merged until dev environments have been updated to use valid certs.

## Who can review

Not me.