### PR TITLE
Raise concourse btrfs monitor levels

### DIFF
--- a/terraform/datadog/concourse.tf
+++ b/terraform/datadog/concourse.tf
@@ -60,11 +60,11 @@ resource "datadog_monitor" "concourse-btrfs" {
   notify_no_data      = false
   require_full_window = false
 
-  query = "${format("max(last_1m):max:system.processes.number{deploy_env:%s,process_name:btrfs} > 100", var.env)}"
+  query = "${format("max(last_1m):max:system.processes.number{deploy_env:%s,process_name:btrfs,deployment:concourse} > 150", var.env)}"
 
   thresholds {
-    warning  = 30
-    critical = 100
+    warning  = 100
+    critical = 150
   }
 
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:concourse"]


### PR DESCRIPTION
## What

The concourse btrfs monitor levels appear to be too low for production as we're getting spurious warnings. This raises the levels and also ensures that we only track btrfs processes on the concourse host rather than the wider cluster.

## How to review

* Code review.
* Check that the levels are higher than what we've seen in production: https://app.datadoghq.com/monitors#2083141?group=*&from_ts=1495098656256&to_ts=1495102256543

## Who can review

Anybody, probably @paroxp.