### PR TITLE
[#153072577] Add UAA client for paas-admin app

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -422,6 +422,7 @@ properties:
             - scim.invite
             - openid
             - cloud_controller.admin
+            - cloud_controller.admin_read_only
             - doppler.firehose
       groups:
         cloud_controller.global_auditor: 'Global Auditor read only group'

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -540,6 +540,14 @@ properties:
         scope: openid,oauth.approvals,cloud_controller.admin_read_only,cloud_controller.read,cloud_controller.global_auditor,cloud_controller.admin
         authorities: cloud_controller.admin_read_only,uaa.resource
         redirect-uri: (( concat "https://paas-usage-events-collector." properties.app_domains[0] "/oauth/callback" ))
+      paas-admin:
+        authorized-grant-types: authorization_code,refresh_token
+        autoapprove: true
+        override: true
+        secret: (( grab secrets.uaa_clients_paas_admin_secret ))
+        scope: openid,oauth.approvals,cloud_controller.read,cloud_controller.admin_read_only,cloud_controller.global_auditor
+        authorities: uaa.none
+        redirect-uri: (( concat "https://paas-admin." properties.app_domains[0] "/auth/cloudfoundry/callback" ))
       cc-service-dashboards:
         secret: (( grab secrets.uaa_clients_cc_service_dashboards_password ))
         authorities: clients.read,clients.write,clients.admin

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -453,6 +453,7 @@ properties:
 
     clients:
       documentation:
+        override: true
         app-icon: (( grab meta.docs_app_icon ))
         app-launch-url: https://docs.cloud.service.gov.uk/#get-started
         show-on-homepage: true
@@ -467,7 +468,6 @@ properties:
         redirect-uri: (( concat "https://login." properties.system_domain ))
         secret: (( grab secrets.uaa_clients_login_secret ))
       cf:
-        id: cf
         override: true
         authorized-grant-types: password,refresh_token
         scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,cloud_controller.admin_read_only,cloud_controller.global_auditor,scim.read,scim.write,scim.invite,doppler.firehose,uaa.user,routing.router_groups.read,routing.router_groups.write
@@ -476,6 +476,7 @@ properties:
         refresh-token-validity: 604800
         secret: ''
       notifications:
+        override: true
         authorities: cloud_controller.admin,scim.read
         authorized-grant-types: client_credentials
         secret: (( grab secrets.uaa_clients_notifications_secret ))
@@ -485,85 +486,91 @@ properties:
         authorized-grant-types: client_credentials
         secret: (( grab secrets.uaa_clients_doppler_secret ))
       cloud_controller_username_lookup:
+        override: true
         authorities: scim.userids
         authorized-grant-types: client_credentials
         secret: (( grab secrets.uaa_clients_cloud_controller_username_lookup_secret ))
       cc_service_key_client:
+        override: true
         authorities: credhub.read,credhub.write
         authorized-grant-types: client_credentials
         secret: (( grab secrets.uaa_clients_cc_service_key_client_secret ))
       cc_routing:
+        override: true
         authorities: routing.router_groups.read
         authorized-grant-types: client_credentials
         secret: (( grab secrets.uaa_cc_routing_secret ))
       gorouter:
+        override: true
         authorities: routing.routes.read
         authorized-grant-types: client_credentials
         secret: (( grab secrets.uaa_clients_gorouter_secret ))
       tcp_emitter:
+        override: true
         authorities: routing.routes.write,routing.routes.read
         authorized-grant-types: client_credentials
         secret: ''
       tcp_router:
+        override: true
         authorities: routing.routes.read
         authorized-grant-types: client_credentials
         secret: ''
       ssh-proxy:
+        override: true
         authorized-grant-types: authorization_code
         autoapprove: true
-        override: true
         redirect-uri: (( concat "https://login." properties.system_domain "/login" ))
         scope: openid,cloud_controller.read,cloud_controller.write,cloud_controller.admin
         secret: (( grab secrets.uaa_clients_ssh_proxy_secret ))
       graphite-nozzle:
+        override: true
         access-token-validity: 1209600
         authorized-grant-types: authorization_code,client_credentials,refresh_token
-        override: true
         secret: (( grab secrets.uaa_clients_firehose_password ))
         scope: openid,oauth.approvals,doppler.firehose
         authorities: oauth.login,doppler.firehose
         redirect-uri: (( concat "https://login." properties.system_domain "/login" ))
       paas-metrics:
+        override: true
         access-token-validity: 1209600
         authorized-grant-types: client_credentials,refresh_token
-        override: true
         secret: (( grab secrets.uaa_clients_paas_metrics_secret ))
         scope: openid,oauth.approvals,cloud_controller.global_auditor
         authorities: oauth.login,cloud_controller.global_auditor
         redirect-uri: (( concat "https://login." properties.system_domain ))
       paas-usage-events-collector:
+        override: true
         access-token-validity: 1209600
         authorized-grant-types: client_credentials,refresh_token,authorization_code
         autoapprove: true
-        override: true
         secret: (( grab secrets.uaa_clients_paas_usage_events_collector_secret ))
         scope: openid,oauth.approvals,cloud_controller.admin_read_only,cloud_controller.read,cloud_controller.global_auditor,cloud_controller.admin
         authorities: cloud_controller.admin_read_only,uaa.resource
         redirect-uri: (( concat "https://paas-usage-events-collector." properties.app_domains[0] "/oauth/callback" ))
       paas-admin:
+        override: true
         authorized-grant-types: authorization_code,refresh_token
         autoapprove: true
-        override: true
         secret: (( grab secrets.uaa_clients_paas_admin_secret ))
         scope: openid,oauth.approvals,cloud_controller.read,cloud_controller.admin_read_only,cloud_controller.global_auditor
         authorities: uaa.none
         redirect-uri: (( concat "https://paas-admin." properties.app_domains[0] "/auth/cloudfoundry/callback" ))
       cc-service-dashboards:
+        override: true
         secret: (( grab secrets.uaa_clients_cc_service_dashboards_password ))
         authorities: clients.read,clients.write,clients.admin
         authorized-grant-types: client_credentials
         redirect-uri: (( concat "https://login." properties.system_domain ))
       cdn_broker:
+        override: true
         authorities: uaa.none
         authorized-grant-types: password
-        id: cdn_broker
         scope: cloud_controller.admin_read_only
         secret: (( grab secrets.uaa_clients_cdn_broker_secret ))
       user_invitation:
+        override: true
         authorities: oauth.login,scim.write,emails.write,scim.userids
         authorized-grant-types: password,refresh_token
-        id: user_invitation
-        override: true
         redirect-uri: "https://www.cloud.service.gov.uk/next-steps?success"
         scope: openid,password.write,scim.read,scim.write,scim.invite,uaa.user
         secret: (( grab secrets.uaa_clients_login_secret ))

--- a/manifests/cf-manifest/scripts/generate-cf-secrets.rb
+++ b/manifests/cf-manifest/scripts/generate-cf-secrets.rb
@@ -48,6 +48,7 @@ generator = SecretGenerator.new(
   "uaa_clients_notifications_secret" => :simple,
   "uaa_clients_paas_metrics_secret" => :simple,
   "uaa_clients_paas_usage_events_collector_secret" => :simple,
+  "uaa_clients_paas_admin_secret" => :simple,
   "uaa_clients_ssh_proxy_secret" => :simple,
   "vcap_password" => :sha512_crypted,
 )

--- a/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
@@ -126,6 +126,7 @@ RSpec.describe "base properties" do
           "tcp_router",
           "ssh-proxy",
           "graphite-nozzle",
+          "paas-admin",
           "paas-metrics",
           "datadog-nozzle",
           "cc-service-dashboards",

--- a/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
@@ -137,6 +137,13 @@ RSpec.describe "base properties" do
         )
       }
 
+      it {
+        clients.each { |_, config|
+          expect(config).to have_key("override")
+          expect(config["override"]).to be true
+        }
+      }
+
       describe "login" do
         subject(:client) { clients.fetch("login") }
         it {

--- a/scripts/lib/uaa_sync_admin_users.rb
+++ b/scripts/lib/uaa_sync_admin_users.rb
@@ -15,6 +15,7 @@ class UaaSyncAdminUsers
 
   DEFAULT_ADMIN_GROUPS = [
     "cloud_controller.admin",
+    "cloud_controller.admin_read_only",
     "uaa.admin",
     "scim.read",
     "scim.write",


### PR DESCRIPTION
## What

We need a UAA client configuration for the paas-admin app to use. It currently has limited permissions, because the app only lists orgs at the moment as proof the authentication works.

## How to review

Review in conjunction with https://github.com/alphagov/paas-admin/pull/1

There is little danger with this commit as the client is configured with much less scope than will eventually be required. This is on purpose.

Eyeball the code and deploy with passing tests should be enough.

## Who can review

Anyone but me, @chrisfarms @camelpunch or @carolinegreen 
