### PR TITLE
Bump the CAPI-release

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -14,12 +14,13 @@ releases:
     # https://www.cloudfoundry.org/cve-2017-8033/
     # https://www.cloudfoundry.org/cve-2017-8035/
     # https://www.cloudfoundry.org/cve-2017-8036/
+    # https://www.cloudfoundry.org/cve-2017-8037/
     # This can be reverted once we are using a cf-release version that ships with
-    # capi-release >=1.35.0
+    # capi-release >=1.38.0
   - name: capi
-    version: 1.35.0
-    url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.35.0
-    sha1: 253d0da57fcc20d4ef3b0b172656f1107e0099dc
+    version: 1.38.0
+    url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.38.0
+    sha1: 24811687a9690c3de21ec2920237be9a662cfd3b
   - name: diego
     version: 1.18.1
     url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=1.18.1


### PR DESCRIPTION
## What

As CVE-2017-8037 is pointing to the incomplete fix for the CAPI access
to CC VM contents, we need to upgrade out CF-release to version v270 or
the CAPI-release to version 1.38.0.

We went with the CAPI upgrade, as it seems to be a smaller change as
oppose to upgrading the whole platform at the time, which we leave for
the future work.

## How to review

- Code review
- Make sure the version used is the version that fixes the CVE.
- Run your pipeline from this branch - I did not do that, due to lack of dev environment running at present.
