### PR TITLE
[#155130407] Replace go-bindata in paas-billing

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -279,7 +279,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-billing
-      tag_filter: v0.13.0
+      tag_filter: v0.14.0
 
 jobs:
   - name: pipeline-lock


### PR DESCRIPTION
## What

Bumps paas-billing version for the associated changes:
https://github.com/alphagov/paas-billing/pull/17

## How to review

* Deploy from this branch with `ENABLE_BILLING_APP=true` and `SELF_UPDATE_PIPELINE=false`
* Ensure paas-billing is still alive and kicking

## ⚠️ Before merging

* Merge https://github.com/alphagov/paas-billing/pull/17
* Replace the [TMP] commit with the proper version from build ci

## Who can review

Not @chrisfarms or @dcarley 
