### PR TITLE
[#146084537] Fix uaa_nginx_access logs

### DIFF
--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -270,6 +270,9 @@ jobs:
             keepalive 10;
             server 127.0.0.1:8080;
           }
+          set_real_ip_from  10.0.0.0/16;
+          real_ip_header    X-Forwarded-For;
+          real_ip_recursive on;
           server {
             listen 9443;
             ssl on;


### PR DESCRIPTION
## What

These logs were passing the UAA ELB IP address as the `nginx.clientip`
field instead of the client IP address. This was due to Nginx not
taking into account the use of X-Forwarded-For headers.

We set `set_real_ip_from` to only trust sources within our own VPC.
Configuration based on the example from Nginx's documentation[1].

[1] http://nginx.org/en/docs/http/ngx_http_realip_module.html

## How to review

Ultimately, we want to be sure that any Nginx access logs have a `nginx.clientip` field which matches the client's IP, not the ELB's. The following example is how you could verify by setting up a user:

Against an existing environment login to the CF CLI and create a user:

```
./scripts/create-user.sh -e 'your.name+1@example.com' -o testers
```

Then search in Kibana for "invite_users", you should find an access log for it. The `nginx.clientip` field will have an ELB IP (in the range 10.0.0.0/16).

Deploy from this branch and repeat the steps above. The IP logged should now be your client IP. If you're in Aviation House it will be in one of these ranges:

* 80.194.77.64/26
* 80.194.77.90/32
* 80.194.77.100/32

## Who can review

Anyone but me
