### PR TITLE
[#151322324] Revert "Move UAA behind gorouter"

### DIFF
--- a/concourse/tasks/create_admin.yml
+++ b/concourse/tasks/create_admin.yml
@@ -55,7 +55,10 @@ run:
             -d '{"origin":"uaa","type":"USER","value":"'${2}'"}'
         )
         # Check that `uaac` output a 201 HTTP status code.
-        if [ $? = 0 ] && echo "${result}" | grep '^201'; then
+        # N.B., It stopped printing `201 Created` during the upgrade to 
+        # CF v269, and now just prints the `201` code on its own line
+        # followed by a space.
+        if [ $? = 0 ] && echo "${result}" | grep '^201 $'; then
           echo "${result}"
           echo "Added $2 to $1"
         else

--- a/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
+++ b/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
@@ -51,7 +51,6 @@ vm_types:
         type: gp2
       elbs:
         - (( grab terraform_outputs.cf_router_elb_name ))
-        - (( grab terraform_outputs.cf_uaa_elb_name ))
 
 # Diego below
 

--- a/manifests/cf-manifest/cloud-config/021-cf-vm-extensions.yml
+++ b/manifests/cf-manifest/cloud-config/021-cf-vm-extensions.yml
@@ -34,6 +34,11 @@ vm_extensions:
       elbs:
         - (( grab terraform_outputs.cf_cc_elb_name ))
 
+  - name: cf_uaa_elb
+    cloud_properties:
+      elbs:
+        - (( grab terraform_outputs.cf_uaa_elb_name ))
+
   - name: cf_doppler_elbs
     cloud_properties:
       elbs:

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -42,12 +42,6 @@ releases:
     version: "51"
     url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=51
     sha1: 869b8e6bf58f5431b3579f730f142814aae39d71
-    # FIXME: remove once https://github.com/cloudfoundry/route-registrar/pull/18
-    # is merged - It is used ONLY for the route-registrar and gorouter
-  - name: routing
-    version: 0.1.2
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/routing-0.1.2.tgz
-    sha1: 9b56da7b99ddbbb8313756f146a06d781d8d0230
 
 stemcells:
   - alias: default

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -135,13 +135,10 @@ jobs:
         release: (( grab meta.release.name ))
       - name: nginx
         release: nginx
-      - name: route_registrar
-      # FIXME: remove once https://github.com/cloudfoundry/route-registrar/pull/18
-      # is merged - It is used ONLY for the route-registrar and gorouter
-        release: routing
     instances: 2
     vm_type: medium
     vm_extensions:
+      - cf_uaa_elb
       - cf_rds_client_sg
     stemcell: default
     networks:
@@ -163,7 +160,6 @@ jobs:
             server 127.0.0.1:8080;
           }
           set_real_ip_from  10.0.0.0/16;
-          set_real_ip_from  127.0.0.1/32;
           real_ip_header    X-Forwarded-For;
           real_ip_recursive on;
           server {
@@ -190,24 +186,6 @@ jobs:
         agent:
           services:
             uaa: {}
-      route_registrar:
-        routes:
-          - name: uaa
-            registration_interval: 10s
-            health_check:
-              name: cf_uaa_health_check
-              script_path: /var/vcap/jobs/uaa/bin/health_check
-              timeout: "5s"
-            port: 8081
-            tls_port: 9443
-            server_cert_domain_san: "uaa.service.cf.internal"
-            tags:
-              component: uaa
-            uris:
-              - (( concat "uaa." properties.system_domain ))
-              - (( concat "*.uaa." properties.system_domain ))
-              - (( concat "login." properties.system_domain ))
-              - (( concat "*.login." properties.system_domain ))
 
   - name: api
     azs: [z1, z2]
@@ -352,9 +330,7 @@ jobs:
       - name: datadog-consul-agent-client
         release: datadog-for-cloudfoundry
       - name: gorouter
-      # FIXME: remove once https://github.com/cloudfoundry/route-registrar/pull/18
-      # is merged - It is used ONLY for the route-registrar and gorouter
-        release: routing
+        release: (( grab meta.release.name ))
         consumes: {nats: nil}
       - name: metron_agent
         release: (( grab meta.release.name ))

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -176,10 +176,6 @@ properties:
     enable_http_redirect_frontend: true
 
   router:
-    backends:
-      enable_tls: true
-      cert_chain: (( grab secrets.router_internal_cert ))
-      private_key: (( grab secrets.router_internal_key ))
     enable_ssl: false
     enable_access_log_streaming: true
     status:

--- a/manifests/cf-manifest/spec/cloud-config/vm_types_spec.rb
+++ b/manifests/cf-manifest/spec/cloud-config/vm_types_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe "vm_types" do
     it "should use the correct elb instance" do
       expect(pool["cloud_properties"]["elbs"]).to match_array([
         terraform_fixture(:cf_router_elb_name),
-        terraform_fixture(:cf_uaa_elb_name),
       ])
     end
   end

--- a/manifests/cf-manifest/spec/manifest/jobs_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/jobs_spec.rb
@@ -112,28 +112,3 @@ RSpec.describe "the jobs definitions block" do
     }
   end
 end
-
-RSpec.describe "uaa jobs" do
-  let(:jobs) { manifest_with_defaults.fetch("jobs") }
-
-  describe "common job properties" do
-    job_name = "uaa"
-    context "job #{job_name}" do
-      subject(:job) { jobs.find { |j| j["name"] == job_name } }
-
-      describe "route registrar" do
-        let(:routes) { job.fetch("properties").fetch("route_registrar").fetch("routes") }
-
-        it "registers the correct uris" do
-          expect(routes.length).to eq(1)
-          expect(routes.first.fetch('uris')).to match_array([
-            "uaa.#{terraform_fixture(:cf_root_domain)}",
-            "*.uaa.#{terraform_fixture(:cf_root_domain)}",
-            "login.#{terraform_fixture(:cf_root_domain)}",
-            "*.login.#{terraform_fixture(:cf_root_domain)}",
-          ])
-        end
-      end
-    end
-  end
-end

--- a/terraform/cloudfoundry/elbs.tf
+++ b/terraform/cloudfoundry/elbs.tf
@@ -59,7 +59,7 @@ resource "aws_elb" "cf_uaa" {
   }
 
   health_check {
-    target              = "HTTP:82/"
+    target              = "HTTPS:9443/healthz"
     interval            = "${var.health_check_interval}"
     timeout             = "${var.health_check_timeout}"
     healthy_threshold   = "${var.health_check_healthy}"
@@ -67,10 +67,10 @@ resource "aws_elb" "cf_uaa" {
   }
 
   listener {
-    instance_port      = 443
-    instance_protocol  = "ssl"
+    instance_port      = 9443
+    instance_protocol  = "https"
     lb_port            = 443
-    lb_protocol        = "ssl"
+    lb_protocol        = "https"
     ssl_certificate_id = "${var.system_domain_cert_arn}"
   }
 }
@@ -86,9 +86,11 @@ resource "aws_lb_ssl_negotiation_policy" "cf_uaa" {
   }
 }
 
-resource "aws_proxy_protocol_policy" "cf_uaa_haproxy" {
-  load_balancer  = "${aws_elb.cf_uaa.name}"
-  instance_ports = ["443"]
+resource "aws_app_cookie_stickiness_policy" "cf_uaa" {
+  name          = "cf-uaa"
+  load_balancer = "${aws_elb.cf_uaa.id}"
+  lb_port       = 443
+  cookie_name   = "JSESSIONID"
 }
 
 resource "aws_elb" "cf_doppler" {


### PR DESCRIPTION
## What

Revert changes from #1081 

Deploying these changes resulted in significant (30mins +) APi downtime
in staging. We're therefore going to revert these changes to unblock the
pipeline while we work out a way to deploy this without the disruption.

## How to review

Verify that this correctly reverts #1081 (for example `git diff HEAD prod-0.1.62`)

## Who can review

Not me.