### PR TITLE
[#155438572] Downgrade garden-runc

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -98,7 +98,7 @@ releases:
 stemcells:
   - alias: default
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3468.22"
+    version: "3468.25"
 
 update:
   canaries: 0

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -33,9 +33,9 @@ releases:
     url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=1.35.0
     sha1: 7525f412d6698f499124f0facee64a40a1e99ec0
   - name: garden-runc
-    version: "1.11.1"
-    url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.11.1
-    sha1: d9a7901c0502d97c043b857496f0f414a5843e8d
+    version: 1.10.0
+    url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.10.0
+    sha1: 9c2ad4a961db49a5349a26d4240b8f8b9b54af88
   - name: cflinuxfs2
     version: "1.187.0"
     url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.187.0

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -639,7 +639,7 @@ properties:
         client_key: (( grab secrets.bbs_client_key ))
         require_ssl: true
       preloaded_rootfses:
-        - cflinuxfs2:/var/vcap/packages/cflinuxfs2/rootfs.tar
+        - "cflinuxfs2:/var/vcap/packages/cflinuxfs2/rootfs"
 
     executor:
       memory_capacity_mb: (( calc "floor(meta.cell.rep_commit_percentage * meta.cell.instance_memory_mb)" ))


### PR DESCRIPTION
## What

This partially reverts d97a9c92085b31c52f88fbdf5f60101b783a4c03 in
order to downgrade the version of the garden-runc release. This is
due to a bug with grootfs[1] causing a live service outage for tenants
using certain Docker images.

[1] https://www.pivotaltracker.com/n/projects/1158420/stories/155391026

## How to review

### Before merging ⚠️ 

This change may not be required if an alternative solution is found by tomorrow (Friday 23 Feb).
 
* Deploy from master.
* Replicate the issue our tenants are having with Docker images:
  * Deploy an app known to be affected:

  ```
  cf push lol --docker-image ppdeploy/spotlight:5292
  ```

  * Check the logs:

  ```
  cf logs lol --recent
  ```

* Expected error will be:

  ```
  2018-02-22T16:55:20.69+0000 [APP/PROC/WEB/0] ERR fs.js:641
  2018-02-22T16:55:20.69+0000 [APP/PROC/WEB/0] ERR   return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
  2018-02-22T16:55:20.69+0000 [APP/PROC/WEB/0] ERR                  ^
  2018-02-22T16:55:20.69+0000 [APP/PROC/WEB/0] ERR Error: ENOENT: no such file or directory, open '/srv/app/public/asset-digest.json'
  2018-02-22T16:55:20.69+0000 [APP/PROC/WEB/0] ERR     at Error (native)
  ```
* Deploy from this branch and check all tests pass.
* Try deploying the same app again and it should work.

## Who can review

Anyone but me.
