### PR TITLE
[Support] Fix create-user.sh to work with bash 4

### DIFF
--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -178,11 +178,11 @@ create_user() {
     fi
   fi
 
-  if [[ -z "${uaa_uuid}" ]] && [[ "${RESET_USER}" == "true" ]]; then
+  if [[ -z "${uaa_uuid:-}" ]] && [[ "${RESET_USER}" == "true" ]]; then
     abort "Trying to reset invite for non-existing user. Is someone trying to trick you into getting an account?"
   fi
 
-  if [[ -z "${uaa_uuid}" ]] || [[ "${RESET_USER}" == "true" ]]; then
+  if [[ -z "${uaa_uuid:-}" ]] || [[ "${RESET_USER}" == "true" ]]; then
     curl -sf "${ssl_arg}" \
       -X POST \
       -H "Authorization: ${auth_token}" \


### PR DESCRIPTION
## What

This script has `set -u` at the top, and was therefore erroring with:
```
./scripts/create-user.sh: line 181: uaa_uuid: unbound variable
```
For some reason this wasn't causing an issue with bash 3 (as included in
OS X). I presume bash 3 is not complaining because this variable is
declared as 'local' at the top of this function.

## How to review

Test creating a new user in a dev environment using both bash 3 and bash 4 (the `--no-email` flag is useful when testing against dev).

Bash 4 is available in homebrew, but the `#!` line in the script will need to be updated to point to it while testing.

## Who can review

Not me.