### PR TITLE
[#156340018] Increase the number of doppler VMs to 2 per AZ

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -128,7 +128,7 @@ instance_groups:
   - z1
   - z2
   - z3
-  instances: 3
+  instances: 6
   vm_type: medium
   stemcell: default
   networks:


### PR DESCRIPTION
[#156340018 Increase number of dopplers per AZ](https://www.pivotaltracker.com/story/show/156340018)

What?
-----

We want to increase the number of doppler nodes to 2 per AZ, as

 - "Two dopplers per AZ is actually the recommended architecture
   for high availability," says cf-deployment v1.7.0.[1]
 - We see that the current instances are using 80-90% CPU which may
   cause them to drop log messages or behave otherwise wrongly.

[1] https://github.com/cloudfoundry/cf-deployment/releases/tag/v1.7.0

How to review?
-------------

 - Code review
 - deploy
 - test this?????

Who?
----

Anyone but @keymon or @camelpunch