### PR TITLE
#[146759947]  Bump the UAA release version to v30.4

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -43,11 +43,12 @@ releases:
     # https://www.cloudfoundry.org/cve-2017-4974/
     # https://www.cloudfoundry.org/cve-2017-4991/
     # https://www.cloudfoundry.org/cve-2017-4992/
-    # Remove once CF is upgraded to >= v260
+    # https://www.cloudfoundry.org/cve-2017-4994/
+    # Remove once CF is upgraded to >= v263
   - name: uaa
-    version: "30.3"
-    url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=30.3
-    sha1: b869e72627df2131930e3da4dd3f3a732fc8679c
+    version: "30.4"
+    url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=30.4
+    sha1: 89cc8082bf8be2bf4b4dd89d210b8af637ac5221
 
 stemcells:
   - alias: default


### PR DESCRIPTION
## What

update  the UAA release, to protect us
against the CVE-2017-4994[1].

[1] https://www.cloudfoundry.org/cve-2017-4994/

## How to review

Code review. I've applied this in a dev env and the tests pass.

## Who can review

Anyone but me
