### PR TITLE
[#154202936] Stemcell bump for CVE-2017-5754 (aka Meltdown)

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -88,7 +88,7 @@ releases:
 stemcells:
   - alias: default
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3468.13"
+    version: "3468.16"
 
 update:
   canaries: 0


### PR DESCRIPTION
## What

Apply mitigations for CVE-2017-5754 (aka Meltdown)

Links:

CVE: https://people.canonical.com/~ubuntu-security/cve/2017/CVE-2017-5754.html
USN: https://usn.ubuntu.com/usn/usn-3522-2/
CF announcement: https://www.cloudfoundry.org/usn-3522-2/

## How to review

Test an upgrade from current master applies cleanly.

## Who can review

Not me.