### PR TITLE
[#133104393] Increase the cell disk size

### DIFF
--- a/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
+++ b/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
@@ -42,7 +42,7 @@ vm_types:
     cloud_properties:
       instance_type: r4.xlarge
       ephemeral_disk:
-        size: 102400
+        size: 204800
         type: gp2
       security_groups:
         - (( grab terraform_outputs.rds_broker_db_clients_security_group ))


### PR DESCRIPTION
## What

As we grow, we're slowly running out of disk space. We've reached a
little over 75% on two of our cells in production environment, according
to DataDog.

We'd like to double the disk space, for the time to stay safe and
alerted when other warnings hit production.

We have decided, to increase the disk space across all environments.

## How to review

- Code sanity check
- I've managed to run the successful deployment on `dev` - You don't _have_ to run it yourself