### PR TITLE
[#145189815] Removed instructions for connecting to BOSH and Concourse

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,41 +199,6 @@ updating pipelines, or you'll get strange terraform errors during cf-terraform.
 ENABLE_DATADOG=true make dev pipelines
 ```
 
-## Using the bosh cli and `bosh ssh`
-
-There's a Makefile target that starts an interactive session on the deployer concourse
-to allow running bosh CLI commands targeting MicroBOSH:
-
-```
-make dev bosh-cli
-```
-
-You can use any environment supported by Makefile.
-
-This connects you to a one-off task in concourse that's already logged into
-bosh and has the deployment set using the CF manifest.
-
-**Note:** `bosh ssh` no longer asks for a sudo password. By default it sets
-this to blank (just press enter when asked for the sudo password within the VM)
-
-## SSH to Deployer Concourse and MicroBOSH
-
-In the `create-deployer` pipeline when creating the initial VPC,
-a keypair is generated and uploaded to AWS to be used by deployed instances.
-`bosh-init` needs this key to be able to create a SSH tunnel to
-forward some ports to the agent of the new VM.
-
-Both public and private keys are also uploaded to S3 to be consumed by
-other jobs in the pipelines as resources and/or by us for troubleshooting.
-
-To ssh to the *Deployer Concourse*, use makefile target ssh_concourse, e.g.
-`make dev ssh_concourse`. This will retrieve required keys and print a sudo
-password before ssh-ing to the concourse VM.
-
-To ssh to the *BOSH*, use makefile target ssh_bosh, e.g.
-`make dev ssh_bosh`. This will retrieve required keys and print a sudo password for
-bosh server before opening the ssh session.
-
 ## Concourse credentials
 
 By default, the environment setup script retrieves the admin user password set

--- a/scripts/bosh_cli_tunnel.sh
+++ b/scripts/bosh_cli_tunnel.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -eu
+
+trap 'make dev stop-tunnel; rm -f /tmp/manifest.yml' EXIT
+
+echo "Making SSH tunnel to Bosh..."
+make dev tunnel TUNNEL=25555:10.0.0.6:25555
+
+echo
+echo "Logging into and targeting Bosh..."
+BOSH_PASSWORD=$(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh-secrets.yml" - | awk '/bosh_admin_password/ {print $2}')
+bosh login admin "$BOSH_PASSWORD"
+bosh target localhost
+
+echo
+echo "Downloading CloudFoundry manifest..."
+aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/cf-manifest.yml" /tmp/manifest.yml
+bosh deployment /tmp/manifest.yml
+
+echo
+echo "You are now in a local shell"
+echo "The bosh CLI is logged into the remote BOSH"
+echo "Run bosh commands such as: bosh vms"
+bash

--- a/scripts/ssh_bosh_expose_vm.sh
+++ b/scripts/ssh_bosh_expose_vm.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+BOSH_KEY=/tmp/bosh_id_rsa.$RANDOM
+trap 'rm -f ${BOSH_KEY}' EXIT
+aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh_id_rsa" ${BOSH_KEY} && chmod 400 ${BOSH_KEY}
+
+BOSH_IP=$(aws ec2 describe-instances \
+              --filters 'Name=tag:Name,Values=*' "Name=key-name,Values=${DEPLOY_ENV}_bosh_ssh_key_pair" \
+              --query 'Reservations[].Instances[].PublicIpAddress' --output text)
+echo
+aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh-secrets.yml" - | \
+  ruby -ryaml -e 'puts "Sudo password is " + YAML.load(STDIN)["secrets"]["bosh_vcap_password_orig"]'
+echo
+
+SSH_OPTIONS='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=60'
+# shellcheck disable=SC2086
+ssh ${SSH_OPTIONS} -i "${BOSH_KEY}" vcap@"${BOSH_IP}"

--- a/scripts/ssh_bosh_temporary_gateway.sh
+++ b/scripts/ssh_bosh_temporary_gateway.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [ -z "${VM_IP:-}" ]; then
+  echo "Error: IPv4 address of the gateway VM must be provided as VM_IP env variable."
+  exit 1
+fi
+
+BOSH_KEY=/tmp/bosh_id_rsa.$RANDOM
+DEPLOY_KEY=/tmp/deploy_id_rsa.$RANDOM
+trap 'rm -f ${BOSH_KEY} ${DEPLOY_KEY}' EXIT
+aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh_id_rsa" ${BOSH_KEY} && chmod 400 ${BOSH_KEY}
+aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/id_rsa" ${DEPLOY_KEY} && chmod 400 ${DEPLOY_KEY}
+
+BOSH_IP=10.0.0.6
+echo
+aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh-secrets.yml" - | \
+  ruby -ryaml -e 'puts "Sudo password is " + YAML.load(STDIN)["secrets"]["bosh_vcap_password_orig"]'
+echo
+
+SSH_OPTIONS='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=60'
+PROXY_COMMAND="ssh ${SSH_OPTIONS} -i ${DEPLOY_KEY} ec2-user@${VM_IP} -W ${BOSH_IP}:22"
+# shellcheck disable=SC2086
+ssh ${SSH_OPTIONS} -o ProxyCommand="${PROXY_COMMAND}" -i "${BOSH_KEY}" vcap@"${BOSH_IP}"


### PR DESCRIPTION
## What

We're expanding the documentation on connecting to BOSH, to handle situations where we can't use `make bosh-cli`. The `paas-cf` README has become quite large, so we're putting this as a guide in the team manual: https://github.com/alphagov/paas-team-manual/pull/137.

## How to review

* Wait until https://github.com/alphagov/paas-team-manual/pull/137 is merged and live.
* Consider if we should add a notice of where to find this information.

## Who can review

Not @46bit @henrytk @timmow
