### PR TITLE
[#154959067] Remove UAA, Product Page, and Tech Docs DNS

### DIFF
--- a/terraform/cloudfoundry/dns-records.tf
+++ b/terraform/cloudfoundry/dns-records.tf
@@ -38,6 +38,18 @@ resource "aws_route53_record" "apps_wildcard" {
   records = ["${aws_elb.cf_router.dns_name}"]
 }
 
+resource "aws_route53_record" "system_apex" {
+  zone_id = "${var.system_dns_zone_id}"
+  name    = "${var.system_dns_zone_name}."
+  type    = "A"
+
+  alias {
+    name                   = "${aws_elb.cf_router_system_domain.dns_name}"
+    zone_id                = "${aws_elb.cf_router_system_domain.zone_id}"
+    evaluate_target_health = true
+  }
+}
+
 resource "aws_route53_record" "apps_apex" {
   zone_id = "${var.apps_dns_zone_id}"
   name    = "${var.apps_dns_zone_name}."

--- a/terraform/cloudfoundry/dns-records.tf
+++ b/terraform/cloudfoundry/dns-records.tf
@@ -6,22 +6,6 @@ resource "aws_route53_record" "cf_cc" {
   records = ["${aws_elb.cf_cc.dns_name}"]
 }
 
-resource "aws_route53_record" "cf_uaa" {
-  zone_id = "${var.system_dns_zone_id}"
-  name    = "uaa.${var.system_dns_zone_name}."
-  type    = "CNAME"
-  ttl     = "60"
-  records = ["${aws_elb.cf_uaa.dns_name}"]
-}
-
-resource "aws_route53_record" "cf_login" {
-  zone_id = "${var.system_dns_zone_id}"
-  name    = "login.${var.system_dns_zone_name}."
-  type    = "CNAME"
-  ttl     = "60"
-  records = ["${aws_elb.cf_uaa.dns_name}"]
-}
-
 resource "aws_route53_record" "cf_doppler" {
   zone_id = "${var.system_dns_zone_id}"
   name    = "doppler.${var.system_dns_zone_name}."

--- a/terraform/cloudfront/cloudfront_distribution/distribution.tf
+++ b/terraform/cloudfront/cloudfront_distribution/distribution.tf
@@ -1,13 +1,3 @@
-resource "aws_route53_record" "cdn_domain" {
-  count = "${length(var.aliases)}"
-
-  zone_id = "${var.system_dns_zone_id}"
-  name    = "${element(var.aliases, count.index)}."
-  type    = "CNAME"
-  ttl     = "60"
-  records = ["${aws_cloudfront_distribution.cdn_instance.domain_name}"]
-}
-
 resource "aws_cloudfront_distribution" "cdn_instance" {
   origin {
     domain_name = "${var.origin}"

--- a/terraform/cloudfront/cloudfront_redirect/distribution.tf
+++ b/terraform/cloudfront/cloudfront_redirect/distribution.tf
@@ -136,17 +136,3 @@ resource "aws_cloudfront_distribution" "simple_redirect" {
     ssl_support_method             = "sni-only"
   }
 }
-
-resource "aws_route53_record" "redirect_domain" {
-  count = "${length(var.aliases)}"
-
-  zone_id = "${var.dns_zone_id}"
-  name    = "${element(var.aliases, count.index)}."
-  type    = "A"
-
-  alias {
-    name                   = "${aws_cloudfront_distribution.simple_redirect.domain_name}"
-    zone_id                = "${aws_cloudfront_distribution.simple_redirect.hosted_zone_id }"
-    evaluate_target_health = true
-  }
-}


### PR DESCRIPTION
## What

Now that we have a system domain ELB, we can switch the DNS over (the wildcard DNS is already in place).

## How to review

~~⚠️ make sure https://github.com/alphagov/paas-cf/pull/1217 has at least started deploying to prod before merging.~~ Done.

You must have an existing deployment that includes https://github.com/alphagov/paas-cf/commit/e664eaffd27d27bdfabfac9b649d78ea0fdbbc83

It would also be useful to have CloudFront Distributions in place for the product page and tech docs.

⚠️ the Terraform needs to be run manually _before_ the deployment happens, to ensure the system domain apex DNS record remains in place. This is true for all environments, so you will have to sit and nurse this through staging and prod.

### Product Pages/Tech Docs

* Use the master branch to deploy the CloudFront Distributions. This will set up DNS. 
* Check traffic is routing correctly
* Switch to this branch and run the same Terraform in plan mode. It should want to destroy two DNS entries. Apply the changes. 
* Check with `dig` that the domain names are resolving to the new ELB.
* Hit the apps with requests to make sure the domains and redirects still work.

### UAA

Run the pipeline and traffic should still route to UAA (all tests should pass).

## Who can review

Preferably Alex, but really anybody but me.
