### PR TITLE
[#150512756] Revert "Use IPv4-only keyserver pool."

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -20,7 +20,6 @@ resources:
       branch: master
       tag_filter: {{paas_cf_tag_filter}}
       commit_verification_key_ids: {{gpg_ids}}
-      gpg_keyserver: hkp://ipv4.pool.sks-keyservers.net/
 
   - name: cf-secrets
     type: s3-iam

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -86,7 +86,6 @@ resources:
       branch: {{branch_name}}
       tag_filter: {{paas_cf_tag_filter}}
       commit_verification_key_ids: {{gpg_ids}}
-      gpg_keyserver: hkp://ipv4.pool.sks-keyservers.net/
 
   - name: graphite-nozzle
     type: git

--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -7,7 +7,6 @@ resources:
       branch: {{branch_name}}
       tag_filter: {{paas_cf_tag_filter}}
       commit_verification_key_ids: {{gpg_ids}}
-      gpg_keyserver: hkp://ipv4.pool.sks-keyservers.net/
 
   - name: deployment-timer
     type: time

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -20,7 +20,6 @@ resources:
       branch: {{branch_name}}
       tag_filter: {{paas_cf_tag_filter}}
       commit_verification_key_ids: {{gpg_ids}}
-      gpg_keyserver: hkp://ipv4.pool.sks-keyservers.net/
 
   - name: cf-tfstate
     type: s3-iam

--- a/concourse/pipelines/failure-testing.yml
+++ b/concourse/pipelines/failure-testing.yml
@@ -20,7 +20,6 @@ resources:
       branch: {{branch_name}}
       tag_filter: {{paas_cf_tag_filter}}
       commit_verification_key_ids: {{gpg_ids}}
-      gpg_keyserver: hkp://ipv4.pool.sks-keyservers.net/
 
   - name: pipeline-trigger
     type: semver-iam


### PR DESCRIPTION
## What

We're enabling IPv6 in the kernel on the Concourse machine (https://github.com/alphagov/paas-bootstrap/pull/90), so this
workaround is no longer needed.

This reverts #1035.

## How to review

🚨  Make sure https://github.com/alphagov/paas-bootstrap/pull/90 is merged and deployed before merging this.

Code review is probably enough once https://github.com/alphagov/paas-bootstrap/pull/90 has been reviewed.

## Who can review

Not me.