### PR TITLE
[#152962527] Upgrade CAPI for CVE-2017-14389

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -45,6 +45,11 @@ releases:
     version: 0.1.2
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/routing-0.1.2.tgz
     sha1: 9b56da7b99ddbbb8313756f146a06d781d8d0230
+    # FIXME: Remove once CF is upgraded to >= v280
+  - name: capi
+    version: "1.45.0"
+    url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.45.0
+    sha1: 3ca25a7853302bdb9cabcd77ad3a4a3879dfe016
 
   ### buildpacks
   - name: binary-buildpack

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -177,10 +177,10 @@ jobs:
         release: (( grab jobs.consul.templates.consul_agent.release ))
         consumes: {consul_client: nil, consul_server: nil, consul_common: nil}
       - name: cloud_controller_ng
-        release: (( grab meta.release.name ))
+        release: capi
         consumes: {nats: nil}
       - name: cloud_controller_clock
-        release: (( grab meta.release.name ))
+        release: capi
         consumes: {nats: nil}
       - name: metron_agent
         release: (( grab meta.release.name ))
@@ -230,7 +230,7 @@ jobs:
         release: (( grab jobs.consul.templates.consul_agent.release ))
         consumes: {consul_client: nil, consul_server: nil, consul_common: nil}
       - name: cloud_controller_worker
-        release: (( grab meta.release.name ))
+        release: capi
         consumes: {nats: nil}
       - name: metron_agent
         release: (( grab meta.release.name ))
@@ -412,9 +412,9 @@ jobs:
       - name: datadog-consul-agent-client
         release: datadog-for-cloudfoundry
       - name: tps
-        release: cf
+        release: capi
       - name: cc_uploader
-        release: cf
+        release: capi
       - name: metron_agent
         release: (( grab meta.release.name ))
     instances: 2


### PR DESCRIPTION
## What

Application Subdomain Takeover via Cloud Foundry Private Domains:

- https://www.cloudfoundry.org/cve-2017-14389/

This takes us from 1.44.0 which is included in cf-release v278 to an
individual release of 1.45.0.

I've updated all of the jobs that appear in this release:

- https://bosh.io/releases/github.com/cloudfoundry/capi-release?version=1.45.0

The release notes for the release say:

> Breaking logging change with introduction of property cc.log_db_queries which
> defaults to false for jobs cloud_controller_ng, cloud_controller_worker, and
> cloud_controller_clock. This causes DB logs to not be logged by default. If you
> want to see these logs then you'll need to switch this value to true.

This shouldn't affect us because we've already gone to
lengths to reduce the amount of noisy logging that CC does in:

- 62c0882c60050d37e9954038660ca8b982360c0b
- cloudfoundry/cloud_controller_ng#618
- cloudfoundry/cloud_controller_ng#617

## How to review

I've deployed this in my dev environment, upgrading from `master` at 43567f967c18dcee668ec922c4e3ed3959b56050, and **all** the tests in the pipeline passed. I don't think the reviewer needs to repeat that but it's up to them.

To review the code you should:

- check that I've upgraded the right things to the right versions according to the advisory
- double check that I haven't missed any jobs that come from CAPI

## Who can review

Anyone.