### PR TITLE
[#120268519] Monitoring gorouter latency

### DIFF
--- a/terraform/datadog/router.tf
+++ b/terraform/datadog/router.tf
@@ -143,16 +143,16 @@ resource "datadog_monitor" "gorouter_healthy" {
 resource "datadog_monitor" "gorouter_latency" {
   name                = "${format("%s gorouter latency", var.env)}"
   type                = "metric alert"
-  message             = "Gorouter latency too high."
+  message             = "${format("Gorouter latency too high. See: %s#Gorouter-high-latency-alerts", var.datadog_documentation_url)}"
   escalation_message  = "Gorouter latency still too high. Check the deployment."
   no_data_timeframe   = "7"
   require_full_window = true
 
-  query = "${format("avg(last_1m):avg:cf.gorouter.latency{deployment:%s,job:router} by {ip} > 800", var.env)}"
+  query = "${format("avg(last_10m):avg:cf.gorouter.latency{deployment:%s,job:router} by {ip} > 2500", var.env)}"
 
   thresholds {
-    warning  = "400.0"
-    critical = "800.0"
+    warning  = "750.0"
+    critical = "1500.0"
   }
 
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:router"]


### PR DESCRIPTION
## What

This commit increases the thresholds on the gorouter monitor in order to
avoid false positives.

The inital monor values were set too low and as a result were triggering
the alert in a flapping manner. This is not useful for us as a team.

## How to review

Code review should suffice.
If you wish you can deploy from this branch with `ENABLE_DATADOG=true`

## Who can review

Not @LeePorte
