### PR TITLE
[#152144657] Fix cred rotation in envs with valid TLS certs

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2856,7 +2856,7 @@ jobs:
               UAA_ADMIN_CLIENT_SECRET=$($VAL_FROM_YAML secrets.uaa_admin_client_secret cf-secrets/cf-secrets.yml)
               UAA_ADMIN_PASSWORD=$($VAL_FROM_YAML secrets.uaa_admin_password rotated-cf-secrets/cf-secrets.yml)
 
-              uaac target "${SKIP_SSL_VALIDATION_OPTION}" "${UAA_ENDPOINT}"
+              uaac target ${SKIP_SSL_VALIDATION_OPTION} "${UAA_ENDPOINT}"
               uaac token client get admin -s "${UAA_ADMIN_CLIENT_SECRET}"
               uaac password set admin -p "${UAA_ADMIN_PASSWORD}"
 


### PR DESCRIPTION
## What

In persistent environments, which have valid TLS certificates, having
CF_SKIP_SSL_VALIDATION unset meant that uaac was passed a quoted empty
string as an argument and failed with `Too many command line parameters given.`

I unquoted the argument to `uaac target` to avoid this happening.

## How to review

Code review. I've run it in my dev env, for what it's worth

## Who can review

Anyone but @bleach
