### PR TITLE
[#151437914] Temporarily disable the Compose acceptance tests.

### DIFF
--- a/platform-tests/src/acceptance/elasticsearch_service_test.go
+++ b/platform-tests/src/acceptance/elasticsearch_service_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Elasticsearch backing service", func() {
 		Expect(plans.Out.Contents()).To(ContainSubstring("tiny"))
 	})
 
-	Context("creating a database instance", func() {
+	PContext("creating a database instance", func() {
 		// Avoid creating additional tests in this block because this setup and
 		// teardown is slow (several minutes).
 

--- a/platform-tests/src/acceptance/mongodb_service_test.go
+++ b/platform-tests/src/acceptance/mongodb_service_test.go
@@ -31,7 +31,7 @@ var _ = Describe("MongoDB backing service", func() {
 		Expect(plans.Out.Contents()).To(ContainSubstring("tiny"))
 	})
 
-	Context("creating a database instance", func() {
+	PContext("creating a database instance", func() {
 		// Avoid creating additional tests in this block because this setup and
 		// teardown is slow (several minutes).
 

--- a/platform-tests/src/acceptance/redis_service_test.go
+++ b/platform-tests/src/acceptance/redis_service_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Redis backing service", func() {
 		Expect(plans.Out.Contents()).To(ContainSubstring("tiny"))
 	})
 
-	Context("creating a database instance", func() {
+	PContext("creating a database instance", func() {
 		// Avoid creating additional tests in this block because this setup and
 		// teardown is slow (several minutes).
 


### PR DESCRIPTION
## What

We've been experiencing intermittent 5xx errors from the Compose API.
This is causing frustration while developing and slowing down delivery.
As the Compose services are currently in private-beta we've therefore
decided to disable these tests until the issues are resolved.

## How to review

Run the pipeline from this branch. Verify the tests that hit the Compose API are marked as skipped in the output from the custom-acceptance-tests.

## Who can review

Not me.