### PR TITLE
[#149928858] Implement logic to rotate CF internal certs

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -62,6 +62,8 @@ groups:
       - rotate-cloudfoundry-credentials
       - clear-cloudfoundry-credentials
       - expire-aws-keys
+      - rotate-cf-internal-certs
+      - delete-old-cf-internal-certs
 resource_types:
 - name: s3-iam
   type: docker-image
@@ -544,7 +546,8 @@ jobs:
                   echo "Extracting extant certs"
                   tar -xvzf cf-certs/cf-certs.tar.gz -C certs
 
-                  ./paas-cf/manifests/cf-manifest/scripts/generate-cf-certs.sh certs bosh-CA/bosh-CA.tar.gz
+                  ./paas-cf/manifests/cf-manifest/scripts/generate-cf-certs.sh \
+                    certs bosh-CA/bosh-CA.tar.gz create
 
                   echo "Creating updated cert tarball"
                   cd certs
@@ -3028,6 +3031,90 @@ jobs:
         put: cf-tfstate
         params:
           file: updated-tfstate/cf.tfstate
+
+  - name: rotate-cf-internal-certs
+    serial: true
+    plan:
+    - aggregate:
+      - get: paas-cf
+      - get: bosh-CA
+      - get: cf-certs
+    - task: rotate-cf-internal-certs
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: governmentpaas/certstrap
+            tag: 465642da06051a55630d39c899697b678f66a7f7
+        inputs:
+          - name: bosh-CA
+          - name: paas-cf
+          - name: cf-certs
+        outputs:
+          - name: generated-cf-certs
+        params:
+          SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+          APPS_DNS_ZONE_NAME: ((apps_dns_zone_name))
+        run:
+          path: sh
+          args:
+            - -e
+            - -c
+            - |
+              mkdir certs
+              echo "Extracting extant certs"
+              tar -xvzf cf-certs/cf-certs.tar.gz -C certs
+
+              ./paas-cf/manifests/cf-manifest/scripts/generate-cf-certs.sh \
+                certs bosh-CA/bosh-CA.tar.gz rotate
+
+              echo "Creating updated cert tarball"
+              cd certs
+              tar -cvzf ../generated-cf-certs/cf-certs.tar.gz .
+      on_success:
+        put: cf-certs
+        params:
+          file: generated-cf-certs/cf-certs.tar.gz
+
+  - name: delete-old-cf-internal-certs
+    serial: true
+    plan:
+    - aggregate:
+      - get: paas-cf
+      - get: cf-certs
+    - task: delete-old-cf-internal-certs
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: governmentpaas/certstrap
+            tag: 465642da06051a55630d39c899697b678f66a7f7
+        inputs:
+          - name: paas-cf
+          - name: cf-certs
+        outputs:
+          - name: generated-cf-certs
+        run:
+          path: sh
+          args:
+            - -e
+            - -c
+            - |
+              mkdir certs
+              echo "Extracting extant certs"
+              tar -xvzf cf-certs/cf-certs.tar.gz -C certs
+
+              rm -vf certs/*_old.*
+
+              echo "Creating updated cert tarball"
+              cd certs
+              tar -cvzf ../generated-cf-certs/cf-certs.tar.gz .
+      on_success:
+        put: cf-certs
+        params:
+          file: generated-cf-certs/cf-certs.tar.gz
 
   - name: generate-git-keys
     plan:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -464,7 +464,7 @@ jobs:
                 - -c
                 - |
                   if  [ -z "$(tar -tvzf existing-ipsec-CA/ipsec-CA.tar.gz)" ] ; then
-                    certstrap init --passphrase "" --common-name ipsec-CA
+                    certstrap init --years "10" --passphrase "" --common-name ipsec-CA
                     (cd out && tar -cvzf ../generated-ipsec-CA/ipsec-CA.tar.gz ipsec-CA.*)
                   else
                     echo "The CA cert already exists, skipping generation..."

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -457,6 +457,8 @@ properties:
         keys:
           default:
             signingKey: (( grab secrets.uaa_jwt_signing_key ))
+          previous:
+            signingKey: (( grab secrets.uaa_jwt_signing_key_old || secrets.uaa_jwt_signing_key ))
         refreshTokenValiditySeconds: 604800
         global:
           refreshTokenValiditySeconds: 604800

--- a/manifests/cf-manifest/scripts/generate-cf-certs.sh
+++ b/manifests/cf-manifest/scripts/generate-cf-certs.sh
@@ -3,8 +3,6 @@
 set -e
 set -u
 
-CERTS_DIR=$(cd "$1" && pwd)
-CA_TARBALL="$2"
 CA_NAME="bosh-CA"
 
 # shellcheck disable=SC2154
@@ -20,6 +18,9 @@ SYSTEM_DOMAINS="*.${SYSTEM_DNS_ZONE_NAME},${SYSTEM_DNS_ZONE_NAME}"
 # Note: ALWAYS add a comma after <name_cert>, even if there are no domains
 #
 CERTS_TO_GENERATE="
+apps_domain,${APPS_DOMAINS}
+system_domain,${SYSTEM_DOMAINS}
+saml,
 auctioneer_server,auctioneer.service.cf.internal
 auctioneer_client,
 bbs_server,bbs.service.cf.internal
@@ -29,8 +30,6 @@ uaa_jwt_signing,
 uaa_internal,uaa.service.cf.internal
 consul_server,server.dc1.cf.internal,server.dc2.cf.internal
 consul_agent,
-apps_domain,${APPS_DOMAINS}
-system_domain,${SYSTEM_DOMAINS}
 doppler,
 metron,
 trafficcontroller,
@@ -38,7 +37,6 @@ cc_trafficcontroller,
 rep_server,*.cell.service.cf.internal,cell.service.cf.internal
 rep_client,
 reverse_log_proxy,
-saml,
 statsd_injector,
 scalablesyslog_adapter,
 scalablesyslog_adapter_scheduler_api,
@@ -47,6 +45,65 @@ cc_server,cloud-controller-ng.service.cf.internal
 cc_client,
 cc_uploader_server,cc-uploader.service.cf.internal
 "
+
+# Certificates that will not be rotated
+ROTATION_BLACK_LIST="
+apps_domain
+system_domain
+"
+
+generate_cert() {
+  _cn="${1}"
+  _domains="${2}"
+  _target_dir="${3}"
+
+  certstrap request-cert \
+    --passphrase "" \
+    --common-name "${_cn}" \
+		${domains:+--domain "${_domains}"}
+  certstrap sign \
+    --CA "${CA_NAME}" \
+    --passphrase "" \
+    --years "2" \
+    "${_cn}"
+
+  mv "out/${_cn}.key" "${_target_dir}/"
+  mv "out/${_cn}.csr" "${_target_dir}/"
+  mv "out/${_cn}.crt" "${_target_dir}/"
+}
+
+rotate_cert() {
+  _cn="${1}"
+  _domains="${2}"
+  _target_dir="${3}"
+
+  mv "${_target_dir}/${_cn}.key" "${_target_dir}/${_cn}_old.key"
+  mv "${_target_dir}/${_cn}.csr" "${_target_dir}/${_cn}_old.csr"
+  mv "${_target_dir}/${_cn}.crt" "${_target_dir}/${_cn}_old.crt"
+
+  generate_cert "${_cn}" "${_domains}" "${_target_dir}"
+}
+
+is_cert_blacklisted() {
+  _cn="$1"
+  for blacklisted_cert in ${ROTATION_BLACK_LIST}; do
+    if [ "${_cn}" = "${blacklisted_cert}" ];then
+      return 0
+    fi
+  done
+  return 1
+}
+
+CERTS_DIR=$(cd "$1" && pwd)
+CA_TARBALL="$2"
+ACTION="${3:-}"
+if [ "${ACTION}" != "create" ] && [ "${ACTION}" != "rotate" ]; then
+  cat <<EOF
+Usage:
+  $0 <create|rotate>
+EOF
+  exit 1
+fi
 
 WORKING_DIR="$(mktemp -dt generate-cf-certs.XXXXXX)"
 trap 'rm -rf "${WORKING_DIR}"' EXIT
@@ -61,13 +118,20 @@ for cert_entry in ${CERTS_TO_GENERATE}; do
   domains=${cert_entry#*,}
 
   if [ -f "${CERTS_DIR}/${cn}.crt" ]; then
-    echo "Certificate ${cn} is already generated, skipping."
+    echo "Certificate ${cn} is already generated."
+    if [ "${ACTION}" = "rotate" ]; then
+      if is_cert_blacklisted "${cn}"; then
+        echo "Certificate ${cn} is blacklisted for rotation. Skipping."
+      else
+        echo "Rotating certificate..."
+        rotate_cert "${cn}" "${domains}" "${CERTS_DIR}"
+      fi
+    else
+      echo "Skipping creation."
+    fi
   else
-    certstrap request-cert --passphrase "" --common-name "${cn}" ${domains:+--domain "${domains}"}
-    certstrap sign --CA "${CA_NAME}" --passphrase "" "${cn}"
-    mv "out/${cn}.key" "${CERTS_DIR}/"
-    mv "out/${cn}.csr" "${CERTS_DIR}/"
-    mv "out/${cn}.crt" "${CERTS_DIR}/"
+    echo "Creating certificate ${cn}..."
+    generate_cert "${cn}" "${domains}" "${CERTS_DIR}"
   fi
 done
 


### PR DESCRIPTION
[#149928858 Deal with internal TLS certs expiring before March] https://www.pivotaltracker.com/n/projects/1275640/stories/149928858

What?
----

We want to be able to rotate the CF internal certificates in a automated
fashion, in a similar way we rotate other CF credentials.

Some public facing certs, like app or sys domains, won't be rotated with
this operation.

How to review?
-------

 - Code review.  See commit for implementation details
 - Rotate the certs:
    1. Run the job rotate-cf-internal-certs
    2. rerun the deploy script. There should be no downtime in the apis but a pair of expected `CF-StatsUnavailable` (fixed by https://github.com/alphagov/paas-cf/pull/1183)
    3. Check you can use the platform, or run acceptance tests.
 - Delete old certs:
    1. run the job delete-old-cf-internal-certs
    2. redeploy and test the platform again
 -  You can check certstrap args with: `docker run -ti governmentpaas/certstrap:465642da06051a55630d39c899697b678f66a7f7 certstrap init -h` or `docker run -ti governmentpaas/certstrap:465642da06051a55630d39c899697b678f66a7f7 certstrap sign -h`

Who?
---

Anyone but @keymon or @LeePorte