### PR TITLE
[#155623416] Restructure/rename instance_groups to match cf-deployment (PR 2 of 4)

### DIFF
--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -25,6 +25,28 @@ instance_groups:
         agent:
           mode: server
 
+  - name: nats
+    azs: [z1, z2]
+    jobs:
+      - name: consul_agent
+        release: consul
+        consumes: {consul_client: nil, consul_server: nil, consul_common: nil}
+      - name: datadog-consul-agent-client
+        release: datadog-for-cloudfoundry
+      - name: nats
+        consumes: {nats: nil}
+        release: nats
+      - name: datadog-nats
+        release: datadog-for-cloudfoundry
+      - name: metron_agent
+        release: loggregator
+    instances: 2
+    vm_type: medium
+    stemcell: default
+    networks:
+      - name: cf
+        static_ips: ((nats_static_ips))
+
   - name: adapter
     azs: [z1, z2, z3]
     instances: 3
@@ -59,78 +81,6 @@ instance_groups:
     update:
       serial: true
       max_in_flight: 1
-
-  - name: scheduler
-    azs: [z1, z2, z3]
-    instances: 3
-    vm_type: medium
-    stemcell: default
-    networks:
-      - name: cf
-    jobs:
-      - name: consul_agent
-        release: consul
-        consumes: {consul: nil, consul_common: nil, consul_server: nil, consul_client: nil}
-      - name: metron_agent
-        release: loggregator
-      - name: cfdot
-        release: diego
-      - name: auctioneer
-        release: diego
-      - name: cloud_controller_clock
-        release: capi
-      - name: statsd_injector
-        release: statsd-injector
-      - name: tps
-        release: capi
-      - name: ssh_proxy
-        release: diego
-      - name: scheduler
-        release: cf-syslog-drain
-    vm_extensions:
-      - ssh_proxy_elb
-      - cf_rds_client_sg
-    properties:
-      scalablesyslog:
-        scheduler:
-          api:
-            url: https://cloud-controller-ng.service.cf.internal:9023
-          tls:
-            client:
-              ca: ((certs_bosh_ca_cert))
-              cert: ((certs_scalablesyslog_adapter_scheduler_client_cert))
-              key: ((certs_scalablesyslog_adapter_scheduler_client_key))
-              adapter_cn: "scalablesyslog_adapter"
-            api:
-              ca: ((certs_bosh_ca_cert))
-              cert: ((certs_scalablesyslog_adapter_scheduler_api_cert))
-              key: ((certs_scalablesyslog_adapter_scheduler_api_key))
-              cn: "cloud-controller-ng.service.cf.internal"
-    update:
-      serial: true
-      max_in_flight: 1
-
-  - name: nats
-    azs: [z1, z2]
-    jobs:
-      - name: consul_agent
-        release: consul
-        consumes: {consul_client: nil, consul_server: nil, consul_common: nil}
-      - name: datadog-consul-agent-client
-        release: datadog-for-cloudfoundry
-      - name: nats
-        consumes: {nats: nil}
-        release: nats
-      - name: datadog-nats
-        release: datadog-for-cloudfoundry
-      - name: metron_agent
-        release: loggregator
-    instances: 2
-    vm_type: medium
-    stemcell: default
-    networks:
-      - name: cf
-        static_ips: ((nats_static_ips))
 
   - name: diego-api
     migrated_from:
@@ -296,45 +246,6 @@ instance_groups:
     properties:
       max_in_flight: 1
 
-  - name: log-api
-    migrated_from:
-    - name: loggregator_trafficcontroller
-    azs: [z1, z2]
-    jobs:
-      - name: consul_agent
-        release: consul
-        consumes: {consul_client: nil, consul_server: nil, consul_common: nil}
-      - name: datadog-consul-agent-client
-        release: datadog-for-cloudfoundry
-      - name: loggregator_trafficcontroller
-        release: loggregator
-        consumes: {doppler: {from: doppler}}
-      - name: metron_agent
-        release: loggregator
-      - name: reverse_log_proxy
-        release: loggregator
-    provides:
-      reverse_log_proxy: {as: reverse_log_proxy, shared: true}
-    instances: 2
-    vm_type: medium
-    vm_extensions:
-      - cf_doppler_elbs
-    stemcell: default
-    networks:
-      - name: cf
-    properties:
-      loggregator:
-        uaa:
-          client_secret: ((secrets_uaa_clients_doppler_secret))
-        reverse_log_proxy:
-          egress:
-            port: 8082
-      consul:
-        agent:
-          services:
-            loggregator_trafficcontroller: {}
-            reverse_log_proxy: {}
-
   - name: router
     azs: [z1, z2]
     jobs:
@@ -370,6 +281,80 @@ instance_groups:
         ports:
         - name: router
           targets: ((terraform_outputs_cell_subnet_cidr_blocks))
+
+  - name: scheduler
+    azs: [z1, z2, z3]
+    instances: 3
+    vm_type: medium
+    stemcell: default
+    networks:
+      - name: cf
+    jobs:
+      - name: consul_agent
+        release: consul
+        consumes: {consul: nil, consul_common: nil, consul_server: nil, consul_client: nil}
+      - name: metron_agent
+        release: loggregator
+      - name: cfdot
+        release: diego
+      - name: auctioneer
+        release: diego
+      - name: cloud_controller_clock
+        release: capi
+      - name: statsd_injector
+        release: statsd-injector
+      - name: tps
+        release: capi
+      - name: ssh_proxy
+        release: diego
+      - name: scheduler
+        release: cf-syslog-drain
+    vm_extensions:
+      - ssh_proxy_elb
+      - cf_rds_client_sg
+    properties:
+      scalablesyslog:
+        scheduler:
+          api:
+            url: https://cloud-controller-ng.service.cf.internal:9023
+          tls:
+            client:
+              ca: ((certs_bosh_ca_cert))
+              cert: ((certs_scalablesyslog_adapter_scheduler_client_cert))
+              key: ((certs_scalablesyslog_adapter_scheduler_client_key))
+              adapter_cn: "scalablesyslog_adapter"
+            api:
+              ca: ((certs_bosh_ca_cert))
+              cert: ((certs_scalablesyslog_adapter_scheduler_api_cert))
+              key: ((certs_scalablesyslog_adapter_scheduler_api_key))
+              cn: "cloud-controller-ng.service.cf.internal"
+    update:
+      serial: true
+      max_in_flight: 1
+
+  - name: doppler
+    azs: [z1, z2, z3]
+    jobs:
+      - name: consul_agent
+        release: consul
+        consumes: {consul_client: nil, consul_server: nil, consul_common: nil}
+      - name: datadog-consul-agent-client
+        release: datadog-for-cloudfoundry
+      - name: doppler
+        release: loggregator
+        provides: {doppler: {as: doppler}}
+      - name: metron_agent
+        release: loggregator
+    instances: 3
+    vm_type: medium
+    stemcell: default
+    networks:
+      - name: cf
+    properties:
+      consul:
+        agent:
+          services:
+            doppler: {}
 
   - name: diego-cell
     migrated_from:
@@ -414,6 +399,45 @@ instance_groups:
         cert: ((certs_cc_client_cert))
         key: ((certs_cc_client_key))
 
+  - name: log-api
+    migrated_from:
+    - name: loggregator_trafficcontroller
+    azs: [z1, z2]
+    jobs:
+      - name: consul_agent
+        release: consul
+        consumes: {consul_client: nil, consul_server: nil, consul_common: nil}
+      - name: datadog-consul-agent-client
+        release: datadog-for-cloudfoundry
+      - name: loggregator_trafficcontroller
+        release: loggregator
+        consumes: {doppler: {from: doppler}}
+      - name: metron_agent
+        release: loggregator
+      - name: reverse_log_proxy
+        release: loggregator
+    provides:
+      reverse_log_proxy: {as: reverse_log_proxy, shared: true}
+    instances: 2
+    vm_type: medium
+    vm_extensions:
+      - cf_doppler_elbs
+    stemcell: default
+    networks:
+      - name: cf
+    properties:
+      loggregator:
+        uaa:
+          client_secret: ((secrets_uaa_clients_doppler_secret))
+        reverse_log_proxy:
+          egress:
+            port: 8082
+      consul:
+        agent:
+          services:
+            loggregator_trafficcontroller: {}
+            reverse_log_proxy: {}
+
   - name: route_emitter
     azs: [z1, z2]
     jobs:
@@ -435,27 +459,3 @@ instance_groups:
     stemcell: default
     networks:
       - name: cf
-
-  - name: doppler
-    azs: [z1, z2, z3]
-    jobs:
-      - name: consul_agent
-        release: consul
-        consumes: {consul_client: nil, consul_server: nil, consul_common: nil}
-      - name: datadog-consul-agent-client
-        release: datadog-for-cloudfoundry
-      - name: doppler
-        release: loggregator
-        provides: {doppler: {as: doppler}}
-      - name: metron_agent
-        release: loggregator
-    instances: 3
-    vm_type: medium
-    stemcell: default
-    networks:
-      - name: cf
-    properties:
-      consul:
-        agent:
-          services:
-            doppler: {}

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -371,27 +371,6 @@ instance_groups:
         - name: router
           targets: ((terraform_outputs_cell_subnet_cidr_blocks))
 
-  # FIXME: Delete me
-  - name: brain
-    azs: [z1, z2]
-    jobs:
-      - name: consul_agent
-        release: consul
-        consumes: {consul_client: nil, consul_server: nil, consul_common: nil}
-      - name: datadog-consul-agent-client
-        release: datadog-for-cloudfoundry
-      - name: auctioneer
-        release: diego
-      - name: cfdot
-        release: diego
-      - name: metron_agent
-        release: loggregator
-    instances: 2
-    vm_type: medium
-    stemcell: default
-    networks:
-      - name: cf
-
   - name: diego-cell
     migrated_from:
     - name: cell
@@ -435,25 +414,6 @@ instance_groups:
         cert: ((certs_cc_client_cert))
         key: ((certs_cc_client_key))
 
-  # FIXME: Delete me
-  - name: cc_bridge
-    azs: [z1, z2]
-    jobs:
-      - name: consul_agent
-        release: consul
-        consumes: {consul_client: nil, consul_server: nil, consul_common: nil}
-      - name: datadog-consul-agent-client
-        release: datadog-for-cloudfoundry
-      - name: tps
-        release: capi
-      - name: metron_agent
-        release: loggregator
-    instances: 2
-    vm_type: medium
-    stemcell: default
-    networks:
-      - name: cf
-
   - name: route_emitter
     azs: [z1, z2]
     jobs:
@@ -472,31 +432,6 @@ instance_groups:
         release: datadog-for-cloudfoundry
     instances: 2
     vm_type: medium
-    stemcell: default
-    networks:
-      - name: cf
-
-  # FIXME: Delete me
-  - name: access
-    azs: [z1, z2]
-    jobs:
-      - name: consul_agent
-        release: consul
-        consumes: {consul_client: nil, consul_server: nil, consul_common: nil}
-      - name: datadog-consul-agent-client
-        release: datadog-for-cloudfoundry
-      - name: ssh_proxy
-        release: diego
-      - name: metron_agent
-        release: loggregator
-      - name: file_server
-        release: diego
-      - name: cfdot
-        release: diego
-    instances: 2
-    vm_type: small
-    vm_extensions:
-      - ssh_proxy_elb
     stemcell: default
     networks:
       - name: cf

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -18,12 +18,12 @@ instance_groups:
     networks:
       - name: cf
         static_ips: ((consul_static_ips))
-    update:
-      serial: true
     properties:
       consul:
         agent:
           mode: server
+    update:
+      serial: true
 
   - name: nats
     azs: [z1, z2]
@@ -78,9 +78,6 @@ instance_groups:
             cert: ((certs_reverse_log_proxy_cert))
             key: ((certs_reverse_log_proxy_key))
             cn: reverse_log_proxy
-    update:
-      serial: true
-      max_in_flight: 1
 
   - name: diego-api
     migrated_from:
@@ -243,8 +240,6 @@ instance_groups:
     stemcell: default
     networks:
       - name: cf
-    properties:
-      max_in_flight: 1
 
   - name: router
     azs: [z1, z2]
@@ -281,6 +276,8 @@ instance_groups:
         ports:
         - name: router
           targets: ((terraform_outputs_cell_subnet_cidr_blocks))
+    update:
+      serial: true
 
   - name: scheduler
     azs: [z1, z2, z3]
@@ -330,7 +327,6 @@ instance_groups:
               cn: "cloud-controller-ng.service.cf.internal"
     update:
       serial: true
-      max_in_flight: 1
 
   - name: doppler
     azs: [z1, z2, z3]
@@ -437,6 +433,8 @@ instance_groups:
           services:
             loggregator_trafficcontroller: {}
             reverse_log_proxy: {}
+    update:
+      serial: true
 
   - name: route_emitter
     azs: [z1, z2]

--- a/manifests/cf-manifest/spec/manifest/instance_group_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/instance_group_spec.rb
@@ -62,24 +62,16 @@ RSpec.describe "the instance_groups definitions block" do
   end
 
   describe "in order to match the upstream Diego instance_group ordering" do
-    it "has database before brain" do
-      expect("diego-api").to be_ordered_before("brain")
+    it "has diego-api before scheduler" do
+      expect("diego-api").to be_ordered_before("scheduler")
     end
 
-    it "has brain before the cells" do
-      expect("brain").to be_ordered_before("diego-cell")
+    it "has scheduler before the diego cells" do
+      expect("scheduler").to be_ordered_before("diego-cell")
     end
 
-    it "has the cells before cc_bridge" do
-      expect("diego-cell").to be_ordered_before("cc_bridge")
-    end
-
-    it "has cc_bridge before route_emitter" do
-      expect("cc_bridge").to be_ordered_before("route_emitter")
-    end
-
-    it "has route_emitter before access" do
-      expect("route_emitter").to be_ordered_before("access")
+    it "has api before scheduler" do
+      expect("api").to be_ordered_before("scheduler")
     end
   end
 


### PR DESCRIPTION
[#155623416 Restructure/rename jobs to match cf-deployment](https://www.pivotaltracker.com/story/show/155623416)

## What

Remove and re-order VMs.

## How to review

Review in conjunction with https://github.com/alphagov/paas-cf/pull/1263. This branch should be deployed on top that one. We need:

* code review
* check app and API availability tests pass.
* check acceptance tests et cetera pass

This pull request involves removing the global route-emitter while we have cell-local route emitters in place, so we are mainly concerned about availability of routes during the deployment.

### Before merging ⚠️ 

* review and merge https://github.com/alphagov/paas-cf/pull/1263 . **Must be deployed in Prod before the rest**
* review and merge https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/23 and replace the temporary commit on this branch with the final release of the datadog-for-cloudfoundry release.
* rebase on master

## Who can review

Anyone but @keymon or me
