### PR TITLE
[SUPPORT] Improve the failure in bosh-tests

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2115,7 +2115,13 @@ jobs:
               ./paas-cf/concourse/scripts/bosh_login.sh {{bosh_fqdn}} bosh-secrets/bosh-secrets.yml
               bosh deployment cf-manifest/cf-manifest.yml
               bosh vms {{deploy_env}} | tee vms.txt
-              [ $(grep '|' vms.txt | grep -cEv "(\-\-|VM|running)") -eq 0 ]
+              vms_not_running=$(grep '|' vms.txt | grep -cEv "(\-\-|VM|running)" || true)
+              if [ ${vms_not_running} -gt "0" ]; then
+                echo "Error: Number of not running VMs: ${vms_not_running}."
+                exit 1
+              else
+                echo "Success: All VMs are up and running."
+              fi
 
   - name: performance-tests
     plan:


### PR DESCRIPTION
## What

Currently, we're not getting any error message which could confuse
someone who hasn't previously encounter this particular error. With this
change, we're reporting on the status of VMs, while the `bosh-tests`
run.

## How to review

- Code review
- Run the pipeline and allow `bosh-tests` to pass
- Optionally, stop (change state) one of the VMs and re-run `bosh-tests` expecting them to fail

## Who can review

Neither @dcarley nor @paroxp