### PR TITLE
[#152067657] Fix rds-broker unbind for legacy bindings

### DIFF
--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -44,9 +44,9 @@ meta:
 
 releases:
   - name: rds-broker
-    version: 0.1.19
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.19.tgz
-    sha1: 33d5545c0558fd432c62344dc9ed46aa00df8829
+    version: 0.1.20
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.20.tgz
+    sha1: d6914b5c274cea55ee06755f8a885bc483892116
 
 jobs:
   - name: rds_broker


### PR DESCRIPTION
## What

This upgrades the broker to a version that includes a fix to allow
unbind to work for legacy bindings[1]

[1]https://github.com/alphagov/paas-rds-broker/pull/71

## How to review

Simulate a legacy binding by doing the following against a deployment from master:
* Create a postgres instance, and bind an app to it.
* Login to the postgres instance as the master user, and delete the user corresponding to the binding. (The master password can be obtained using the [rds-broker-password](https://github.com/alphagov/paas-rds-broker/tree/master/rds-broker-passwd) utility.)
* Attempt to unbind the app and observe it fail.

Deploy the fix and test again:
* Deploy from this branch, and verify everything passes.
* RE-attempt the unbind, and verify that it now succeeds.

## Before merging

:rotating_light: This branch must be updated to reference the boshrelease built from master once https://github.com/alphagov/paas-rds-broker-boshrelease/pull/49 has been merged.

## Who can review

Not me.