### PR TITLE
[#147123149] Introduce compose enterprise clusters

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -253,7 +253,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-compose-broker
-      tag_filter: v0.1.0
+      tag_filter: v0.2.0
 
 jobs:
   - name: pipeline-lock
@@ -1484,6 +1484,7 @@ jobs:
             params:
               COMPOSE_ACCESS_TOKEN: {{compose_access_token}}
               DB_PREFIX: {{deploy_env}}
+              CLUSTER_NAME: "gds-eu-west1-c00"
             run:
               path: sh
               args:
@@ -1507,6 +1508,7 @@ jobs:
                       'PASSWORD' => '${COMPOSE_BROKER_PASS}',
                       'ACCESS_TOKEN' => '${COMPOSE_ACCESS_TOKEN}',
                       'DB_PREFIX' => '${DB_PREFIX}',
+                      'CLUSTER_NAME' => '${CLUSTER_NAME}',
                     }}
                     manifest['applications'].each { |app| app.merge!(env) }
                     File.write('manifest.yml', manifest.to_yaml)


### PR DESCRIPTION
## What

Bump version of compose broker to the one that supports enterprise clusters.

## How to review

- code review https://github.com/alphagov/paas-compose-broker/pull/4
- Deploy, create a DB, and check if it's using our enterprise cluster ( you need to enable it manually https://docs.cloudfoundry.org/services/access-control.html#enable-access )
- merge https://github.com/alphagov/paas-compose-broker/pull/4
- tag master with `v0.2.0` label
- remove https://github.com/alphagov/paas-cf/commit/14b2a2c408f7016e4c7ae25a8626688632bcf7d4

## Who can review

Not @timmow or @combor
