### PR TITLE
Shorten xxxx-cf-router system-domain elb name

### DIFF
--- a/terraform/cloudfoundry/elbs.tf
+++ b/terraform/cloudfoundry/elbs.tf
@@ -94,7 +94,7 @@ resource "aws_proxy_protocol_policy" "cf_uaa_haproxy" {
 }
 
 resource "aws_elb" "cf_router_system_domain" {
-  name                        = "${var.env}-cf-router-system-domain"
+  name                        = "${var.env}-cf-system-domain"
   subnets                     = ["${split(",", var.infra_subnet_ids)}"]
   idle_timeout                = 19
   cross_zone_load_balancing   = "true"


### PR DESCRIPTION
## What

Shorten the name of the new system-domain elb.

## Why

* The new `xxx-cf-router-system-domain` elb has a long name.
* There is a limit of 32 characters for elb names.
* Each name is prefixed with the `$DEPLOY_ENV`.
* This means any `$DEPLOY_ENV` must currently be less than 8 characters.
* My `$DEPLOY_ENV` is not less than 8 characters and so I cannot run `create-cloudfoundry` or `destroy-cloudfoundry` pipelines as they refuse to apply terraform

## If we don't do this

Any pre-existing deployments with DEPLOY_ENV > 8 characters  get stuck unable to run terraform tasks due to the character limitation.

cf-terraform job will fail with:

```
Error: aws_elb.cf_router_system_domain: "name" cannot be longer than 32 characters: "xxxxxxxxxx-cf-router-system-domain"
```

## How to review

Please review carefully, I do not believe I have all the context for the implications of this change. I just wanted to get my environment up and running and this fixed it!

Things to consider:

* Can ELBs be renamed? or do they just get destroyed and re-created?
* Are the elbs referenced by name anywhere?
* Does the new name make sense?

## Who can review

Not @chrisfarms

...I believe @henrytk might have the context for this change