### PR TITLE
[#146463199] Do not require full window of CDN TLS metrics

### DIFF
--- a/terraform/datadog/certificates.tf
+++ b/terraform/datadog/certificates.tf
@@ -22,11 +22,11 @@ resource "datadog_monitor" "invalid_cdn_tls_cert" {
   type              = "metric alert"
   message           = "${format("{{hostname.name}} CloudFront certificate {{#is_alert}}is invalid!{{/is_alert}}{{#is_warning}}expires in {{value}} days{{/is_warning}}\n\nSee [Team Manual > Responding to alerts > Invalid Certificates](%s#invalid-certificates) for more info.", var.datadog_documentation_url)}"
   notify_no_data    = true
-  no_data_timeframe = 240
+  no_data_timeframe = 480
 
   query = "${format("min(last_4h):min:cdn.tls.certificates.validity{deploy_env:%s} by {hostname} <= 7", var.env)}"
 
-  require_full_window = true
+  require_full_window = false
 
   thresholds {
     warning  = 21


### PR DESCRIPTION
## What

We have been getting 'no data' alerts in prod for this monitor.  These
metrics are only collected every hour, which seems to be too sparse for
Datadog to consider it a 'full window' of data[1]. Also, Datadog advise
the 'no data' period be at least twice the window being evaluated.

[1] https://help.datadoghq.com/hc/en-us/articles/115002630843?input_string=no_data+alerts

## How to review

Using the Datadog console. Make these changes manually and confirm the monitor turns healthy (should take 1 minute, as Datadog refreshes the monitor every minute).

## Who can review

Preferably @camelpunch, as he has context. Failing that, anybody else.
