### PR TITLE
[#154395415] Update paas-billing release tag

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -279,7 +279,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-billing
-      tag_filter: v0.9.0
+      tag_filter: v0.12.0
 
 jobs:
   - name: pipeline-lock


### PR DESCRIPTION
## What

This PR updates the tag used for paas-billing to the latest version.

## How to review

Update the temp commit with the tag value created by CI after merging https://github.com/alphagov/paas-billing/pull/14

## Who can review

Not @camelpunch or @LeePorte
