### PR TITLE
[#150847112] Handle errors in MultiMetricReader

### DIFF
--- a/tools/metrics/metrics.go
+++ b/tools/metrics/metrics.go
@@ -116,7 +116,13 @@ func NewMultiMetricReader(rs ...MetricReader) MetricReadCloser {
 		}
 	}()
 	for _, r := range rs {
-		go CopyMetrics(buf, r)
+		go func(r MetricReader) {
+			for {
+				if err := CopyMetrics(buf, r); err != nil {
+					buf.events <- event{err: err}
+				}
+			}
+		}(r)
 	}
 	return buf
 }

--- a/tools/metrics/metrics_test.go
+++ b/tools/metrics/metrics_test.go
@@ -225,7 +225,7 @@ func TestMultiMetricReader(t *testing.T) {
 	t.Run("closing", func(t *testing.T) {
 		multi.Close()
 		if _, err := multi.ReadMetric(); err != EOS {
-			t.Fatal("expected MultReader to be closed")
+			t.Fatal("expected MultiReader to be closed")
 		}
 		for i := 0; i < len(buffers); i++ {
 			if _, err := buffers[i].ReadMetric(); err != EOS {

--- a/tools/metrics/metrics_test.go
+++ b/tools/metrics/metrics_test.go
@@ -183,7 +183,7 @@ func TestMultiMetricReader(t *testing.T) {
 	}
 
 	out := map[string]bool{}
-	for i := 0; i < 3; i++ {
+	for i := 0; i < len(buffers); i++ {
 		m, err := multi.ReadMetric()
 		if err != nil {
 			t.Fatal(err)
@@ -192,10 +192,10 @@ func TestMultiMetricReader(t *testing.T) {
 	}
 
 	t.Run("reading", func(t *testing.T) {
-		if len(out) != 3 {
-			t.Fatalf("expected to read 3 metrics out from the MultiReader got: %v", len(out))
+		if len(out) != len(buffers) {
+			t.Fatalf("expected to read %d metrics out from the MultiReader got: %v", len(buffers), len(out))
 		}
-		for i := 0; i < 3; i++ {
+		for i := 0; i < len(buffers); i++ {
 			name := fmt.Sprintf("test.multi.buf%d", i)
 			t.Run(name, func(t *testing.T) {
 				if !out[name] {


### PR DESCRIPTION
## What

Previously the error would be lost and the reader would halt if one of the
readers in a MultiMetricReader returned an error. We think this is the cause
of `ops.users.count` not being reported occasionally.

Handle this by sending the error to the buffer (which will be surfaced by
`ReadMetric()`) and restarting `CopyMetrics()` in a loop. We test this by
sending an error to one of the readers before sending the real metrics,
checking that we get our synthetic error, and then checking that we get all
of the metrics as before.

We had to change the type of `buffers` in order to have access to the
unexported `events` field. This means that we no longer need to do a type
assertion for `WriteMetrics()`. A new slice, of the interface type
`MetricReader`, then had to be made for `NewMultiMetricReader()`. Errors are
collected as a slice to check that we only get one and of the right content.

## How to review

1. Code review
1. Check that the unit tests pass in Travis

We're reasonably confident that this will fix the problem with the `ops.users.count` metric being reported. Especially as we've seen it reported correctly for a short time after the metric app is restarted. However we haven't tested it end-to-end because of the time it takes to setup DataDog. I suggest we merge this if we're happy with the code, wait for it to deploy in prod, and then observe.

## Who can review

Not @dcarley or @LeePorte 