### PR TITLE
[#152150403] Suppress update-ca-certificates skipped warning in the logs.

### DIFF
--- a/concourse/scripts/import_bosh_ca.sh
+++ b/concourse/scripts/import_bosh_ca.sh
@@ -3,4 +3,8 @@ set -eu
 
 echo "Adding bosh-CA to root certificates"
 tar -xzf bosh-CA/bosh-CA.tar.gz -C /usr/local/share/ca-certificates bosh-CA.crt
-update-ca-certificates
+
+UPDATE_OUTPUT=$(update-ca-certificates 2>&1)
+set +e
+printf "%s" "${UPDATE_OUTPUT}" | grep -v "^WARNING: ca-certificates\.crt does not contain exactly one certificate or CRL: skipping$"
+set -e


### PR DESCRIPTION
## What

This change will suppress the following warning message:
WARNING: ca-certificates.crt does not contain exactly one certificate or CRL: skipping

It's not actually an indication of a problem but it could distract a team member working on an incident.

## How to review

Run your CF pipeline and check if we're not logging the warnings anymore (e.g. pre-deploy/wait-for-app-availability-tests)

## Who can review

Not @bandesz
