### PR TITLE
[#151838550] Add usage events collector app and billing database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ globals:
 dev: globals ## Set Environment to DEV
 	$(eval export AWS_ACCOUNT=dev)
 	$(eval export ENABLE_METRICS ?= false)
+	$(eval export ENABLE_USAGE_EVENTS_COLLECTION ?= false)
 	$(eval export CF_SKIP_SSL_VALIDATION=true)
 	$(eval export ENABLE_DESTROY=true)
 	$(eval export ENABLE_AUTODELETE=true)
@@ -104,6 +105,7 @@ dev: globals ## Set Environment to DEV
 staging: globals ## Set Environment to Staging
 	$(eval export AWS_ACCOUNT=staging)
 	$(eval export ENABLE_METRICS=false)
+	$(eval export ENABLE_USAGE_EVENTS_COLLECTION=false)
 	$(eval export ENABLE_AUTO_DEPLOY=true)
 	$(eval export SKIP_UPLOAD_GENERATED_CERTS=true)
 	$(eval export TAG_PREFIX=prod-)
@@ -122,6 +124,7 @@ staging: globals ## Set Environment to Staging
 prod: globals ## Set Environment to Production
 	$(eval export AWS_ACCOUNT=prod)
 	$(eval export ENABLE_METRICS=true)
+	$(eval export ENABLE_USAGE_EVENTS_COLLECTION=true)
 	$(eval export ENABLE_AUTO_DEPLOY=true)
 	$(eval export SKIP_UPLOAD_GENERATED_CERTS=true)
 	$(eval export PAAS_CF_TAG_FILTER=prod-*)

--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -89,6 +89,9 @@ jobs:
       - task: remove-healthcheck-db
         file: paas-cf/concourse/tasks/remove-healthcheck-db.yml
 
+      - task: remove-billing-db
+        file: paas-cf/concourse/tasks/remove-billing-db.yml
+
       - task: datadog-TF-destroy
         file: paas-cf/concourse/tasks/terraform_destroy_datadog.yml
         params:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1933,8 +1933,7 @@ jobs:
                     File.write('manifest.yml', manifest.to_yaml)
                   "
 
-                  cf blue-green-deploy paas-usage-events-collector
-                  cf delete -f paas-usage-events-collector-old
+                  cf push paas-usage-events-collector
 
         - task: deploy-paas-compose-scraper
           config:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -267,6 +267,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-usage-events-collector
+      tag_filter: v0.1.0
 
 jobs:
   - name: pipeline-lock

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -263,6 +263,11 @@ resources:
       uri: https://github.com/alphagov/paas-compose-scraper
       tag_filter: v0.1.0
 
+  - name: paas-usage-events-collector
+    type: git
+    source:
+      uri: https://github.com/alphagov/paas-usage-events-collector
+
 jobs:
   - name: pipeline-lock
     serial: true
@@ -1246,6 +1251,7 @@ jobs:
           - get: paas-rubbernecker
           - get: paas-compose-broker
           - get: paas-compose-scraper
+          - get: paas-usage-events-collector
 
       - aggregate:
         - task: extract-cf-terraform-outputs
@@ -1440,6 +1446,7 @@ jobs:
                   cf create-space monitoring -o admin
                   cf create-space service-brokers -o admin
                   cf create-space healthchecks -o admin
+                  cf create-space billing -o admin
 
                   cf create-org govuk-paas
                   cf create-space docs -o govuk-paas
@@ -1863,6 +1870,71 @@ jobs:
             put: deployed-healthcheck
             params:
               file: deployed-healthcheck/healthcheck-deployed
+
+        - task: deploy-paas-usage-events-collector
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/cf-cli
+                tag: 465642da06051a55630d39c899697b678f66a7f7
+            params:
+              ENABLE_USAGE_EVENTS_COLLECTION: ((enable_usage_events_collection))
+              CF_SKIP_SSL_VALIDATION: ((cf_skip_ssl_validation))
+            inputs:
+              - name: paas-cf
+              - name: paas-usage-events-collector
+              - name: config
+              - name: cf-secrets
+              - name: bosh-CA
+            run:
+              path: sh
+              args:
+                - -e
+                - -u
+                - -c
+                - |
+                  if  [ "${ENABLE_USAGE_EVENTS_COLLECTION:-}" != "true" ] ; then
+                    echo "ENABLE_USAGE_EVENTS_COLLECTION=${ENABLE_USAGE_EVENTS_COLLECTION} so skipping paas-usage-events-collector deploy"
+                    exit 0
+                  fi
+
+                  VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
+                  CF_CLIENT_SECRET=$($VAL_FROM_YAML secrets.uaa_clients_paas_usage_events_collector_secret cf-secrets/cf-secrets.yml)
+                  ./paas-cf/concourse/scripts/import_bosh_ca.sh
+
+                  . ./config/config.sh
+                  echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS} -o admin -s billing
+
+                  if ! cf service billing-db > /dev/null; then
+                    cf create-service postgres M-dedicated-9.5 billing-db
+                    while ! cf service billing-db | grep -q 'Status: create succeeded'; do
+                      echo "Waiting for creation of service to complete..."
+                      sleep 30
+                    done
+                  fi
+
+                  cd paas-usage-events-collector
+
+                  ruby -ryaml -e "
+                    env = {
+                      'CF_CLIENT_ID' => 'paas-usage-events-collector',
+                      'CF_CLIENT_SECRET' => '${CF_CLIENT_SECRET}',
+                      'CF_API_ADDRESS' => '${API_ENDPOINT}',
+                      'CF_SKIP_SSL_VALIDATION' => '${CF_SKIP_SSL_VALIDATION}',
+                    }
+                    manifest = YAML.load_file('manifest.yml')
+                    manifest['applications'].each { |app|
+                      app['env'] = {} unless app['env']
+                      app['env'].merge!(env)
+                      app['services'] = ['billing-db']
+                    }
+                    File.write('manifest.yml', manifest.to_yaml)
+                  "
+
+                  cf blue-green-deploy paas-usage-events-collector
+                  cf delete -f paas-usage-events-collector-old
 
         - task: deploy-paas-compose-scraper
           config:

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -163,6 +163,9 @@ jobs:
       - task: remove-healthcheck-db
         file: paas-cf/concourse/tasks/remove-healthcheck-db.yml
 
+      - task: remove-billing-db
+        file: paas-cf/concourse/tasks/remove-billing-db.yml
+
       - task: datadog-TF-destroy
         file: paas-cf/concourse/tasks/terraform_destroy_datadog.yml
         params:

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -124,6 +124,7 @@ debug: ${DEBUG:-}
 cf_release_version: v${cf_release_version}
 cf_graphite_version: ${cf_graphite_version}
 cf_env_specific_manifest: ${ENV_SPECIFIC_CF_MANIFEST}
+cf_skip_ssl_validation: ${CF_SKIP_SSL_VALIDATION:-}
 paas_cf_tag_filter: ${PAAS_CF_TAG_FILTER:-}
 TAG_PREFIX: ${TAG_PREFIX:-}
 system_dns_zone_name: ${SYSTEM_DNS_ZONE_NAME}
@@ -154,6 +155,7 @@ oauth_client_id: ${oauth_client_id:-}
 oauth_client_secret: ${oauth_client_secret:-}
 pagerduty_api_token: ${pagerduty_api_token:-}
 enable_metrics: ${ENABLE_METRICS}
+enable_usage_events_collection: ${ENABLE_USAGE_EVENTS_COLLECTION}
 auto_deploy: $([ "${ENABLE_AUTO_DEPLOY:-}" ] && echo "true" || echo "false")
 continuous_smoke_tests_trigger: $([ "${ALERT_EMAIL_ADDRESS:-}" ] && echo "true" || echo "false")
 disable_user_creation: $([ "${NEW_ACCOUNT_EMAIL_ADDRESS:-}" ] && echo "false" || echo "true")

--- a/concourse/tasks/remove-billing-db.yml
+++ b/concourse/tasks/remove-billing-db.yml
@@ -1,0 +1,34 @@
+---
+platform: linux
+inputs:
+  - name: paas-cf
+  - name: bosh-CA
+  - name: config
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/cf-cli
+    tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+run:
+  path: sh
+  args:
+    - -e
+    - -c
+    - |
+      ./paas-cf/concourse/scripts/import_bosh_ca.sh
+      . ./config/config.sh
+      if ! curl -I -f $API_ENDPOINT/info; then
+        echo "CF API unavailable. Skipping..."
+        exit 0
+      fi
+      if ! echo | cf login -a ${API_ENDPOINT} -u ${CF_ADMIN} -p ${CF_PASS}; then
+        echo "Login failed.  Skipping..."
+        exit 0
+      fi
+      cf target -o admin -s billing
+      if cf apps | grep -q paas-usage-events-collector; then
+        cf delete paas-usage-events-collector -f -r
+      fi
+      if cf services | grep -q billing-db; then
+        cf delete-service billing-db -f
+      fi

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -522,6 +522,14 @@ properties:
         scope: openid,oauth.approvals,cloud_controller.global_auditor
         authorities: oauth.login,cloud_controller.global_auditor
         redirect-uri: (( concat "https://login." properties.system_domain ))
+      paas-usage-events-collector:
+        access-token-validity: 1209600
+        authorized-grant-types: client_credentials,refresh_token
+        override: true
+        secret: (( grab secrets.uaa_clients_paas_usage_events_collector_secret ))
+        scope: openid,oauth.approvals,cloud_controller.admin_read_only
+        authorities: oauth.login,cloud_controller.admin_read_only
+        redirect-uri: (( concat "https://login." properties.system_domain ))
       cc-service-dashboards:
         secret: (( grab secrets.uaa_clients_cc_service_dashboards_password ))
         authorities: clients.read,clients.write,clients.admin

--- a/manifests/cf-manifest/scripts/generate-cf-secrets.rb
+++ b/manifests/cf-manifest/scripts/generate-cf-secrets.rb
@@ -34,6 +34,7 @@ generator = SecretGenerator.new(
   "uaa_clients_cc_service_dashboards_password" => :simple,
   "uaa_clients_cdn_broker_secret" => :simple,
   "uaa_clients_paas_metrics_secret" => :simple,
+  "uaa_clients_paas_usage_events_collector_secret" => :simple,
   "loggregator_endpoint_shared_secret" => :simple,
   "consul_encrypt_keys" => :simple_in_array,
   "grafana_admin_password" => :simple,

--- a/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
@@ -131,6 +131,7 @@ RSpec.describe "base properties" do
           "cc-service-dashboards",
           "cc_service_key_client",
           "cdn_broker",
+          "paas-usage-events-collector",
         )
       }
 


### PR DESCRIPTION
## What

We created a usage events collector application to collect app and service usage events for billing purposes. Cloud Foundry keeps the usage events only for a limited time (in our case currently for 45 days) and we need these events to be persisted for long-term.

The app repository can be found [here](https://github.com/alphagov/paas-usage-events-collector).

This pull requests contains the following changes:
 * creates a new billing space in the admin organisation
 * creates a new billing database in the billing space
 * creates a new UAA client with admin_read_only scope (global_auditor is not able to read usage events)
 * starts the usage events collector application in the billing space
 * the database and the app is only created in prod
 * on dev you can enable the database and the app by setting ENABLE_USAGE_EVENTS_COLLECTION to true

The application PR can be found [here](https://github.com/alphagov/paas-usage-events-collector/pull/1).

## How to review

* update your CF pipelines and run the create CF pipeline:
```
BRANCH=usage-events-collector ENABLE_USAGE_EVENTS_COLLECTION=true SELF_UPDATE_PIPELINE=false make dev pipelines
```
* log in to CF, select admin org + billing space and check:
  * the billing-db service should exist
  * a paas-usage-event-collector app should be running
  * the paas-usage-event-collector logs should contain multiple json lines with record_count > 0
  * the postgres database should contain records in the app_usage_events and service_usage_events tables
  * the usage events should be inserted regularly expect for events newer than 5 minutes

❗️ After the review please remove the https://github.com/alphagov/paas-cf/pull/1073/commits/3882c0064771b6c47b91d001304b5fc450141cd6 temporary commit which sets the paas-usage-events-collector branch to create_app_151838550.

## Who can review

Not me or @henrytk 
