### PR TITLE
[#152670116] Bump UAA version to 52.1

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -37,11 +37,12 @@ releases:
     version: 1.11.7
     url: https://github.com/cloudfoundry-community/nginx-release/releases/download/v1.11.7/nginx-1.11.7.tgz
     sha1: 133bb2260411b197924fff08d4cbd923cc8ec7eb
-    # FIXME: remove once CF is upgraded to >= v276
+    # FIXME: remove once CF is upgraded to > v278
+    # NOTE: The UAA fix has not been introduced to CF release just yet.
   - name: uaa
-    version: "51"
-    url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=51
-    sha1: 869b8e6bf58f5431b3579f730f142814aae39d71
+    version: "52.1"
+    url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=52.1
+    sha1: 6135cb68188e1fd69893395c739532a5028bd4c2
     # FIXME: remove once https://github.com/cloudfoundry/route-registrar/pull/18
     # is merged - It is used ONLY for the route-registrar and gorouter
   - name: routing


### PR DESCRIPTION
## What

In order to protect ourselves from [CVE-2017-8031](https://www.cloudfoundry.org/cve-2017-8031/) exposure, we need to
upgrade the UAA release to at least version 52.1.

## How to review

- Make sure that the version used will cover us against this CVE

~~I haven't tested this yet. It's still deploying in my pipelines.~~
