### PR TITLE
[#153435666] Enable continuous smoke tests in dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,11 +83,13 @@ globals:
 .PHONY: dev
 dev: globals ## Set Environment to DEV
 	$(eval export AWS_ACCOUNT=dev)
+	$(eval export PERSISTENT_ENVIRONMENT=false)
 	$(eval export ENABLE_BILLING_APP ?= false)
 	$(eval export ENABLE_DESTROY=true)
 	$(eval export ENABLE_AUTODELETE=true)
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
 	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipelineapps.digital)
+	$(eval export ALERT_EMAIL_ADDRESS=govpaas-alerting-dev@digital.cabinet-office.gov.uk)
 	$(eval export SKIP_COMMIT_VERIFICATION=true)
 	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-default.yml)
 	$(eval export DISABLE_HEALTHCHECK_DB=true)
@@ -101,6 +103,7 @@ dev: globals ## Set Environment to DEV
 .PHONY: staging
 staging: globals ## Set Environment to Staging
 	$(eval export AWS_ACCOUNT=staging)
+	$(eval export PERSISTENT_ENVIRONMENT=true)
 	$(eval export ENABLE_BILLING_APP=false)
 	$(eval export ENABLE_AUTO_DEPLOY=true)
 	$(eval export TAG_PREFIX=prod-)
@@ -118,6 +121,7 @@ staging: globals ## Set Environment to Staging
 .PHONY: prod
 prod: globals ## Set Environment to Production
 	$(eval export AWS_ACCOUNT=prod)
+	$(eval export PERSISTENT_ENVIRONMENT=true)
 	$(eval export ENABLE_BILLING_APP=true)
 	$(eval export ENABLE_AUTO_DEPLOY=true)
 	$(eval export PAAS_CF_TAG_FILTER=prod-*)

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -3044,60 +3044,88 @@ jobs:
     build_logs_to_retain: 10000
     plan:
       - aggregate:
+        - get: smoke-tests-timer
+          trigger: true
+        - get: deployed-healthcheck
         - get: cf-smoke-tests
         - get: paas-cf
           passed: ['post-deploy']
         - get: cf-manifest
           passed: ['post-deploy']
         - get: bosh-CA
-        - get: smoke-tests-timer
-          trigger: ((continuous_smoke_tests_trigger))
         - get: cf-secrets
           passed: ['post-deploy']
 
-      - do:
-        - task: create-temp-user
-          file: paas-cf/concourse/tasks/create_admin.yml
-          params:
-            PREFIX: cont-smoketest-user
-
-        - task: smoke-tests-config
-          file: paas-cf/concourse/tasks/generate-test-config.yml
-          params:
-            TEST_PROPERTIES: smoke_tests
-
-        - task: smoke-tests-run
-          file: paas-cf/concourse/tasks/smoke-tests-run.yml
-          on_failure:
-            task: alert
-            config:
-              platform: linux
-              image_resource:
-                type: docker-image
-                source:
-                  repository: governmentpaas/awscli
-                  tag: b2495d6ed07f680125d19aa7d1701da7efabb289
-              params:
-                AWS_DEFAULT_REGION: ((aws_region))
-                DEPLOY_ENV: ((deploy_env))
-                SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
-                ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
-              inputs:
-                - name: paas-cf
-              run:
-                path: sh
-                args:
-                - -e
-                - -c
-                - |
-                  paas-cf/concourse/scripts/smoke_tests_email.sh \
-                    "${DEPLOY_ENV}" "${SYSTEM_DNS_ZONE_NAME}" "${ALERT_EMAIL_ADDRESS}"
-          ensure:
-            task: upload-test-artifacts
-            file: paas-cf/concourse/tasks/upload-test-artifacts.yml
+      - try:
+          task: assert-should-run
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: alpine
+                tag: latest
+            inputs:
+              - name: deployed-healthcheck
             params:
-              TEST_ARTIFACTS_BUCKET: ((test_artifacts_bucket))
+              PERSISTENT_ENVIRONMENT: ((persistent_environment))
+            run:
+              path: sh
+              args:
+              - -e
+              - -c
+              - |
+                HEALTHCHECK_DEPLOYED=$(cat deployed-healthcheck/healthcheck-deployed)
+                if [ "$HEALTHCHECK_DEPLOYED" = "no" ] && [ "$PERSISTENT_ENVIRONMENT" != "true" ]; then
+                  echo "Healthcheck is not deployed and this is not a persistent environment"
+                  echo "Skipping smoke tests"
+                  exit 1
+                fi
 
-        ensure:
-          task: remove-temp-user
-          file: paas-cf/concourse/tasks/delete_admin.yml
+          on_success:
+            do:
+            - task: create-temp-user
+              file: paas-cf/concourse/tasks/create_admin.yml
+              params:
+                PREFIX: cont-smoketest-user
+
+            - task: smoke-tests-config
+              file: paas-cf/concourse/tasks/generate-test-config.yml
+              params:
+                TEST_PROPERTIES: smoke_tests
+
+            - task: smoke-tests-run
+              file: paas-cf/concourse/tasks/smoke-tests-run.yml
+              on_failure:
+                task: alert
+                config:
+                  platform: linux
+                  image_resource:
+                    type: docker-image
+                    source:
+                      repository: governmentpaas/awscli
+                      tag: b2495d6ed07f680125d19aa7d1701da7efabb289
+                  params:
+                    AWS_DEFAULT_REGION: ((aws_region))
+                    DEPLOY_ENV: ((deploy_env))
+                    SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+                    ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
+                  inputs:
+                    - name: paas-cf
+                  run:
+                    path: sh
+                    args:
+                    - -e
+                    - -c
+                    - |
+                      paas-cf/concourse/scripts/smoke_tests_email.sh \
+                        "${DEPLOY_ENV}" "${SYSTEM_DNS_ZONE_NAME}" "${ALERT_EMAIL_ADDRESS}"
+              ensure:
+                task: upload-test-artifacts
+                file: paas-cf/concourse/tasks/upload-test-artifacts.yml
+                params:
+                  TEST_ARTIFACTS_BUCKET: ((test_artifacts_bucket))
+
+            ensure:
+              task: remove-temp-user
+              file: paas-cf/concourse/tasks/delete_admin.yml

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -121,7 +121,7 @@ oauth_client_id: ${oauth_client_id:-}
 oauth_client_secret: ${oauth_client_secret:-}
 enable_billing_app: ${ENABLE_BILLING_APP}
 auto_deploy: $([ "${ENABLE_AUTO_DEPLOY:-}" ] && echo "true" || echo "false")
-continuous_smoke_tests_trigger: $([ "${ALERT_EMAIL_ADDRESS:-}" ] && echo "true" || echo "false")
+persistent_environment: ${PERSISTENT_ENVIRONMENT}
 disable_user_creation: $([ "${NEW_ACCOUNT_EMAIL_ADDRESS:-}" ] && echo "false" || echo "true")
 gpg_ids: ${gpg_ids}
 EOF


### PR DESCRIPTION
## What

We want to run continuous smoke tests in dev, because they can catch
errors caused by things outside of the normal pipeline run, such as
during credential rotation[1]. We use the existing pattern of checking
whether the healthcheck app is deployed to ensure they should be
running.

We use the standard Alpine container to check whether the smoke tests
need to run because this container has no special requirements and the
Docker Hub standard library[2] containers are officially maintained.

We use the govpaas-alerting-dev email address[3] because most people do
not subscribe to this and therefore reduces noise.

[1] https://www.pivotaltracker.com/n/projects/1275640/stories/153435666
[2] https://hub.docker.com/u/library/
[3] https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/govpaas-alerting-dev;context-place=myforums

## How to review

* Have a kick-off for the story
* Make sure:
  * Smoke tests run in dev
  * You get an email if they fail (you can use `bosh stop api` to force quick failure).
* Code review to confirm they should run in staging and prod (we will get NO_DATA alerts if they don't).

## Who can review

Anyone but me.
