### PR TITLE
[#147088283] Bump the UAA release version to v30.5

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -44,11 +44,12 @@ releases:
     # https://www.cloudfoundry.org/cve-2017-4991/
     # https://www.cloudfoundry.org/cve-2017-4992/
     # https://www.cloudfoundry.org/cve-2017-4994/
-    # Remove once CF is upgraded to >= v263
+    # https://www.cloudfoundry.org/cve-2017-8032/
+    # Remove once CF is upgraded to >= v264
   - name: uaa
-    version: "30.4"
-    url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=30.4
-    sha1: 89cc8082bf8be2bf4b4dd89d210b8af637ac5221
+    version: "30.5"
+    url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=30.5
+    sha1: 6eedd46ebf1d37ca6f0a8731fe3792e85ad01589
 
 stemcells:
   - alias: default


### PR DESCRIPTION
# What

It's a recommended version of the UAA release that includes the fix for
CVE-2017-8032[1]

[1] https://www.cloudfoundry.org/cve-2017-8032/

## How to review

Code review. I've deployed this in a dev env, and the tests all pass.