### PR TITLE
[#154959067] Redirect HTTP system domain traffic to HTTPS

### DIFF
--- a/platform-tests/src/platform/acceptance/plain_http_test.go
+++ b/platform-tests/src/platform/acceptance/plain_http_test.go
@@ -1,13 +1,17 @@
 package acceptance_test
 
 import (
+	"encoding/json"
 	"fmt"
-	"net"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
+	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("plain HTTP requests", func() {
@@ -21,6 +25,45 @@ var _ = Describe("plain HTTP requests", func() {
 			_, err := net.DialTimeout("tcp", uri, CONNECTION_TIMEOUT)
 			Expect(err).To(HaveOccurred(), "should not connect")
 			Expect(err.(net.Error).Timeout()).To(BeTrue(), "should timeout")
+		})
+	})
+
+	Describe("to UAA", func() {
+		var uaaDomain string
+
+		BeforeEach(func() {
+			infoCommand := cf.Cf("curl", "/v2/info")
+			Expect(infoCommand.Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
+
+			var infoResp struct {
+				TokenEndpoint string `json:"token_endpoint"`
+			}
+			err := json.Unmarshal(infoCommand.Buffer().Contents(), &infoResp)
+			Expect(err).NotTo(HaveOccurred())
+
+			uaaHttpsURL, err := url.Parse(infoResp.TokenEndpoint)
+			Expect(err).NotTo(HaveOccurred())
+			uaaDomain = strings.Split(uaaHttpsURL.Host, ":")[0]
+		})
+
+		It("is redirected to the https endpoint", func() {
+			req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/", uaaDomain), nil)
+			Expect(err).NotTo(HaveOccurred())
+			resp, err := http.DefaultTransport.RoundTrip(req)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(resp.StatusCode).To(Equal(301))
+			Expect(resp.Header.Get("Location")).To(Equal(fmt.Sprintf("https://%s/", uaaDomain)))
+		})
+
+		It("has any path and query components removed when redirecting", func() {
+			req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/oauth/token", uaaDomain), nil)
+			Expect(err).NotTo(HaveOccurred())
+			resp, err := http.DefaultTransport.RoundTrip(req)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(resp.StatusCode).To(Equal(301))
+			Expect(resp.Header.Get("Location")).To(Equal(fmt.Sprintf("https://%s/", uaaDomain)))
 		})
 	})
 

--- a/platform-tests/src/platform/acceptance/plain_http_test.go
+++ b/platform-tests/src/platform/acceptance/plain_http_test.go
@@ -21,10 +21,14 @@ var _ = Describe("plain HTTP requests", func() {
 
 	Describe("to the API", func() {
 		It("has the connection refused", func() {
-			uri := testConfig.ApiEndpoint + ":80"
-			_, err := net.DialTimeout("tcp", uri, CONNECTION_TIMEOUT)
-			Expect(err).To(HaveOccurred(), "should not connect")
-			Expect(err.(net.Error).Timeout()).To(BeTrue(), "should timeout")
+			req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/v2/info", testConfig.ApiEndpoint), nil)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = http.DefaultTransport.RoundTrip(req)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(Or(
+				ContainSubstring("connection refused"),
+				ContainSubstring("connection reset by peer"),
+			)))
 		})
 	})
 

--- a/terraform/cloudfoundry/elbs.tf
+++ b/terraform/cloudfoundry/elbs.tf
@@ -75,6 +75,13 @@ resource "aws_elb" "cf_router_system_domain" {
     lb_protocol        = "ssl"
     ssl_certificate_id = "${data.aws_acm_certificate.system.arn}"
   }
+
+  listener {
+    lb_port           = "80"
+    lb_protocol       = "http"
+    instance_port     = "83"
+    instance_protocol = "http"
+  }
 }
 
 resource "aws_lb_ssl_negotiation_policy" "cf_router_system_domain" {

--- a/terraform/cloudfoundry/security-groups.tf
+++ b/terraform/cloudfoundry/security-groups.tf
@@ -20,6 +20,20 @@ resource "aws_security_group" "cf_api_elb" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  // Allow for HTTP redirects
+  ingress {
+    from_port = 80
+    to_port   = 80
+    protocol  = "tcp"
+
+    cidr_blocks = [
+      "${compact(var.admin_cidrs)}",
+      "${compact(var.api_access_cidrs)}",
+      "${var.concourse_elastic_ip}/32",
+      "${formatlist("%s/32", aws_eip.cf.*.public_ip)}",
+    ]
+  }
+
   ingress {
     from_port = 443
     to_port   = 443


### PR DESCRIPTION
## What

A regression was introduced (you're welcome) when we removed the
CloudFront distributions in front of the Product Page. This follows
the same pattern used by the apps domain ELB to defer the redirection
to HAProxy.

## How to review

* Deploy
* Check tests pass
* This should work:

```
curl http://www.${DEPLOY_ENV}.dev.cloudpipeline.digital -L
```

## Who can review

Anyone but me
