### PR TITLE
[#155623416] Restructure/rename instance_groups to match cf-deployment - move route-emitter (PR 3 of 4)

### DIFF
--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -372,6 +372,26 @@ instance_groups:
         release: diego
       - name: metron_agent
         release: loggregator
+      - name: route_emitter
+        release: diego
+        properties:
+          diego:
+            route_emitter:
+              local_mode: true
+              dropsonde_port: ((dropsonde_incoming_port))
+              bbs:
+                api_location: bbs.service.cf.internal:8889
+                ca_cert: ((certs_bosh_ca_cert))
+                client_cert: ((certs_bbs_client_cert))
+                client_key: ((certs_bbs_client_key))
+                require_ssl: true
+              nats:
+                machines: ((nats_static_ips))
+                user: nats_user
+                password: ((secrets_nats_password))
+                port: ((nats_port))
+      - name: datadog-route-emitter
+        release: datadog-for-cloudfoundry
       - name: datadog-rep
         release: datadog-for-cloudfoundry
       - name: datadog-garden
@@ -436,6 +456,7 @@ instance_groups:
     update:
       serial: true
 
+  # FIXME: Delete me
   - name: route_emitter
     azs: [z1, z2]
     jobs:

--- a/manifests/cf-manifest/manifest/020-cf-properties.yml
+++ b/manifests/cf-manifest/manifest/020-cf-properties.yml
@@ -651,6 +651,7 @@ properties:
     executor:
       memory_capacity_mb: ((cell_memory_capacity_mb))
 
+    # FIXME: Delete me
     route_emitter:
       dropsonde_port: ((dropsonde_incoming_port))
       bbs:


### PR DESCRIPTION
[#155623416 Restructure/rename jobs to match cf-deployment](https://www.pivotaltracker.com/story/show/155623416)

What?
-----

We want to refactor our manifest to be based on the upstream [cf-deployment](https://github.com/cloudfoundry/cf-deployment).

In pr https://github.com/alphagov/paas-cf/pull/1263 we did several changes, but we decided to delay this change to a specific separated PR, as it is an important change in the architecture and there is some risk when running route_emitter in global and local_mode.

In this PR we move the `route_emitter` to the `diego-cell` and we run it at the same time in global mode in the `route_emitter` instance group and in local mode in the cells.

We had to split this change in two different PRs, as moving services between instance groups in one go caused downtime. In other PR we remove the old unnecessary instance_groups and we do other changes.

How to review?
--------------

 - Code review
 - Deploy the master branch
 - Deploy this branch

There should not be any downtime in the application availability test. We spec one or two errors on the API deployment, but not a lot.

After deploy
-------------

Check it works fine in prod. To revert, deploy previous version.

Who?
---

Anyone but @keymon or @henrytk