### PR TITLE
[#145666887] Bump the UAA release version to v30.2

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -41,11 +41,12 @@ releases:
     # https://www.cloudfoundry.org/cve-2017-4972/
     # https://www.cloudfoundry.org/cve-2017-4973/
     # https://www.cloudfoundry.org/cve-2017-4974/
-    # Remove once CF is upgraded to >= v257
+    # https://www.cloudfoundry.org/cve-2017-4991/
+    # Remove once CF is upgraded to >= v260
   - name: uaa
-    version: "30.1"
-    url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=30.1
-    sha1: dde2405c7c909b3c30a18a6f16e0a13a3f26dede
+    version: "30.2"
+    url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=30.2
+    sha1: 14f34a93e21c2723ccde11bff5b693a465cb72df
 
 stemcells:
   - alias: default


### PR DESCRIPTION
## What

It's a recommended version of the UAA release, that will protect us
against the [CVE-2016-4991](https://www.cloudfoundry.org/cve-2017-4991/).

## How to review

- Check if the correct release is tagged
- I've managed to run the successful deployment on `dev` - You don't _have_ to run it yourself