### PR TITLE
[#155625342] Cleanup final RDS snapshots

### DIFF
--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -57,6 +57,16 @@ instance_groups:
     networks:
       - name: cf
     jobs:
+      - name: rds-broker-cron
+        release: rds-broker
+        properties:
+          rds-broker:
+            aws_access_key_id: ""
+            aws_secret_access_key: ""
+            aws_region: "eu-west-1"
+            broker_name: "((terraform_outputs_environment))"
+            cron_schedule: "0 0 * * *"
+            keep_snapshots_for_days: 35
       - name: rds-broker
         release: rds-broker
         properties:

--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -44,9 +44,9 @@ meta:
 
 releases:
   - name: rds-broker
-    version: 0.1.21
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.21.tgz
-    sha1: 8f52931dd63f2ac7e0335b2269633edfba40e3eb
+    version: 0.1.24
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.24.tgz
+    sha1: e060b260fb534a679de91a6305d62ecd3d181bed
 
 instance_groups:
   - name: rds_broker

--- a/terraform/prod.vpc_peering.json
+++ b/terraform/prod.vpc_peering.json
@@ -46,5 +46,17 @@
         "account_id": "471146266171",
         "vpc_id": "vpc-33a35155",
         "subnet_cidr": "172.16.16.0/22"
+    },
+    {
+        "peer_name": "dit-trade-remedies-dev",
+        "account_id": "621036312122",
+        "vpc_id": "vpc-048745d02c20b63f6",
+        "subnet_cidr": "172.16.28.0/22"
+    },
+    {
+        "peer_name": "dit-trade-remedies-prod",
+        "account_id": "604925858717",
+        "vpc_id": "vpc-08f2b2a7787348c52",
+        "subnet_cidr": "172.16.32.0/22"
     }
 ]


### PR DESCRIPTION
## What

We added a cron job process to the RDS broker to clean up old RDS snapshots. We only delete manual snapshots which have a matching `Broker Name` AWS tag.

We define a separate job for it so it can run as a separate process.

The cron process will only run on the first instance.

Related PRs:
* https://github.com/alphagov/paas-rds-broker-boshrelease/pull/53
* https://github.com/alphagov/paas-rds-broker/pull/73

❗️ This PR contains a temporary commit which needs to replaced when the final rds-broker BOSH release was built.

## How to review

1. If you want to see the cron job working you need to add a temporary commit to change the rds-broker-cron config to run every minute and delete some RDS snapshots. Alternatively you can change this manually on the VM when testing.

```diff
--- a/manifests/cf-manifest/manifest/050-rds-broker.yml
+++ b/manifests/cf-manifest/manifest/050-rds-broker.yml
@@ -65,8 +65,8 @@ instance_groups:
             aws_secret_access_key: ""
             aws_region: "eu-west-1"
             broker_name: "((terraform_outputs_environment))"
-            cron_schedule: "0 0 * * *"
-            keep_snapshots_for_days: 35
+            cron_schedule: "0 * * * *"
+            keep_snapshots_for_days: 3
```

1. Deploy your CF from this branch:
   ```BRANCH=cleanup_final_snapshots_155625342 make dev pipelines```

1. SSH onto the rds_broker VMs and check if the cron process runs only on one VM (`paas-rds-broker -cron [...]`)

1. Check the logs under /var/vcap/data/sys/log/rds-broker-cron/. If you have some old snapshots in the dev account (there are for: farms, andrew, dcarley, henry) you can see the cron job deleting them.

```
{"timestamp":"1521650640.783340454","source":"rds-broker","message":"rds-broker.db-instance.delete-snapshot","log_level":1,"data":{"session":"1","snapshot_id":"rdsbroker-d507e153-c703-4532-aaf3-03d7bb6a115e-final-snapshot"}}
```

## Who can review

Not me.
