### PR TITLE
[support] Amend the EC2 CPU monitor

### DIFF
--- a/terraform/datadog/aws.tf
+++ b/terraform/datadog/aws.tf
@@ -62,7 +62,7 @@ resource "datadog_monitor" "rds-failure" {
 resource "datadog_monitor" "ec2-cpu-utilisation" {
   name                = "${format("%s EC2 high CPU utilisation", var.env)}"
   type                = "metric alert"
-  query               = "${format("avg(last_1h):avg:aws.ec2.cpuutilization{deploy_env:%s,!job:cell} by {bosh-job,bosh-index} > 90", var.env)}"
+  query               = "${format("avg(last_1h):avg:aws.ec2.cpuutilization{deploy_env:%s,!job:cell,!job:elasticsearch_master} by {bosh-job,bosh-index} > 90", var.env)}"
   message             = "{{bosh-job.name}}/{{bosh-index.name}} CPU utilisation has been over {{#is_warning}}{{warn_threshold}}{{/is_warning}}{{#is_alert}}{{threshold}}{{/is_alert}}% for 1h"
   notify_no_data      = false
   require_full_window = false
@@ -73,4 +73,20 @@ resource "datadog_monitor" "ec2-cpu-utilisation" {
   }
 
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:all"]
+}
+
+resource "datadog_monitor" "ec2-cpu-utilisation-es" {
+  name                = "${format("%s EC2 high CPU utilisation - ElasticSearch", var.env)}"
+  type                = "metric alert"
+  query               = "${format("avg(last_1h):avg:aws.ec2.cpuutilization{deploy_env:%s,job:elasticsearch_master} by {bosh-job,bosh-index} > 95", var.env)}"
+  message             = "{{bosh-job.name}}/{{bosh-index.name}} CPU utilisation has been over {{#is_warning}}{{warn_threshold}}{{/is_warning}}{{#is_alert}}{{threshold}}{{/is_alert}}% for 1h"
+  notify_no_data      = false
+  require_full_window = false
+
+  thresholds {
+    critical = "95"
+    warning  = "90"
+  }
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:elasticsearch_master"]
 }


### PR DESCRIPTION
## What

We've decided to amend the monitor in order to prevent it from being in
a warning stage constantly. We thought it would be the best thing to do,
due to our upcoming plans of moving to logit.

## How to review

- Sanity check