### PR TITLE
Add a 2xlarge quota definition

### DIFF
--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -281,6 +281,11 @@ properties:
         total_services: 80
         non_basic_services_allowed: true
         total_routes: 1000
+      2xlarge:
+        memory_limit: 409600
+        total_services: 160
+        non_basic_services_allowed: true
+        total_routes: 1000
       test_apps:
         memory_limit: 2048
         total_services: 10


### PR DESCRIPTION
## What

Add a 2xlarge quota definition, because Notify want to scale up, and are restricted by xlarge.

## How to review

Code review, possibly involving a deployment to dev. It should be pretty safe, though.

## Who can review

Anyone by @camelpunch