### PR TITLE
[#154437854] Use Bosh CLI v2

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -138,6 +138,30 @@ jobs:
           run:
             path: ./paas-cf/concourse/scripts/sleep_for_deploy_env.sh
 
+      - task: extract-bosh-CA-crt
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: alpine
+              tag: "3.4"
+          inputs:
+            - name: bosh-CA
+          outputs:
+            - name: bosh-CA-crt
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                tar -xvzf bosh-CA/bosh-CA.tar.gz -C bosh-CA-crt
+        on_success:
+          put: bosh-CA-crt
+          params:
+            file: bosh-CA-crt/bosh-CA.crt
+
       - task: delete-deployment
         config:
           platform: linux

--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -56,6 +56,13 @@ resources:
       region_name: ((aws_region))
       versioned_file: bosh-CA.tar.gz
 
+  - name: bosh-CA-crt
+    type: s3-iam
+    source:
+      bucket: ((state_bucket))
+      region_name: ((aws_region))
+      versioned_file: bosh-CA.crt
+
   - name: deployed-healthcheck
     type: s3-iam
     source:
@@ -82,6 +89,7 @@ jobs:
       - get: cf-manifest
       - get: bosh-CA
       - get: datadog-tfstate
+      - get: bosh-CA-crt
 
       - task: get-cf-cli-config
         file: paas-cf/concourse/tasks/get-cf-cli-config.yml
@@ -137,21 +145,26 @@ jobs:
             - name: delete-timer
             - name: bosh-secrets
             - name: paas-cf
+            - name: bosh-CA-crt
+          params:
+            BOSH_ENVIRONMENT: ((bosh_fqdn))
+            BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
+            BOSH_DEPLOYMENT: ((deploy_env))
           outputs:
             - name: deployed-healthcheck
           image_resource:
             type: docker-image
             source:
-              repository: governmentpaas/bosh-cli
-              tag: 465642da06051a55630d39c899697b678f66a7f7
+              repository: governmentpaas/bosh-cli-v2
+              tag: c735581beb174ecc95ca1a7b57eff444af3bf099
           run:
             path: sh
             args:
               - -e
               - -c
               - |
-                ./paas-cf/concourse/scripts/bosh_login.sh "((bosh_fqdn))" bosh-secrets/bosh-secrets.yml
-                bosh -n delete deployment "((deploy_env))" --force
+                ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
+                bosh -n delete-deployment --force
 
                 echo "no" > deployed-healthcheck/healthcheck-deployed
         on_success:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -134,6 +134,13 @@ resources:
       region_name: ((aws_region))
       versioned_file: bosh-CA.tar.gz
 
+  - name: bosh-CA-crt
+    type: s3-iam
+    source:
+      bucket: ((state_bucket))
+      region_name: ((aws_region))
+      versioned_file: bosh-CA.crt
+
   - name: ipsec-CA
     type: s3-iam
     source:
@@ -1215,6 +1222,7 @@ jobs:
           - get: cf-manifest
             passed: ['generate-cf-config']
           - get: bosh-secrets
+          - get: bosh-CA-crt
 
       - aggregate:
         - task: get-and-upload-stemcell
@@ -1223,12 +1231,17 @@ jobs:
             image_resource:
               type: docker-image
               source:
-                repository: governmentpaas/bosh-cli
-                tag: 4c863ad28bcb252bc35e1500e1afef386f5debfa
+                repository: governmentpaas/bosh-cli-v2
+                tag: upgrade_bosh_cli_v2
             inputs:
               - name: bosh-secrets
               - name: paas-cf
               - name: cf-manifest
+              - name: bosh-CA-crt
+            params:
+              BOSH_ENVIRONMENT: ((bosh_fqdn))
+              BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
+              BOSH_DEPLOYMENT: ((deploy_env))
             run:
               path: sh
               args:
@@ -1247,8 +1260,8 @@ jobs:
                     STEMCELL_NAME=$($VAL_FROM_YAML "stemcells.${stemcell_index}.name" cf-manifest/cf-manifest.yml)
 
                     wget "https://bosh.io/d/stemcells/${STEMCELL_NAME}?v=${STEMCELL_VERSION}" -O stemcell.tgz
-                    ./paas-cf/concourse/scripts/bosh_login.sh "((bosh_fqdn))" bosh-secrets/bosh-secrets.yml
-                    bosh upload stemcell stemcell.tgz --skip-if-exists
+                    ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
+                    bosh -n upload-stemcell stemcell.tgz
 
                     stemcell_index=$((stemcell_index + 1))
                   done
@@ -1259,20 +1272,25 @@ jobs:
             image_resource:
               type: docker-image
               source:
-                repository: governmentpaas/bosh-cli
-                tag: 4c863ad28bcb252bc35e1500e1afef386f5debfa
+                repository: governmentpaas/bosh-cli-v2
+                tag: c735581beb174ecc95ca1a7b57eff444af3bf099
             inputs:
               - name: cloud-config
               - name: bosh-secrets
               - name: paas-cf
+              - name: bosh-CA-crt
+            params:
+              BOSH_ENVIRONMENT: ((bosh_fqdn))
+              BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
+              BOSH_DEPLOYMENT: ((deploy_env))
             run:
               path: sh
               args:
                 - -e
                 - -c
                 - |
-                  ./paas-cf/concourse/scripts/bosh_login.sh "((bosh_fqdn))" bosh-secrets/bosh-secrets.yml
-                  bosh update cloud-config cloud-config/cloud-config.yml
+                  ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
+                  bosh -n update-cloud-config cloud-config/cloud-config.yml
 
       - task: cf-deploy
         config:
@@ -1280,28 +1298,25 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: governmentpaas/bosh-cli
-              tag: 4c863ad28bcb252bc35e1500e1afef386f5debfa
+              repository: governmentpaas/bosh-cli-v2
+              tag: c735581beb174ecc95ca1a7b57eff444af3bf099
           inputs:
             - name: paas-cf
             - name: cf-manifest
             - name: bosh-secrets
-          outputs:
-            - name: updated-cf-manifest
+            - name: bosh-CA-crt
+          params:
+            BOSH_ENVIRONMENT: ((bosh_fqdn))
+            BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
+            BOSH_DEPLOYMENT: ((deploy_env))
           run:
             path: sh
             args:
               - -e
               - -c
               - |
-                ./paas-cf/concourse/scripts/bosh_login.sh "((bosh_fqdn))" bosh-secrets/bosh-secrets.yml
-                sed -e "s/^director_uuid:.*/director_uuid: $(bosh status --uuid)/" < cf-manifest/cf-manifest.yml > updated-cf-manifest/cf-manifest.yml
-                bosh deployment updated-cf-manifest/cf-manifest.yml
-                bosh -n deploy
-
-      - put: cf-manifest
-        params:
-          file: updated-cf-manifest/cf-manifest.yml
+                ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
+                bosh -n deploy cf-manifest/cf-manifest.yml
 
   - name: post-deploy
     serial: true
@@ -1321,6 +1336,7 @@ jobs:
       - get: cf-secrets
         passed: ['generate-cf-config']
       - get: bosh-CA
+      - get: bosh-CA-crt
       - get: graphite-nozzle
       - get: datadog-tfstate
       - get: paas-compose-broker
@@ -2043,20 +2059,24 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: governmentpaas/bosh-cli
-              tag: 4c863ad28bcb252bc35e1500e1afef386f5debfa
+              repository: governmentpaas/bosh-cli-v2
+              tag: c735581beb174ecc95ca1a7b57eff444af3bf099
           inputs:
             - name: paas-cf
             - name: bosh-secrets
+            - name: bosh-CA-crt
+          params:
+            BOSH_ENVIRONMENT: ((bosh_fqdn))
+            BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
+            BOSH_DEPLOYMENT: ((deploy_env))
           run:
             path: sh
             args:
               - -e
               - -c
               - |
-                ./paas-cf/concourse/scripts/bosh_login.sh "((bosh_fqdn))" bosh-secrets/bosh-secrets.yml
-
-                bosh cleanup --all
+                ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
+                bosh -n clean-up --all
 
     - aggregate:
       - do:
@@ -2537,34 +2557,40 @@ jobs:
             passed: ['post-deploy','app-availability-tests','api-availability-tests']
           - get: cf-manifest
           - get: bosh-secrets
+          - get: bosh-CA-crt
       - task: test-bosh-vms
         config:
           platform: linux
           image_resource:
             type: docker-image
             source:
-              repository: governmentpaas/bosh-cli
-              tag: 4c863ad28bcb252bc35e1500e1afef386f5debfa
+              repository: governmentpaas/bosh-cli-v2
+              tag: c735581beb174ecc95ca1a7b57eff444af3bf099
           inputs:
-          - name: paas-cf
-          - name: cf-manifest
-          - name: bosh-secrets
+            - name: paas-cf
+            - name: cf-manifest
+            - name: bosh-secrets
+            - name: bosh-CA-crt
+          params:
+            BOSH_ENVIRONMENT: ((bosh_fqdn))
+            BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
+            BOSH_DEPLOYMENT: ((deploy_env))
           run:
             path: sh
             args:
-            - -e
-            - -c
-            - |
-              ./paas-cf/concourse/scripts/bosh_login.sh "((bosh_fqdn))" bosh-secrets/bosh-secrets.yml
-              bosh deployment cf-manifest/cf-manifest.yml
-              bosh vms "((deploy_env))" | tee vms.txt
-              vms_not_running=$(grep '|' vms.txt | grep -cEv "(\-\-|VM|running)" || true)
-              if [ "${vms_not_running}" -gt "0" ]; then
-                echo "Error: Number of not running VMs: ${vms_not_running}."
-                exit 1
-              else
-                echo "Success: All VMs are up and running."
-              fi
+              - -e
+              - -c
+              - |
+                ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
+                bosh deployment
+                bosh vms | tee vms.txt
+                vms_not_running=$(grep '|' vms.txt | grep -cEv "(\-\-|VM|running)" || true)
+                if [ "${vms_not_running}" -gt "0" ]; then
+                  echo "Error: Number of not running VMs: ${vms_not_running}."
+                  exit 1
+                else
+                  echo "Success: All VMs are up and running."
+                fi
 
   - name: performance-tests
     plan:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -411,6 +411,7 @@ jobs:
                 paas-cf/concourse/scripts/s3init.sh "((state_bucket))" id_rsa paas-cf/concourse/init_files/zero_bytes
                 paas-cf/concourse/scripts/s3init.sh "((state_bucket))" id_rsa.pub paas-cf/concourse/init_files/zero_bytes
                 paas-cf/concourse/scripts/s3init.sh "((state_bucket))" healthcheck-deployed paas-cf/concourse/init_files/string-no
+                paas-cf/concourse/scripts/s3init.sh "((state_bucket))" bosh-CA.crt paas-cf/concourse/init_files/zero_bytes
 
   - name: generate-secrets
     serial_groups: [cf-deploy]
@@ -428,8 +429,33 @@ jobs:
           - get: cf-secrets
           - get: ssh-private-key
           - get: ssh-public-key
+          - get: bosh-CA-crt
 
       - aggregate:
+        - task: extract-bosh-CA-crt
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: alpine
+                tag: "3.4"
+            inputs:
+              - name: bosh-CA
+            outputs:
+              - name: bosh-CA-crt
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  tar -xvzf bosh-CA/bosh-CA.tar.gz -C bosh-CA-crt
+          on_success:
+            put: bosh-CA-crt
+            params:
+              file: bosh-CA-crt/bosh-CA.crt
+
         - task: generate-ipsec-CA
           config:
             platform: linux

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -70,6 +70,13 @@ resources:
       region_name: ((aws_region))
       versioned_file: bosh-CA.tar.gz
 
+  - name: bosh-CA-crt
+    type: s3-iam
+    source:
+      bucket: ((state_bucket))
+      region_name: ((aws_region))
+      versioned_file: bosh-CA.crt
+
   - name: cf-secrets
     type: s3-iam
     source:
@@ -149,6 +156,7 @@ jobs:
           - get: cf-secrets
           - get: cf-manifest
           - get: datadog-tfstate
+          - get: bosh-CA-crt
 
       - task: get-cf-cli-config
         file: paas-cf/concourse/tasks/get-cf-cli-config.yml
@@ -188,11 +196,16 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: governmentpaas/bosh-cli
-              tag: 465642da06051a55630d39c899697b678f66a7f7
+              repository: governmentpaas/bosh-cli-v2
+              tag: c735581beb174ecc95ca1a7b57eff444af3bf099
           inputs:
             - name: bosh-secrets
             - name: paas-cf
+            - name: bosh-CA-crt
+          params:
+            BOSH_ENVIRONMENT: ((bosh_fqdn))
+            BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
+            BOSH_DEPLOYMENT: ((deploy_env))
           outputs:
             - name: deployed-healthcheck
           run:
@@ -201,8 +214,8 @@ jobs:
               - -e
               - -c
               - |
-                ./paas-cf/concourse/scripts/bosh_login.sh "((bosh_fqdn))" bosh-secrets/bosh-secrets.yml
-                bosh -n delete deployment --force "((deploy_env))"
+                ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
+                bosh -n delete-deployment --force
                 echo "no" > deployed-healthcheck/healthcheck-deployed
         on_success:
           put: deployed-healthcheck

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -158,6 +158,30 @@ jobs:
           - get: datadog-tfstate
           - get: bosh-CA-crt
 
+      - task: extract-bosh-CA-crt
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: alpine
+              tag: "3.4"
+          inputs:
+            - name: bosh-CA
+          outputs:
+            - name: bosh-CA-crt
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                tar -xvzf bosh-CA/bosh-CA.tar.gz -C bosh-CA-crt
+        on_success:
+          put: bosh-CA-crt
+          params:
+            file: bosh-CA-crt/bosh-CA.crt
+
       - task: get-cf-cli-config
         file: paas-cf/concourse/tasks/get-cf-cli-config.yml
 

--- a/concourse/scripts/bosh_login.sh
+++ b/concourse/scripts/bosh_login.sh
@@ -1,11 +1,9 @@
 #!/bin/sh
 set -eu
 
-bosh_host=$1
-bosh_secrets_file=$2
+bosh_secrets_file=$1
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 bosh_password=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.bosh_admin_password "${bosh_secrets_file}")
 
-bosh -t "${bosh_host}" login admin -- "${bosh_password}"
-bosh target "${bosh_host}"
+bosh login --client="admin" --client-secret="${bosh_password}"

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -2,7 +2,6 @@ meta:
   environment: (( grab terraform_outputs.environment ))
 
 name: (( grab meta.environment ))
-director_uuid: ~
 
 releases:
   - name: consul


### PR DESCRIPTION
## What

We have migrated to using BOSH CLI v2 commands. This includes updates to use the latest binaries in bosh-cli-v2 docker images.

Changes:
* We extract the bosh_CA.crt file as a separate resource so we can use it easily for `bosh login` commands easily. This is done in bootstrap already but we duplicate it here to avoid requiring running create-bosh-concourse.
* Don't generate director_uuid into the deployment manifest (the v2 cli doesn't need it)

## Before merging

⚠️ Please ensure that the `bosh-cli-v2` docker images referenced are using the SHA not the tag before merging.

⚠️ Please ensure that the paas-bootstrap is merged and applied to staging/production environments before merging.

## How to review

* Try to deploy from master.
* Try from from [paas-bootstrap](https://github.com/alphagov/paas-bootstrap/pull/140)
* Try to destroy/autodelete (remember that the branch is pinned to master for destroy pipelines so you will have to manually tweak it and push pipelines to test)

## Who can review

Not @chrisfarms or @bandesz 