### PR TITLE
[SUPPORT] Add an additional IP address for each new parser

### DIFF
--- a/manifests/cf-manifest/manifest/800-logsearch.yml
+++ b/manifests/cf-manifest/manifest/800-logsearch.yml
@@ -40,6 +40,7 @@ jobs:
   - name: cf
     static_ips:
       - 10.0.16.14
+      - 10.0.16.15
   properties:
     redis:
       host: (( grab jobs.queue.networks.cf.static_ips.[0] ))
@@ -60,6 +61,7 @@ jobs:
   - name: cf
     static_ips:
       - 10.0.17.14
+      - 10.0.17.15
   properties:
     redis:
       host: (( grab jobs.queue.networks.cf.static_ips.[1] ))


### PR DESCRIPTION
## What

The parsers are set up with static IP addresses. This allocates another
one for the newly added instances.

## How to review

Code review

## Who can review

Not @LeePorte
