### PR TITLE
[#151948132] Use new gorouter health check

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -22,9 +22,9 @@ releases:
     url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.166.0
     sha1: 283fcf78d0d2d68bc502523320c9ad973f6fa679
   - name: paas-haproxy
-    version: 0.1.4
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/paas-haproxy-0.1.4.tgz
-    sha1: 2048d2bd05678a2ebf18e53a49e056b0faa6aaab
+    version: 0.1.5
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/paas-haproxy-0.1.5.tgz
+    sha1: c8c90a4c14ea2201a37469596b5cef309864a394
   - name: datadog-for-cloudfoundry
     version: 0.1.17
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.1.17.tgz

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -168,6 +168,7 @@ properties:
     go_router:
       servers: [ "127.0.0.1" ]
       port: 80
+      healthcheck_port: (( grab properties.router.status.port ))
     additional_frontend_config: |
       capture response header strict-transport-security len 128
       http-response add-header Strict-Transport-Security max-age=31536000;\ includeSubDomains;\ preload unless { capture.res.hdr(0) -m found }
@@ -185,6 +186,7 @@ properties:
     status:
       user: router_user
       password: (( grab secrets.router_password ))
+      port: 8080
     drain_wait: 120
     route_services_secret: (( grab secrets.route_services_secret ))
     max_idle_connections: 0

--- a/terraform/cloudfoundry/elbs.tf
+++ b/terraform/cloudfoundry/elbs.tf
@@ -61,7 +61,7 @@ resource "aws_elb" "cf_uaa" {
   }
 
   health_check {
-    target              = "HTTP:82/"
+    target              = "HTTP:82/health"
     interval            = "${var.health_check_interval}"
     timeout             = "${var.health_check_timeout}"
     healthy_threshold   = "${var.health_check_healthy}"
@@ -152,7 +152,7 @@ resource "aws_elb" "cf_router" {
   }
 
   health_check {
-    target              = "HTTP:82/"
+    target              = "HTTP:82/health"
     interval            = "${var.health_check_interval}"
     timeout             = "${var.health_check_timeout}"
     healthy_threshold   = "${var.health_check_healthy}"


### PR DESCRIPTION
## What

The old health checking method is deprecated so we'll start to use the new one. (Details: https://github.com/cloudfoundry/gorouter#healthchecking-from-a-load-balancer)

Changes:
 - use new haproxy release which creates a new frontend for the health checks
 - use the /health path for health checking on the UAA and the router ELBs

## How to review

1. Update your dev CF from this branch
1. Confirm that the `api-availability-tests` passed or only had some 503 errors. Confirm that the `app-availability-tests` had no errors.
1. Deploy from a temporary branch that includes the following stemcell change for `router` and `uaa`:

    ```patch
    diff --git a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
    index fc24d003..e639d6a4 100644
    --- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
    +++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
    @@ -84,6 +84,9 @@ stemcells:
       - alias: default
         name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
         version: "3468.5"
    +  - alias: test
    +    name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
    +    version: "3468"

     update:
       canaries: 0
    diff --git a/manifests/cf-manifest/manifest/010-cf-jobs.yml b/manifests/cf-manifest/manifest/010-cf-jobs.yml
    index 0df27b98..ce3fa21a 100644
    --- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
    +++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
    @@ -141,7 +141,7 @@ jobs:
         vm_type: medium
         vm_extensions:
           - cf_rds_client_sg
    -    stemcell: default
    +    stemcell: test
         networks:
           - name: cf
         properties:
    @@ -329,7 +329,7 @@ jobs:
             release: datadog-for-cloudfoundry
         instances: 2
         vm_type: router
    -    stemcell: default
    +    stemcell: test
         networks:
           - name: router
         properties:
    ```
1. Confirm that the `api-availability-tests` passed or only had some 503 errors. Confirm that the `app-availability-tests` had no errors.

## Who can review

Not @bandesz

## Before merge

❗️ The haproxy-release has to be merged first: https://github.com/alphagov/paas-haproxy-release/pull/11

Please replace the temporary commit which sets the haproxy-release to a dev version with the final version. 