### PR TITLE
[#153561855] Add custom loggregator release

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -34,6 +34,12 @@ releases:
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/ipsec-0.1.3.tgz
     sha1: 6a9e252162519e50f6c511c489ba304a286d496a
 
+  # TODO: remove after https://github.com/cloudfoundry/loggregator-release/pull/356 was merged
+  - name: loggregator
+    version: 0.1.3
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/loggregator-0.1.3.tgz
+    sha1: dcd4c2f936efed6d3882221963425a4bf82a1f60
+
   ### buildpacks
   - name: binary-buildpack
     version: "1.0.15"

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -279,10 +279,10 @@ jobs:
       - name: datadog-consul-agent-client
         release: datadog-for-cloudfoundry
       - name: loggregator_trafficcontroller
-        release: (( grab meta.release.name ))
+        release: loggregator
         consumes: {doppler: nil}
       - name: metron_agent
-        release: (( grab meta.release.name ))
+        release: loggregator
     instances: 2
     vm_type: medium
     vm_extensions:


### PR DESCRIPTION
## What

Use custom loggregator BOSH release

We added a drain script to the loggregator_trafficcontroller job to make sure
traffic controller is stopped before the consul-agent. Previously when the VM
was stopped we got CF-StatsUnavailable from the CF API which was caused by the
following traffic controller errors:

```
2018/01/23 15:13:28 Could not get app information: [Get
https://cloud-controller-ng.service.cf.internal:9023/internal/v4/log_access/6ba02750-f073-444f-ba73-ee3cf4a02ec6:
dial tcp: lookup cloud-controller-ng.service.cf.internal on 10.0.0.2:53: no such host
```

We saw these errors when the consul-agent was stopped before the
trafficcontroller service and stopped providing DNS resolution.

❗️ This PR contains a temporary commit with the dev build of the loggregator-release. Please replace it with the final one before merging.

## How to review

Check out the following PRs first:
* https://github.com/alphagov/paas-loggregator-release/pull/2
* https://github.com/alphagov/paas-release-ci/pull/51

We also created an upstream PR:
 * https://github.com/cloudfoundry/loggregator-release/pull/356

### Steps

1. Review and merge the https://github.com/alphagov/paas-release-ci/pull/51 first.

1. Build the loggregator-release on the build CI

1. Replace the temporary commit with your own build version.

1. Deploy the pipeline from this branch:
    ```BRANCH=add_custom_loggregator_release_153561855 make dev pipelines```

2. Change the stemcell only for the loggregator (e.g. to 3468.20) and run the pipeline again. The api-availability tests shouldn't fail during the deployment.

## Who can review

Not @keymon or @bandesz