### PR TITLE
[#152507627] Upgrade cflinuxfs2 and stemcells for CVEs

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -18,9 +18,9 @@ releases:
     url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.9.3
     sha1: a153fd2b9d85d01772e9c6907b8c9e5005059c9e
   - name: cflinuxfs2
-    version: 1.156.0
-    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.156.0
-    sha1: f47391f8ee5dce2aacfaf4e82d3cdcf78234a2ac
+    version: 1.161.0
+    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.161.0
+    sha1: 9eee181c745f8c086dcce570e3ecfbb8553b8f5a
   - name: paas-haproxy
     version: 0.1.4
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/paas-haproxy-0.1.4.tgz

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -80,7 +80,7 @@ releases:
 stemcells:
   - alias: default
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3445.11"
+    version: "3445.15"
 
 update:
   canaries: 0


### PR DESCRIPTION
## What

### Upgrade stemcell for CVEs

To fix the following:

- https://www.cloudfoundry.org/usn-3424-1/
- https://www.cloudfoundry.org/usn-3434-1/
- https://www.cloudfoundry.org/usn-3444-2/
- https://www.cloudfoundry.org/usn-3454-1/
- https://www.cloudfoundry.org/usn-3441-1/
- https://www.cloudfoundry.org/usn-3432-1/

They all reference the same minimum version of 3445.15 (for the stemcell
series that we're using).

### Upgrade cflinuxfs2 for CVEs

To fix the following:

- https://www.cloudfoundry.org/usn-3454-1/
- https://www.cloudfoundry.org/usn-3424-1/
- https://www.cloudfoundry.org/usn-3434-1/
- https://www.cloudfoundry.org/usn-3441-1/
- https://www.cloudfoundry.org/usn-3432-1/
- https://www.cloudfoundry.org/usn-3437-1/

Version 1.161.0 is the minimum specified by USN-3454-1, whereas the other
advisories reference older versions.

## How to review

I've run this in my dev environment. All acceptance tests passed, but it causes downtime for UAA which we intend to fix in #1086 and #1087:
```
Report:
==============
Total task executions: 30139
Total Successes: 29807
Total failures: 332
Elaspsed time: 1h20m22.90782056s
Average rate: 6.25 tasks/sec
```

Based on the contents of the CVEs (mostly denial of service) I don't have a strong opinion about whether we deploy with some downtime or wait for the UAA changes to be deployed first.

It took over an hour to test in my dev environment, so I don't think there's value in a second person repeating the same exercise and that code review from hereon would be sufficient:

- check that I've upgraded the right components according to those CVEs
- check that I've selected the right versions according to those CVEs

## Who can review

Anyone.