### PR TITLE
[SUPPORT] Update performance-tests

### DIFF
--- a/platform-tests/src/platform/performance/load_test.go
+++ b/platform-tests/src/platform/performance/load_test.go
@@ -49,7 +49,6 @@ func generateJsonReport(m *vegeta.Metrics, filename string) {
 }
 
 var _ = Describe("Load performance", func() {
-
 	var appName string
 
 	BeforeEach(func() {
@@ -69,22 +68,22 @@ var _ = Describe("Load performance", func() {
 	AfterEach(func() {
 		Expect(cf.Cf("delete", appName, "-f", "-r").Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
 	})
+
 	Context("without HTTP Keep-Alive", func() {
 		It("has a response latency within our threshold", func() {
 			metrics, latency := loadTest(appName, loadTestRate, loadTestDuration, false)
 			generateJsonReport(metrics, "load-test-no-keep-alive.json")
 			vegeta.NewTextReporter(metrics).Report(os.Stdout)
 			Expect(time.Duration.Nanoseconds(latency)).To(BeNumerically("<", loadTestLatency))
-
 		})
 	})
+
 	Context("with HTTP Keep-Alive", func() {
 		It("has a response latency within our threshold", func() {
 			metrics, latency := loadTest(appName, loadTestRate, loadTestDuration, true)
 			generateJsonReport(metrics, "load-test-keep-alive.json")
 			vegeta.NewTextReporter(metrics).Report(os.Stdout)
 			Expect(time.Duration.Nanoseconds(latency)).To(BeNumerically("<", loadTestLatency))
-
 		})
 	})
 })

--- a/platform-tests/src/platform/performance/load_test.go
+++ b/platform-tests/src/platform/performance/load_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Load performance", func() {
 			metrics, latency := loadTest(appName, loadTestRate, loadTestDuration, false)
 			generateJsonReport(metrics, "load-test-no-keep-alive.json")
 			vegeta.NewTextReporter(metrics).Report(os.Stdout)
-			Expect(time.Duration.Nanoseconds(latency)).To(BeNumerically("<", loadTestLatency))
+			Expect(latency).To(BeNumerically("<", loadTestLatency))
 		})
 	})
 
@@ -83,7 +83,7 @@ var _ = Describe("Load performance", func() {
 			metrics, latency := loadTest(appName, loadTestRate, loadTestDuration, true)
 			generateJsonReport(metrics, "load-test-keep-alive.json")
 			vegeta.NewTextReporter(metrics).Report(os.Stdout)
-			Expect(time.Duration.Nanoseconds(latency)).To(BeNumerically("<", loadTestLatency))
+			Expect(latency).To(BeNumerically("<", loadTestLatency))
 		})
 	})
 })

--- a/platform-tests/src/platform/performance/load_test.go
+++ b/platform-tests/src/platform/performance/load_test.go
@@ -18,7 +18,7 @@ import (
 const (
 	loadTestRate     = 100
 	loadTestDuration = 10 * time.Second
-	loadTestLatency  = 300 * time.Millisecond
+	loadTestLatency  = 50 * time.Millisecond
 )
 
 func loadTest(appName string, rate uint64, duration time.Duration, keepalive bool) (m *vegeta.Metrics) {
@@ -74,7 +74,7 @@ var _ = Describe("Load performance", func() {
 			metrics := loadTest(appName, loadTestRate, loadTestDuration, false)
 			generateJsonReport(metrics, "load-test-no-keep-alive.json")
 			vegeta.NewTextReporter(metrics).Report(os.Stdout)
-			Expect(metrics.Latencies.P99).To(BeNumerically("<", loadTestLatency))
+			Expect(metrics.Latencies.P95).To(BeNumerically("<", loadTestLatency))
 		})
 	})
 
@@ -83,7 +83,7 @@ var _ = Describe("Load performance", func() {
 			metrics := loadTest(appName, loadTestRate, loadTestDuration, true)
 			generateJsonReport(metrics, "load-test-keep-alive.json")
 			vegeta.NewTextReporter(metrics).Report(os.Stdout)
-			Expect(metrics.Latencies.P99).To(BeNumerically("<", loadTestLatency))
+			Expect(metrics.Latencies.P95).To(BeNumerically("<", loadTestLatency))
 		})
 	})
 })


### PR DESCRIPTION
## What

Refactor the tests and..

While waiting for the performance-tests to run I was reminded that I've long
thought that the 300ms threshold was too high to tell us anything useful. To
find out what it should be I took the output of builds over the past year in
production:

    for i in {300..687}; do ./bin/fly -t ${DEPLOY_ENV} watch -j create-cloudfoundry/performance-tests -b $i | awk ' "/Latencies/ {print $i,\$0}"; done | tee perf_times.log

I then parsed the output with `awk` against various thresholds to find a value
that wouldn't alert us unnecessarily. Interestingly this build should have
failed with our current threshold, but I can't see why it didn't and I can't
reproduce it when the threshold is lowered:

- https://deployer.cloud.service.gov.uk/teams/main/pipelines/create-cloudfoundry/jobs/performance-tests/builds/572

I found that while the 99pc is usually 10-20ms, it's too variable to set the
threshold any lower than 150-200ms. The 95pc is much more stable and would
allow us to reduce the threshold to 50ms. Besides the oddity described above
the last time this would have alerted is in May:

    ➜  paas-cf git:(support/refactor_perf_test) ✗ awk -F'[^0-9.]*' '$7 > 50 {print}' perf_times.log
    300 Latencies     [mean, 50, 95, 99, max]  116.183338ms, 3.322562ms, 919.838675ms, 1.261690072s, 2.724815443s
    384 Latencies     [mean, 50, 95, 99, max]  18.846398ms, 12.441568ms, 54.160118ms, 100.242059ms, 127.56083ms
    385 Latencies     [mean, 50, 95, 99, max]  27.359259ms, 14.110628ms, 99.702751ms, 178.538262ms, 222.02543ms
    386 Latencies     [mean, 50, 95, 99, max]  20.656836ms, 13.385662ms, 55.300287ms, 162.846703ms, 261.034954ms
    399 Latencies     [mean, 50, 95, 99, max]  31.280994ms, 14.103349ms, 107.981864ms, 141.508866ms, 201.567917ms
    400 Latencies     [mean, 50, 95, 99, max]  26.440345ms, 14.688543ms, 51.995744ms, 58.585995ms, 248.296022ms
    408 Latencies     [mean, 50, 95, 99, max]  30.176296ms, 12.435646ms, 79.600648ms, 108.389221ms, 122.539117ms
    414 Latencies     [mean, 50, 95, 99, max]  20.74172ms, 11.972472ms, 50.658856ms, 208.865072ms, 306.553965ms
    572 Latencies     [mean, 50, 95, 99, max]  24.211931ms, 11.261346ms, 54.227544ms, 436.685048ms, 564.243124ms

## How to review

1. Read the individual commits and check my rationale.
1. Deploy the branch and check that the tests pass.

If you're feeling impatient then you can trigger the job without waiting for the whole pipeline:
```
make dev run_job JOB=performance-tests
```

## Who can review

Anyone.