### PR TITLE
Use medium VM type for queue VMs

### DIFF
--- a/manifests/cf-manifest/env-specific/cf-default.yml
+++ b/manifests/cf-manifest/env-specific/cf-default.yml
@@ -3,3 +3,4 @@ cell_instances: 3
 elasticsearch_master_disk_size: 307400
 elasticsearch_master_instance_type: m4.large
 parser_instance_type: c4.large
+queue_vm_type: small

--- a/manifests/cf-manifest/env-specific/cf-prod.yml
+++ b/manifests/cf-manifest/env-specific/cf-prod.yml
@@ -3,3 +3,4 @@ cell_instances: 24
 elasticsearch_master_disk_size: 3072000
 elasticsearch_master_instance_type: c4.2xlarge
 parser_instance_type: c4.xlarge
+queue_vm_type: medium

--- a/manifests/cf-manifest/env-specific/cf-staging.yml
+++ b/manifests/cf-manifest/env-specific/cf-staging.yml
@@ -3,3 +3,4 @@ cell_instances: 6
 elasticsearch_master_disk_size: 460800
 elasticsearch_master_instance_type: c4.2xlarge
 parser_instance_type: c4.xlarge
+queue_vm_type: small

--- a/manifests/cf-manifest/manifest/operations/080-logsearch.yml
+++ b/manifests/cf-manifest/manifest/operations/080-logsearch.yml
@@ -27,7 +27,7 @@
       release: logsearch
     - name: datadog-logsearch-queue
       release: datadog-for-cloudfoundry
-    vm_type: small
+    vm_type: ((queue_vm_type))
     stemcell: "3468"
     instances: 2
     networks:


### PR DESCRIPTION
## What

This increases the queue VMs from t2.small to m3.medium instances.
We have been seeing the queue VMs maxing out on CPU and running out
of credits. The m3.medium instances offer twice the vCPU and a fixed
performance.

~~There is the option to change this just in prod, as we only see the
high stress on the queue VM CPU in that environment, but we do not
have many instances of this VM, so the environment parity seems more
valuable than the cost saving.~~

**Update:**
    This has been made into an environment-specific configuration because
    we anticipate our logging stack to be scaled in numerous ways as we
    grow, so there will be large cumulative cost savings.


## How to review

Code review should be enough. I have deployed it and it didn't cause chaos and destruction.

## Who can review

Anyone but me
