### PR TITLE
[#150881142] Fix autodelete/destroy pipelines and remove gpg_ids sed hack

### DIFF
--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -157,19 +157,15 @@ enable_metrics: ${ENABLE_METRICS}
 auto_deploy: $([ "${ENABLE_AUTO_DEPLOY:-}" ] && echo "true" || echo "false")
 continuous_smoke_tests_trigger: $([ "${ALERT_EMAIL_ADDRESS:-}" ] && echo "true" || echo "false")
 disable_user_creation: $([ "${NEW_ACCOUNT_EMAIL_ADDRESS:-}" ] && echo "false" || echo "true")
+gpg_ids: ${gpg_ids}
 EOF
   echo -e "pipeline_lock_git_private_key: |\n  ${git_id_rsa//$'\n'/$'\n'  }"
-}
-
-generate_manifest_file() {
-  sed -e "s/((gpg_ids))/${gpg_ids}/" \
-    < "${SCRIPT_DIR}/../pipelines/${pipeline_name}.yml"
 }
 
 upload_pipeline() {
   bash "${SCRIPT_DIR}/deploy-pipeline.sh" \
         "${pipeline_name}" \
-        <(generate_manifest_file) \
+        "${SCRIPT_DIR}/../pipelines/${pipeline_name}.yml" \
         <(generate_vars_file)
 }
 

--- a/concourse/tasks/terraform_destroy_datadog.yml
+++ b/concourse/tasks/terraform_destroy_datadog.yml
@@ -17,7 +17,7 @@ run:
     - -c
     - |
       cleanup=false
-      if [ -n "${TF_VAR_datadog_api_key}" ] && [ -n "${TF_VAR_datadog_app_key}" ] && [ "${ENABLE_DATADOG}" = "false" ]; then
+      if [ "null" != "${TF_VAR_datadog_api_key:-null}" ] && [ "null" != "${TF_VAR_datadog_app_key:-null}" ] && [ "${ENABLE_DATADOG}" = "false" ]; then
         cleanup=true
         echo "Datadog disabled but keys present, running check cleanup..."
       fi


### PR DESCRIPTION
## What

Fixes the autodelete-cloudfoundry and destroy-cloudfoundry pipelines. If the datadog parameters (datadog_api_key, datadog_app_key) are empty they are passed as "null" string instead of empty strings. It seems this only happens when we trigger an external task in the pipeline.

Also removes a sed hack during the manifest generation which is not needed anymore because the new parameter format is able to handle arrays properly.

## How to review

I added a temporary commit for testing to set the branch name to this one for the autodelete pipeline.

* Set your datadog keys (datadog_api_key, datadog_app_key) in the datadog-secrets.yml to an empty string
* Update the pipelines with ```BRANCH=fix_pipeline_variables_150881142 SKIP_COMMIT_VERIFICATION=false``` and check the diff
* Run the autodelete pipeline and check if it finishes successfully
* Run the deployment-kick-off, it should run successfully
* Restore your datadog secrets

## Before merging

❗️  Remove the temporary commit prefixed with "[TMP]".

## Who can review

Not me
