### PR TITLE
Increase prod cells from 24 to 33

### DIFF
--- a/manifests/cf-manifest/env-specific/cf-prod.yml
+++ b/manifests/cf-manifest/env-specific/cf-prod.yml
@@ -1,6 +1,6 @@
 ---
 meta:
   cell:
-    instances: 24
+    instances: 33
   elasticsearch_master:
     disk_size: 768000


### PR DESCRIPTION
# What

As suggested by:

    $ make prod show-cf-memory-usage
    >>
    Memory reserved by orgs: 1315840 MB (1285 GB)
    Memory reserved by apps: 446052 MB (435.6 GB)

    Total cell memory required to meet ADR017: 986880 MB (963.8 GB)

cells use r4.xlarge which have 30G RAM, so this gives us:

    bc -q
    963 / 30
    32

We increase by three each time so that they are balanced across 3 AZs,
giving 33 cells

## How to review

The code change doesn't apply to any environment except prod so you won't be able to test this in dev.

So instead, code review, make sure the numbers make sense, and that the syntax is correct.

Important: Check with product team that we are ok to add this many VMS before merging

## Who can review

Anyone but me