### PR TITLE
[Support] Fix custom-acceptance-tests artifacts capture.

### DIFF
--- a/concourse/tasks/custom-acceptance-tests-run.yml
+++ b/concourse/tasks/custom-acceptance-tests-run.yml
@@ -19,8 +19,7 @@ run:
     - -c
     - |
       ./paas-cf/concourse/scripts/import_bosh_ca.sh
-      mkdir -p /var/vcap/sys
-      ln -s $(pwd)/artifacts /var/vcap/sys/log
+      ln -s $(pwd)/artifacts /tmp/artifacts
       echo "Running tests"
       export CONFIG
       CONFIG="$(pwd)/test-config/config.json"


### PR DESCRIPTION
## What

The test config[1] sets the artifact directory to `/tmp/artifacts`, which
didn't match where this was putting them. They therefore weren't being
found up by the upload task.

This change was missed in #895 when we switched away from using the
simulated errand environment.

[1] manifests/cf-manifest/manifest/900-cf-tests.yml line 23

## How to review

Run the pipeline and verify that the artifacts from the custom-acceptance-tests get uploaded. This can be verified by looking at the output from the `upload-test-artifacts` step in this job, and fetching the artifacts as described there.

## Who can review

Not me.