### PR TITLE
[#151014551] Tag app and service `paas-metrics` with their org's quota

### DIFF
--- a/tools/metrics/gauges.go
+++ b/tools/metrics/gauges.go
@@ -177,7 +177,7 @@ func ServiceCountGauge(c *Client, interval time.Duration) MetricReadCloser {
 		}
 
 		// Number of relevant service instances in
-		// - ORG_IS_TRIAL: boolean of whether each app is owned by a trial organisation
+		// - ORG_IS_TRIAL: boolean of whether each instance is owned by a trial organisation
 		// - SERVICE_PLAN_IS_FREE: whether the instance's service plan is free
 		// - NAME_OF_SERVICE: e.g., "mysql" or "postgres"
 		// counters[ORG_IS_TRIAL][SERVICE_PLAN_IS_FREE][NAME_OF_SERVICE]

--- a/tools/metrics/gauges.go
+++ b/tools/metrics/gauges.go
@@ -118,6 +118,10 @@ func AppCountGauge(c *Client, interval time.Duration) MetricReadCloser {
 			return err
 		}
 
+		// Number of relevant apps in
+		// - APP_STATE: string of whether each app is "started" or "stopped"
+		// - ORG_IS_TRIAL: boolean of whether each app is owned by a trial organisation
+		// counters[APP_STATE][ORG_IS_TRIAL]
 		counters := map[string]map[bool]int{
 			"started": map[bool]int{},
 			"stopped": map[bool]int{},
@@ -170,6 +174,11 @@ func ServiceCountGauge(c *Client, interval time.Duration) MetricReadCloser {
 			return nil
 		}
 
+		// Number of relevant service instances in
+		// - ORG_IS_TRIAL: boolean of whether each app is owned by a trial organisation
+		// - SERVICE_PLAN_IS_FREE: whether the instance's service plan is free
+		// - NAME_OF_SERVICE: e.g., "mysql" or "postgres"
+		// counters[ORG_IS_TRIAL][SERVICE_PLAN_IS_FREE][NAME_OF_SERVICE]
 		counters := map[bool]map[bool]map[string]int{
 			true: map[bool]map[string]int{
 				true:  map[string]int{},


### PR DESCRIPTION
## What

We have added new tags to app and services metrics reported by the `paas-metrics` application. This allows the product dashboard to be broken down by those tags. The caveat of this work is that minor business logic (the names of trial org quotas and free service plans) is now contained within that app. See the commit message for more details.

## How to review

* I've already shown the Datadog results to Tom and he seems happy
* Thoughts on how we're detecting trial orgs and free services?
* Code review?

## Who can review

Not @46bit @LeePorte.