### PR TITLE
[Support] Add cf_subshell_scoped_login helper script.

### DIFF
--- a/scripts/cf_subshell_scoped_login
+++ b/scripts/cf_subshell_scoped_login
@@ -40,4 +40,4 @@ echo
 echo "You are now in a subshell with CF_HOME set to ${CF_HOME}"
 echo "This will be cleaned up when this shell is closed."
 echo
-bash -il
+${SHELL:-bash} -il

--- a/scripts/cf_subshell_scoped_login
+++ b/scripts/cf_subshell_scoped_login
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+set -eu
+
+if [ $# -lt 1 ]; then
+  echo "Usage $0 <target>" 1>&2
+  exit 1
+fi
+
+TARGET=${1}
+
+case $TARGET in
+  prod)
+    API_URL="https://api.cloud.service.gov.uk"
+    ;;
+  staging)
+    API_URL="https://api.staging.cloudpipeline.digital"
+    ;;
+  *)
+    echo "Unrecognised target '${TARGET}'" 1>&2
+    exit 1
+    ;;
+esac
+
+TMPDIR=${TMPDIR:-/tmp}
+CF_HOME=$(mktemp -d "${TMPDIR}/cf_home.XXXXXX")
+cleanup() {
+  echo "Cleaning up temporary CF_HOME..."
+  cf logout || true
+  rm -r "${CF_HOME}"
+}
+trap 'cleanup' EXIT
+
+export CF_HOME
+
+cf api "${API_URL}"
+cf login --sso
+
+echo
+echo "You are now in a subshell with CF_HOME set to ${CF_HOME}"
+echo "This will be cleaned up when this shell is closed."
+echo
+bash -il


### PR DESCRIPTION
## What

This is useful when you want to login to one of the persistent
environments for a specific task without that affecting other terminal
sessions.

For context, the CF CLI keeps information about the currently targeted
API endpoint along with auth tokens etc in $CF_HOME/.cf/config.json. If
CF_HOME is unset, it detaults to $HOME.

This script therefore creates a temporary directory and sets CF_HOME to
that before dropping into a subshell. An exit trap cleans all this up.

## How to review

* Consider whether the script name makes sense (I found it hard to come up with a good name for this).
* In one terminal log in to a dev environment.
* In another terminal window, use this script to log in to staging or prod (`./scripts/cf_subshell_scoped_login staging`).
* Verify that first terminal session is unaffected and remains logged into the dev environment

## Who can review

Not me.

P.S. I realise I'm no longer on support, but this is something I started while on support last week.