### PR TITLE
[#138512111] Remove rubbernecker deployment from pipeline.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,6 @@ prod: globals ## Set Environment to Production
 	$(eval export DISABLE_CF_ACCEPTANCE_TESTS=true)
 	$(eval export ENABLE_DATADOG=true)
 	$(eval export ENABLE_PAAS_DASHBOARD=true)
-	$(eval export DEPLOY_RUBBERNECKER=true)
 	$(eval export DEPLOY_ENV=prod)
 	$(eval export COMPOSE_PASSWORD_STORE_HIGH_DIR?=${HOME}/.paas-pass-high)
 	@true
@@ -189,12 +188,6 @@ upload-google-oauth-secrets: check-env ## Decrypt and upload Google Admin Consol
 	$(if ${OAUTH_PASSWORD_STORE_DIR},,$(error Must pass OAUTH_PASSWORD_STORE_DIR=<path_to_password_store>))
 	$(if $(wildcard ${OAUTH_PASSWORD_STORE_DIR}),,$(error Password store ${OAUTH_PASSWORD_STORE_DIR} does not exist))
 	@scripts/upload-google-oauth-secrets.sh
-
-upload-tracker-token: check-env ## Decrypt and upload Pivotal tracker API token to S3
-	pass pivotal/tracker_token | aws s3 cp - "s3://gds-paas-${DEPLOY_ENV}-state/tracker_token"
-
-upload-pagerduty-token: check-env ## Decrypt and upload Pagerduty API token to S3
-	pass pagerduty/rubbernecker_api_token | aws s3 cp - "s3://gds-paas-${DEPLOY_ENV}-state/pagerduty_api_token"
 
 .PHONY: manually_upload_certs
 CERT_PASSWORD_STORE_DIR?=~/.paas-pass-high

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -397,6 +397,24 @@ jobs:
                 paas-cf/concourse/scripts/s3init.sh "((state_bucket))" id_rsa.pub paas-cf/concourse/init_files/zero_bytes
                 paas-cf/concourse/scripts/s3init.sh "((state_bucket))" healthcheck-deployed paas-cf/concourse/init_files/string-no
 
+      # FIXME: remove this once it's run everywhere.
+      - task: cleanup-unused-secrets
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/awscli
+              tag: 1ab7d6cdac70f2c32563ea173da0cd7791309be5
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                aws s3 rm "s3://((state_bucket))/tracker_token"
+                aws s3 rm "s3://((state_bucket))/pagerduty_api_token"
+
   - name: generate-secrets
     serial_groups: [cf-deploy]
     serial: true

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -247,11 +247,6 @@ resources:
     source:
       interval: 5m
 
-  - name: paas-rubbernecker
-    type: git
-    source:
-      uri: https://github.com/alphagov/paas-rubbernecker
-
   - name: paas-compose-broker
     type: git
     source:
@@ -1252,7 +1247,6 @@ jobs:
           - get: bosh-CA
           - get: graphite-nozzle
           - get: datadog-tfstate
-          - get: paas-rubbernecker
           - get: paas-compose-broker
           - get: paas-compose-scraper
           - get: paas-usage-events-collector
@@ -2262,48 +2256,6 @@ jobs:
                   echo Setting DD_APP_KEY...
                   cf set-env paas-dashboard DD_APP_KEY "${DATADOG_APP_KEY}" > /dev/null
                   cf start paas-dashboard
-
-        - task: deploy-rubbernecker
-          config:
-            platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: governmentpaas/cf-cli
-                tag: 465642da06051a55630d39c899697b678f66a7f7
-            inputs:
-              - name: paas-cf
-              - name: config
-              - name: bosh-CA
-              - name: paas-rubbernecker
-            params:
-              DEPLOY_RUBBERNECKER: ((deploy_rubbernecker))
-              PIVOTAL_PROJECT_ID: ((pivotal_project_id))
-              TRACKER_TOKEN: ((tracker_token))
-              PAGERDUTY_API_TOKEN: ((pagerduty_api_token))
-            run:
-              path: sh
-              args:
-                - -e
-                - -c
-                - |
-                  if [ "${DEPLOY_RUBBERNECKER}" != "true" ]; then
-                    echo Rubbernecker disabled
-                    exit 0
-                  fi
-                  ./paas-cf/concourse/scripts/import_bosh_ca.sh
-                  . ./config/config.sh
-                  cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}" \
-                    -o govuk-paas -s tools
-
-                  cf push --no-start -p paas-rubbernecker -f paas-rubbernecker/manifest.yml
-                  echo Setting PIVOTAL_API_KEY...
-                  cf set-env rubbernecker PIVOTAL_API_KEY "${TRACKER_TOKEN}" > /dev/null
-                  echo Setting PAGERDUTY_API_TOKEN...
-                  cf set-env rubbernecker PAGERDUTY_API_TOKEN "${PAGERDUTY_API_TOKEN}" > /dev/null
-                  echo Setting PIVOTAL_PROJECT_ID...
-                  cf set-env rubbernecker PIVOTAL_PROJECT_ID "${PIVOTAL_PROJECT_ID}"
-                  cf start rubbernecker
 
         - task: deploy-paas-metrics
           config:

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -37,22 +37,6 @@ get_git_concourse_pool_clone_full_url_ssh() {
   rm -f "${tfstate_file}"
 }
 
-get_tracker_token() {
-  secrets_uri="s3://${state_bucket}/tracker_token"
-  export tracker_token
-  if aws s3 ls "${secrets_uri}" > /dev/null ; then
-    tracker_token=$(aws s3 cp "${secrets_uri}" -)
-  fi
-}
-
-get_pagerduty_api_token() {
-  secrets_uri="s3://${state_bucket}/pagerduty_api_token"
-  export pagerduty_api_token
-  if aws s3 ls "${secrets_uri}" > /dev/null ; then
-    pagerduty_api_token=$(aws s3 cp "${secrets_uri}" -)
-  fi
-}
-
 prepare_environment() {
   "${SCRIPT_DIR}/fly_sync_and_login.sh"
 
@@ -94,16 +78,6 @@ prepare_environment() {
   fi
 
   export EXPOSE_PIPELINE=1
-
-  get_tracker_token
-  get_pagerduty_api_token
-  if [ "${DEPLOY_RUBBERNECKER:-false}" = "true" ] ; then
-    if [ -z "${tracker_token+x}" ] ; then
-      echo "Rubbernecker deployment enabled but could not retrieve the API token. Did you run \`make <env> upload-tracker-token\`?"
-      exit 1
-    fi
-  fi
-
 }
 
 generate_vars_file() {
@@ -147,13 +121,9 @@ compose_billing_email: ${compose_billing_email:-}
 compose_billing_password: ${compose_billing_password:-}
 enable_datadog: ${ENABLE_DATADOG}
 enable_paas_dashboard: ${ENABLE_PAAS_DASHBOARD:-false}
-deploy_rubbernecker: ${DEPLOY_RUBBERNECKER:-false}
-tracker_token: ${tracker_token:-}
-pivotal_project_id: ${PIVOTAL_PROJECT_ID:-1275640}
 concourse_atc_password: ${CONCOURSE_ATC_PASSWORD}
 oauth_client_id: ${oauth_client_id:-}
 oauth_client_secret: ${oauth_client_secret:-}
-pagerduty_api_token: ${pagerduty_api_token:-}
 enable_metrics: ${ENABLE_METRICS}
 enable_usage_events_collection: ${ENABLE_USAGE_EVENTS_COLLECTION}
 auto_deploy: $([ "${ENABLE_AUTO_DEPLOY:-}" ] && echo "true" || echo "false")


### PR DESCRIPTION
## What

This is being moved to a separate pipeline on the build concourse as
it's not really related to the CF deployment.

With this, we no longer need the Pivotal tracker, or Pagerduty APi
tokens in the pipeline anywhere, so the handling for these can be
cleaned up as well.

## How to review

Review in conjunction with https://github.com/alphagov/paas-release-ci/pull/46

Run the pipeline from this branch and verify nothing breaks.

## Who can review

Not me.