### PR TITLE
[support] Update cflinuxfs2 version to match release URL

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -18,7 +18,7 @@ releases:
     url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.5.0
     sha1: c86150d54162e80597cfa2959137014c41512bbf
   - name: cflinuxfs2
-    version: 1.117.0
+    version: 1.126.0
     url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.126.0
     sha1: f6765799fe9b92bce2c1ceaf1c99103bcaaa832f
   - name: paas-haproxy

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -1,0 +1,23 @@
+require 'uri'
+
+RSpec.describe "release versions" do
+  matcher :match_version_from_url do |url|
+    match do |version|
+      if url =~ %r{\?v=(.+)\z}
+        url_version = $1
+      elsif url =~ %r{-([\d.]+)\.tgz\z}
+        url_version = $1
+      else
+        raise "Failed to extract version from URL '#{url}'"
+      end
+      version == url_version
+    end
+  end
+
+  specify "release versions match their download URL version" do
+    manifest_with_defaults.fetch("releases").each do |release|
+      expect(release.fetch('version')).to match_version_from_url(release.fetch('url')),
+        "expected release #{release['name']} version #{release['version']} to have matching version in URL: #{release['url']}"
+    end
+  end
+end


### PR DESCRIPTION
## What

This was missed in a929e3e8. Existing BOSH directors will not have used the
new release because it was already considered present. New BOSH directors
fail with the following:

    Checking whether release cflinuxfs2/1.117.0 already exists...NO
    Using remote release 'https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.126.0'

    Director task 29
      Started downloading remote release > Downloading remote release. Done (00:00:05)

      Started verifying remote release > Verifying remote release. Done (00:00:01)

      Started extracting release > Extracting release. Done (00:00:01)

      Started verifying manifest > Verifying manifest. Done (00:00:00)

      Started resolving package dependencies > Resolving package dependencies. Done (00:00:00)

      Started processing 1 existing package > Processing 1 existing package. Done (00:00:00)

      Started processing 2 existing jobs > Processing 2 existing jobs. Done (00:00:00)

      Started release has been created > cflinuxfs2/1.126.0. Done (00:00:00)

    …

    Deploying
    ---------

    Director task 30
      Started preparing deployment > Preparing deployment. Failed: Release version 'cflinuxfs2/1.117.0' doesn't exist (00:00:00)

    Error 30006: Release version 'cflinuxfs2/1.117.0' doesn't exist

Alex is going to look separately at whether it would be possible to test this
in the future.

## How to review

I've used this in dev against a new BOSH director. I think code review only is sufficient. Talk to me if you're unsure.

## Who can review

Anyone.