### PR TITLE
Improve pingdom script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 **/*.tfstate
 bin/fly*
+bin/terraform*
 .idea/
 platform-tests/pkg
 platform-tests/src/results

--- a/terraform/scripts/set-up-pingdom.sh
+++ b/terraform/scripts/set-up-pingdom.sh
@@ -18,12 +18,18 @@ PAAS_CF_DIR=$(pwd)
 WORKING_DIR=$(mktemp -d terraform-pingdom.XXXXXX)
 trap 'rm -r "${PAAS_CF_DIR}/${WORKING_DIR}"' EXIT
 
-wget "https://github.com/alphagov/paas-terraform-provider-pingdom/releases/download/${VERSION}/${BINARY}" \
-  -O "${WORKING_DIR}"/terraform-provider-pingdom
-chmod +x "${WORKING_DIR}"/terraform-provider-pingdom
+if [ ! -d bin/ ]; then
+  mkdir bin/
+fi
+
+#wget can only check timestamp on a file in work dir
+cd bin/
+wget -N "https://github.com/alphagov/paas-terraform-provider-pingdom/releases/download/${VERSION}/${BINARY}" 
+cp ./"${BINARY}" "${PAAS_CF_DIR}"/"${WORKING_DIR}"/terraform-provider-pingdom
+chmod +x "${PAAS_CF_DIR}"/"${WORKING_DIR}"/terraform-provider-pingdom
 
 # Work in tmp dir to ensure there's no local state before we kick off terraform, it prioritises it
-cd "${WORKING_DIR}"
+cd "${PAAS_CF_DIR}"/"${WORKING_DIR}"
 
 # Configure Terraform remote state
 terraform remote config \


### PR DESCRIPTION
## What

This was crafted out of my frustration while testing https://github.com/alphagov/paas-cf/pull/993

Now we make sure we pin and require terraform version. The version was unpinned and newer terraform doesn’t have `remote` command. Also the state file doesn’t match pingdom plugin version and complains that it was created with newer terraform while trying to use 0.8.5

Also, we try to not download terraform plugin every time. This was supper annoying while working via VPN and trying to find out while this script fails as the download was very slow.

## How to review

Run `make ci pingdom ACTION=plan` and check if it works

## Who can review
Not me