### PR TITLE
[#152916557] Add custom redirection on user invite

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -550,6 +550,14 @@ properties:
         id: cdn_broker
         scope: cloud_controller.admin_read_only
         secret: (( grab secrets.uaa_clients_cdn_broker_secret ))
+      user_invitation:
+        authorities: oauth.login,scim.write,emails.write,scim.userids
+        authorized-grant-types: password,refresh_token
+        id: user_invitation
+        override: true
+        redirect-uri: "https://www.cloud.service.gov.uk/next-steps?success"
+        scope: openid,password.write,scim.read,scim.write,scim.invite,uaa.user
+        secret: (( grab secrets.uaa_clients_login_secret ))
 
     zones:
       internal:

--- a/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
@@ -132,6 +132,7 @@ RSpec.describe "base properties" do
           "cc_service_key_client",
           "cdn_broker",
           "paas-usage-events-collector",
+          "user_invitation",
         )
       }
 

--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -22,6 +22,7 @@ https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!managemembers/
 As a welcome message you can use the text from here:
 https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/gov-uk-paas-announce
 '
+REDIRECT_URI="https://www.cloud.service.gov.uk/next-steps?success"
 
 ###########################################################################
 usage() {
@@ -161,7 +162,7 @@ create_user() {
       -H "Authorization: ${auth_token}" \
       -H "Accept: application/json" -H "Content-Type: application/json" \
       -d "{\"emails\": [\"${EMAIL}\"]}" \
-      "${uaa_endpoint}/invite_users?redirect_uri=" >"${TMP_OUTPUT}"
+      "${uaa_endpoint}/invite_users?redirect_uri=${REDIRECT_URI}&client_id=user_invitation" >"${TMP_OUTPUT}"
 
     if ! jq -e '.new_invites | length == 1' "${TMP_OUTPUT}" >/dev/null; then
       cat "${TMP_OUTPUT}"


### PR DESCRIPTION
## What

When the user receives an email to complete their registration it will
ask them to provide their password. Once the password is set
successfully, user has accepted an invitation and will be redirected to
the UAA home page.

It isn't very useful page, especially if you're just starting off with
CF. We've created our own landing page we'd like to be providing to our
users upon registration.

## How to review

- Code review
- To be reviewed with alphagov/paas-product-page#41
- Deploy from this branch
- Create a new user in your `dev` env `./scripts/create-user.sh -e user@example.com -o govuk-paas --no-email`
- Click/Copy paste the URL into your browser
- Set user name
- Expect to be redirected into correct page (you may see 404 if the page is not deployed)

## Before merge :bee:

The alphagov/paas-product-page#41 needs to be merged first in order not to redirect people to `404`.