### PR TITLE
[#149929104] Add uaa_lock_user.rb script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ test: spec lint_yaml lint_terraform lint_shellcheck lint_concourse lint_ruby lin
 
 spec:
 	cd scripts &&\
+		go test
+	cd scripts &&\
 		BUNDLE_GEMFILE=Gemfile bundle exec rspec
 	cd tools/metrics &&\
 		go test

--- a/scripts/scripts_suite_test.go
+++ b/scripts/scripts_suite_test.go
@@ -1,0 +1,13 @@
+package scripts_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestScripts(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Scripts Suite")
+}

--- a/scripts/uaa_lock_user.rb
+++ b/scripts/uaa_lock_user.rb
@@ -1,0 +1,74 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+require 'uaa'
+require 'ostruct'
+
+STATE_MAP = {
+  true => "unlocked",
+  false => "locked",
+}.freeze
+
+def parse_args
+  desired_active_state = false
+  settings = OpenStruct.new(
+    target: "",
+    token: "",
+    insecure: false,
+  )
+
+  optparse = OptionParser.new do |opts|
+    opts.banner = <<EOS
+Usage: uaa_lock_user.rb [options] USERNAME
+
+You need to provide the following environment variables:
+
+  TARGET=$(cf curl /v2/info | jq -r .token_endpoint)
+  TOKEN=$(cf oauth-token)
+
+EOS
+
+    opts.on("--skip-ssl-validation", "Skip verification of the API endpoint. Not recommended!") do
+      settings.insecure = true
+    end
+
+    opts.on("-u", "--unlock", "Unlock user") do
+      desired_active_state = true
+    end
+  end
+  optparse.parse!
+
+  if ARGV.size != 1 || !ENV.include?("TARGET") || !ENV.include?("TOKEN")
+    puts optparse
+    exit 2
+  end
+
+  username = ARGV[0]
+  settings.target = ENV.fetch("TARGET")
+  settings.token = ENV.fetch("TOKEN")
+
+  [username, desired_active_state, settings]
+end
+
+def update_user(username, active, uaac)
+  query = { filter: "username eq '#{username}'" }
+  users = uaac.all_pages(:user, query)
+
+  if users.empty?
+    abort "Username not found"
+  elsif users.size > 1
+    abort "Username is not unique"
+  end
+  user = users.first
+
+  if user.fetch('active') != active
+    user['active'] = active
+    uaac.patch(:user, user)
+  end
+
+  "#{STATE_MAP.fetch(active)} #{username}"
+end
+
+username, active, settings = parse_args
+uaac = CF::UAA::Scim.new(settings.target, settings.token, skip_ssl_validation: settings.insecure)
+puts update_user(username, active, uaac)

--- a/scripts/uaa_lock_user_test.go
+++ b/scripts/uaa_lock_user_test.go
@@ -1,0 +1,154 @@
+package scripts_test
+
+import (
+	"net/http"
+	"os"
+	"os/exec"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+	"github.com/onsi/gomega/ghttp"
+)
+
+type Response struct {
+	Resources    []UserResource `json:"resources"`
+	StartIndex   int            `json:"startIndex"`
+	ItemsPerPage int            `json:"itemsPerPage"`
+	TotalResults int            `json:"totalResults"`
+	Schemas      []string       `json:"schemas"`
+}
+
+type UserResource struct {
+	ID       string `json:"id"`
+	Username string `json:"userName"`
+	Active   bool   `json:"active"`
+}
+
+var _ = Describe("uaa_lock_user.rb", func() {
+	var (
+		args       []string
+		session    *gexec.Session
+		server     *ghttp.Server
+		response   *Response
+		statusCode int
+	)
+
+	BeforeEach(func() {
+		args = []string{"jane.smith@gov.uk"}
+
+		statusCode = http.StatusOK
+		response = &Response{
+			Resources: []UserResource{{
+				ID:       "17742243-4250-4266-ba8b-5d76dc97d52e",
+				Username: "jane.smith@gov.uk",
+			}},
+			StartIndex:   1,
+			ItemsPerPage: 100,
+			TotalResults: 1,
+			Schemas:      []string{"urn:scim:schemas:core:1.0"},
+		}
+
+		server = ghttp.NewServer()
+		server.RouteToHandler("GET", "/Users", ghttp.RespondWithJSONEncodedPtr(&statusCode, &response))
+	})
+
+	AfterEach(func() {
+		server.Close()
+	})
+
+	JustBeforeEach(func() {
+		os.Setenv("TARGET", server.URL())
+		os.Setenv("TOKEN", "faketoken")
+
+		args = append([]string{"exec", "./uaa_lock_user.rb"}, args...)
+		command := exec.Command("bundle", args...)
+
+		var err error
+		session, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Context("user doesn't exist", func() {
+		BeforeEach(func() {
+			args = []string{"john.smith@gov.uk"}
+
+			response.Resources = []UserResource{}
+			response.TotalResults = 0
+		})
+
+		It("returns an error", func() {
+			Eventually(session).Should(gexec.Exit(1))
+			Expect(session.Err).To(gbytes.Say("Username not found"))
+		})
+	})
+
+	Context("more than one user", func() {
+		BeforeEach(func() {
+			response.Resources = append(response.Resources, response.Resources[0])
+			response.TotalResults = 2
+		})
+
+		It("returns an error", func() {
+			Eventually(session).Should(gexec.Exit(1))
+			Expect(session.Err).To(gbytes.Say("Username is not unique"))
+		})
+	})
+
+	Context("lock existing user", func() {
+		Context("user is not locked", func() {
+			BeforeEach(func() {
+				response.Resources[0].Active = true
+
+				server.RouteToHandler("PATCH", "/Users/17742243-4250-4266-ba8b-5d76dc97d52e", ghttp.RespondWith(statusCode, ""))
+			})
+
+			It("prints success message", func() {
+				Eventually(session).Should(gexec.Exit(0))
+				Expect(session.Out).To(gbytes.Say("locked jane.smith@gov.uk"))
+			})
+		})
+
+		Context("user is locked", func() {
+			BeforeEach(func() {
+				response.Resources[0].Active = false
+			})
+
+			It("prints success message", func() {
+				Eventually(session).Should(gexec.Exit(0))
+				Expect(session.Out).To(gbytes.Say("locked jane.smith@gov.uk"))
+			})
+		})
+	})
+
+	Context("unlock existing user", func() {
+		BeforeEach(func() {
+			args = append(args, "-u")
+		})
+
+		Context("user is not locked", func() {
+			BeforeEach(func() {
+				response.Resources[0].Active = true
+			})
+
+			It("prints success message", func() {
+				Eventually(session).Should(gexec.Exit(0))
+				Expect(session.Out).To(gbytes.Say("unlocked jane.smith@gov.uk"))
+			})
+		})
+
+		Context("user is locked", func() {
+			BeforeEach(func() {
+				response.Resources[0].Active = false
+
+				server.RouteToHandler("PATCH", "/Users/17742243-4250-4266-ba8b-5d76dc97d52e", ghttp.RespondWith(statusCode, ""))
+			})
+
+			It("prints success message", func() {
+				Eventually(session).Should(gexec.Exit(0))
+				Expect(session.Out).To(gbytes.Say("unlocked jane.smith@gov.uk"))
+			})
+		})
+	})
+})


### PR DESCRIPTION
## What

This will replace the rather cumbersome process for locking (or unlocking)
users that's currently described in the team manual:

- https://government-paas-team-manual.readthedocs.io/en/latest/guides/CF_UAA_user_management/#locking-a-user-account

I've mocked just enough of the UAA responses to make it work and verify that
we're sending PATCH requests when the state needs to change.

Per the original script, I've left TARGET and TOKEN as environments, to call
out the fact that they are mandatory and to help avoid you storing tokens in
your shell history.

## How to review

1. Code review
1. See if the tests make sense and pass
1. Try it in a dev environment:
    1. Create an account using `scripts/create-user.sh`
    1. Verify that you can login
    1. Lock the account and verify that you can no longer login
    1. Unlock the account and verify that you can login again

## Who can review

Anyone.