### PR TITLE
[Support] Require CR in create-user.sh org prompt

### DIFF
--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -104,7 +104,7 @@ check_params_and_environment() {
 
 create_org_space() {
   if ! cf org "${ORG}" 2&> /dev/null; then
-    read -p "The org $ORG doesn't exist yet. Do you want to create it? [Yy] " -n 1 -r
+    read -p "The org $ORG doesn't exist yet. Do you want to create it? [Yy] " -r
     if [[ "$REPLY" =~ ^[Yy]$ ]]; then
       echo
       cf create-org "${ORG}"


### PR DESCRIPTION
## What

Making this require a CR makes it consistent with our uses of read in
other places.

## How to review

* Login to a dev environment
* create a new org with `./scripts/create-user.sh -o foo -e foo@example.com --no-email`
* Verify that the new-org prompt behaves as expected

## Who can review

Not me.