### PR TITLE
[#151808174] Upgrade UAA to v51

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -37,6 +37,11 @@ releases:
     version: 1.11.7
     url: https://github.com/cloudfoundry-community/nginx-release/releases/download/v1.11.7/nginx-1.11.7.tgz
     sha1: 133bb2260411b197924fff08d4cbd923cc8ec7eb
+    # FIXME: remove once CF is upgraded to >= v276
+  - name: uaa
+    version: "51"
+    url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=51
+    sha1: 869b8e6bf58f5431b3579f730f142814aae39d71
 
 stemcells:
   - alias: default

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -127,7 +127,8 @@ jobs:
       - name: datadog-consul-agent-client
         release: datadog-for-cloudfoundry
       - name: uaa
-        release: (( grab meta.release.name ))
+        # FIXME: remove once CF is upgrade to >= v276
+        release: uaa
       - name: metron_agent
         release: (( grab meta.release.name ))
       - name: statsd_injector


### PR DESCRIPTION
## What

In v50 there was a memory leak issue which was fixed in v51. We're
manually bumping the version of UAA to prevent this happening again.

This should be reverted once we upgrade the CF release to >= v276.

This is a critical release as the memory leak can cause another downtime in production soon.

## How to review

* sanity check
* deploy the changes
* all tests should pass

## Who can review

not me or @paroxp 
