### PR TITLE
[#145751037] Upgrade Go version used by the healthcheck app

### DIFF
--- a/platform-tests/example-apps/healthcheck/Godeps/Godeps.json
+++ b/platform-tests/example-apps/healthcheck/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "healthcheck",
-	"GoVersion": "go1.6",
-	"GodepVersion": "v60",
+	"GoVersion": "go1.8",
+	"GodepVersion": "v79",
 	"Packages": [
 		"."
 	],


### PR DESCRIPTION
## What

Upgrade to Go 1.8 because that is the latest version supported by
the Go buildpack we are currently using[1]. The buildpack is Godep-aware
and will compile based on this version.

Files changed using `godep update -goversion`, which changes the files
based on what you have installed locally. Godep v79 is the version supported
by the buildpack[1].

The app is pushed using the blue-green-deployment plugin, which creates
a new app, therefore eliminating the need to restage when this is deployed.

[1] https://github.com/cloudfoundry/go-buildpack/releases/tag/v1.7.19

## How to review

The staging output is often supressed, so I am not sure how you prove it has compiled it using Go 1.8. I didn't see the staging output or the [`staging_task_id`](https://apidocs.cloudfoundry.org/258/apps/get_app_summary.html) anywhere in Kibana.

## Who can review

Anyone but me.
