### PR TITLE
WIP: Remove Aviation House IPs from the whitelist

### DIFF
--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -101,8 +101,6 @@ variable "admin_cidrs" {
   description = "List of CIDR addresses with access to operator/admin endpoints"
 
   default = [
-    "80.194.77.90/32",
-    "80.194.77.100/32",
     "85.133.67.244/32",
     "213.86.153.212/32",
     "213.86.153.213/32",


### PR DESCRIPTION
According to our IT wiki[1] these were from Aviation House and have
been entirely shutdown.

[1] https://sites.google.com/a/digital.cabinet-office.gov.uk/gds-internal-it/news/aviationhouse-sourceipaddresses

## What

Describe what you have changed and why.

## How to review

Describe the steps required to test the changes.

## Who can review

Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.
