### PR TITLE
Revert "Increase smoke test timeout"

### DIFF
--- a/platform-tests/upstream/run_smoke_tests.sh
+++ b/platform-tests/upstream/run_smoke_tests.sh
@@ -2,22 +2,6 @@
 
 set -eu
 
-# FIXME: Remove this once we have resolved the performance issues resulting
-# in the SMOKE_TESTS org taking longer than 30 seconds to delete.
-(
-  cd  "$(pwd)/cf-release/src/smoke-tests/"
-  expected_commit_hash="03093de70a9f63f44e0cde15adcccc1281c8da42"
-  current_commit_hash="$(git log --pretty=format:'%H' -n 1)"
-  if [ "${expected_commit_hash}" != "${current_commit_hash}" ]; then
-    echo "ERROR: Current commit for smoke-tests is different than expected one: ${expected_commit_hash} != ${current_commit_hash}"
-    echo "Double check if we still need to pull our branch"
-    exit 1
-  fi
-  git remote add alphagov https://github.com/alphagov/paas-cf-smoke-tests.git
-  git fetch alphagov
-  git checkout increase-timeout
-)
-
 export CONFIG
 CONFIG="$(pwd)/test-config/config.json"
 


### PR DESCRIPTION
## What

No associated Pivotal story.

This reverts commit 93a24f38af8fe5beec52bf0c5249e51a91429ad6.

We now know the smoke test failures were due to degraded API performance
caused by the CDN broker taking a long time to process the last operation
requests. This timeout should be restored so we can detect similar performance
degradations in future.

## How to review

In my opinion deployment of this is unnecessary and a code review alone is sufficient.

## Who can review

Anyone but me.