### PR TITLE
[#146074923] Reduce output in API availability tests

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -776,6 +776,7 @@ jobs:
                 JOB_FILE="jobs/${PIPELINE_TRIGGER_VERSION}/api-availability-tests"
 
                 echo "Writing $JOB_FILE to S3 to signal job start"
+                export DEBIAN_FRONTEND=noninteractive
                 apt-get -qq update && apt-get install -y awscli > /dev/null
                 bucket={{state_bucket}}
                 echo 'started' > ./jobstate

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -776,7 +776,7 @@ jobs:
                 JOB_FILE="jobs/${PIPELINE_TRIGGER_VERSION}/api-availability-tests"
 
                 echo "Writing $JOB_FILE to S3 to signal job start"
-                apt-get update && apt-get install -y awscli
+                apt-get -qq update && apt-get install -y awscli > /dev/null
                 bucket={{state_bucket}}
                 echo 'started' > ./jobstate
                 aws s3 cp ./jobstate "s3://${bucket}/$JOB_FILE"

--- a/platform-tests/src/api/api_test.go
+++ b/platform-tests/src/api/api_test.go
@@ -16,7 +16,7 @@ const (
 )
 
 func lg(things ...interface{}) {
-	fmt.Fprintln(GinkgoWriter, things...)
+	fmt.Fprintln(os.Stdout, things...)
 }
 
 var _ = Describe("API Availability Monitoring", func() {

--- a/platform-tests/src/api/run_tests.sh
+++ b/platform-tests/src/api/run_tests.sh
@@ -2,5 +2,5 @@
 
 set -eu
 
-go test -timeout 12h -ginkgo.v
+go test -timeout 12h
 


### PR DESCRIPTION
## What

Reduce the amount of output in the API availability tests so that it's easier to see the report.

## How to review

1. Deploy the branch
1. Run the pipeline and look at the output of the `api-availability-tests` job
1. Code review

## Who can review

Anyone. @chrisfarms or @46bit have existing context.