### PR TITLE
[#151167914] Workaround for bosh-cli timeout

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2882,3 +2882,11 @@ jobs:
               uuid=$(bosh status --uuid)
               sed -e "s/^director_uuid:.*$/director_uuid: ${uuid}/" cf-manifest/cf-manifest.yml > cf-manifest-with-uuid.yml
               bosh deployment ./cf-manifest-with-uuid.yml
+              # FIXME: this wait loop and keep-alive hackery is a workaround for: https://github.com/concourse/concourse/issues/1269
+              # If the issue is resolved upstream then this block can likely be removed and the bosh-cli.sh script simplified.
+              echo "Waiting for 5mins for a connection to bosh-cli job"
+              sleep 300
+              while test "$(find /dev/pts/ | wc -l)" -gt "2"; do
+                echo "There is at least one connection to the bosh-cli job, keeping alive..."
+                sleep 300
+              done


### PR DESCRIPTION
# What

I've been using this successfully for ~week now, so it might be of interest to others...

The current bosh-cli make target works by hijacking a concourse
container that has recently run (and succeeded) to use as a temporary
shell to access bosh.

Some recent concourse updates changed the behaviour of how long and when
old containers are garbage collected, and where it used to be the case
that if you were logged in to a hijacked container the container would
be protected from garbage collection (or at least stay around for a very
long time), it is now the case that containers are cleaned up after
around 5mins and we get kicked out of our bosh-cli shell.... which is
frustrating.

To workaround this issue the following changes are made:

* the run-bosh-cli task will now sleep for as long as more than pseudo-terminals are listed in /dev/pts (ie at least one other console is attached)
and only 'succeed' after 5mins of inactivity
slave is detected (ie someone has a terminal wired up to the container)
* the script to launch the job will wait until the container is running,
then connect to it
* the script to launch to shell will abort the job on EXIT to clean up
faster that the /dev/pts based safety net

## How to review


* make dev pipeline
* make dev bosh-cli
* do some boshing for 5mins
* continue doing some boshing for 10mins
* do even more boshing for hours
* exit
* check that the container exits (should be marked "aborted") or if not that it exits after ~5mins of inactivity.

If this seems like an acceptable workaround... then please check that any other tasks that use the bosh-cli script are unaffected. I do not have much context around this.

Also consider the effect of long running jobs/tasks on the prod concourse instance, against I have little context here. 

## Who can review

Not @chrisfarms
