### PR TITLE
[#149962332] Increase prod cells from 21 to 24

### DIFF
--- a/manifests/cf-manifest/env-specific/cf-prod.yml
+++ b/manifests/cf-manifest/env-specific/cf-prod.yml
@@ -1,6 +1,6 @@
 ---
 meta:
   cell:
-    instances: 21
+    instances: 24
   elasticsearch_master:
     disk_size: 768000


### PR DESCRIPTION
## What

Increase prod cells from 21 to 24

As suggested by:

    ➜  paas-cf git:(bugfix/149962332-increase_prod_cells) ✗ make prod show-cf-memory-usage
    …
    Memory reserved by orgs: 906240 MB (885 GB)
    Memory reserved by apps: 308836 MB (301.6 GB)

    Total cell memory required to meet ADR017: 679680 MB (663.8 GB)

cells use r4.xlarge which have 30G RAM, so this gives us:

    ➜  paas-cf git:(bugfix/149962332-increase_prod_cells) ✗ bc -q
    21 * 30
    630
    24 * 30
    720

We increase by three each time so that they are balance across 3 AZs.

## How to review

The code change doesn't apply to any environment except prod so you won't be able to test this in dev.

So instead, code review, make sure the numbers make sense, and that the syntax is correct.

## Who can review

Anyone.