### PR TITLE
[#154329640] paas-billing v0.9.0 add pricing estimation endpoint

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -272,7 +272,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-billing
-      tag_filter: v0.7.0
+      tag_filter: v0.9.0
 
 jobs:
   - name: pipeline-lock


### PR DESCRIPTION
[#154329640 Pricing Calculator: Implement price estimation via billing API](https://www.pivotaltracker.com/story/show/154329640)


What?
-----

Bump version of paas-billing to v0.9.0

We want to deploy the pricing simulation feature implemented in alphagov/paas-billing#11

How to review?
------------
 - Review and merge alphagov/paas-billing#11 first
 - ~~Once our CI tagged a new version (expected to be v0.8.0), remove the WIP commit in this branch.~~

Who?
---

Anyone but @dcarley or @keymon