### PR TITLE
Metrics test: avoid a race

### DIFF
--- a/tools/metrics/pingdumb/pingdumb_test.go
+++ b/tools/metrics/pingdumb/pingdumb_test.go
@@ -54,8 +54,14 @@ var _ = Describe("Pingdumb", func() {
 			Resolvers: resolvers,
 			Timeout:   1 * time.Second,
 		}
-		r, err := GetReport(config)
-		Expect(err).NotTo(HaveOccurred())
+		var (
+			r   *Report
+			err error
+		)
+		Eventually(func() error {
+			r, err = GetReport(config)
+			return err
+		}).Should(Succeed())
 		Expect(len(r.Checks)).To(BeNumerically(">", 1))
 
 		By("not translating HTTP error codes into failures")


### PR DESCRIPTION
## What

This avoids a race between the pingdumb test's custom DNS server spinning up and the test being run.

See e.g. https://travis-ci.org/alphagov/paas-cf/builds/313015567 for an example build failure that should no longer occur.

## How to review

Run `ginkgo -untilItFails tools/metrics/pingdumb` before and after the commit.

## Who can review

Anyone but @camelpunch