### PR TITLE
Start collecting broker ELB logs

### DIFF
--- a/terraform/cloudfoundry/cdn_broker.tf
+++ b/terraform/cloudfoundry/cdn_broker.tf
@@ -6,6 +6,12 @@ resource "aws_elb" "cdn_broker" {
   internal                  = true
   security_groups           = ["${aws_security_group.service_brokers.id}"]
 
+  access_logs {
+    bucket        = "${aws_s3_bucket.elb_access_log.id}"
+    bucket_prefix = "cf-broker-cdn"
+    interval      = 5
+  }
+
   health_check {
     target              = "HTTP:3000/healthcheck/http"
     interval            = "${var.health_check_interval}"

--- a/terraform/cloudfoundry/rds_broker.tf
+++ b/terraform/cloudfoundry/rds_broker.tf
@@ -6,6 +6,12 @@ resource "aws_elb" "rds_broker" {
   internal                  = true
   security_groups           = ["${aws_security_group.service_brokers.id}"]
 
+  access_logs {
+    bucket        = "${aws_s3_bucket.elb_access_log.id}"
+    bucket_prefix = "cf-broker-rds"
+    interval      = 5
+  }
+
   health_check {
     target              = "HTTP:80/healthcheck"
     interval            = "${var.health_check_interval}"


### PR DESCRIPTION
## What

We do this to help with debugging issues reported by tenants when
doing various broker operations. We can use the existing bucket for
ELB logs as the prefix provides a suitable namespace.

## How to review

I haven't deployed this, so you should. Run the pipeline, check it doesn't break anything, then look in the bucket for the logs.

There is a slight cost implication for storage.

## Who can review

Anyone but me.
