### PR TITLE
Order create-cloudfoundry pipeline first in concourse.

### DIFF
--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -185,6 +185,8 @@ update_pipeline() {
   case $pipeline_name in
     create-cloudfoundry)
       upload_pipeline
+      "${SCRIPT_DIR}/set_pipeline_ordering.rb" "${pipeline_name}"
+      echo "ordered '${pipeline_name}' pipeline first"
     ;;
     deployment-kick-off)
       if [ "${ENABLE_MORNING_DEPLOYMENT:-}" = "true" ]; then

--- a/concourse/scripts/set_pipeline_ordering.rb
+++ b/concourse/scripts/set_pipeline_ordering.rb
@@ -1,0 +1,46 @@
+#!/usr/bin/env ruby
+
+require 'net/http'
+require 'yaml'
+require 'json'
+
+if ARGV.length != 1
+  abort <<-EOT
+Usage:
+
+   #{$0} <pipeline_order>
+
+Being:
+
+   pipeline_order comma-separated list of pipeline names
+
+  EOT
+end
+pipelines = ARGV[0].split(",")
+
+if ENV["FLY_TARGET"].nil? || ENV["FLY_TARGET"].empty?
+  abort "FLY_TARGET not set"
+end
+flyrc = YAML.load_file("#{ENV['HOME']}/.flyrc")
+if flyrc.fetch("targets")[ENV['FLY_TARGET']].nil?
+  abort "Target '#{ENV['FLY_TARGET']}' not found in .flyrc. Use the fly command to set this target up before using this script"
+end
+concourse_url = flyrc.fetch("targets").fetch(ENV['FLY_TARGET']).fetch('api')
+bearer_token = flyrc.fetch("targets").fetch(ENV['FLY_TARGET']).fetch('token').fetch('value')
+
+uri = URI.parse("#{concourse_url}/api/v1/teams/main/pipelines/ordering")
+req = Net::HTTP::Put.new(uri.request_uri)
+
+req["Authorization"] = "Bearer #{bearer_token}"
+
+req.content_type = "application/json"
+req.body = JSON.dump(pipelines)
+
+resp = nil
+Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+  resp = http.request(req)
+end
+
+unless resp.code.to_i == 200
+  abort "Non-200 response '#{resp.code}' from concourse\n#{resp.body}"
+end

--- a/concourse/scripts/set_pipeline_ordering_test.go
+++ b/concourse/scripts/set_pipeline_ordering_test.go
@@ -1,0 +1,179 @@
+package scripts_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+	"github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("set_pipeline_ordering", func() {
+	const (
+		flyrcTarget = `unit-test`
+		bearerToken = `2d5ebf5efbac7997025e9364f0319304ce89480724077d5f7103c234460e8d0de928f884553686aa30afc9629278b9595059d0e0be41ff5ffc5cf3a04f67e57f`
+	)
+
+	var (
+		concourse *ghttp.Server
+		tmpHome   string
+	)
+
+	BeforeEach(func() {
+		var err error
+		concourse = ghttp.NewServer()
+		tmpHome, err = ioutil.TempDir("", "tmphome")
+		Expect(err).NotTo(HaveOccurred())
+	})
+	AfterEach(func() {
+		concourse.Close()
+		os.RemoveAll(tmpHome)
+	})
+
+	It("makes the request to concourse", func() {
+		concourse.AppendHandlers(ghttp.CombineHandlers(
+			ghttp.VerifyRequest("PUT", "/api/v1/teams/main/pipelines/ordering"),
+			ghttp.VerifyHeaderKV("Authorization", "Bearer "+bearerToken),
+			ghttp.VerifyJSON(`["pipeline-one","pipeline-two"]`),
+			ghttp.RespondWith(200, ""),
+		))
+
+		populateFlyrc(tmpHome, flyrcTarget, concourse.URL(), bearerToken)
+
+		cmd := exec.Command("./set_pipeline_ordering.rb", "pipeline-one,pipeline-two")
+		cmd.Env = mergeEnvLists(
+			[]string{"HOME=" + tmpHome, "FLY_TARGET=" + flyrcTarget},
+			os.Environ(),
+		)
+		session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(session, 1).Should(gexec.Exit(0))
+
+		Expect(concourse.ReceivedRequests()).To(HaveLen(1))
+	})
+
+	It("errors if no pipelines given on cmdline", func() {
+		cmd := exec.Command("./set_pipeline_ordering.rb")
+		cmd.Env = mergeEnvLists(
+			[]string{"HOME=" + tmpHome, "FLY_TARGET=" + flyrcTarget},
+			os.Environ(),
+		)
+		session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(session, 1).Should(gexec.Exit(1))
+		Expect(session.Err).To(gbytes.Say("Usage:"))
+
+		Expect(concourse.ReceivedRequests()).To(HaveLen(0))
+	})
+
+	It("errors if FLY_TARGET isn't set", func() {
+		cmd := exec.Command("./set_pipeline_ordering.rb", "pipeline-one,pipeline-two")
+		cmd.Env = mergeEnvLists(
+			[]string{"HOME=" + tmpHome},
+			os.Environ(),
+		)
+		session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(session, 1).Should(gexec.Exit(1))
+
+		Expect(concourse.ReceivedRequests()).To(HaveLen(0))
+
+		cmd = exec.Command("./set_pipeline_ordering.rb", "pipeline-one,pipeline-two")
+		cmd.Env = mergeEnvLists(
+			[]string{"HOME=" + tmpHome, "FLY_TARGET="},
+			os.Environ(),
+		)
+		session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(session, 1).Should(gexec.Exit(1))
+
+		Expect(concourse.ReceivedRequests()).To(HaveLen(0))
+	})
+
+	It("errors if FLY_TARGET doesn't exist in flyrc", func() {
+		populateFlyrc(tmpHome, flyrcTarget, concourse.URL(), bearerToken)
+
+		cmd := exec.Command("./set_pipeline_ordering.rb", "pipeline-one,pipeline-two")
+		cmd.Env = mergeEnvLists(
+			[]string{"HOME=" + tmpHome, "FLY_TARGET=different-target"},
+			os.Environ(),
+		)
+		session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(session, 1).Should(gexec.Exit(1))
+		Expect(session.Err).To(gbytes.Say("Target 'different-target' not found in .flyrc"))
+
+		Expect(concourse.ReceivedRequests()).To(HaveLen(0))
+	})
+
+	It("errors if concourse returns non-200 response", func() {
+		concourse.AppendHandlers(ghttp.RespondWith(401, "unauthorized"))
+
+		populateFlyrc(tmpHome, flyrcTarget, concourse.URL(), bearerToken)
+
+		cmd := exec.Command("./set_pipeline_ordering.rb", "pipeline-one,pipeline-two")
+		cmd.Env = mergeEnvLists(
+			[]string{"HOME=" + tmpHome, "FLY_TARGET=" + flyrcTarget},
+			os.Environ(),
+		)
+		session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(session, 1).Should(gexec.Exit(1))
+		Expect(session.Err).To(gbytes.Say("Non-200 response '401'"))
+
+		Expect(concourse.ReceivedRequests()).To(HaveLen(1))
+	})
+})
+
+// MergeEnvLists merges the two environment lists such that
+// variables with the same name in "in" replace those in "out".
+// This always returns a newly allocated slice.
+//
+// Lifted from src/cmd/go/internal/base/env.go in the go source tree.
+//
+// FIXME: When we upgrade to Go 1.9, this can be removed and replaced with a
+// simple `cmd.Env := append(os.Environ(), "FOO=bar")` because Go 1.9 de-dups
+// the list (https://golang.org/doc/go1.9#os/exec).
+func mergeEnvLists(in, out []string) []string {
+	out = append([]string(nil), out...)
+NextVar:
+	for _, inkv := range in {
+		k := strings.SplitAfterN(inkv, "=", 2)[0]
+		for i, outkv := range out {
+			if strings.HasPrefix(outkv, k) {
+				out[i] = inkv
+				continue NextVar
+			}
+		}
+		out = append(out, inkv)
+	}
+	return out
+}
+
+func populateFlyrc(homedir, target, url, token string) {
+	filePath := homedir + "/.flyrc"
+	file, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0755)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	_, err = fmt.Fprintf(
+		file,
+		"targets:\n"+
+			"  %s:\n"+
+			"    api: %s\n"+
+			"    team: main\n"+
+			"    token:\n"+
+			"      type: Bearer\n"+
+			"      value: %s\n",
+		target,
+		url,
+		token,
+	)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	err = file.Close()
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+}


### PR DESCRIPTION
## What

This makes it the default pipeline displayed when you go to the
concourse URL.

The fly command doesn't presently have a command to do this, so this
includes a ruby script to interact with the API using credentials read
from the `.flyrc` file. I've opened https://github.com/concourse/concourse/issues/1561
to request that a command be added to fly.

This is something that's been an irritation since https://www.pivotaltracker.com/story/show/137364635 was played to include
 the `create-bosh-concourse` pipeline. This one was ordered first because it's
the first pipeline pushed to the Concourse.

## How to review

Run the pipeline from this branch and verify that the `self-update-pipelines` step changes the ordering of the pipelines so that the `create-cloudfoundry` pipeline is first.

## Who can review

Not me.