### PR TITLE
[#154769249] Update cfdot cert paths for BBS health check

### DIFF
--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -132,6 +132,12 @@ jobs:
         release: datadog-for-cloudfoundry
       - name: datadog-bbs
         release: datadog-for-cloudfoundry
+        properties:
+          bbs:
+            url: (( concat "https://" meta.bbs.api_location "/v1/actual_lrp_groups/list" ))
+            client_cert: "/var/vcap/jobs/cfdot/config/certs/cfdot/client.crt"
+            client_key: "/var/vcap/jobs/cfdot/config/certs/cfdot/client.key"
+            ca_cert: "/var/vcap/jobs/cfdot/config/certs/cfdot/ca.crt"
       - name: bbs
         release: diego
       - name: cfdot
@@ -147,9 +153,6 @@ jobs:
       - name: cf
     update:
       serial: true
-    properties:
-      bbs:
-          url: (( concat "https://" meta.bbs.api_location "/v1/actual_lrp_groups/list" ))
 
   - name: uaa
     azs: [z1, z2]


### PR DESCRIPTION
## What

These recently changed in diego-release v1.33.0 and later which caused our BBS
check to fail with certificate errors because it couldn't do mutual TLS against
BBS:

- cloudfoundry/diego-release@c9ff9ed3b9ea40b14b1b46b3ae3c985183dddee7

The defaults are hardcoded in alphagov/paas-datadog-bbs-integration but
that's difficult to update because:

- the tests are currently failing because of unpinned dependencies
- it requires three PRs to update the submodule and releases

So I'm fixing it here for the moment. I've set them as properties of the
job, rather than the VM, just in case the `bbs` key overrides something
in the `bbs` job. I've had to move the `url` because otherwise the job
properties overwrite it.

## How to review

If you currently have DataDog enabled in your dev environment then you can deploy this branch and confirm that the "BBS healthy" monitor is no longer triggered.

If you don't then you can check the paths are correct with `bosh ssh` to a database VM.

## Who can review

Anyone.