### PR TITLE
[#152962527] val_from_yaml.rb: Fix array lookup by position

### DIFF
--- a/concourse/scripts/val_from_yaml.rb
+++ b/concourse/scripts/val_from_yaml.rb
@@ -18,7 +18,7 @@ class PropertyTree
                  when Hash
                    tree[current_key]
                  when Array
-                   if current_key === /\A[-+]?\d+\z/ # If the key is an int, access by index
+                   if current_key =~ /\A[-+]?\d+\z/ # If the key is an int, access by index
                      tree[current_key.to_i]
                    else # if not, search for a element with `name: current_key`
                      tree.select { |x| x.is_a?(Hash) && x['name'] == current_key }.first

--- a/concourse/scripts/val_from_yaml_test.go
+++ b/concourse/scripts/val_from_yaml_test.go
@@ -120,4 +120,16 @@ val2: b
 			Expect(session.Err.Contents()).To(BeEmpty())
 		})
 	})
+
+	Context("argument references a string value within an array indexed by position", func() {
+		BeforeEach(func() {
+			cmdArg = "foo.array1.0.val"
+		})
+
+		It("returns a single string", func() {
+			Eventually(session).Should(gexec.Exit(0))
+			Expect(session.Out.Contents()).To(Equal([]byte("array1_item1_value\n")))
+			Expect(session.Err.Contents()).To(BeEmpty())
+		})
+	})
 })


### PR DESCRIPTION
## What

Rubocop autocorrect in 97a8a506 changed the order of a comparison which
broke `val_from_yaml.rb` when looking up array items by position. We noticed
this when `get-and-upload-stemcells` in the `create-cloudfoundry` pipeline
no longer uploaded the stemcell so a fresh deployment failed with:

    Error 50003: Stemcell 'bosh-aws-xen-hvm-ubuntu-trusty-go_agent/3468.5' doesn't exist

The use of `===` meant that the order of the comparison arguments were
significant. When regex is the first argument it compares the other value to
the regex, but when a string is the first argument it also asserts that the
other argument is also a `String`.

- https://apidock.com/ruby/Regexp/%3D%3D%3D
- https://apidock.com/ruby/String/%3D%3D%3D

Fix this by explicitly using `=~` to compare to a regex. I've added a test
to prevent this happening again.

## How to review

Code review. I've tested it in my previously-broken environment.

## Who can review

Anyone.