### PR TITLE
[#152638275] Restyle the 'Welcome to PaaS' email

### DIFF
--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -11,39 +11,8 @@ source "${SCRIPT_DIR}/common.sh"
 DEFAULT_SPACE=sandbox
 FROM_ADDRESS='gov-uk-paas-support@digital.cabinet-office.gov.uk'
 # shellcheck disable=SC2016
-SUBJECT='Welcome to GOV.UK PaaS'
+SUBJECT='Create your GOV.UK PaaS account'
 # shellcheck disable=SC2016,SC1078
-MESSAGE='Hello,
-
-Your account for GOV.UK PaaS is ready:
-
- - username: ${EMAIL}${ORG:+
- - organisation: ${ORG}}
-
-Please use this link to activate your account and set a password. The link will only work once:
-${INVITE_URL}
-
-You can find advice about choosing a password:
-https://docs.cloud.service.gov.uk/#choosing-passwords
-
-To get started, look at our Quick Setup Guide:
-https://docs.cloud.service.gov.uk/#quick-setup-guide
-
-You can find our privacy policy here:
-https://docs.cloud.service.gov.uk/#privacy-policy
-
-To check the status of GOV.UK PaaS, and see the availability of live
-applications and database connectivity, visit
-https://status.cloud.service.gov.uk.  We recommend you sign up to this service
-to get alerts and incident updates.
-
-Regards,
-The GOV.UK PaaS team
-
-PS Some departmental email systems will check links in inbound emails as part of
-their virus protection. This may have invalidated your one-time link. If this is
-the case please contact support to set your password another way.
-'
 NOTIFICATION='
 As the account has been created now please remeber to update gov-uk-paas-announce
 mailing list. You can do that by inviting the user to the group by usng this URL:
@@ -227,7 +196,12 @@ get_subject() {
 
 # Expand variables from message body, escaping new lines and quotes
 get_body() {
-  eval "echo \"${MESSAGE}\"" | \
+  erb email="${EMAIL}" org="${ORG:-}" invite_url="${INVITE_URL}" "${SCRIPT_DIR}/templates/create_user_plain.erb" | \
+    awk '{gsub(/"/, "\\\""); printf "%s\\n", $0}'
+}
+
+get_html_body() {
+  erb email="${EMAIL}" org="${ORG:-}" invite_url="${INVITE_URL}" "${SCRIPT_DIR}/templates/create_user_html.erb" | \
     awk '{gsub(/"/, "\\\""); printf "%s\\n", $0}'
 }
 
@@ -241,6 +215,10 @@ send_mail() {
     \"Body\": {
       \"Text\": {
         \"Data\": \"$(get_body)\",
+        \"Charset\": \"utf8\"
+      },
+      \"Html\": {
+        \"Data\": \"$(get_html_body)\",
         \"Charset\": \"utf8\"
       }
     }

--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -86,6 +86,10 @@ check_params_and_environment() {
     abort "You need to have jq installed"
   fi
 
+  if ! command -v erb >/dev/null 2>&1; then
+    abort "You need to have ruby installed to run erb"
+  fi
+
   if ! cf orgs >/dev/null 2>&1; then
     abort "You need to be logged into CF CLI"
   fi

--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -8,11 +8,11 @@ source "${SCRIPT_DIR}/common.sh"
 
 ###########################################################################
 # Defaults
+TEMPLATES_DIR="${SCRIPT_DIR}/templates"
 DEFAULT_SPACE=sandbox
 FROM_ADDRESS='gov-uk-paas-support@digital.cabinet-office.gov.uk'
-# shellcheck disable=SC2016
-SUBJECT='Create your GOV.UK PaaS account'
-# shellcheck disable=SC2016,SC1078
+SUBJECT_CREATE='Create your GOV.UK PaaS account'
+SUBJECT_RESET='Reset your password on GOV.UK PaaS'
 NOTIFICATION='
 As the account has been created now please remeber to update gov-uk-paas-announce
 mailing list. You can do that by inviting the user to the group by usng this URL:
@@ -190,18 +190,33 @@ set_user_roles() {
 
 # Expand variables from subject, escaping quotes
 get_subject() {
+  if [[ "${RESET_USER}" == "true" ]]; then
+    SUBJECT=${SUBJECT_RESET}
+  else
+    SUBJECT=${SUBJECT_CREATE}
+  fi
   eval "echo ${SUBJECT}" | \
     awk '{gsub(/"/, "\\\""); print }'
 }
 
 # Expand variables from message body, escaping new lines and quotes
 get_body() {
-  erb email="${EMAIL}" org="${ORG:-}" invite_url="${INVITE_URL}" "${SCRIPT_DIR}/templates/create_user_plain.erb" | \
+  if [[ "${RESET_USER}" == "true" ]]; then
+    TEMPLATE="reset_password_plain.erb"
+  else
+    TEMPLATE="create_user_plain.erb"
+  fi
+  erb email="${EMAIL}" org="${ORG:-}" invite_url="${INVITE_URL}" "${TEMPLATES_DIR}/${TEMPLATE}" | \
     awk '{gsub(/"/, "\\\""); printf "%s\\n", $0}'
 }
 
 get_html_body() {
-  erb email="${EMAIL}" org="${ORG:-}" invite_url="${INVITE_URL}" "${SCRIPT_DIR}/templates/create_user_html.erb" | \
+  if [[ "${RESET_USER}" == "true" ]]; then
+    TEMPLATE="reset_password_html.erb"
+  else
+    TEMPLATE="create_user_html.erb"
+  fi
+  erb body="${TEMPLATES_DIR}/${TEMPLATE}" email="${EMAIL}" org="${ORG:-}" invite_url="${INVITE_URL}" "${TEMPLATES_DIR}/email_template.erb" | \
     awk '{gsub(/"/, "\\\""); printf "%s\\n", $0}'
 }
 

--- a/scripts/templates/create_user_html.erb
+++ b/scripts/templates/create_user_html.erb
@@ -1,74 +1,19 @@
-<table width="100%" style="min-width:100%;width:100%!important" cellpadding="0" cellspacing="0" border="0">
-  <tbody>
-    <tr>
-      <td width="100%" height="53" bgcolor="#0b0c0c">
-        <table width="100%" style="max-width:580px" cellpadding="0" cellspacing="0" border="0" align="center">
-          <tbody>
-            <tr>
-              <td width="70" bgcolor="#0b0c0c" valign="middle">
-                <a href="https://www.gov.uk" style="text-decoration:none" target="_blank"><img src="https://www.cloud.service.gov.uk/images/gov.uk_logotype_crown.png" alt="" height="32" border="0" style="margin-top:4px;margin-left:10px"></a>
-              </td>
-              <td width="100%" bgcolor="#0b0c0c" valign="middle" align="left">
-                <span style="padding-left:5px"><a href="https://www.gov.uk" style="font-family:Helvetica,Arial,sans-serif;font-size:28px;line-height:1.315789474;font-weight:700;color:#ffffff;text-decoration:none" target="_blank">GOV.UK</a></span>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-<table align="center" cellpadding="0" cellspacing="0" border="0" style="max-width:580px;width:100%!important" width="100%">
-  <tbody>
-    <tr>
-      <td width="10" height="10" valign="middle"></td>
-      <td>
-        <table width="100%" cellpadding="0" cellspacing="0" border="0">
-          <tbody>
-            <tr>
-              <td bgcolor="#005EA5" width="100%" height="10"></td>
-            </tr>
-          </tbody>
-        </table>
-      </td>
-      <td width="10" valign="middle" height="10"></td>
-    </tr>
-  </tbody>
-</table>
-
-<table align="center" cellpadding="0" cellspacing="0" border="0" style="max-width:580px;width:100%!important" width="100%">
-  <tbody>
-    <tr>
-      <td height="30">&nbsp;</td>
-    </tr>
-    <tr>
-      <td width="10" valign="middle">&nbsp;</td>
-      <td style="font-family:Helvetica,Arial,sans-serif;font-size:19px;line-height:1.315789474;max-width:560px">
-        <p style="Margin:0 0 20px 0;font-size:19px;line-height:25px;color:#0b0c0c">
-          Hi,
-        </p>
-        <p style="Margin:0 0 20px 0;font-size:19px;line-height:25px;color:#0b0c0c">
-          This is your account on GOV.UK PaaS:
-        </p>
-        <p style="Margin:0 0 20px 0;font-size:19px;line-height:25px;color:#0b0c0c">
-          Username: <%= email %><% if defined?(org) && org != "" %><br>
-          Organisation: <%= org %><% end %>
-        </p>
-        <p style="Margin:0 0 20px 0;font-size:19px;line-height:25px;color:#0b0c0c">
-          Open this link to create your account and set your password. It only works once.
-        </p>
-        <p style="Margin:0 0 20px 0;font-size:19px;line-height:25px;color:#0b0c0c">
-          <a style="word-wrap:break-word" href="<%= invite_url %>" target="_blank"><%= invite_url %></a>
-        </p>
-        <p style="Margin:0 0 20px 0;font-size:19px;line-height:25px;color:#0b0c0c">
-          In some departments antivirus systems check and invalidate links in inbound emails. If you’re unable to access the URL above, please contact <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a>
-        </p>
-      </td>
-      <td width="10" valign="middle">&nbsp;</td>
-    </tr>
-    <tr>
-      <td height="30">&nbsp;</td>
-    </tr>
-  </tbody>
-</table>
+<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">
+  Hello,
+</p>
+<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">
+  Open this link to create your account and set your password. It only works once.
+</p>
+<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">
+  <a style="word-wrap:break-word" href="<%= invite_url %>" target="_blank"><%= invite_url %></a>
+</p>
+<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">
+  In some departments antivirus systems check and invalidate links in inbound emails. If you’re unable to access the URL above, please contact <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a>.
+</p>
+<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">
+  We’ve added your account to the following organisation:
+</p>
+<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;"><%= org %></p>
+<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">
+  Read more about <a href="https://docs.cloud.service.gov.uk/#organisations" target="_blank">organisations</a>.
+</p>

--- a/scripts/templates/create_user_html.erb
+++ b/scripts/templates/create_user_html.erb
@@ -1,0 +1,74 @@
+<table width="100%" style="min-width:100%;width:100%!important" cellpadding="0" cellspacing="0" border="0">
+  <tbody>
+    <tr>
+      <td width="100%" height="53" bgcolor="#0b0c0c">
+        <table width="100%" style="max-width:580px" cellpadding="0" cellspacing="0" border="0" align="center">
+          <tbody>
+            <tr>
+              <td width="70" bgcolor="#0b0c0c" valign="middle">
+                <a href="https://www.gov.uk" style="text-decoration:none" target="_blank"><img src="https://www.cloud.service.gov.uk/images/gov.uk_logotype_crown.png" alt="" height="32" border="0" style="margin-top:4px;margin-left:10px"></a>
+              </td>
+              <td width="100%" bgcolor="#0b0c0c" valign="middle" align="left">
+                <span style="padding-left:5px"><a href="https://www.gov.uk" style="font-family:Helvetica,Arial,sans-serif;font-size:28px;line-height:1.315789474;font-weight:700;color:#ffffff;text-decoration:none" target="_blank">GOV.UK</a></span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<table align="center" cellpadding="0" cellspacing="0" border="0" style="max-width:580px;width:100%!important" width="100%">
+  <tbody>
+    <tr>
+      <td width="10" height="10" valign="middle"></td>
+      <td>
+        <table width="100%" cellpadding="0" cellspacing="0" border="0">
+          <tbody>
+            <tr>
+              <td bgcolor="#005EA5" width="100%" height="10"></td>
+            </tr>
+          </tbody>
+        </table>
+      </td>
+      <td width="10" valign="middle" height="10"></td>
+    </tr>
+  </tbody>
+</table>
+
+<table align="center" cellpadding="0" cellspacing="0" border="0" style="max-width:580px;width:100%!important" width="100%">
+  <tbody>
+    <tr>
+      <td height="30">&nbsp;</td>
+    </tr>
+    <tr>
+      <td width="10" valign="middle">&nbsp;</td>
+      <td style="font-family:Helvetica,Arial,sans-serif;font-size:19px;line-height:1.315789474;max-width:560px">
+        <p style="Margin:0 0 20px 0;font-size:19px;line-height:25px;color:#0b0c0c">
+          Hi,
+        </p>
+        <p style="Margin:0 0 20px 0;font-size:19px;line-height:25px;color:#0b0c0c">
+          This is your account on GOV.UK PaaS:
+        </p>
+        <p style="Margin:0 0 20px 0;font-size:19px;line-height:25px;color:#0b0c0c">
+          Username: <%= email %><% if defined?(org) && org != "" %><br>
+          Organisation: <%= org %><% end %>
+        </p>
+        <p style="Margin:0 0 20px 0;font-size:19px;line-height:25px;color:#0b0c0c">
+          Open this link to create your account and set your password. It only works once.
+        </p>
+        <p style="Margin:0 0 20px 0;font-size:19px;line-height:25px;color:#0b0c0c">
+          <a style="word-wrap:break-word" href="<%= invite_url %>" target="_blank"><%= invite_url %></a>
+        </p>
+        <p style="Margin:0 0 20px 0;font-size:19px;line-height:25px;color:#0b0c0c">
+          In some departments antivirus systems check and invalidate links in inbound emails. If you’re unable to access the URL above, please contact <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a>
+        </p>
+      </td>
+      <td width="10" valign="middle">&nbsp;</td>
+    </tr>
+    <tr>
+      <td height="30">&nbsp;</td>
+    </tr>
+  </tbody>
+</table>

--- a/scripts/templates/create_user_html.erb
+++ b/scripts/templates/create_user_html.erb
@@ -17,3 +17,15 @@
 <p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">
   Read more about <a href="https://docs.cloud.service.gov.uk/#organisations" target="_blank">organisations</a>.
 </p>
+<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">
+  You can find advice about <a href="https://docs.cloud.service.gov.uk/#choosing-passwords">choosing a password</a>.
+</p>
+<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">
+  To get started, look at our <a href="https://docs.cloud.service.gov.uk/#quick-setup-guide">Quick Setup Guide</a>.
+</p>
+<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">
+  You can find our privacy policy <a href="https://docs.cloud.service.gov.uk/#privacy-policy">here</a>.
+</p>
+<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">
+  To check the status of GOV.UK PaaS, and see the availability of live applications and database connectivity, visit our <a href="https://status.cloud.service.gov.uk">status page</a>. We recommend you sign up to this service to get alerts and incident updates.
+</p>

--- a/scripts/templates/create_user_plain.erb
+++ b/scripts/templates/create_user_plain.erb
@@ -12,4 +12,19 @@ We’ve added your account to the following organisation:
 
 <%= org %>
 
-Read more about organisations: https://docs.cloud.service.gov.uk/#organisations
+Read more about organisations:
+https://docs.cloud.service.gov.uk/#organisations
+
+You can find advice about choosing a password:
+https://docs.cloud.service.gov.uk/#choosing-passwords
+
+To get started, look at our Quick Setup Guide:
+https://docs.cloud.service.gov.uk/#quick-setup-guide
+
+You can find our privacy policy here:
+https://docs.cloud.service.gov.uk/#privacy-policy
+
+To check the status of GOV.UK PaaS, and see the availability of live
+applications and database connectivity, visit
+https://status.cloud.service.gov.uk. We recommend you sign up to this service
+to get alerts and incident updates.

--- a/scripts/templates/create_user_plain.erb
+++ b/scripts/templates/create_user_plain.erb
@@ -1,9 +1,4 @@
-Hi,
-
-This is your account on GOV.UK PaaS:
-
-Username: <%= email %><% if defined?(org) && org != "" %>
-Organisation: <%= org %><% end %>
+Hello,
 
 Open this link to create your account and set your password. It only works once.
 
@@ -12,3 +7,9 @@ Open this link to create your account and set your password. It only works once.
 In some departments antivirus systems check and invalidate links in inbound
 emails. If you’re unable to access the URL above, please contact
 gov-uk-paas-support@digital.cabinet-office.gov.uk.
+
+We’ve added your account to the following organisation:
+
+<%= org %>
+
+Read more about organisations: https://docs.cloud.service.gov.uk/#organisations

--- a/scripts/templates/create_user_plain.erb
+++ b/scripts/templates/create_user_plain.erb
@@ -1,0 +1,14 @@
+Hi,
+
+This is your account on GOV.UK PaaS:
+
+Username: <%= email %><% if defined?(org) && org != "" %>
+Organisation: <%= org %><% end %>
+
+Open this link to create your account and set your password. It only works once.
+
+<%= invite_url %>
+
+In some departments antivirus systems check and invalidate links in inbound
+emails. If you’re unable to access the URL above, please contact
+gov-uk-paas-support@digital.cabinet-office.gov.uk.

--- a/scripts/templates/email_template.erb
+++ b/scripts/templates/email_template.erb
@@ -1,0 +1,93 @@
+<table role="presentation" width="100%" style="min-width: 100%;width: 100% !important;" cellpadding="0" cellspacing="0" border="0">
+  <tr>
+    <td width="100%" height="53" bgcolor="#0b0c0c">
+      <!--[if (gte mso 9)|(IE)]>
+         <table role="presentation" width="580" align="center" cellpadding="0" cellspacing="0" border="0">
+           <tr>
+             <td>
+       <![endif]-->
+      <table role="presentation" width="100%" style="max-width: 580px;" cellpadding="0" cellspacing="0" border="0" align="center">
+        <tr>
+          <td width="70" bgcolor="#0b0c0c" valign="middle">
+            <a href="https://www.gov.uk" style="text-decoration: none;"><img
+                     src="https://www.cloud.service.gov.uk/images/gov.uk_logotype_crown.png"
+                     alt="" height="32" border="0" style="margin-top: 4px; margin-left: 10px;"></a>
+          </td>
+          <td width="100%" bgcolor="#0b0c0c" valign="middle" align="left">
+            <span style="padding-left: 5px;"><a href="https://www.gov.uk" style="
+                 font-family: Helvetica, Arial, sans-serif;
+                 font-size: 28px;
+                 line-height: 1.315789474;
+                 font-weight: 700;
+                 color: #ffffff;
+                 text-decoration: none;
+             "
+             >GOV.UK</a></span>
+          </td>
+        </tr>
+      </table>
+      <!--[if (gte mso 9)|(IE)]>
+             </td>
+           </tr>
+         </table>
+       <![endif]-->
+    </td>
+  </tr>
+</table>
+<table role="presentation" class="content" align="center" cellpadding="0" cellspacing="0" border="0" style="max-width: 580px; width: 100% !important;" width="100%">
+  <tr>
+    <td width="10" height="10" valign="middle"></td>
+    <td>
+      <!--[if (gte mso 9)|(IE)]>
+         <table role="presentation" width="580" align="center" cellpadding="0" cellspacing="0" border="0">
+           <tr>
+             <td height="10">
+       <![endif]-->
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+        <tr>
+          <td bgcolor="#005EA5" width="100%" height="10"></td>
+        </tr>
+      </table>
+      <!--[if (gte mso 9)|(IE)]>
+             </td>
+           </tr>
+         </table>
+       <![endif]-->
+    </td>
+    <td width="10" valign="middle" height="10"></td>
+  </tr>
+</table>
+<table
+    role="presentation"
+    class="content"
+    align="center"
+    cellpadding="0"
+    cellspacing="0"
+    border="0"
+    style="max-width: 580px; width: 100% !important;"
+    width="100%"
+>
+  <tr>
+    <td height="30">&nbsp;</td>
+  </tr>
+  <tr>
+    <td width="10" valign="middle">&nbsp;</td>
+    <td style="font-family: Helvetica, Arial, sans-serif; font-size: 19px; line-height: 1.315789474; max-width: 560px;">
+      <!--[if (gte mso 9)|(IE)]>
+        <table role="presentation" width="560" align="center" cellpadding="0" cellspacing="0" border="0">
+          <tr>
+            <td style="font-family: Helvetica, Arial, sans-serif; font-size: 19px; line-height: 1.315789474;">
+      <![endif]-->
+              <%= ERB.new(File.read(body), nil, nil, '_body').result(binding) %>
+      <!--[if (gte mso 9)|(IE)]>
+            </td>
+          </tr>
+        </table>
+      <![endif]-->
+    </td>
+    <td width="10" valign="middle">&nbsp;</td>
+  </tr>
+  <tr>
+    <td height="30">&nbsp;</td>
+  </tr>
+</table>

--- a/scripts/templates/reset_password_html.erb
+++ b/scripts/templates/reset_password_html.erb
@@ -1,0 +1,12 @@
+<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">
+  Hello,
+</p>
+<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">
+  Use this link to reset your password. It only works once.
+</p>
+<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">
+  <a style="word-wrap:break-word" href="<%= invite_url %>" target="_blank"><%= invite_url %></a>
+</p>
+<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">
+  In some departments antivirus systems check and invalidate links in inbound emails. If you’re unable to access the URL above, please contact <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a>
+</p>

--- a/scripts/templates/reset_password_plain.erb
+++ b/scripts/templates/reset_password_plain.erb
@@ -1,0 +1,9 @@
+Hello,
+
+Use this link to reset your password. It only works once.
+
+<%= invite_url %>
+
+In some departments antivirus systems check and invalidate links in inbound
+emails. If you’re unable to access the URL above, please contact
+gov-uk-paas-support@digital.cabinet-office.gov.uk.


### PR DESCRIPTION
## What

This change adds a HTML version to our 'Welcome to PaaS' email which we send
when we create a new user or reset the password for an existing user.

I copied the HTML template from Notify: https://github.com/alphagov/notifications-utils/blob/master/notifications_utils/jinja_templates/email_template.jinja2

I extracted the existing plain text template to a Ruby ERB template and saved
the new HTML template next to it. The HTML code would be hard to handle in the
script and this way the templates are easier to manage.

Also we decided to separate the create user and the reset password emails therefore the multiple templates.

I added an email template file so we only have to define the content for the different emails.

## How to review

If your not using your gov.uk email for testing you may have to verify it in SES: https://eu-west-1.console.aws.amazon.com/ses/home?region=eu-west-1#verified-senders-email

1. Run the create user script to create a new user, ORG_NAME can be an existing one or a new:

```
./scripts/create-user.sh -o [ORG_NAME] -e [YOUR_EMAIL]
```

This email should say to create your account and include the organisation name.

2. Run the create user script to reset the password for your user:

```
./scripts/create-user.sh -r -e [YOUR_EMAIL]
```
This email should say to reset your password and not include the organisation name.

3. You should get two emails. Please check if the emails are correct and all links work as expected. Also check the email source (in Gmail: Show original) and verify if the plain text version is correct.

## Who can review

Not @bandesz