### PR TITLE
Update generated prefix for redis instances

### DIFF
--- a/platform-tests/src/acceptance/redis_service_test.go
+++ b/platform-tests/src/acceptance/redis_service_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Redis backing service", func() {
 		)
 		BeforeEach(func() {
 			appName = generator.PrefixedRandomName("CATS-APP-")
-			dbInstanceName = generator.PrefixedRandomName("test-es-")
+			dbInstanceName = generator.PrefixedRandomName("test-redis-")
 			Expect(cf.Cf("create-service", serviceName, testPlanName, dbInstanceName).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
 
 			pollForServiceCreationCompletion(dbInstanceName)


### PR DESCRIPTION
## What

I got confused looking at test output when the database name was test-es
and assumed these were elasticsearch intstances - redis is more
descriptive

## How to review

This should probably be applied to an environment - i'm in the middle of testing another story at the moment and we are having issues with composse so i've not done this yet. I'm slightly concerned if there are any issues around the length of the service name in compose

## Who can review

Anyone but me