### PR TITLE
[Support] Embiggen staging elasticsearch disks.

### DIFF
--- a/manifests/cf-manifest/env-specific/cf-staging.yml
+++ b/manifests/cf-manifest/env-specific/cf-staging.yml
@@ -3,5 +3,5 @@ meta:
   cell:
     instances: 6
   elasticsearch_master:
-    disk_size: 307400
+    disk_size: 460800
     instance_type: c4.2xlarge


### PR DESCRIPTION
## What

Staging is [hovering around the 75%](https://app.datadoghq.com/metric/explorer?live=false&page=0&is_auto=false&from_ts=1514764800000&to_ts=1519948799999&tile_size=m&exp_metric=system.disk.in_use&exp_scope=deploy_env%3Astaging%2Cbosh-job%3Aelasticsearch_master%2Cdevice%3A%2Fdev%2Fxvdf1&exp_group=bosh-index&exp_agg=avg&exp_row_type=metric) mark at the moment, and has been for
nearly a month. Adding another 50% will give us some headroom until we
get to migrate away.

## How to review

Code review. Check my rationale makes sense.

## Who can review

Not me.