### PR TITLE
[#149558193] Upgrade compose-broker to v0.10.0 and update service catalog

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -256,7 +256,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-compose-broker
-      tag_filter: v0.8.0
+      tag_filter: v0.9.0
 
 jobs:
   - name: pipeline-lock

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -256,7 +256,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-compose-broker
-      tag_filter: v0.9.0
+      tag_filter: v0.10.0
 
 jobs:
   - name: pipeline-lock

--- a/config/service-brokers/compose/catalog.json
+++ b/config/service-brokers/compose/catalog.json
@@ -23,13 +23,16 @@
       "description": "1GB Storage / 102MB RAM.",
       "metadata": {
         "displayName": "Mongo Tiny",
-        "bullets": [],
-        "units": 1
+        "bullets": []
+      },
+      "compose": {
+        "units": 1,
+        "databaseType": "mongodb"
       }
     }]
   },{
     "id": "6e9202f2-c2e1-4de8-8d4a-a8c898fc2d8c",
-    "name": "elastic_search",
+    "name": "elasticsearch",
     "bindable": true,
     "description": "Elasticsearch instance",
     "requires": [],
@@ -51,8 +54,11 @@
       "description": "2GB Storage / 2048MB RAM.",
       "metadata": {
         "displayName": "Elasticsearch Tiny",
-        "bullets": [],
-        "units": 1
+        "bullets": []
+      },
+      "compose": {
+        "units": 1,
+        "databaseType": "elastic_search"
       }
     }]
   }]


### PR DESCRIPTION
## What

Upgrades compose-broker to v0.9.0

The catalog config has changed slightly in compose-broker v0.9.0 to
allow setting kind (databaseType) and scale (units) per service plan.

The public facing service name for Elasticsearch should be
'elasticsearch' not 'elastic_search'

## How to review

* [x] Ensure [paas-compose-broker PR](https://github.com/alphagov/paas-compose-broker/pull/13) is merged
* [ ] Ensure v0.9.0 is correct version
* [x] Ensure deploys ok
* [x] Ensure Elasticsearch service is available under the correct name "elasticsearch"

## Who can review

Not @chrisfarms no @henrytk 
