### PR TITLE
Update readme to include start and end date params

### DIFF
--- a/scripts/usage_reporting/README.md
+++ b/scripts/usage_reporting/README.md
@@ -25,6 +25,8 @@ Example:
 ```
 go run event.go process_events.go \
   -org "<ORG_UUID>" \
+  -start "2017-10-01T00:00:00Z" \
+  -finish "2017-11-01T00:00:00Z" \
   < events.json \
   | tee usage.csv
 ```


### PR DESCRIPTION
## What

process_events.go now has start and end flags, these were not
documented when they were added. This commit adds them into the example in the
readme.

## How to review

Code review

## Who can review

Not @LeePorte
