### PR TITLE
[#154240758] Bump paas-usage-event-collector to v0.6.0

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -271,7 +271,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-usage-events-collector
-      tag_filter: v0.5.0
+      tag_filter: v0.6.0
 
 jobs:
   - name: pipeline-lock


### PR DESCRIPTION
## What

We tweaked some CSS in the Billing API output in paas-usage-event-collector. This bumps the version of the paas-usage-event-collector that is pulled in.

## How to review

⚠️ Merge [the paas-usage-events-collector PR](https://github.com/alphagov/paas-usage-events-collector/pull/8) first!

⚠️ The version tag has been guessed. Ensure it is correct before merging!

This change does not change any logic in the event collection or billing api, and code review should be enough.

## Who can review

Not @chrisfarms or @keymon 
