### PR TITLE
[#150926071] Add RDS Instance management

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -158,7 +158,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/awscli
-              tag: 465642da06051a55630d39c899697b678f66a7f7
+              tag: 1ab7d6cdac70f2c32563ea173da0cd7791309be5
           run:
             path: ./paas-cf/concourse/scripts/rds_instances.sh
             args:

--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -145,3 +145,21 @@ jobs:
           put: deployed-healthcheck
           params:
             file: deployed-healthcheck/healthcheck-deployed
+
+      - task: shutdown-rds-instances
+        config:
+          platform: linux
+          inputs:
+            - name: paas-cf
+          params:
+            AWS_DEFAULT_REGION: {{aws_region}}
+            DEPLOY_ENV: {{deploy_env}}
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/awscli
+              tag: 465642da06051a55630d39c899697b678f66a7f7
+          run:
+            path: ./paas-cf/concourse/scripts/rds_instances.sh
+            args:
+              - stop

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -635,7 +635,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/awscli
-              tag: 465642da06051a55630d39c899697b678f66a7f7
+              tag: 1ab7d6cdac70f2c32563ea173da0cd7791309be5
           run:
             path: sh
             args:
@@ -2843,7 +2843,7 @@ jobs:
                 type: docker-image
                 source:
                   repository: governmentpaas/awscli
-                  tag: 465642da06051a55630d39c899697b678f66a7f7
+                  tag: 1ab7d6cdac70f2c32563ea173da0cd7791309be5
               params:
                 AWS_DEFAULT_REGION: {{aws_region}}
                 DEPLOY_ENV: {{deploy_env}}

--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -40,6 +40,24 @@ jobs:
           run:
             path: ./paas-cf/concourse/scripts/sleep_for_deploy_env.sh
 
+      - task: startup-rds-instances
+        config:
+          platform: linux
+          inputs:
+            - name: paas-cf
+          params:
+            AWS_DEFAULT_REGION: {{aws_region}}
+            DEPLOY_ENV: {{deploy_env}}
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/awscli
+              tag: 465642da06051a55630d39c899697b678f66a7f7
+          run:
+            path: ./paas-cf/concourse/scripts/rds_instances.sh
+            args:
+              - start
+
       - task: kick-off-create-cloudfoundry-pipeline
         config:
           platform: linux

--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -52,7 +52,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/awscli
-              tag: 465642da06051a55630d39c899697b678f66a7f7
+              tag: 1ab7d6cdac70f2c32563ea173da0cd7791309be5
           run:
             path: ./paas-cf/concourse/scripts/rds_instances.sh
             args:

--- a/concourse/scripts/rds_instances.sh
+++ b/concourse/scripts/rds_instances.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+set -euo pipefail
+
+ACTION=$1
+CMD=""
+STATE_BEFORE=""
+STATE_AFTER=""
+
+case $ACTION in
+  start)
+    CMD=start-db-instance
+    STATE_BEFORE="stopped"
+    STATE_AFTER="available"
+  ;;
+  stop)
+    CMD=stop-db-instance
+    STATE_BEFORE="available"
+    STATE_AFTER="stopped"
+  ;;
+  *)
+    echo "Action '${ACTION}' is not supported... Please try 'start' or 'stop' instead."
+    exit 1
+  ;;
+esac
+
+# Obtain the VPC ID from the AWS API and make sure there is only one that we can
+# use.
+vpc_ids=$(
+  aws ec2 describe-vpcs \
+    --filters "Name=tag:Name,Values=${DEPLOY_ENV}" \
+    --query 'Vpcs[].VpcId' \
+    --output text
+)
+
+vpc_ids_count=$(echo "${vpc_ids}" | awk '{print NF}')
+
+if [ ! "${vpc_ids_count}" -eq 1 ]; then
+  echo "Number of VPCs need to be exactly 1. Got: ${vpc_ids}"
+  exit 1
+fi
+
+# Make a list of RDS Instances that are assigned to the specific VPC ID, are not
+# MultiAZ and are/do not contain any replicas.
+instance_ids=$(
+  aws rds describe-db-instances \
+    --query "DBInstances[?DBSubnetGroup.VpcId == \`${vpc_ids}\` && DBInstanceStatus == \`${STATE_BEFORE}\` && MultiAZ == \`false\` && ReadReplicaDBInstanceIdentifiers == \`[]\`].DBInstanceIdentifier" --output text | tr '\t' '\n' | sort
+)
+
+for instance_id in $instance_ids; do
+  aws rds "${CMD}" --db-instance-identifier "${instance_id}"
+done
+
+for _ in $(seq 1 20); do
+  instance_ids_after=$(
+    aws rds describe-db-instances \
+      --query "DBInstances[?DBSubnetGroup.VpcId == \`${vpc_ids}\` && DBInstanceStatus == \`${STATE_AFTER}\` && MultiAZ == \`false\` && ReadReplicaDBInstanceIdentifiers == \`[]\`].DBInstanceIdentifier" --output text | tr '\t' '\n' | sort
+  )
+
+  if [ "${instance_ids}" = "${instance_ids_after}" ]; then
+    echo "All done. Happy days."
+    exit 0
+  fi
+
+  echo "Waiting for the instances to ${ACTION}. Sleeping for 60 seconds..."
+
+  sleep 60
+done
+
+echo "We have waited for too long. Nothing we can do. Check it out yourself..."
+echo "${instance_ids_after}"
+exit 1

--- a/concourse/tasks/kill-instance.yml
+++ b/concourse/tasks/kill-instance.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/awscli
-    tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+    tag: 1ab7d6cdac70f2c32563ea173da0cd7791309be5
 platform: linux
 run:
   path: sh

--- a/concourse/tasks/upload-test-artifacts.yml
+++ b/concourse/tasks/upload-test-artifacts.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/awscli
-    tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+    tag: 1ab7d6cdac70f2c32563ea173da0cd7791309be5
 inputs:
   - name: paas-cf
   - name: artifacts


### PR DESCRIPTION
## What

We believe it will decrease the costs for the development environments to
turn off the RDS instances over the night along with the rest of
`autodelete-cloudfoundry` pipeline.

These will start back up in the morning, with the use of
`deployment-kick-off` pipeline.

We've prepared a script which could be also used locally if needed in
order to not duplicate the same functionality before start/stop call.

We need some of the functionality from the newer version of AWS CLI. We
did that in our alphagov/paas-docker-cloudfoundry-tools#100 repo and needed to
include it in our pipelines.

## How to review

- Code review
- Run `autodelete` pipeline
- Check all RDS instances have stopped for your environment
- Run the `kick-off` pipeline
- Check all RDS instances have started again
- Check `create-cloudfoundry` pipeline completes

## Who can review

Neither @dcarley nor myself.

## ~~Before merging~~ 🐝 🐝 🐝 

~~This PR has a [WIP] commit which is tagging a branch tag from docker hub. We need to update that with the proper hash before merging.~~