### PR TITLE
[#150879493] Upgrade the RDS Broker

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -253,7 +253,7 @@ properties:
 
     broker_client_timeout_seconds: 70
     broker_client_default_async_poll_interval_seconds: ~
-    broker_client_max_async_poll_duration_minutes: ~
+    broker_client_max_async_poll_duration_minutes: 11520
 
     resource_pool:
       resource_directory_key: (( concat meta.environment "-cf-resources" ))

--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -44,9 +44,9 @@ meta:
 
 releases:
   - name: rds-broker
-    version: 0.1.17
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.17.tgz
-    sha1: 9178989db9f2ea1462c9dadde073f2f945e2f74e
+    version: 0.1.18
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.18.tgz
+    sha1: dd707d9d8f061d8c3cd18612af1915ead6862c2e
 
 jobs:
   - name: rds_broker


### PR DESCRIPTION
## What

As part of the #150879493, we're reworking the parameters on the RDS
broker so that `cf update-service` commands trigger changes to applied immediately by default.

We're also fixing some other previously in correctly documented parameters to our users.

## How to review

Deploy from this branch, then check that you can upgrade a plan for an RDS service instance by running something like:

```
cf update-service pg -p S-HA-dedicated-9.5
```

... the process of upgrading should begin immediately (visible from AWS console) and should complete in about an hour (from our experience)

Once that's done you can then check that you can request upgrade during a maintenance window using something like:

```
cf update-service pg -p M-HA-dedicated-9.5 -c '{"apply_at_maintenance_window": true, "preferred_maintenance_window": "tue:01:00-tue:02:00", "preferred_backup_window": "05:00-07:00"}'
```

...the process of upgrading should NOT begin immediately.
(The "preferred_backup_window" _may_ be required if your selected maintenance window overlaps with the current backup window)

Once you are happy with these changes the PRs for the [rds-broker](https://github.com/alphagov/paas-rds-broker/pull/69) and [rds-broker's boshrelease](https://github.com/alphagov/paas-rds-broker-boshrelease/pull/47) should be merged ensuring the references are updated as required. 

## Who can review

Not @chrisfarms nor @paroxp 
