### PR TITLE
[#150397953] Migrate away from legacy bridge components

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -360,6 +360,15 @@ properties:
       public_cert: (( grab secrets.cc_server_cert ))
       private_key: (( grab secrets.cc_server_key ))
 
+    diego:
+      temporary_local_staging: true
+      temporary_local_tasks: true
+      temporary_local_apps: true
+      temporary_local_tps: true
+      temporary_local_sync: true
+      temporary_cc_uploader_mtls: true
+      temporary_droplet_download_mtls: true
+
   ccdb:
     db_scheme: postgres
     address: (( grab terraform_outputs.cf_db_address ))

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -567,8 +567,7 @@ properties:
         ca_cert: (( grab properties.diego.rep.ca_cert ))
         client_cert: (( grab secrets.rep_client_cert ))
         client_key: (( grab secrets.rep_client_key ))
-        # FIXME: set this to true once certs have been rolled out.
-        require_tls: false
+        require_tls: true
       dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
 
     bbs:
@@ -584,8 +583,7 @@ properties:
         ca_cert: (( grab properties.diego.auctioneer.ca_cert ))
         client_cert: (( grab secrets.auctioneer_client_cert ))
         client_key: (( grab secrets.auctioneer_client_key ))
-        # FIXME: set this to true once certs have been rolled out.
-        require_tls: false
+        require_tls: true
       etcd:
         machines: []
         ca_cert: ""
@@ -596,8 +594,7 @@ properties:
         ca_cert: (( grab properties.diego.rep.ca_cert ))
         client_cert: (( grab secrets.rep_client_cert ))
         client_key: (( grab secrets.rep_client_key ))
-        # FIXME: set this to true once certs have been rolled out.
-        require_tls: false
+        require_tls: true
       sql:
         db_username: bbs
         db_password: (( grab secrets.cf_db_bbs_password ))


### PR DESCRIPTION
## What

This enables mutual TLS between CloudController and Diego components. This change also means that much of this communication now happens directly as opposed to going through the cc_bridge components. Once this is deployed, there will be a follow-up PR to remove the unneeded cc_bridge components.

This PR is built on top of #1056, and includes the commits from that PR.

## How to review

🚨  #1056 must be merged and deployed to prod before this is merged.

* Deploy from this branch against an environment with #1056 deployed.
* Verify that the deploy succeeds without any downtime, and that all the tests pass.

## Who can review

Not @bandesz or myself.