### PR TITLE
[155326674] Add VAT rates to the paas-billing app

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -279,7 +279,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-billing
-      tag_filter: v0.15.0
+      tag_filter: v0.17.0
 
 jobs:
   - name: pipeline-lock


### PR DESCRIPTION
## What

We update the paas-billing app, see https://github.com/alphagov/paas-billing/pull/20 for details.

❗️ This PR contains a temporary commit, please replace it with the final release tag before merging.

## How to review

1. Deploy the paas-billing app from this branch
    ```BRANCH=paas_billing_vat_rates_155326674 ENABLE_BILLING_APP=true SELF_UPDATE_PIPELINE=false make dev pipelines```

1. Test the price updater script:
    ```COLLECTOR_URL=https://paas-billing.${DEPLOY_ENV}.dev.cloudpipelineapps.digital ./push-pricing.sh update pricing_plans.json pricing_plan_components.json```

    It should not return with an error and it should populate the pricing_plan and pricing_plan_components tables.

## Who can review

Not me.
