### PR TITLE
[#147010925] Specify only major DB version in RDS-broker catalog.

### DIFF
--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -2,7 +2,7 @@ meta:
   rds_broker:
     default_postgres_rds_properties:
       engine: "postgres"
-      engine_version: "9.5.4"
+      engine_version: "9.5"
       storage_type: "gp2"
       auto_minor_version_upgrade: true
       multi_az: false

--- a/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "RDS broker properties" do
           let(:rds_properties) { subject.fetch("rds_properties") }
 
           it "uses postgres 9.5" do
-            expect(rds_properties["engine_version"]).to start_with("9.5.")
+            expect(rds_properties["engine_version"]).to eq("9.5")
           end
           it "uses solid state storage" do
             expect(rds_properties).to include("storage_type" => "gp2")


### PR DESCRIPTION
## What

So that instances get created with an up-to-date version immediately
instead of being created wityh an older version, and then being upgraded
at the next maintenance window.

## How to review

Run the pipeline from this branch and verify that all the tests pass. You can verify in the AWS console that the created RDS instances are using the most recent minor version.

## Who can review

Not me.