### PR TITLE
[#152150279] Tune the Latency monitor

### DIFF
--- a/terraform/datadog/elb.tf
+++ b/terraform/datadog/elb.tf
@@ -3,11 +3,11 @@ resource "datadog_monitor" "abnormal_api_latency_cc" {
   type    = "query alert"
   message = "${format("{{#is_alert}}We're experiencing >= {{threshold}} change in ELB Latency.{{/is_alert}} \n{{#is_warning}}We're experiencing >= {{warn_threshold}} change in ELB Latency.{{/is_warning}} \n\nVisit the [Team Manual > Responding to alerts > API Latency](%s#api-latency) for more info.", var.datadog_documentation_url)}"
 
-  query = "${format("avg(last_15m):anomalies(avg:aws.elb.latency{name:%s-cf-cc}, 'basic', 2, direction='both') > 0.3", var.env)}"
+  query = "${format("max(last_1h):avg:aws.elb.latency{name:%s-cf-cc} > 2", var.env)}"
 
   thresholds {
-    warning  = 0.15
-    critical = 0.3
+    warning  = 1
+    critical = 2
   }
 
   require_full_window = true
@@ -20,7 +20,7 @@ resource "datadog_monitor" "abnormal_api_latency_doppler" {
   type    = "query alert"
   message = "${format("{{#is_alert}}We're experiencing >= {{threshold}} change in ELB Latency.{{/is_alert}} \n{{#is_warning}}We're experiencing >= {{warn_threshold}} change in ELB Latency.{{/is_warning}} \n\nVisit the [Team Manual > Responding to alerts > API Latency](%s#api-latency) for more info.", var.datadog_documentation_url)}"
 
-  query = "${format("avg(last_15m):anomalies(avg:aws.elb.latency{name:%s-cf-doppler}, 'basic', 2, direction='both') > 0.3", var.env)}"
+  query = "${format("avg(last_1h):anomalies(avg:aws.elb.latency{name:%s-cf-doppler}, 'basic', 2, direction='above') > 0.3", var.env)}"
 
   require_full_window = true
 
@@ -37,7 +37,7 @@ resource "datadog_monitor" "abnormal_api_latency_uaa" {
   type    = "query alert"
   message = "${format("{{#is_alert}}We're experiencing >= {{threshold}} change in ELB Latency.{{/is_alert}} \n{{#is_warning}}We're experiencing >= {{warn_threshold}} change in ELB Latency.{{/is_warning}} \n\nVisit the [Team Manual > Responding to alerts > API Latency](%s#api-latency) for more info.", var.datadog_documentation_url)}"
 
-  query = "${format("avg(last_15m):anomalies(avg:aws.elb.latency{name:%s-cf-uaa}, 'basic', 2, direction='both') > 0.3", var.env)}"
+  query = "${format("avg(last_1h):anomalies(avg:aws.elb.latency{name:%s-cf-uaa}, 'basic', 2, direction='above') > 0.3", var.env)}"
 
   require_full_window = true
 

--- a/terraform/datadog/elb.tf
+++ b/terraform/datadog/elb.tf
@@ -32,23 +32,6 @@ resource "datadog_monitor" "abnormal_api_latency_doppler" {
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:doppler"]
 }
 
-resource "datadog_monitor" "abnormal_api_latency_router" {
-  name    = "${format("%s Abnormal API Latency - Router", var.env)}"
-  type    = "query alert"
-  message = "${format("{{#is_alert}}We're experiencing >= {{threshold}} change in ELB Latency.{{/is_alert}} \n{{#is_warning}}We're experiencing >= {{warn_threshold}} change in ELB Latency.{{/is_warning}} \n\nVisit the [Team Manual > Responding to alerts > API Latency](%s#api-latency) for more info.", var.datadog_documentation_url)}"
-
-  query = "${format("avg(last_15m):anomalies(avg:aws.elb.latency{name:%s-cf-router}, 'basic', 2, direction='both') > 0.3", var.env)}"
-
-  require_full_window = true
-
-  thresholds {
-    warning  = 0.15
-    critical = 0.3
-  }
-
-  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:router"]
-}
-
 resource "datadog_monitor" "abnormal_api_latency_uaa" {
   name    = "${format("%s Abnormal API Latency - UAA", var.env)}"
   type    = "query alert"


### PR DESCRIPTION
## What

We realised that the CC ELB will create a lot of noise in our production environment. We decided to amend the thresholds as well as the window to for the metrics to be monitored.

I've updated the window on other monitors too and took the decision to change the latency check from "both" to "above" as we probably don't care if it took less time than usual to serve the response.

We're also removing the router monitor as it's not strictly part of the API we mean to monitor and we may get some false alerts if tenant application would take time to serve response.

## How to review

- Code review
- Deploy from this branch with DataDog enabled 
  ```
  BRANCH=$(git rev-parse --abbrev-ref HEAD) ENABLE_DATADOG=true SELF_UPDATE_PIPELINE=false make dev pipelines
  ```
- Go into the DataDog and manually change the monitors (CC in particular), to point to production. For instnace: `name:prod-cf-cc`.
- Have a good long stare at the graph and be sure it wouldn't produce a lot of faulty noise