### PR TITLE
[#149928858] Fix wrong name for old jwt signing key

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -458,7 +458,7 @@ properties:
           default:
             signingKey: (( grab secrets.uaa_jwt_signing_key ))
           previous:
-            signingKey: (( grab secrets.uaa_jwt_signing_key_old || secrets.uaa_jwt_signing_key ))
+            signingKey: (( grab secrets.uaa_jwt_signing_old_key || secrets.uaa_jwt_signing_key ))
         refreshTokenValiditySeconds: 604800
         global:
           refreshTokenValiditySeconds: 604800

--- a/manifests/cf-manifest/spec/manifest/uaa_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/uaa_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe "uaa properties" do
+  context "with the default certificates" do
+    let(:manifest) { manifest_with_defaults }
+    let(:properties) { manifest.fetch("properties") }
+
+    it "has the same certificate for jwt policy signing keys" do
+      jwt_keys = properties.fetch("uaa").fetch("jwt").fetch("policy").fetch("keys")
+      default_key = jwt_keys.fetch("default")
+      previous_key = jwt_keys.fetch("previous")
+      expect(default_key.fetch("signingKey")).not_to be_empty
+      expect(default_key).to eq(previous_key)
+    end
+  end
+  context "with and old certificate for jwt signing" do
+    let(:manifest) {
+      manifest_with_custom_stub %{---
+secrets:
+  uaa_jwt_signing_old_key: |
+    -----BEGIN RSA PRIVATE KEY-----
+    STUB_UAA_JWT_SIGNING_KEY_111111111111111111111111111111111111111
+    1111111111111111111111111111111111111111111111111111111111111111
+    1111111111111111111111111111111111111111111111111111111111111111
+    1111111111111111111111111111111111111111111111111111111111111111
+    1111111111111111111111111111111111111111111111111111111111111111
+    -----END RSA PRIVATE KEY-----}
+    }
+    let(:properties) { manifest.fetch("properties") }
+
+    it "has a different certificate for jwt policy signing keys" do
+      jwt_keys = properties.fetch("uaa").fetch("jwt").fetch("policy").fetch("keys")
+      default_key = jwt_keys.fetch("default")
+      previous_key = jwt_keys.fetch("previous")
+      expect(default_key.fetch("signingKey")).not_to be_empty
+      expect(default_key).not_to eq(previous_key)
+    end
+  end
+end

--- a/manifests/cf-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/cf-manifest/spec/support/manifest_helpers.rb
@@ -18,6 +18,14 @@ module ManifestHelpers
     Cache.instance.manifest_with_defaults ||= render_manifest
   end
 
+  def manifest_with_custom_stub(stub_content)
+    Tempfile.open(['custom-stub', '.yml']) do |file|
+      file.write(stub_content)
+      file.flush
+      render_manifest("default", [file.path])
+    end
+  end
+
   def cloud_config_with_defaults
     Cache.instance.cloud_config_with_defaults ||= render_cloud_config
   end
@@ -66,7 +74,7 @@ private
     file
   end
 
-  def render_manifest(environment = "default")
+  def render_manifest(environment = "default", extra_stubs = [])
     manifest = render([
         File.expand_path("../../../../shared/build_manifest.sh", __FILE__),
         File.expand_path("../../../manifest/*.yml", __FILE__),
@@ -78,7 +86,7 @@ private
         File.expand_path("../../../cell.yml", __FILE__),
         File.expand_path("../../../env-specific/cf-#{environment}.yml", __FILE__),
         File.expand_path("../../../stubs/datadog-nozzle.yml", __FILE__),
-    ])
+    ].concat(extra_stubs))
 
     # Deep freeze the object so that it's safe to use across multiple examples
     # without risk of state leaking.


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/149928858

What?
-----

Follow up of https://github.com/alphagov/paas-cf/pull/1184

We made a typo in the name of the key when pulling the old jwt
signing key for UAA during the certificate rotation.

The name should be <cert-name> + _old + _key, as per [1].

The issue would be shadowed by spruce, as we pull a default value
if the key is not defined. We added a test for this specific
case in the manifest.

[1] https://github.com/alphagov/paas-cf/blob/0567d631f09a8b352fc8629375a81731f523069a/concourse/pipelines/create-cloudfoundry.yml#L1304-L1313

How to review?
----------

Code review, the tests in travis shall run.

Who?
----

Anyone but @keymon, likely @alext