### PR TITLE
[#120268519] Make gorouter latency query match thresholds

### DIFF
--- a/terraform/datadog/router.tf
+++ b/terraform/datadog/router.tf
@@ -148,7 +148,7 @@ resource "datadog_monitor" "gorouter_latency" {
   no_data_timeframe   = "7"
   require_full_window = true
 
-  query = "${format("avg(last_10m):avg:cf.gorouter.latency{deployment:%s,job:router} by {ip} > 2500", var.env)}"
+  query = "${format("avg(last_10m):avg:cf.gorouter.latency{deployment:%s,job:router} by {ip} > 1500", var.env)}"
 
   thresholds {
     warning  = "750.0"


### PR DESCRIPTION
## What

Or it fails to apply with this annoying error that we haven't seen for a while:

    * datadog_monitor.gorouter_latency: error updating monitor: API error 400 Bad Request: {"errors":["Critical threshold (1500.0) does not match that used in the query (2500.0)."]}

## How to review

Code review.

## Who can review

Anyone.