### PR TITLE
[#152150260] Exclude cells from CPU utilisation monitor

### DIFF
--- a/terraform/datadog/aws.tf
+++ b/terraform/datadog/aws.tf
@@ -59,32 +59,17 @@ resource "datadog_monitor" "rds-failure" {
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:all"]
 }
 
-resource "datadog_monitor" "ec2-cpu-utilisation-warning" {
-  name                = "${format("%s CPU utilisation has been moderately high for a long time on {{bosh-job.name}}/{{bosh-index.name}}", var.env)}"
+resource "datadog_monitor" "ec2-cpu-utilisation" {
+  name                = "${format("%s EC2 high CPU utilisation", var.env)}"
   type                = "metric alert"
-  query               = "${format("avg(last_2h):avg:aws.ec2.cpuutilization{deploy_env:%s} by {bosh-job,bosh-index} > 100", var.env)}"
-  message             = "Instance has more than {{warn_threshold}}% CPU usage over 2 hours."
+  query               = "${format("avg(last_1h):avg:aws.ec2.cpuutilization{deploy_env:%s,!job:cell} by {bosh-job,bosh-index} > 90", var.env)}"
+  message             = "{{bosh-job.name}}/{{bosh-index.name}} CPU utilisation has been over {{#is_warning}}{{warn_threshold}}{{/is_warning}}{{#is_alert}}{{threshold}}{{/is_alert}}% for 1h"
   notify_no_data      = false
   require_full_window = false
 
   thresholds {
-    warning  = "50"
-    critical = "100"
-  }
-
-  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:all"]
-}
-
-resource "datadog_monitor" "ec2-cpu-utilisation-critical" {
-  name                = "${format("%s CPU utilisation has been high on {{bosh-job.name}}/{{bosh-index.name}}", var.env)}"
-  type                = "metric alert"
-  query               = "${format("avg(last_30m):avg:aws.ec2.cpuutilization{deploy_env:%s} by {bosh-job,bosh-index} > 80", var.env)}"
-  message             = "Instance has more than {{threshold}}% CPU usage."
-  notify_no_data      = false
-  require_full_window = false
-
-  thresholds {
-    critical = "80"
+    critical = "90"
+    warning  = "70"
   }
 
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:all"]


### PR DESCRIPTION
## What

* We have excluded cells from the CPU utilisation monitor
* We have replaced the two CPU monitors with a single CPU monitor
* We have altered the name of the monitor 

## Why

It is expected behaviour that cells spike to relatively high levels of CPU for prolonged periods of time due to tenant activity, but this behaviour is currently triggering our CPU monitors and causing unwanted noise for support. We want to exclude them from these alerts and 

We were also seeing both "critical" and "warning" level notifications at the same time due to our split of "moderately high cpu over a long time" and "high cpu over a short time". We decided this doesn't add too much value, so have switched to using a single monitor with higher thresholds over a 1hr period instead.

The names were altered for consistency with the other monitors and so that the template variables are not visible in the general "triggered monitors" lists that we primarily use. 

## How to review

* Enable Datadog in your dev environment, update the pipelines and run the create-cloudfoundry pipeline
`BRANCH=exclude_cells_from_cpu_monitor_152150260 ENABLE_DATADOG=true SELF_UPDATE_PIPELINE=false make dev pipelines`
* The cf-deploy job should successfully create all your Datadog monitors (datadog-terraform-apply task)
* Search for "#DEPLOY_ENV# EC2 high CPU utilisation" monitor and check whether its parameters make sense and the original data is valid
* To test the alerts then you can change the deploy_env filter to staging or prod and set the thresholds to a low value and the alerts should be present in 5-10 minutes. Please check if the alerts have the right title and message.

## Who can review

Not @chrisfarms 
