### PR TITLE
[#129452551] Delete admin users from CF, not UAA

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1772,8 +1772,8 @@ jobs:
                   . ./config/config.sh
 
                   VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
-                  export UAA_CLIENT_SECRET
-                  UAA_CLIENT_SECRET=$($VAL_FROM_YAML secrets.uaa_admin_client_secret cf-secrets/cf-secrets.yml)
+                  export UAA_ADMIN_PASSWORD
+                  UAA_ADMIN_PASSWORD=$($VAL_FROM_YAML secrets.uaa_admin_password cf-secrets/cf-secrets.yml)
                   cd paas-cf/scripts
                   bundle
                   bundle exec sync-admin-users.rb "${API_ENDPOINT}" ../config/admin_users.yml "((NEW_ACCOUNT_EMAIL_ADDRESS))"

--- a/scripts/lib/uaa_sync_admin_users.rb
+++ b/scripts/lib/uaa_sync_admin_users.rb
@@ -1,3 +1,5 @@
+require 'net/https'
+require 'json'
 require 'securerandom'
 require 'time'
 require 'set'
@@ -11,7 +13,7 @@ require 'pp'
 # UaaSyncAdminUsers::DEFAULT_ADMIN_GROUPS
 #
 class UaaSyncAdminUsers
-  attr_accessor :ua, :token_issuer, :admin_groups
+  attr_accessor :target, :ua, :token_issuer, :admin_groups
 
   DEFAULT_ADMIN_GROUPS = [
     "cloud_controller.admin",
@@ -29,23 +31,55 @@ class UaaSyncAdminUsers
   # credentials.
   #
   # Params:
-  # - target: UAA target
-  # - admin_client: Admin client name for UAA with permissions to manage users
-  # - admin_password: Admin client password
+  # - cf_api_url: CF API URL
+  # - cf_admin_username: CF admin user's name
+  # - cf_admin_password: CF admin user's password
   # - options: Hash of options. Examples and defaults
   #   - skip_ssl_validation: default=false
   #   - extra_admin_groups: default=[] Additional admin groups apart of DEFAULT_ADMIN_GROUPS
   #   - log_level: default: :warn. Options: :debug, :trace, :warn
-  def initialize(target, admin_client, admin_password, options = nil)
-    @target = target
-    @admin_client = admin_client
-    @admin_password = admin_password
+  def initialize(cf_api_url, cf_admin_username, cf_admin_password, options = nil)
+    @cf_api_url = cf_api_url
+    @target = get_uaa_target
+    @cf_admin_username = cf_admin_username
+    @cf_admin_password = cf_admin_password
     @options = options
 
     self.admin_groups = DEFAULT_ADMIN_GROUPS + options.fetch(:extra_admin_groups, [])
 
-    self.token_issuer = CF::UAA::TokenIssuer.new(@target, @admin_client, @admin_password, @options)
+    self.token_issuer = CF::UAA::TokenIssuer.new(@target, 'cf', '', @options)
     self.token_issuer.logger = self.get_logger
+  end
+
+  def get_uaa_target
+    api_info = cf_api_request('GET', '/v2/info')
+    api_info.fetch("token_endpoint")
+  end
+
+  def cf_api_request(method, path, headers = {})
+    uri = URI.parse(@cf_api_url) + path
+    http = Net::HTTP.new(uri.host, uri.port)
+    if uri.instance_of? URI::HTTPS
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE if ENV['SKIP_SSL_VERIFICATION'].to_s.casecmp("true").zero?
+    end
+
+    request = case method.upcase
+              when 'GET' then Net::HTTP::Get.new(uri.request_uri, headers)
+              when 'DELETE' then Net::HTTP::Delete.new(uri.request_uri, headers)
+              end
+
+    response = http.request(request)
+
+    # when deleting a user via the CF API a nil body is returned (204 No Content)
+    if response.code.to_i > 299
+      raise "Error connecting to API endpoint #{uri}: #{response}"
+    end
+    if response.body.nil?
+      response.body = '{}'
+    end
+
+    JSON.parse(response.body)
   end
 
   # Returns the logger for this object.
@@ -107,7 +141,11 @@ class UaaSyncAdminUsers
 
   # Authenticates the client with the UAA server and requests a new token.
   def request_token
-    @token = self.token_issuer.client_credentials_grant.info
+    @token = self.token_issuer.owner_password_grant(@cf_admin_username, @cf_admin_password, [
+      'cloud_controller.read', 'cloud_controller.write', 'openid', 'password.write',
+      'cloud_controller.admin', 'cloud_controller.admin_read_only', 'cloud_controller.global_auditor',
+      'scim.read', 'scim.write', 'scim.invite', 'uaa.user'
+    ]).info
     self.ua = CF::UAA::Scim.new(@target, self.auth_header, @options)
     self.ua.logger = self.get_logger
     self
@@ -137,7 +175,7 @@ class UaaSyncAdminUsers
         user_info = self.create_user(user)
         created_users << user
       elsif user_info.fetch("origin") != user[:origin]
-        self.ua.delete(:user, user_info.fetch("id"))
+        cf_api_request('DELETE', "/v2/users/#{user_info.fetch('id')}", 'Authorization' => self.auth_header)
         deleted_users << user
         user_info = self.create_user(user)
         created_users << user
@@ -191,7 +229,7 @@ class UaaSyncAdminUsers
 
       if Time.parse(user_info.fetch("meta").fetch("created")) < (Time.now - HOURS_TO_KEEP_TEST_USERS * 60 * 60)
         get_logger.info("Deleting admin user #{user_info.fetch('username')} which is not in the list.")
-        ua.delete(:user, user_id)
+        cf_api_request('DELETE', "/v2/users/#{user_id}", 'Authorization' => self.auth_header)
         deleted_users << { username: user_info.fetch("username"), email: user_info.fetch("emails").fetch(0).fetch("value") }
       else
         get_logger.info("Not deleting user #{user_info.fetch('username')} created in the last #{HOURS_TO_KEEP_TEST_USERS} hours.")

--- a/scripts/spec/uaa_sync_admin_users_spec.rb
+++ b/scripts/spec/uaa_sync_admin_users_spec.rb
@@ -112,20 +112,28 @@ RSpec.describe UaaSyncAdminUsers do
   end
 
   context "when connecting to a fake server" do
-    let(:target) { "https://test.uaa.target" }
+    let(:cf_api_url) { "https://api.test.target" }
     let(:admin_user) { "admin" }
     let(:admin_password) { "password" }
     let(:uaa_sync_admin_users) {
-      UaaSyncAdminUsers.new(target, admin_user, admin_password, skip_ssl_validation: true, log_level: :warn)
+      UaaSyncAdminUsers.new(cf_api_url, admin_user, admin_password, skip_ssl_validation: true, log_level: :warn)
     }
 
     before :each do
-      WebMock.stub_request(:post, %r{https://.+:.+@[^/]+/oauth/token}).
-        to_return(
-          status: 200,
-          headers: { "content-type" => "application/json" },
-          body: json_admin_token_response,
-      )
+      WebMock.stub_request(:get, "#{cf_api_url}/v2/info").
+         to_return(
+           status: 200,
+           headers: {},
+           body: '{"token_endpoint": "https://uaa.test"}',
+         )
+
+      WebMock.stub_request(:post, "https://cf:@uaa.test/oauth/token").
+         with(body: 'grant_type=password&username=admin&password=password&scope=cloud_controller.read+cloud_controller.write+openid+password.write+cloud_controller.admin+cloud_controller.admin_read_only+cloud_controller.global_auditor+scim.read+scim.write+scim.invite+uaa.user').
+         to_return(
+           status: 200,
+           headers: { "content-type" => "application/json" },
+           body: json_admin_token_response,
+         )
 
       uaa_sync_admin_users.request_token
     end
@@ -135,6 +143,7 @@ RSpec.describe UaaSyncAdminUsers do
     end
 
     context "when updating from a list with existing and new users" do
+      let(:uaa_api_url) { uaa_sync_admin_users.target }
       let(:users) {
         [
           { username: "existing_user", email: "existing_user@example.com", origin: "uaa" },
@@ -143,14 +152,14 @@ RSpec.describe UaaSyncAdminUsers do
       }
 
       before(:each) do
-        WebMock.stub_request(:get, %r{^#{target}/Users.*}).
+        WebMock.stub_request(:get, %r{^#{uaa_api_url}/Users.*}).
           to_return(
             status: 200,
             headers: { "content-type" => "application/json" },
             body: json_query_responses([])
         )
         %w(admin existing_user removed_user).each { |user_to_match|
-          WebMock.stub_request(:get, %r{#{target}/Users\?filter=username eq "#{user_to_match}".*}).
+          WebMock.stub_request(:get, %r{#{uaa_api_url}/Users\?filter=username eq "#{user_to_match}".*}).
             to_return(
               status: 200,
               headers: { "content-type" => "application/json" },
@@ -158,7 +167,7 @@ RSpec.describe UaaSyncAdminUsers do
                 json_user_response(user_to_match, "#{user_to_match}@example.com"),
               ])
           )
-          WebMock.stub_request(:get, %r{#{target}/Users\?filter=id eq "#{user_uuid(user_to_match)}".*}).
+          WebMock.stub_request(:get, %r{#{uaa_api_url}/Users\?filter=id eq "#{user_uuid(user_to_match)}".*}).
             to_return(
               status: 200,
               headers: { "content-type" => "application/json" },
@@ -168,7 +177,7 @@ RSpec.describe UaaSyncAdminUsers do
           )
         }
         %w(test_user_1 test_user_2).each { |user_to_match|
-          WebMock.stub_request(:get, %r{#{target}/Users\?filter=id eq "#{user_uuid(user_to_match)}".*}).
+          WebMock.stub_request(:get, %r{#{uaa_api_url}/Users\?filter=id eq "#{user_uuid(user_to_match)}".*}).
             to_return(
               status: 200,
               headers: { "content-type" => "application/json" },
@@ -177,7 +186,7 @@ RSpec.describe UaaSyncAdminUsers do
               ])
           )
         }
-        WebMock.stub_request(:post, %r{^#{target}/Users.*}).
+        WebMock.stub_request(:post, %r{^#{uaa_api_url}/Users.*}).
           with(
             body: /"userName":"new_user".*"emails":\[{"value":"new_user@example\.com"}/,
           ).
@@ -188,7 +197,7 @@ RSpec.describe UaaSyncAdminUsers do
           )
 
         uaa_sync_admin_users.admin_groups.each { |group_name|
-          WebMock.stub_request(:get, %r{^#{target}/Groups\?filter=displayName eq "#{group_name}".*}).
+          WebMock.stub_request(:get, %r{^#{uaa_api_url}/Groups\?filter=displayName eq "#{group_name}".*}).
             to_return(
               status: 200,
               headers: { "content-type" => "application/json" },
@@ -196,7 +205,7 @@ RSpec.describe UaaSyncAdminUsers do
                 json_group_response(group_name, %w(admin existing_user removed_user test_user_1 test_user_2))
               ])
             )
-          WebMock.stub_request(:put, %r{^#{target}/Groups/#{group_uuid(group_name)}$}).
+          WebMock.stub_request(:put, %r{^#{uaa_api_url}/Groups/#{group_uuid(group_name)}$}).
             to_return(
               status: 200,
               headers: { "content-type" => "application/json" },
@@ -204,11 +213,11 @@ RSpec.describe UaaSyncAdminUsers do
           )
         }
 
-        WebMock.stub_request(:delete, "#{target}/Users/__user__removed_user__uuid__").
+        WebMock.stub_request(:delete, "#{cf_api_url}/v2/users/__user__removed_user__uuid__").
           to_return(
             status: 200,
             headers: { "content-type" => "application/json" },
-            body: json_user_response("removed_user", "removed_user@example.com"),
+            body: "{}",
         )
 
         @created_users, @deleted_users = uaa_sync_admin_users.update_admin_users(users)
@@ -216,12 +225,12 @@ RSpec.describe UaaSyncAdminUsers do
 
       it "creates only the new users" do
         expect(WebMock).to have_requested(
-          :post, "#{target}/Users"
+          :post, "#{uaa_api_url}/Users"
         ).with(
           body: /"userName":"new_user"/,
         ).once
         expect(WebMock).not_to have_requested(
-          :post, "#{target}/Users"
+          :post, "#{uaa_api_url}/Users"
         ).with(
           body: /"userName":"existing_user"/,
         ).once
@@ -230,7 +239,7 @@ RSpec.describe UaaSyncAdminUsers do
       it "new users are added as members of admin groups" do
         uaa_sync_admin_users.admin_groups.each { |groupname|
           expect(WebMock).to have_requested(
-            :put, "#{target}/Groups/__group__#{groupname}__uuid__"
+            :put, "#{uaa_api_url}/Groups/__group__#{groupname}__uuid__"
           ).with(
             body: /"members":.*"__user__new_user__uuid__"/,
           ).once
@@ -240,35 +249,36 @@ RSpec.describe UaaSyncAdminUsers do
       it "existing members and admin are kept in the groups" do
         uaa_sync_admin_users.admin_groups.each { |groupname|
           expect(WebMock).to have_requested(
-            :put, "#{target}/Groups/__group__#{groupname}__uuid__"
+            :put, "#{uaa_api_url}/Groups/__group__#{groupname}__uuid__"
           ).with(
             body: /"members":.*"__user__existing_user__uuid__"/,
           ).once
           expect(WebMock).to have_requested(
-            :put, "#{target}/Groups/__group__#{groupname}__uuid__"
+            :put, "#{uaa_api_url}/Groups/__group__#{groupname}__uuid__"
           ).with(
             body: /"members":.*"__user__admin__uuid__"/,
           ).once
         }
       end
+
       it "does not delete the admin user" do
         expect(WebMock).not_to have_requested(
-          :delete, "#{target}/Users/__user__admin__uuid__"
+          :delete, "#{cf_api_url}/v2/users/__user__admin__uuid__"
         )
       end
 
       it "deletes extra users older than 2h" do
         expect(WebMock).to have_requested(
-          :delete, "#{target}/Users/__user__removed_user__uuid__"
+          :delete, "#{cf_api_url}/v2/users/__user__removed_user__uuid__"
         )
       end
 
       it "keeps extra users newer than 2h" do
         expect(WebMock).not_to have_requested(
-          :delete, "#{target}/Users/__user__test_user_1__uuid__"
+          :delete, "#{cf_api_url}/v2/users/__user__test_user_1__uuid__"
         )
         expect(WebMock).not_to have_requested(
-          :delete, "#{target}/Users/__user__test_user_2__uuid__"
+          :delete, "#{cf_api_url}/v2/users/__user__test_user_2__uuid__"
         )
       end
 
@@ -281,6 +291,7 @@ RSpec.describe UaaSyncAdminUsers do
     end
 
     context "when changing authentication origin" do
+      let(:uaa_api_url) { uaa_sync_admin_users.target }
       let(:users) {
         [
           { username: "google_user", email: "google_user@example.com", origin: "google" },
@@ -289,7 +300,7 @@ RSpec.describe UaaSyncAdminUsers do
 
       before(:each) do
         %w(admin google_user).each { |user_to_match|
-          WebMock.stub_request(:get, %r{#{target}/Users\?filter=username eq "#{user_to_match}".*}).
+          WebMock.stub_request(:get, %r{#{uaa_api_url}/Users\?filter=username eq "#{user_to_match}".*}).
             to_return(
               status: 200,
               headers: { "content-type" => "application/json" },
@@ -297,7 +308,7 @@ RSpec.describe UaaSyncAdminUsers do
                 json_user_response(user_to_match, "#{user_to_match}@example.com"),
               ])
           )
-          WebMock.stub_request(:get, %r{#{target}/Users\?filter=id eq "#{user_uuid(user_to_match)}".*}).
+          WebMock.stub_request(:get, %r{#{uaa_api_url}/Users\?filter=id eq "#{user_uuid(user_to_match)}".*}).
             to_return(
               status: 200,
               headers: { "content-type" => "application/json" },
@@ -307,7 +318,7 @@ RSpec.describe UaaSyncAdminUsers do
           )
         }
 
-        WebMock.stub_request(:post, %r{^#{target}/Users.*}).
+        WebMock.stub_request(:post, %r{^#{uaa_api_url}/Users.*}).
           with(
             body: /"userName":"google_user".*"emails":\[{"value":"google_user@example\.com"}/,
           ).
@@ -318,7 +329,7 @@ RSpec.describe UaaSyncAdminUsers do
           )
 
         uaa_sync_admin_users.admin_groups.each { |group_name|
-          WebMock.stub_request(:get, %r{^#{target}/Groups\?filter=displayName eq "#{group_name}".*}).
+          WebMock.stub_request(:get, %r{^#{uaa_api_url}/Groups\?filter=displayName eq "#{group_name}".*}).
             to_return(
               status: 200,
               headers: { "content-type" => "application/json" },
@@ -326,7 +337,7 @@ RSpec.describe UaaSyncAdminUsers do
                 json_group_response(group_name, %w(admin google_user))
               ])
             )
-          WebMock.stub_request(:put, %r{^#{target}/Groups/#{group_uuid(group_name)}$}).
+          WebMock.stub_request(:put, %r{^#{uaa_api_url}/Groups/#{group_uuid(group_name)}$}).
             to_return(
               status: 200,
               headers: { "content-type" => "application/json" },
@@ -334,11 +345,11 @@ RSpec.describe UaaSyncAdminUsers do
           )
         }
 
-        WebMock.stub_request(:delete, "#{target}/Users/__user__google_user__uuid__").
+        WebMock.stub_request(:delete, "#{cf_api_url}/v2/users/__user__google_user__uuid__").
           to_return(
             status: 200,
             headers: { "content-type" => "application/json" },
-            body: json_user_response("google_user", "google_user@example.com"),
+            body: "{}",
         )
 
         @created_users, @deleted_users = uaa_sync_admin_users.update_admin_users(users)
@@ -346,10 +357,10 @@ RSpec.describe UaaSyncAdminUsers do
 
       it "recreates the user" do
         expect(WebMock).to have_requested(
-          :delete, "#{target}/Users/__user__google_user__uuid__"
+          :delete, "#{cf_api_url}/v2/users/__user__google_user__uuid__"
         )
         expect(WebMock).to have_requested(
-          :post, "#{target}/Users"
+          :post, "#{uaa_api_url}/Users"
         ).with(
           body: /"userName":"google_user"/
         ).once

--- a/scripts/sync-admin-users.rb
+++ b/scripts/sync-admin-users.rb
@@ -1,25 +1,8 @@
 #!/usr/bin/env ruby
-require 'json'
 require 'yaml'
-require 'net/https'
 
 require File.expand_path("../lib/mail_credentials_helper", __FILE__)
 require File.expand_path("../lib/uaa_sync_admin_users", __FILE__)
-
-def get_uaa_target(api_url)
-  uri = URI.parse(api_url) + "/v2/info"
-  http = Net::HTTP.new(uri.host, uri.port)
-  if uri.instance_of? URI::HTTPS
-    http.use_ssl = true
-    http.verify_mode = OpenSSL::SSL::VERIFY_NONE if ENV['SKIP_SSL_VERIFICATION'].to_s.casecmp("true").zero?
-  end
-  response = http.request(Net::HTTP::Get.new(uri.request_uri))
-  if response.code != "200"
-    raise "Error connecting to API endpoint #{uri}: #{response}"
-  end
-  api_info = JSON.parse(response.body)
-  api_info.fetch("token_endpoint")
-end
 
 def load_admin_user_list(filename)
   users = YAML.load_file(filename)
@@ -32,28 +15,27 @@ def load_admin_user_list(filename)
   }
 end
 
-api_url = ARGV[0] || raise("You must pass API endpoint as first argument")
+cf_api_url = ARGV[0] || raise("You must pass API endpoint as first argument")
 users_filename = ARGV[1] || raise("You must pass a file of users as second argument")
 source_address = ARGV[2] || raise("You must pass an SES-validated address as third argument")
 
-admin_user = ENV.fetch('UAA_CLIENT', "admin")
-admin_password = ENV['UAA_CLIENT_SECRET'] || raise("Must set $UAA_CLIENT_SECRET env var")
+cf_admin_username = 'admin'
+cf_admin_password = ENV['UAA_ADMIN_PASSWORD'] || raise("Must set $UAA_ADMIN_PASSWORD env var")
 
-puts "Syncing Admin users in #{api_url}..."
+puts "Syncing Admin users in #{cf_api_url}..."
 
-target = get_uaa_target(api_url)
 users = load_admin_user_list(users_filename)
 
 options = {}
 options[:skip_ssl_validation] = true if ENV['SKIP_SSL_VERIFICATION'].to_s.casecmp("true").zero?
 
-uaa_sync_admin_users = UaaSyncAdminUsers.new(target, admin_user, admin_password, options)
+uaa_sync_admin_users = UaaSyncAdminUsers.new(cf_api_url, cf_admin_username, cf_admin_password, options)
 uaa_sync_admin_users.request_token
 created_users, deleted_users = uaa_sync_admin_users.update_admin_users(users)
 
 created_users.each { |user|
   puts "Sending notification to new user #{user.fetch(:username)}"
-  EmailCredentialsHelper.send_notification(api_url, user, source_address)
+  EmailCredentialsHelper.send_notification(cf_api_url, user, source_address)
 }
 
 puts "Created users: #{created_users.length}"


### PR DESCRIPTION
## What

We want to use the CF API to delete users, not UAA. This is because
deleting them from UAA leaves an orphaned record in the Cloud Controller
database.

The UAA token being used was one from the UAA admin client, using the client
credentials grant. This token is not scoped to perform admin operations
in Cloud Foundry, so we have to get a user's token via the `cf` UAA client
and our CF admin user's name and password.

Also, if an admin has never logged in via SSO they will not exist in Cloud
Foundry, so if we get 404 trying to delete them we should attempt
deletion via UAA, as they may still exist in UAA's database.

## How to review

* Amend the temporary commit to set up emails. I experienced complications by using the plus sign trick (`your-email+1@gmail.com`), so try to avoid that. Our dev accounts don't allow use of AWS SES for unverified emails, so you can verify yours and remove it afterwards:

  ```
  aws ses verify-email-identity --email 'your-email@example.com'
  aws ses delete-identity --identity 'your-email@example.com'
  ```

* Configure pipelines:

  ```
  DEPLOY_ENV=your-deploy-env BRANCH=user-deletion SELF_UPDATE_PIPELINE=false NEW_ACCOUNT_EMAIL_ADDRESS=your-email@example.com ALERT_EMAIL_ADDRESS=your-email@example.com make dev pipelines
  ```
* Deploy. It should set up the user(s).
* Cloud Foundry doesn't create an SSO user until it is logged in for the first time. You have to log in with that user and check it is there in Cloud Foundry (`cf curl /v2/users`) to ensure they have been created. The script should still work if the user hasn't been created, so perhaps you could set up one user to be deleted before first login and one after.
* Edit the temporary commit as necessary to change the admin users.
* Deploy. Users should be deleted from Cloud Foundry and UAA.
* Remove the temporary commit.

If you want to play around without waiting on deployments you can grab the `UAA_ADMIN_PASSWORD` and invoke the script locally:

```
export UAA_ADMIN_PASSWORD=$(./concourse/scripts/val_from_yaml.rb \
  secrets.uaa_admin_password <(aws s3 cp s3://gds-paas-${DEPLOY_ENV}-state/cf-secrets.yml -) \
)
export SKIP_SSL_VERIFICATION=true

cd paas-cf/scripts
./sync-admin-users.rb <your CF API URL> ../config/admin_users.yml <your-email-address>
```

### Before merging ⚠️ 

Remove temporary commit.

## Who can review

Anyone but me.

  
  
  