### PR TITLE
[#154477526] Run the smoke tests from paas-cf-smoke-tests

### DIFF
--- a/platform-tests/upstream/run_smoke_tests.sh
+++ b/platform-tests/upstream/run_smoke_tests.sh
@@ -2,6 +2,22 @@
 
 set -eu
 
+# FIXME: Remove this once https://github.com/cloudfoundry/cf-smoke-tests/pull/39 was merged
+# and our CF release contains the fix.
+(
+  cd  "$(pwd)/cf-release/src/smoke-tests/"
+  expected_commit_hash="1f219aa5cb8f3b6bfad312654ca66ff54d0cae5e"
+  current_commit_hash="$(git log --pretty=format:'%H' -n 1)"
+  if [ "${expected_commit_hash}" != "${current_commit_hash}" ]; then
+    echo "ERROR: Current commit for smoke-tests is different than expected one: ${expected_commit_hash} != ${current_commit_hash}"
+    echo "Double check if we still need to pull our branch"
+    exit 1
+  fi
+  git remote add alphagov https://github.com/alphagov/paas-cf-smoke-tests.git
+  git fetch alphagov
+  git checkout fix_app_scale_tests_154477526
+)
+
 export CONFIG
 CONFIG="$(pwd)/test-config/config.json"
 


### PR DESCRIPTION
## What

We had to fix the smoke tests because of a tightly timed test which used to fail randomly.

In the "can be pushed, scaled and deleted" tests the application is upscaled to two instances. The tests wait until both application instances are in a running state and run up to 30 requests to check whether both instances get traffic.

The timing of these tests are really tight, as the route registration can be still pending even if the API returns a running state for the second instance and the requests are too quick (we are seeing only ~400ms for all 30 requests). In rare cases the tests fail although the route is eventually registered a little bit later (some hundreds of milliseconds).

We add some sleep between the requests, which adds an extra 5 seconds window for the new route registration to finish.

We used the previously applied pattern to override the cf-smoke-tests git submodule before running the tests and include a check whether we need to update or remove our fork if the submodule was updated in a new release.

## Related PRs

* paas-cf-smoke-tests: https://github.com/alphagov/paas-cf-smoke-tests/pull/1
* cf-smoke-tests: https://github.com/cloudfoundry/cf-smoke-tests/pull/39

## How to review

1. Review and merge https://github.com/alphagov/paas-cf-smoke-tests/pull/1 first
1. Delete the branch and create a tag on paas-cf-smoke-tests on gds_master called fix_app_scale_tests_154477526 (same name as the branch) - this is to avoid the branch accidentally being deleted
1. Deploy your CF from this branch successfully
    ```BRANCH=fix_app_scale_tests_154477526 make dev pipelines```

## Who can review

Not @henrytk or @bandesz
