### PR TITLE
[Support] Script to cleanup unused CDN broker IAM certs

### DIFF
--- a/scripts/cleanup_unused_cdn_broker_iam_certs.rb
+++ b/scripts/cleanup_unused_cdn_broker_iam_certs.rb
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+
+require 'json'
+
+unless system "aws iam list-account-aliases > /dev/null"
+  abort "Make sure you've configured your AWS keys"
+end
+
+all_cdn_certs = JSON.parse %x(aws iam list-server-certificates --query 'ServerCertificateMetadataList[?Path == `/cloudfront/prod-letsencrypt/`]')
+
+cloudfront_used_certs = JSON.parse %x(aws cloudfront list-distributions --query 'DistributionList.Items[].ViewerCertificate.Certificate')
+
+all_cdn_certs.each do |cert|
+  if cloudfront_used_certs.include?(cert['ServerCertificateId'])
+    puts "skipping used cert #{cert['ServerCertificateId']} #{cert['ServerCertificateName']}"
+    next
+  end
+
+  puts "deleting unused cert #{cert['ServerCertificateId']} #{cert['ServerCertificateName']}"
+
+  system "aws iam delete-server-certificate --server-certificate-name '#{cert['ServerCertificateName']}'"
+end


### PR DESCRIPTION
## What

We're seeing multiple IAM server certificates for earh cdn-broker
service instance. Only the most recent one for each instance is actually
in use. These unused certs are causing us to come close to hitting the
AWS service limits for IAM server certificates.

This adds a script to clean these up. This is only a temporary solution
until the cdn-broker can be updated to clean these up itself.

## How to review

Check the script makes sense.

This is one of those things that's hard to test in a dev environment because there won't be any cdn-broker instances in this state. Having said that, I believe this is low-risk because AWS won't allow us to delete a cert that's in use.

## Who can review

Not me.