### PR TITLE
[#147833555] Pass the platform egress IPs to the Compose broker

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -251,7 +251,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-compose-broker
-      tag_filter: v0.12.0
+      tag_filter: v0.13.0
 
   - name: paas-compose-scraper
     type: git
@@ -1425,6 +1425,7 @@ jobs:
                 export CDN_BROKER_SERVER=$($VAL_FROM_YAML terraform_outputs.cdn_broker_elb_dns_name cf-terraform-outputs.yml)
                 export CDN_BROKER_PASS=$($VAL_FROM_YAML secrets.cdn_broker_admin_password cf-secrets/cf-secrets.yml)
                 export COMPOSE_BROKER_PASS=$($VAL_FROM_YAML secrets.compose_broker_admin_password cf-secrets/cf-secrets.yml)
+                export COMPOSE_BROKER_IP_WHITELIST=$($VAL_FROM_YAML terraform_outputs.nat_public_ips_csv cf-terraform-outputs.yml)
                 export ELASTICACHE_BROKER_PASS=$($VAL_FROM_YAML secrets.elasticache_broker_admin_password cf-secrets/cf-secrets.yml)
                 export ELASTICACHE_BROKER_SERVER=$($VAL_FROM_YAML terraform_outputs.elasticache_broker_elb_dns_name cf-terraform-outputs.yml)
                 EOT
@@ -1665,6 +1666,7 @@ jobs:
                       'COMPOSE_API_KEY' => '${COMPOSE_API_KEY}',
                       'DB_PREFIX' => '${DB_PREFIX}',
                       'CLUSTER_NAME' => '${CLUSTER_NAME}',
+                      'IP_WHITELIST' => '${COMPOSE_BROKER_IP_WHITELIST}',
                     }
                     manifest = YAML.load_file('manifest.yml')
                     manifest['applications'].each { |app|

--- a/terraform/cloudfoundry/outputs.tf
+++ b/terraform/cloudfoundry/outputs.tf
@@ -173,3 +173,7 @@ output "cell_subnet_cidr_blocks" {
 output "router_subnet_cidr_blocks" {
   value = ["${aws_subnet.router.*.cidr_block}"]
 }
+
+output "nat_public_ips_csv" {
+  value = "${join(",", aws_eip.cf.*.public_ip)}"
+}


### PR DESCRIPTION
## What

Pass the NAT gateway IPs along to the compose-broker app environment as a comma-separated list.

The broker consumes these IPs in https://github.com/alphagov/paas-compose-broker/pull/22

paas-bootstrap got https://github.com/alphagov/paas-bootstrap/pull/112 but I think this was for consistency (@henrytk can you confirm?)

## How to review

- Deploy a dev environment with `BRANCH=paas-egres-ips` [sic].
- Once deployed, enable a compose service e.g. `cf enable-service-access compose-redis`
- Create a service instance with e.g. `cf create-service compose-redis tiny myredis`
- Push an app e.g. `cd rails-demo; cf push`
- Bind the service e.g. `cf bind-service rails-blog myredis`
- Restage the app, as the nice message says.
- Get the app's env to retrieve the redis URL: `cf env rails-blog | grep 'uri"'`
- Test that connecting doesn't work from your workstation:
    ```
    $ netcat -v SOME_HOST SOME_PORT
    Connection to SOME_HOST SOME_PORT port [tcp/*] succeeded!
    keys *
    $ # this means you got disconnected    
    ```
- ssh to the app: `cf ssh rails-blog`
- Repeat the previous `netcat` test to ensure that you instead get `-NOAUTH Authentication required.`
- Optional: repeat the above for prod, to ensure that the test was good (but @camelpunch has already checked)

## Before merge

❗️ There is a temporary commit setting the paas-compose-broker repository to the dev branch. After merging paas-compose-broker please replace that commit with the final tag.

## Who can review

Not @henrytk, @camelpunch, or @46bit 
