### PR TITLE
[#150043715] Upgrade CAPI and backport CATS

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -14,12 +14,13 @@ releases:
     # https://www.cloudfoundry.org/cve-2017-8033/
     # https://www.cloudfoundry.org/cve-2017-8035/
     # https://www.cloudfoundry.org/cve-2017-8036/
+    # https://www.cloudfoundry.org/cve-2017-8037/
     # This can be reverted once we are using a cf-release version that ships with
-    # capi-release >=1.35.0
+    # capi-release >=1.38.0
   - name: capi
-    version: 1.35.0
-    url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.35.0
-    sha1: 253d0da57fcc20d4ef3b0b172656f1107e0099dc
+    version: 1.38.0
+    url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.38.0
+    sha1: 24811687a9690c3de21ec2920237be9a662cfd3b
   - name: diego
     version: 1.18.1
     url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=1.18.1

--- a/platform-tests/upstream/run_acceptance_tests.sh
+++ b/platform-tests/upstream/run_acceptance_tests.sh
@@ -8,7 +8,7 @@ if  [ "${DISABLE_CF_ACCEPTANCE_TESTS:-}" = "true" ]; then
 fi
 
 # FIXME: Remove this once we are deploying a version of cf-release
-# that includes capi-release >= 1.35.0.
+# that includes capi-release >= 1.38.0.
 (
   cd  "$(pwd)/cf-release/src/github.com/cloudfoundry/cf-acceptance-tests/"
   expected_commit_hash="4a6c59b27bf09aac222ffa02628d1fd47b3a708d"
@@ -20,7 +20,7 @@ fi
   fi
   git remote add alphagov https://github.com/alphagov/paas-cf-acceptance-tests.git
   git fetch alphagov
-  git checkout fix-v3-app-delete
+  git checkout bugfix/backport_for_capi_1.38.0
 )
 
 


### PR DESCRIPTION
## What

Upgrade CAPI in response to a CVE. Backport CATS to make the tests pass. See the commit messages for more detail.

## How to review

I've run the tests in my dev environment, so I think a code review would be sufficient:

- check that we're using the correct release
- check that I've backported the right things from CATS

## Who can review

Not @dcarley