### PR TITLE
[#120268519] Add gorouter latency monitor to datadog

### DIFF
--- a/terraform/datadog/router.tf
+++ b/terraform/datadog/router.tf
@@ -139,3 +139,21 @@ resource "datadog_monitor" "gorouter_healthy" {
 
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:router"]
 }
+
+resource "datadog_monitor" "gorouter_latency" {
+  name                = "${format("%s gorouter latency", var.env)}"
+  type                = "metric alert"
+  message             = "Gorouter latency too high."
+  escalation_message  = "Gorouter latency still too high. Check the deployment."
+  no_data_timeframe   = "7"
+  require_full_window = true
+
+  query = "${format("avg(last_1m):avg:cf.gorouter.latency{deployment:%s,job:router} by {ip} > 800", var.env)}"
+
+  thresholds {
+    warning  = "400.0"
+    critical = "800.0"
+  }
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:router"]
+}


### PR DESCRIPTION
## What

This sets up a gorouter datadog monitor with a warning threshold of
400ms and a critical threshold set at 800ms. These values have been
derived from reviewing the data held in datadog for the past month. If
we had them implemented during the load testing session then they would
have fired.

## How to review

Deploy from this branch with `ENABLE_DATADOG=true` and check the monitors for your deployment in datadog.

## Who can review

Not @LeePorte
