### PR TITLE
[#146074949] Add a CF API Pingdom check

### DIFF
--- a/doc/pingdom.md
+++ b/doc/pingdom.md
@@ -4,7 +4,7 @@
 
 The checks are defined in terraform configuration file `terraform/pingdom/pingdom.tf`.
 
-The IDs of the contacts to be notified are stored as a comma-delimited string in variable `$PINGDOM_CONTACT_IDS` in the Makefile.
+The IDs of the contacts to be notified are stored in `paas-cf/terraform/${AWS_ACCOUNT}.tfvars`.
 
 ### Requirements
 
@@ -27,7 +27,7 @@ make <ENV> pingdom ACTION=apply
 
 #### Requirements
 You must have a [golang environment](https://golang.org/doc/install) configured. We currently test with Go 1.6.
- 
+
 #### Download
 Download the provider and its dependencies:
 

--- a/terraform/pingdom/pingdom.tf
+++ b/terraform/pingdom/pingdom.tf
@@ -7,6 +7,7 @@ variable "pingdom_api_key" {}
 variable "pingdom_account_email" {}
 
 variable "apps_dns_zone_name" {}
+variable "system_dns_zone_name" {}
 
 variable "env" {}
 
@@ -42,6 +43,21 @@ resource "pingdom_check" "paas_db_healthcheck" {
   host                     = "healthcheck.${var.apps_dns_zone_name}"
   url                      = "/db"
   shouldcontain            = "\"success\": true"
+  encryption               = true
+  resolution               = 1
+  uselegacynotifications   = true
+  sendtoemail              = true
+  sendnotificationwhendown = 2
+  notifywhenbackup         = true
+  contactids               = ["${var.pingdom_contact_ids}"]
+}
+
+resource "pingdom_check" "cf_api_healthcheck" {
+  type                     = "http"
+  name                     = "PaaS CF API - ${var.env}"
+  host                     = "api.${var.system_dns_zone_name}"
+  url                      = "/v2/info"
+  shouldcontain            = "api_version"
   encryption               = true
   resolution               = 1
   uselegacynotifications   = true

--- a/terraform/scripts/set-up-pingdom.sh
+++ b/terraform/scripts/set-up-pingdom.sh
@@ -41,4 +41,5 @@ terraform "${TERRAFORM_ACTION}" \
 	-var "pingdom_api_key=${PINGDOM_API_KEY}" \
 	-var "pingdom_account_email=${PINGDOM_ACCOUNT_EMAIL}" \
 	-var "apps_dns_zone_name=${APPS_DNS_ZONE_NAME}" \
+	-var "system_dns_zone_name=${SYSTEM_DNS_ZONE_NAME}" \
   "${PAAS_CF_DIR}"/terraform/pingdom


### PR DESCRIPTION
## What

We want to monitor the availability of the API in Pingdom, so that
we can report on its availability.

https://www.pivotaltracker.com/n/projects/1275640/stories/146074949

## How to review

* Plan with `make dev pingdom ACTION=plan`. It should want to create all three Pingdom checks. When the same is done for ci, staging, and prod it should only want to create the new check.
* Apply with `make dev pingdom ACTION=apply`. This will test it can create them properly, but won't test the checks actually work because we don't have proper certificates in dev.
* It should alert `the-multi-cloud-paas-team@digital.cabinet-office.gov.uk` after two consecutive failed checks, which should run every minute.
* merge and apply the checks to ci, staging, and prod.

## Who can review

Anyone but me