### PR TITLE
[#151516133] Enable automatic certificate renewal cron job on cdn-broker

### DIFF
--- a/manifests/cf-manifest/manifest/060-cdn-broker.yml
+++ b/manifests/cf-manifest/manifest/060-cdn-broker.yml
@@ -1,8 +1,8 @@
 releases:
   - name: cdn-broker
-    version: 0.1.4
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.4.tgz
-    sha1: 5b42b6240c04db1943de89d44157bd34351da9f1
+    version: 0.1.5
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.5.tgz
+    sha1: 9d0cef5c10677fa9d9bf921c8af36e205ad910ab
 
 jobs:
   - name: cdn_broker
@@ -12,6 +12,8 @@ jobs:
     stemcell: default
     templates:
       - name: cdn-broker
+        release: cdn-broker
+      - name: cdn-cron
         release: cdn-broker
       - name: datadog-cdn-broker
         release: datadog-for-cloudfoundry


### PR DESCRIPTION
## What

cdn-broker version is updated to 0.1.5 and cdn-cron is added to the cdn_broker job.

The certificate renewal will run every hour (default schedule).

The cdn-broker changes can be found here: https://github.com/alphagov/paas-cdn-broker-boshrelease/pull/6

## How to review

 * Deploy the changes
 * We expect this to only run one instance of the cdn-cron job, to avoid race conditions in the renewal of certificates.
 * Note: The renewal process was already tested as part of the cdn-broker bosh release PR.

## Who can review

Not me or @henrytk 
