### PR TITLE
[#154332167] Remove 'no backups' from Redis plan description.

### DIFF
--- a/manifests/cf-manifest/manifest/070-elasticache-broker.yml
+++ b/manifests/cf-manifest/manifest/070-elasticache-broker.yml
@@ -46,7 +46,7 @@ jobs:
               plans:
                 - id: 3a51701c-eef3-447c-882b-907ad2bcb7ab
                   name: tiny
-                  description: 568MB RAM, 1 shard, single node, no backups, no failover
+                  description: 568MB RAM, 1 shard, single node, no failover
                   free: true
                   metadata:
                     displayName: Redis Tiny


### PR DESCRIPTION
## What

We enabled automated backups in
https://github.com/alphagov/paas-cf/pull/1199, so this entry in the
description is no longer correct.

## How to review

Verify the rationale makes sense.

## Who can review

Not me.