### PR TITLE
[#147124125] Add deployment kick-off functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ dev: globals ## Set Environment to DEV
 	$(eval export CONCOURSE_AUTH_DURATION=48h)
 	$(eval export DISABLE_PIPELINE_LOCKING=true)
 	$(eval export TEST_HEAVY_LOAD=true)
+	$(eval export ENABLE_MORNING_DEPLOYMENT=true)
 	@true
 
 .PHONY: ci
@@ -151,6 +152,10 @@ bosh-cli: check-env ## Create interactive connnection to BOSH container
 .PHONY: pipelines
 pipelines: check-env ## Upload pipelines to Concourse
 	concourse/scripts/pipelines-cloudfoundry.sh
+
+.PHONY: trigger-deploy
+trigger-deploy: check-env ## Trigger a run of the create-cloudfoundry pipeline.
+	concourse/scripts/trigger-deploy.sh
 
 .PHONY: showenv
 showenv: check-env ## Display environment information

--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -102,6 +102,12 @@ jobs:
           params:
             file: updated-datadog-tfstate/datadog.tfstate
 
+
+      - task: await-turn
+        file: paas-cf/concourse/tasks/splay.yml
+        params:
+          DEPLOY_ENV: {{deploy_env}}
+
       - task: delete-deployment
         config:
           platform: linux
@@ -121,17 +127,7 @@ jobs:
             args:
               - -e
               - -c
-              # The following sleep monstrosity deterministically sleeps for a
-              # period of time between 0-20mins in order to prevent all our
-              # deletion jobs running at the same time. See the commit message for
-              # how it works.
               - |
-                sum=$(echo {{deploy_env}} | md5sum);
-                short=$(echo $sum | cut -b 1-15)
-                decimal=$((0x$short));
-                sleeptime=$((${decimal##-} % 60*20));
-                echo "Sleeping for $sleeptime seconds before deletion.."
-                sleep $sleeptime
                 ./paas-cf/concourse/scripts/bosh_login.sh {{bosh_fqdn}} bosh-secrets/bosh-secrets.yml
                 bosh -n delete deployment {{deploy_env}} --force
 

--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -1,0 +1,56 @@
+---
+resources:
+  - name: paas-cf
+    type: git
+    source:
+      uri: https://github.com/alphagov/paas-cf.git
+      branch: {{branch_name}}
+      tag_filter: {{paas_cf_tag_filter}}
+      commit_verification_key_ids: {{gpg_ids}}
+
+  - name: deployment-timer
+    type: time
+    source:
+      days: [Monday, Tuesday, Wednesday, Thursday, Friday]
+      location: Europe/London
+      start: 7:45 AM
+      stop: 8:15 AM
+
+jobs:
+  - name: kick-off
+    serial: true
+    plan:
+      - get: deployment-timer
+        trigger: true
+      - get: paas-cf
+
+      - task: await-turn
+        file: paas-cf/concourse/tasks/splay.yml
+        inputs:
+          - name: deployment-timer
+        params:
+          DEPLOY_ENV: {{deploy_env}}
+
+      - task: kick-off-create-cloudfoundry-pipeline
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/self-update-pipelines
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+          inputs:
+            - name: paas-cf
+          params:
+            AWS_ACCOUNT: {{aws_account}}
+            DEPLOY_ENV: {{deploy_env}}
+            SKIP_AWS_CREDENTIAL_VALIDATION: true
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                echo "Pipeline kick-off is enabled. Updating. (set ENABLE_MORNING_DEPLOYMENT=false to disable)"
+
+                make -C ./paas-cf "${AWS_ACCOUNT}" trigger-deploy

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -58,7 +58,7 @@ prepare_environment() {
 
   export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-eu-west-1}
 
-  pipelines_to_update="${PIPELINES_TO_UPDATE:-create-cloudfoundry destroy-cloudfoundry autodelete-cloudfoundry failure-testing}"
+  pipelines_to_update="${PIPELINES_TO_UPDATE:-create-cloudfoundry deployment-kick-off destroy-cloudfoundry autodelete-cloudfoundry failure-testing}"
   bosh_az=${BOSH_AZ:-eu-west-1a}
 
   state_bucket=gds-paas-${DEPLOY_ENV}-state
@@ -184,6 +184,13 @@ update_pipeline() {
   case $pipeline_name in
     create-cloudfoundry)
       upload_pipeline
+    ;;
+    deployment-kick-off)
+      if [ "${ENABLE_MORNING_DEPLOYMENT:-}" = "true" ]; then
+        upload_pipeline
+      else
+        remove_pipeline
+      fi
     ;;
     failure-testing)
       if [ "${ENABLE_FAILURE_TESTING:-}" = "true" ]; then

--- a/concourse/scripts/trigger-deploy.sh
+++ b/concourse/scripts/trigger-deploy.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Required variables are:
+# - DEPLOY_ENV
+# - AWS_ACCOUNT
+
+set -u
+set -e
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+echo "Pipeline kick-off is enabled. Updating. (set ENABLE_MORNING_DEPLOYMENT=false to disable)"
+
+export TARGET_CONCOURSE=deployer
+# shellcheck disable=SC2091
+$("${SCRIPT_DIR}/environment.sh")
+"${SCRIPT_DIR}/fly_sync_and_login.sh"
+FLY="$FLY_CMD -t ${FLY_TARGET}"
+
+${FLY} trigger-job -j "create-cloudfoundry/pipeline-lock"

--- a/concourse/tasks/splay.yml
+++ b/concourse/tasks/splay.yml
@@ -1,0 +1,23 @@
+---
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/bosh-cli
+    tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+platform: linux
+run:
+  path: sh
+  args:
+    - -e
+    - -c
+    # The following sleep monstrosity deterministically sleeps for a
+    # period of time between 0-20mins in order to prevent all our
+    # deletion jobs running at the same time. See the commit message for
+    # how it works.
+    - |
+      sum=$(echo ${DEPLOY_ENV} | md5sum);
+      short=$(echo $sum | cut -b 1-15)
+      decimal=$((0x$short));
+      sleeptime=$((${decimal##-} % 60*20));
+      echo "Sleeping for $sleeptime seconds before continuing..."
+      sleep $sleeptime


### PR DESCRIPTION
## What

We'd like to kick our environments every morning if possible. To achieve
that, we can create a trigger based on the `time-resource` provided by
concourse, which has pretty neat configuration.

The intention is to speed up our development process.

## How to review

- Code review
- Either:
  - Deploy from branch right before leaving work and expect it to run the next morning
  - Branch off from here and amend the `start` value; `git push`; `make dev pipelines` from a new branch

## Related

- alphagov/paas-bootstrap#71