### PR TITLE
[#153170266] Extend rds-broker instance log retention to 7 days

### DIFF
--- a/terraform/cloudfoundry/rds_broker.tf
+++ b/terraform/cloudfoundry/rds_broker.tf
@@ -89,6 +89,11 @@ resource "aws_db_parameter_group" "rds_broker_postgres95" {
     name         = "rds.force_ssl"
     value        = "1"
   }
+
+  parameter {
+    name  = "rds.log_retention_period"
+    value = "10080"                    // 7 days in minutes
+  }
 }
 
 resource "aws_db_parameter_group" "rds_broker_mysql57" {


### PR DESCRIPTION
## What

The default is 3 days which means that over the weekend, useful messages
can be gone and it's too late to investigate any issues on a Monday
morning.

## How to review

* Create a Postgres instance in a dev env deployed from master.
* Deploy from this branch
* Verify that the log retention is updated on the instance (parameter group should be "in-sync")

## Who can review

Not me.