### PR TITLE
[#155463715] Move UAA oauth properties to the UAA job

### DIFF
--- a/manifests/cf-manifest/stubs/oauth.yml
+++ b/manifests/cf-manifest/stubs/oauth.yml
@@ -1,22 +1,26 @@
-properties:
-  login:
-    oauth:
-      providers:
-        google:
-          type: oidc1.0
-          authUrl: https://accounts.google.com/o/oauth2/v2/auth
-          tokenUrl: https://www.googleapis.com/oauth2/v4/token
-          tokenKeyUrl: https://www.googleapis.com/oauth2/v3/certs
-          issuer: https://accounts.google.com
-          redirectUrl: https://login.((system_domain))/uaa
-          scopes:
-            - openid
-            - email
-          linkText: GOV.UK PaaS internal account login
-          showLinkText: true
-          addShadowUserOnLogin: false
-          relyingPartyId: ((oauth_client_id))
-          relyingPartySecret: ((oauth_client_secret))
-          skipSslValidation: false
-          attributeMappings:
-            user_name: email
+instance_groups:
+- name: uaa
+  jobs:
+  - name: uaa
+    properties:
+      login:
+        oauth:
+          providers:
+            google:
+              type: oidc1.0
+              authUrl: https://accounts.google.com/o/oauth2/v2/auth
+              tokenUrl: https://www.googleapis.com/oauth2/v4/token
+              tokenKeyUrl: https://www.googleapis.com/oauth2/v3/certs
+              issuer: https://accounts.google.com
+              redirectUrl: https://login.((system_domain))/uaa
+              scopes:
+                - openid
+                - email
+              linkText: GOV.UK PaaS internal account login
+              showLinkText: true
+              addShadowUserOnLogin: false
+              relyingPartyId: ((oauth_client_id))
+              relyingPartySecret: ((oauth_client_secret))
+              skipSslValidation: false
+              attributeMappings:
+                user_name: email


### PR DESCRIPTION
## What

Previously we moved all global properties to the specific jobs. We tested everything on dev but we missed the oauth properties as those are only added in staging and prod.

❗️ we have to set up a new staging Google Ouath client before we merge this.

## How to review

Code review only.

I ran the following command and validated from the generated manifest, that the oauth config is properly added to the uaa job.

```
BRANCH=move_properties_to_specific_jobs_155463715_fix_oauth SELF_UPDATE_PIPELINE=false NEW_ACCOUNT_EMAIL_ADDRESS=andras.ferencz-szabo@digital.cabinet-office.gov.uk make dev pipelines
```

## Who can review

Not me or @keymon 