### PR TITLE
[#154879166] Bump stemcell version to 3468.19

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -101,7 +101,7 @@ releases:
 stemcells:
   - alias: default
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3468.17"
+    version: "3468.19"
 
 update:
   canaries: 0


### PR DESCRIPTION
## What

Due to [USN-3534], we'd like to upgrade our stemcell to the version that
fixes the vulnerabilities. The USN info mention it to be version 3468.19
which happens to be the closest one to ours.

[USN-3534]: https://www.cloudfoundry.org/blog/usn-3534-1/

## How to review

- Sanity check - validate the version used is sufficient
- Deploy from this branch
- Run `create-cloudfoundry` pipeline (running mine at the moment)
- Expect successes
