### PR TITLE
[#147992413] Fix returned database name for mongodb

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -253,7 +253,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-compose-broker
-      tag_filter: v0.2.0
+      tag_filter: v0.3.0
 
 jobs:
   - name: pipeline-lock


### PR DESCRIPTION
## What

This bumps the broker to pull in the changes from https://github.com/alphagov/paas-compose-broker/pull/5

## How to review

* Run the pipeline from this branch.
* Verify you can create and destroy a mongo service instance (you'll need to enable access first - `cf enable-service-access mongodb -o myorg`)

## Before merging

* Ensure https://github.com/alphagov/paas-compose-broker/pull/5 has been merged, and tagged as `v0.3.0`.
* Remove the TMP commit from this branch.

## Who can review

Not me.