### PR TITLE
[#145583253] Update descriptions of CF Security Groups

### DIFF
--- a/terraform/cloudfoundry/security-groups.tf
+++ b/terraform/cloudfoundry/security-groups.tf
@@ -9,7 +9,7 @@ resource "aws_security_group" "cloud_controller" {
 }
 
 resource "aws_security_group" "cf_api_elb" {
-  name        = "${var.env}-cf-api-elb"
+  name_prefix = "${var.env}-cf-api-elb-"
   description = "Security group for CF API public endpoints"
   vpc_id      = "${var.vpc_id}"
 
@@ -36,10 +36,14 @@ resource "aws_security_group" "cf_api_elb" {
   tags {
     Name = "${var.env}-cf-api"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group" "metrics_elb" {
-  name        = "${var.env}-metrics"
+  name_prefix = "${var.env}-metrics-"
   description = "Security group for graphite/grafana ELB. Allows access from admin IP ranges."
   vpc_id      = "${var.vpc_id}"
 
@@ -73,10 +77,14 @@ resource "aws_security_group" "metrics_elb" {
   tags {
     Name = "${var.env}-metrics_elb"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group" "web" {
-  name        = "${var.env}-cf-web"
+  name_prefix = "${var.env}-cf-web-"
   description = "Security group for web that allows HTTPS traffic from anywhere"
   vpc_id      = "${var.vpc_id}"
 
@@ -98,10 +106,14 @@ resource "aws_security_group" "web" {
   tags {
     Name = "${var.env}-cf-web"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group" "sshproxy" {
-  name        = "${var.env}-sshproxy-cf"
+  name_prefix = "${var.env}-sshproxy-cf-"
   description = "Security group that allows TCP/2222 for cf ssh support"
   vpc_id      = "${var.vpc_id}"
 
@@ -127,10 +139,14 @@ resource "aws_security_group" "sshproxy" {
   tags {
     Name = "${var.env}-cf-sshproxy"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group" "service_brokers" {
-  name        = "${var.env}-service-brokers"
+  name_prefix = "${var.env}-service-brokers-"
   description = "Group for service brokers that allows CloudController to connect"
   vpc_id      = "${var.vpc_id}"
 
@@ -153,5 +169,9 @@ resource "aws_security_group" "service_brokers" {
 
   tags {
     Name = "${var.env}-service-brokers"
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }

--- a/terraform/cloudfoundry/security-groups.tf
+++ b/terraform/cloudfoundry/security-groups.tf
@@ -10,7 +10,7 @@ resource "aws_security_group" "cloud_controller" {
 
 resource "aws_security_group" "cf_api_elb" {
   name        = "${var.env}-cf-api-elb"
-  description = "Security group for CF API public endpoints that allows web traffic from whitelisted IPs"
+  description = "Security group for CF API public endpoints"
   vpc_id      = "${var.vpc_id}"
 
   egress {
@@ -40,7 +40,7 @@ resource "aws_security_group" "cf_api_elb" {
 
 resource "aws_security_group" "metrics_elb" {
   name        = "${var.env}-metrics"
-  description = "Security group for graphite/grafana ELB"
+  description = "Security group for graphite/grafana ELB. Allows access from admin IP ranges."
   vpc_id      = "${var.vpc_id}"
 
   egress {
@@ -77,7 +77,7 @@ resource "aws_security_group" "metrics_elb" {
 
 resource "aws_security_group" "web" {
   name        = "${var.env}-cf-web"
-  description = "Security group for web that allows web traffic from the office"
+  description = "Security group for web that allows HTTPS traffic from anywhere"
   vpc_id      = "${var.vpc_id}"
 
   egress {
@@ -102,7 +102,7 @@ resource "aws_security_group" "web" {
 
 resource "aws_security_group" "sshproxy" {
   name        = "${var.env}-sshproxy-cf"
-  description = "Security group for web that allows TCP/2222 for ssh-proxy from the office"
+  description = "Security group that allows TCP/2222 for cf ssh support"
   vpc_id      = "${var.vpc_id}"
 
   egress {
@@ -131,7 +131,7 @@ resource "aws_security_group" "sshproxy" {
 
 resource "aws_security_group" "service_brokers" {
   name        = "${var.env}-service-brokers"
-  description = "Group for service brokers"
+  description = "Group for service brokers that allows CloudController to connect"
   vpc_id      = "${var.vpc_id}"
 
   egress {


### PR DESCRIPTION
## What

Change the description attributes of Cloud Foundry aws_security_group resources so that they accurately describe the purposes of the security groups.

The descriptions are out-of-date and misleading. For example, they suggest that traffic only comes from the office, and refer to the whitelist which has since been removed.

## How to review

* Code review - check the new descriptions make sense.
* Run the pipeline against an existing deployment. Verify that it updates successfully, and that the availability tests pass.

## Who can review

Not me.