### PR TITLE
[#156302820] Enable blackbox and stop truncating/splitting logs

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -895,7 +895,6 @@ instance_groups:
           cert_chain: "((router_ssl.certificate))"
           private_key: "((router_ssl.private_key))"
         enable_ssl: false
-        enable_access_log_streaming: true
         status:
           user: router_user
           password: ((secrets_router_password))

--- a/manifests/cf-manifest/manifest/operations/080-logsearch.yml
+++ b/manifests/cf-manifest/manifest/operations/080-logsearch.yml
@@ -73,10 +73,10 @@
                 add_tag => ["gorouter", "gorouter_access_log"]
               }
               kv {
-                source => "router_keys"
+                source => "routerkeys"
                 target => "[gorouter][header]"
                 value_split => ":"
-                remove_field => "router_keys"
+                remove_field => "routerkeys"
               }
             }
             date {

--- a/manifests/cf-manifest/manifest/operations/080-logsearch.yml
+++ b/manifests/cf-manifest/manifest/operations/080-logsearch.yml
@@ -70,8 +70,7 @@
                   "@message" =>
                     '%{HOSTNAME:[gorouter][host]} - \[%{TIMESTAMP_ISO8601:[gorouter][timestamp]}\] "%{WORD:[gorouter][method]} %{URIPATHPARAM:[gorouter][request]} %{NOTSPACE:[gorouter][httpversion]}" %{BASE10NUM:[gorouter][status]} %{BASE10NUM:[gorouter][bytesreceived]} %{BASE10NUM:[gorouter][bytessent]} %{QUOTEDSTRING:[gorouter][referer]} %{QUOTEDSTRING:[gorouter][useragent]} %{QUOTEDSTRING:[gorouter][clientaddr]} %{QUOTEDSTRING:[gorouter][upstreamaddr]} %{GREEDYDATA:routerkeys}'
                   }
-                tag_on_failure => ["fail/cloudfoundry/gorouter/grok"]
-                add_tag => ["gorouter"]
+                add_tag => ["gorouter", "gorouter_access_log"]
               }
               kv {
                 source => "router_keys"

--- a/manifests/cf-manifest/manifest/operations/080-logsearch.yml
+++ b/manifests/cf-manifest/manifest/operations/080-logsearch.yml
@@ -12,10 +12,9 @@
   path: /releases/-
   value:
     name: logsearch-for-cloudfoundry
-    version: 0.1.4
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/logsearch-for-cloudfoundry-0.1.4.tgz
-    sha1: 7b450ea1ed91fe434eadd667f393f5d877321f1f
-
+    version: 0.1.5
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/logsearch-for-cloudfoundry-0.1.5.tgz
+    sha1: dee838e3a9c317c406ae1bcb84ae42ae862829c2
 - type: replace
   path: /instance_groups/-
   value:

--- a/manifests/cf-manifest/manifest/operations/080-logsearch.yml
+++ b/manifests/cf-manifest/manifest/operations/080-logsearch.yml
@@ -203,6 +203,14 @@
             - shards-and-replicas: /var/vcap/jobs/elasticsearch_config/index-templates/shards-and-replicas.json
             - index-settings: /var/vcap/jobs/elasticsearch_config/index-templates/index-settings.json
             - index-mappings-lfc: /var/vcap/jobs/elasticsearch-config-lfc/index-mappings.json
+            - index-settings-total-fields: |
+                {
+                  "template": "logstash-*",
+                  "order": 200,
+                  "settings": {
+                    "index.mapping.total_fields.limit": 2000
+                  }
+                }
     - name: curator
       release: logsearch
       properties:

--- a/manifests/cf-manifest/spec/manifest/router_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/router_spec.rb
@@ -1,9 +1,0 @@
-RSpec.describe "router properties" do
-  let(:manifest) { manifest_with_defaults }
-  let(:properties) { manifest.fetch("instance_groups.router.jobs.gorouter.properties") }
-
-  it "streams the access_logs to logging" do
-    enable_access_log_streaming = properties.fetch("router").fetch("enable_access_log_streaming")
-    expect(enable_access_log_streaming).to be true
-  end
-end


### PR DESCRIPTION
## What

The logs were truncated for multiple reasons:
 - the logger command splits the messages at 1k
 - the rsyslog max message size is 4k (this will also result in log splitting)

We enabled blackbox with TCP mode which would replace logger therefore eliminating the 1k size limit. It turned out blackbox (probably accidentally) truncates the messages at ~10k. We opened an issue [1] and PR [2] upstream to fix this (to increase it to ~100k).
We forked and patched blackbox. Because of this we have to use the paas-syslog-release fork again.

We also increased the rsyslog max message size to 64k.
Messages sent by logger (tagged with vcap.*) will be ignored by rsyslog.

By enabling blackbox we'll finally have all logs in logsearch which were written to a file under /var/vcap/sys/log

We had to amend some of the logstash filters because they were expecting logs with "vcap.*" @source.component, but blackbox doesn't append the vcap prefix

We also disabled gorouter to send access logs directory to syslog.

We increased the max allowed fields for the logstash indexes in Elasticsearch because we tipped just over the current limit (we were hovering below 1k).

I collected some rough iostats before and after blackbox while writing ~3500 lines per second to a logfile (by comparison we have peaks of ~5000 lines/sec on our whole system in prod). The disk write was roughly the same in both cases. When enabling blackbox rsyslog usage increased by <5% and blackbox was using ~10% cpu. I don't think we need a more academic comparison as the extra CPU usage seems small enough. I advise though to check the overall system cpu stats on prod after deploy in Datadog.

[1] https://github.com/concourse/blackbox/issues/7
[2] https://github.com/cloudfoundry/blackbox/pull/1 https://github.com/concourse/blackbox/pull/8

❗️ This PR contains a temporary commit which needs to be updated after https://github.com/alphagov/paas-logsearch-for-cloudfoundry/pull/6 was merged.

## How to review

1. Review the following PRs first:
    * https://github.com/alphagov/paas-logsearch-for-cloudfoundry/pull/6
    * https://github.com/alphagov/paas-bootstrap/pull/150
    * https://github.com/alphagov/paas-team-manual/pull/196

1. Make sure you ran the create-bosh-concourse pipeline (see https://github.com/alphagov/paas-bootstrap/pull/150)

1. Update your CF from this branch and wait untill all VMs are updated:
    ```BRANCH=enable_blackbox_156302820 paas-andras make dev pipelines```

1. Validate in logsearch that you don't see any invalid values for @source.components (previously this contained a lot of partial log snippets, like `.10.10"` or `mponent"`.

You can list all @source.component values with the following Kibana visualisation. You may have to wait a little to get a clear 15 minutes window with the new setup.

```
https://logsearch.${DEPLOY_ENV}.dev.cloudpipeline.digital/app/kibana#/visualize/edit/Component-values?_g=()&_a=(filters:!(),linked:!f,query:(query_string:(analyze_wildcard:!t,query:'*')),uiState:(vis:(params:(sort:(columnIndex:!n,direction:!n)))),vis:(aggs:!((enabled:!t,id:'1',params:(),schema:metric,type:count),(enabled:!t,id:'2',params:(field:'@source.component.keyword',order:desc,orderBy:'1',size:500),schema:bucket,type:terms)),listeners:(),params:(perPage:500,showMeticsAtAllLevels:!f,showPartialRows:!f,showTotal:!f,sort:(columnIndex:!n,direction:!n),totalFunc:sum),title:'Component%20values',type:table))
```

1. Search for `"route-emitter.watcher.emit-external.emitting-nats-messages"` in Kibana and check if the message contains a fairly big but valid JSON.

## Who can review

Not @dcarley or me.