### PR TITLE
[#146290921] Remove MigrateLegacyAdminUsers code

### DIFF
--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -44,9 +44,9 @@ meta:
 
 releases:
   - name: rds-broker
-    version: 0.1.18
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.18.tgz
-    sha1: dd707d9d8f061d8c3cd18612af1915ead6862c2e
+    version: 0.1.19
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.19.tgz
+    sha1: 33d5545c0558fd432c62344dc9ed46aa00df8829
 
 jobs:
   - name: rds_broker


### PR DESCRIPTION
## What 

**NOTE: review migration scripts first and run them on prod**

As the migration period has passed some time ago we've decided to remove
the code responsible for migration to reduce codebase complexity and
maintenance burden.

This needs to be updated after
https://github.com/alphagov/paas-rds-broker-boshrelease/pull/48
is merged.

## How to review


- deploy from this branch, create a service, bind it to an app and finally unbind

## Who can review

Not @combor or @46bit 
