### PR TITLE
[#151321276] Upgrade stemcell and cflinuxfs2 to fix USNs

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -30,9 +30,9 @@ releases:
     url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.9.0
     sha1: 77bfe8bdb2c3daec5b40f5116a6216badabd196c
   - name: cflinuxfs2
-    version: 1.148.0
-    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.148.0
-    sha1: 65436c83d2ac05f7c1fc37e9073c8a665a63ef4c
+    version: 1.156.0
+    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.156.0
+    sha1: f47391f8ee5dce2aacfaf4e82d3cdcf78234a2ac
   - name: paas-haproxy
     version: 0.1.3
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/paas-haproxy-0.1.3.tgz
@@ -53,7 +53,7 @@ releases:
 stemcells:
   - alias: default
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3421.20"
+    version: "3421.26"
 
 update:
   canaries: 0


### PR DESCRIPTION
## What

To fix the following:

USN-3418-1: GDK-PixBuf vulnerabilities
USN-3415-1: tcpdump vulnerabilities
USN-3411-1: Bazaar vulnerability
USN-3410-1: GD library vulnerability
USN-3405-2: Linux kernel (Xenial HWE) vulnerabilities
USN-3398-1: graphite2 vulnerabilities
USN-3420-2: Linux kernel (Xenial HWE) vulnerabilities

## How to review

Deploy from this branch against an existing deployment. Verify that all the tests pass.

## Who can review

Not me.
