### PR TITLE
[SUPPORT] Increase the ES disk size

### DIFF
--- a/manifests/cf-manifest/env-specific/cf-prod.yml
+++ b/manifests/cf-manifest/env-specific/cf-prod.yml
@@ -3,4 +3,4 @@ meta:
   cell:
     instances: 15
   elasticsearch_master:
-    disk_size: 512000
+    disk_size: 768000


### PR DESCRIPTION
## What

We're getting alerts on running low on the disk space in production. For
the time being, we'd like to increase the disk space size, as we don't
have any archiving in place.

This change will add additional 256G to the current disk, which
currently is 512G.

## How to review

- Sanity review over the change
- Agreement upon additional space

## Who can review

Preferably @alext 