### PR TITLE
[#131354667] Overcommit cells by 66%

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1127,6 +1127,7 @@ jobs:
                 ./paas-cf/manifests/cf-manifest/cloud-config/*.yml
                 ./terraform-outputs/*.yml
                 ./cf-secrets/cf-secrets.yml
+                ./paas-cf/manifests/cf-manifest/cell.yml
                 ./paas-cf/manifests/cf-manifest/env-specific/((cf_env_specific_manifest))
             run:
               path: sh
@@ -1170,6 +1171,7 @@ jobs:
                 ./cf-secrets/cf-secrets.yml
                 ./certs/*.yml
                 ./grafana-dashboards-manifest/grafana-dashboards-manifest.yml
+                ./paas-cf/manifests/cf-manifest/cell.yml
                 ./paas-cf/manifests/cf-manifest/env-specific/((cf_env_specific_manifest))
                 ./vpc-peering-manifest/*.yml
               AWS_ACCOUNT: ((aws_account))

--- a/manifests/cf-manifest/cell.yml
+++ b/manifests/cf-manifest/cell.yml
@@ -1,0 +1,6 @@
+---
+meta:
+  cell:
+    instance_type: r4.xlarge
+    instance_memory_mb: 30662
+    rep_commit_percentage: 1.66

--- a/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
+++ b/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
@@ -59,7 +59,7 @@ vm_types:
     network: cell
     env: (( grab meta.default_env ))
     cloud_properties:
-      instance_type: r4.xlarge
+      instance_type: (( grab meta.cell.instance_type ))
       ephemeral_disk:
         size: 204800
         type: gp2

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -666,6 +666,9 @@ properties:
       preloaded_rootfses:
         - "cflinuxfs2:/var/vcap/packages/cflinuxfs2/rootfs"
 
+    executor:
+      memory_capacity_mb: (( calc "floor(meta.cell.rep_commit_percentage * meta.cell.instance_memory_mb)" ))
+
     route_emitter:
       dropsonde_port: (( grab properties.metron_agent.dropsonde_incoming_port ))
       bbs:

--- a/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
@@ -173,6 +173,20 @@ RSpec.describe "base properties" do
     end
   end
 
+  describe "diego" do
+    subject(:diego) { properties.fetch("diego") }
+
+    describe "executor" do
+      subject(:executor) { diego.fetch("executor") }
+
+      it "should have a memory_capacity_mb of at least 30G" do
+        memory_capacity_mb = executor['memory_capacity_mb']
+        expect(memory_capacity_mb).to be_a_kind_of(Integer)
+        expect(memory_capacity_mb).to be >= (30 * 1024)
+      end
+    end
+  end
+
   describe "buildpacks" do
     let(:api_job) { manifest_with_defaults.fetch("jobs").find { |j| j.fetch("name") == "api" } }
     let(:api_template_names) { api_job.fetch("templates").map { |t| t.fetch("name") } }

--- a/manifests/cf-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/cf-manifest/spec/support/manifest_helpers.rb
@@ -75,6 +75,7 @@ private
         cf_secrets_file,
         File.expand_path("../../../../shared/spec/fixtures/cf-ssl-certificates.yml", __FILE__),
         grafana_dashboards_manifest,
+        File.expand_path("../../../cell.yml", __FILE__),
         File.expand_path("../../../env-specific/cf-#{environment}.yml", __FILE__),
         File.expand_path("../../../stubs/datadog-nozzle.yml", __FILE__),
     ])
@@ -89,6 +90,7 @@ private
         File.expand_path("../../../../shared/build_manifest.sh", __FILE__),
         File.expand_path("../../../cloud-config/*.yml", __FILE__),
         File.expand_path("../../../../shared/spec/fixtures/terraform/*.yml", __FILE__),
+        File.expand_path("../../../cell.yml", __FILE__),
         File.expand_path("../../../env-specific/cf-#{environment}.yml", __FILE__),
         cf_secrets_file,
     ])


### PR DESCRIPTION
## What

This has `rep` advertise cells as having 66% more memory capacity than they really have. This is safe: apps running on the platform use ~34% of their reserved memory, and we calculated this change assuming a more conservative 60% utilisation. See commit messages for details.

## How to review

* Code review
* Deploy in your dev environment and check the `rep` metrics and monitors look good

## Who can review

Not @46bit @camelpunch 