### PR TITLE
Increase service instances in larger plans

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -312,12 +312,12 @@ properties:
         total_routes: 1000
       large:
         memory_limit: 102400
-        total_services: 20
+        total_services: 40
         non_basic_services_allowed: true
         total_routes: 1000
       xlarge:
         memory_limit: 204800
-        total_services: 20
+        total_services: 80
         non_basic_services_allowed: true
         total_routes: 1000
       test_apps:


### PR DESCRIPTION
## What

Our tenants are hitting their service instance limits. This change increases the limits by applying a doubling function between plans.

## How to review

Eyeball it. Deploy it if you want. It'll get caught in staging if something is horribly wrong.

## Who can review

Anyone
