### PR TITLE
[#150397953] Cleanup legacy bridge components

### DIFF
--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -425,16 +425,10 @@ jobs:
         consumes: {consul_client: nil, consul_server: nil, consul_common: nil}
       - name: datadog-consul-agent-client
         release: datadog-for-cloudfoundry
-      - name: stager
-        release: cf
-      - name: nsync
-        release: cf
       - name: tps
         release: cf
       - name: cc_uploader
         release: cf
-      - name: cfdot
-        release: diego
       - name: metron_agent
         release: (( grab meta.release.name ))
     instances: 2

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -685,40 +685,11 @@ properties:
         client_cert: (( grab secrets.cc_client_cert ))
         client_key: (( grab secrets.cc_client_key ))
 
-    nsync:
-      dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
-      bbs:
-        api_location: (( grab meta.bbs.api_location ))
-        ca_cert: (( grab secrets.bosh_ca_cert ))
-        client_cert: (( grab secrets.bbs_client_cert  ))
-        client_key: (( grab secrets.bbs_client_key  ))
-        require_ssl: true
-
-      cc:
-        base_url:  (( grab properties.cc.srv_api_uri ))
-        basic_auth_password: (( grab properties.cc.internal_api_password ))
-        staging_upload_user: (( grab properties.cc.staging_upload_user ))
-        staging_upload_password: (( grab properties.cc.staging_upload_password ))
-
-    stager:
-      dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
-      bbs:
-        api_location: (( grab meta.bbs.api_location ))
-        ca_cert: (( grab secrets.bosh_ca_cert ))
-        client_cert: (( grab secrets.bbs_client_cert ))
-        client_key: (( grab secrets.bbs_client_key ))
-        require_ssl: true
-      cc:
-        base_url: (( grab properties.cc.srv_api_uri ))
-        basic_auth_password: (( grab properties.cc.internal_api_password ))
-        staging_upload_user: (( grab properties.cc.staging_upload_user ))
-        staging_upload_password: (( grab properties.cc.staging_upload_password ))
-
     tps:
+      listener_enabled: false
       dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
       cc:
         base_url: (( grab properties.cc.srv_api_uri ))
-        basic_auth_password: (( grab properties.cc.internal_api_password ))
         staging_upload_user: (( grab properties.cc.staging_upload_user ))
         staging_upload_password: (( grab properties.cc.staging_upload_password ))
         ca_cert: (( grab secrets.bosh_ca_cert ))

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -630,6 +630,7 @@ properties:
       server_cert: (( grab secrets.rep_server_cert ))
       server_key: (( grab secrets.rep_server_key ))
       require_tls: true
+      enable_legacy_api_endpoints: false
       dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
       bbs:
         api_location: (( grab meta.bbs.api_location ))


### PR DESCRIPTION
## What

Following on from #1058, this cleans up the legacy bridge components that are no longer needed.

## How to review

🚨  #1058 must be merged and deployed to prod before this is merged.

* Deploy from this branch against an environment with #1058 deployed.
* Verify that the deploy succeeds without any downtime, and that all the tests pass.

## Who can review

Not @bandesz or myself.