### PR TITLE
[#152885584] Reduce load on API during availability tests

### DIFF
--- a/platform-tests/src/platform/availability/api/api_test.go
+++ b/platform-tests/src/platform/availability/api/api_test.go
@@ -18,7 +18,8 @@ import (
 const (
 	maxConcourseConnectionFailures = 5
 	maxWarnings                    = 5
-	numWorkers                     = 16
+	numWorkers                     = 4
+	taskRatePerSecond              = 2
 )
 
 func lg(things ...interface{}) {
@@ -38,7 +39,7 @@ var _ = Describe("API Availability Monitoring", func() {
 			Password:          helpers.MustGetenv("CF_PASS"),
 			SkipSslValidation: helpers.MustGetenv("SKIP_SSL_VALIDATION") == "true",
 		}
-		monitor := monitor.NewMonitor(cfConfig, os.Stdout, numWorkers, warningMatchers)
+		monitor := monitor.NewMonitor(cfConfig, os.Stdout, numWorkers, warningMatchers, taskRatePerSecond)
 		deployment := helpers.ConcourseDeployment()
 
 		monitor.Add("Listing all apps in a space", func(cfg *cfclient.Config) error {


### PR DESCRIPTION
## What

https://www.pivotaltracker.com/story/show/152885584
    
We want to avoid putting the API and UAA under unnecessary load during availability tests. We only care about the API being continually available, this is not a form of load testing.
    
The tasks performed against the API are not simple, single-request tasks, so we can't use a library such as Vegeta to perform the rate limiting. For simplicity, the rate at which tasks are added to the queue has been throttled.
    
Under the new configuration we will not need as many workers, as only two tasks per second will be added to the queue.

## How to review

If you have a deployment from master you can deploy from this branch and the temporary commit will rotate the `api/*` and `uaa/*` VM stemcells.

We want to know when a deployment happens the API availability tests don't put the API under unnecessary load. The kick-off of the story agreed an API request rate of around 10 per second. Results in my dev environment show they are between 10 and 20. I think that's okay.

### Before merging ⚠️ 

Remove the temporary commit.

## Who can review

Anyone but me
