### PR TITLE
[#151322324] Move UAA behind Gorouter 2/2

### DIFF
--- a/manifests/cf-manifest/cloud-config/021-cf-vm-extensions.yml
+++ b/manifests/cf-manifest/cloud-config/021-cf-vm-extensions.yml
@@ -34,11 +34,6 @@ vm_extensions:
       elbs:
         - (( grab terraform_outputs.cf_cc_elb_name ))
 
-  - name: cf_uaa_elb
-    cloud_properties:
-      elbs:
-        - (( grab terraform_outputs.cf_uaa_elb_name ))
-
   - name: cf_doppler_elbs
     cloud_properties:
       elbs:

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -142,7 +142,6 @@ jobs:
     instances: 2
     vm_type: medium
     vm_extensions:
-      - cf_uaa_elb
       - cf_rds_client_sg
     stemcell: default
     networks:

--- a/terraform/cloudfoundry/elbs.tf
+++ b/terraform/cloudfoundry/elbs.tf
@@ -59,7 +59,7 @@ resource "aws_elb" "cf_uaa" {
   }
 
   health_check {
-    target              = "HTTPS:9443/healthz"
+    target              = "HTTP:82/"
     interval            = "${var.health_check_interval}"
     timeout             = "${var.health_check_timeout}"
     healthy_threshold   = "${var.health_check_healthy}"
@@ -67,10 +67,10 @@ resource "aws_elb" "cf_uaa" {
   }
 
   listener {
-    instance_port      = 9443
-    instance_protocol  = "https"
+    instance_port      = 443
+    instance_protocol  = "ssl"
     lb_port            = 443
-    lb_protocol        = "https"
+    lb_protocol        = "ssl"
     ssl_certificate_id = "${var.system_domain_cert_arn}"
   }
 }
@@ -86,11 +86,9 @@ resource "aws_lb_ssl_negotiation_policy" "cf_uaa" {
   }
 }
 
-resource "aws_app_cookie_stickiness_policy" "cf_uaa" {
-  name          = "cf-uaa"
-  load_balancer = "${aws_elb.cf_uaa.id}"
-  lb_port       = 443
-  cookie_name   = "JSESSIONID"
+resource "aws_proxy_protocol_policy" "cf_uaa_haproxy" {
+  load_balancer  = "${aws_elb.cf_uaa.name}"
+  instance_ports = ["443"]
 }
 
 resource "aws_elb" "cf_doppler" {


### PR DESCRIPTION
## What

Our previous approach #1081 causes a 30 minute downtime caused by the
modification of terraform resource and not updating the configuration in time.

We're eliminating this problem by splitting the previous approach into two separate
PRs, where at first we register the routes and prepare the use of newly configured 
ELB, causing the healthchecks to fail and not sending any traffic to it, and in the
second PR, we actually reconfigure the ELB which otherwise would cause the 
downtime, until the `cf-deploy` job ran its tasks.

---

Whilst investigating UAA downtime during deploys we decided that we should move
UAA to run behind gorouter. This should mean we reduce (and possibly eliminate)
downtime during deploys because connections will be drained by removing the
route whilst UAA is shutting down.

In order to move UAA behind the gorouter, we will need a different way
of registrating our routes. We decided to fallback onto upstream to get
closer to the setup the community is running. We've implemented the
route-registrar configuration, strictly specific to UAA at this point.

Haproxy automatically adds a reason text to its http response statuses. E.g.
"201 Created" instead of plain 201. In our create_admin.yml task we should only
check if the response starts with 201, as the UAA was moved behind gorouter +
haproxy and the tests started to panic.

There is some extra functionality that has been implemented in the
gorouter such as `tls_port` and `server_cert_domain_san`, which we would
be delite to use upon our UAA move behind Gorouter.

This is to ensure the traffic between the two is encrypted.

The release also consists of the custom change to the route_registrar,
simply duplicating the two properties listed above from the gorouter in
order to allow smooth registration.

This should be safe to be reverted when:

- We upgrade cf-release / cf-deployment to the version that contains new
gorouter
- The changes we need have been applied upstream for the route-registrar

## How to review

- Make sure you've deployed from #1086 
- Code check
- Deploy your pipeline from this branch
- Expect all acceptance tests to succeed

🐝  Needs to be merged after the #1086

## Who can review

Neither @bandesz, @dcarley, @chrisfarms nor myself