### PR TITLE
[#151322324] Move UAA behind Gorouter 1/2

### DIFF
--- a/concourse/tasks/create_admin.yml
+++ b/concourse/tasks/create_admin.yml
@@ -55,11 +55,8 @@ run:
             -d "{\"origin\":\"uaa\",\"type\":\"USER\",\"value\":\"${2}\"}"
         )
         # Check that `uaac` output a 201 HTTP status code.
-        # N.B., It stopped printing `201 Created` during the upgrade to 
-        # CF v269, and now just prints the `201` code on its own line
-        # followed by a space.
         # shellcheck disable=SC2181
-        if [ $? = 0 ] && echo "${result}" | grep '^201 $'; then
+        if [ $? = 0 ] && echo "${result}" | grep '^201'; then
           echo "${result}"
           echo "Added $2 to $1"
         else

--- a/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
+++ b/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
@@ -51,6 +51,7 @@ vm_types:
         type: gp2
       elbs:
         - (( grab terraform_outputs.cf_router_elb_name ))
+        - (( grab terraform_outputs.cf_uaa_elb_name ))
 
 # Diego below
 

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -42,6 +42,12 @@ releases:
     version: "51"
     url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=51
     sha1: 869b8e6bf58f5431b3579f730f142814aae39d71
+    # FIXME: remove once https://github.com/cloudfoundry/route-registrar/pull/18
+    # is merged - It is used ONLY for the route-registrar and gorouter
+  - name: routing
+    version: 0.1.2
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/routing-0.1.2.tgz
+    sha1: 9b56da7b99ddbbb8313756f146a06d781d8d0230
 
   ### buildpacks
   - name: binary-buildpack

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -135,6 +135,8 @@ jobs:
         release: (( grab meta.release.name ))
       - name: nginx
         release: nginx
+      - name: route_registrar
+        release: (( grab meta.release.name ))
     instances: 2
     vm_type: medium
     vm_extensions:
@@ -160,6 +162,7 @@ jobs:
             server 127.0.0.1:8080;
           }
           set_real_ip_from  10.0.0.0/16;
+          set_real_ip_from  127.0.0.1/32;
           real_ip_header    X-Forwarded-For;
           real_ip_recursive on;
           server {
@@ -186,6 +189,24 @@ jobs:
         agent:
           services:
             uaa: {}
+      route_registrar:
+        routes:
+          - name: uaa
+            registration_interval: 10s
+            health_check:
+              name: cf_uaa_health_check
+              script_path: /var/vcap/jobs/uaa/bin/health_check
+              timeout: "5s"
+            port: 8081
+            tls_port: 9443
+            server_cert_domain_san: "uaa.service.cf.internal"
+            tags:
+              component: uaa
+            uris:
+              - (( concat "uaa." properties.system_domain ))
+              - (( concat "*.uaa." properties.system_domain ))
+              - (( concat "login." properties.system_domain ))
+              - (( concat "*.login." properties.system_domain ))
 
   - name: api
     azs: [z1, z2]

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -136,7 +136,9 @@ jobs:
       - name: nginx
         release: nginx
       - name: route_registrar
-        release: (( grab meta.release.name ))
+      # FIXME: remove once https://github.com/cloudfoundry/route-registrar/pull/18
+      # is merged - It is used ONLY for the route-registrar and gorouter
+        release: routing
     instances: 2
     vm_type: medium
     vm_extensions:
@@ -351,7 +353,9 @@ jobs:
       - name: datadog-consul-agent-client
         release: datadog-for-cloudfoundry
       - name: gorouter
-        release: (( grab meta.release.name ))
+      # FIXME: remove once https://github.com/cloudfoundry/route-registrar/pull/18
+      # is merged - It is used ONLY for the route-registrar and gorouter
+        release: routing
         consumes: {nats: nil}
       - name: metron_agent
         release: (( grab meta.release.name ))

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -176,6 +176,10 @@ properties:
     enable_http_redirect_frontend: true
 
   router:
+    backends:
+      enable_tls: true
+      cert_chain: (( grab secrets.router_internal_cert ))
+      private_key: (( grab secrets.router_internal_key ))
     enable_ssl: false
     enable_access_log_streaming: true
     status:

--- a/manifests/cf-manifest/spec/cloud-config/vm_types_spec.rb
+++ b/manifests/cf-manifest/spec/cloud-config/vm_types_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "vm_types" do
     it "should use the correct elb instance" do
       expect(pool["cloud_properties"]["elbs"]).to match_array([
         terraform_fixture(:cf_router_elb_name),
+        terraform_fixture(:cf_uaa_elb_name),
       ])
     end
   end

--- a/manifests/cf-manifest/spec/manifest/jobs_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/jobs_spec.rb
@@ -112,3 +112,28 @@ RSpec.describe "the jobs definitions block" do
     }
   end
 end
+
+RSpec.describe "uaa jobs" do
+  let(:jobs) { manifest_with_defaults.fetch("jobs") }
+
+  describe "common job properties" do
+    job_name = "uaa"
+    context "job #{job_name}" do
+      subject(:job) { jobs.find { |j| j["name"] == job_name } }
+
+      describe "route registrar" do
+        let(:routes) { job.fetch("properties").fetch("route_registrar").fetch("routes") }
+
+        it "registers the correct uris" do
+          expect(routes.length).to eq(1)
+          expect(routes.first.fetch('uris')).to match_array([
+            "uaa.#{terraform_fixture(:cf_root_domain)}",
+            "*.uaa.#{terraform_fixture(:cf_root_domain)}",
+            "login.#{terraform_fixture(:cf_root_domain)}",
+            "*.login.#{terraform_fixture(:cf_root_domain)}",
+          ])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Our previous approach #1081 causes a 30 minute downtime caused by the
modification of terraform resource and not updating the configuration in time.

We're eliminating this problem by splitting the previous approach into two separate
PRs, where at first we register the routes and prepare the use of newly configured 
ELB, causing the healthchecks to fail and not sending any traffic to it, and in the
second PR, we actually reconfigure the ELB which otherwise would cause the 
downtime, until the `cf-deploy` job ran its tasks.

---

Whilst investigating UAA downtime during deploys we decided that we should move
UAA to run behind gorouter. This should mean we reduce (and possibly eliminate)
downtime during deploys because connections will be drained by removing the
route whilst UAA is shutting down.

In order to move UAA behind the gorouter, we will need a different way
of registrating our routes. We decided to fallback onto upstream to get
closer to the setup the community is running. We've implemented the
route-registrar configuration, strictly specific to UAA at this point.

Haproxy automatically adds a reason text to its http response statuses. E.g.
"201 Created" instead of plain 201. In our create_admin.yml task we should only
check if the response starts with 201, as the UAA was moved behind gorouter +
haproxy and the tests started to panic.

There is some extra functionality that has been implemented in the
gorouter such as `tls_port` and `server_cert_domain_san`, which we would
be delite to use upon our UAA move behind Gorouter.

This is to ensure the traffic between the two is encrypted.

The release also consists of the custom change to the route_registrar,
simply duplicating the two properties listed above from the gorouter in
order to allow smooth registration.

This should be safe to be reverted when:

- We upgrade cf-release / cf-deployment to the version that contains new
gorouter
- The changes we need have been applied upstream for the route-registrar

## How to review

- Code check
- Deploy your pipeline from this branch
- Expect all acceptance tests to succeed

To be closely followed by #1087 

## Who can review

Neither @bandesz, @dcarley, @chrisfarms nor myself