### PR TITLE
[#145517679] Use anomaly detection for cc errors.

### DIFF
--- a/terraform/datadog/cloud_controller.tf
+++ b/terraform/datadog/cloud_controller.tf
@@ -71,18 +71,13 @@ resource "datadog_monitor" "cc_failed_job_count_total_increase" {
 }
 
 resource "datadog_monitor" "cc_log_count_error_increase" {
-  name                = "${format("%s Cloud Controller API log error count", var.env)}"
-  type                = "query alert"
-  message             = "${format("Amount of logged errors in Cloud Controller API grew considerably. See logsearch: '@source.component:cloud_controller_ng AND @level:ERROR' {{#is_alert}}%s{{/is_alert}}", var.datadog_notification_in_hours)}"
-  escalation_message  = "Amount of logged errors in Cloud Controller API still growing considerably. See logsearch: '@source.component:cloud_controller_ng AND @level:ERROR'"
-  require_full_window = false
+  name               = "${format("%s Cloud Controller API log error count", var.env)}"
+  type               = "query alert"
+  message            = "${format("Amount of logged errors in Cloud Controller API grew considerably. See logsearch: '@source.component:cloud_controller_ng AND @level:ERROR' {{#is_alert}}%s{{/is_alert}}", var.datadog_notification_in_hours)}"
+  escalation_message = "Amount of logged errors in Cloud Controller API still growing considerably. See logsearch: '@source.component:cloud_controller_ng AND @level:ERROR'"
 
-  query = "${format("change(max(last_1m),last_30m):sum:cf.cc.log_count.error{deployment:%s}.rollup(avg, 30) > 15", var.env)}"
-
-  thresholds {
-    warning  = "10"
-    critical = "15"
-  }
+  query               = "${format("avg(last_30m):anomalies(sum:cf.cc.log_count.error{deployment:%s}, 'agile', 2, direction='above') >= 0.5", var.env)}"
+  require_full_window = true
 
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:api"]
 }


### PR DESCRIPTION
## What

Current alert triggers always if the change if more that 15 errors per half an hour which feels not very suitable for prod. Also we've got false positives when metric is reset after CC redeployment.
The anomaly detection method works for UAA and it seems to be correctly detecting anomalies
while allowing for counter resets.

## How to review

We use exactly same settings for uaa so compare this code with https://github.com/alphagov/paas-cf/blob/master/terraform/datadog/uaa.tf#L6 . Checking on dev may be time consuming as agile algorithm need one day of historical data to learn.  

## Who can review
Not @combor
