### PR TITLE
[WIP] [#185157352] Adopt use of fewer Elasticache Parameter groups

### DIFF
--- a/manifests/cf-manifest/manifest/070-elasticache-broker.yml
+++ b/manifests/cf-manifest/manifest/070-elasticache-broker.yml
@@ -43,22 +43,55 @@ jobs:
               bindable: true
               plan_updateable: false
               plans:
-                - id: 3a51701c-eef3-447c-882b-907ad2bcb7ab
-                  name: tiny
-                  description: 568MB RAM, 1 shard, single node, no backups, no failover
+                - id: 3a51701c-eef3-447c-882b-907ad2bcb7ac
+                  name: tiny-volatile-ttl
+                  description: 568MB RAM, 1 shard, single node, volatile-ttl maxmemory-policy, no backups, no failover
                   free: true
                   metadata:
-                    displayName: Redis Tiny
+                    displayName: Redis Tiny volatile-ttl
+                - id: 3a51701c-eef3-447c-882b-907ad2bcb7ad
+                  name: tiny-allkeys-random
+                  description: 568MB RAM, 1 shard, single node, allkeys-random maxmemory-policy, no backups, no failover
+                  free: true
+                  metadata:
+                    displayName: Redis Tiny allkeys-random
+                - id: 3a51701c-eef3-447c-882b-907ad2bcb7ae
+                  name: tiny-allkeys-lru
+                  description: 568MB RAM, 1 shard, single node, allkeys-lru maxmemory-policy, no backups, no failover
+                  free: true
+                  metadata:
+                    displayName: Redis Tiny allkeys-lru
 
         plan_configs:
-          3a51701c-eef3-447c-882b-907ad2bcb7ab:
+          3a51701c-eef3-447c-882b-907ad2bcb7ac:
             instance_type: cache.t2.micro
             replicas_per_node_group: 0
             shard_count: 1
             snapshot_retention_limit: 0
             automatic_failover_enabled: false
+            cache_parameter_group_name: tiny-volatile-ttl
             parameters:
-              maxmemory-policy: volatile-lru
+              maxmemory-policy: volatile-ttl
+              reserved-memory: '0'
+          3a51701c-eef3-447c-882b-907ad2bcb7ad:
+            instance_type: cache.t2.micro
+            replicas_per_node_group: 0
+            shard_count: 1
+            snapshot_retention_limit: 0
+            automatic_failover_enabled: false
+            cache_parameter_group_name: tiny-allkeys-random
+            parameters:
+              maxmemory-policy: allkeys-random
+              reserved-memory: '0'
+          3a51701c-eef3-447c-882b-907ad2bcb7ae:
+            instance_type: cache.t2.micro
+            replicas_per_node_group: 0
+            shard_count: 1
+            snapshot_retention_limit: 0
+            automatic_failover_enabled: false
+            cache_parameter_group_name: tiny-allkeys-lru
+            parameters:
+              maxmemory-policy: allkeys-lru
               reserved-memory: '0'
 
 properties:

--- a/manifests/cf-manifest/manifest/070-elasticache-broker.yml
+++ b/manifests/cf-manifest/manifest/070-elasticache-broker.yml
@@ -1,8 +1,8 @@
 releases:
   - name: elasticache-broker
-    version: 0.0.1517235806
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/elasticache-broker-0.0.1517235806.tgz
-    sha1: 3f0375bd2f95dacfa154fabe0c3c16255e70b7e1
+    version: 0.0.1517306780
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/elasticache-broker-0.0.1517306780.tgz
+    sha1: 95af149bcb496fc3450ca74dac6b89d2c883f175
 jobs:
   - name: elasticache_broker
     azs: [z1, z2]

--- a/manifests/cf-manifest/manifest/070-elasticache-broker.yml
+++ b/manifests/cf-manifest/manifest/070-elasticache-broker.yml
@@ -1,9 +1,8 @@
 releases:
   - name: elasticache-broker
-    version: 0.1.2
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/elasticache-broker-0.1.2.tgz
-    sha1: 0095601a8b6d6355f8bc1a5a40923a76cd980990
-
+    version: 0.0.1517235806
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/elasticache-broker-0.0.1517235806.tgz
+    sha1: 3f0375bd2f95dacfa154fabe0c3c16255e70b7e1
 jobs:
   - name: elasticache_broker
     azs: [z1, z2]

--- a/manifests/cf-manifest/manifest/070-elasticache-broker.yml
+++ b/manifests/cf-manifest/manifest/070-elasticache-broker.yml
@@ -72,7 +72,7 @@ jobs:
             cache_parameter_group_name: tiny-volatile-ttl
             parameters:
               maxmemory-policy: volatile-ttl
-              reserved-memory: '0'
+              reserved-memory-percent: 25
           3a51701c-eef3-447c-882b-907ad2bcb7ad:
             instance_type: cache.t2.micro
             replicas_per_node_group: 0
@@ -82,7 +82,7 @@ jobs:
             cache_parameter_group_name: tiny-allkeys-random
             parameters:
               maxmemory-policy: allkeys-random
-              reserved-memory: '0'
+              reserved-memory-percent: 25
           3a51701c-eef3-447c-882b-907ad2bcb7ae:
             instance_type: cache.t2.micro
             replicas_per_node_group: 0
@@ -92,7 +92,7 @@ jobs:
             cache_parameter_group_name: tiny-allkeys-lru
             parameters:
               maxmemory-policy: allkeys-lru
-              reserved-memory: '0'
+              reserved-memory-percent: 25
 
 properties:
   cc:

--- a/manifests/cf-manifest/manifest/070-elasticache-broker.yml
+++ b/manifests/cf-manifest/manifest/070-elasticache-broker.yml
@@ -72,7 +72,7 @@ jobs:
             cache_parameter_group_name: tiny-volatile-ttl
             parameters:
               maxmemory-policy: volatile-ttl
-              reserved-memory-percent: 25
+              reserved-memory-percent: '25'
           3a51701c-eef3-447c-882b-907ad2bcb7ad:
             instance_type: cache.t2.micro
             replicas_per_node_group: 0
@@ -82,7 +82,7 @@ jobs:
             cache_parameter_group_name: tiny-allkeys-random
             parameters:
               maxmemory-policy: allkeys-random
-              reserved-memory-percent: 25
+              reserved-memory-percent: '25'
           3a51701c-eef3-447c-882b-907ad2bcb7ae:
             instance_type: cache.t2.micro
             replicas_per_node_group: 0
@@ -92,7 +92,7 @@ jobs:
             cache_parameter_group_name: tiny-allkeys-lru
             parameters:
               maxmemory-policy: allkeys-lru
-              reserved-memory-percent: 25
+              reserved-memory-percent: '25'
 
 properties:
   cc:

--- a/platform-tests/src/platform/acceptance/redis_service_test.go
+++ b/platform-tests/src/platform/acceptance/redis_service_test.go
@@ -16,7 +16,7 @@ import (
 var _ = Describe("Redis backing service", func() {
 	const (
 		serviceName  = "redis"
-		testPlanName = "tiny"
+		testPlanName = "tiny-allkeys-random"
 	)
 
 	It("is registered in the marketplace", func() {


### PR DESCRIPTION
## What

Use the [updated Elasticache broker](https://github.com/alphagov/paas-elasticache-broker/pull/8) that uses fewer Elasticache parameter groups. We can no longer specify the Redis `maxmemory-policy` when `cf create-service-instance`, so also add a plan for each of those that suit our expected usecases.

## How to review

* Check the plans are suitable
* Deploy to dev and check that you can provision yourself a nice Redis

## 🐝 Before merge!

Make sure to update the WIP commit to point to the merged release of the Elasticache broker.

## Who can review

Not @46bit @chrisfarms 