### PR TITLE
[SUPPORT] Use European keyservers in git-resource GPG check

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -18,6 +18,7 @@ resources:
       branch: master
       tag_filter: {{paas_cf_tag_filter}}
       commit_verification_key_ids: {{gpg_ids}}
+      gpg_keyserver: hkp://eu.pool.sks-keyservers.net/
 
   - name: cf-secrets
     type: s3-iam

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -81,6 +81,7 @@ resources:
       branch: {{branch_name}}
       tag_filter: {{paas_cf_tag_filter}}
       commit_verification_key_ids: {{gpg_ids}}
+      gpg_keyserver: hkp://eu.pool.sks-keyservers.net/
 
   - name: graphite-nozzle
     type: git

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -18,6 +18,7 @@ resources:
       branch: {{branch_name}}
       tag_filter: {{paas_cf_tag_filter}}
       commit_verification_key_ids: {{gpg_ids}}
+      gpg_keyserver: hkp://eu.pool.sks-keyservers.net/
 
   - name: cf-tfstate
     type: s3-iam

--- a/concourse/pipelines/failure-testing.yml
+++ b/concourse/pipelines/failure-testing.yml
@@ -18,6 +18,7 @@ resources:
       branch: {{branch_name}}
       tag_filter: {{paas_cf_tag_filter}}
       commit_verification_key_ids: {{gpg_ids}}
+      gpg_keyserver: hkp://eu.pool.sks-keyservers.net/
 
   - name: pipeline-trigger
     type: semver-iam


### PR DESCRIPTION
## What

We have seen intermittent problems with requests to keyservers timing out
and failing the `pipeline-lock` job in our pipeline:

    gpg: requesting key 6DCAB6FA from hkp server keys.gnupg.net
    gpg: keyserver timed out
    gpg: keyserver receive failed: Keyserver error

The default of `keys.gnupg.net` is a CNAME for `pool.sks-keyservers.net`
which is described at:

- https://sks-keyservers.net/overview-of-pools.php

Try using the European pool, instead of the default pool, in the hope that
the lower latency will make them more reliable. If this doesn't work and we
think it's still a problem them we could consider inline all of the public
key contents in the future.

## How to review

1. Temporarily enable commit verification in your dev environment:

    ```patch
   diff --git a/Makefile b/Makefile
    index 1e2e2c4..5fe3444 100644
    --- a/Makefile
    +++ b/Makefile
    @@ -84,7 +84,6 @@ dev: globals ## Set Environment to DEV
            $(eval export ENABLE_AUTODELETE=true)
            $(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
            $(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipelineapps.digital)
    -       $(eval export SKIP_COMMIT_VERIFICATION=true)
            $(eval export ENV_SPECIFIC_CF_MANIFEST=cf-default.yml)
            $(eval export DISABLE_HEALTHCHECK_DB=true)
            $(eval export ENABLE_DATADOG ?= false)
    ```
1. Checkout this branch:

    ```
    git fetch && git checkout bugfix/support-use_eu_keyservers
    ```
1. Deploy the pipelines from this branch but don't change the branch used by the pipelines (because the commit isn't signed):

    ```
    SELF_UPDATE_PIPELINE=false make dev pipelines
    ```
1. Run the `pipeline-lock` job and confirm that it downloads the keys and verifies the commit signature

## Who can review

Not @dcarley