### PR TITLE
[#145024711] Skip HTTP edge cases

### DIFF
--- a/platform-tests/src/acceptance/http_edge_cases_test.go
+++ b/platform-tests/src/acceptance/http_edge_cases_test.go
@@ -26,7 +26,7 @@ const (
 	utfchars = "スタック・オーバーフロー はプログラマ"
 )
 
-var _ = Describe("HTTP edge cases", func() {
+var _ = XDescribe("HTTP edge cases", func() {
 	Describe("Using dora", func() {
 		var appName string
 


### PR DESCRIPTION
## What

As HTTP edge cases tests are misbehaving we have decided to temporarily
disable them to investigate the root cause.

This PR should be reverted once we know how to fix underlying
problem.

## How to review

Sanity check.

## Who can review

Not @acombor
