### PR TITLE
[#149558193] Add a basic Elasticsearch plan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ upload-datadog-secrets: check-env ## Decrypt and upload Datadog credentials to S
 	@scripts/upload-datadog-secrets.sh
 
 .PHONY: upload-compose-secrets
-upload-compose-secrets: check-env ## Decrypt and upload Datadog credentials to S3
+upload-compose-secrets: check-env ## Decrypt and upload Compose credentials to S3
 	$(eval export COMPOSE_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
 	$(if ${AWS_ACCOUNT},,$(error Must set environment to dev/ci/staging/prod))
 	$(if ${COMPOSE_PASSWORD_STORE_DIR},,$(error Must pass COMPOSE_PASSWORD_STORE_DIR=<path_to_password_store>))

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1165,7 +1165,6 @@ jobs:
               DISABLE_USER_CREATION: {{disable_user_creation}}
               OAUTH_CLIENT_ID: {{oauth_client_id}}
               OAUTH_CLIENT_SECRET: {{oauth_client_secret}}
-              COMPOSE_ACCESS_TOKEN: {{compose_access_token}}
             run:
               path: sh
               args:
@@ -1603,7 +1602,7 @@ jobs:
               - name: config
               - name: bosh-CA
             params:
-              COMPOSE_ACCESS_TOKEN: {{compose_access_token}}
+              COMPOSE_API_KEY: {{compose_api_key}}
               DB_PREFIX: {{deploy_env}}
               CLUSTER_NAME: "gds-eu-west1-c00"
             run:
@@ -1627,7 +1626,7 @@ jobs:
                       'LOG_LEVEL' => 'DEBUG',
                       'USERNAME' => 'compose-broker',
                       'PASSWORD' => '${COMPOSE_BROKER_PASS}',
-                      'ACCESS_TOKEN' => '${COMPOSE_ACCESS_TOKEN}',
+                      'COMPOSE_API_KEY' => '${COMPOSE_API_KEY}',
                       'DB_PREFIX' => '${DB_PREFIX}',
                       'CLUSTER_NAME' => '${CLUSTER_NAME}',
                     }}

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -256,7 +256,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-compose-broker
-      tag_filter: v0.5.0
+      tag_filter: v0.8.0
 
 jobs:
   - name: pipeline-lock

--- a/concourse/scripts/lib/compose.sh
+++ b/concourse/scripts/lib/compose.sh
@@ -5,12 +5,12 @@ set -u
 get_compose_secrets() {
   # shellcheck disable=SC2154
   secrets_uri="s3://${state_bucket}/compose-secrets.yml"
-  export compose_access_token
+  export compose_api_key
   if aws s3 ls "${secrets_uri}" > /dev/null ; then
     secrets_file=$(mktemp -t compose-secrets.XXXXXX)
 
     aws s3 cp "${secrets_uri}" "${secrets_file}"
-    compose_access_token=$("${SCRIPT_DIR}"/val_from_yaml.rb compose_access_token "${secrets_file}")
+    compose_api_key=$("${SCRIPT_DIR}"/val_from_yaml.rb compose_api_key "${secrets_file}")
 
     rm -f "${secrets_file}"
   fi

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -88,7 +88,7 @@ prepare_environment() {
   fi
 
   # shellcheck disable=SC2154
-  if [ -z "${compose_access_token+x}" ] ; then
+  if [ -z "${compose_api_key+x}" ] ; then
     echo "Could not retrieve access token for compose. Did you do run \`make ${AWS_ACCOUNT} upload-compose-secrets\`?"
     exit 1
   fi
@@ -141,7 +141,7 @@ disable_custom_acceptance_tests: ${DISABLE_CUSTOM_ACCEPTANCE_TESTS:-}
 disable_pipeline_locking: ${DISABLE_PIPELINE_LOCKING:-}
 datadog_api_key: ${datadog_api_key:-}
 datadog_app_key: ${datadog_app_key:-}
-compose_access_token: ${compose_access_token:-}
+compose_api_key: ${compose_api_key:-}
 enable_datadog: ${ENABLE_DATADOG}
 enable_paas_dashboard: ${ENABLE_PAAS_DASHBOARD:-false}
 deploy_rubbernecker: ${DEPLOY_RUBBERNECKER:-false}

--- a/config/service-brokers/compose/catalog.json
+++ b/config/service-brokers/compose/catalog.json
@@ -3,7 +3,7 @@
     "id": "36f8bf47-c9e7-46d9-880f-5dfc838d05cb",
     "name": "mongodb",
     "bindable": true,
-    "description": "Compose MongoDB instance",
+    "description": "MongoDB instance",
     "requires": [],
     "tags": [
       "mongo",
@@ -12,7 +12,7 @@
     "metadata": {
       "displayName": "MongoDB",
       "imageUrl": "https://webassets.mongodb.com/_com_assets/cms/MongoDB-Logo-5c3a7405a85675366beb3a5ec4c032348c390b3f142f5e6dddf1d78e2df5cb5c.png",
-      "longDescription": "Compose MongoDB instance",
+      "longDescription": "MongoDB instance",
       "providerDisplayName": "GOV.UK PaaS",
       "documentationUrl": "https://compose.com/mongodb",
       "supportUrl": "https://www.cloud.service.gov.uk/support.html"
@@ -23,6 +23,34 @@
       "description": "1GB Storage / 102MB RAM.",
       "metadata": {
         "displayName": "Mongo Tiny",
+        "bullets": [],
+        "units": 1
+      }
+    }]
+  },{
+    "id": "6307bd82-2b6b-4e32-83c7-90d200334728",
+    "name": "elastic_search",
+    "bindable": true,
+    "description": "Elasticsearch instance",
+    "requires": [],
+    "tags": [
+    "elasticsearch",
+    "compose"
+    ],
+    "metadata": {
+      "displayName": "Elasticsearch",
+      "imageUrl": "https://static-www.elastic.co/assets/blt9a26f88bfbd20eb5/icon-elasticsearch-bb.svg",
+      "longDescription": "Elasticsearch instance",
+      "providerDisplayName": "GOV.UK PaaS",
+      "documentationUrl": "https://compose.com/databases/elasticsearch",
+      "supportUrl": "https://www.cloud.service.gov.uk/support.html"
+    },
+    "plans": [{
+      "id": "b0a58205-9cdb-4d6f-9d00-003be5ef1b73",
+      "name": "tiny",
+      "description": "2GB Storage / 2048MB RAM.",
+      "metadata": {
+        "displayName": "Elasticsearch Tiny",
         "bullets": [],
         "units": 1
       }

--- a/config/service-brokers/compose/catalog.json
+++ b/config/service-brokers/compose/catalog.json
@@ -28,7 +28,7 @@
       }
     }]
   },{
-    "id": "6307bd82-2b6b-4e32-83c7-90d200334728",
+    "id": "6e9202f2-c2e1-4de8-8d4a-a8c898fc2d8c",
     "name": "elastic_search",
     "bindable": true,
     "description": "Elasticsearch instance",
@@ -46,7 +46,7 @@
       "supportUrl": "https://www.cloud.service.gov.uk/support.html"
     },
     "plans": [{
-      "id": "b0a58205-9cdb-4d6f-9d00-003be5ef1b73",
+      "id": "6d051078-0913-403c-9763-1d03ecee50d9",
       "name": "tiny",
       "description": "2GB Storage / 2048MB RAM.",
       "metadata": {

--- a/scripts/upload-compose-secrets.sh
+++ b/scripts/upload-compose-secrets.sh
@@ -4,14 +4,15 @@ set -eu
 
 export PASSWORD_STORE_DIR=${COMPOSE_PASSWORD_STORE_DIR}
 
-COMPOSE_ACCESS_TOKEN=$(pass "compose/${AWS_ACCOUNT}/access_token")
+COMPOSE_API_KEY=$(pass "compose/${AWS_ACCOUNT}/access_token")
 
 SECRETS=$(mktemp secrets.yml.XXXXXX)
 trap 'rm  "${SECRETS}"' EXIT
 
 cat > "${SECRETS}" << EOF
 ---
-compose_access_token: ${COMPOSE_ACCESS_TOKEN}
+compose_api_key: ${COMPOSE_API_KEY}
+compose_access_token: ${COMPOSE_API_KEY}
 EOF
 
 aws s3 cp "${SECRETS}" "s3://gds-paas-${DEPLOY_ENV}-state/compose-secrets.yml"


### PR DESCRIPTION
## What

This is a minimal plan which can be used for the private beta testing phase. The word
'Compose' has been removed from the catalog because tenants don't need
to know what the underlying provider is (although they still have a
link to the Compose documentation if needed).

Merging this PR will add the catalogue and use the updated version of compose-broker.

## How to review

Code Review

## Who can review

Not @henrytk or me.
