### PR TITLE
[SUPPORT] Revert "Remove *_monitors tag from CC monitors"

### DIFF
--- a/terraform/datadog/cloud_controller.tf
+++ b/terraform/datadog/cloud_controller.tf
@@ -67,7 +67,7 @@ resource "datadog_monitor" "cc_failed_job_count_total_increase" {
     critical = "5"
   }
 
-  tags = ["deployment:${var.env}", "job:api"]
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:api"]
 }
 
 resource "datadog_monitor" "cc_log_count_error_increase" {
@@ -84,7 +84,7 @@ resource "datadog_monitor" "cc_log_count_error_increase" {
     critical = "5"
   }
 
-  tags = ["deployment:${var.env}", "job:api"]
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:api"]
 }
 
 resource "datadog_monitor" "cc_job_queue_length" {


### PR DESCRIPTION
## What

This reverts commit 00cfcd466b94cf066616a9e19f5bd0b679b79ace.

I believe that this was fixed by 7bf2b74f58b69f203e32f9c606b2b749754f64ef so
we should display these on the dashboard again. I noticed this because I was
called out by PagerDuty in-hours and the alert wasn't on the dashboard.

## How to review

Code review.

## Who can review

Anyone.