### PR TITLE
Scale cell VMs

### DIFF
--- a/manifests/cf-manifest/env-specific/cf-prod.yml
+++ b/manifests/cf-manifest/env-specific/cf-prod.yml
@@ -1,6 +1,6 @@
 ---
 meta:
   cell:
-    instances: 33
+    instances: 36
   elasticsearch_master:
     disk_size: 1536000


### PR DESCRIPTION
## What

We need to scale the cell VMs in order to satisfy ADR017[1].

Output from `make prod show-cf-memory-usage`:

```
Memory reserved by orgs: 1408000 MB (1375 GB)
Memory reserved by apps: 510380 MB (498.4 GB)

Total cell memory required to meet ADR017: 1056000 MB (1031.3 GB)
```

Current cell memory = 1006.5GB = 30.5 (r4.xlarge memory) * 33 (number of cell VMs in prod).

This means we are currently not satisfying ADR017. 36 instances is enough to
cover the current shortfall and respond to a recent request to increase an
organisation's quota.

[1] https://government-paas-team-manual.readthedocs.io/en/latest/architecture_decision_records/ADR017-cell-capacity-assignment/

## How to review

Code review. The chance of human error is small, but the consequences of error are potentially catastrophic.

Check my math.

ADR017 is apparently old news, and we may be revising the threshold we need. Perhaps a chat between product people and tech arch is required? I raised this pull request to be a stickler for the rules.

## Who can review

Anyone but me.
