### PR TITLE
[#148289089] Fix healthcheck-db destroy.

### DIFF
--- a/concourse/tasks/remove-healthcheck-db.yml
+++ b/concourse/tasks/remove-healthcheck-db.yml
@@ -25,11 +25,7 @@ run:
         echo "Login failed.  Skipping..."
         exit 0
       fi
-      if ! cf org testers > /dev/null; then
-        echo "Org 'testers' not found. Skipping..."
-        exit 0
-      fi
-      cf target -o testers -s healthcheck
+      cf target -o admin -s healthchecks
       cf delete healthcheck -f -r
       if cf services | grep -q healthcheck-db; then
         cf delete-service healthcheck-db -f


### PR DESCRIPTION
## What

This was missed when we moved the healthcheck app into a different
org(#991). This therefore updates this task to look in the correct
org/space for the app.

I've removed the test for the org existing because the admin org always
exists.

## How to review

Code review is probably enough. Alternatively, you could run the destroy pipeline, and verify that the `remove-healthcheck-db` task runs, and deletes the healthcheck app. (The DB isn't enabled in dev by default).

## Who can review

Not me.