### PR TITLE
[#126788891] Change default ELB security policy to ELBSecurityPolicy-TLS-1-2-2017-01

### DIFF
--- a/terraform/cloudfoundry/cdn_broker.tf
+++ b/terraform/cloudfoundry/cdn_broker.tf
@@ -29,6 +29,17 @@ resource "aws_elb" "cdn_broker" {
   }
 }
 
+resource "aws_lb_ssl_negotiation_policy" "cdn_broker" {
+  name          = "paas-${var.default_elb_security_policy}"
+  load_balancer = "${aws_elb.cdn_broker.id}"
+  lb_port       = 443
+
+  attribute {
+    name  = "Reference-Security-Policy"
+    value = "${var.default_elb_security_policy}"
+  }
+}
+
 resource "aws_s3_bucket" "cdn_broker_bucket" {
   bucket        = "gds-paas-${var.env}-cdn-broker-challenge"
   acl           = "private"

--- a/terraform/cloudfoundry/elasticache_broker.tf
+++ b/terraform/cloudfoundry/elasticache_broker.tf
@@ -29,6 +29,17 @@ resource "aws_elb" "elasticache_broker" {
   }
 }
 
+resource "aws_lb_ssl_negotiation_policy" "elasticache_broker" {
+  name          = "paas-${var.default_elb_security_policy}"
+  load_balancer = "${aws_elb.elasticache_broker.id}"
+  lb_port       = 443
+
+  attribute {
+    name  = "Reference-Security-Policy"
+    value = "${var.default_elb_security_policy}"
+  }
+}
+
 resource "aws_elasticache_subnet_group" "elasticache_broker" {
   name        = "elasticache-broker-${var.env}"
   description = "Subnet group for ElastiCache broker managed instances"

--- a/terraform/cloudfoundry/logsearch.tf
+++ b/terraform/cloudfoundry/logsearch.tf
@@ -26,6 +26,17 @@ resource "aws_elb" "logsearch_ingestor" {
   }
 }
 
+resource "aws_lb_ssl_negotiation_policy" "logsearch_ingestor" {
+  name          = "paas-${var.default_elb_security_policy}"
+  load_balancer = "${aws_elb.logsearch_ingestor.id}"
+  lb_port       = 6514
+
+  attribute {
+    name  = "Reference-Security-Policy"
+    value = "${var.default_elb_security_policy}"
+  }
+}
+
 resource "aws_elb" "logsearch_es_master" {
   name                      = "${var.env}-logsearch-es-master"
   subnets                   = ["${split(",", var.infra_subnet_ids)}"]

--- a/terraform/cloudfoundry/rds_broker.tf
+++ b/terraform/cloudfoundry/rds_broker.tf
@@ -29,6 +29,17 @@ resource "aws_elb" "rds_broker" {
   }
 }
 
+resource "aws_lb_ssl_negotiation_policy" "rds_broker" {
+  name          = "paas-${var.default_elb_security_policy}"
+  load_balancer = "${aws_elb.rds_broker.id}"
+  lb_port       = 443
+
+  attribute {
+    name  = "Reference-Security-Policy"
+    value = "${var.default_elb_security_policy}"
+  }
+}
+
 resource "aws_db_subnet_group" "rds_broker" {
   name        = "rdsbroker-${var.env}"
   description = "Subnet group for RDS broker managed instances"

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -120,7 +120,7 @@ variable "api_access_cidrs" {
 # See https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-policy-table.html
 variable "default_elb_security_policy" {
   description = "Which Security policy to use for ELBs. This controls things like available SSL protocols/ciphers."
-  default     = "ELBSecurityPolicy-2016-08"
+  default     = "ELBSecurityPolicy-TLS-1-2-2017-01"
 }
 
 # List of Elastic Load Balancing Account ID to configure ELB access log policies


### PR DESCRIPTION
## What

To make the ELB traffic more secure we want to remove support for TLSv1 and TLSv1.1.

The ELBSecurityPolicy-TLS-1-2-2017-01 additionally disables the following SSL ciphers:
 - ECDHE-ECDSA-AES128-SHA
 - ECDHE-ECDSA-AES256-SHA
 - ECDHE-RSA-AES128-SHA
 - ECDHE-RSA-AES256-SHA
 - AES128-SHA
 - AES256-SHA

The change effects the following ELBs:
 - cf-cc
 - cf-uaa
 - cf-doppler
 - cf-router
 - metrics
 - logsearch-kibana
 - cdn-broker
 - elasticache-broker
 - rds-broker
 - logsearch-ingestor

The following ELBs don't terminate SSL traffic:
 - logsearch-es-master
 - ssh-proxy

## How to review

1. Update and run your create-cloudfoundry pipeline successfully:
    ```
    $ BRANCH=elb_require_tls12_126788891 make dev pipelines
    ```

2. Check if the CF API doesn't accept TLSv1 or TLSv1.1 connections:
    ```
    $ openssl s_client -connect ${DEPLOY_ENV}.dev.cloudpipelineapps.digital:443 -tls1
    CONNECTED(00000006)
    write:errno=54
    [...]

    $ openssl s_client -connect ${DEPLOY_ENV}.dev.cloudpipelineapps.digital:443 -tls1_1
    CONNECTED(00000006)
    write:errno=54
    ```

3. Check if CF API accepts TLSv1.2 connections:
    ```
    $ openssl s_client -connect ${DEPLOY_ENV}.dev.cloudpipelineapps.digital:443 -tls1_2
    CONNECTED(00000006)
    depth=1 CN = bosh-CA
    [...]
    ---
    [waiting to receive]
    ```

4. Check if Kibana still works and shows fresh logs: (https://logsearch.${DEPLOY_ENV}.dev.cloudpipeline.digital)

For al the other ELBs I suggest it should be enough to check from the AWS console manually whether they all have the "ELBSecurityPolicy-TLS-1-2-2017-01" SSL negotiation policy (EC2 Console > Load balancers > Select ELB > Listeners > Click Change in Cipher column).

## Who can review

Not @bandesz
