### PR TITLE
Adjust the box position

### DIFF
--- a/tools/paas_dashboard/dashboards/paas-overview.erb
+++ b/tools/paas_dashboard/dashboards/paas-overview.erb
@@ -7,12 +7,12 @@ $(function() {
 </script>
 <div class="gridster">
   <ul>
-    <li data-row="2" data-col="1" data-sizex="1" data-sizey="1">
+    <li data-row="1" data-col="1" data-sizex="1" data-sizey="1">
       <a href="https://app.datadoghq.com/monitors#triggered?query=service:staging_monitors" target="_blank">
         <div data-title="Staging" data-id="staging_counts" data-view="Health"></div>
       </a>
     </li>
-    <li data-row="3" data-col="1" data-sizex="1" data-sizey="1">
+    <li data-row="2" data-col="1" data-sizex="1" data-sizey="1">
       <a href="https://app.datadoghq.com/monitors#triggered?query=service:prod_monitors" target="_blank">
         <div data-title="Prod" data-id="prod_counts" data-view="Health"></div>
       </a>


### PR DESCRIPTION
## What

We've previously removed the CI box without adjusting the existing boxes
to fill the screen.

At the moment, JavaScript is pushing the production box into third half
of the screen. Decreasing the number on these will essentially mean
they'll fit in a single view.

## How to review

- Run the dashboard locally - or wait until it reaches production to see the changes :trollface: 
