### PR TITLE
[#153696695] Update cflinuxfs2 for Ubuntu CVEs

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -18,9 +18,9 @@ releases:
     url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.9.6
     sha1: 55fdcc0f2bda526f126d28827fbae7b21c6b0d1c
   - name: cflinuxfs2
-    version: 1.168.0
-    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.168.0
-    sha1: cd5cfc8c73520b1d0c3a13b4ffaee7170edac762
+    version: 1.176.0
+    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.176.0
+    sha1: a66aa24c2ffb9016e2a82605673a5962e98c02df
   - name: paas-haproxy
     version: 0.1.5
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/paas-haproxy-0.1.5.tgz


### PR DESCRIPTION
## What

This fixes the following:

- https://www.cloudfoundry.org/usn-3498-1/
- https://www.cloudfoundry.org/usn-3496-3/
- https://www.cloudfoundry.org/usn-3489-1/
- https://www.cloudfoundry.org/usn-3504-1/
- https://www.cloudfoundry.org/usn-3496-1/

Most of them specify a minimum version of 1.171.0 except for USN-3504-1
which specifies 1.173.0 - nonetheless I'm taking the latest version
available because it contains other package updates. The release notes are
available here:

- https://github.com/cloudfoundry/cflinuxfs2-release/releases

## How to review

I've deployed this to a dev environment, which was upgraded from `master` at cff9886e. All of the tests in the pipeline passed. For this reason I think it's sufficient to code review and check that I've chosen a suitable version.

## Who can review

Anyone.