### PR TITLE
[#150512301] Fix bug in compose-broker manifest generation

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1632,7 +1632,7 @@ jobs:
                     }
                     manifest = YAML.load_file('manifest.yml')
                     manifest['applications'].each { |app|
-                      app['env'] ||= app['env']
+                      app['env'] ||= {}
                       app['env'].merge!(env)
                     }
                     File.write('manifest.yml', manifest.to_yaml)


### PR DESCRIPTION
## What

Fixes a small bug/typo in the merging of the compose broker manifest
with the generated environment. It would cause deployment to fail if the
broker's manifest file was altered to not contain any env variables of
it's own.

## How to review

It's a minor change, I suspect code review to be enough

## Who can review

Not @chrisfarms
