### PR TITLE
[#146446991] 	Remove unused loggregator ELB

### DIFF
--- a/manifests/cf-manifest/cloud-config/021-cf-vm-extensions.yml
+++ b/manifests/cf-manifest/cloud-config/021-cf-vm-extensions.yml
@@ -43,7 +43,6 @@ vm_extensions:
     cloud_properties:
       elbs:
         - (( grab terraform_outputs.cf_doppler_elb_name ))
-        - (( grab terraform_outputs.cf_loggregator_elb_name ))
 
   - name: ssh_proxy_elb
     cloud_properties:

--- a/manifests/cf-manifest/cloud-config/021-cf-vm-extensions.yml
+++ b/manifests/cf-manifest/cloud-config/021-cf-vm-extensions.yml
@@ -39,7 +39,7 @@ vm_extensions:
       elbs:
         - (( grab terraform_outputs.cf_uaa_elb_name ))
 
-  - name: cf_loggregator_elbs
+  - name: cf_doppler_elbs
     cloud_properties:
       elbs:
         - (( grab terraform_outputs.cf_doppler_elb_name ))

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -349,7 +349,7 @@ jobs:
     instances: 2
     vm_type: medium
     vm_extensions:
-      - cf_loggregator_elbs
+      - cf_doppler_elbs
     stemcell: default
     networks:
       - name: cf

--- a/manifests/shared/spec/fixtures/terraform/terraform-outputs.yml
+++ b/manifests/shared/spec/fixtures/terraform/terraform-outputs.yml
@@ -23,7 +23,6 @@ terraform_outputs:
   cf_router_elb_name: unit-test-cf-router-elb
   cf_cc_elb_name: stub_cf_cc_elb
   cf_uaa_elb_name: stub_cf_uaa_elb
-  cf_loggregator_elb_name: stub_cf_loggregator_elb
   cf_doppler_elb_name: stub_cf_doppler_elb
   cf_ssh_proxy_elb_name: stub_cf_ssh_proxy_elb
   logsearch_ingestor_elb_name: stub_ingestor_elb

--- a/terraform/cloudfoundry/dns-records.tf
+++ b/terraform/cloudfoundry/dns-records.tf
@@ -22,14 +22,6 @@ resource "aws_route53_record" "cf_login" {
   records = ["${aws_elb.cf_uaa.dns_name}"]
 }
 
-resource "aws_route53_record" "cf_loggregator" {
-  zone_id = "${var.system_dns_zone_id}"
-  name    = "loggregator.${var.system_dns_zone_name}."
-  type    = "CNAME"
-  ttl     = "60"
-  records = ["${aws_elb.cf_loggregator.dns_name}"]
-}
-
 resource "aws_route53_record" "cf_doppler" {
   zone_id = "${var.system_dns_zone_id}"
   name    = "doppler.${var.system_dns_zone_name}."

--- a/terraform/cloudfoundry/elbs.tf
+++ b/terraform/cloudfoundry/elbs.tf
@@ -93,50 +93,6 @@ resource "aws_app_cookie_stickiness_policy" "cf_uaa" {
   cookie_name   = "JSESSIONID"
 }
 
-resource "aws_elb" "cf_loggregator" {
-  name                      = "${var.env}-cf-loggregator"
-  subnets                   = ["${split(",", var.infra_subnet_ids)}"]
-  idle_timeout              = "${var.elb_idle_timeout}"
-  cross_zone_load_balancing = "true"
-
-  security_groups = [
-    "${aws_security_group.cf_api_elb.id}",
-  ]
-
-  access_logs {
-    bucket        = "${aws_s3_bucket.elb_access_log.id}"
-    bucket_prefix = "cf-loggregator"
-    interval      = 5
-  }
-
-  health_check {
-    target              = "TCP:8080"
-    interval            = "${var.health_check_interval}"
-    timeout             = "${var.health_check_timeout}"
-    healthy_threshold   = "${var.health_check_healthy}"
-    unhealthy_threshold = "${var.health_check_unhealthy}"
-  }
-
-  listener {
-    instance_port      = 8080
-    instance_protocol  = "tcp"
-    lb_port            = 443
-    lb_protocol        = "ssl"
-    ssl_certificate_id = "${var.system_domain_cert_arn}"
-  }
-}
-
-resource "aws_lb_ssl_negotiation_policy" "cf_loggregator" {
-  name          = "paas-${var.default_elb_security_policy}"
-  load_balancer = "${aws_elb.cf_loggregator.id}"
-  lb_port       = 443
-
-  attribute {
-    name  = "Reference-Security-Policy"
-    value = "${var.default_elb_security_policy}"
-  }
-}
-
 resource "aws_elb" "cf_doppler" {
   name                      = "${var.env}-cf-doppler"
   subnets                   = ["${split(",", var.infra_subnet_ids)}"]

--- a/terraform/cloudfoundry/outputs.tf
+++ b/terraform/cloudfoundry/outputs.tf
@@ -66,10 +66,6 @@ output "cf_uaa_elb_name" {
   value = "${aws_elb.cf_uaa.name}"
 }
 
-output "cf_loggregator_elb_name" {
-  value = "${aws_elb.cf_loggregator.name}"
-}
-
 output "cf_doppler_elb_name" {
   value = "${aws_elb.cf_doppler.name}"
 }


### PR DESCRIPTION
## What

This endpoint has been deprecated and is no longer used. It will be [removed
from CC's info endpoint][0] in CF v260.

We tried to do this before in 7c71f5f during the upgrade from CF v240 to
v245 but reverted it in a9530cf because we saw this error instead of
getting staging logs during a `cf push`, but the deploy continued:

    Warning: error tailing logs
    Error dialing loggregator server: dial tcp: lookup loggregator.hector.dev.cloudpipeline.digital on 127.0.1.1:53: no such host.
    Please ask your Cloud Foundry Operator to check the platform configuration (loggregator endpoint is wss://loggregator.hector.dev.cloudpipeline.digital:443).

This [error comes from][1] the old loggregator_consumer library when connecting
to the loggregator endpoint. We can tell from the error message and the
codebase that it actually attempts to make a connection to the endpoint,
rather than just looking up the hostname.

I tested pushing an app with several versions of cf CLI:

- 6.17.0 predates support for the new Doppler endpoint so it reports the
  same error as above after this commit is applied. However it currently
  reports a [similar error][2] because the [ELB doesn't have any health
  instances][3], so the user experience is no worse.
- 6.17.1 [added support][4] for the new Doppler endpoint which is used when
  the API version is greater than 2.29.0 (CF v239), so it continues to work.
- 6.24.0 [removed support][5] for the old Loggregator endpoint so it also
  continues to work.

I also checked the CC logs in Kibana to see what versions of cf CLI tenants
were using. Besides one outlier, who last accessed on 2016-06-08 with
version 6.14.0, everyone is using 6.21.0 and later, with most people using
versions between 6.25.0 and 6.27.0.

For these reasons I think it is safe to remove the ELB without sending out
an announcement to tenants.

[0]: cloudfoundry/cloud_controller_ng@b02a23c
[1]: https://github.com/cloudfoundry-attic/loggregator_consumer/blob/eef2afce51e4fa4d56ed94eb02c9bba38d7b4572/consumer.go#L367
[2]:

    Warning: error tailing logs
    Error dialing loggregator server: unexpected EOF.
    Please ask your Cloud Foundry Operator to check the platform configuration (loggregator endpoint is wss://loggregator.dcarley.dev.cloudpipeline.digital:443).

[3]:

    ➜  paas-cf git:(fe3fb729) ✗ aws elb describe-instance-health --load-balancer-name prod-cf-loggregator
    {
        "InstanceStates": [
            {
                "InstanceId": "i-REDACTED",
                "ReasonCode": "Instance",
                "State": "OutOfService",
                "Description": "Instance has failed at least the UnhealthyThreshold number of health checks consecutively."
            },
            {
                "InstanceId": "i-REDACTED",
                "ReasonCode": "Instance",
                "State": "OutOfService",
                "Description": "Instance has failed at least the UnhealthyThreshold number of health checks consecutively."
            }
        ]
    }

[4]: cloudfoundry/cli@8c9068e#diff-b0ab293ebcc3c7d6916aaa1720533504R112
[5]: cloudfoundry/cli@853d09a#diff-b0ab293ebcc3c7d6916aaa1720533504L124

## How to review

- Check that I haven't forgotten to remove anything related to this ELB.
- Deploy from this branch.
- Make sure all the tests in the pipeline pass.
- Confirm that your understanding of the user experience matches what I have described above.
- Optionally: download some older versions of the `cf` CLI binary, delete `~/.cf/config.json`, then login and push an app with the old binary.

## Who can review

Anyone.