### PR TITLE
[#155178552] Link to logsearch queue alert in team manual

### DIFF
--- a/terraform/datadog/queue.tf
+++ b/terraform/datadog/queue.tf
@@ -2,7 +2,7 @@ resource "datadog_monitor" "queue_logsearch_redis_queue_length" {
   name                = "${format("%s Logsearch Redis queue length", var.env)}"
   type                = "metric alert"
   query               = "${format("max(last_5m):avg:redis.key.length{deploy_env:%s,bosh-job:queue,key:logstash} > 1000000", var.env)}"
-  message             = "Logsearch Redis queue length is over {{#is_warning}}{{warn_threshold}}{{/is_warning}}{{#is_alert}}{{threshold}}, Logsearch started to drop log messages.{{/is_alert}}. Please check whether all components of Logsearch functions properly."
+  message             = "${format("Logsearch Redis queue length is over {{#is_warning}}{{warn_threshold}}{{/is_warning}}{{#is_alert}}{{threshold}}, Logsearch started to drop log messages.{{/is_alert}}. See [Team Manual > Responding to alerts > Logsearch/ELK queue threshold limits](%s#logsearchelk-queue-threshold-limits) for more info.", var.datadog_documentation_url)}"
   notify_no_data      = true
   require_full_window = true
 


### PR DESCRIPTION
## What

So that the person viewing the alert can more easily discover how to
respond to it.

This is a minor tweak I noticed while approving the story and it didn't seem worth sending it all the way back to doing.

## How to review

It takes ages to deploy DataDog to a dev environment so I haven't tested this.

I think that eyeballing the change to see if the formatting is correct should be sufficient. You can compare it to one of the other alerts that also use this format.

## Who can review

Anyone.