### PR TITLE
Don't delete healthcheck app when deleting healthcheck DB

### DIFF
--- a/concourse/tasks/remove-healthcheck-db.yml
+++ b/concourse/tasks/remove-healthcheck-db.yml
@@ -26,7 +26,7 @@ run:
         exit 0
       fi
       cf target -o admin -s healthchecks
-      cf delete healthcheck -f -r
       if cf services | grep -q healthcheck-db; then
+        cf unbind-service healthcheck healthcheck-db || true
         cf delete-service healthcheck-db -f
       fi


### PR DESCRIPTION
## What

This task runs early in the autodelete-cloudfoundry pipeline, and
previously would delete the healthcheck app so that it's database could
be deleted. If a job later in the pipeline failed, the system would be
left in a state where the app had been deleted, but the flag file in the
state bucket still indicated it was deployed. This then caused problems
in the next deployment as the availability tests would run and fail.

There's no need to delete the app in this task, and it's non-obvious
from the name that it will be. This therefore updates the task to merely
unbind the app from the database before deleting the database.

## How to review

* Run a deploy from this branch to create the healthcheck DB.
* Run the `autodelete-cloudfoundry` pipeline and verify that the healthcheck DB is successfully deleted (the pipeline can be aborted after that task if you don't want to tear down the whole deployment).

:rotating_light: Remove the `[TMP]` commit before merging this.

## Who can review

Not me.
