### PR TITLE
[#141398611] Increase window for CVE monitor to 10m

### DIFF
--- a/terraform/datadog/cve.tf
+++ b/terraform/datadog/cve.tf
@@ -4,7 +4,7 @@ resource "datadog_monitor" "cve-reporter" {
   name    = "${format("%s New CVE Reported", var.env)}"
   type    = "event alert"
   message = "${format("{{#is_alert}}Check https://government-paas-team-manual.readthedocs.io/en/latest/team/responding_to_security_issues/ for instructions @%s{{/is_alert}}", var.support_email)}"
-  query   = "events('sources:feed priority:all status:info tags:cve,service:pivotal').rollup('count').last('5m') >= 1"
+  query   = "events('sources:feed priority:all status:info tags:cve,service:pivotal').rollup('count').last('10m') >= 1"
 
   thresholds {
     ok       = "1"


### PR DESCRIPTION
## What

As suggested by DataDog support in this email thread:

- https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!msg/the-multi-cloud-paas-team/g5OfF62lGbs/4HN6zSUlAgAJ

I'm not very confident about their explanation. However we should do what
they suggest. If the monitor doesn't notify us about the next CVE then we
should revisit the other options described in the thread, including the
IFTTT notification that Alex has setup.

## How to review

Code review.

## Who can review

Anyone.