### PR TITLE
bosh-cli: download manifest from bosh

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2855,7 +2855,6 @@ jobs:
       - aggregate:
           - get: paas-cf
           - get: bosh-secrets
-          - get: cf-manifest
 
       - task: run-bosh-cli
         config:
@@ -2867,7 +2866,6 @@ jobs:
               tag: 4c863ad28bcb252bc35e1500e1afef386f5debfa
           inputs:
             - name: paas-cf
-            - name: cf-manifest
             - name: bosh-secrets
           params:
             SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
@@ -2879,9 +2877,8 @@ jobs:
             - |
               ./paas-cf/concourse/scripts/bosh_login.sh bosh.${SYSTEM_DNS_ZONE_NAME} bosh-secrets/bosh-secrets.yml
 
-              uuid=$(bosh status --uuid)
-              sed -e "s/^director_uuid:.*$/director_uuid: ${uuid}/" cf-manifest/cf-manifest.yml > cf-manifest-with-uuid.yml
-              bosh deployment ./cf-manifest-with-uuid.yml
+              bosh download manifest "((deploy_env))" ./cf-manifest.yml
+              bosh deployment ./cf-manifest.yml
               # FIXME: this wait loop and keep-alive hackery is a workaround for: https://github.com/concourse/concourse/issues/1269
               # If the issue is resolved upstream then this block can likely be removed and the bosh-cli.sh script simplified.
               echo "Waiting for 5mins for a connection to bosh-cli job"


### PR DESCRIPTION
## What

This is currently using the manifest from the state bucket. There have
been situations where this manifest doesn't match what's currently
deployed to bosh. In this case it can cause problems when interacting
with bosh because it complains that a deployment hasn't completed etc.

Switching this task to instead download the manifest from the bosh
director ensures that the manifest we're using matches Bosh's view of
the world.

## How to review

Push pipelines from this branch, and then run `make dev bosh-cli`. Verify that you're logged into bosh correctly, and that the deployment is set correctly.

## Who can review

Not me.