### PR TITLE
[#148415719] Enable Zipkin tracing in the router

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -190,6 +190,8 @@ properties:
     drain_wait: 120
     route_services_secret: (( grab secrets.route_services_secret ))
     max_idle_connections: 0
+    tracing:
+      enable_zipkin: true
 
   cc:
     jobs:

--- a/manifests/cf-manifest/manifest/900-cf-tests.yml
+++ b/manifests/cf-manifest/manifest/900-cf-tests.yml
@@ -20,6 +20,7 @@ properties:
     include_ssh: true
     include_docker: true
     include_route_services: true
+    include_zipkin: true
     artifacts_directory: "/tmp/artifacts"
     use_existing_user: false
 


### PR DESCRIPTION
## What

This PR enables Zipkin tracing within Cloud Foundry for use by tenants to monitor distributed requests through their applications.

The tests are separately enabled with a test config flag, so we can make sure the Zipkin functionality is always tested.

Related CF docs:
 * https://docs.cloudfoundry.org/adminguide/zipkin_tracing.html
 * https://docs.cloudfoundry.org/concepts/http-routing.html#http-headers

The upstream acceptance tests check two test cases:
 - if there are no Zipkin trace headers in the request the router will generate new ones and these should be visible in the application request logs
 - if there are Zipkin trace headers in the request the router should passed them to the application

## How to review

1. Update and deploy your CF pipeline from this branch
```
BRANCH=148415719-Enable_zipkin make dev pipelines
```
2. Check if the acceptance tests succeed

## Who can review

Not @bandesz
