### PR TITLE
[#155178552] Monitor Logsearch Redis queue length

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -50,9 +50,9 @@ releases:
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/paas-haproxy-0.1.5.tgz
     sha1: c8c90a4c14ea2201a37469596b5cef309864a394
   - name: datadog-for-cloudfoundry
-    version: 0.1.17
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.1.17.tgz
-    sha1: 1c9457bbddcf1207129a3669772f472ff0a5feef
+    version: 0.1.18
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.1.18.tgz
+    sha1: a1de9fed600f8edabe391a536118b4b720f974ae
   - name: ipsec
     version: 0.1.3
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/ipsec-0.1.3.tgz

--- a/manifests/cf-manifest/manifest/800-logsearch.yml
+++ b/manifests/cf-manifest/manifest/800-logsearch.yml
@@ -15,6 +15,8 @@ jobs:
   templates:
   - name: queue
     release: logsearch
+  - name: datadog-logsearch-queue
+    release: datadog-for-cloudfoundry
   vm_type: small
   stemcell: default
   instances: 2

--- a/terraform/datadog/queue.tf
+++ b/terraform/datadog/queue.tf
@@ -1,0 +1,15 @@
+resource "datadog_monitor" "queue_logsearch_redis_queue_length" {
+  name                = "${format("%s Logsearch Redis queue length", var.env)}"
+  type                = "metric alert"
+  query               = "${format("max(last_5m):avg:redis.key.length{deploy_env:%s,bosh-job:queue,key:logstash} > 1000000", var.env)}"
+  message             = "Logsearch Redis queue length is over {{#is_warning}}{{warn_threshold}}{{/is_warning}}{{#is_alert}}{{threshold}}, Logsearch started to drop log messages.{{/is_alert}}. Please check whether all components of Logsearch functions properly."
+  notify_no_data      = true
+  require_full_window = true
+
+  thresholds {
+    critical = "1000000"
+    warning  = "100000"
+  }
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:queue"]
+}


### PR DESCRIPTION
## What

We want to monitor the queue length in Redis as the ingestor will start to drop messages if the queue reaches 1 million items [1]. We want to be alerted before this happens and manually intervene if necessary.

[1] https://github.com/logsearch/logsearch-boshrelease/blob/v203.0.0/jobs/ingestor_syslog/spec#L61-L63

❗️ This PR contains a temporary commit, please update the `datadog-for-cloudfoundry` Bosh release params after 

## How to review

1. Deploy your CF from this branch and enable Datadog in `paas-bootstrap` and `paas-cf`:
```
paas-bootstrap$ make dev deployer-concourse pipelines DEPLOY_ENV=hector BRANCH=$(git rev-parse --abbrev-ref HEAD)  SELF_UPDATE_PIPELINE=false ENABLE_DATADOG=true 

paas-cf$ make dev pipelines BRANCH=$(git rev-parse --abbrev-ref HEAD)  SELF_UPDATE_PIPELINE=false DEPLOY_ENV=hector ENABLE_DATADOG=true
```

2. Go to Datadog and search for the `Logsearch Redis queue length` monitor. Check if it exists, has data and the settings make sense.

OR if you are lazy, check the deployment from `DEPLOY_ENV=hector`: https://deployer.hector.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/cf-deploy


## How to release

1. https://github.com/alphagov/paas-release-ci/pull/55 was merged already - it fixed a Bosh release naming issue for the dev releases.
1. Review and merge https://github.com/alphagov/paas-release-ci/pull/56 - it fixes a Bosh release naming issue for the final releases.
1. Merge https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/21
1. Replace the temporary commit with the final `datadog-for-cloudfoundry` release
1. Merge this PR

## Who can review

Not @keymon or me.