### PR TITLE
WIP [#155398419] Stemcell upgrade to v3541.5

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -102,6 +102,9 @@ stemcells:
   - alias: logsearch
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
     version: "3468.22"
+  - alias: graphite
+    name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
+    version: "3468.22"
 
 update:
   canaries: 0

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -98,6 +98,9 @@ releases:
 stemcells:
   - alias: default
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
+    version: "3541.5"
+  - alias: logsearch
+    name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
     version: "3468.22"
 
 update:

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -45,9 +45,9 @@ releases:
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/paas-haproxy-0.1.5.tgz
     sha1: c8c90a4c14ea2201a37469596b5cef309864a394
   - name: datadog-for-cloudfoundry
-    version: "0.1.18"
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.1.18.tgz
-    sha1: a1de9fed600f8edabe391a536118b4b720f974ae
+    version: 0.0.1519983658
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.0.1519983658.tgz
+    sha1: 74cb67929e37c8742881e095cbcd13d44956ff59
   - name: ipsec
     version: "0.1.3"
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/ipsec-0.1.3.tgz

--- a/manifests/cf-manifest/manifest/040-graphite.yml
+++ b/manifests/cf-manifest/manifest/040-graphite.yml
@@ -24,7 +24,7 @@ jobs:
   azs: [z1]
   instances: 1
   vm_type: graphite
-  stemcell: default
+  stemcell: graphite
   persistent_disk_type: graphite_data
   networks:
     - name: cf

--- a/manifests/cf-manifest/manifest/800-logsearch.yml
+++ b/manifests/cf-manifest/manifest/800-logsearch.yml
@@ -18,7 +18,7 @@ jobs:
   - name: datadog-logsearch-queue
     release: datadog-for-cloudfoundry
   vm_type: small
-  stemcell: default
+  stemcell: logsearch
   instances: 2
   networks:
   - name: cf
@@ -36,7 +36,7 @@ jobs:
   - name: logsearch-for-cloudfoundry-filters
     release: logsearch-for-cloudfoundry
   vm_type: parser
-  stemcell: default
+  stemcell: logsearch
   instances: 1
   networks:
   - name: cf
@@ -56,7 +56,7 @@ jobs:
   - name: logsearch-for-cloudfoundry-filters
     release: logsearch-for-cloudfoundry
   vm_type: parser
-  stemcell: default
+  stemcell: logsearch
   instances: 1
   networks:
   - name: cf
@@ -74,7 +74,7 @@ jobs:
   - name: elasticsearch
     release: logsearch
   vm_type: elasticsearch_master
-  stemcell: default
+  stemcell: logsearch
   instances: 3
   networks:
   - name: cf
@@ -104,7 +104,7 @@ jobs:
   - name: logsearch-for-cloudfoundry-filters
     release: logsearch-for-cloudfoundry
   vm_type: small
-  stemcell: default
+  stemcell: logsearch
   networks:
   - name: cf
   properties:
@@ -121,7 +121,7 @@ jobs:
   - name: haproxy
     release: logsearch
   vm_type: kibana
-  stemcell: default
+  stemcell: logsearch
   instances: 1
   networks:
   - name: cf
@@ -133,7 +133,7 @@ jobs:
   - name: ingestor_syslog
     release: logsearch
   vm_type: ingestor
-  stemcell: default
+  stemcell: logsearch
   instances: 1
   networks:
   - name: cf
@@ -153,7 +153,7 @@ jobs:
   - name: ingestor_syslog
     release: logsearch
   vm_type: ingestor
-  stemcell: default
+  stemcell: logsearch
   instances: 1
   networks:
   - name: cf


### PR DESCRIPTION
## What

We upgrade the stemcell version to v3541.5 (except for Logsearch and Graphite VMS).

Some of the Logsearch VMs and the Graphite VMs are not compatible with the v3541.x images, as the permission hardening caused issues in a previous upgrade attempt. [1]

We also upgrade Datadog as it couldn't read its own configuration+log files because of the permission changes. See [2] for details.

❗️This PR contains a temporary commit which should be replaced when the final datadog-for-cloudfoundry release was built.

[1] https://www.pivotaltracker.com/story/show/154769249
[2] https://github.com/alphagov/paas-datadog-agent-boshrelease/pull/12

## How to review

TODO

## Who can review

Not me
