### PR TITLE
[#144690295] Add new log parsers

### DIFF
--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -257,7 +257,7 @@ jobs:
     properties:
       nginx_conf: |
         worker_processes  2;
-        error_log syslog:server=127.0.0.1 info;
+        error_log syslog:server=127.0.0.1 error;
         events {
           worker_connections  1024;
         }

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -257,13 +257,13 @@ jobs:
     properties:
       nginx_conf: |
         worker_processes  2;
-        error_log syslog:server=127.0.0.1 error;
+        error_log syslog:server=127.0.0.1,severity=error,tag=uaa_nginx_error error;
         events {
           worker_connections  1024;
         }
         http {
           include /var/vcap/packages/nginx/conf/mime.types;
-          access_log syslog:server=127.0.0.1 combined;
+          access_log syslog:server=127.0.0.1,severity=info,tag=uaa_nginx_access combined;
           sendfile on;
           keepalive_timeout 20s;
           upstream uaa {

--- a/manifests/cf-manifest/manifest/800-logsearch.yml
+++ b/manifests/cf-manifest/manifest/800-logsearch.yml
@@ -185,6 +185,15 @@ properties:
           '
         }
       }
+      if [@source][component] == "vcap_nginx_access" {
+        grok {
+          match => {
+            "@message" =>
+            '%{IPORHOST:[nginx][clientip]} - \[%{HTTPDATE:[nginx][timestamp]}\] "%{WORD:[nginx][verb]} %{URIPATHPARAM:[nginx][request]} HTTP/%{NUMBER:[nginx][httpversion]}" %{NUMBER:[nginx][response]} (?:%{NUMBER:[nginx][bytes]}|-) (?:"(?:%{URI:[nginx][referrer]}|-)"|%{QS:[nginx][referrer]}) %{QS:[nginx][agent]} %{DATA:[nginx][x_forwarded_for]} vcap_request_id:%{UUID:[nginx][vcap_request_id]} response_time:%{NUMBER:[nginx][response_time]}'
+            }
+        }
+      }
+
   curator:
     purge_logs:
       retention_period: 30

--- a/manifests/cf-manifest/manifest/800-logsearch.yml
+++ b/manifests/cf-manifest/manifest/800-logsearch.yml
@@ -193,6 +193,14 @@ properties:
             }
         }
       }
+      if [@source][component] == "uaa_nginx_access" {
+        grok {
+          match => {
+            "@message" =>
+            '%{IPORHOST:[nginx][clientip]} - %{USER:[nginx][auth]} \[%{HTTPDATE:[nginx][timestamp]}\] "%{WORD:[nginx][verb]} %{URIPATHPARAM:[nginx][request]} HTTP/%{NUMBER:[nginx][httpversion]}" %{NUMBER:[nginx][response]} (?:%{NUMBER:[nginx][bytes]}|-) (?:"(?:%{URI:[nginx][referrer]}|-)"|%{QS:[nginx][referrer]}) %{QS:[nginx][agent]}'
+          }
+        }
+      }
 
   curator:
     purge_logs:

--- a/manifests/cf-manifest/manifest/800-logsearch.yml
+++ b/manifests/cf-manifest/manifest/800-logsearch.yml
@@ -201,6 +201,13 @@ properties:
           }
         }
       }
+      date {
+        match => [ "[nginx][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601" ]
+        target => "@timestamp"
+      }
+      mutate {
+        remove_field => [ "[nginx][timestamp]" ]
+      }
 
   curator:
     purge_logs:


### PR DESCRIPTION
## What

We'd like to parse all fields from all access logs that appear in logsearch.

## How to review

- Code review
- Check and memorise current state of `nginx` logs
- Deploy from this branch
- Interact with UAA for instance
- Re-check the logs and note the differences in extracted fields

## Who can review

Neither @saliceti nor myself.
