### PR TITLE
[#154769249] Add new hostnames to Rep cert

### DIFF
--- a/manifests/cf-manifest/scripts/generate-cf-certs.sh
+++ b/manifests/cf-manifest/scripts/generate-cf-certs.sh
@@ -31,7 +31,7 @@ doppler,
 metron,
 trafficcontroller,
 cc_trafficcontroller,
-rep_server,*.cell.service.cf.internal,cell.service.cf.internal
+rep_server,*.cell.service.cf.internal,cell.service.cf.internal,localhost,127.0.0.1
 rep_client,
 reverse_log_proxy,
 statsd_injector,


### PR DESCRIPTION
## What

cf-deployment v1.4.0 says:

> The rep jobs from Diego require that their certs be valid for
> localhost and 127.0.0.1, so the manifest includes a new variable
> called diego_rep_agent_v2.

https://www.pivotaltracker.com/n/projects/1003146/stories/154565563

After deploying We'll need to run the:

- `rotate-cf-internal-certs` job,
- `create-cloudfoundry` pipeline
- `delete-old-cf-internal-certs` job

After that we can merge the PR which makes use of the new certs.

## How to review

Check that the description and links make sense and that what we're proposing to do isn't krazy.

## Who can review

Not @dcarley or @LeePorte 