### PR TITLE
Add 6 more cells in prod.

### DIFF
--- a/manifests/cf-manifest/env-specific/cf-prod.yml
+++ b/manifests/cf-manifest/env-specific/cf-prod.yml
@@ -1,6 +1,6 @@
 ---
 meta:
   cell:
-    instances: 15
+    instances: 21
   elasticsearch_master:
     disk_size: 768000


### PR DESCRIPTION
## What

Our current memory allocation doesn't fit within the limit described in
ADR017[1]. Wu currently have c. 450Gig total memory. To comply with the
ADR, we need 567Gig. Adding 6 more cells at c. 30Gig each will being us
within the limts again.

[1]https://government-paas-team-manual.readthedocs.io/en/latest/architecture_decision_records/ADR017-cell-capacity-assignment/

## How to review

* Code review.
* Verify the current limit in prod allows for 21 r4.xlarge VMs.

## Who can review

Not me.