### PR TITLE
[#152840181] Increase the splay for the deployment kick-off jobs

### DIFF
--- a/concourse/scripts/sleep_for_deploy_env.sh
+++ b/concourse/scripts/sleep_for_deploy_env.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-splay=$((60*20))
+splay=$((60*60))
 # The following sleep monstrosity deterministically sleeps for a
 # period of time between 0-${splay} seconds in order to prevent all our
 # deletion jobs running at the same time. See the commit message for

--- a/concourse/scripts/sleep_for_deploy_env.sh
+++ b/concourse/scripts/sleep_for_deploy_env.sh
@@ -2,14 +2,15 @@
 
 set -eu
 
+splay=$((60*20))
 # The following sleep monstrosity deterministically sleeps for a
-# period of time between 0-20mins in order to prevent all our
+# period of time between 0-${splay} seconds in order to prevent all our
 # deletion jobs running at the same time. See the commit message for
 # how it works.
 
 sum=$(echo "${DEPLOY_ENV}" | md5sum);
 short=$(echo "${sum}" | cut -b 1-15)
 decimal=$((0x${short}));
-sleeptime=$((${decimal##-} % 60*20));
+sleeptime=$((${decimal##-} % splay));
 echo "Sleeping for ${sleeptime} seconds before continuing..."
 sleep ${sleeptime}


### PR DESCRIPTION
## What

We're seeing the deployment kick-off job fail regularly due to
rate-limiting and the like. For some people it almost never completes
successfully. This is an attempt to avoid this by increasing the
spread of the morning deployments to hopefully avoid the rate-limiting.

## How to review

Code review

Verify the script still works (eg `docker run -ti --rm -v $(pwd):/app --env DEPLOY_ENV=foo alpine:3.4 /app/concourse/scripts/sleep_for_deploy_env.sh`)

## Who can review

Not me.