### PR TITLE
[#145991105] Set redirect_uri for datadog-nozzle

### DIFF
--- a/manifests/cf-manifest/stubs/datadog-nozzle.yml
+++ b/manifests/cf-manifest/stubs/datadog-nozzle.yml
@@ -40,3 +40,4 @@ properties:
         secret: (( grab secrets.uaa_clients_datadog_firehose_password ))
         scope: openid,oauth.approvals,doppler.firehose
         authorities: oauth.login,doppler.firehose
+        redirect-uri: (( concat "https://login." properties.system_domain "/login" ))


### PR DESCRIPTION
## What

This was missed in 1be8635f because we don't enable DataDog in dev
environments. It failed in CI with:

    Error 100: Unable to render instance groups for deployment. Errors are:
      - Unable to render jobs for instance group 'uaa'. Errors are:
        - Unable to render templates for job 'uaa'. Errors are:
          - Error filling in template 'uaa.yml.erb' (line 57:
          Missing property: uaa.clients.datadog-nozzle.redirect-uri)

I'm not sure the actual URI matters. I've copied the value we've used for
`graphite-nozzle`.

## How to review

This is a bit time sensitive because we told tenants we'd be doing an upgrade on Tuesday. Given how long it takes to enable DataDog in an environment I think code review only is sufficient.

## Who can review

Anyone.