### PR TITLE
[#153750019] Update ELB log bucket policy

### DIFF
--- a/terraform/cloudfoundry/policies/elb_access_log_bucket.json.tpl
+++ b/terraform/cloudfoundry/policies/elb_access_log_bucket.json.tpl
@@ -4,7 +4,7 @@
     {
       "Effect": "Allow",
       "Action": "s3:PutObject",
-      "Resource": "arn:aws:s3:::${bucket_name}/*/AWSLogs/*/*",
+      "Resource": "arn:aws:s3:::${bucket_name}/*/AWSLogs/*",
       "Principal": {
         "AWS": "arn:aws:iam::${principal}:root"
       }


### PR DESCRIPTION
## What

This commit updates the policy in place for ELB log writing access to S3 in order to remove the false positives recently seen in Trusted Advisor. This will prevent us wasting time chasing false positives.

## How to review

1. Deploy from this branch in your dev environment
1. Check that your elb-access-log bucket is no longer listed in the Trusted Advisor warnings
1. Check that logs are still being written to the bucket 

## Who can review

Not @LeePorte
