### PR TITLE
[#143584125] Enable password resets

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -171,7 +171,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/awscli
-              tag: 1ab7d6cdac70f2c32563ea173da0cd7791309be5
+              tag: b2495d6ed07f680125d19aa7d1701da7efabb289
           run:
             path: ./paas-cf/concourse/scripts/rds_instances.sh
             args:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1655,6 +1655,51 @@ jobs:
                   cf enable-feature-flag diego_docker
 
       - aggregate:
+        - task: block-create-account-endpoints
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/cf-cli
+                tag: 465642da06051a55630d39c899697b678f66a7f7
+            inputs:
+              - name: paas-cf
+              - name: config
+              - name: bosh-CA
+            run:
+              path: sh
+              args:
+                - -e
+                - -u
+                - -c
+                - |
+                  ./paas-cf/concourse/scripts/import_bosh_ca.sh
+
+                  . ./config/config.sh
+                  cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}" \
+                    -o admin -s assets
+
+                  cd paas-cf/platform-tests/example-apps/create-account-holding-page/
+                  cf push
+
+                  if ! cf domains | grep -q "login.((system_dns_zone_name))"; then
+                    cf create-domain admin "login.((system_dns_zone_name))"
+                  fi
+                  if ! cf domains | grep -q "uaa.((system_dns_zone_name))"; then
+                    cf create-domain admin "uaa.((system_dns_zone_name))"
+                  fi
+
+                  cf create-route assets "login.((system_dns_zone_name))" --path create_account
+                  cf create-route assets "login.((system_dns_zone_name))" --path create_account.do
+                  cf create-route assets "uaa.((system_dns_zone_name))" --path create_account
+                  cf create-route assets "uaa.((system_dns_zone_name))" --path create_account.do
+
+                  cf map-route create-account-holding-page "login.((system_dns_zone_name))" --path create_account
+                  cf map-route create-account-holding-page "login.((system_dns_zone_name))" --path create_account.do
+                  cf map-route create-account-holding-page "uaa.((system_dns_zone_name))" --path create_account
+                  cf map-route create-account-holding-page "uaa.((system_dns_zone_name))" --path create_account.do
+
         - task: deploy-compose-service-broker
           config:
             platform: linux

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2956,6 +2956,7 @@ jobs:
       - get: cf-secrets
         passed: ['rotate-cloudfoundry-credentials']
         trigger: true
+      - get: cf-tfstate
 
     - task: clear-passwords
       config:
@@ -2986,6 +2987,15 @@ jobs:
         params:
           file: modified-cf-secrets/cf-secrets.yml
 
+    - task: forget-ses-smtp-access-key
+      file: paas-cf/concourse/tasks/forget-ses-smtp-access-key.yml
+      params:
+        AWS_DEFAULT_REGION: ((aws_region))
+      ensure:
+        put: cf-tfstate
+        params:
+          file: updated-tfstate/cf.tfstate
+
   - name: expire-ses-smtp-credentials
     serial: true
     plan:
@@ -2995,35 +3005,14 @@ jobs:
       - get: smtp-credential-rotation-timer
         trigger: true
     - task: forget-ses-smtp-access-key
-      config:
-        platform: linux
-        image_resource:
-          type: docker-image
-          source:
-            repository: governmentpaas/terraform
-            tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
-        inputs:
-          - name: cf-tfstate
-        outputs:
-          - name: updated-tfstate
-        params:
-          AWS_DEFAULT_REGION: ((aws_region))
-        run:
-          path: sh
-          args:
-            - -e
-            - -c
-            - |
-              cp cf-tfstate/cf.tfstate updated-tfstate/cf.tfstate
-              terraform state rm \
-                -state=updated-tfstate/cf.tfstate \
-                aws_iam_access_key.ses_smtp
-              echo "ses smtp access key no longer managed by terraform."
-              echo "next successful deployment run will revoke the expired keys"
+      file: paas-cf/concourse/tasks/forget-ses-smtp-access-key.yml
+      params:
+        AWS_DEFAULT_REGION: ((aws_region))
       ensure:
         put: cf-tfstate
         params:
           file: updated-tfstate/cf.tfstate
+
   - name: generate-git-keys
     plan:
       - task: ssh-keygen

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -985,6 +985,26 @@ jobs:
           params:
             file: updated-tfstate/cf.tfstate
 
+      # FIXME: Move this operation to Terraform when this feature is added:
+      # https://github.com/terraform-providers/terraform-provider-aws/issues/113
+      - task: add-aws-users-to-groups
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/awscli
+              tag: b2495d6ed07f680125d19aa7d1701da7efabb289
+          params:
+            DEPLOY_ENV: ((deploy_env))
+          run:
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              aws iam add-user-to-group --user-name "ses-smtp-${DEPLOY_ENV}" --group-name email-senders
+
       - task: extract-cf-terraform-outputs
         config:
           platform: linux
@@ -1008,6 +1028,7 @@ jobs:
                 SCFILE="extract_tf_vars_from_terraform_state.rb"
                 $SCPATH/$SCFILE < cf-tfstate/cf.tfstate > cf-terraform-outputs/cf.tfstate.sh
                 ls -l cf-terraform-outputs/cf.tfstate.sh
+
       - task: init-db
         config:
           platform: linux
@@ -1051,6 +1072,7 @@ jobs:
           - get: bosh-tfstate
           - get: cf-tfstate
             passed: ['cf-terraform']
+
       - aggregate:
         - task: extract-terraform-outputs
           config:
@@ -1076,8 +1098,8 @@ jobs:
                 - |
                   for state in vpc bosh concourse cf; do
                     ./paas-cf/concourse/scripts/extract_terraform_state_to_yaml.rb \
-                      < $state-tfstate/$state.tfstate \
-                      > terraform-outputs/$state.yml
+                      < ${state}-tfstate/${state}.tfstate \
+                      > terraform-outputs/${state}.yml
                     ./paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
                       < ${state}-tfstate/${state}.tfstate \
                       > terraform-outputs/${state}.tfvars.sh
@@ -1105,28 +1127,28 @@ jobs:
                   ${CF_MANIFEST_DIR}/scripts/grafana-dashboards-manifest.rb ${CF_MANIFEST_DIR}/grafana \
                     > grafana-dashboards-manifest/grafana-dashboards-manifest.yml
 
-      - task: generate-peer-manifest
-        config:
-          platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: ruby
-              tag: 2.2-slim
-          inputs:
-            - name: paas-cf
-          outputs:
-            - name: vpc-peering-manifest
-          run:
-            path: sh
-            args:
-              - -e
-              - -c
-              - |
-                ruby paas-cf/terraform/scripts/generate_vpc_peering_manifest.rb "paas-cf/terraform/((aws_account)).vpc_peering.json" \
-                > vpc-peering-manifest/vpc-peers.yml
+        - task: generate-peer-manifest
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: ruby
+                tag: 2.2-slim
+            inputs:
+              - name: paas-cf
+            outputs:
+              - name: vpc-peering-manifest
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  ruby paas-cf/terraform/scripts/generate_vpc_peering_manifest.rb "paas-cf/terraform/((aws_account)).vpc_peering.json" \
+                  > vpc-peering-manifest/vpc-peers.yml
 
-                cat vpc-peering-manifest/vpc-peers.yml
+                  cat vpc-peering-manifest/vpc-peers.yml
 
       - aggregate:
         - task: generate-cloud-config

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -11,6 +11,7 @@ groups:
       - cf-terraform
       - generate-cf-config
       - cf-deploy
+      - post-deploy
       - smoke-tests
       - acceptance-tests
       - custom-acceptance-tests
@@ -27,6 +28,7 @@ groups:
       - cf-terraform
       - generate-cf-config
       - cf-deploy
+      - post-deploy
       - smoke-tests
       - acceptance-tests
       - custom-acceptance-tests
@@ -59,6 +61,7 @@ groups:
     jobs:
       - rotate-cloudfoundry-credentials
       - clear-cloudfoundry-credentials
+      - expire-ses-smtp-credentials
 resource_types:
 - name: s3-iam
   type: docker-image
@@ -246,6 +249,11 @@ resources:
     type: time
     source:
       interval: 5m
+
+  - name: smtp-credential-rotation-timer
+    type: time
+    source:
+      interval: 720h
 
   - name: paas-compose-broker
     type: git
@@ -577,6 +585,49 @@ jobs:
             put: cf-secrets
             params:
               file: generated-cf-secrets/cf-secrets.yml
+
+  - name: post-deploy
+    serial: true
+    plan:
+    - aggregate:
+      - get: cf-tfstate
+      - get: pipeline-trigger
+        passed: ['cf-deploy', 'api-availability-tests', 'app-availability-tests']
+        trigger: true
+    - task: remove-unused-ses-smtp-access-keys
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: governmentpaas/awscli
+            tag: b2495d6ed07f680125d19aa7d1701da7efabb289
+        inputs:
+          - name: cf-tfstate
+        params:
+          DEPLOY_ENV: ((deploy_env))
+          AWS_DEFAULT_REGION: ((aws_region))
+        run:
+          path: sh
+          args:
+            - -e
+            - -c
+            - |
+              SES_SMTP_ACCESS_KEY_ID=$(jq -r '.modules[].outputs.ses_smtp_aws_access_key_id.value' cf-tfstate/cf.tfstate)
+              if [ -z "$SES_SMTP_ACCESS_KEY_ID" ]; then
+                echo "could not find ses_smtp_aws_access_key_id in terraform outputs"
+                exit 1
+              fi
+
+              UNUSED_ACCESS_KEYS=$(aws iam list-access-keys --user-name "ses-smtp-${DEPLOY_ENV}" | jq -r ".AccessKeyMetadata[] | select(.AccessKeyId != \"${SES_SMTP_ACCESS_KEY_ID}\") | .AccessKeyId")
+              if [ -z "$UNUSED_ACCESS_KEYS" ]; then
+                echo "no access keys to revoke"
+              else
+                for key in $UNUSED_ACCESS_KEYS; do
+                  echo "deleting key = $key"
+                  aws iam delete-access-key --user-name "ses-smtp-${DEPLOY_ENV}" --access-key-id "$key"
+                done
+              fi
 
   - name: pre-deploy
     plan:
@@ -2473,7 +2524,7 @@ jobs:
     plan:
       - aggregate:
           - get: pipeline-trigger
-            passed: ['cf-deploy','app-availability-tests','api-availability-tests']
+            passed: ['post-deploy']
             trigger: true
           - get: cf-release
             params:
@@ -2481,7 +2532,7 @@ jobs:
                 - src/github.com/cloudfoundry/cf-acceptance-tests
             passed: ['cf-deploy']
           - get: paas-cf
-            passed: ['cf-deploy','app-availability-tests','api-availability-tests']
+            passed: ['cf-deploy']
           - get: cf-manifest
             passed: ['cf-deploy']
           - get: bosh-CA
@@ -2538,10 +2589,10 @@ jobs:
     plan:
       - aggregate:
           - get: pipeline-trigger
-            passed: ['cf-deploy','app-availability-tests','api-availability-tests']
+            passed: ['post-deploy']
             trigger: true
           - get: paas-cf
-            passed: ['cf-deploy','app-availability-tests','api-availability-tests']
+            passed: ['cf-deploy']
           - get: cf-manifest
             passed: ['cf-deploy']
           - get: bosh-CA
@@ -2935,6 +2986,44 @@ jobs:
         params:
           file: modified-cf-secrets/cf-secrets.yml
 
+  - name: expire-ses-smtp-credentials
+    serial: true
+    plan:
+    - aggregate:
+      - get: paas-cf
+      - get: cf-tfstate
+      - get: smtp-credential-rotation-timer
+        trigger: true
+    - task: forget-ses-smtp-access-key
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: governmentpaas/terraform
+            tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
+        inputs:
+          - name: cf-tfstate
+        outputs:
+          - name: updated-tfstate
+        params:
+          AWS_DEFAULT_REGION: ((aws_region))
+        run:
+          path: sh
+          args:
+            - -e
+            - -c
+            - |
+              cp cf-tfstate/cf.tfstate updated-tfstate/cf.tfstate
+              terraform state rm \
+                -state=updated-tfstate/cf.tfstate \
+                aws_iam_access_key.ses_smtp
+              echo "ses smtp access key no longer managed by terraform."
+              echo "next successful deployment run will revoke the expired keys"
+      ensure:
+        put: cf-tfstate
+        params:
+          file: updated-tfstate/cf.tfstate
   - name: generate-git-keys
     plan:
       - task: ssh-keygen

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -413,7 +413,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/awscli
-              tag: 1ab7d6cdac70f2c32563ea173da0cd7791309be5
+              tag: b2495d6ed07f680125d19aa7d1701da7efabb289
           run:
             path: sh
             args:
@@ -706,7 +706,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/awscli
-              tag: 1ab7d6cdac70f2c32563ea173da0cd7791309be5
+              tag: b2495d6ed07f680125d19aa7d1701da7efabb289
           run:
             path: sh
             args:
@@ -3120,7 +3120,7 @@ jobs:
                 type: docker-image
                 source:
                   repository: governmentpaas/awscli
-                  tag: 1ab7d6cdac70f2c32563ea173da0cd7791309be5
+                  tag: b2495d6ed07f680125d19aa7d1701da7efabb289
               params:
                 AWS_DEFAULT_REGION: ((aws_region))
                 DEPLOY_ENV: ((deploy_env))

--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -52,7 +52,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/awscli
-              tag: 1ab7d6cdac70f2c32563ea173da0cd7791309be5
+              tag: b2495d6ed07f680125d19aa7d1701da7efabb289
           run:
             path: ./paas-cf/concourse/scripts/rds_instances.sh
             args:

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -216,7 +216,6 @@ jobs:
           params:
             file: deployed-healthcheck/healthcheck-deployed
 
-
   - name: terraform-destroy
     serial_groups: [ destroy ]
     serial: true

--- a/concourse/tasks/forget-ses-smtp-access-key.yml
+++ b/concourse/tasks/forget-ses-smtp-access-key.yml
@@ -1,0 +1,24 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/terraform
+    tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
+inputs:
+  - name: paas-cf
+  - name: cf-tfstate
+outputs:
+  - name: updated-tfstate
+run:
+  path: sh
+  args:
+    - -e
+    - -c
+    - |
+      cp cf-tfstate/cf.tfstate updated-tfstate/cf.tfstate
+      terraform state rm \
+        -state=updated-tfstate/cf.tfstate \
+        aws_iam_access_key.ses_smtp
+      echo "ses smtp access key no longer managed by terraform."
+      echo "next successful deployment run will revoke the expired keys"

--- a/concourse/tasks/kill-instance.yml
+++ b/concourse/tasks/kill-instance.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/awscli
-    tag: 1ab7d6cdac70f2c32563ea173da0cd7791309be5
+    tag: b2495d6ed07f680125d19aa7d1701da7efabb289
 platform: linux
 run:
   path: sh

--- a/concourse/tasks/upload-test-artifacts.yml
+++ b/concourse/tasks/upload-test-artifacts.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/awscli
-    tag: 1ab7d6cdac70f2c32563ea173da0cd7791309be5
+    tag: b2495d6ed07f680125d19aa7d1701da7efabb289
 inputs:
   - name: paas-cf
   - name: artifacts

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -163,9 +163,7 @@ jobs:
               component: uaa
             uris:
               - (( concat "uaa." properties.system_domain ))
-              - (( concat "*.uaa." properties.system_domain ))
               - (( concat "login." properties.system_domain ))
-              - (( concat "*.login." properties.system_domain ))
 
   - name: api
     azs: [z1, z2]

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -393,6 +393,14 @@ properties:
       serviceProviderKey: ((grab secrets.saml_key))
       serviceProviderKeyPassword: ""
       serviceProviderCertificate: ((grab secrets.saml_cert))
+    smtp:
+      host: (( grab terraform_outputs.ses_smtp_host ))
+      port: 587
+      from_address: "gov-uk-paas-support@digital.cabinet-office.gov.uk"
+      user: (( grab terraform_outputs.ses_smtp_aws_access_key_id ))
+      password: (( grab terraform_outputs.ses_smtp_password ))
+      auth: true
+      starttls: true
     enabled: true
     self_service_links_enabled: false
     links:

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -402,11 +402,11 @@ properties:
       auth: true
       starttls: true
     enabled: true
-    self_service_links_enabled: false
+    self_service_links_enabled: true
     links:
       passwd: (( concat "https://login." properties.system_domain "/forgot_password" ))
-      signup: (( concat "https://login." properties.system_domain "/create_account" ))
-      homeRedirect: (( concat "https://www." properties.system_domain "/next-steps" ))
+      signup: "https://www.cloud.service.gov.uk/signup"
+      homeRedirect: "https://www.cloud.service.gov.uk/next-steps?account-updated"
     branding:
       company_name: "GOV.UK PaaS"
     asset_base_url: (( concat "https://paas-uaa-assets." terraform_outputs.cf_apps_domain ))

--- a/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
@@ -94,6 +94,14 @@ RSpec.describe "base properties" do
   describe "login" do
     subject(:login) { properties.fetch("login") }
 
+    describe "smtp" do
+      subject(:smtp) { login.fetch("smtp") }
+
+      it { is_expected.to include("host" => "SmtpHost") }
+      it { is_expected.to include("user" => "SmtpAccessTokenID") }
+      it { is_expected.to include("password" => "SmtpPassword") }
+    end
+
     describe "links" do
       subject(:links) { login.fetch("links") }
 

--- a/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
@@ -106,8 +106,8 @@ RSpec.describe "base properties" do
       subject(:links) { login.fetch("links") }
 
       it { is_expected.to include("passwd" => "https://login.#{terraform_fixture(:cf_root_domain)}/forgot_password") }
-      it { is_expected.to include("signup" => "https://login.#{terraform_fixture(:cf_root_domain)}/create_account") }
-      it { is_expected.to include("homeRedirect" => "https://www.#{terraform_fixture(:cf_root_domain)}/next-steps") }
+      it { is_expected.to include("signup" => "https://www.cloud.service.gov.uk/signup") }
+      it { is_expected.to include("homeRedirect" => "https://www.cloud.service.gov.uk/next-steps?account-updated") }
     end
   end
 

--- a/manifests/cf-manifest/spec/manifest/jobs_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/jobs_spec.rb
@@ -128,9 +128,7 @@ RSpec.describe "uaa jobs" do
           expect(routes.length).to eq(1)
           expect(routes.first.fetch('uris')).to match_array([
             "uaa.#{terraform_fixture(:cf_root_domain)}",
-            "*.uaa.#{terraform_fixture(:cf_root_domain)}",
             "login.#{terraform_fixture(:cf_root_domain)}",
-            "*.login.#{terraform_fixture(:cf_root_domain)}",
           ])
         end
       end

--- a/manifests/shared/spec/fixtures/terraform/terraform-outputs.yml
+++ b/manifests/shared/spec/fixtures/terraform/terraform-outputs.yml
@@ -51,3 +51,6 @@ terraform_outputs:
   cloud_controller_security_group: sg-0000000
   cell_subnet_cidr_blocks: ""
   router_subnet_cidr_blocks: ""
+  ses_smtp_host: "SmtpHost"
+  ses_smtp_aws_access_key_id: "SmtpAccessTokenID"
+  ses_smtp_password: "SmtpPassword"

--- a/platform-tests/example-apps/create-account-holding-page/index.html
+++ b/platform-tests/example-apps/create-account-holding-page/index.html
@@ -1,0 +1,1 @@
+Account creation has been disabled

--- a/platform-tests/example-apps/create-account-holding-page/manifest.yml
+++ b/platform-tests/example-apps/create-account-holding-page/manifest.yml
@@ -1,0 +1,7 @@
+---
+applications:
+ - name: create-account-holding-page
+   memory: 64M
+   disk_quota: 100M
+   instances: 2
+   buildpack: staticfile_buildpack

--- a/platform-tests/example-apps/create-account-holding-page/nginx.conf
+++ b/platform-tests/example-apps/create-account-holding-page/nginx.conf
@@ -1,0 +1,54 @@
+worker_processes  1;
+daemon off;
+
+error_log <%= ENV.fetch("APP_ROOT") %>/nginx/logs/error.log;
+events {
+  worker_connections 1024;
+}
+
+http {
+  charset utf-8;
+  log_format access_json '{"logType": "nginx-access", '
+                         ' "remoteHost": "$remote_addr", '
+                         ' "user": "$remote_user", '
+                         ' "time": "$time_local", '
+                         ' "request": "$request", '
+                         ' "status": $status, '
+                         ' "size": $body_bytes_sent, '
+                         ' "referer": "$http_referer", '
+                         ' "userAgent": "$http_user_agent", '
+                         ' "requestTime": $request_time, '
+                         ' "httpHost": "$http_host"}';
+
+  access_log <%= ENV.fetch("APP_ROOT") %>/nginx/logs/access.log.json access_json;
+
+  upstream static_backend {
+    server localhost:8989;
+  }
+
+  server {
+    listen <%= ENV.fetch("PORT") %>;
+    server_name localhost;
+
+    location / {
+      root <%= ENV["APP_ROOT"] %>/public;
+      try_files $uri /index.html;
+    }
+
+    error_page 405 =200 @405;
+    location @405 {
+      proxy_method GET;
+      proxy_pass http://static_backend;
+    }
+  }
+
+  server {
+    listen 8989;
+    server_name _;
+
+    location / {
+      root <%= ENV["APP_ROOT"] %>/public;
+      try_files $uri /index.html;
+    }
+  }
+}

--- a/platform-tests/src/platform/acceptance/account_management_test.go
+++ b/platform-tests/src/platform/acceptance/account_management_test.go
@@ -15,12 +15,13 @@ import (
 )
 
 var _ = Describe("AccountManagement", func() {
-	const email = "the-multi-cloud-paas-team+account-test@digital.cabinet-office.gov.uk"
+	const email = "the-multi-cloud-paas-team+this-should-not-be-created@digital.cabinet-office.gov.uk"
 
 	var (
 		params   url.Values
 		password string
 		authURL  *url.URL
+		tokenURL *url.URL
 	)
 
 	BeforeEach(func() {
@@ -35,6 +36,7 @@ var _ = Describe("AccountManagement", func() {
 
 		var infoResp struct {
 			AuthorizationEndpoint string `json:"authorization_endpoint"`
+			TokenEndpoint         string `json:"token_endpoint"`
 		}
 
 		err := json.Unmarshal(infoCommand.Buffer().Contents(), &infoResp)
@@ -42,9 +44,12 @@ var _ = Describe("AccountManagement", func() {
 
 		authURL, err = url.Parse(infoResp.AuthorizationEndpoint)
 		Expect(err).NotTo(HaveOccurred())
+
+		tokenURL, err = url.Parse(infoResp.TokenEndpoint)
+		Expect(err).NotTo(HaveOccurred())
 	})
 
-	Describe("login server /create_account endpoint", func() {
+	Describe("login server", func() {
 		It("should not allow access to the create account page", func() {
 			createAccountURL := authURL
 			createAccountURL.Path = "/create_account"
@@ -55,8 +60,8 @@ var _ = Describe("AccountManagement", func() {
 			defer resp.Body.Close()
 			body, err := ioutil.ReadAll(resp.Body)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(http.StatusNotFound), "wrong status code, body:\n\n %s", body)
-			Expect(body).To(ContainSubstring("Something went amiss"))
+			Expect(resp.StatusCode).To(Equal(http.StatusOK), "wrong status code, body:\n\n %s", body)
+			Expect(body).To(ContainSubstring("Account creation has been disabled"))
 		})
 
 		It("should not allow anonymous users to create accounts", func() {
@@ -73,13 +78,11 @@ var _ = Describe("AccountManagement", func() {
 			defer resp.Body.Close()
 			body, err := ioutil.ReadAll(resp.Body)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(http.StatusNotFound), "wrong status code, body:\n\n %s", body)
-			Expect(body).To(ContainSubstring("Something went amiss"))
+			Expect(resp.StatusCode).To(Equal(http.StatusOK), "wrong status code, body:\n\n %s", body)
+			Expect(body).To(ContainSubstring("Account creation has been disabled"))
 		})
-	})
 
-	Describe("login server /forgot_password endpoint", func() {
-		It("should not allow access to the forgot password page", func() {
+		It("should allow access to the forgot password page", func() {
 			resetPasswordURL := authURL
 			resetPasswordURL.Path = "/forgot_password"
 
@@ -91,11 +94,11 @@ var _ = Describe("AccountManagement", func() {
 			defer resp.Body.Close()
 			body, err := ioutil.ReadAll(resp.Body)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(http.StatusNotFound), "wrong status code, body:\n\n %s", body)
-			Expect(body).To(ContainSubstring("Something went amiss"))
+			Expect(resp.StatusCode).To(Equal(http.StatusOK), "wrong status code, body:\n\n %s", body)
+			Expect(body).To(ContainSubstring("Reset Password"))
 		})
 
-		It("should not allow users to reset forgotten passwords", func() {
+		It("should allow users to reset forgotten passwords", func() {
 			resetPasswordURL := authURL
 			resetPasswordURL.Path = "/forgot_password.do"
 
@@ -107,8 +110,74 @@ var _ = Describe("AccountManagement", func() {
 			defer resp.Body.Close()
 			body, err := ioutil.ReadAll(resp.Body)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(http.StatusNotFound), "wrong status code, body:\n\n %s", body)
-			Expect(body).To(ContainSubstring("Something went amiss"))
+			Expect(resp.StatusCode).To(Equal(http.StatusOK), "wrong status code, body:\n\n %s", body)
+			Expect(body).To(ContainSubstring("Instructions Sent"))
+		})
+	})
+
+	Describe("auth server", func() {
+		It("should not allow access to the create account page", func() {
+			createAccountURL := tokenURL
+			createAccountURL.Path = "/create_account"
+
+			resp, err := httpClient.Get(createAccountURL.String())
+			Expect(err).NotTo(HaveOccurred())
+
+			defer resp.Body.Close()
+			body, err := ioutil.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusOK), "wrong status code, body:\n\n %s", body)
+			Expect(body).To(ContainSubstring("Account creation has been disabled"))
+		})
+
+		It("should not allow anonymous users to create accounts", func() {
+			createAccountURL := tokenURL
+			createAccountURL.Path = "/create_account.do"
+
+			params.Set("email", email)
+			params.Set("password", password)
+			params.Set("password_confirmation", password)
+
+			resp, err := httpClient.PostForm(createAccountURL.String(), params)
+			Expect(err).NotTo(HaveOccurred())
+
+			defer resp.Body.Close()
+			body, err := ioutil.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusOK), "wrong status code, body:\n\n %s", body)
+			Expect(body).To(ContainSubstring("Account creation has been disabled"))
+		})
+
+		It("should allow access to the forgot password page", func() {
+			resetPasswordURL := tokenURL
+			resetPasswordURL.Path = "/forgot_password"
+
+			params.Set("username", email)
+
+			resp, err := httpClient.Get(resetPasswordURL.String())
+			Expect(err).NotTo(HaveOccurred())
+
+			defer resp.Body.Close()
+			body, err := ioutil.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusOK), "wrong status code, body:\n\n %s", body)
+			Expect(body).To(ContainSubstring("Reset Password"))
+		})
+
+		It("should allow users to reset forgotten passwords", func() {
+			resetPasswordURL := tokenURL
+			resetPasswordURL.Path = "/forgot_password.do"
+
+			params.Set("username", email)
+
+			resp, err := httpClient.PostForm(resetPasswordURL.String(), params)
+			Expect(err).NotTo(HaveOccurred())
+
+			defer resp.Body.Close()
+			body, err := ioutil.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusOK), "wrong status code, body:\n\n %s", body)
+			Expect(body).To(ContainSubstring("Instructions Sent"))
 		})
 	})
 })

--- a/terraform/cloudfoundry/outputs.tf
+++ b/terraform/cloudfoundry/outputs.tf
@@ -177,3 +177,15 @@ output "router_subnet_cidr_blocks" {
 output "nat_public_ips_csv" {
   value = "${join(",", aws_eip.cf.*.public_ip)}"
 }
+
+output "ses_smtp_host" {
+  value = "email-smtp.${var.region}.amazonaws.com"
+}
+
+output "ses_smtp_aws_access_key_id" {
+  value = "${aws_iam_access_key.ses_smtp.id}"
+}
+
+output "ses_smtp_password" {
+  value = "${aws_iam_access_key.ses_smtp.ses_smtp_password}"
+}

--- a/terraform/cloudfoundry/smtp.tf
+++ b/terraform/cloudfoundry/smtp.tf
@@ -1,0 +1,30 @@
+resource "aws_iam_user" "ses_smtp" {
+  name = "ses-smtp-${var.env}"
+}
+
+# Until this feature request is not solved https://github.com/terraform-providers/terraform-provider-aws/issues/113,
+# `aws_iam_group_membership` will wipe all the other members from the
+# shared group.
+#
+# The workaround is use aws cli:
+#
+#   aws iam add-user-to-group --user-name "ses-smtp-${DEPLOY_ENV}" --group-name ses-smtp
+#
+# We could do it using terraform provisioner local-exec calling out awscli
+# but we want to avoid this pattern so we will do it in a script in
+# the next step.
+#
+# Once they fix it upstream, we can replace it with this code:
+#
+# resource "aws_iam_group_membership" "ses_smtp" {
+#    name = "ses_smtp"
+#    group = "ses_smtp"
+#    users = [
+#        "${aws_iam_user.ses_smtp.name}",
+#    ]
+#    append = true
+#}
+
+resource "aws_iam_access_key" "ses_smtp" {
+  user = "${aws_iam_user.ses_smtp.name}"
+}


### PR DESCRIPTION
## What

We want to allow tenants to be able to reset their passwords, but not enable account creation.

See commit messages for details.

## How to review

* deploy from this branch and make sure all tests pass
* check you can reset a user's password. You may need to verify your email with SES as our dev account is still in the sandbox:

  ```
  aws ses verify-email-identity --email-address your-email@example.com
  ```
* check all account creation endpoints are blocked. I am not going to tell you what they are, you have to try and hack it. Go on, I dare you.
* check the password rotation works. Related pull request in the team manual: https://github.com/alphagov/paas-team-manual/pull/176

## Who can review

Anyone but me, @chrisfarms, or @46bit 
