### PR TITLE
[#134014357] Upgrade syslog release 

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -182,7 +182,7 @@ properties:
       cert_chain: (( grab secrets.router_internal_cert ))
       private_key: (( grab secrets.router_internal_key ))
     enable_ssl: false
-    enable_access_log_streaming: true
+    enable_access_log_streaming: false
     status:
       user: router_user
       password: (( grab secrets.router_password ))

--- a/manifests/cf-manifest/manifest/800-logsearch.yml
+++ b/manifests/cf-manifest/manifest/800-logsearch.yml
@@ -4,10 +4,9 @@ releases:
   version: 203.0.0
   sha1: 4872c3d89fb2587d844dabbc93b124fb43b720d8
 - name: logsearch-for-cloudfoundry
-  version: 0.1.2
-  url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/logsearch-for-cloudfoundry-0.1.2.tgz
-  sha1: 9e124f94e36fbc2521b8bf12c3f1ffa7eec03ffd
-
+  version: 0.1.3
+  url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/logsearch-for-cloudfoundry-0.1.3.tgz
+  sha1: 5b7618c22224dfe7c1948dfad009aff1cdf661c4
 jobs:
 - (( append ))
 - name: queue

--- a/manifests/cf-manifest/manifest/800-logsearch.yml
+++ b/manifests/cf-manifest/manifest/800-logsearch.yml
@@ -225,6 +225,18 @@ properties:
         remove_field => [ "[nginx][timestamp]" ]
       }
 
+      # Remove unnecessary or empty fields
+      mutate {
+        remove_field => [
+          "syslog5424_ver",
+          "syslog_msgid",
+          "syslog_procid",
+          "syslog_sd_id",
+          "syslog_sd_params",
+          "[@source][director]"
+        ]
+      }
+
   curator:
     purge_logs:
       retention_period: 30

--- a/manifests/cf-manifest/manifest/800-logsearch.yml
+++ b/manifests/cf-manifest/manifest/800-logsearch.yml
@@ -176,14 +176,6 @@ properties:
       - logstash: /var/vcap/packages/logsearch-for-cloudfoundry-filters/logstash-filters-default.conf
       - custom-filters: /var/vcap/jobs/logsearch-for-cloudfoundry-filters/config/logstash-filters-custom.conf
     custom_filters: |
-      if ("lrps" in [auctioneer][data]) {
-        ruby {
-          code => '
-            lrps_hash = event["auctioneer"]["data"]["lrps"]
-            event["auctioneer"]["data"]["lrps"] = lrps_hash.keys
-          '
-        }
-      }
       if [@source][component] == "gorouter" {
         mutate { replace => { "type" => "gorouter" } }
         grok {

--- a/manifests/cf-manifest/spec/manifest/router_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/router_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe "router properties" do
   let(:manifest) { manifest_with_defaults }
   let(:properties) { manifest.fetch("properties") }
 
-  it "streams the access_logs to logging" do
+  it "does not streams the access_logs to syslog" do
     enable_access_log_streaming = properties.fetch("router").fetch("enable_access_log_streaming")
-    expect(enable_access_log_streaming).to be true
+    expect(enable_access_log_streaming).to be false
   end
 end


### PR DESCRIPTION
## What

This PR updates the logsearch filters we are using to be in line with the upstream release of logsearch. It also removes a no longer required filter.

## How to review

In Dev

1. Code review and run https://github.com/alphagov/paas-bootstrap/pull/127
    ```BRANCH=upgrade_syslog_release_134014357 make dev deployer-concourse pipelines```
1. Code review  #https://github.com/alphagov/paas-logsearch-for-cloudfoundry/pull/3
1. Code review and run this branch
    ```BRANCH=upgrade_syslog_release_134014357 make dev pipelines```
1. Ensure logs are still being delivered to the ELK stack

## How to release

1. Merge https://github.com/alphagov/paas-logsearch-for-cloudfoundry/pull/3 and update the temp commit in this PR with the final build created in CI
1. Merge this PR and run the create-cloudfoundry pipeline 
1. Merge https://github.com/alphagov/paas-bootstrap/pull/127 and run the create-bosh-concourse pipeline
1. Run the create-cloudfoundry pipeline again
1. Review https://github.com/alphagov/paas-team-manual/pull/180 for clarity in wording and merge.

## Who can review

Not @LeePorte or @bandesz
