### PR TITLE
[#154842336] Set up production domain for the billing app

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2136,6 +2136,7 @@ jobs:
           params:
             ENABLE_BILLING_APP: ((enable_billing_app))
             APPS_DNS_ZONE_NAME: ((apps_dns_zone_name))
+            SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
             COMPOSE_API_KEY: ((compose_api_key))
           inputs:
             - name: paas-cf
@@ -2176,7 +2177,7 @@ jobs:
                   env = {
                     'CF_CLIENT_ID' => 'paas-billing',
                     'CF_CLIENT_SECRET' => '${CF_CLIENT_SECRET}',
-                    'CF_CLIENT_REDIRECT_URL' => 'https://paas-billing.${APPS_DNS_ZONE_NAME}/oauth/callback',
+                    'CF_CLIENT_REDIRECT_URL' => 'https://billing.${SYSTEM_DNS_ZONE_NAME}/oauth/callback',
                     'CF_API_ADDRESS' => '${API_ENDPOINT}',
                     'COMPOSE_API_KEY' => '${COMPOSE_API_KEY}',
                   }
@@ -2185,6 +2186,9 @@ jobs:
                     app['env'] = {} unless app['env']
                     app['env'].merge!(env)
                     app['services'] = ['billing-db']
+                    app['routes'] = [
+                      { 'route' => 'billing.${SYSTEM_DNS_ZONE_NAME}' }
+                    ]
                   }
                   File.write('manifest.yml', manifest.to_yaml)
                 "

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2195,6 +2195,11 @@ jobs:
 
                 cf push paas-billing
 
+                # TODO: remove after the new route was deployed to staging/prod
+                if cf app paas-billing | grep -q "paas-billing.${APPS_DNS_ZONE_NAME}"; then
+                  cf delete-route -f "${APPS_DNS_ZONE_NAME}" --hostname paas-billing
+                fi
+
       - task: deploy-paas-compose-scraper
         config:
           platform: linux

--- a/manifests/cf-manifest/manifest/010-cf-jobs.yml
+++ b/manifests/cf-manifest/manifest/010-cf-jobs.yml
@@ -391,7 +391,7 @@ instance_groups:
                 secret: ((secrets_uaa_clients_paas_billing_secret))
                 scope: openid,oauth.approvals,cloud_controller.admin_read_only,cloud_controller.read,cloud_controller.global_auditor,cloud_controller.admin
                 authorities: cloud_controller.admin_read_only,uaa.resource
-                redirect-uri: https://paas-billing.((app_domain))/oauth/callback
+                redirect-uri: https://billing.((system_domain))/oauth/callback
               paas-admin:
                 override: true
                 authorized-grant-types: authorization_code,refresh_token


### PR DESCRIPTION
## What

Change billing app domain to billing.${system_domain}.

We want to have a "production" domain for the paas-billing app.
We don't recommend that our tenants use *.cloudapps.digital domains for live services and so we should follow our own advice.

Notes:
* the old route has to be deleted separately as `cf push` doesn't remove it. I automated this in the deploy task
* at the moment we can't use blue-green deploy for the API as the app also runs the collectors which should not run in parallel multiple times. There will be a follow up story to have separate commands in the billing app.

## How to review

1. Deploy your CF from this branch:
    ```BRANCH=paas_billing_domain_154842336 SELF_UPDATE_PIPELINE=false ENABLE_BILLING_APP=true make dev pipelines```

1. Go e.g. to billing.${DEPLOY_ENV}.dev.cloudpipeline.digital/events and you should be able to do the OAuth login without any issues.

1. Check that the app should no longer be accessible from paas-billing.${DEPLOY_ENV}.dev.cloudpipelineapps.digital

1. If you want to double check the old route clean up, the quick way is:
    ```make dev run_job JOB=post-deploy```

## Who can review

Not me.
