### PR TITLE
[#147674123] Monitor RDS for instances failures and disk utilisation

### DIFF
--- a/terraform/datadog/aws.tf
+++ b/terraform/datadog/aws.tf
@@ -31,3 +31,20 @@ resource "datadog_monitor" "rds-cpu-credits" {
 
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:all"]
 }
+
+resource "datadog_monitor" "rds-disk-utilisation" {
+  name           = "${format("%s RDS Disk utilisation", var.env)}"
+  type           = "query alert"
+  message        = "${format("Instance is {{#is_warning}}low on{{/is_warning}}{{#is_alert}}critically low on{{/is_alert}} storage space. See: %s#rds-disk-utilisation @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_documentation_url, var.aws_account)}"
+  notify_no_data = false
+  query          = "${format("min(last_1h):min:aws.rds.free_storage_space{aws_account:%s} by {hostname} / min:aws.rds.total_storage_space{aws_account:%s} by {hostname} <= 0.1", var.aws_account, var.aws_account)}"
+
+  thresholds {
+    warning  = "0.2"
+    critical = "0.1"
+  }
+
+  require_full_window = false
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:all"]
+}

--- a/terraform/datadog/aws.tf
+++ b/terraform/datadog/aws.tf
@@ -48,3 +48,13 @@ resource "datadog_monitor" "rds-disk-utilisation" {
 
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:all"]
 }
+
+resource "datadog_monitor" "rds-failure" {
+  name           = "${format("%s RDS Failure", var.env)}"
+  type           = "event alert"
+  message        = "${format("Instance has failed. See: %s#rds-failure @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_documentation_url, var.aws_account)}"
+  notify_no_data = false
+  query          = "${format("events('sources:rds priority:all tags:aws_account:%s,event_type:failure').by('hostname').rollup('count').last('5m') > 0", var.aws_account)}"
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:all"]
+}


### PR DESCRIPTION
## What

We want in-hours alerting when RDS instances fail or run low storage. This applies to both tenant and platform instances. This PR creates both - see the commits for more information.

## How to review

1. The final commit is purely for reviewing and should be removed before merging. With that commit present, the monitors will be created to monitor the staging environment. This is necessary because we have no Datadog RDS Integration in dev.
2. Create RDS instances in staging and fill them with data. You should see warnings generated when they reach 80% and alerts when they reach 90%. We have added an app in a temporary, not-to-be-merged app in the `filler` branch that can fill up MySQL instances but it does not work for Postgres.
3. We cannot generate test `failure` events, but you can temporarily modify that monitor if desired to target events that we can trigger.

To be merged alongside https://github.com/alphagov/paas-team-manual/pull/153. **Make sure to remove the `[TMP]` commit before merging.**

## Who can review

Not @46bit @paroxp.