### PR TITLE
[#149806558] Fix upload-compose-secrets for staging and prod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ staging: globals ## Set Environment to Staging
 	$(eval export ENABLE_DATADOG=true)
 	$(eval export DEPLOY_ENV=staging)
 	$(eval export TEST_HEAVY_LOAD=true)
+	$(eval export COMPOSE_PASSWORD_STORE_HIGH_DIR?=${HOME}/.paas-pass-high)
 	@true
 
 .PHONY: prod
@@ -132,6 +133,7 @@ prod: globals ## Set Environment to Production
 	$(eval export ENABLE_PAAS_DASHBOARD=true)
 	$(eval export DEPLOY_RUBBERNECKER=true)
 	$(eval export DEPLOY_ENV=prod)
+	$(eval export COMPOSE_PASSWORD_STORE_HIGH_DIR?=${HOME}/.paas-pass-high)
 	@true
 
 .PHONY: bosh-cli

--- a/scripts/upload-compose-secrets.sh
+++ b/scripts/upload-compose-secrets.sh
@@ -3,10 +3,13 @@
 set -eu
 
 export PASSWORD_STORE_DIR=${COMPOSE_PASSWORD_STORE_DIR}
-
-COMPOSE_API_KEY=$(pass "compose/${AWS_ACCOUNT}/access_token")
 COMPOSE_BILLING_EMAIL=$(pass "compose/billing/email_address")
 COMPOSE_BILLING_PASSWORD=$(pass "compose/billing/password")
+
+if [ -n "${COMPOSE_PASSWORD_STORE_HIGH_DIR:-}" ]; then
+  export PASSWORD_STORE_DIR=${COMPOSE_PASSWORD_STORE_HIGH_DIR}
+fi
+COMPOSE_API_KEY=$(pass "compose/${AWS_ACCOUNT}/access_token")
 
 SECRETS=$(mktemp secrets.yml.XXXXXX)
 trap 'rm  "${SECRETS}"' EXIT


### PR DESCRIPTION
## What

This stopped working with the following error:

    ➜  paas-cf git:(master) ✗ make staging upload-compose-secrets
    Error: compose/staging/access_token is not in the password store.
    make: *** [upload-compose-secrets] Error 1

Because we have:

1. Moved the `compose/{staging,prod}/api_token` to
alphagov/paas-credentials-high and left `compose/dev/api_token` in
alphagov/paas-credentials.
2. Added `compose/billing/{email_address,password}` to
alphagov/paas-credentials which is used for all environments.

Fix this by setting an additional environment variable for the high
credential store location in the `staging` and `prod` make targets, and
using that to get the `api_token` if it's present.

This assume that you have the high credential store checked out in
`~/.paas-pass-high` which is the path also referenced by the
`manually_upload_certs` make target. We may look at refactoring or
standardising this in the future.

## How to review

1. Code review
1. Checkout the branch
1. Check that `make dev upload-compose-secrets` still works
1. Check that `make staging upload-compose-secrets` now works - I have run it previously to unblock the pipeline
1. Once you've merged, run `make prod upload-compose-secrets` and unblock the prod pipeline

## Who can review

Anyone that has access to https://github.com/alphagov/paas-credentials-high