### PR TITLE
Revert "Skip HTTP edge cases"

### DIFF
--- a/platform-tests/src/acceptance/http_edge_cases_test.go
+++ b/platform-tests/src/acceptance/http_edge_cases_test.go
@@ -26,7 +26,7 @@ const (
 	utfchars = "スタック・オーバーフロー はプログラマ"
 )
 
-var _ = XDescribe("HTTP edge cases", func() {
+var _ = Describe("HTTP edge cases", func() {
 	Describe("Using dora", func() {
 		var appName string
 


### PR DESCRIPTION
## What

The underlying cause of these test failures has been found and is fixed in #946. As a result
these tests can be reenabled.

## How to review

1. Ensure that #946 has been merged
2. deploy from this branch, and wait for test results

## Who can review

Not me
