### PR TITLE
[Support] Fix create-user.sh email validation

### DIFF
--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -99,7 +99,7 @@ check_params_and_environment() {
     abort_usage "Email must be defined"
   fi
 
-  local email_expr="^[A-Za-z0-9._%+\'-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}$"
+  local email_expr="^[A-Za-z0-9._%+\'-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$"
   if ! [[ "${EMAIL}" =~ ${email_expr} ]]; then
     abort "You must specify a valid email"
   fi


### PR DESCRIPTION
## What

This required all email addresses to end in a component that was 2-4
characters long. We need to use emails from domains that don't fit this
pattern (the specific example in this case was an address like
user@example.email).

With the introduction of generic top-level domains, there are now many
domains that don't fit this pattern[1], so this commit therefore removes
the upper limit on this component.

[1]https://en.wikipedia.org/wiki/List_of_Internet_top-level_domains#ICANN-era_generic_top-level_domains

## How to review

Code-review is probably enough. You could test with a long email address against a dev environment.

## Who can review

Not me.