### PR TITLE
[#156188483] Stop NATS instances from being constantly redeployed

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -1361,9 +1361,9 @@ releases:
   version: "191"
   sha1: 61b429ae13e0fde0ebdb98fce99e08f7baf60a16
 - name: datadog-for-cloudfoundry
-  url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.1.22.tgz
-  version: 0.1.22
-  sha1: af4bf4a83c3e7542eaf8851ab003fd3262df9cc8
+  version: 0.1.23
+  url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.1.23.tgz
+  sha1: 09f70cbd87ec6045d44aa346e23fd6dd9bf14bfa
 - name: diego
   url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=1.35.0
   version: 1.35.0


### PR DESCRIPTION
## What

We accidentally used `<%=` instead of `<%` which printed the object reference to a BOSH job template. This caused the nats instances being constantly redeployed.

The generated template looked something like this:
```
#<Bosh::Template::EvaluationContext::InactiveElseBlock:0x00007fdd049545f0>

init_config:
...
```

See https://github.com/cloudfoundry/bosh/issues/1923 for details.

❗️ This PR contains a temporary commit which needs to be updated with the final datadog-for-cloudfoundry BOSH release.

## How to review

1. Code review: https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/27

1. Deploy your CF twice from this branch:
    ```BRANCH=nats_port_156188483 make dev pipelines```

    In the second deployment you should not see the nats instances being redeployed.

## Who can review

Not me.
