### PR TITLE
Increase API instances to M4.Large. [146603775]

### DIFF
--- a/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
+++ b/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
@@ -23,6 +23,15 @@ vm_types:
         size: 10240
         type: gp2
 
+  - name: large
+    network: cf
+    env: (( grab meta.default_env ))
+    cloud_properties:
+      instance_type: m4.large
+      ephemeral_disk:
+        size: 10240
+        type: gp2
+
   - name: router
     network: router
     env: (( grab meta.default_env ))

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -302,7 +302,7 @@ jobs:
     azs: [z1, z2]
     templates: (( grab meta.api_templates ))
     instances: 2
-    vm_type: medium
+    vm_type: large
     vm_extensions:
       - 64g_ephemeral_disk
       - cf_cc_instance_profile


### PR DESCRIPTION
## What

As part of the investigation into the 504 errors from the API we tested
different approaches, including scaling up the number of API instances
and increasing the instance size.

Increasing the instance size proved to be the most reliable method of
fixing this issue. This has not seen any test failures using the stress testing branch investigate_504_in_tests-146603775 

## How to review

Deploy from this branch and all tests will pass

Additionally the following branch can be used to test as this contains this fix and a set of modified tests designed to place additional stress on the API instances. The branch is investigate_504_in_tests-146603775 

## Who can review

Not me or @bleach 
