### PR TITLE
[SUPPORT] Change DIT peering VPC

### DIFF
--- a/terraform/prod.vpc_peering.json
+++ b/terraform/prod.vpc_peering.json
@@ -2,7 +2,7 @@
     {
         "peer_name": "dit",
         "account_id": "513071381340",
-        "vpc_id": "vpc-4b0c122f",
+        "vpc_id": "vpc-c1f83da6",
         "subnet_cidr": "172.16.1.0/24"
     }
 ]


### PR DESCRIPTION
## What

As requested in DeskPro ticket 5157. They have recreated the VPC in order to
fit subnets from all 3 availability zones into the 172.16.1.0/24 subnet. The
account ID remains the same.

## How to review

1. Code review, there's no way to test this outside of production
1. Confirm that the details match the ticket: https://gaap.deskpro.com/agent/#app.tickets,inbox:agent,t.o:5157,vis:7

## Who can review

Anyone.