### PR TITLE
[#150881142] Check for "null" string in the terraform_destroy_datadog task.

### DIFF
--- a/concourse/tasks/terraform_destroy_datadog.yml
+++ b/concourse/tasks/terraform_destroy_datadog.yml
@@ -17,7 +17,7 @@ run:
     - -c
     - |
       cleanup=false
-      if [ -n "${TF_VAR_datadog_api_key}" ] && [ -n "${TF_VAR_datadog_app_key}" ] && [ "${ENABLE_DATADOG}" = "false" ]; then
+      if [ "null" != "${TF_VAR_datadog_api_key:-null}" ] && [ "null" != "${TF_VAR_datadog_app_key:-null}" ] && [ "${ENABLE_DATADOG}" = "false" ]; then
         cleanup=true
         echo "Datadog disabled but keys present, running check cleanup..."
       fi


### PR DESCRIPTION
## What

If the datadog parameters (datadog_api_key, datadog_app_key) are empty they are
passed as "null" string instead of empty strings. It seems this only happens
when we trigger an external task in the pipeline (e.g. in
destroy-cloudfoundry.yml).

## How to review

You should set your datadog keys to empty strings (or remove them completely) and destroy your development environment. The pipeline should succeed.

## Who can review

Not me or @paroxp .
