### PR TITLE
Increase smoke test timeout

### DIFF
--- a/platform-tests/upstream/run_smoke_tests.sh
+++ b/platform-tests/upstream/run_smoke_tests.sh
@@ -2,6 +2,22 @@
 
 set -eu
 
+# FIXME: Remove this once we have resolved the performance issues resulting
+# in the SMOKE_TESTS org taking longer than 30 seconds to delete.
+(
+  cd  "$(pwd)/cf-release/src/smoke-tests/"
+  expected_commit_hash="03093de70a9f63f44e0cde15adcccc1281c8da42"
+  current_commit_hash="$(git log --pretty=format:'%H' -n 1)"
+  if [ "${expected_commit_hash}" != "${current_commit_hash}" ]; then
+    echo "ERROR: Current commit for smoke-tests is different than expected one: ${expected_commit_hash} != ${current_commit_hash}"
+    echo "Double check if we still need to pull our branch"
+    exit 1
+  fi
+  git remote add alphagov https://github.com/alphagov/paas-cf-smoke-tests.git
+  git fetch alphagov
+  git checkout increase-timeout
+)
+
 export CONFIG
 CONFIG="$(pwd)/test-config/config.json"
 


### PR DESCRIPTION
## What

No associated Pivotal story

We are having performance issues with certain CF API operations, such
as deleting orgs during the smoke tests. This means it is taking over
the timeout of 30 seconds and therefore causing continuous smoke test
failures.

We will patch the tests temporarily until the performance issue is investigated.

## How to review

This has not been tested yet. It is unlikely you will experience the same performance issues as production, so I recommend:
* deploying from this branch
* hijacking the smoke tests container while they are running
* verifying the imported cf-release contains a smoke test module with this patch: https://github.com/cloudfoundry/cf-smoke-tests/compare/master...alphagov:increase-timeout
* doing a code review on https://github.com/cloudfoundry/cf-smoke-tests/compare/master...alphagov:increase-timeout to make sure it really does increase the timeout.

## Who can review

Anyone but me.
