### PR TITLE
[#155856825] Register routes for Cloud Controller

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -542,7 +542,6 @@ instance_groups:
         db_encryption_key: ((secrets_cc_db_encryption_key))
         logging_level: info
         db_logging_level: debug
-        directories: ~
         stacks: ~
         disable_custom_buildpacks: false
         broker_client_timeout_seconds: 70

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -730,6 +730,22 @@ instance_groups:
     release: python-buildpack
   - name: staticfile-buildpack
     release: staticfile-buildpack
+  - name: route_registrar
+    release: routing
+    properties:
+      route_registrar:
+        routes:
+        - name: api
+          registration_interval: 20s
+          port: 9022
+          tags:
+            component: CloudController
+          uris:
+          - api.((system_domain))
+          health_check:
+            name: api-health-check
+            script_path: "/var/vcap/jobs/cloud_controller_ng/bin/cloud_controller_ng_health_check"
+            timeout: 3s
   - name: datadog-consul-agent-client
     release: datadog-for-cloudfoundry
   - name: datadog-cc

--- a/manifests/cf-manifest/spec/manifest/instance_group_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/instance_group_spec.rb
@@ -89,16 +89,26 @@ RSpec.describe "the instance_groups definitions block" do
   end
 end
 
-RSpec.describe "uaa route_registrar registers uaa" do
-  let(:routes) {
+RSpec.describe "registration of routes for services behind GoRouter" do
+  let(:uaa_routes) {
     manifest_with_defaults.fetch("instance_groups.uaa.jobs.route_registrar.properties.route_registrar.routes")
   }
+  let(:api_routes) {
+    manifest_with_defaults.fetch("instance_groups.api.jobs.route_registrar.properties.route_registrar.routes")
+  }
 
-  it "registers the correct uris" do
-    expect(routes.length).to eq(1)
-    expect(routes.first.fetch('uris')).to match_array([
+  it "registers the correct uris for uaa" do
+    expect(uaa_routes.length).to eq(1)
+    expect(uaa_routes.first.fetch('uris')).to match_array([
       "uaa.#{terraform_fixture(:cf_root_domain)}",
       "login.#{terraform_fixture(:cf_root_domain)}",
+    ])
+  end
+
+  it "registers the correct uris for api" do
+    expect(api_routes.length).to eq(1)
+    expect(api_routes.first.fetch('uris')).to match_array([
+      "api.#{terraform_fixture(:cf_root_domain)}",
     ])
   end
 end


### PR DESCRIPTION
## What

This is the first step in a three-part deployment to move Cloud Controller behind GoRouter.

## How to review

* deploy on top of master.
* confirm the route is set up. One way of doing this:
  * get an IP address for a system domain ELB IP:

  ```
  dig "irrelevant-subdomain-due-to-dns-wildcard.${DEPLOY_ENV}.dev.cloudpipeline.digital"
  ```

  * use `curl` to prove the route is set up by resolving the hostname of the API to the IP you just fetched:

  ```
  # Swap the IP
  curl \
    --resolve "api.${DEPLOY_ENV}.dev.cloudpipeline.digital:443:52.209.9.54" \
    "https://api.${DEPLOY_ENV}.dev.cloudpipeline.digital/v2/info"
  ```
* make sure all tests pass, particularly availability tests.

A lot of properties for the api instance group have been removed, so you may want to check I didn't bin anything important :)

## Who can review

Anyone but me