### PR TITLE
[#142503647] Monitor TLS Certificate Validity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,6 @@ globals:
 .PHONY: dev
 dev: globals ## Set Environment to DEV
 	$(eval export AWS_ACCOUNT=dev)
-	$(eval export ENABLE_METRICS ?= false)
 	$(eval export ENABLE_USAGE_EVENTS_COLLECTION ?= false)
 	$(eval export CF_SKIP_SSL_VALIDATION=true)
 	$(eval export ENABLE_DESTROY=true)
@@ -103,7 +102,6 @@ dev: globals ## Set Environment to DEV
 .PHONY: staging
 staging: globals ## Set Environment to Staging
 	$(eval export AWS_ACCOUNT=staging)
-	$(eval export ENABLE_METRICS=false)
 	$(eval export ENABLE_USAGE_EVENTS_COLLECTION=false)
 	$(eval export ENABLE_AUTO_DEPLOY=true)
 	$(eval export SKIP_UPLOAD_GENERATED_CERTS=true)
@@ -122,7 +120,6 @@ staging: globals ## Set Environment to Staging
 .PHONY: prod
 prod: globals ## Set Environment to Production
 	$(eval export AWS_ACCOUNT=prod)
-	$(eval export ENABLE_METRICS=true)
 	$(eval export ENABLE_USAGE_EVENTS_COLLECTION=true)
 	$(eval export ENABLE_AUTO_DEPLOY=true)
 	$(eval export SKIP_UPLOAD_GENERATED_CERTS=true)

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2335,7 +2335,13 @@ jobs:
                       'DATADOG_APP_KEY' => '${DATADOG_APP_KEY:-}',
                       'DEPLOY_ENV' => '${DEPLOY_ENV}',
                       'ELB_ADDRESS' => 'https://healthcheck.${APPS_DNS_ZONE_NAME}/',
-                      'TLS_DOMAINS' => 'healthcheck.${APPS_DNS_ZONE_NAME},api.${SYSTEM_DNS_ZONE_NAME},uaa.${SYSTEM_DNS_ZONE_NAME},deployer.${SYSTEM_DNS_ZONE_NAME}',
+                      'TLS_DOMAINS' => [
+                        'healthcheck.${APPS_DNS_ZONE_NAME}',
+                        'api.${SYSTEM_DNS_ZONE_NAME}',
+                        'uaa.${SYSTEM_DNS_ZONE_NAME}',
+                        'deployer.${SYSTEM_DNS_ZONE_NAME}',
+                        '${APPS_DNS_ZONE_NAME}'
+                      ].join(','),
                     }
                     manifest = YAML.load_file('manifest.yml')
                     manifest['applications'].each { |app|

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2293,11 +2293,12 @@ jobs:
                 repository: governmentpaas/cf-cli
                 tag: 465642da06051a55630d39c899697b678f66a7f7
             params:
-              ENABLE_METRICS: ((enable_metrics))
+              ENABLE_DATADOG: ((enable_datadog))
               DATADOG_API_KEY: ((datadog_api_key))
               DATADOG_APP_KEY: ((datadog_app_key))
               DEPLOY_ENV: ((deploy_env))
               APPS_DNS_ZONE_NAME: ((apps_dns_zone_name))
+              SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
             inputs:
               - name: paas-cf
               - name: config
@@ -2310,8 +2311,8 @@ jobs:
                 - -u
                 - -c
                 - |
-                  if  [ "${ENABLE_METRICS:-}" != "true" ] ; then
-                    echo "ENABLE_METRICS=${ENABLE_METRICS} so skipping paas-metrics deploy"
+                  if  [ "${ENABLE_DATADOG:-}" != "true" ] ; then
+                    echo "ENABLE_DATADOG=${ENABLE_DATADOG} so skipping paas-metrics deploy"
                     exit 0
                   fi
 
@@ -2334,6 +2335,7 @@ jobs:
                       'DATADOG_APP_KEY' => '${DATADOG_APP_KEY:-}',
                       'DEPLOY_ENV' => '${DEPLOY_ENV}',
                       'ELB_ADDRESS' => 'https://healthcheck.${APPS_DNS_ZONE_NAME}/',
+                      'TLS_DOMAINS' => 'healthcheck.${APPS_DNS_ZONE_NAME},api.${SYSTEM_DNS_ZONE_NAME}',
                     }
                     manifest = YAML.load_file('manifest.yml')
                     manifest['applications'].each { |app|

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2335,7 +2335,7 @@ jobs:
                       'DATADOG_APP_KEY' => '${DATADOG_APP_KEY:-}',
                       'DEPLOY_ENV' => '${DEPLOY_ENV}',
                       'ELB_ADDRESS' => 'https://healthcheck.${APPS_DNS_ZONE_NAME}/',
-                      'TLS_DOMAINS' => 'healthcheck.${APPS_DNS_ZONE_NAME},api.${SYSTEM_DNS_ZONE_NAME}',
+                      'TLS_DOMAINS' => 'healthcheck.${APPS_DNS_ZONE_NAME},api.${SYSTEM_DNS_ZONE_NAME},uaa.${SYSTEM_DNS_ZONE_NAME},deployer.${SYSTEM_DNS_ZONE_NAME}',
                     }
                     manifest = YAML.load_file('manifest.yml')
                     manifest['applications'].each { |app|

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2339,7 +2339,6 @@ jobs:
                         'healthcheck.${APPS_DNS_ZONE_NAME}',
                         'api.${SYSTEM_DNS_ZONE_NAME}',
                         'uaa.${SYSTEM_DNS_ZONE_NAME}',
-                        'deployer.${SYSTEM_DNS_ZONE_NAME}',
                         '${APPS_DNS_ZONE_NAME}'
                       ].join(','),
                     }

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -124,7 +124,6 @@ enable_paas_dashboard: ${ENABLE_PAAS_DASHBOARD:-false}
 concourse_atc_password: ${CONCOURSE_ATC_PASSWORD}
 oauth_client_id: ${oauth_client_id:-}
 oauth_client_secret: ${oauth_client_secret:-}
-enable_metrics: ${ENABLE_METRICS}
 enable_usage_events_collection: ${ENABLE_USAGE_EVENTS_COLLECTION}
 auto_deploy: $([ "${ENABLE_AUTO_DEPLOY:-}" ] && echo "true" || echo "false")
 continuous_smoke_tests_trigger: $([ "${ALERT_EMAIL_ADDRESS:-}" ] && echo "true" || echo "false")

--- a/terraform/datadog/certificates.tf
+++ b/terraform/datadog/certificates.tf
@@ -5,13 +5,13 @@ resource "datadog_monitor" "invalid_tls_cert" {
   notify_no_data    = true
   no_data_timeframe = 120
 
-  query = "${format("min(last_1h):min:tls.certificates.validity{deploy_env:%s} by {hostname} <= 1", var.env)}"
+  query = "${format("min(last_1h):min:tls.certificates.validity{deploy_env:%s} by {hostname} <= 7", var.env)}"
 
   require_full_window = true
 
   thresholds {
-    warning  = 7
-    critical = 1
+    warning  = 30
+    critical = 7
   }
 
   tags = ["deployment:${var.env}", "service:${var.env}_monitors"]

--- a/terraform/datadog/certificates.tf
+++ b/terraform/datadog/certificates.tf
@@ -1,0 +1,18 @@
+resource "datadog_monitor" "invalid_tls_cert" {
+  name              = "${format("%s Invalid TLS/SSL Certificate", var.env)}"
+  type              = "metric alert"
+  message           = "${format("{{hostname.name}} certificate {{#is_alert}}is invalid!{{/is_alert}}{{#is_warning}}expires in {{value}} days{{/is_warning}}\n\nSee [Team Manual > Responding to alerts > Invalid Certificates](%s#invalid-certificates) for more info.", var.datadog_documentation_url)}"
+  notify_no_data    = true
+  no_data_timeframe = 120
+
+  query = "${format("min(last_1h):min:tls.certificates.validity{deploy_env:%s} by {hostname} <= 0", var.env)}"
+
+  require_full_window = true
+
+  thresholds {
+    warning  = 7
+    critical = 0
+  }
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors"]
+}

--- a/terraform/datadog/certificates.tf
+++ b/terraform/datadog/certificates.tf
@@ -5,13 +5,13 @@ resource "datadog_monitor" "invalid_tls_cert" {
   notify_no_data    = true
   no_data_timeframe = 120
 
-  query = "${format("min(last_1h):min:tls.certificates.validity{deploy_env:%s} by {hostname} <= 0", var.env)}"
+  query = "${format("min(last_1h):min:tls.certificates.validity{deploy_env:%s} by {hostname} <= 1", var.env)}"
 
   require_full_window = true
 
   thresholds {
     warning  = 7
-    critical = 0
+    critical = 1
   }
 
   tags = ["deployment:${var.env}", "service:${var.env}_monitors"]

--- a/tools/metrics/README.md
+++ b/tools/metrics/README.md
@@ -21,6 +21,7 @@ The following metrics are currently collected:
 |`op.quotas.memory.allocated` | Gauge | Total amount of memory promised to apps | |
 |`op.quotas.services.reserved` | Gauge | Total number of services promised to orgs | |
 |`op.quotas.services.allocated` | Gauge | Total number of services assigned | |
+|`tls.certificates.validity` | Gauge | Number of days cert is valid for | `hostname` |
 
 ### Deploying as a Cloud Foundry app
 
@@ -42,6 +43,7 @@ cf set-env paas-metrics CF_CLIENT_SECRET "SECRET"           # uaa client secret
 cf set-env paas-metrics CF_SKIP_SSL_VALIDATION "true"       # [OPTIONAL] set to true if insecure
 cf set-env paas-metrics LOG_LEVEL "0"                       # [OPTIONAL] set to 0 for more detailed logs
 cf set-env paas-metrics DEPLOY_ENV "prod"                   # [OPTIONAL] set to tag metrics with env
+cf set-env paas-metrics TLS_DOMAINS "ssl1.com,ssl2.com"     # [OPTIONAL] csv list of domains to monitor TLS certs for
 ```
 
 Start the app...

--- a/tools/metrics/gauges.go
+++ b/tools/metrics/gauges.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"net"
 	"net/url"
 	"strings"
 	"time"
@@ -18,13 +19,17 @@ func TLSValidityGauge(logger lager.Logger, addr string, interval time.Duration) 
 		if !strings.Contains(addr, ":") {
 			addr += ":443"
 		}
+		host, _, err := net.SplitHostPort(addr)
+		if err != nil {
+			return err
+		}
 		metric := Metric{
 			Kind:  Gauge,
 			Time:  time.Now(),
 			Name:  "tls.certificates.validity",
 			Value: float64(0),
 			Tags: []string{
-				fmt.Sprintf("hostname:%s", strings.Split(addr, ":")[0]),
+				fmt.Sprintf("hostname:%s", host),
 			},
 		}
 		cert, err := tlscheck.GetCertificate(addr)

--- a/tools/metrics/gauges_test.go
+++ b/tools/metrics/gauges_test.go
@@ -171,5 +171,11 @@ var _ = Describe("Gauges", func() {
 			_, err := gauge.ReadMetric()
 			Expect(err).To(HaveOccurred())
 		})
+
+		It("returns err when addr is a URL", func() {
+			gauge := TLSValidityGauge(logger, "http://badssl.com", 1*time.Second)
+			_, err := gauge.ReadMetric()
+			Expect(err).To(HaveOccurred())
+		})
 	})
 })

--- a/tools/metrics/tlscheck/tls.go
+++ b/tools/metrics/tlscheck/tls.go
@@ -1,0 +1,45 @@
+package tlscheck
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"strings"
+)
+
+func GetCertificate(addr string) (*x509.Certificate, error) {
+	conn, err := tls.Dial("tcp", addr, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	for _, chain := range conn.ConnectionState().VerifiedChains {
+		for _, cert := range chain {
+			if !cert.IsCA {
+				return cert, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("no certificate found")
+}
+
+func IsCertificateError(err error) bool {
+	switch v := err.(type) {
+	case x509.CertificateInvalidError,
+		x509.HostnameError,
+		x509.SystemRootsError,
+		x509.UnknownAuthorityError,
+		x509.InsecureAlgorithmError:
+		return true
+	case *net.OpError:
+		if v.Op == "remote error" && strings.Contains(err.Error(), "handshake failure") {
+			return true // handshake error
+		}
+		return false
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
## What

We want a monitor that will alert us if any of our public-facing TLS certs are invalid, or due to expire soon.

`paas-metrics` is extended to accept a list of domains for which you want to check the validity of SSL certificates for, and emit metrics for the number of valid days remaining. This is done via environment variable:

```
TLS_DOMAINS=x.example.com,y.example.com
```

A datadog monitor is created to emit WARNINGs at < 7 days and critical alerts at < 1 day.

The metrics also catch some misconfigurations (like incorrect common name, untrusted CA) by marking the cert as invalid (0days validity).

We want these checks in staging too, so have removed the `ENABLE_METRICS` pipeline flag so that deployment is soley based on the `ENABLE_DATADOG` flag.

## How to review

* Code review
* Deploy this branch to dev with `ENABLE_DATADOG=true`
* Setup valid certs for your ELBs in aws console
* Watch the datadog monitor

## Additional

There is a sibling PR for the team-manual: https://github.com/alphagov/paas-team-manual/pull/171

## Who can review

Not @chrisfarms
