### PR TITLE
[#144940081] Open API in CI and staging

### DIFF
--- a/terraform/dev.tfvars
+++ b/terraform/dev.tfvars
@@ -5,6 +5,7 @@ cf_db_multi_az = "false"
 cf_db_backup_retention_period = "0"
 cf_db_skip_final_snapshot = "true"
 cf_db_maintenance_window = "Mon:07:00-Mon:08:00"
+api_access_cidrs = []
 cdn_db_multi_az = "false"
 cdn_db_backup_retention_period = "0"
 cdn_db_skip_final_snapshot = "true"

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -107,10 +107,10 @@ variable "admin_cidrs" {
   ]
 }
 
-/* Note: This is overridden in prod.tfvars to allow world access */
+/* Note: This is overridden in dev.tfvars to disallow world access */
 variable "api_access_cidrs" {
   description = "List of CIDR addresses with access to CloudFoundry API"
-  default     = []
+  default     = ["0.0.0.0/0"]
 }
 
 # See https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-policy-table.html

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -10,9 +10,6 @@ cdn_db_multi_az = "true"
 cdn_db_backup_retention_period = "35"
 cdn_db_skip_final_snapshot = "false"
 cdn_db_maintenance_window = "Thu:07:00-Thu:08:00"
-api_access_cidrs = [
-  "0.0.0.0/0",
-]
 bosh_db_backup_retention_period = "35"
 bosh_db_skip_final_snapshot = "false"
 support_email="gov-uk-paas-support@digital.cabinet-office.gov.uk"


### PR DESCRIPTION
## What

Story: [Open up staging and CI so they match prod](https://www.pivotaltracker.com/story/show/144940081)

API is now open by default as in prod. We only override the value in DEV as we may want to restrict access to potentially insecure environments running experimental features.

## How to review

* Deploy with this branch
* Check there is no change in cf-terraform job (DEV remains closed)
* Delete the `api_access_cidrs` variable in `dev.tfvars` to simulate CI/staging/prod in a TEMP commit
* Push, run the pipeline
* Access `https://api.<env>.dev.cloudpipeline.digital/` from outside (ex: your phone), It should be available
* Remove the TEMP commit and push

## Who can review

Not me