### PR TITLE
[#155462110] Use alpine instead of bosh-cli where needed

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -130,7 +130,7 @@ jobs:
             type: docker-image
             source:
               repository: alpine
-              tag: "3.4"
+              tag: latest
           inputs:
             - name: paas-cf
           params:
@@ -145,7 +145,7 @@ jobs:
             type: docker-image
             source:
               repository: alpine
-              tag: "3.4"
+              tag: latest
           inputs:
             - name: bosh-CA
           outputs:

--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -129,8 +129,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: governmentpaas/bosh-cli
-              tag: 465642da06051a55630d39c899697b678f66a7f7
+              repository: alpine
+              tag: "3.4"
           inputs:
             - name: paas-cf
           params:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -331,7 +331,7 @@ jobs:
               type: docker-image
               source:
                 repository: alpine
-                tag: "3.4"
+                tag: latest
             platform: linux
             params:
               DISABLE_PIPELINE_LOCKING: ((disable_pipeline_locking))
@@ -439,7 +439,7 @@ jobs:
               type: docker-image
               source:
                 repository: alpine
-                tag: "3.4"
+                tag: latest
             inputs:
               - name: bosh-CA
             outputs:
@@ -1121,7 +1121,7 @@ jobs:
               type: docker-image
               source:
                 repository: alpine
-                tag: "3.4"
+                tag: latest
             inputs:
               - name: paas-cf
             outputs:
@@ -1156,7 +1156,7 @@ jobs:
               type: docker-image
               source:
                 repository: alpine
-                tag: "3.4"
+                tag: latest
             inputs:
               - name: paas-cf
               - name: cf-certs
@@ -2908,7 +2908,7 @@ jobs:
               type: docker-image
               source:
                 repository: alpine
-                tag: "3.4"
+                tag: latest
             platform: linux
             params:
               DISABLE_PIPELINE_LOCKING: ((disable_pipeline_locking))

--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -31,7 +31,7 @@ jobs:
             type: docker-image
             source:
               repository: alpine
-              tag: "3.4"
+              tag: latest
           inputs:
             - name: paas-cf
             - name: deployment-timer

--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -30,8 +30,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: governmentpaas/bosh-cli
-              tag: 465642da06051a55630d39c899697b678f66a7f7
+              repository: alpine
+              tag: "3.4"
           inputs:
             - name: paas-cf
             - name: deployment-timer

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -165,7 +165,7 @@ jobs:
             type: docker-image
             source:
               repository: alpine
-              tag: "3.4"
+              tag: latest
           inputs:
             - name: bosh-CA
           outputs:


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/155462110

What?
----

We were using the bosh-cli docker image in some places where it was not
needed as we did not use the bosh cli.

In this commit we remove such dependency. Alpine is enough.

How to review?
------------

Code review. You can try to run the job.

Who?
---

Anyone but @keymon