### PR TITLE
[Support] API-availability-tests: Don't assert for >0 successes.

### DIFF
--- a/platform-tests/src/platform/availability/api/api_test.go
+++ b/platform-tests/src/platform/availability/api/api_test.go
@@ -129,7 +129,6 @@ var _ = Describe("API Availability Monitoring", func() {
 		report := monitor.Run()
 		lg(report.String())
 		Expect(report.Errors).To(BeEmpty(), "expected no errors")
-		Expect(report.SuccessCount).To(BeNumerically(">", int64(0)), "expected at least one success")
 		Expect(report.FailureCount).To(Equal(int64(0)), "expected 0 failures")
 		Expect(report.WarningCount).To(BeNumerically("<=", int64(maxWarnings)), "expected at most %d warnings", maxWarnings)
 	})


### PR DESCRIPTION
## What

It's enough for this to assert that no failures occurred.

By asserting for >0 successes, it means that this job can't be
re-triggered in the event of a failure to unblock the pipeline as the
cf-deploy job won't be running, and the re-run of this will therefore
make 0 requests.

## How to review

Code review. Verify that my rationale makes sense.

## Who can review

Not me.