### PR TITLE
[#147668907] Upgrade stemcells to mitigate USN-3392-2

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -53,7 +53,7 @@ releases:
 stemcells:
   - alias: default
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3421.19"
+    version: "3421.20"
 
 update:
   canaries: 0


### PR DESCRIPTION
## What

This commit applies the mitigation to USN3392-2 by upgrading the
stemcells in use from 3421.19 to 3421.20

## How to review

Deploy this branch on top of a dev master.

Some small API downtime may be recorded in the API availability tests.

## Who can review

Anyone but @LeePorte
