### PR TITLE
Add pagerduty support to rubbernecker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,9 @@ upload-google-oauth-secrets: check-env ## Decrypt and upload Google Admin Consol
 upload-tracker-token: check-env ## Decrypt and upload Pivotal tracker API token to S3
 	pass pivotal/tracker_token | aws s3 cp - "s3://gds-paas-${DEPLOY_ENV}-state/tracker_token"
 
+upload-pagerduty-token: check-env ## Decrypt and upload Pagerduty API token to S3
+	pass pagerduty/rubbernecker_api_token | aws s3 cp - "s3://gds-paas-${DEPLOY_ENV}-state/pagerduty_api_token"
+
 .PHONY: manually_upload_certs
 CERT_PASSWORD_STORE_DIR?=~/.paas-pass-high
 manually_upload_certs: check-env ## Manually upload to AWS the SSL certificates for public facing endpoints

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1984,6 +1984,7 @@ jobs:
               DEPLOY_RUBBERNECKER: {{deploy_rubbernecker}}
               PIVOTAL_PROJECT_ID: {{pivotal_project_id}}
               TRACKER_TOKEN: {{tracker_token}}
+              PAGERDUTY_API_TOKEN: {{pagerduty_api_token}}
             run:
               path: sh
               args:
@@ -2002,6 +2003,8 @@ jobs:
                   cf push --no-start -p paas-rubbernecker -f paas-rubbernecker/manifest.yml
                   echo Setting PIVOTAL_API_KEY...
                   cf set-env rubbernecker PIVOTAL_API_KEY ${TRACKER_TOKEN} > /dev/null
+                  echo Setting PAGERDUTY_API_TOKEN...
+                  cf set-env rubbernecker PAGERDUTY_API_TOKEN ${PAGERDUTY_API_TOKEN} > /dev/null
                   echo Setting PIVOTAL_PROJECT_ID...
                   cf set-env rubbernecker PIVOTAL_PROJECT_ID ${PIVOTAL_PROJECT_ID}
                   cf start rubbernecker

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -45,6 +45,14 @@ get_tracker_token() {
   fi
 }
 
+get_pagerduty_api_token() {
+  secrets_uri="s3://${state_bucket}/pagerduty_api_token"
+  export pagerduty_api_token
+  if aws s3 ls "${secrets_uri}" > /dev/null ; then
+    pagerduty_api_token=$(aws s3 cp "${secrets_uri}" -)
+  fi
+}
+
 prepare_environment() {
   "${SCRIPT_DIR}/fly_sync_and_login.sh"
 
@@ -88,6 +96,7 @@ prepare_environment() {
   export EXPOSE_PIPELINE=1
 
   get_tracker_token
+  get_pagerduty_api_token
   if [ "${DEPLOY_RUBBERNECKER:-false}" = "true" ] ; then
     if [ -z "${tracker_token+x}" ] ; then
       echo "Rubbernecker deployment enabled but could not retrieve the API token. Did you run \`make <env> upload-tracker-token\`?"
@@ -142,6 +151,7 @@ pivotal_project_id: ${PIVOTAL_PROJECT_ID:-1275640}
 concourse_atc_password: ${CONCOURSE_ATC_PASSWORD}
 oauth_client_id: ${oauth_client_id:-}
 oauth_client_secret: ${oauth_client_secret:-}
+pagerduty_api_token: ${pagerduty_api_token:-}
 EOF
   echo -e "pipeline_lock_git_private_key: |\n  ${git_id_rsa//$'\n'/$'\n'  }"
 }


### PR DESCRIPTION
## What

New rubbernecker feature, involves the listing of people on support. In
order to achieve that, it needs to communicate with PagerDuty.

We're providing a separate PagerDuty API token to authorise the
connection with their API.

## How to review

- Deploy from this branch with `DEPLOY_RUBBERNECKER=true`
- If the alphagov/paas-rubbernecker#21 is not merged yet, `cf push` the app manually
- Visit it on your dev environment
- Experience no issues

## Relations 

- alphagov/paas-rubbernecker#21
- credentials

## After merge

- Run `make prod upload-pagerduty-token`