### PR TITLE
[#139001857] Allow platform RDS instances to auto_minor_version_upgrade

### DIFF
--- a/terraform/cloudfoundry/cdn_broker.tf
+++ b/terraform/cloudfoundry/cdn_broker.tf
@@ -86,7 +86,7 @@ resource "aws_db_instance" "cdn" {
   identifier           = "${var.env}-cdn"
   allocated_storage    = 10
   engine               = "postgres"
-  engine_version       = "9.5.4"
+  engine_version       = "9.5"
   instance_class       = "db.t2.small"
   name                 = "cdn"
   username             = "dbadmin"
@@ -102,7 +102,7 @@ resource "aws_db_instance" "cdn" {
   final_snapshot_identifier  = "${var.env}-cf-cdn-final-snapshot"
   skip_final_snapshot        = "${var.cf_db_skip_final_snapshot}"
   vpc_security_group_ids     = ["${aws_security_group.cdn_rds.id}"]
-  auto_minor_version_upgrade = false
+  auto_minor_version_upgrade = true
 
   tags {
     Name = "${var.env}-cdn"

--- a/terraform/cloudfoundry/cf_rds.tf
+++ b/terraform/cloudfoundry/cf_rds.tf
@@ -39,7 +39,7 @@ resource "aws_db_instance" "cf" {
   identifier           = "${var.env}-cf"
   allocated_storage    = 10
   engine               = "postgres"
-  engine_version       = "9.5.4"
+  engine_version       = "9.5"
   instance_class       = "db.m3.medium"
   username             = "dbadmin"
   password             = "${var.secrets_cf_db_master_password}"
@@ -54,7 +54,7 @@ resource "aws_db_instance" "cf" {
   final_snapshot_identifier  = "${var.env}-cf-rds-final-snapshot"
   skip_final_snapshot        = "${var.cf_db_skip_final_snapshot}"
   vpc_security_group_ids     = ["${aws_security_group.cf_rds.id}"]
-  auto_minor_version_upgrade = false
+  auto_minor_version_upgrade = true
 
   tags {
     Name       = "${var.env}-cf"


### PR DESCRIPTION
## What

So that we automatically get upgraded to newer point releases when there
are security issues etc.
    
This includes updating the engine_version to only specify the major
version so that terraform won't attempt to downgrade instances that have
been upgraded. It also means that newly created instances will get the
latest point release.

## How to review

* Run the bootstrap pipeline.
* Observe that the CF and CDN RDS instance get auto_minot_version_upgrade set to true.
* Observe that terraform doesn't attempt to change the engine versions.

## Who can review

Not me.
