### PR TITLE
[#149220549] Split capi-release from cf-release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ ci: globals ## Set Environment to CI
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-ci.yml)
 	$(eval export ENABLE_DATADOG=true)
 	$(eval export TEST_HEAVY_LOAD=true)
+	$(eval export DISABLE_CF_ACCEPTANCE_TESTS=true)
 	@true
 
 .PHONY: staging

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -9,6 +9,17 @@ releases:
     version: "264"
     url: https://bosh.io/d/github.com/cloudfoundry/cf-release?v=264
     sha1: 37f93b7064a15d5fdc942e0dcaf4bb9f002dc8d6
+
+    # FIXME: capi-release has been split from cf-release due to these CVEs:
+    # https://www.cloudfoundry.org/cve-2017-8033/
+    # https://www.cloudfoundry.org/cve-2017-8035/
+    # https://www.cloudfoundry.org/cve-2017-8036/
+    # This can be reverted once we are using a cf-release version that ships with
+    # capi-release >=1.35.0
+  - name: capi
+    version: 1.35.0
+    url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.35.0
+    sha1: 253d0da57fcc20d4ef3b0b172656f1107e0099dc
   - name: diego
     version: 1.18.1
     url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=1.18.1

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -213,7 +213,7 @@ jobs:
     azs: [z1, z2]
     templates:
       - name: consul_agent
-        release: cf
+        release: (( grab meta.release.name ))
       - name: datadog-consul-agent-client
         release: datadog-for-cloudfoundry
       - name: datadog-bbs
@@ -223,7 +223,7 @@ jobs:
       - name: cfdot
         release: diego
       - name: metron_agent
-        release: cf
+        release: (( grab meta.release.name ))
     instances: 2
     vm_type: medium
     vm_extensions:
@@ -378,7 +378,7 @@ jobs:
     azs: [z1, z2]
     templates:
       - name: consul_agent
-        release: cf
+        release: (( grab meta.release.name ))
       - name: datadog-consul-agent-client
         release: datadog-for-cloudfoundry
       - name: auctioneer
@@ -386,7 +386,7 @@ jobs:
       - name: cfdot
         release: diego
       - name: metron_agent
-        release: cf
+        release: (( grab meta.release.name ))
     instances: 2
     vm_type: medium
     stemcell: default
@@ -397,7 +397,7 @@ jobs:
     azs: [z1, z2, z3]
     templates:
       - name: consul_agent
-        release: cf
+        release: (( grab meta.release.name ))
       - name: datadog-consul-agent-client
         release: datadog-for-cloudfoundry
       - name: rep
@@ -409,7 +409,7 @@ jobs:
       - name: cfdot
         release: diego
       - name: metron_agent
-        release: cf
+        release: (( grab meta.release.name ))
       - name: datadog-rep
         release: datadog-for-cloudfoundry
       - name: datadog-garden
@@ -433,7 +433,7 @@ jobs:
     azs: [z1, z2]
     templates:
       - name: consul_agent
-        release: cf
+        release: (( grab meta.release.name ))
       - name: datadog-consul-agent-client
         release: datadog-for-cloudfoundry
       - name: stager
@@ -447,7 +447,7 @@ jobs:
       - name: cfdot
         release: diego
       - name: metron_agent
-        release: cf
+        release: (( grab meta.release.name ))
     instances: 2
     vm_type: medium
     stemcell: default
@@ -458,7 +458,7 @@ jobs:
     azs: [z1, z2]
     templates:
       - name: consul_agent
-        release: cf
+        release: (( grab meta.release.name ))
       - name: datadog-consul-agent-client
         release: datadog-for-cloudfoundry
       - name: route_emitter
@@ -466,7 +466,7 @@ jobs:
       - name: cfdot
         release: diego
       - name: metron_agent
-        release: cf
+        release: (( grab meta.release.name ))
       - name: datadog-route-emitter
         release: datadog-for-cloudfoundry
     instances: 2
@@ -479,13 +479,13 @@ jobs:
     azs: [z1, z2]
     templates:
       - name: consul_agent
-        release: cf
+        release: (( grab meta.release.name ))
       - name: datadog-consul-agent-client
         release: datadog-for-cloudfoundry
       - name: ssh_proxy
         release: diego
       - name: metron_agent
-        release: cf
+        release: (( grab meta.release.name ))
       - name: file_server
         release: diego
       - name: cfdot

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -10,10 +10,10 @@ meta:
     release: (( grab meta.consul_templates.consul_agent.release ))
     consumes: {consul_client: nil, consul_server: nil, consul_common: nil}
   - name: cloud_controller_ng
-    release: (( grab meta.release.name ))
+    release: capi
     consumes: {nats: nil}
   - name: cloud_controller_clock
-    release: (( grab meta.release.name ))
+    release: capi
     consumes: {nats: nil}
   - name: metron_agent
     release: (( grab meta.release.name ))
@@ -45,7 +45,7 @@ meta:
     release: (( grab meta.consul_templates.consul_agent.release ))
     consumes: {consul_client: nil, consul_server: nil, consul_common: nil}
   - name: cloud_controller_worker
-    release: (( grab meta.release.name ))
+    release: capi
     consumes: {nats: nil}
   - name: metron_agent
     release: (( grab meta.release.name ))
@@ -437,13 +437,13 @@ jobs:
       - name: datadog-consul-agent-client
         release: datadog-for-cloudfoundry
       - name: stager
-        release: cf
+        release: capi
       - name: nsync
-        release: cf
+        release: capi
       - name: tps
-        release: cf
+        release: capi
       - name: cc_uploader
-        release: cf
+        release: capi
       - name: cfdot
         release: diego
       - name: metron_agent


### PR DESCRIPTION
## What

Split capi-release from cf-release to mitigate CVEs without having to upgrade Cloud Foundry. See commit message for details.

## How to review

* Deploy from master. Make sure the healthcheck app deploys correctly.
* Deploy from this branch. This makes the deployment representative of upgrading a persistent environment.
* Restage the healthcheck app. (don't blue-green deploy). The idea here is to test that the changes to the way resources are stored in [capi-release 1.31.0](https://github.com/cloudfoundry/capi-release/releases/tag/1.31.0) doesn't cause problems.

The acceptance tests have been disabled while we work on patching them. You will probably want to override this and run the acceptance tests to verify we are not disabling them erroneously. The expected failures are documented in [the Pivotal story](https://www.pivotaltracker.com/n/projects/1275640/stories/149220549).

Read [capi-release release notes](https://github.com/cloudfoundry/capi-release/releases) for what will be changed.

## Who can review

Anyone but me or @dcarley 
