### PR TITLE
[#145266177] Update the URL for GitHub Enterprise

### DIFF
--- a/doc/ssl_certs.md
+++ b/doc/ssl_certs.md
@@ -89,7 +89,7 @@ The certificates and the intermediate CA cert need to be stored in the
 
 Currently the process requires a `system_domain` and `apps_domain` cert.
 
-[credentials-high]: https://github.gds/government-paas/credentials-high
+[credentials-high]: https://github.digital.cabinet-office.gov.uk/government-paas/credentials-high
 
 ### Initial deployment of an environment
 


### PR DESCRIPTION
## What

It moved to a "real" hostname with a real certificate on the evening of
2017-05-11 as described in this announcement:

- https://sites.google.com/a/digital.cabinet-office.gov.uk/gds-internal-it/github-enterprise-change-5-30pm-6pm-11th-may-2017/githubdigitalcabinet-officegovuk

## How to review

Code review only.

## Who can review

Not @dcarley