### PR TITLE
[#145517679] Increase thresholds for cc.log_count.error alert

### DIFF
--- a/terraform/datadog/cloud_controller.tf
+++ b/terraform/datadog/cloud_controller.tf
@@ -77,11 +77,11 @@ resource "datadog_monitor" "cc_log_count_error_increase" {
   escalation_message  = "Amount of logged errors in Cloud Controller API still growing considerably, check the API health."
   require_full_window = false
 
-  query = "${format("change(max(last_1m),last_30m):sum:cf.cc.log_count.error{deployment:%s}.rollup(avg, 30) > 5", var.env)}"
+  query = "${format("change(max(last_1m),last_30m):sum:cf.cc.log_count.error{deployment:%s}.rollup(avg, 30) > 15", var.env)}"
 
   thresholds {
-    warning  = "3"
-    critical = "5"
+    warning  = "10"
+    critical = "15"
   }
 
   tags = ["deployment:${var.env}", "job:api"]


### PR DESCRIPTION
## What

Somethings appears to have changed since the CF v257 upgrade and the
acceptance tests are now alerting me via PagerDuty on every successful run.

I've tracked this down to a log entry and found the corresponding API
requests in the test artefacts:

    Stager error: Unsupported buildpack type: 'CATS-5-BPK-c816e215-00d4-4b56-7'

However I'm not able to find a fix yet and the alerts are very distracting.
I also think that this threshold is too low, so it seems safe to raise it.

## How to review

Code review.

## Who can review

Anyone.