### PR TITLE
[Support] Change ES instance type to compute optimised

### DIFF
--- a/manifests/cf-manifest/cloud-config/030-logsearch.yml
+++ b/manifests/cf-manifest/cloud-config/030-logsearch.yml
@@ -22,7 +22,7 @@ vm_types:
     network: (( grab vm_types.medium.network ))
     env: (( grab meta.default_env ))
     cloud_properties:
-      instance_type: m4.large
+      instance_type: c4.xlarge
       ephemeral_disk:
         size: 10240
         type: gp2


### PR DESCRIPTION
## What

This PR changes the instance type used by Elasticsearch to a compute
optimised type as we are currently hitting the CPU limits of the general
purpose instance type.

## How to review

Code review and deploy this branch to dev

## Who can review

Not @LeePorte