### PR TITLE
[support] Fix the tagged version of paas-billing

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -273,7 +273,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-billing
-      tag_filter: 0.7.0
+      tag_filter: v0.7.0
 
 jobs:
   - name: pipeline-lock


### PR DESCRIPTION
## What

This hasn't been spotted upon review and resulted in stalling the
concourse pipeline in staging. The GitHub repo, has the tags prefixed
with a letter `v`, which in upgrade from `v0.6.0` to `0.7.0` has been
omitted.

Adding it back to merge in quickly.

## How to review

- Check for sanity
- Ideally, run the DEV pipeline from branch to confirm
