### PR TITLE
[#149809192] Add "xlarge" quota

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -307,6 +307,11 @@ properties:
         total_services: 10
         non_basic_services_allowed: true
         total_routes: 1000
+      xlarge:
+        memory_limit: 204800
+        total_services: 10
+        non_basic_services_allowed: true
+        total_routes: 1000
       test_apps:
         memory_limit: 2048
         total_services: 10


### PR DESCRIPTION
## What

We need to add a larger plan so larger services don't need to create workarounds.

This adds an `xlarge` quota (200GB) which is double the previous `large` quota
(100GB).

## How to review

I have tested this in a dev env so code review may be enough for this change, or deploy to dev
and check that the `xlarge` quota is available in `cf quotas`

## Who can review

Not @chrisfarms or @henrytk 
