### PR TITLE
[support] Temporarily increase threshold for Compose memory

### DIFF
--- a/terraform/datadog/compose_scraper.tf
+++ b/terraform/datadog/compose_scraper.tf
@@ -5,12 +5,7 @@ resource "datadog_monitor" "compose_host_ram_in_use" {
   no_data_timeframe = "20"
   notify_no_data    = true
   renotify_interval = "20"
-  query             = "${format("max(last_10m):max:compose.cluster.host.ram.in_use{deployment:%s} by {host} >= 80", var.env)}"
-
-  thresholds {
-    warning  = "70"
-    critical = "80"
-  }
+  query             = "${format("max(last_10m):max:compose.cluster.host.ram.in_use{deployment:%s} by {host} >= 85", var.env)}"
 
   require_full_window = false
 


### PR DESCRIPTION
## What

This is constantly warning at the moment. We're attempting to increase
the size of our Compose cluster, but we don't know how long it will take
to go through procurement.

Increase the critical threshold so that it still tells us when we've
reached a level that makes it unlikely we'll be able to provision any
more service instances. This is based behaviour that we observed last
week. Remove the warning threshold because we no longer have enough
headroom for this to be useful.

This commit should be reverted when the cluster has been resized.

## How to review

I haven't tested this in dev because of the amount it time it takes to `ENABLE_DATADOG`. I don't think that you should either. Code review should be sufficient and we'll fix it if something goes terribly wrong in prod.

## Who can review

Anyone.