### PR TITLE
[#152241494] Enable Billing API Auth

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -263,7 +263,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-usage-events-collector
-      tag_filter: v0.1.0
+      tag_filter: v0.3.0
 
 jobs:
   - name: pipeline-lock

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1901,6 +1901,7 @@ jobs:
             params:
               ENABLE_USAGE_EVENTS_COLLECTION: ((enable_usage_events_collection))
               CF_SKIP_SSL_VALIDATION: ((cf_skip_ssl_validation))
+              APPS_DNS_ZONE_NAME: ((apps_dns_zone_name))
             inputs:
               - name: paas-cf
               - name: paas-usage-events-collector
@@ -1940,6 +1941,7 @@ jobs:
                     env = {
                       'CF_CLIENT_ID' => 'paas-usage-events-collector',
                       'CF_CLIENT_SECRET' => '${CF_CLIENT_SECRET}',
+                      'CF_CLIENT_REDIRECT_URL' => 'https://paas-usage-events-collector.${APPS_DNS_ZONE_NAME}/oauth/callback',
                       'CF_API_ADDRESS' => '${API_ENDPOINT}',
                       'CF_SKIP_SSL_VALIDATION' => '${CF_SKIP_SSL_VALIDATION}',
                     }

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -533,12 +533,13 @@ properties:
         redirect-uri: (( concat "https://login." properties.system_domain ))
       paas-usage-events-collector:
         access-token-validity: 1209600
-        authorized-grant-types: client_credentials,refresh_token
+        authorized-grant-types: client_credentials,refresh_token,authorization_code
+        autoapprove: true
         override: true
         secret: (( grab secrets.uaa_clients_paas_usage_events_collector_secret ))
-        scope: openid,oauth.approvals,cloud_controller.admin_read_only
-        authorities: oauth.login,cloud_controller.admin_read_only
-        redirect-uri: (( concat "https://login." properties.system_domain ))
+        scope: openid,oauth.approvals,cloud_controller.admin_read_only,cloud_controller.read,cloud_controller.global_auditor,cloud_controller.admin
+        authorities: cloud_controller.admin_read_only,uaa.resource
+        redirect-uri: (( concat "https://paas-usage-events-collector." properties.app_domains[0] "/oauth/callback" ))
       cc-service-dashboards:
         secret: (( grab secrets.uaa_clients_cc_service_dashboards_password ))
         authorities: clients.read,clients.write,clients.admin


### PR DESCRIPTION
## What

* Update the UAA client spec to allow the billing api app to request authorization for a selection of read-only scopes.
* Set paas-usage-events-collector app to pull in the branch at https://github.com/alphagov/paas-usage-events-collector/pull/5

## How to review

Deploy this branch to your dev environment using:

```
ENABLE_USAGE_EVENTS_COLLECTION=true SELF_UPDATE_PIPELINE=false BRANCH=calculate_billing_152241494 make dev pipelines
```

## Before merge

Update the [TMP] commit to point to a tag not a branch.

## Who can review

not @chrisfarms
