### PR TITLE
Don't let app or API availability tests overlap

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -710,6 +710,7 @@ jobs:
                 exit 1
 
   - name: app-availability-tests
+    serial: true
     plan:
       - aggregate:
           - get: pipeline-trigger
@@ -763,6 +764,7 @@ jobs:
                 ./paas-cf/platform-tests/run_tests.sh ./paas-cf/platform-tests/src/platform/availability/app
 
   - name: api-availability-tests
+    serial: true
     plan:
       - aggregate:
           - get: pipeline-trigger


### PR DESCRIPTION
## What

Set `serial: true` on app and API availability test jobs.

I frequently have to manually stop these tests to avoid false negatives.
We don't ever want them to run on top of each other.

## How to review

Run in dev env, think about the consequences. It means that jobs might queue up instead of overlapping.

## Who can review

Anyone but @camelpunch