### PR TITLE
[#152150260] Add Datadog monitors for high CPU usage

### DIFF
--- a/terraform/datadog/aws.tf
+++ b/terraform/datadog/aws.tf
@@ -58,3 +58,34 @@ resource "datadog_monitor" "rds-failure" {
 
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:all"]
 }
+
+resource "datadog_monitor" "ec2-cpu-utilisation-warning" {
+  name                = "${format("%s CPU utilisation has been moderately high for a long time on {{bosh-job.name}}/{{bosh-index.name}}", var.env)}"
+  type                = "metric alert"
+  query               = "${format("avg(last_2h):avg:aws.ec2.cpuutilization{deploy_env:%s} by {bosh-job,bosh-index} > 100", var.env)}"
+  message             = "Instance has more than {{warn_threshold}}% CPU usage over 2 hours."
+  notify_no_data      = false
+  require_full_window = false
+
+  thresholds {
+    warning  = "50"
+    critical = "100"
+  }
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:all"]
+}
+
+resource "datadog_monitor" "ec2-cpu-utilisation-critical" {
+  name                = "${format("%s CPU utilisation has been high on {{bosh-job.name}}/{{bosh-index.name}}", var.env)}"
+  type                = "metric alert"
+  query               = "${format("avg(last_30m):avg:aws.ec2.cpuutilization{deploy_env:%s} by {bosh-job,bosh-index} > 80", var.env)}"
+  message             = "Instance has more than {{threshold}}% CPU usage."
+  notify_no_data      = false
+  require_full_window = false
+
+  thresholds {
+    critical = "80"
+  }
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:all"]
+}


### PR DESCRIPTION
## What

We would like to know if any of our EC2 instances has high CPU usage as it
might affect our services. We introduce two alerts:
 * a warning if an EC2 instance has at least 50% CPU usage on average for two
   hours or more
 * a critical alert if an EC2 instance has at least 80% CPU usage on average
   for 30 minutes or more

Please note that there is at least 10 minutes delay for AWS metrics.

In the warning alert we still have to specify a critical threshold, but it will never fire. We have to do this because we want to check different time windows for the two alerts.

## How to review

* Enable Datadog in your dev environment, update the pipelines and run the create-cloudfoundry pipeline
    ```BRANCH=cpu_usage_monitors_152150260 ENABLE_DATADOG=true SELF_UPDATE_PIPELINE=false make dev pipelines```
* The cf-deploy job should successfully create all your Datadog monitors (datadog-terraform-apply task)
* Search for "#DEPLOY_ENV# CPU load" monitors and check whether the monitor parameters make sense and the original data is valid
* To test the alerts then you can change the deploy_env filter to staging or prod and set the thresholds to a low value and the alerts should be present in 5-10 minutes. Please check if the alerts have the right title and message.

## Who can review

Not me or @chrisfarms 
