### PR TITLE
[#147829023] Force TLS for MySQL service instances

### DIFF
--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -58,9 +58,9 @@ meta:
 
 releases:
   - name: rds-broker
-    version: 0.1.12
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.12.tgz
-    sha1: 9444b467a36600884a5c5e9f1af11afbabc67e7c
+    version: 0.1.13
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.13.tgz
+    sha1: 0678db4ceb7aecf2452cb13623c85ad1b59eaef5
 
 jobs:
   - name: rds_broker


### PR DESCRIPTION
## What

Use a new version of the RDS broker than forces TLS connections to MySQL service instances. Adjust the acceptance tests to verify this in the same way we do for Postgres.

## How to review

It's best to look at alphagov/paas-rds-broker#52

Before merging:

1. Make sure you've updated alphagov/paas-rds-broker-boshrelease#40 to use a merge commit
1. Make sure you've updated the `wip` commit in this PR to use a final build

## Who can review

Anyone.