### PR TITLE
[#150512756] IPv4 Keyservers

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -20,6 +20,7 @@ resources:
       branch: master
       tag_filter: {{paas_cf_tag_filter}}
       commit_verification_key_ids: {{gpg_ids}}
+      gpg_keyserver: hkp://ipv4.pool.sks-keyservers.net/
 
   - name: cf-secrets
     type: s3-iam

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -86,6 +86,7 @@ resources:
       branch: {{branch_name}}
       tag_filter: {{paas_cf_tag_filter}}
       commit_verification_key_ids: {{gpg_ids}}
+      gpg_keyserver: hkp://ipv4.pool.sks-keyservers.net/
 
   - name: graphite-nozzle
     type: git

--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -7,6 +7,7 @@ resources:
       branch: {{branch_name}}
       tag_filter: {{paas_cf_tag_filter}}
       commit_verification_key_ids: {{gpg_ids}}
+      gpg_keyserver: hkp://ipv4.pool.sks-keyservers.net/
 
   - name: deployment-timer
     type: time

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -20,6 +20,7 @@ resources:
       branch: {{branch_name}}
       tag_filter: {{paas_cf_tag_filter}}
       commit_verification_key_ids: {{gpg_ids}}
+      gpg_keyserver: hkp://ipv4.pool.sks-keyservers.net/
 
   - name: cf-tfstate
     type: s3-iam

--- a/concourse/pipelines/failure-testing.yml
+++ b/concourse/pipelines/failure-testing.yml
@@ -20,6 +20,7 @@ resources:
       branch: {{branch_name}}
       tag_filter: {{paas_cf_tag_filter}}
       commit_verification_key_ids: {{gpg_ids}}
+      gpg_keyserver: hkp://ipv4.pool.sks-keyservers.net/
 
   - name: pipeline-trigger
     type: semver-iam


### PR DESCRIPTION
## What

Use IPv4-only GPG keyserver pool.

We're experiencing an intermittent problem since we've upgraded
Concourse and garden-runc where gpg will intermittently return an error:
```
gpg: keyserver receive failed: Address family not supported by protocol
```
Switching to an IPv4-only pool works around this, and will unblock the
pipeline while we investigate further.

## How to review

* Push the pipelines using this branch: `BRANCH=ipv4_keyservers make dev pipelines`
* Run the pipeline
* Verify the git fetch in the first job succeeds.

🚨  Remove the `[TMP]` commit before merging.

## Who can review

Not me.