### PR TITLE
[#143876117] Compose broker version bump

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,14 @@ upload-datadog-secrets: check-env ## Decrypt and upload Datadog credentials to S
 	$(if $(wildcard ${DATADOG_PASSWORD_STORE_DIR}),,$(error Password store ${DATADOG_PASSWORD_STORE_DIR} does not exist))
 	@scripts/upload-datadog-secrets.sh
 
+.PHONY: upload-compose-secrets
+upload-compose-secrets: check-env ## Decrypt and upload Datadog credentials to S3
+	$(eval export COMPOSE_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
+	$(if ${AWS_ACCOUNT},,$(error Must set environment to dev/ci/staging/prod))
+	$(if ${COMPOSE_PASSWORD_STORE_DIR},,$(error Must pass COMPOSE_PASSWORD_STORE_DIR=<path_to_password_store>))
+	$(if $(wildcard ${COMPOSE_PASSWORD_STORE_DIR}),,$(error Password store ${COMPOSE_PASSWORD_STORE_DIR} does not exist))
+	@scripts/upload-compose-secrets.sh
+
 .PHONY: upload-google-oauth-secrets
 upload-google-oauth-secrets: check-env ## Decrypt and upload Google Admin Console credentials to S3
 	$(eval export OAUTH_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)

--- a/README.md
+++ b/README.md
@@ -42,8 +42,15 @@ services for the platform.
 
 You will need a working [Deployer Concourse](#deployer-concourse).
 
+Upload the necessary credentials:
+
+```
+make dev upload-compose-secrets
+```
+
 Deploy the pipeline configurations using `make`. Select the target based on
 which AWS account you want to work with. For instance, execute:
+
 ```
 make dev pipelines
 ```

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1124,6 +1124,7 @@ jobs:
           - get: datadog-tfstate
           - get: paas-rubbernecker
           - get: paas-compose-broker
+            version: "04d277d7c20d8674df40d355a2c1a6a109b15d5a"
 
       - aggregate:
         - task: extract-cf-terraform-outputs

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1500,7 +1500,13 @@ jobs:
                   cd paas-compose-broker/
                   ruby -ryaml -e "
                     manifest = YAML.load_file('manifest.yml')
-                    env = { 'env' => {'LOG_LEVEL' => 'DEBUG' , 'USERNAME' => 'compose-broker', 'PASSWORD' => '${COMPOSE_BROKER_PASS}', 'ACCESS_TOKEN' => '${COMPOSE_ACCESS_TOKEN}', 'ACCOUNT_ID' => '${COMPOSE_ACCOUNT_ID}'} }
+                    env = { 'env' => {
+                      'LOG_LEVEL' => 'DEBUG',
+                      'USERNAME' => 'compose-broker',
+                      'PASSWORD' => '${COMPOSE_BROKER_PASS}',
+                      'ACCESS_TOKEN' => '${COMPOSE_ACCESS_TOKEN}',
+                      'ACCOUNT_ID' => '${COMPOSE_ACCOUNT_ID}',
+                    }}
                     manifest['applications'].each { |app| app.merge!(env) }
                     File.write('manifest.yml', manifest.to_yaml)
                   "

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1046,6 +1046,8 @@ jobs:
               DISABLE_USER_CREATION: {{disable_user_creation}}
               OAUTH_CLIENT_ID: {{oauth_client_id}}
               OAUTH_CLIENT_SECRET: {{oauth_client_secret}}
+              COMPOSE_ACCOUNT_ID: {{compose_account_id}}
+              COMPOSE_ACCESS_TOKEN: {{compose_access_token}}
             run:
               path: sh
               args:
@@ -1478,6 +1480,9 @@ jobs:
               - name: paas-compose-broker
               - name: config
               - name: bosh-CA
+            params:
+              COMPOSE_ACCESS_TOKEN: {{compose_access_token}}
+              COMPOSE_ACCOUNT_ID: {{compose_account_id}}
             run:
               path: sh
               args:
@@ -1495,7 +1500,7 @@ jobs:
                   cd paas-compose-broker/
                   ruby -ryaml -e "
                     manifest = YAML.load_file('manifest.yml')
-                    env = { 'env' => {'LOG_LEVEL' => 'DEBUG' , 'USERNAME' => 'compose-broker', 'PASSWORD' => '${COMPOSE_BROKER_PASS}'} }
+                    env = { 'env' => {'LOG_LEVEL' => 'DEBUG' , 'USERNAME' => 'compose-broker', 'PASSWORD' => '${COMPOSE_BROKER_PASS}', 'ACCESS_TOKEN' => '${COMPOSE_ACCESS_TOKEN}', 'ACCOUNT_ID' => '${COMPOSE_ACCOUNT_ID}'} }
                     manifest['applications'].each { |app| app.merge!(env) }
                     File.write('manifest.yml', manifest.to_yaml)
                   "

--- a/concourse/scripts/lib/compose.sh
+++ b/concourse/scripts/lib/compose.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+set -u
+
+get_compose_secrets() {
+  # shellcheck disable=SC2154
+  secrets_uri="s3://${state_bucket}/compose-secrets.yml"
+  export compose_account_id
+  export compose_access_token
+  if aws s3 ls "${secrets_uri}" > /dev/null ; then
+    secrets_file=$(mktemp -t compose-secrets.XXXXXX)
+
+    aws s3 cp "${secrets_uri}" "${secrets_file}"
+    compose_account_id=$("${SCRIPT_DIR}"/val_from_yaml.rb compose_account_id "${secrets_file}")
+    compose_access_token=$("${SCRIPT_DIR}"/val_from_yaml.rb compose_access_token "${secrets_file}")
+
+    rm -f "${secrets_file}"
+  fi
+}

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -10,6 +10,9 @@ $("${SCRIPT_DIR}/environment.sh" "$@")
 . "${SCRIPT_DIR}/lib/datadog.sh"
 
 # shellcheck disable=SC1090
+. "${SCRIPT_DIR}/lib/compose.sh"
+
+# shellcheck disable=SC1090
 . "${SCRIPT_DIR}/lib/google-oauth.sh"
 
 download_git_id_rsa() {
@@ -65,6 +68,7 @@ prepare_environment() {
   download_git_id_rsa
   get_git_concourse_pool_clone_full_url_ssh
   get_datadog_secrets
+  get_compose_secrets
   get_google_oauth_secrets
 
   if [ "${ENABLE_DATADOG}" = "true" ] ; then
@@ -73,6 +77,12 @@ prepare_environment() {
       echo "Datadog enabled but could not retrieve api or app key. Did you do run \`make dev upload-datadog-secrets\`?"
       exit 1
     fi
+  fi
+
+  # shellcheck disable=SC2154
+  if [ -z "${compose_account_id+x}" ] || [ -z "${compose_access_token+x}" ] ; then
+    echo "Could not retrieve access token or account id for compose. Did you do run \`make dev upload-compose-secrets\`?"
+    exit 1
   fi
 
   export EXPOSE_PIPELINE=1
@@ -122,6 +132,8 @@ disable_custom_acceptance_tests: ${DISABLE_CUSTOM_ACCEPTANCE_TESTS:-}
 disable_pipeline_locking: ${DISABLE_PIPELINE_LOCKING:-}
 datadog_api_key: ${datadog_api_key:-}
 datadog_app_key: ${datadog_app_key:-}
+compose_account_id: ${compose_account_id:-}
+compose_access_token: ${compose_access_token:-}
 enable_datadog: ${ENABLE_DATADOG}
 enable_paas_dashboard: ${ENABLE_PAAS_DASHBOARD:-false}
 deploy_rubbernecker: ${DEPLOY_RUBBERNECKER:-false}

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -81,7 +81,7 @@ prepare_environment() {
 
   # shellcheck disable=SC2154
   if [ -z "${compose_account_id+x}" ] || [ -z "${compose_access_token+x}" ] ; then
-    echo "Could not retrieve access token or account id for compose. Did you do run \`make dev upload-compose-secrets\`?"
+    echo "Could not retrieve access token or account id for compose. Did you do run \`make ${AWS_ACCOUNT} upload-compose-secrets\`?"
     exit 1
   fi
 

--- a/config/service-brokers/compose/catalog.json
+++ b/config/service-brokers/compose/catalog.json
@@ -1,43 +1,31 @@
 {
-   "services":[
-      {
-      "id":"76066f82-5388-48c8-9daf-044cf7b432f2",
-         "name":"mongo",
-         "description":"Compose MongoDB instance",
-         "requires":[],
-         "tags":[
-            "mongo",
-            "compose"
-         ],
-         "metadata":{
-            "displayName":"mongo",
-            "imageUrl":"https://webassets.mongodb.com/_com_assets/cms/MongoDB-Logo-5c3a7405a85675366beb3a5ec4c032348c390b3f142f5e6dddf1d78e2df5cb5c.png",
-            "longDescription":"Compose MongoDB instance",
-            "providerDisplayName":"GOV.UK PaaS",
-            "documentationUrl":"https://compose.com/mongodb",
-            "supportUrl":"https://www.cloud.service.gov.uk/support.html"
-         },
-         "plans":[
-            {
-               "id":"6c09a422-5f0e-4c8e-9c2d-92710b594589",
-               "name":"Mongo small",
-               "description":"Small plan",
-               "metadata":{
-                  "bullets":[
-                     "1 unit"
-                  ],
-                  "costs":[
-                     {
-                        "amount":{
-                           "GBP":1
-                        },
-                        "unit":"MONTHLY"
-                    }
-                  ],
-                  "displayName":"Mongo small"
-	       }
-	    }
-         ]
+  "services": [{
+    "id": "36f8bf47-c9e7-46d9-880f-5dfc838d05cb",
+    "name": "mongodb",
+    "bindable": true,
+    "description": "Compose MongoDB instance",
+    "requires": [],
+    "tags": [
+      "mongo",
+      "compose"
+    ],
+    "metadata": {
+      "displayName": "MongoDB",
+      "imageUrl": "https://webassets.mongodb.com/_com_assets/cms/MongoDB-Logo-5c3a7405a85675366beb3a5ec4c032348c390b3f142f5e6dddf1d78e2df5cb5c.png",
+      "longDescription": "Compose MongoDB instance",
+      "providerDisplayName": "GOV.UK PaaS",
+      "documentationUrl": "https://compose.com/mongodb",
+      "supportUrl": "https://www.cloud.service.gov.uk/support.html"
+    },
+    "plans": [{
+      "id": "fdfd4fc1-ce69-451c-a436-c2e2795b9abe",
+      "name": "tiny",
+      "description": "1GB Storage / 102MB RAM.",
+      "metadata": {
+        "displayName": "Mongo Tiny",
+        "bullets": [],
+        "units": 1
       }
-   ]
+    }]
+  }]
 }

--- a/platform-tests/src/acceptance/compose_broker_test.go
+++ b/platform-tests/src/acceptance/compose_broker_test.go
@@ -11,7 +11,7 @@ import (
 var _ = Describe("ComposeBroker", func() {
 
 	const (
-		serviceName = "mongo"
+		serviceName = "mongodb"
 	)
 
 	It("is registered in the marketplace", func() {

--- a/platform-tests/src/acceptance/init_test.go
+++ b/platform-tests/src/acceptance/init_test.go
@@ -64,7 +64,7 @@ func TestSuite(t *testing.T) {
 		// FIXME this should be removed once the broker is generally available.
 		org := context.RegularUserContext().Org
 		cf.AsUser(context.AdminUserContext(), context.ShortTimeout(), func() {
-			enableServiceAccess := cf.Cf("enable-service-access", "mongo", "-o", org).Wait(DEFAULT_TIMEOUT)
+			enableServiceAccess := cf.Cf("enable-service-access", "mongodb", "-o", org).Wait(DEFAULT_TIMEOUT)
 			Expect(enableServiceAccess).To(Exit(0))
 			Expect(enableServiceAccess).To(Say("OK"))
 		})

--- a/scripts/upload-compose-secrets.sh
+++ b/scripts/upload-compose-secrets.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -eu
+
+export PASSWORD_STORE_DIR=${COMPOSE_PASSWORD_STORE_DIR}
+
+COMPOSE_ACCOUNT_ID=$(pass "compose/account_id")
+COMPOSE_ACCESS_TOKEN=$(pass "compose/${AWS_ACCOUNT}/access_token")
+
+SECRETS=$(mktemp secrets.yml.XXXXXX)
+trap 'rm  "${SECRETS}"' EXIT
+
+cat > "${SECRETS}" << EOF
+---
+compose_account_id: ${COMPOSE_ACCOUNT_ID}
+compose_access_token: ${COMPOSE_ACCESS_TOKEN}
+EOF
+
+aws s3 cp "${SECRETS}" "s3://gds-paas-${DEPLOY_ENV}-state/compose-secrets.yml"

--- a/terraform/cloudfoundry/security-groups.tf
+++ b/terraform/cloudfoundry/security-groups.tf
@@ -9,7 +9,7 @@ resource "aws_security_group" "cloud_controller" {
 }
 
 resource "aws_security_group" "cf_api_elb" {
-  name        = "${var.env}-cf-api-elb"
+  name_prefix = "${var.env}-cf-api-elb-"
   description = "Security group for CF API public endpoints"
   vpc_id      = "${var.vpc_id}"
 
@@ -36,10 +36,14 @@ resource "aws_security_group" "cf_api_elb" {
   tags {
     Name = "${var.env}-cf-api"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group" "metrics_elb" {
-  name        = "${var.env}-metrics"
+  name_prefix = "${var.env}-metrics-"
   description = "Security group for graphite/grafana ELB. Allows access from admin IP ranges."
   vpc_id      = "${var.vpc_id}"
 
@@ -73,10 +77,14 @@ resource "aws_security_group" "metrics_elb" {
   tags {
     Name = "${var.env}-metrics_elb"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group" "web" {
-  name        = "${var.env}-cf-web"
+  name_prefix = "${var.env}-cf-web-"
   description = "Security group for web that allows HTTPS traffic from anywhere"
   vpc_id      = "${var.vpc_id}"
 
@@ -98,10 +106,14 @@ resource "aws_security_group" "web" {
   tags {
     Name = "${var.env}-cf-web"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group" "sshproxy" {
-  name        = "${var.env}-sshproxy-cf"
+  name_prefix = "${var.env}-sshproxy-cf-"
   description = "Security group that allows TCP/2222 for cf ssh support"
   vpc_id      = "${var.vpc_id}"
 
@@ -127,10 +139,14 @@ resource "aws_security_group" "sshproxy" {
   tags {
     Name = "${var.env}-cf-sshproxy"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group" "service_brokers" {
-  name        = "${var.env}-service-brokers"
+  name_prefix = "${var.env}-service-brokers-"
   description = "Group for service brokers that allows CloudController to connect"
   vpc_id      = "${var.vpc_id}"
 
@@ -153,5 +169,9 @@ resource "aws_security_group" "service_brokers" {
 
   tags {
     Name = "${var.env}-service-brokers"
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }

--- a/terraform/cloudfoundry/security-groups.tf
+++ b/terraform/cloudfoundry/security-groups.tf
@@ -10,7 +10,7 @@ resource "aws_security_group" "cloud_controller" {
 
 resource "aws_security_group" "cf_api_elb" {
   name        = "${var.env}-cf-api-elb"
-  description = "Security group for CF API public endpoints that allows web traffic from whitelisted IPs"
+  description = "Security group for CF API public endpoints"
   vpc_id      = "${var.vpc_id}"
 
   egress {
@@ -40,7 +40,7 @@ resource "aws_security_group" "cf_api_elb" {
 
 resource "aws_security_group" "metrics_elb" {
   name        = "${var.env}-metrics"
-  description = "Security group for graphite/grafana ELB"
+  description = "Security group for graphite/grafana ELB. Allows access from admin IP ranges."
   vpc_id      = "${var.vpc_id}"
 
   egress {
@@ -77,7 +77,7 @@ resource "aws_security_group" "metrics_elb" {
 
 resource "aws_security_group" "web" {
   name        = "${var.env}-cf-web"
-  description = "Security group for web that allows web traffic from the office"
+  description = "Security group for web that allows HTTPS traffic from anywhere"
   vpc_id      = "${var.vpc_id}"
 
   egress {
@@ -102,7 +102,7 @@ resource "aws_security_group" "web" {
 
 resource "aws_security_group" "sshproxy" {
   name        = "${var.env}-sshproxy-cf"
-  description = "Security group for web that allows TCP/2222 for ssh-proxy from the office"
+  description = "Security group that allows TCP/2222 for cf ssh support"
   vpc_id      = "${var.vpc_id}"
 
   egress {
@@ -131,7 +131,7 @@ resource "aws_security_group" "sshproxy" {
 
 resource "aws_security_group" "service_brokers" {
   name        = "${var.env}-service-brokers"
-  description = "Group for service brokers"
+  description = "Group for service brokers that allows CloudController to connect"
   vpc_id      = "${var.vpc_id}"
 
   egress {


### PR DESCRIPTION
## What

This PR deploys new version of compose broker with single free plan that can provision a mongodb instance with 1 unit of resources. 

## How to review

- code review
- run `make dev upload-compose-secrets`
- Deploy from this pipeline and check if all tests pass. 
- Try to enable the broker services with `cf enable-service-access mongodb` and provision a database
- run `make $env upload-compose-secrets` to apply to all other environments.
- ⚠️ make sure you merge https://github.com/alphagov/paas-compose-broker/pull/2 first
- ⚠️ remove https://github.com/alphagov/paas-cf/pull/945/commits/522a5b35637da87a1b69ebf47eb975d1c8ccce42

## Who can review
- Not @paroxp or @henrytk or @combor 