### PR TITLE
[#154808699] Investigate/fix CF-StatsUnavailable error

### DIFF
--- a/platform-tests/src/platform/availability/api/api_test.go
+++ b/platform-tests/src/platform/availability/api/api_test.go
@@ -28,6 +28,7 @@ func lg(things ...interface{}) {
 
 var warningMatchers = []*regexp.Regexp{
 	regexp.MustCompile("cannot fetch token: 503 Service Unavailable"),
+	regexp.MustCompile(`error \(200002\): CF-StatsUnavailable`),
 }
 
 var _ = Describe("API Availability Monitoring", func() {


### PR DESCRIPTION
## What

Handle CF-StatsUnavailable errors as warning in the api-availability tests

We investigated the remaining CF-StatsUnavailable errors and decided that it
isn't worth to fix them. We don't want these errors to make the pipeline fail,
so we handle them as warnings. Too many warnings will still make the pipeline
fail.

These errors usually happen in a really small time window (<1s)

We found two causes:
* When the Consul servers are updated the clients can fail to resolve some DNS
  requests when the leader is restarted. This could be solved by handling retry
  in the Consul agents. See [1] and [2]. We would need to upgrade to Consul 1.x
  which would need a lot of work (there is no BOSH release for it) and eventually
  we plan to remove it completely.
* BBS is running with a hot-standby and at any given time only one BBS is active.
  This is handled with a Consul lock. When the database VM with the active BBS is
  restarted there is a short time period while there is no active BBS which can
  cause this issue.

## How to review

Code review.

It's hard to make these error occur so we don't think there is value in trying to test this again. We validated with 4 errors that the api-availability-tests didn't fail and only registered warnings.

## Who can review

Not @chrisfarms or me.