### PR TITLE
[#15517855] Change Redis queue length alert to check hosts individually.

### DIFF
--- a/terraform/datadog/queue.tf
+++ b/terraform/datadog/queue.tf
@@ -1,7 +1,7 @@
 resource "datadog_monitor" "queue_logsearch_redis_queue_length" {
   name                = "${format("%s Logsearch Redis queue length", var.env)}"
   type                = "metric alert"
-  query               = "${format("max(last_5m):avg:redis.key.length{deploy_env:%s,bosh-job:queue,key:logstash} > 1000000", var.env)}"
+  query               = "${format("max(last_5m):max:redis.key.length{deploy_env:%s,bosh-job:queue,key:logstash} by {host} > 1000000", var.env)}"
   message             = "${format("Logsearch Redis queue length is over {{#is_warning}}{{warn_threshold}}{{/is_warning}}{{#is_alert}}{{threshold}}, Logsearch started to drop log messages.{{/is_alert}}. See [Team Manual > Responding to alerts > Logsearch/ELK queue threshold limits](%s#logsearchelk-queue-threshold-limits) for more info.", var.datadog_documentation_url)}"
   notify_no_data      = true
   require_full_window = true


### PR DESCRIPTION
## What

We accidentally averaged over all Redis queues which would cause us not to be
alerted properly for individual Redis issues.

I also changed avg to max which shouldn't matter, but would have been safer in the first place.

## How to review

Code review.

I don't think there is value in enabling Datadog in a dev env just for this. I got the fixed query from Datadog directly.

## Who can review

Not me.