### PR TITLE
[Support] Update Docker image for Bosh CLI cve-2018-1231

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1212,7 +1212,7 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/bosh-cli-v2
-                tag: c735581beb174ecc95ca1a7b57eff444af3bf099
+                tag: 777204b5c870fc7ebf0d2b7aa55fcccddfa29c4b
             inputs:
               - name: paas-cf
               - name: terraform-outputs
@@ -1337,7 +1337,7 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/bosh-cli-v2
-                tag: c735581beb174ecc95ca1a7b57eff444af3bf099
+                tag: 777204b5c870fc7ebf0d2b7aa55fcccddfa29c4b
             inputs:
               - name: cloud-config
               - name: bosh-secrets
@@ -1414,7 +1414,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli-v2
-              tag: c735581beb174ecc95ca1a7b57eff444af3bf099
+              tag: 777204b5c870fc7ebf0d2b7aa55fcccddfa29c4b
           inputs:
             - name: paas-cf
             - name: cf-manifest
@@ -2187,7 +2187,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli-v2
-              tag: c735581beb174ecc95ca1a7b57eff444af3bf099
+              tag: 777204b5c870fc7ebf0d2b7aa55fcccddfa29c4b
           inputs:
             - name: paas-cf
             - name: bosh-secrets
@@ -2673,7 +2673,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli-v2
-              tag: c735581beb174ecc95ca1a7b57eff444af3bf099
+              tag: 777204b5c870fc7ebf0d2b7aa55fcccddfa29c4b
           inputs:
             - name: paas-cf
             - name: cf-manifest

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -221,7 +221,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli-v2
-              tag: c735581beb174ecc95ca1a7b57eff444af3bf099
+              tag: 777204b5c870fc7ebf0d2b7aa55fcccddfa29c4b
           inputs:
             - name: bosh-secrets
             - name: paas-cf

--- a/concourse/tasks/generate-test-config.yml
+++ b/concourse/tasks/generate-test-config.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/bosh-cli-v2
-    tag: c735581beb174ecc95ca1a7b57eff444af3bf099
+    tag: 777204b5c870fc7ebf0d2b7aa55fcccddfa29c4b
 inputs:
   - name: paas-cf
   - name: admin-creds


### PR DESCRIPTION
## What

This PR uses the new bosh-cli-v2 image that contains Bosh CLI 3.0.1
to mitigate against https://www.cloudfoundry.org/blog/cve-2018-1231/

## How to review

Code review against https://hub.docker.com/r/governmentpaas/bosh-cli-v2/tags/ for the tag
Deploy in your environment on top of master and see the tests pass

## Who can review

Not @LeePorte
