### PR TITLE
[#149144401] Upgrade RDS broker

### DIFF
--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -58,9 +58,9 @@ meta:
 
 releases:
   - name: rds-broker
-    version: 0.1.15
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.15.tgz
-    sha1: 026a23fdbc32f18075245058998faa31de493052
+    version: 0.1.16
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.16.tgz
+    sha1: 85d1b1f7f08004f7b23e61f117b6463bb10f434b
 
 jobs:
   - name: rds_broker


### PR DESCRIPTION
## What

This pins the version of the broker which introduced the ability for
users to run `CREATE SCHEMA`[1][2].

[1] https://github.com/alphagov/paas-rds-broker-boshrelease/pull/45
[2] https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/rds-broker-release/jobs/build-final-release/builds/16

## How to review

* deploy from this branch.
* check the usual tests pass.

(code review was done as part of https://github.com/alphagov/paas-rds-broker/pull/64)

## Who can review

Anyone but me or @chrisfarms 
