### PR TITLE
[#152507627] Upgrade stemcell to 3445.16

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -86,7 +86,7 @@ releases:
 stemcells:
   - alias: default
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3445.15"
+    version: "3445.16"
 
 update:
   canaries: 0


### PR DESCRIPTION
## What

This supersedes the upgrade to 3445.15 in 961e427d because that stemcell
doesn't have a "light" version published. Meaning that:

- the same URL redirects to the "fat" version instead
- it takes longer to download/upload
- it possibly requires more time recompiling packages when deploying VMs,
  but haven't haven't confirmed that
- it's not usable with bosh-init from a container

In order to be consistent with previous deployments and the stemcell that we
have to use in paas-bootstrap we're going to skip .15 in production and go
straight to .16 - the only difference in the contents are Ubuntu package
updates.

## How to review

I've tested my dev environment upgrading from 3445.15 to 3445.16 - it took about an hour to run cf-deploy and the acceptance tests passed afterwards.

I'll leave it to the reviewer to decide whether they want to repeat that exercise or test the upgrade from 3445.11 to 3445.16

At a minimum:

- confirm what I've written makes sense
- agree whether it's sensible to skip a version in prod while the pipelines are paused

The pipeline will need unlocking in production.

## Who can review

Anyone.