### PR TITLE
[support] Replace concourse.ci domain in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This repository contains [Concourse][] pipelines and related [Terraform][]
 and [BOSH][] manifests that allow provisioning of [CloudFoundry][] on AWS.
 
-[Concourse]: http://concourse.ci/
+[Concourse]: http://concourse-ci.org/
 [Terraform]: https://terraform.io/
 [BOSH]: https://bosh.io/
 [CloudFoundry]: https://www.cloudfoundry.org/


### PR DESCRIPTION
## What

The website has moved to a new domain after the old domain as hijacked:

- https://www.cloudfoundry.org/blog/cve-2018-1227/

## How to review

Check that the domain matches the advisory and that I haven't missed any occurrences.

## Who can review

Anyone.