### PR TITLE
[#152543946] Eliminate most of the errors during UAA deploys

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -33,10 +33,6 @@ releases:
     version: 0.1.3
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/ipsec-0.1.3.tgz
     sha1: 6a9e252162519e50f6c511c489ba304a286d496a
-  - name: nginx
-    version: 1.11.7
-    url: https://github.com/cloudfoundry-community/nginx-release/releases/download/v1.11.7/nginx-1.11.7.tgz
-    sha1: 133bb2260411b197924fff08d4cbd923cc8ec7eb
     # FIXME: remove once CF is upgraded to > v278
     # NOTE: The UAA fix has not been introduced to CF release just yet.
   - name: uaa

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -133,8 +133,6 @@ jobs:
         release: (( grab meta.release.name ))
       - name: statsd_injector
         release: (( grab meta.release.name ))
-      - name: nginx
-        release: nginx
       - name: route_registrar
       # FIXME: remove once https://github.com/cloudfoundry/route-registrar/pull/18
       # is merged - It is used ONLY for the route-registrar and gorouter
@@ -147,43 +145,6 @@ jobs:
     networks:
       - name: cf
     properties:
-      nginx_conf: |
-        worker_processes  2;
-        error_log syslog:server=127.0.0.1,severity=error,tag=uaa_nginx_error error;
-        events {
-          worker_connections  1024;
-        }
-        http {
-          include /var/vcap/packages/nginx/conf/mime.types;
-          access_log syslog:server=127.0.0.1,severity=info,tag=uaa_nginx_access combined;
-          sendfile on;
-          keepalive_timeout 20s;
-          upstream uaa {
-            keepalive 10;
-            server 127.0.0.1:8080;
-          }
-          set_real_ip_from  10.0.0.0/16;
-          set_real_ip_from  127.0.0.1/32;
-          real_ip_header    X-Forwarded-For;
-          real_ip_recursive on;
-          server {
-            listen 9443;
-            ssl on;
-            ssl_certificate_key /var/vcap/jobs/nginx/etc/ssl.key.pem;
-            ssl_certificate  /var/vcap/jobs/nginx/etc/ssl_chained.crt.pem;
-
-            location / {
-              rewrite ^/create_account(.do)?$ /create_account_disabled break;
-              rewrite ^/forgot_password(.do)?$ /create_account_disabled break;
-
-              proxy_pass http://uaa;
-              proxy_set_header Host $host;
-              proxy_set_header X-Forwarded-For $remote_addr;
-              proxy_http_version 1.1;
-              proxy_set_header Connection "";
-            }
-          }
-        }
       ssl_key: (( grab secrets.uaa_internal_key ))
       ssl_chained_cert: (( grab secrets.uaa_internal_cert ))
       consul:
@@ -199,7 +160,7 @@ jobs:
               script_path: /var/vcap/jobs/uaa/bin/health_check
               timeout: "5s"
             port: 8081
-            tls_port: 9443
+            tls_port: 8443
             server_cert_domain_san: "uaa.service.cf.internal"
             tags:
               component: uaa

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -395,7 +395,7 @@ properties:
       serviceProviderCertificate: ((grab secrets.saml_cert))
     enabled: true
     brand: oss
-    self_service_links_enabled: "false"
+    self_service_links_enabled: false
     links:
       passwd: (( concat "https://login." properties.system_domain "/forgot_password" ))
       signup: (( concat "https://login." properties.system_domain "/create_account" ))

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -185,7 +185,7 @@ properties:
     status:
       user: router_user
       password: (( grab secrets.router_password ))
-    drain_wait: 30
+    drain_wait: 120
     route_services_secret: (( grab secrets.route_services_secret ))
     max_idle_connections: 0
 

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -185,7 +185,7 @@ properties:
     status:
       user: router_user
       password: (( grab secrets.router_password ))
-    drain_wait: 15
+    drain_wait: 30
     route_services_secret: (( grab secrets.route_services_secret ))
     max_idle_connections: 0
 

--- a/manifests/cf-manifest/manifest/800-logsearch.yml
+++ b/manifests/cf-manifest/manifest/800-logsearch.yml
@@ -210,14 +210,6 @@ properties:
             }
         }
       }
-      if [@source][component] == "uaa_nginx_access" {
-        grok {
-          match => {
-            "@message" =>
-            '%{IPORHOST:[nginx][clientip]} - %{USER:[nginx][auth]} \[%{HTTPDATE:[nginx][timestamp]}\] "%{WORD:[nginx][verb]} %{URIPATHPARAM:[nginx][request]} HTTP/%{NUMBER:[nginx][httpversion]}" %{NUMBER:[nginx][response]} (?:%{NUMBER:[nginx][bytes]}|-) (?:"(?:%{URI:[nginx][referrer]}|-)"|%{QS:[nginx][referrer]}) %{QS:[nginx][agent]}'
-          }
-        }
-      }
       date {
         match => [ "[nginx][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601" ]
         target => "@timestamp"

--- a/platform-tests/src/platform/acceptance/account_management_test.go
+++ b/platform-tests/src/platform/acceptance/account_management_test.go
@@ -83,7 +83,7 @@ var _ = Describe("AccountManagement", func() {
 			resetPasswordURL := authURL
 			resetPasswordURL.Path = "/forgot_password"
 
-			params.Set("email", email)
+			params.Set("username", email)
 
 			resp, err := httpClient.Get(resetPasswordURL.String())
 			Expect(err).NotTo(HaveOccurred())
@@ -99,7 +99,7 @@ var _ = Describe("AccountManagement", func() {
 			resetPasswordURL := authURL
 			resetPasswordURL.Path = "/forgot_password.do"
 
-			params.Set("email", email)
+			params.Set("username", email)
 
 			resp, err := httpClient.PostForm(resetPasswordURL.String(), params)
 			Expect(err).NotTo(HaveOccurred())

--- a/platform-tests/src/platform/acceptance/account_management_test.go
+++ b/platform-tests/src/platform/acceptance/account_management_test.go
@@ -79,13 +79,13 @@ var _ = Describe("AccountManagement", func() {
 	})
 
 	Describe("login server /forgot_password endpoint", func() {
-		It("should not allow anonymous users to initiate password resets", func() {
+		It("should not allow access to the forgot password page", func() {
 			resetPasswordURL := authURL
-			resetPasswordURL.Path = "/forgot_password.do"
+			resetPasswordURL.Path = "/forgot_password"
 
 			params.Set("email", email)
 
-			resp, err := httpClient.PostForm(resetPasswordURL.String(), params)
+			resp, err := httpClient.Get(resetPasswordURL.String())
 			Expect(err).NotTo(HaveOccurred())
 
 			defer resp.Body.Close()
@@ -94,13 +94,14 @@ var _ = Describe("AccountManagement", func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNotFound), "wrong status code, body:\n\n %s", body)
 			Expect(body).To(ContainSubstring("Something went amiss"))
 		})
-		It("should not allow anonymous users to initiate password resets page", func() {
+
+		It("should not allow users to reset forgotten passwords", func() {
 			resetPasswordURL := authURL
-			resetPasswordURL.Path = "/forgot_password"
+			resetPasswordURL.Path = "/forgot_password.do"
 
 			params.Set("email", email)
 
-			resp, err := httpClient.Get(resetPasswordURL.String())
+			resp, err := httpClient.PostForm(resetPasswordURL.String(), params)
 			Expect(err).NotTo(HaveOccurred())
 
 			defer resp.Body.Close()

--- a/terraform/cloudfoundry/elbs.tf
+++ b/terraform/cloudfoundry/elbs.tf
@@ -43,11 +43,12 @@ resource "aws_lb_ssl_negotiation_policy" "cf_cc" {
 }
 
 resource "aws_elb" "cf_uaa" {
-  name                      = "${var.env}-cf-uaa"
-  subnets                   = ["${split(",", var.infra_subnet_ids)}"]
-  idle_timeout              = 19
-  cross_zone_load_balancing = "true"
-  connection_draining       = true
+  name                        = "${var.env}-cf-uaa"
+  subnets                     = ["${split(",", var.infra_subnet_ids)}"]
+  idle_timeout                = 19
+  cross_zone_load_balancing   = "true"
+  connection_draining         = true
+  connection_draining_timeout = 15
 
   security_groups = [
     "${aws_security_group.cf_api_elb.id}",

--- a/terraform/cloudfoundry/elbs.tf
+++ b/terraform/cloudfoundry/elbs.tf
@@ -47,6 +47,7 @@ resource "aws_elb" "cf_uaa" {
   subnets                   = ["${split(",", var.infra_subnet_ids)}"]
   idle_timeout              = 19
   cross_zone_load_balancing = "true"
+  connection_draining       = true
 
   security_groups = [
     "${aws_security_group.cf_api_elb.id}",

--- a/terraform/cloudfoundry/elbs.tf
+++ b/terraform/cloudfoundry/elbs.tf
@@ -48,7 +48,7 @@ resource "aws_elb" "cf_uaa" {
   idle_timeout                = 19
   cross_zone_load_balancing   = "true"
   connection_draining         = true
-  connection_draining_timeout = 15
+  connection_draining_timeout = 20
 
   security_groups = [
     "${aws_security_group.cf_api_elb.id}",


### PR DESCRIPTION
## What

Sadly we still see some 503 errors. Out of 6 deploys only 2 had 1-1 errors.

We made the following changes:
 * Nginx was removed from UAA as it was causing some of the downtime (the route-registrar health check was running against UAA and not Nginx) - this removed the 502 errors we saw
 * We enabled the connection draining on the UAA ELB (with default draining timeout which is 300s), which removed the remaining EOF errors but introduced new 503 errors (from the haproxy in front of the gorouter).
 * We set the drain_wait to 120s on the gorouter which decreased the number of 503 errors
 * The uaa.self_service_links_enabled parameter now disables the self-service links (like create account and reset password links), not just removes the links therefore there is no need for nginx anymore.

Minor changes:
 * The uaa.self_service_links_enabled parameter was changed to bool true (was a string value)
 * We had to change the tests checking the create account and reset password links as now UAA handles this and returns with a different status code
 * Reorder+rename forgot password tests
 * Changed the UAA ELB drain timeout from the default 300s to 20s (although it doesn't matter much, but it might help when we remove an instance from an ELB)

Remaining errors:
 * We suspect that haproxy should also drain connections at some point (it doesn't have draining atm). As we timeboxed this story we don't go into it any further. Also there is good chance haproxy will be removed soon anyway which might solve this for good.

Note: we intentionally made separate commits to reflect how the story evolved.

## How to review

1. Deploy from this branch. It is expected that the `api-availability-tests` may fail at this stage.
2. Deploy from a temporary branch that includes the following stemcell change for `router` and `uaa`:
    ```patch
    diff --git a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
    index 6583319c..dc0dfc39 100644
    --- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
    +++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
    @@ -84,6 +84,9 @@ stemcells:
       - alias: default
         name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
         version: "3468.5"
    +  - alias: test
    +    name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
    +    version: "3468"

     update:
       canaries: 0
    diff --git a/manifests/cf-manifest/manifest/010-cf-jobs.yml b/manifests/cf-manifest/manifest/010-cf-jobs.yml
    index 0df27b98..ce3fa21a 100644
    --- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
    +++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
    @@ -141,7 +141,7 @@ jobs:
         vm_type: medium
         vm_extensions:
           - cf_rds_client_sg
    -    stemcell: default
    +    stemcell: test
         networks:
           - name: cf
         properties:
    @@ -329,7 +329,7 @@ jobs:
             release: datadog-for-cloudfoundry
         instances: 2
         vm_type: router
    -    stemcell: default
    +    stemcell: test
         networks:
           - name: router
         properties:
    ```

1. Confirm that the `api-availability-tests` passed or only had some 503 errors (we saw less than 5 errors)

Also check the following:
 * the client IP is still recorded correctly in UAA log

## Who can review

Not @dcarley or @bandesz.
