### PR TITLE
[#154959067] System domain should not be listening on port 80

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2514,6 +2514,7 @@ jobs:
             DISABLE_CUSTOM_ACCEPTANCE_TESTS: ((disable_custom_acceptance_tests))
             DEPLOY_ENV: ((deploy_env))
             AWS_REGION: ((aws_region))
+            SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
 
           ensure:
             task: upload-test-artifacts

--- a/platform-tests/src/platform/acceptance/plain_http_test.go
+++ b/platform-tests/src/platform/acceptance/plain_http_test.go
@@ -20,74 +20,78 @@ var _ = Describe("plain HTTP requests", func() {
 		CONNECTION_TIMEOUT = 11 * time.Second
 	)
 
-	Describe("to the CC API", func() {
-		It("has the connection refused", func() {
-			uri := testConfig.ApiEndpoint + ":80"
-			_, err := net.DialTimeout("tcp", uri, CONNECTION_TIMEOUT)
-			Expect(err).To(HaveOccurred(), "should not connect")
-			Expect(err.(net.Error).Timeout()).To(BeTrue(), "should timeout")
+	Context("to the system domain", func() {
+		Describe("for the CC API", func() {
+			It("has the connection refused", func() {
+				uri := testConfig.ApiEndpoint + ":80"
+				_, err := net.DialTimeout("tcp", uri, CONNECTION_TIMEOUT)
+				Expect(err).To(HaveOccurred(), "should not connect")
+				Expect(err.(net.Error).Timeout()).To(BeTrue(), "should timeout")
+			})
+		})
+
+		Describe("for UAA", func() {
+			var uaaDomain string
+
+			BeforeEach(func() {
+				infoCommand := cf.Cf("curl", "/v2/info")
+				Expect(infoCommand.Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
+
+				var infoResp struct {
+					TokenEndpoint string `json:"token_endpoint"`
+				}
+				err := json.Unmarshal(infoCommand.Buffer().Contents(), &infoResp)
+				Expect(err).NotTo(HaveOccurred())
+
+				uaaHttpsURL, err := url.Parse(infoResp.TokenEndpoint)
+				Expect(err).NotTo(HaveOccurred())
+				uaaDomain = strings.Split(uaaHttpsURL.Host, ":")[0]
+			})
+
+			It("has the connection refused", func() {
+				uri := uaaDomain + ":80"
+				_, err := net.DialTimeout("tcp", uri, CONNECTION_TIMEOUT)
+				Expect(err).To(HaveOccurred(), "should not connect")
+				Expect(err.(net.Error).Timeout()).To(BeTrue(), "should timeout")
+			})
+		})
+
+		Describe("for the product page", func() {
+			It("has the connection refused", func() {
+				systemDomain := GetConfigFromEnvironment("SYSTEM_DNS_ZONE_NAME")
+				uri := fmt.Sprintf("www.%s:80", systemDomain)
+				_, err := net.DialTimeout("tcp", uri, CONNECTION_TIMEOUT)
+				Expect(err).To(HaveOccurred(), "should not connect")
+				Expect(err.(net.Error).Timeout()).To(BeTrue(), "should timeout")
+			})
 		})
 	})
 
-	Describe("to UAA", func() {
-		var uaaDomain string
+	Context("to the apps domain", func() {
+		Describe("for an app", func() {
+			It("is redirected to the https endpoint", func() {
+				req, err := http.NewRequest("GET", fmt.Sprintf("http://foo.%s/", testConfig.AppsDomain), nil)
+				Expect(err).NotTo(HaveOccurred())
+				resp, err := http.DefaultTransport.RoundTrip(req)
+				Expect(err).NotTo(HaveOccurred())
 
-		BeforeEach(func() {
-			infoCommand := cf.Cf("curl", "/v2/info")
-			Expect(infoCommand.Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
+				Expect(resp.StatusCode).To(Equal(301))
+				Expect(resp.Header.Get("Location")).To(Equal(fmt.Sprintf("https://foo.%s/", testConfig.AppsDomain)))
 
-			var infoResp struct {
-				TokenEndpoint string `json:"token_endpoint"`
-			}
-			err := json.Unmarshal(infoCommand.Buffer().Contents(), &infoResp)
-			Expect(err).NotTo(HaveOccurred())
+				By("does not include an HSTS header")
+				// See https://tools.ietf.org/html/rfc6797#section-7.2
+				Expect(resp.Header.Get("Strict-Transport-Security")).To(BeEmpty())
+			})
 
-			uaaHttpsURL, err := url.Parse(infoResp.TokenEndpoint)
-			Expect(err).NotTo(HaveOccurred())
-			uaaDomain = strings.Split(uaaHttpsURL.Host, ":")[0]
-		})
+			It("has any path and query components removed when redirecting", func() {
+				req, err := http.NewRequest("GET", fmt.Sprintf("http://foo.%s/bar?baz=qux", testConfig.AppsDomain), nil)
+				Expect(err).NotTo(HaveOccurred())
+				resp, err := http.DefaultTransport.RoundTrip(req)
+				Expect(err).NotTo(HaveOccurred())
 
-		It("has the connection refused", func() {
-			uri := uaaDomain + ":80"
-			_, err := net.DialTimeout("tcp", uri, CONNECTION_TIMEOUT)
-			Expect(err).To(HaveOccurred(), "should not connect")
-			Expect(err.(net.Error).Timeout()).To(BeTrue(), "should timeout")
-		})
-	})
-
-	Describe("to the product page", func() {
-		It("has the connection refused", func() {
-			systemDomain := GetConfigFromEnvironment("SYSTEM_DNS_ZONE_NAME")
-			uri := fmt.Sprintf("www.%s:80", systemDomain)
-			_, err := net.DialTimeout("tcp", uri, CONNECTION_TIMEOUT)
-			Expect(err).To(HaveOccurred(), "should not connect")
-			Expect(err.(net.Error).Timeout()).To(BeTrue(), "should timeout")
-		})
-	})
-
-	Describe("to an app", func() {
-		It("is redirected to the https endpoint", func() {
-			req, err := http.NewRequest("GET", fmt.Sprintf("http://foo.%s/", testConfig.AppsDomain), nil)
-			Expect(err).NotTo(HaveOccurred())
-			resp, err := http.DefaultTransport.RoundTrip(req)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(resp.StatusCode).To(Equal(301))
-			Expect(resp.Header.Get("Location")).To(Equal(fmt.Sprintf("https://foo.%s/", testConfig.AppsDomain)))
-
-			By("does not include an HSTS header")
-			// See https://tools.ietf.org/html/rfc6797#section-7.2
-			Expect(resp.Header.Get("Strict-Transport-Security")).To(BeEmpty())
-		})
-
-		It("has any path and query components removed when redirecting", func() {
-			req, err := http.NewRequest("GET", fmt.Sprintf("http://foo.%s/bar?baz=qux", testConfig.AppsDomain), nil)
-			Expect(err).NotTo(HaveOccurred())
-			resp, err := http.DefaultTransport.RoundTrip(req)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(resp.StatusCode).To(Equal(301))
-			Expect(resp.Header.Get("Location")).To(Equal(fmt.Sprintf("https://foo.%s/", testConfig.AppsDomain)))
+				Expect(resp.StatusCode).To(Equal(301))
+				Expect(resp.Header.Get("Location")).To(Equal(fmt.Sprintf("https://foo.%s/", testConfig.AppsDomain)))
+			})
 		})
 	})
 })


### PR DESCRIPTION
## What

Test our new behaviour that we don't listen on port 80 for the system domain. See commit messages for more details.

N.B. for @samcrang: I've ignored the situation where these are run from our office (behind its HTTP proxy.) The connection being closed instead of not accepted could happen at various points, so it wouldn't guarantee that HTTP requests weren't sent over the wire.

## How to review

I have successfully run these custom acceptance tests in my dev environment and think that code review will suffice.

## Who can review

Not @46bit