### PR TITLE
[#149220549] Patch cf acceptance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,6 @@ ci: globals ## Set Environment to CI
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-ci.yml)
 	$(eval export ENABLE_DATADOG=true)
 	$(eval export TEST_HEAVY_LOAD=true)
-	$(eval export DISABLE_CF_ACCEPTANCE_TESTS=true)
 	@true
 
 .PHONY: staging

--- a/platform-tests/upstream/run_acceptance_tests.sh
+++ b/platform-tests/upstream/run_acceptance_tests.sh
@@ -7,6 +7,23 @@ if  [ "${DISABLE_CF_ACCEPTANCE_TESTS:-}" = "true" ]; then
   exit 0
 fi
 
+# FIXME: Remove this once we are deploying a version of cf-release
+# that includes capi-release >= 1.35.0.
+(
+  cd  "$(pwd)/cf-release/src/github.com/cloudfoundry/cf-acceptance-tests/"
+  expected_commit_hash="4a6c59b27bf09aac222ffa02628d1fd47b3a708d"
+  current_commit_hash="$(git log --pretty=format:'%H' -n 1)"
+  if [ "${expected_commit_hash}" != "${current_commit_hash}" ]; then
+    echo "ERROR: Current commit for cf-acceptance-test is different than expected one: ${expected_commit_hash} != ${current_commit_hash}"
+    echo "Double check if we still need to pull our branch"
+    exit 1
+  fi
+  git remote add alphagov https://github.com/alphagov/paas-cf-acceptance-tests.git
+  git fetch alphagov
+  git checkout fix-v3-app-delete
+)
+
+
 SLEEPTIME=90
 NODES=5
 SKIP_REGEX='routing.API|allows\spreviously-blocked\sip|Adding\sa\swildcard\sroute\sto\sa\sdomain|forwards\sapp\smessages\sto\sregistered\ssyslog\sdrains|uses\sa\sbuildpack\sfrom\sa\sgit\surl|when\sapp\shas\smultiple\sports\smapped'


### PR DESCRIPTION
## What

Until we have a version of capi-release that is compatible with the cf-release we will need to patch the cf-acceptance-tests. See commit message for further details.

## How to review

Deploy on top of master. Make sure the acceptance tests actually run and pass.

The patch of the cf-acceptance-tests is stored on [a branch of our fork of the upstream tests](https://github.com/alphagov/paas-cf-acceptance-tests/tree/fix-v3-app-delete). This is just a branch with no intention to be merged into anything, because it is only useful to us.

## Who can review

Anyone but me or @chrisfarms 
