### PR TITLE
[#154332167] Enable redis backups

### DIFF
--- a/manifests/cf-manifest/manifest/070-elasticache-broker.yml
+++ b/manifests/cf-manifest/manifest/070-elasticache-broker.yml
@@ -56,8 +56,7 @@ jobs:
             instance_type: cache.t2.micro
             replicas_per_node_group: 0
             shard_count: 1
-            snapshot_retention_limit: 0
-            automatic_failover_enabled: false
+            snapshot_retention_limit: 7
             parameters:
               maxmemory-policy: volatile-lru
               reserved-memory: '0'

--- a/manifests/cf-manifest/manifest/070-elasticache-broker.yml
+++ b/manifests/cf-manifest/manifest/070-elasticache-broker.yml
@@ -1,8 +1,8 @@
 releases:
   - name: elasticache-broker
-    version: 0.1.2
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/elasticache-broker-0.1.2.tgz
-    sha1: 0095601a8b6d6355f8bc1a5a40923a76cd980990
+    version: 0.1.3
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/elasticache-broker-0.1.3.tgz
+    sha1: 843c38df9efb3a11f58aa95c40ab2fac13694c38
 
 jobs:
   - name: elasticache_broker


### PR DESCRIPTION
## What

We want to enable backups of Elasticache Redis instances.

## How to review

Review https://github.com/alphagov/paas-elasticache-broker/pull/9 and then https://github.com/alphagov/paas-elasticache-broker-boshrelease/pull/5 first. The [final release of the Bosh release](https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/elasticache-broker-release) will provide the manifest details to replace the temporary commit on this branch. 

* deploy
* check custom acceptance tests pass

We've created a tiny Redis instance already, so you can check with our whether a backup has been created. If you want to do it yourself:

* `cf enable-service-access redis`
* create a tiny Redis instance
* [wait for 1 day](http://fabquote.co/every-day-you-wait-is-one-day-youll-never-get-back-quote/)
* check a backup is created

## Before merging ⚠️ 

Replace the temporary commit with details from the [final release of the Bosh release](https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/elasticache-broker-release) 

## Who can review

Anyone but me or @chrisfarms 
