### PR TITLE
[#149400231] Upgrade from Cloud Foundry v264 to v269

### DIFF
--- a/concourse/tasks/create_admin.yml
+++ b/concourse/tasks/create_admin.yml
@@ -47,10 +47,24 @@ run:
       set +e
       add_member(){
         GID=$(uaac group get $1 -a id | awk '{print $2}')
-        uaac curl -k "/Groups/${GID}/members" -XPOST -H'Content-Type: application/json' \
-                  -d'{"origin":"uaa","type":"USER","value":"'${2}'"}' | tee result | grep -q '201 Created'
-        [ $? != 0 ] && cat result && exit 1
-        echo "Added $2 to $1"
+        result=$(
+          uaac curl \
+            -k "/Groups/${GID}/members" \
+            -XPOST \
+            -H 'Content-Type: application/json' \
+            -d '{"origin":"uaa","type":"USER","value":"'${2}'"}'
+        )
+        # Check that `uaac` output a 201 HTTP status code.
+        # N.B., It stopped printing `201 Created` during the upgrade to 
+        # CF v269, and now just prints the `201` code on its own line
+        # followed by a space.
+        if [ $? = 0 ] && echo "${result}" | grep '^201 $'; then
+          echo "${result}"
+          echo "Added $2 to $1"
+        else
+          echo "${result}"
+          exit 1
+        fi
       }
 
       add_member cloud_controller.admin "${USERID}"

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -30,9 +30,9 @@ releases:
     url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.9.0
     sha1: 77bfe8bdb2c3daec5b40f5116a6216badabd196c
   - name: cflinuxfs2
-    version: 1.145.0
-    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.145.0
-    sha1: 7d987fb36e3d303f1b88970a3532d0babd8555b1
+    version: 1.148.0
+    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.148.0
+    sha1: 65436c83d2ac05f7c1fc37e9073c8a665a63ef4c
   - name: paas-haproxy
     version: 0.1.3
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/paas-haproxy-0.1.3.tgz
@@ -53,7 +53,7 @@ releases:
 stemcells:
   - alias: default
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3421.18"
+    version: "3421.19"
 
 update:
   canaries: 0

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -6,9 +6,9 @@ director_uuid: ~
 
 releases:
   - name: cf
-    version: "264"
-    url: https://bosh.io/d/github.com/cloudfoundry/cf-release?v=264
-    sha1: 37f93b7064a15d5fdc942e0dcaf4bb9f002dc8d6
+    version: "269"
+    url: https://bosh.io/d/github.com/cloudfoundry/cf-release?v=269
+    sha1: 3f7f0e600e2711315df2cb57a3e4edad52f2f713
 
     # FIXME: capi-release has been split from cf-release due to these CVEs:
     # https://www.cloudfoundry.org/cve-2017-8033/
@@ -22,21 +22,17 @@ releases:
     url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.38.0
     sha1: 24811687a9690c3de21ec2920237be9a662cfd3b
   - name: diego
-    version: 1.18.1
-    url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=1.18.1
-    sha1: 6c862da40ca7418a7defa47005de3d52e7a66948
+    version: 1.23.2
+    url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=1.23.2
+    sha1: 9ba94ee14cb0660e233001ca3ddaea12be638744
   - name: garden-runc
-    version: 1.8.0
-    url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.8.0
-    sha1: 0c112d0bdcb52e61db7251e99b2a116982201c99
+    version: 1.9.0
+    url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.9.0
+    sha1: 77bfe8bdb2c3daec5b40f5116a6216badabd196c
   - name: cflinuxfs2
     version: 1.145.0
     url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.145.0
     sha1: 7d987fb36e3d303f1b88970a3532d0babd8555b1
-  - name: nodejs-buildpack
-    version: 1.6.2
-    url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.6.2
-    sha1: aca4bdea51e8a10a410312db629b7ba3f0a15b7e
   - name: paas-haproxy
     version: 0.1.3
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/paas-haproxy-0.1.3.tgz

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -304,6 +304,7 @@ jobs:
     networks:
       - name: cf
     properties:
+      max_in_flight: 1
       consul:
         agent:
           services: (( grab meta.api_consul_services ))
@@ -320,6 +321,8 @@ jobs:
     stemcell: default
     networks:
       - name: cf
+    properties:
+      max_in_flight: 1
 
   - name: doppler
     azs: [z1, z2, z3]

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -113,8 +113,6 @@ meta:
   - name: nats
     consumes: {nats: nil}
     release: (( grab meta.release.name ))
-  - name: nats_stream_forwarder
-    release: (( grab meta.release.name ))
   - name: datadog-nats
     release: datadog-for-cloudfoundry
   - name: metron_agent

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -26,7 +26,7 @@ meta:
   - name: binary-buildpack
     release: (( grab meta.release.name ))
   - name: nodejs-buildpack
-    release: nodejs-buildpack
+    release: (( grab meta.release.name ))
   - name: ruby-buildpack
     release: (( grab meta.release.name ))
   - name: php-buildpack

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -141,8 +141,6 @@ properties:
   metron_agent:
     deployment: (( grab meta.environment ))
     dropsonde_incoming_port: (( grab properties.loggregator.dropsonde_incoming_port ))
-    # Remove this after logregator v90.1 upgrade
-    health_port: 14824
 
   metron_endpoint:
     shared_secret: (( grab properties.loggregator_endpoint.shared_secret ))

--- a/platform-tests/upstream/run_acceptance_tests.sh
+++ b/platform-tests/upstream/run_acceptance_tests.sh
@@ -7,23 +7,6 @@ if  [ "${DISABLE_CF_ACCEPTANCE_TESTS:-}" = "true" ]; then
   exit 0
 fi
 
-# FIXME: Remove this once we are deploying a version of cf-release
-# that includes capi-release >= 1.38.0.
-(
-  cd  "$(pwd)/cf-release/src/github.com/cloudfoundry/cf-acceptance-tests/"
-  expected_commit_hash="4a6c59b27bf09aac222ffa02628d1fd47b3a708d"
-  current_commit_hash="$(git log --pretty=format:'%H' -n 1)"
-  if [ "${expected_commit_hash}" != "${current_commit_hash}" ]; then
-    echo "ERROR: Current commit for cf-acceptance-test is different than expected one: ${expected_commit_hash} != ${current_commit_hash}"
-    echo "Double check if we still need to pull our branch"
-    exit 1
-  fi
-  git remote add alphagov https://github.com/alphagov/paas-cf-acceptance-tests.git
-  git fetch alphagov
-  git checkout bugfix/backport_for_capi_1.38.0
-)
-
-
 SLEEPTIME=90
 NODES=5
 SKIP_REGEX='routing.API|allows\spreviously-blocked\sip|Adding\sa\swildcard\sroute\sto\sa\sdomain|forwards\sapp\smessages\sto\sregistered\ssyslog\sdrains|when\sapp\shas\smultiple\sports\smapped'

--- a/terraform/datadog/nats.tf
+++ b/terraform/datadog/nats.tf
@@ -17,25 +17,6 @@ resource "datadog_monitor" "nats_process_running" {
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:nats"]
 }
 
-resource "datadog_monitor" "nats_stream_forwarded_process_running" {
-  name                = "${format("%s NATS stream forwarder process running", var.env)}"
-  type                = "service check"
-  message             = "NATS stream forwarder process not running. Check nats state."
-  escalation_message  = "NATS stream forwarder process still not running. Check NATS state."
-  notify_no_data      = false
-  require_full_window = true
-
-  query = "${format("'process.up'.over('deploy_env:%s','process:nats_stream_forwarder').last(4).count_by_status()", var.env)}"
-
-  thresholds {
-    ok       = 1
-    warning  = 2
-    critical = 3
-  }
-
-  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:nats"]
-}
-
 resource "datadog_monitor" "nats_service_open" {
   name                = "${format("%s NATS service is accepting connections", var.env)}"
   type                = "service check"


### PR DESCRIPTION
## What

This PR upgrades our release to CF v269 from CF v264. Due to recent CVEs being addressed through individual component upgrades the overall upgrade is quite small. The NodeJS-buildpack has been unpinned as the current release version is ahead of our pinned version.

Additionally due to the creation of the API Availability Tests within the pipeline we have been able to monitor the downtime during both releases and upgrades. During this upgrade story we discovered the `max_in_flight` property that controls the number of individual components restarted at any one time. By setting this property to `1` we have been able to reduce the API downtime significantly.

## How to review

Deploy from this branch on top of current Master brach in your dev environment.
Expect a small number of API Availability Test response failures to be generated during the deploy. These will not prevent the pipeline from progressing.

## Who can review

Not @46bit @LeePorte.