### PR TITLE
[#148289089] Rationalise our CF orgs

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1717,10 +1717,19 @@ jobs:
 
                   . ./config/config.sh
                   echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
-                  cf create-org testers
-                  cf set-quota testers test_apps
-                  cf create-space healthcheck -o testers
-                  cf target -o testers -s healthcheck
+
+                  # FIXME: remove this once it's been cleaned up everywhere.
+                  if [ "${DISABLE_HEALTHCHECK_DB:-}" != "true" ] && cf target -o testers -s healthcheck ; then
+                    cf unbind-service healthcheck healthcheck-db
+                    cf delete-service healthcheck-db -f
+                    while cf services | grep -q 'healthcheck-db'; do
+                      echo "Waiting for deletion of old healthcheck-db..."
+                      sleep 30
+                    done
+                  fi
+                  cf delete-org -f testers
+
+                  cf target -o admin -s healthchecks
                   BUILD_ROOT=$(pwd)
                   cd paas-cf/platform-tests/example-apps/healthcheck
 

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1313,7 +1313,12 @@ jobs:
                   . ./config/config.sh
                   echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
                   cf create-org admin
-                  cf create-space admin -o admin
+
+                  # FIXME: remove this once it's been renamed everywhere.
+                  cf target -o admin
+                  cf rename-space admin monitoring || true
+
+                  cf create-space monitoring -o admin
                   cf create-org service-brokers
                   cf set-quota service-brokers small
                   cf create-space compose -o service-brokers
@@ -1640,10 +1645,9 @@ jobs:
                   ./paas-cf/concourse/scripts/import_bosh_ca.sh
 
                   . ./config/config.sh
-                  cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS} \
-                    -o admin -s admin
+                  echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
 
-                  cf target -o admin -s admin
+                  cf target -o admin -s monitoring
 
                   cat <<EOF > graphite-nozzle.json
                   [
@@ -1651,7 +1655,7 @@ jobs:
                   ]
                   EOF
                   cf create-security-group graphite-nozzle graphite-nozzle.json
-                  cf bind-security-group graphite-nozzle admin admin
+                  cf bind-security-group graphite-nozzle admin monitoring
 
                   cd graphite-nozzle
 
@@ -1960,7 +1964,7 @@ jobs:
                   ./paas-cf/concourse/scripts/import_bosh_ca.sh
                   . ./config/config.sh
                   cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS} \
-                    -o admin -s admin
+                    -o admin -s monitoring
                   cd paas-cf/tools/paas_dashboard
                   cf push --no-start paas-dashboard
                   echo Setting DD_API_KEY...
@@ -2000,7 +2004,7 @@ jobs:
                   ./paas-cf/concourse/scripts/import_bosh_ca.sh
                   . ./config/config.sh
                   cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS} \
-                    -o admin -s admin
+                    -o admin -s monitoring
 
                   cf push --no-start -p paas-rubbernecker -f paas-rubbernecker/manifest.yml
                   echo Setting PIVOTAL_API_KEY...

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1319,9 +1319,11 @@ jobs:
                   cf rename-space admin monitoring || true
 
                   cf create-space monitoring -o admin
-                  cf create-org service-brokers
-                  cf set-quota service-brokers small
-                  cf create-space compose -o service-brokers
+                  cf create-space service-brokers -o admin
+
+                  # FIXME: remove this once it's been cleaned up everywhere.
+                  cf delete-org -f service-brokers
+
                   cf create-org govuk-paas
                   cf create-space docs -o govuk-paas
                   cf create-space tools -o govuk-paas
@@ -1501,8 +1503,8 @@ jobs:
                   ./paas-cf/concourse/scripts/import_bosh_ca.sh
 
                   . ./config/config.sh
-                  echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
-                  cf target -o service-brokers -s compose
+                  cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS} \
+                    -o admin -s service-brokers
 
                   cp ./paas-cf/config/service-brokers/compose/catalog.json ./paas-compose-broker/
                   cd paas-compose-broker/

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1324,6 +1324,7 @@ jobs:
                   cf create-space compose -o service-brokers
                   cf create-org govuk-paas
                   cf create-space docs -o govuk-paas
+                  cf create-space tools -o govuk-paas
                   cf target -o govuk-paas
                   cf create-route docs "${APPS_DNS_ZONE_NAME}" --hostname www
                   cf create-route docs "${APPS_DNS_ZONE_NAME}" --hostname api
@@ -2004,7 +2005,12 @@ jobs:
                   ./paas-cf/concourse/scripts/import_bosh_ca.sh
                   . ./config/config.sh
                   cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS} \
-                    -o admin -s monitoring
+                    -o govuk-paas -s tools
+
+                  # FIXME: remove this once it's been moved everywhere
+                  cf target -o admin -s monitoring
+                  cf delete -r -f rubbernecker
+                  cf target -o govuk-paas -s tools
 
                   cf push --no-start -p paas-rubbernecker -f paas-rubbernecker/manifest.yml
                   echo Setting PIVOTAL_API_KEY...

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1313,6 +1313,7 @@ jobs:
                   . ./config/config.sh
                   echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
                   cf create-org admin
+                  cf set-quota admin medium
 
                   # FIXME: remove this once it's been renamed everywhere.
                   cf target -o admin
@@ -1320,6 +1321,7 @@ jobs:
 
                   cf create-space monitoring -o admin
                   cf create-space service-brokers -o admin
+                  cf create-space healthchecks -o admin
 
                   # FIXME: remove this once it's been cleaned up everywhere.
                   cf delete-org -f service-brokers
@@ -1554,10 +1556,11 @@ jobs:
 
                   . ./config/config.sh
                   echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}
-                  cf create-org heavy-testers
-                  cf set-quota heavy-testers medium
-                  cf create-space test-application -o heavy-testers
-                  cf target -o heavy-testers -s test-application
+
+                  # FIXME: remove this once it's cleaned up everywhere.
+                  cf delete-org -f heavy-testers
+
+                  cf target -o admin -s healthchecks
 
                   cd paas-cf/platform-tests/example-apps/healthcheck
                   cf push simulated-load -i 180

--- a/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
+++ b/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
@@ -9,7 +9,7 @@ vm_types:
     network: cf
     env: (( grab meta.default_env ))
     cloud_properties:
-      instance_type: t2.small
+      instance_type: t2.medium
       ephemeral_disk:
         size: 10240
         type: gp2

--- a/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
+++ b/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
@@ -9,7 +9,7 @@ vm_types:
     network: cf
     env: (( grab meta.default_env ))
     cloud_properties:
-      instance_type: t2.medium
+      instance_type: t2.small
       ephemeral_disk:
         size: 10240
         type: gp2


### PR DESCRIPTION
## What

We're currently using several orgs in prod. We want to rationalise this down to 2 orgs - `admin` for things that form part of the running of the platform itself, and `govuk-paas` for things relating to our team.

This reorganises the existing things we deploy in the pipeline into these 2 orgs.

**Note:** 🚨  moving the healthcheck app can't be done without downtime, so this will cause the availability tests to fail during deployment. We discussed this at kickoff, and decided that this was acceptable in this case.

## How to review

To test thoroughly, it will be necessary to enable some things that are normally disabled in dev:
* rubbernecker - add `$(eval export DEPLOY_RUBBERNECKER=true)` to dev section of Makefile, and upload necessary creds (`make dev upload-tracker-token upload-pagerduty-token`)
* healthcheck-db - remove `$(eval export DISABLE_HEALTHCHECK_DB=true)` line from dev section of Makefile.

Run from this branch against an existing deployment to verify everything gets moved correctly.

## Who can review

Not me