### PR TITLE
[#153369885] Use gorouter.timestamp as the common timestamp in logsearch

### DIFF
--- a/manifests/cf-manifest/manifest/800-logsearch.yml
+++ b/manifests/cf-manifest/manifest/800-logsearch.yml
@@ -202,6 +202,13 @@ properties:
           remove_field => "router_keys"
         }
       }
+      date {
+        match => [ "[gorouter][timestamp]", "ISO8601" ]
+        target => "@timestamp"
+      }
+      mutate {
+        remove_field => [ "[gorouter][timestamp]" ]
+      }
       if [@source][component] == "vcap_nginx_access" {
         grok {
           match => {


### PR DESCRIPTION
## What

For the router logs in Kibana the timestamps displayed in the `Time` column from the `@timestamp` field are misleading and don't match the real time of the request in the `gorouter.timestamp` field.

This commit sets the @timestamp to @gorouter.timestamp and removes @gorouter.timestamp.

## How to review

1. Deploy your CF from this branch:
  ```BRANCH=fix_gorouter_timestamp_153369885 paas-dev make dev pipelines```  
2. Run the following search in Kibana:
    ```@source.component:gorouter AND healthcheck```
    Check a message that arrived after the change was deployed

    The @raw field looks like this:
    ```<6>2017-12-20T14:13:57.651426+00:00 10.0.49.101 vcap.gorouter [job=router index=1]  healthcheck.*.dev.cloudpipelineapps.digital - [2017-12-20T14:13:57.643+0000] ...```

    You should see the second timestamp (2017-12-20T14:13:57.643+0000) as the value of the @timestamp, not the first one.
    The gorouter.timestamp field should be gone from the field list.

## Who can review

Not @bandesz
