### PR TITLE
[#155936773] Use bosh-job instead of job in datadog queries

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -45,10 +45,9 @@ releases:
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/paas-haproxy-0.1.5.tgz
     sha1: c8c90a4c14ea2201a37469596b5cef309864a394
   - name: datadog-for-cloudfoundry
-    version: 0.1.20
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.1.20.tgz
-    sha1: 152a2c1830c7d4457cb7d75d7909af17fe5e12ac
-
+    version: 0.1.21
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.1.21.tgz
+    sha1: 5f751cf5006d722633c4a53e7e600ca0059bcfd7
   - name: ipsec
     version: "0.1.3"
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/ipsec-0.1.3.tgz

--- a/terraform/datadog/aws.tf
+++ b/terraform/datadog/aws.tf
@@ -62,7 +62,7 @@ resource "datadog_monitor" "rds-failure" {
 resource "datadog_monitor" "ec2-cpu-utilisation" {
   name                = "${format("%s EC2 high CPU utilisation", var.env)}"
   type                = "metric alert"
-  query               = "${format("avg(last_1h):avg:aws.ec2.cpuutilization{deploy_env:%s,!job:diego-cell,!job:elasticsearch_master} by {bosh-job,bosh-index} > 90", var.env)}"
+  query               = "${format("avg(last_1h):avg:aws.ec2.cpuutilization{deploy_env:%s,!bosh-job:diego-cell,!bosh-job:elasticsearch_master} by {bosh-job,bosh-index} > 90", var.env)}"
   message             = "{{bosh-job.name}}/{{bosh-index.name}} CPU utilisation has been over {{#is_warning}}{{warn_threshold}}{{/is_warning}}{{#is_alert}}{{threshold}}{{/is_alert}}% for 1h"
   notify_no_data      = false
   require_full_window = false
@@ -78,7 +78,7 @@ resource "datadog_monitor" "ec2-cpu-utilisation" {
 resource "datadog_monitor" "ec2-cpu-utilisation-es" {
   name                = "${format("%s EC2 high CPU utilisation - ElasticSearch", var.env)}"
   type                = "metric alert"
-  query               = "${format("avg(last_1h):avg:aws.ec2.cpuutilization{deploy_env:%s,job:elasticsearch_master} by {bosh-job,bosh-index} > 95", var.env)}"
+  query               = "${format("avg(last_1h):avg:aws.ec2.cpuutilization{deploy_env:%s,bosh-job:elasticsearch_master} by {bosh-job,bosh-index} > 95", var.env)}"
   message             = "{{bosh-job.name}}/{{bosh-index.name}} CPU utilisation has been over {{#is_warning}}{{warn_threshold}}{{/is_warning}}{{#is_alert}}{{threshold}}{{/is_alert}}% for 1h"
   notify_no_data      = false
   require_full_window = false


### PR DESCRIPTION
What?
-----

Fix some issues caused in datadog after renaming the instance_groups:

 1. For the EC2 metrics monitors, after renaming the `instance_group` the VM did not get recreated and the AWS tag `job:` is still the old one. To solve it we use the tag `bosh-job:*` emitted by the datadog agent, as it will be always updated .

 2. The CC worker includes the `instance_group` in the process. We need to use a new process search include the job name from https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/24

How to review
-------------
 - Review first https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/24, wait for a new build in https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/datadog-for-cloudfoundry-release and update the latest commit
 - Code review
 - deploy the new monitors, check that work.

Note: the monitor for CPU would not work because we do not have metrics from ec2 in development

Who?
---

Anyone but @keymon