### PR TITLE
[Support] Enlarge the parser VMs in staging and prod.

### DIFF
--- a/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
+++ b/manifests/cf-manifest/cloud-config/020-cf-vm-types.yml
@@ -39,7 +39,7 @@ vm_types:
       bosh:
         password: ((secrets_vcap_password))
     cloud_properties:
-      instance_type: c4.large
+      instance_type: ((parser_instance_type))
       ephemeral_disk:
         size: 10240
         type: gp2

--- a/manifests/cf-manifest/env-specific/cf-default.yml
+++ b/manifests/cf-manifest/env-specific/cf-default.yml
@@ -2,3 +2,4 @@
 cell_instances: 3
 elasticsearch_master_disk_size: 307400
 elasticsearch_master_instance_type: m4.large
+parser_instance_type: c4.large

--- a/manifests/cf-manifest/env-specific/cf-prod.yml
+++ b/manifests/cf-manifest/env-specific/cf-prod.yml
@@ -2,3 +2,4 @@
 cell_instances: 24
 elasticsearch_master_disk_size: 3072000
 elasticsearch_master_instance_type: c4.2xlarge
+parser_instance_type: c4.xlarge

--- a/manifests/cf-manifest/env-specific/cf-staging.yml
+++ b/manifests/cf-manifest/env-specific/cf-staging.yml
@@ -2,3 +2,4 @@
 cell_instances: 6
 elasticsearch_master_disk_size: 460800
 elasticsearch_master_instance_type: c4.2xlarge
+parser_instance_type: c4.xlarge

--- a/manifests/cf-manifest/spec/cloud-config/env_spec.rb
+++ b/manifests/cf-manifest/spec/cloud-config/env_spec.rb
@@ -7,10 +7,22 @@ RSpec.describe "Environment specific configuration" do
     cloud_config["disk_types"].select { |j| j["name"] == disk_name }.first["disk_size"]
   end
 
+  def get_instance_type(cloud_config, vm_type)
+    cloud_config["vm_types"].find { |v| v["name"] == vm_type }["cloud_properties"]["instance_type"]
+  end
+
+
   it "should specify a larger elasticsearch disk size in production" do
     default_es_disk_size = get_disk_size(default_cloud_config, "elasticsearch_master")
     prod_es_disk_size = get_disk_size(prod_cloud_config, "elasticsearch_master")
 
     expect(default_es_disk_size).to be < prod_es_disk_size
+  end
+
+  it "should specify a different parser VM size in production" do
+    default_parser_vm = get_instance_type(default_cloud_config, "parser")
+    prod_parser_vm = get_instance_type(prod_cloud_config, "parser")
+
+    expect(prod_parser_vm).not_to eq(default_parser_vm)
   end
 end


### PR DESCRIPTION
## What

They are [not presently keeping up](https://app.datadoghq.com/notebook/21812/Logsearch%20metrics) with the volume of incoming messages.
This is partly due to issues with the logging stack not being balanced,
meaning that often one of the queues is empty with all incoming messages
going to the other queue.

We believe that the underlying cause for this unbalance is down to how
the ingestors are load-ballanced. Because all the VMs use persistent TCP
connections to the ingestors via the ELB, when one of the ingestors is
restarted this results in all the VMs connecting to the other one, and
therefore all log messages ending up in one queue.

A longer term fix would be to restructure things so that we use a single
shared queue (possibly using AWS Elasticache), however given we hope to
have migrated off this stack before long enklarging the parsers is the
simplest thing we can do to ensure things don't back up.

## How to review

Code review may be sufficient.

This change should be a no-op in a dev environment, so to test it there it'll be necessary to make a temporary commit increasing the VM size in dev to match staging and prod.

## Who can review

Not me.