### PR TITLE
[#152150279] Create API Latency monitor

### DIFF
--- a/terraform/datadog/elb.tf
+++ b/terraform/datadog/elb.tf
@@ -1,0 +1,67 @@
+resource "datadog_monitor" "abnormal_api_latency_cc" {
+  name    = "${format("%s Abnormal API Latency - CC", var.env)}"
+  type    = "query alert"
+  message = "${format("{{#is_alert}}We're experiencing >= {{threshold}} change in ELB Latency.{{/is_alert}} \n{{#is_warning}}We're experiencing >= {{warn_threshold}} change in ELB Latency.{{/is_warning}} \n\nVisit the [Team Manual > Responding to alerts > API Latency](%s#api-latency) for more info.", var.datadog_documentation_url)}"
+
+  query = "${format("avg(last_15m):anomalies(avg:aws.elb.latency{name:%s-cf-cc}, 'basic', 2, direction='both') > 0.3", var.env)}"
+
+  thresholds {
+    warning  = 0.15
+    critical = 0.3
+  }
+
+  require_full_window = true
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:cc"]
+}
+
+resource "datadog_monitor" "abnormal_api_latency_doppler" {
+  name    = "${format("%s Abnormal API Latency - Doppler", var.env)}"
+  type    = "query alert"
+  message = "${format("{{#is_alert}}We're experiencing >= {{threshold}} change in ELB Latency.{{/is_alert}} \n{{#is_warning}}We're experiencing >= {{warn_threshold}} change in ELB Latency.{{/is_warning}} \n\nVisit the [Team Manual > Responding to alerts > API Latency](%s#api-latency) for more info.", var.datadog_documentation_url)}"
+
+  query = "${format("avg(last_15m):anomalies(avg:aws.elb.latency{name:%s-cf-doppler}, 'basic', 2, direction='both') > 0.3", var.env)}"
+
+  require_full_window = true
+
+  thresholds {
+    warning  = 0.15
+    critical = 0.3
+  }
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:doppler"]
+}
+
+resource "datadog_monitor" "abnormal_api_latency_router" {
+  name    = "${format("%s Abnormal API Latency - Router", var.env)}"
+  type    = "query alert"
+  message = "${format("{{#is_alert}}We're experiencing >= {{threshold}} change in ELB Latency.{{/is_alert}} \n{{#is_warning}}We're experiencing >= {{warn_threshold}} change in ELB Latency.{{/is_warning}} \n\nVisit the [Team Manual > Responding to alerts > API Latency](%s#api-latency) for more info.", var.datadog_documentation_url)}"
+
+  query = "${format("avg(last_15m):anomalies(avg:aws.elb.latency{name:%s-cf-router}, 'basic', 2, direction='both') > 0.3", var.env)}"
+
+  require_full_window = true
+
+  thresholds {
+    warning  = 0.15
+    critical = 0.3
+  }
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:router"]
+}
+
+resource "datadog_monitor" "abnormal_api_latency_uaa" {
+  name    = "${format("%s Abnormal API Latency - UAA", var.env)}"
+  type    = "query alert"
+  message = "${format("{{#is_alert}}We're experiencing >= {{threshold}} change in ELB Latency.{{/is_alert}} \n{{#is_warning}}We're experiencing >= {{warn_threshold}} change in ELB Latency.{{/is_warning}} \n\nVisit the [Team Manual > Responding to alerts > API Latency](%s#api-latency) for more info.", var.datadog_documentation_url)}"
+
+  query = "${format("avg(last_15m):anomalies(avg:aws.elb.latency{name:%s-cf-uaa}, 'basic', 2, direction='both') > 0.3", var.env)}"
+
+  require_full_window = true
+
+  thresholds {
+    warning  = 0.15
+    critical = 0.3
+  }
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:uaa"]
+}


### PR DESCRIPTION
## What

Following on the UAA downtime incident from October 9, we would like to
monitor our API latency and get alerted if anomaly is detected.

This will create a monitor for each of four components:
- uaa
- cc
- router
- doppler

This will not trigger PagerDuty incident but will trigger our dashboard
to report a single alert.

## How to review

- Code review
- Check if the threshold numbers make sense
- **Optionally:** Deploy from this branch, and manually change from `name:${DEPLOY_ENV}-cf-uaa` to `name:staging-cf-yaa` and perhaps change the thresholds to `c:1`, `w:0` to see the alerts

## Who can review

Neither @camelpunch nor myself
