### PR TITLE
[#151003385] Add XL RDS plans and increase M and L storage sizes.

### DIFF
--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -34,10 +34,13 @@ meta:
       allocated_storage: 20
     medium_plan_rds_properties:
       db_instance_class: "db.m4.large"
-      allocated_storage: 20
+      allocated_storage: 100
     large_plan_rds_properties:
       db_instance_class: "db.m4.2xlarge"
-      allocated_storage: 20
+      allocated_storage: 512
+    xlarge_plan_rds_properties:
+      db_instance_class: "db.m4.4xlarge"
+      allocated_storage: 2048
 
 releases:
   - name: rds-broker
@@ -133,7 +136,7 @@ jobs:
 
                 - id: "9b882524-ab58-4c18-b501-d2a3f4619104"
                   name: "M-dedicated-9.5"
-                  description: "20GB Storage, Dedicated Instance, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.large."
+                  description: "100GB Storage, Dedicated Instance, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.large."
                   free: false
                   metadata:
                     costs:
@@ -149,7 +152,7 @@ jobs:
 
                 - id: "bf5b99c2-7990-4b66-b341-1bb83566d76e"
                   name: "M-HA-dedicated-9.5"
-                  description: "20GB Storage, Dedicated Instance, Highly Available, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.large."
+                  description: "100GB Storage, Dedicated Instance, Highly Available, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.large."
                   free: false
                   metadata:
                     costs:
@@ -166,7 +169,7 @@ jobs:
 
                 - id: "8d50ccc5-707c-4306-be8f-f59a158eb736"
                   name: "M-HA-enc-dedicated-9.5"
-                  description: "20GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.large."
+                  description: "100GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.large."
                   free: false
                   metadata:
                     costs:
@@ -185,7 +188,7 @@ jobs:
 
                 - id: "238a1328-4f77-4b70-9bd9-2cdbbfb999c8"
                   name: "L-dedicated-9.5"
-                  description: "20GB Storage, Dedicated Instance, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.2xlarge."
+                  description: "512GB Storage, Dedicated Instance, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.2xlarge."
                   free: false
                   metadata:
                     costs:
@@ -201,7 +204,7 @@ jobs:
 
                 - id: "dfe4ab2b-2069-41a5-ba08-2be21b0c76d3"
                   name: "L-HA-dedicated-9.5"
-                  description: "20GB Storage, Dedicated Instance, Highly Available, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.2xlarge."
+                  description: "512GB Storage, Dedicated Instance, Highly Available, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.2xlarge."
                   free: false
                   metadata:
                     costs:
@@ -218,7 +221,7 @@ jobs:
 
                 - id: "620055b3-fe7c-46fc-87ad-c7d8f4fe7f34"
                   name: "L-HA-enc-dedicated-9.5"
-                  description: "20GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.2xlarge."
+                  description: "512GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.2xlarge."
                   free: false
                   metadata:
                     costs:
@@ -232,6 +235,58 @@ jobs:
                   rds_properties:
                     defaults: (( inject meta.rds_broker.default_postgres_rds_properties ))
                     plan: (( inject meta.rds_broker.large_plan_rds_properties ))
+                    multi_az: true
+                    storage_encrypted: true
+
+                - id: "1065c353-54dd-4f6b-a5b4-a4b5aa4575c6"
+                  name: "XL-dedicated-9.5"
+                  description: "2TB Storage, Dedicated Instance, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.4xlarge."
+                  free: false
+                  metadata:
+                    costs:
+                      - amount:
+                          usd: 1.612
+                        unit: "HOUR"
+                    bullets:
+                      - "Dedicated Postgres 9.5 server"
+                      - "AWS RDS"
+                  rds_properties:
+                    defaults: (( inject meta.rds_broker.default_postgres_rds_properties ))
+                    plan: (( inject meta.rds_broker.xlarge_plan_rds_properties ))
+
+                - id: "7119925f-518d-4263-96ac-16990295aad6"
+                  name: "XL-HA-dedicated-9.5"
+                  description: "2TB Storage, Dedicated Instance, Highly Available, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.4xlarge."
+                  free: false
+                  metadata:
+                    costs:
+                      - amount:
+                          usd: 3.224
+                        unit: "HOUR"
+                    bullets:
+                      - "Dedicated Postgres 9.5 server"
+                      - "AWS RDS"
+                  rds_properties:
+                    defaults: (( inject meta.rds_broker.default_postgres_rds_properties ))
+                    plan: (( inject meta.rds_broker.xlarge_plan_rds_properties ))
+                    multi_az: true
+
+                - id: "a91c8e59-8869-42fd-8a99-8989151d7353"
+                  name: "XL-HA-enc-dedicated-9.5"
+                  description: "2TB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.4xlarge."
+                  free: false
+                  metadata:
+                    costs:
+                      - amount:
+                          usd: 3.224
+                        unit: "HOUR"
+                    bullets:
+                      - "Dedicated Postgres 9.5 server"
+                      - "Storage Encrypted"
+                      - "AWS RDS"
+                  rds_properties:
+                    defaults: (( inject meta.rds_broker.default_postgres_rds_properties ))
+                    plan: (( inject meta.rds_broker.xlarge_plan_rds_properties ))
                     multi_az: true
                     storage_encrypted: true
 
@@ -298,7 +353,7 @@ jobs:
 
                 - id: "4eb35ca9-a7ec-46c6-b137-d819848536cd"
                   name: "M-dedicated-5.7"
-                  description: "20GB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.m4.large."
+                  description: "100GB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.m4.large."
                   free: false
                   metadata:
                     costs:
@@ -314,7 +369,7 @@ jobs:
 
                 - id: "e60edf62-b701-4e38-846f-b0b3db728349"
                   name: "M-HA-dedicated-5.7"
-                  description: "20GB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.m4.large."
+                  description: "100GB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.m4.large."
                   free: false
                   metadata:
                     costs:
@@ -331,7 +386,7 @@ jobs:
 
                 - id: "8d139b9e-bc82-4749-8ad6-7733980292d6"
                   name: "M-HA-enc-dedicated-5.7"
-                  description: "20GB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.large."
+                  description: "100GB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.large."
                   free: false
                   metadata:
                     costs:
@@ -350,7 +405,7 @@ jobs:
 
                 - id: "6725bf1f-71e8-447a-b6a1-659247fcc03c"
                   name: "L-dedicated-5.7"
-                  description: "20GB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.m4.2xlarge."
+                  description: "512GB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.m4.2xlarge."
                   free: false
                   metadata:
                     costs:
@@ -366,7 +421,7 @@ jobs:
 
                 - id: "63cdac92-9e44-42a6-ba3f-7be3dccf5dc6"
                   name: "L-HA-dedicated-5.7"
-                  description: "20GB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.m4.2xlarge."
+                  description: "512GB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.m4.2xlarge."
                   free: false
                   metadata:
                     costs:
@@ -383,7 +438,7 @@ jobs:
 
                 - id: "d5efbf83-5e00-47a5-a668-2ef1307d5a23"
                   name: "L-HA-enc-dedicated-5.7"
-                  description: "20GB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.2xlarge."
+                  description: "512GB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.2xlarge."
                   free: false
                   metadata:
                     costs:
@@ -397,6 +452,58 @@ jobs:
                   rds_properties:
                     defaults: (( inject meta.rds_broker.default_mysql_rds_properties ))
                     plan: (( inject meta.rds_broker.large_plan_rds_properties ))
+                    multi_az: true
+                    storage_encrypted: true
+
+                - id: "a37144bf-4e05-451b-87ba-0a2c57a23a91"
+                  name: "XL-dedicated-5.7"
+                  description: "2TB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.m4.4xlarge."
+                  free: false
+                  metadata:
+                    costs:
+                      - amount:
+                          usd: 1.545
+                        unit: "HOUR"
+                    bullets:
+                      - "Dedicated MySQL 5.7 server"
+                      - "AWS RDS"
+                  rds_properties:
+                    defaults: (( inject meta.rds_broker.default_mysql_rds_properties ))
+                    plan: (( inject meta.rds_broker.xlarge_plan_rds_properties ))
+
+                - id: "065a7de5-28e8-4de1-8a39-4b4f752e2f2f"
+                  name: "XL-HA-dedicated-5.7"
+                  description: "2TB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.m4.4xlarge."
+                  free: false
+                  metadata:
+                    costs:
+                      - amount:
+                          usd: 3.090
+                        unit: "HOUR"
+                    bullets:
+                      - "Dedicated MySQL 5.4 server"
+                      - "AWS RDS"
+                  rds_properties:
+                    defaults: (( inject meta.rds_broker.default_mysql_rds_properties ))
+                    plan: (( inject meta.rds_broker.xlarge_plan_rds_properties ))
+                    multi_az: true
+
+                - id: "4edc975c-3f07-46f1-bd87-ecb35b76298f"
+                  name: "XL-HA-enc-dedicated-5.7"
+                  description: "2TB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.4xlarge."
+                  free: false
+                  metadata:
+                    costs:
+                      - amount:
+                          usd: 3.090
+                        unit: "HOUR"
+                    bullets:
+                      - "Dedicated MySQL 5.7 server"
+                      - "Storage Encrypted"
+                      - "AWS RDS"
+                  rds_properties:
+                    defaults: (( inject meta.rds_broker.default_mysql_rds_properties ))
+                    plan: (( inject meta.rds_broker.xlarge_plan_rds_properties ))
                     multi_az: true
                     storage_encrypted: true
 

--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -1,59 +1,41 @@
 meta:
   rds_broker:
+    default_rds_properties:
+      storage_type: "gp2"
+      auto_minor_version_upgrade: true
+      multi_az: false
+      storage_encrypted: false
+      publicly_accessible: false
+      copy_tags_to_snapshot: true
+      skip_final_snapshot: false
+      backup_retention_period: 7
+      db_subnet_group_name: (( grab terraform_outputs.rds_broker_dbs_subnet_group ))
+      vpc_security_group_ids:
+        - (( grab terraform_outputs.rds_broker_dbs_security_group_id ))
     default_postgres_rds_properties:
+      inject: (( inject meta.rds_broker.default_rds_properties ))
       engine: "postgres"
       engine_version: "9.5"
-      storage_type: "gp2"
-      auto_minor_version_upgrade: true
-      multi_az: false
-      storage_encrypted: false
-      publicly_accessible: false
-      copy_tags_to_snapshot: true
-      skip_final_snapshot: false
-      backup_retention_period: 7
-      db_subnet_group_name: (( grab terraform_outputs.rds_broker_dbs_subnet_group ))
-      vpc_security_group_ids:
-        - (( grab terraform_outputs.rds_broker_dbs_security_group_id ))
       db_parameter_group_name: (( grab terraform_outputs.rds_broker_postgres95_db_parameter_group ))
       postgres_extensions: ["uuid-ossp", "postgis"]
-    small_postgres_rds_properties:
-      inject: (( inject meta.rds_broker.default_postgres_rds_properties ))
-      db_instance_class: "db.t2.small"
-      allocated_storage: 20
-    medium_postgres_rds_properties:
-      inject: (( inject meta.rds_broker.default_postgres_rds_properties ))
-      db_instance_class: "db.m4.large"
-      allocated_storage: 20
-    large_postgres_rds_properties:
-      inject: (( inject meta.rds_broker.default_postgres_rds_properties ))
-      db_instance_class: "db.m4.2xlarge"
-      allocated_storage: 20
-
     default_mysql_rds_properties:
+      inject: (( inject meta.rds_broker.default_rds_properties ))
       engine: "mysql"
       engine_version: "5.7"
-      storage_type: "gp2"
-      auto_minor_version_upgrade: true
-      multi_az: false
-      storage_encrypted: false
-      publicly_accessible: false
-      copy_tags_to_snapshot: true
-      skip_final_snapshot: false
-      backup_retention_period: 7
-      db_subnet_group_name: (( grab terraform_outputs.rds_broker_dbs_subnet_group ))
-      vpc_security_group_ids:
-        - (( grab terraform_outputs.rds_broker_dbs_security_group_id ))
       db_parameter_group_name: (( grab terraform_outputs.rds_broker_mysql57_db_parameter_group ))
-    small_mysql_rds_properties:
-      inject: (( inject meta.rds_broker.default_mysql_rds_properties ))
+
+    free_plan_rds_properties:
+      db_instance_class: "db.t2.micro"
+      allocated_storage: 5
+      backup_retention_period: 0
+      skip_final_snapshot: true
+    small_plan_rds_properties:
       db_instance_class: "db.t2.small"
       allocated_storage: 20
-    medium_mysql_rds_properties:
-      inject: (( inject meta.rds_broker.default_mysql_rds_properties ))
+    medium_plan_rds_properties:
       db_instance_class: "db.m4.large"
       allocated_storage: 20
-    large_mysql_rds_properties:
-      inject: (( inject meta.rds_broker.default_mysql_rds_properties ))
+    large_plan_rds_properties:
       db_instance_class: "db.m4.2xlarge"
       allocated_storage: 20
 
@@ -113,11 +95,8 @@ jobs:
                       - "Dedicated Postgres 9.5 server"
                       - "AWS RDS"
                   rds_properties:
-                    inject: (( inject meta.rds_broker.default_postgres_rds_properties ))
-                    db_instance_class: "db.t2.micro"
-                    allocated_storage: 5
-                    backup_retention_period: 0
-                    skip_final_snapshot: true
+                    defaults: (( inject meta.rds_broker.default_postgres_rds_properties ))
+                    plan: (( inject meta.rds_broker.free_plan_rds_properties ))
 
                 - id: "b7d0a368-ac92-4eff-9b8d-ab4ba45bed0e"
                   name: "S-dedicated-9.5"
@@ -132,7 +111,8 @@ jobs:
                       - "Dedicated Postgres 9.5 server"
                       - "AWS RDS"
                   rds_properties:
-                    inject: (( inject meta.rds_broker.small_postgres_rds_properties ))
+                    defaults: (( inject meta.rds_broker.default_postgres_rds_properties ))
+                    plan: (( inject meta.rds_broker.small_plan_rds_properties ))
 
                 - id: "359bcb39-0264-46bd-9120-0182c3829067"
                   name: "S-HA-dedicated-9.5"
@@ -147,7 +127,8 @@ jobs:
                       - "Dedicated Postgres 9.5 server"
                       - "AWS RDS"
                   rds_properties:
-                    inject: (( inject meta.rds_broker.small_postgres_rds_properties ))
+                    defaults: (( inject meta.rds_broker.default_postgres_rds_properties ))
+                    plan: (( inject meta.rds_broker.small_plan_rds_properties ))
                     multi_az: true
 
                 - id: "9b882524-ab58-4c18-b501-d2a3f4619104"
@@ -163,7 +144,8 @@ jobs:
                       - "Dedicated Postgres 9.5 server"
                       - "AWS RDS"
                   rds_properties:
-                    inject: (( inject meta.rds_broker.medium_postgres_rds_properties ))
+                    defaults: (( inject meta.rds_broker.default_postgres_rds_properties ))
+                    plan: (( inject meta.rds_broker.medium_plan_rds_properties ))
 
                 - id: "bf5b99c2-7990-4b66-b341-1bb83566d76e"
                   name: "M-HA-dedicated-9.5"
@@ -178,7 +160,8 @@ jobs:
                       - "Dedicated Postgres 9.5 server"
                       - "AWS RDS"
                   rds_properties:
-                    inject: (( inject meta.rds_broker.medium_postgres_rds_properties ))
+                    defaults: (( inject meta.rds_broker.default_postgres_rds_properties ))
+                    plan: (( inject meta.rds_broker.medium_plan_rds_properties ))
                     multi_az: true
 
                 - id: "8d50ccc5-707c-4306-be8f-f59a158eb736"
@@ -195,7 +178,8 @@ jobs:
                       - "Storage Encrypted"
                       - "AWS RDS"
                   rds_properties:
-                    inject: (( inject meta.rds_broker.medium_postgres_rds_properties ))
+                    defaults: (( inject meta.rds_broker.default_postgres_rds_properties ))
+                    plan: (( inject meta.rds_broker.medium_plan_rds_properties ))
                     multi_az: true
                     storage_encrypted: true
 
@@ -212,7 +196,8 @@ jobs:
                       - "Dedicated Postgres 9.5 server"
                       - "AWS RDS"
                   rds_properties:
-                    inject: (( inject meta.rds_broker.large_postgres_rds_properties ))
+                    defaults: (( inject meta.rds_broker.default_postgres_rds_properties ))
+                    plan: (( inject meta.rds_broker.large_plan_rds_properties ))
 
                 - id: "dfe4ab2b-2069-41a5-ba08-2be21b0c76d3"
                   name: "L-HA-dedicated-9.5"
@@ -227,7 +212,8 @@ jobs:
                       - "Dedicated Postgres 9.5 server"
                       - "AWS RDS"
                   rds_properties:
-                    inject: (( inject meta.rds_broker.large_postgres_rds_properties ))
+                    defaults: (( inject meta.rds_broker.default_postgres_rds_properties ))
+                    plan: (( inject meta.rds_broker.large_plan_rds_properties ))
                     multi_az: true
 
                 - id: "620055b3-fe7c-46fc-87ad-c7d8f4fe7f34"
@@ -244,7 +230,8 @@ jobs:
                       - "Storage Encrypted"
                       - "AWS RDS"
                   rds_properties:
-                    inject: (( inject meta.rds_broker.large_postgres_rds_properties ))
+                    defaults: (( inject meta.rds_broker.default_postgres_rds_properties ))
+                    plan: (( inject meta.rds_broker.large_plan_rds_properties ))
                     multi_az: true
                     storage_encrypted: true
 
@@ -273,11 +260,8 @@ jobs:
                       - "Dedicated MySQL 5.7 server"
                       - "AWS RDS"
                   rds_properties:
-                    inject: (( inject meta.rds_broker.default_mysql_rds_properties ))
-                    db_instance_class: "db.t2.micro"
-                    allocated_storage: 5
-                    backup_retention_period: 0
-                    skip_final_snapshot: true
+                    defaults: (( inject meta.rds_broker.default_mysql_rds_properties ))
+                    plan: (( inject meta.rds_broker.free_plan_rds_properties ))
 
                 - id: "7fdde6ea-cc27-466c-86aa-46181fc20d25"
                   name: "S-dedicated-5.7"
@@ -292,7 +276,8 @@ jobs:
                       - "Dedicated MySQL 5.7 server"
                       - "AWS RDS"
                   rds_properties:
-                    inject: (( inject meta.rds_broker.small_mysql_rds_properties ))
+                    defaults: (( inject meta.rds_broker.default_mysql_rds_properties ))
+                    plan: (( inject meta.rds_broker.small_plan_rds_properties ))
 
                 - id: "72279ebd-6001-4e38-aaef-72b68c4fa6fd"
                   name: "S-HA-dedicated-5.7"
@@ -307,7 +292,8 @@ jobs:
                       - "Dedicated MySQL 5.7 server"
                       - "AWS RDS"
                   rds_properties:
-                    inject: (( inject meta.rds_broker.small_mysql_rds_properties ))
+                    defaults: (( inject meta.rds_broker.default_mysql_rds_properties ))
+                    plan: (( inject meta.rds_broker.small_plan_rds_properties ))
                     multi_az: true
 
                 - id: "4eb35ca9-a7ec-46c6-b137-d819848536cd"
@@ -323,7 +309,8 @@ jobs:
                       - "Dedicated MySQL 5.7 server"
                       - "AWS RDS"
                   rds_properties:
-                    inject: (( inject meta.rds_broker.medium_mysql_rds_properties ))
+                    defaults: (( inject meta.rds_broker.default_mysql_rds_properties ))
+                    plan: (( inject meta.rds_broker.medium_plan_rds_properties ))
 
                 - id: "e60edf62-b701-4e38-846f-b0b3db728349"
                   name: "M-HA-dedicated-5.7"
@@ -338,7 +325,8 @@ jobs:
                       - "Dedicated MySQL 5.7 server"
                       - "AWS RDS"
                   rds_properties:
-                    inject: (( inject meta.rds_broker.medium_mysql_rds_properties ))
+                    defaults: (( inject meta.rds_broker.default_mysql_rds_properties ))
+                    plan: (( inject meta.rds_broker.medium_plan_rds_properties ))
                     multi_az: true
 
                 - id: "8d139b9e-bc82-4749-8ad6-7733980292d6"
@@ -355,7 +343,8 @@ jobs:
                       - "Storage Encrypted"
                       - "AWS RDS"
                   rds_properties:
-                    inject: (( inject meta.rds_broker.medium_mysql_rds_properties ))
+                    defaults: (( inject meta.rds_broker.default_mysql_rds_properties ))
+                    plan: (( inject meta.rds_broker.medium_plan_rds_properties ))
                     multi_az: true
                     storage_encrypted: true
 
@@ -372,7 +361,8 @@ jobs:
                       - "Dedicated MySQL 5.7 server"
                       - "AWS RDS"
                   rds_properties:
-                    inject: (( inject meta.rds_broker.large_mysql_rds_properties ))
+                    defaults: (( inject meta.rds_broker.default_mysql_rds_properties ))
+                    plan: (( inject meta.rds_broker.large_plan_rds_properties ))
 
                 - id: "63cdac92-9e44-42a6-ba3f-7be3dccf5dc6"
                   name: "L-HA-dedicated-5.7"
@@ -387,7 +377,8 @@ jobs:
                       - "Dedicated MySQL 5.4 server"
                       - "AWS RDS"
                   rds_properties:
-                    inject: (( inject meta.rds_broker.large_mysql_rds_properties ))
+                    defaults: (( inject meta.rds_broker.default_mysql_rds_properties ))
+                    plan: (( inject meta.rds_broker.large_plan_rds_properties ))
                     multi_az: true
 
                 - id: "d5efbf83-5e00-47a5-a668-2ef1307d5a23"
@@ -404,7 +395,8 @@ jobs:
                       - "Storage Encrypted"
                       - "AWS RDS"
                   rds_properties:
-                    inject: (( inject meta.rds_broker.large_mysql_rds_properties ))
+                    defaults: (( inject meta.rds_broker.default_mysql_rds_properties ))
+                    plan: (( inject meta.rds_broker.large_plan_rds_properties ))
                     multi_az: true
                     storage_encrypted: true
 

--- a/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
@@ -92,15 +92,22 @@ RSpec.describe "RDS broker properties" do
     shared_examples "medium sized plans" do
       let(:rds_properties) { subject.fetch("rds_properties") }
 
-      it { expect(rds_properties).to include("allocated_storage" => 20) }
+      it { expect(rds_properties).to include("allocated_storage" => 100) }
       it { expect(rds_properties).to include("db_instance_class" => "db.m4.large") }
     end
 
     shared_examples "large sized plans" do
       let(:rds_properties) { subject.fetch("rds_properties") }
 
-      it { expect(rds_properties).to include("allocated_storage" => 20) }
+      it { expect(rds_properties).to include("allocated_storage" => 512) }
       it { expect(rds_properties).to include("db_instance_class" => "db.m4.2xlarge") }
+    end
+
+    shared_examples "xlarge sized plans" do
+      let(:rds_properties) { subject.fetch("rds_properties") }
+
+      it { expect(rds_properties).to include("allocated_storage" => 2048) }
+      it { expect(rds_properties).to include("db_instance_class" => "db.m4.4xlarge") }
     end
 
     shared_examples "backup enabled plans" do
@@ -154,7 +161,7 @@ RSpec.describe "RDS broker properties" do
 
       it "contains only specific plans" do
         pg_plan_names = pg_plans.map { |p| p["name"] }
-        expect(pg_plan_names).to contain_exactly("Free", "S-dedicated-9.5", "S-HA-dedicated-9.5", "M-dedicated-9.5", "M-HA-dedicated-9.5", "M-HA-enc-dedicated-9.5", "L-dedicated-9.5", "L-HA-dedicated-9.5", "L-HA-enc-dedicated-9.5")
+        expect(pg_plan_names).to contain_exactly("Free", "S-dedicated-9.5", "S-HA-dedicated-9.5", "M-dedicated-9.5", "M-HA-dedicated-9.5", "M-HA-enc-dedicated-9.5", "L-dedicated-9.5", "L-HA-dedicated-9.5", "L-HA-enc-dedicated-9.5", "XL-dedicated-9.5", "XL-HA-dedicated-9.5", "XL-HA-enc-dedicated-9.5")
       end
 
       describe "plan rds_properties" do
@@ -255,6 +262,36 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption enabled plans"
         end
 
+        describe "XL-dedicated-9.5" do
+          subject { pg_plans.find { |p| p["name"] == "XL-dedicated-9.5" } }
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "xlarge sized plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption disabled plans"
+        end
+
+        describe "XL-HA-dedicated-9.5" do
+          subject { pg_plans.find { |p| p["name"] == "XL-HA-dedicated-9.5" } }
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "xlarge sized plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "HA plans"
+          it_behaves_like "Encryption disabled plans"
+        end
+
+        describe "XL-HA-enc-dedicated-9.5" do
+          subject { pg_plans.find { |p| p["name"] == "XL-HA-enc-dedicated-9.5" } }
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "xlarge sized plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "HA plans"
+          it_behaves_like "Encryption enabled plans"
+        end
+
         describe "free plan" do
           subject { pg_plans.find { |p| p["name"] == "Free" } }
 
@@ -277,7 +314,7 @@ RSpec.describe "RDS broker properties" do
 
       it "contains only specific plans" do
         my_plan_names = my_plans.map { |p| p["name"] }
-        expect(my_plan_names).to contain_exactly("Free", "S-dedicated-5.7", "S-HA-dedicated-5.7", "M-dedicated-5.7", "M-HA-dedicated-5.7", "M-HA-enc-dedicated-5.7", "L-dedicated-5.7", "L-HA-dedicated-5.7", "L-HA-enc-dedicated-5.7")
+        expect(my_plan_names).to contain_exactly("Free", "S-dedicated-5.7", "S-HA-dedicated-5.7", "M-dedicated-5.7", "M-HA-dedicated-5.7", "M-HA-enc-dedicated-5.7", "L-dedicated-5.7", "L-HA-dedicated-5.7", "L-HA-enc-dedicated-5.7", "XL-dedicated-5.7", "XL-HA-dedicated-5.7", "XL-HA-enc-dedicated-5.7")
       end
 
       describe "plan rds_properties" do
@@ -373,6 +410,36 @@ RSpec.describe "RDS broker properties" do
 
           it_behaves_like "all mysql plans"
           it_behaves_like "large sized plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "HA plans"
+          it_behaves_like "Encryption enabled plans"
+        end
+
+        describe "XL-dedicated-5.7" do
+          subject { my_plans.find { |p| p["name"] == "XL-dedicated-5.7" } }
+
+          it_behaves_like "all mysql plans"
+          it_behaves_like "xlarge sized plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption disabled plans"
+        end
+
+        describe "XL-HA-dedicated-5.7" do
+          subject { my_plans.find { |p| p["name"] == "XL-HA-dedicated-5.7" } }
+
+          it_behaves_like "all mysql plans"
+          it_behaves_like "xlarge sized plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "HA plans"
+          it_behaves_like "Encryption disabled plans"
+        end
+
+        describe "XL-HA-enc-dedicated-5.7" do
+          subject { my_plans.find { |p| p["name"] == "XL-HA-enc-dedicated-5.7" } }
+
+          it_behaves_like "all mysql plans"
+          it_behaves_like "xlarge sized plans"
           it_behaves_like "backup enabled plans"
           it_behaves_like "HA plans"
           it_behaves_like "Encryption enabled plans"


### PR DESCRIPTION
## What

We've had tenants asking for databases with increased storage sizes, so
this adds/amends the existing plans to offer a range of sizes.

This won't affect existing instances. We're going to upgrade these separately once this has been deployed.

As part of this change, I've taken the opportunity to refactor how we define the plans to avoid some of the duplication between Postgres and Mysql.

## How to review

* Code review - Verify the tests pass.
* Deploy from this branch and verify that the plans do update, and appear correctly in `cf marketplace`.
* You could go as far as to provision an instance with one of the changed plans and verify that the storage is as specified.

## Who can review

Not me.