### PR TITLE
[#134014357] Revert "Stop sending gorouter logs to syslog"

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -182,7 +182,7 @@ properties:
       cert_chain: (( grab secrets.router_internal_cert ))
       private_key: (( grab secrets.router_internal_key ))
     enable_ssl: false
-    enable_access_log_streaming: false
+    enable_access_log_streaming: true
     status:
       user: router_user
       password: (( grab secrets.router_password ))

--- a/manifests/cf-manifest/spec/manifest/router_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/router_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe "router properties" do
   let(:manifest) { manifest_with_defaults }
   let(:properties) { manifest.fetch("properties") }
 
-  it "does not streams the access_logs to syslog" do
+  it "streams the access_logs to logging" do
     enable_access_log_streaming = properties.fetch("router").fetch("enable_access_log_streaming")
-    expect(enable_access_log_streaming).to be false
+    expect(enable_access_log_streaming).to be true
   end
 end


### PR DESCRIPTION
## What

We disabled sending the gorouter access logs to syslog as we planned to enable Blackbox which would pick up the access logs from files. At this moment the access logs are not sent to Logsearch at all.

This reverts commit b3b25e4e9592f96775dc9cd7fbb109d51005f84c.

By enabling blackbox some logs written by the logger command are written to the
disk six times wouch could cause disk fillup and adverse effects on CPU and
disk usage.
Blackbox duplicates the logs handled by the logger command as usually the job
scripts write the logs both to a file and syslog. See [2].

In the latest syslog release notes [1] they only able to partially solve the
issue, that these duplicated logs are not sent to Logsearch but still written
to the disk duplicated.

We decided to not enable blackbox (syslog.forward_files) and wait for a
solution from upstream.

Because of this we have to reenable sending the access logs directly to syslog.

[1] https://github.com/cloudfoundry/syslog-release/releases/tag/v11.1.1
[2] cloudfoundry/syslog-release#31

## How to review

1. Update your CF from this branch
    ```BRANCH=disable_blackbox_134014357 paas-dev make dev pipelines```
2. Validate in Kibana that you see the access logs.

## Who can review

Not @bandesz
