### PR TITLE
[#145588187] Reserve common hostnames on the apps domain

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1299,6 +1299,8 @@ jobs:
               - name: paas-cf
               - name: config
               - name: bosh-CA
+            params:
+              APPS_DNS_ZONE_NAME: {{apps_dns_zone_name}}
             run:
               path: sh
               args:
@@ -1308,11 +1310,17 @@ jobs:
                   ./paas-cf/concourse/scripts/import_bosh_ca.sh
                   . ./config/config.sh
                   echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
-                  echo | cf create-org admin
+                  cf create-org admin
                   cf create-space admin -o admin
                   cf create-org service-brokers
                   cf set-quota service-brokers small
                   cf create-space compose -o service-brokers
+                  cf create-org govuk-paas
+                  cf create-space docs -o govuk-paas
+                  cf target -o govuk-paas
+                  cf create-route docs "${APPS_DNS_ZONE_NAME}" --hostname www
+                  cf create-route docs "${APPS_DNS_ZONE_NAME}" --hostname api
+                  cf create-route docs "${APPS_DNS_ZONE_NAME}" --hostname status
 
         - task: register-rds-broker
           config:


### PR DESCRIPTION
## What

We do not want a tenant to be able to push an app using any of these
names, as it could be misleading to others[1].

There was a suggestion these hostnames should redirect to the product
page, but it was agreed to not add that complexity at this stage.
However, in case we do they have been placed in the same org as the
product page (govuk-paas), which seems to have been created manually
in the past.

The redundant `echo | ` has been removed because it does not appear
to do anything with our current usage of the CF CLI.

[1] https://www.pivotaltracker.com/story/show/145588187

## How to review

Make sure a tenant in a different org can't push an app called api, www, or status.

## Who can review

Anyone but me
