### PR TITLE
[#154764726] Improve deployment kickoff pipeline

### DIFF
--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -13,8 +13,8 @@ resources:
     source:
       days: [Monday, Tuesday, Wednesday, Thursday, Friday]
       location: Europe/London
-      start: 7:45 AM
-      stop: 8:15 AM
+      start: 7:00 AM
+      stop: 7:30 AM
 
 jobs:
   - name: kick-off

--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -4,7 +4,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-cf.git
-      branch: ((branch_name))
+      branch: master
       tag_filter: ((paas_cf_tag_filter))
       commit_verification_key_ids: ((gpg_ids))
 


### PR DESCRIPTION
## What

A Couple of tweaks to this pipeline:

* Pin it to master branch of paas-cf - for consistency with the autodelete, and so that it resumes RDS instances, even if the dev branch no longer exists.
* Trigger the job earlier - since we increased the splay, this hasn't been completing in time to be used for some people.

## How to review

Code review is probably enough.

## Who can review

Not me.