### PR TITLE
Fix pipeline pinning for acceptance tests.

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2460,11 +2460,11 @@ jobs:
     plan:
       - aggregate:
           - get: pipeline-trigger
-            passed: ['post-deploy']
+            passed: ['post-deploy','app-availability-tests','api-availability-tests']
             trigger: true
           - get: cf-acceptance-tests
           - get: paas-cf
-            passed: ['post-deploy']
+            passed: ['post-deploy','app-availability-tests','api-availability-tests']
           - get: cf-manifest
             passed: ['post-deploy']
           - get: bosh-CA
@@ -2521,10 +2521,10 @@ jobs:
     plan:
       - aggregate:
           - get: pipeline-trigger
-            passed: ['post-deploy']
+            passed: ['post-deploy','app-availability-tests','api-availability-tests']
             trigger: true
           - get: paas-cf
-            passed: ['post-deploy']
+            passed: ['post-deploy','app-availability-tests','api-availability-tests']
           - get: cf-manifest
             passed: ['post-deploy']
           - get: bosh-CA


### PR DESCRIPTION
## What

These 2 should be pinned on the output of post-deploy and the 2
availability tests. Otherwise they will start running even if the
availability tests fail.

These look to have been erroneously removed in the refactoring in
3344249

## How to review

* Verify this makes sense.
* Push the pipeline to a concourse and verify the pinning looks correct.

## Who can review

Not me.