### PR TITLE
[Support] Override default certificate renewal cron

### DIFF
--- a/manifests/cf-manifest/manifest/060-cdn-broker.yml
+++ b/manifests/cf-manifest/manifest/060-cdn-broker.yml
@@ -36,3 +36,4 @@ jobs:
         client_id: "cdn_broker"
         client_secret: (( grab secrets.uaa_clients_cdn_broker_secret ))
         default_origin: (( grab terraform_outputs.cf_apps_domain ))
+        schedule: "0 0 * * 6"


### PR DESCRIPTION
## What

We are currently hitting rate limits from Let's Encrypt for certificate
renewals. This change will override the default and set it to run once
per week on a Sunday at midnight.

## How to review

Code review

## Who can review

Not @LeePorte
