### PR TITLE
[#154769249] Downgrade stemcell to 3468 series

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -99,9 +99,6 @@ releases:
 stemcells:
   - alias: default
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3541.2"
-  - alias: legacy
-    name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
     version: "3468.22"
 
 update:

--- a/manifests/cf-manifest/manifest/040-graphite.yml
+++ b/manifests/cf-manifest/manifest/040-graphite.yml
@@ -24,7 +24,7 @@ jobs:
   azs: [z1]
   instances: 1
   vm_type: graphite
-  stemcell: legacy
+  stemcell: default
   persistent_disk_type: graphite_data
   networks:
     - name: cf

--- a/manifests/cf-manifest/manifest/800-logsearch.yml
+++ b/manifests/cf-manifest/manifest/800-logsearch.yml
@@ -74,7 +74,7 @@ jobs:
   - name: elasticsearch
     release: logsearch
   vm_type: elasticsearch_master
-  stemcell: legacy
+  stemcell: default
   instances: 3
   networks:
   - name: cf


### PR DESCRIPTION
## What

The `datadog-agent-forwarder` job is failing to start in staging with the
following error:

    Couldn't initialize logging: [Errno 13] Permission denied: '/var/vcap/data/packages/datadog-agent/4ed37e76994196bbc48fbd89ba2d9ffdf9ab7bf3/agent/datadog.conf'

It feels like this could be the same problem we saw with umask changes for
logsearch in 94a70d11. I tried 3541.4, which includes some umask fixes,
but that didn't make any difference.

In order to unblock the pipelines in the meantime we're going to
downgrade all VMs to the latest version of the previous series. We'll
investigate a proper fix for upgrading series later.

## How to review

I've tested this in a dev environment. I don't think you need to repeat this. You should check that I've used the right stemcell from https://github.com/cloudfoundry/bosh-linux-stemcell-builder/releases

## Who can review

Anyone.