### PR TITLE
[#151289532] Add small encrypted RDS plans.

### DIFF
--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -134,6 +134,24 @@ jobs:
                     plan: (( inject meta.rds_broker.small_plan_rds_properties ))
                     multi_az: true
 
+                - id: "d9f1d61d-0a65-45ad-8fc9-88c921d038d2"
+                  name: "S-HA-enc-dedicated-9.5"
+                  description: "20GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t2.small."
+                  free: false
+                  metadata:
+                    costs:
+                      - amount:
+                          usd: 0.078
+                        unit: "HOUR"
+                    bullets:
+                      - "Dedicated Postgres 9.5 server"
+                      - "AWS RDS"
+                  rds_properties:
+                    defaults: (( inject meta.rds_broker.default_postgres_rds_properties ))
+                    plan: (( inject meta.rds_broker.small_plan_rds_properties ))
+                    multi_az: true
+                    storage_encrypted: true
+
                 - id: "9b882524-ab58-4c18-b501-d2a3f4619104"
                   name: "M-dedicated-9.5"
                   description: "100GB Storage, Dedicated Instance, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.large."
@@ -350,6 +368,24 @@ jobs:
                     defaults: (( inject meta.rds_broker.default_mysql_rds_properties ))
                     plan: (( inject meta.rds_broker.small_plan_rds_properties ))
                     multi_az: true
+
+                - id: "6aa563c1-5aeb-46a1-9509-badcf5995c96"
+                  name: "S-HA-enc-dedicated-5.7"
+                  description: "20GB Storage, Dedicated Instance, Highly Available. Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.t2.small."
+                  free: false
+                  metadata:
+                    costs:
+                      - amount:
+                          usd: 0.072
+                        unit: "HOUR"
+                    bullets:
+                      - "Dedicated MySQL 5.7 server"
+                      - "AWS RDS"
+                  rds_properties:
+                    defaults: (( inject meta.rds_broker.default_mysql_rds_properties ))
+                    plan: (( inject meta.rds_broker.small_plan_rds_properties ))
+                    multi_az: true
+                    storage_encrypted: true
 
                 - id: "4eb35ca9-a7ec-46c6-b137-d819848536cd"
                   name: "M-dedicated-5.7"

--- a/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe "RDS broker properties" do
 
       it "contains only specific plans" do
         pg_plan_names = pg_plans.map { |p| p["name"] }
-        expect(pg_plan_names).to contain_exactly("Free", "S-dedicated-9.5", "S-HA-dedicated-9.5", "M-dedicated-9.5", "M-HA-dedicated-9.5", "M-HA-enc-dedicated-9.5", "L-dedicated-9.5", "L-HA-dedicated-9.5", "L-HA-enc-dedicated-9.5", "XL-dedicated-9.5", "XL-HA-dedicated-9.5", "XL-HA-enc-dedicated-9.5")
+        expect(pg_plan_names).to contain_exactly("Free", "S-dedicated-9.5", "S-HA-dedicated-9.5", "S-HA-enc-dedicated-9.5", "M-dedicated-9.5", "M-HA-dedicated-9.5", "M-HA-enc-dedicated-9.5", "L-dedicated-9.5", "L-HA-dedicated-9.5", "L-HA-enc-dedicated-9.5", "XL-dedicated-9.5", "XL-HA-dedicated-9.5", "XL-HA-enc-dedicated-9.5")
       end
 
       describe "plan rds_properties" do
@@ -200,6 +200,16 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "backup enabled plans"
           it_behaves_like "HA plans"
           it_behaves_like "Encryption disabled plans"
+        end
+
+        describe "S-HA-enc-dedicated-9.5" do
+          subject { pg_plans.find { |p| p["name"] == "S-HA-enc-dedicated-9.5" } }
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "small sized plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "HA plans"
+          it_behaves_like "Encryption enabled plans"
         end
 
         describe "M-dedicated-9.5" do
@@ -314,7 +324,7 @@ RSpec.describe "RDS broker properties" do
 
       it "contains only specific plans" do
         my_plan_names = my_plans.map { |p| p["name"] }
-        expect(my_plan_names).to contain_exactly("Free", "S-dedicated-5.7", "S-HA-dedicated-5.7", "M-dedicated-5.7", "M-HA-dedicated-5.7", "M-HA-enc-dedicated-5.7", "L-dedicated-5.7", "L-HA-dedicated-5.7", "L-HA-enc-dedicated-5.7", "XL-dedicated-5.7", "XL-HA-dedicated-5.7", "XL-HA-enc-dedicated-5.7")
+        expect(my_plan_names).to contain_exactly("Free", "S-dedicated-5.7", "S-HA-dedicated-5.7", "S-HA-enc-dedicated-5.7", "M-dedicated-5.7", "M-HA-dedicated-5.7", "M-HA-enc-dedicated-5.7", "L-dedicated-5.7", "L-HA-dedicated-5.7", "L-HA-enc-dedicated-5.7", "XL-dedicated-5.7", "XL-HA-dedicated-5.7", "XL-HA-enc-dedicated-5.7")
       end
 
       describe "plan rds_properties" do
@@ -353,6 +363,16 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "backup enabled plans"
           it_behaves_like "HA plans"
           it_behaves_like "Encryption disabled plans"
+        end
+
+        describe "S-HA-enc-dedicated-5.7" do
+          subject { my_plans.find { |p| p["name"] == "S-HA-enc-dedicated-5.7" } }
+
+          it_behaves_like "all mysql plans"
+          it_behaves_like "small sized plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "HA plans"
+          it_behaves_like "Encryption enabled plans"
         end
 
         describe "M-dedicated-5.7" do


### PR DESCRIPTION
## What

We've had a request for smaller plans with encryption enabled. Amazon
now support encryption for t2.small instances[1], so this adds the
corresponding plans.

[1] https://aws.amazon.com/about-aws/whats-new/2017/06/amazon-rds-enables-encryption-at-rest-for-additional-t2-instance-types/

## How to review

* Deploy from this branch.
* Verify that the new plans are visible in `cf marketplace`.
* Create an instance using one of these new plans. Verify it creates successfully and that the storage is encrypted.

## Who can review

Not me.