### PR TITLE
[#154332832] Upgrade compose broker

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -260,7 +260,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-compose-broker
-      tag_filter: v0.14.0
+      tag_filter: v0.15.0
 
   - name: paas-compose-scraper
     type: git


### PR DESCRIPTION
## What

Update the Compose broker to allow tenants to restore backups as new service instances for Elasticsearch and MongoDB.

We didn't add tests for restoring Redis as we will remove it from the broker in the near future.

## How to review

* Review https://github.com/alphagov/paas-compose-broker/pull/24
* Check if the integration tests on the build CI pass

# How to release

Review and merge https://github.com/alphagov/paas-compose-broker/pull/24 first.

❗️ Replace the temporary commit in this branch to point the paas-compose-broker repository to the latest release tag (similarly to what was done in https://github.com/alphagov/paas-cf/commit/0e401ba0.)

## Who can review

Not @LeePorte, @46bit or @bandesz
