### PR TITLE
[#145024711 ] Reduce http_tester instance memory

### DIFF
--- a/platform-tests/example-apps/http_tester/manifest.yml
+++ b/platform-tests/example-apps/http_tester/manifest.yml
@@ -1,0 +1,8 @@
+---
+applications:
+- name: http_tester
+  memory: 64M
+  disk_quota: 64M
+  instances: 1
+  buildpack: go_buildpack
+  command: ./bin/http_tester; sleep 1; echo 'done'

--- a/platform-tests/src/acceptance/http_edge_cases_test.go
+++ b/platform-tests/src/acceptance/http_edge_cases_test.go
@@ -26,12 +26,9 @@ const (
 	utfchars = "スタック・オーバーフロー はプログラマ"
 )
 
-var (
-	appName string
-)
-
 var _ = Describe("HTTP edge cases", func() {
 	Describe("Using dora", func() {
+		var appName string
 
 		BeforeEach(func() {
 			appName = generator.PrefixedRandomName("CATS-APP-DORA-")
@@ -65,10 +62,9 @@ var _ = Describe("HTTP edge cases", func() {
 			appName = generator.PrefixedRandomName("CATS-APP-HTTP-TESTER-")
 			Expect(cf.Cf(
 				"push", appName,
-				"-b", config.GoBuildpackName,
 				"-p", "../../example-apps/http_tester",
+				"-f", "../../example-apps/http_tester/manifest.yml",
 				"-d", config.AppsDomain,
-				"-c", "./bin/http_tester; sleep 1; echo 'done'",
 			).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 		})
 
@@ -133,10 +129,9 @@ var _ = Describe("HTTP edge cases", func() {
 			appName2 := generator.PrefixedRandomName("CATS-APP-HTTP-TESTER-")
 			Expect(cf.Cf(
 				"push", appName2,
-				"-b", config.GoBuildpackName,
 				"-p", "../../example-apps/http_tester",
+				"-f", "../../example-apps/http_tester/manifest.yml",
 				"-d", config.AppsDomain,
-				"-c", "./bin/http_tester; sleep 1; echo 'done'",
 			).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 			curlArgs := []string{"-k"}
 			response := helpers.CurlApp(appName, fmt.Sprintf("/egress?domain=%s.%s", appName2, config.AppsDomain), curlArgs...)

--- a/platform-tests/src/acceptance/http_forwarded_for_test.go
+++ b/platform-tests/src/acceptance/http_forwarded_for_test.go
@@ -43,10 +43,9 @@ var _ = Describe("X-Forwarded headers", func() {
 		appName := generator.PrefixedRandomName("CATS-APP-")
 		Expect(cf.Cf(
 			"push", appName,
-			"-b", config.GoBuildpackName,
 			"-p", "../../example-apps/http_tester",
+			"-f", "../../example-apps/http_tester/manifest.yml",
 			"-d", config.AppsDomain,
-			"-c", "./bin/http_tester; sleep 1; echo 'done'",
 		).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 
 		curlArgs := []string{"-f", "-H", fmt.Sprintf("X-Forwarded-For: %s", fakeProxyIP)}

--- a/platform-tests/src/acceptance/http_forwarded_proto_test.go
+++ b/platform-tests/src/acceptance/http_forwarded_proto_test.go
@@ -21,10 +21,9 @@ var _ = Describe("X-Forwarded headers", func() {
 		appName := generator.PrefixedRandomName("CATS-APP-")
 		Expect(cf.Cf(
 			"push", appName,
-			"-b", config.GoBuildpackName,
 			"-p", "../../example-apps/http_tester",
+			"-f", "../../example-apps/http_tester/manifest.yml",
 			"-d", config.AppsDomain,
-			"-c", "./bin/http_tester; sleep 1; echo 'done'",
 		).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 
 		curlArgs := []string{"-f", "-H", "X-Forwarded-Proto: IPoAC"}


### PR DESCRIPTION
## What

As we run tests in parallel we deploy multiple instances of http_tester
app at once. This may have an impact on the platform so we decided to
reduce available instance memory to 64m

## How to review

Run the pipeline and check if tests pass. 

## Who can review
Not @combor
