### PR TITLE
[#145037767] Monitor CDN broker

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -26,9 +26,9 @@ releases:
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/paas-haproxy-0.1.3.tgz
     sha1: 732ceb817afe33ee117b85a202d87f6f5c3dd760
   - name: datadog-for-cloudfoundry
-    version: 0.1.15
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.1.15.tgz
-    sha1: 8270937b7519fa15d58d80810a62ccc2badb90a2
+    version: 0.1.16
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.1.16.tgz
+    sha1: 268944eb92dacbdcc8e5920eb36e824dbdb715c0
   - name: ipsec
     version: 0.1.2
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/ipsec-0.1.2.tgz

--- a/manifests/cf-manifest/manifest/060-cdn-broker.yml
+++ b/manifests/cf-manifest/manifest/060-cdn-broker.yml
@@ -13,6 +13,8 @@ jobs:
     templates:
       - name: cdn-broker
         release: cdn-broker
+      - name: datadog-cdn-broker
+        release: datadog-for-cloudfoundry
     networks:
       - name: cf
     properties:

--- a/manifests/cf-manifest/manifest/060-cdn-broker.yml
+++ b/manifests/cf-manifest/manifest/060-cdn-broker.yml
@@ -1,8 +1,8 @@
 releases:
   - name: cdn-broker
-    version: 0.1.2
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.2.tgz
-    sha1: 7953d0c5f85f645e9906bbac3c4de7a4026757f4
+    version: 0.1.3
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.3.tgz
+    sha1: 0b76b21361b617e9a7c9daac3c09edb18e6451bd
 
 jobs:
   - name: cdn_broker

--- a/terraform/cloudfoundry/cdn_broker.tf
+++ b/terraform/cloudfoundry/cdn_broker.tf
@@ -7,7 +7,7 @@ resource "aws_elb" "cdn_broker" {
   security_groups           = ["${aws_security_group.service_brokers.id}"]
 
   health_check {
-    target              = "HTTP:3000/healthcheck"
+    target              = "HTTP:3000/healthcheck/http"
     interval            = "${var.health_check_interval}"
     timeout             = "${var.health_check_timeout}"
     healthy_threshold   = "${var.health_check_healthy}"

--- a/terraform/datadog/cdn_broker.tf
+++ b/terraform/datadog/cdn_broker.tf
@@ -1,0 +1,16 @@
+resource "datadog_monitor" "cdn_broker_healthy" {
+  name                = "${format("%s cdn_broker healthy", var.env)}"
+  type                = "service check"
+  message             = "Large portion of cdn brokers unhealthy. Check deployment state."
+  escalation_message  = "Large portion of cdn brokers still unhealthy. Check deployment state."
+  no_data_timeframe   = "7"
+  require_full_window = true
+
+  query = "${format("'http.can_connect'.over('deploy_env:%s','instance:cdn_broker','url:http://localhost:3000/healthcheck').by('*').last(1).pct_by_status()", var.env)}"
+
+  thresholds {
+    critical = 50
+  }
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:cdn_broker"]
+}


### PR DESCRIPTION
## What

This installs the new CDN broker healthchecks added in https://github.com/alphagov/paas-cdn-broker/pull/3 and configures a new datadog check for the master "check all the things" endpoint.

## How to review

Note from @dcarley: I have tested this, but also contributed to it. I think code review only would be suitable especially because of the amount of time it takes to enable DataDog on an environment. Please talk to me if you're unsure.

* Deploy from this branch (with datadog enabled)
  * [Instructions for paas-bootstrap](https://github.com/alphagov/paas-bootstrap/blob/master/doc/datadog.md)
  * [Instructions for paas-cf](https://github.com/alphagov/paas-cf/blob/master/doc/datadog.md)
* Check that you have a green datadog healthcheck for the cdn-broker
* Check that the monitor goes red when one of the dependencies are down
  * Easiest way to test this is `bosh stop api/0 && bosh stop api/1`
* SSH to a host that can hit the cdn-broker, and curl the following URL's, ensuring they get a 200:
  * http://$CDN_BROKER_IP:3000/healthcheck/cloudfoundry
  * http://$CDN_BROKER_IP:3000/healthcheck/cloudfront
  * http://$CDN_BROKER_IP:3000/healthcheck/letsencrypt
  * http://$CDN_BROKER_IP:3000/healthcheck/postgresql
  * http://$CDN_BROKER_IP:3000/healthcheck/s3

## Before merging

* Merge https://github.com/alphagov/paas-team-manual/pull/123
* Merge https://github.com/alphagov/paas-cdn-broker-boshrelease/pull/3
* Merge https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/19
* Update the "TEMP" commit on this branch to refer to the final builds from https://concourse.build.ci.cloudpipeline.digital
* Merge this PR

## Who can review

Not @timmow, @LeePorte, or @jonty (because he's no longer here) or @dcarley (because he updated this)

🐝