### PR TITLE
[#148839033] Upgrade nodejs-buildpack for advisory

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -21,6 +21,10 @@ releases:
     version: 1.133.0
     url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.133.0
     sha1: caf2f0488f844fb6ea7937299b33b2a4e64b23b0
+  - name: nodejs-buildpack
+    version: 1.6.2
+    url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.6.2
+    sha1: aca4bdea51e8a10a410312db629b7ba3f0a15b7e
   - name: paas-haproxy
     version: 0.1.3
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/paas-haproxy-0.1.3.tgz

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -28,7 +28,7 @@ meta:
   - name: binary-buildpack
     release: (( grab meta.release.name ))
   - name: nodejs-buildpack
-    release: (( grab meta.release.name ))
+    release: nodejs-buildpack
   - name: ruby-buildpack
     release: (( grab meta.release.name ))
   - name: php-buildpack

--- a/scripts/generate_buildpack_release_notes.sh
+++ b/scripts/generate_buildpack_release_notes.sh
@@ -76,6 +76,9 @@ for buildpack_release in src/*buildpack-release; do
         dotnet-core-buildpack*)
         continue # Ignore dotnet ones
         ;;
+        nodejs-buildpack*)
+        continue # Upgraded independent of cf-release
+        ;;
     esac
 
     commit_a=$(git diff "${CF_RELEASE_VERSION_A}..${CF_RELEASE_VERSION_B}" "${buildpack_release}" | grep "Subproject commit" | cut -f 3 -d " " | head -n 1)

--- a/scripts/generate_buildpack_release_notes.sh
+++ b/scripts/generate_buildpack_release_notes.sh
@@ -44,7 +44,7 @@ Example:
 
 or:
 
-    CF_RELEASE_DIR=~/workspace/cf-release/ GITHUB_USER=keymon GITHUB_TOKEN=1234567891234567890 $0 v251 v253
+    CF_RELEASE_DIR=~/workspace/cf-release/ GITHUB_USER=keymon GITHUB_API_TOKEN=1234567891234567890 $0 v251 v253
 
 EOF
     exit 1


### PR DESCRIPTION
## What

Describe what you have changed and why.

Upgrade nodejs-buildpack for advisory …In response to:

- https://nodejs.org/en/blog/vulnerability/july-2017-security-releases/

Which is fixed in versions:

- https://nodejs.org/en/blog/release/v8.1.4
- https://nodejs.org/en/blog/release/v7.10.1
- https://nodejs.org/en/blog/release/v6.11.1
- https://nodejs.org/en/blog/release/v4.8.4

This is the first time that we've taken a buildpack from outside a version
cf-release. It is something that we hope to do more frequently in the
future, so that we can respond to security advisories and bugs independent
of CF upgrades.

I've omitted nodejs-buildpack from the output of the release notes script so
that we don't send conflicting messages to tenants.

It takes us from the following versions in nodejs-buildpack v1.5.31 from
cf-release v257:

    name    version    cf_stacks
    node    4.8.0    cflinuxfs2
    node    4.8.1    cflinuxfs2
    node    6.10.0    cflinuxfs2
    node    6.10.1    cflinuxfs2
    node    7.7.3    cflinuxfs2
    node    7.7.4    cflinuxfs2
    yarn    0.22.0    cflinuxfs2

Past the following versions in nodejs-buildpack v1.5.36 from cf-release
v264, that we were about to upgrade to in another story:

    name    version    cf_stacks
    node    4.8.2    cflinuxfs2
    node    4.8.3    cflinuxfs2
    node    6.10.2    cflinuxfs2
    node    6.10.3    cflinuxfs2
    node    7.10.0    cflinuxfs2
    node    7.9.0    cflinuxfs2
    node    8.0.0    cflinuxfs2
    yarn    0.24.6    cflinuxfs2

To the following:

    name    version    cf_stacks
    node    4.8.3    cflinuxfs2
    node    4.8.4    cflinuxfs2
    node    6.11.0    cflinuxfs2
    node    6.11.1    cflinuxfs2
    node    7.10.0    cflinuxfs2
    node    7.10.1    cflinuxfs2
    node    8.1.3    cflinuxfs2
    node    8.1.4    cflinuxfs2
    yarn    0.27.5    cflinuxfs

## How to review

1. Code review
1. I think deploying to your dev environment is optional, because I've deployed it to mine and all of the tests passed
1. Before merging confirm with @jollery or @tomskerous when the announcement should go out (see Pivotal summary)
1. I'd like a second opinion on:
    1. Whether the version changes are safe? I think they are because we retain a major version of each series and I can't see any backwards incompatible changes from my naive reading of the release notes.
    1. Whether CATS testing is enough? I think it probably is because it deploys two apps that use the latest version of Node.

## Who can review

Anyone.