### PR TITLE
[#155367490] Provide more RAM for production ELK Elasticsearch

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1247,6 +1247,8 @@ jobs:
             passed: ['generate-cf-config']
           - get: cf-manifest
             passed: ['generate-cf-config']
+          - get: cf-tfstate
+            passed: ['generate-cf-config']
           - get: bosh-secrets
           - get: bosh-CA-crt
 
@@ -1318,6 +1320,57 @@ jobs:
                   ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
                   bosh -n update-cloud-config cloud-config/cloud-config.yml
 
+        - do:
+          - task: extract-cf-terraform-outputs
+            config:
+              platform: linux
+              image_resource:
+                type: docker-image
+                source:
+                  repository: ruby
+                  tag: 2.2-slim
+              inputs:
+                - name: paas-cf
+                - name: cf-tfstate
+              outputs:
+                - name: cf-terraform-outputs
+              run:
+                path: sh
+                args:
+                  - -e
+                  - -c
+                  - |
+                    SCPATH="./paas-cf/concourse/scripts"
+                    SCFILE="extract_tf_vars_from_terraform_state.rb"
+                    $SCPATH/$SCFILE < cf-tfstate/cf.tfstate > cf-terraform-outputs/cf.tfstate.sh
+                    ls -l cf-terraform-outputs/cf.tfstate.sh
+
+          - try:
+              task: disable-elasticsearch-shard-reallocation
+              config:
+                platform: linux
+                image_resource:
+                  type: docker-image
+                  source:
+                    repository: governmentpaas/curl-ssl
+                    tag: 465642da06051a55630d39c899697b678f66a7f7
+                inputs:
+                - name: paas-cf
+                - name: cf-terraform-outputs
+                run:
+                  path: sh
+                  args:
+                  - -e
+                  - -c
+                  - |
+                    echo "This task will fail if you have no Elasticserch master and that is OK."
+                    . cf-terraform-outputs/cf.tfstate.sh
+                    export TF_VAR_logsearch_elastic_master_elb_dns_name
+                    curl -s \
+                      -X PUT \
+                      -d '{"transient":{"cluster.routing.allocation.enable":"none"}}' \
+                      "${TF_VAR_logsearch_elastic_master_elb_dns_name}:9200/_cluster/settings"
+
       - task: cf-deploy
         config:
           platform: linux
@@ -1344,6 +1397,31 @@ jobs:
                 ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
                 bosh -n deploy cf-manifest/cf-manifest.yml
 
+      - task: enable-elasticsearch-shard-reallocation
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/curl-ssl
+              tag: 465642da06051a55630d39c899697b678f66a7f7
+          inputs:
+          - name: paas-cf
+          - name: cf-terraform-outputs
+          run:
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              . cf-terraform-outputs/cf.tfstate.sh
+              export TF_VAR_logsearch_elastic_master_elb_dns_name
+
+              curl -s \
+                -X PUT \
+                -d '{"transient":{"cluster.routing.allocation.enable":"all"}}' \
+                "${TF_VAR_logsearch_elastic_master_elb_dns_name}:9200/_cluster/settings"
+
   - name: post-deploy
     serial: true
     plan:
@@ -1369,84 +1447,59 @@ jobs:
       - get: paas-compose-scraper
       - get: paas-billing
 
-    - aggregate:
-      - task: extract-cf-terraform-outputs
-        config:
-          platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: ruby
-              tag: 2.2-slim
-          inputs:
-            - name: paas-cf
-            - name: cf-tfstate
-          outputs:
-            - name: cf-terraform-outputs
-          run:
-            path: sh
-            args:
-              - -e
-              - -c
-              - |
-                SCPATH="./paas-cf/concourse/scripts"
-                SCFILE="extract_tf_vars_from_terraform_state.rb"
-                $SCPATH/$SCFILE < cf-tfstate/cf.tfstate > cf-terraform-outputs/cf.tfstate.sh
-                ls -l cf-terraform-outputs/cf.tfstate.sh
+    - task: retrieve-config
+      config:
+        platform: linux
+        inputs:
+          - name: paas-cf
+          - name: cf-secrets
+          - name: cf-manifest
+          - name: cf-tfstate
+        outputs:
+          - name: config
+        params:
+        image_resource:
+          type: docker-image
+          source:
+            repository: ruby
+            tag: 2.2-slim
+        run:
+          path: sh
+          args:
+            - -e
+            - -c
+            - |
+              VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
 
-      - task: retrieve-config
-        config:
-          platform: linux
-          inputs:
-            - name: paas-cf
-            - name: cf-secrets
-            - name: cf-manifest
-            - name: cf-tfstate
-          outputs:
-            - name: config
-          params:
-          image_resource:
-            type: docker-image
-            source:
-              repository: ruby
-              tag: 2.2-slim
-          run:
-            path: sh
-            args:
-              - -e
-              - -c
-              - |
-                VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
+              ./paas-cf/concourse/scripts/extract_terraform_state_to_yaml.rb \
+                < cf-tfstate/cf.tfstate \
+                > cf-terraform-outputs.yml
 
-                ./paas-cf/concourse/scripts/extract_terraform_state_to_yaml.rb \
-                  < cf-tfstate/cf.tfstate \
-                  > cf-terraform-outputs.yml
+              cat << EOT > config/config.sh
+              export CF_ADMIN=admin
+              export CF_PASS=$($VAL_FROM_YAML secrets.uaa_admin_password cf-secrets/cf-secrets.yml)
+              export FIREHOSE_USER=graphite-nozzle
+              export FIREHOSE_PASS=$($VAL_FROM_YAML secrets.uaa_clients_firehose_password cf-secrets/cf-secrets.yml)
+              export API_ENDPOINT=$($VAL_FROM_YAML properties.cc.srv_api_uri cf-manifest/cf-manifest.yml)
+              export UAA_ENDPOINT=$($VAL_FROM_YAML properties.uaa.url cf-manifest/cf-manifest.yml)
+              export DOPPLER_ENDPOINT=$($VAL_FROM_YAML properties.loggregator.traffic_controller_url cf-manifest/cf-manifest.yml)
+              export GRAPHITE_SERVER=$($VAL_FROM_YAML jobs.graphite.networks.cf.static_ips.0 cf-manifest/cf-manifest.yml)
+              export RDS_BROKER_SERVER=$($VAL_FROM_YAML terraform_outputs.rds_broker_elb_dns_name cf-terraform-outputs.yml)
+              export RDS_BROKER_PASS=$($VAL_FROM_YAML secrets.rds_broker_admin_password cf-secrets/cf-secrets.yml)
+              export CDN_BROKER_SERVER=$($VAL_FROM_YAML terraform_outputs.cdn_broker_elb_dns_name cf-terraform-outputs.yml)
+              export CDN_BROKER_PASS=$($VAL_FROM_YAML secrets.cdn_broker_admin_password cf-secrets/cf-secrets.yml)
+              export COMPOSE_BROKER_PASS=$($VAL_FROM_YAML secrets.compose_broker_admin_password cf-secrets/cf-secrets.yml)
+              export COMPOSE_BROKER_IP_WHITELIST=$($VAL_FROM_YAML terraform_outputs.nat_public_ips_csv cf-terraform-outputs.yml)
+              export ELASTICACHE_BROKER_PASS=$($VAL_FROM_YAML secrets.elasticache_broker_admin_password cf-secrets/cf-secrets.yml)
+              export ELASTICACHE_BROKER_SERVER=$($VAL_FROM_YAML terraform_outputs.elasticache_broker_elb_dns_name cf-terraform-outputs.yml)
+              export METRICS_AWS_ACCESS_KEY_ID=$($VAL_FROM_YAML terraform_outputs.metrics_exporter_aws_access_key_id cf-terraform-outputs.yml)
+              export METRICS_AWS_SECRET_ACCESS_KEY=$($VAL_FROM_YAML terraform_outputs.metrics_exporter_aws_secret_access_key cf-terraform-outputs.yml)
+              EOT
 
-                cat << EOT > config/config.sh
-                export CF_ADMIN=admin
-                export CF_PASS=$($VAL_FROM_YAML secrets.uaa_admin_password cf-secrets/cf-secrets.yml)
-                export FIREHOSE_USER=graphite-nozzle
-                export FIREHOSE_PASS=$($VAL_FROM_YAML secrets.uaa_clients_firehose_password cf-secrets/cf-secrets.yml)
-                export API_ENDPOINT=$($VAL_FROM_YAML properties.cc.srv_api_uri cf-manifest/cf-manifest.yml)
-                export UAA_ENDPOINT=$($VAL_FROM_YAML properties.uaa.url cf-manifest/cf-manifest.yml)
-                export DOPPLER_ENDPOINT=$($VAL_FROM_YAML properties.loggregator.traffic_controller_url cf-manifest/cf-manifest.yml)
-                export GRAPHITE_SERVER=$($VAL_FROM_YAML jobs.graphite.networks.cf.static_ips.0 cf-manifest/cf-manifest.yml)
-                export RDS_BROKER_SERVER=$($VAL_FROM_YAML terraform_outputs.rds_broker_elb_dns_name cf-terraform-outputs.yml)
-                export RDS_BROKER_PASS=$($VAL_FROM_YAML secrets.rds_broker_admin_password cf-secrets/cf-secrets.yml)
-                export CDN_BROKER_SERVER=$($VAL_FROM_YAML terraform_outputs.cdn_broker_elb_dns_name cf-terraform-outputs.yml)
-                export CDN_BROKER_PASS=$($VAL_FROM_YAML secrets.cdn_broker_admin_password cf-secrets/cf-secrets.yml)
-                export COMPOSE_BROKER_PASS=$($VAL_FROM_YAML secrets.compose_broker_admin_password cf-secrets/cf-secrets.yml)
-                export COMPOSE_BROKER_IP_WHITELIST=$($VAL_FROM_YAML terraform_outputs.nat_public_ips_csv cf-terraform-outputs.yml)
-                export ELASTICACHE_BROKER_PASS=$($VAL_FROM_YAML secrets.elasticache_broker_admin_password cf-secrets/cf-secrets.yml)
-                export ELASTICACHE_BROKER_SERVER=$($VAL_FROM_YAML terraform_outputs.elasticache_broker_elb_dns_name cf-terraform-outputs.yml)
-                export METRICS_AWS_ACCESS_KEY_ID=$($VAL_FROM_YAML terraform_outputs.metrics_exporter_aws_access_key_id cf-terraform-outputs.yml)
-                export METRICS_AWS_SECRET_ACCESS_KEY=$($VAL_FROM_YAML terraform_outputs.metrics_exporter_aws_secret_access_key cf-terraform-outputs.yml)
-                EOT
+              paas-cf/scripts/job_instances.rb cf-manifest/cf-manifest.yml \
+                > config/job_instances.tfvars
 
-                paas-cf/scripts/job_instances.rb cf-manifest/cf-manifest.yml \
-                  > config/job_instances.tfvars
-
-                ls -l config/*
+              ls -l config/*
 
     - aggregate:
       - task: create-orgs
@@ -2196,31 +2249,6 @@ jobs:
               ES_HOST=$(ruby "${SCRIPT_DIR}/val_from_yaml.rb" terraform_outputs.logsearch_elastic_master_elb_dns_name cf-tfstate.yaml)
               export ES_PORT="9200"
               ruby "${SCRIPT_DIR}/kibana_set_utc.rb"
-
-      - task: enable-elasticsearch-shard-reallocation
-        config:
-          platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/curl-ssl
-              tag: 465642da06051a55630d39c899697b678f66a7f7
-          inputs:
-          - name: paas-cf
-          - name: cf-terraform-outputs
-          run:
-            path: sh
-            args:
-            - -e
-            - -c
-            - |
-              export TF_VAR_logsearch_elastic_master_elb_dns_name
-              . cf-terraform-outputs/cf.tfstate.sh
-
-              curl -s \
-                -X PUT \
-                -d '{"transient":{"cluster.routing.allocation.enable":"all"}}' \
-                "${TF_VAR_logsearch_elastic_master_elb_dns_name}:9200/_cluster/settings"
 
       - task: datadog-terraform-apply
         config:

--- a/manifests/cf-manifest/cloud-config/030-logsearch.yml
+++ b/manifests/cf-manifest/cloud-config/030-logsearch.yml
@@ -22,7 +22,7 @@ vm_types:
     network: (( grab vm_types.medium.network ))
     env: (( grab meta.default_env ))
     cloud_properties:
-      instance_type: c4.xlarge
+      instance_type: (( grab meta.elasticsearch_master.instance_type ))
       ephemeral_disk:
         size: 10240
         type: gp2

--- a/manifests/cf-manifest/env-specific/cf-default.yml
+++ b/manifests/cf-manifest/env-specific/cf-default.yml
@@ -4,4 +4,4 @@ meta:
     instances: 3
   elasticsearch_master:
     disk_size: 307400
-    instance_type: c4.xlarge
+    instance_type: m4.large

--- a/manifests/cf-manifest/env-specific/cf-default.yml
+++ b/manifests/cf-manifest/env-specific/cf-default.yml
@@ -4,3 +4,4 @@ meta:
     instances: 3
   elasticsearch_master:
     disk_size: 307400
+    instance_type: c4.xlarge

--- a/manifests/cf-manifest/env-specific/cf-prod.yml
+++ b/manifests/cf-manifest/env-specific/cf-prod.yml
@@ -4,3 +4,4 @@ meta:
     instances: 24
   elasticsearch_master:
     disk_size: 3072000
+    instance_type: c4.2xlarge

--- a/manifests/cf-manifest/env-specific/cf-staging.yml
+++ b/manifests/cf-manifest/env-specific/cf-staging.yml
@@ -4,3 +4,4 @@ meta:
     instances: 6
   elasticsearch_master:
     disk_size: 307400
+    instance_type: c4.2xlarge


### PR DESCRIPTION
## What

* Use `c4.2xlarge` AWS instances for production and staging;
* Use `m4.large` AWS instances for dev;
* Redeploy Elasticsearch faster.

See commit messages for details.

## How to review

Suggested:

* Consider our rationale for using larger instances;
* Critique our choice of instances;
* Critique our faster deployment process.

We've tested this in a dev environment. We suggest pausing prod before this is deployed, so as to check that staging Kibana looks good before rolling out to prod.

## Who can review

Not @46bit nor @dcarley. I'd suggest @henrytk and @LeePorte as they have some knowledge of this problem but weren't involved in choosing a solution.