### PR TITLE
[#155326294] update paas-billing release

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -335,7 +335,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-billing
-      tag_filter: v0.17.0
+      tag_filter: v0.20.0
 
   - name: paas-admin
     type: git


### PR DESCRIPTION
## What

Bump paas-billing to the latest version that brings in many of the recent changes such as VAT calculations, declarative configuration of pricing, sub components, and more... see https://github.com/alphagov/paas-billing/pull/23 for more details.

## How to review

If you want to test deployment in your dev env then:

```
ENABLE_BILLING_APP=true SELF_UPDATE_PIPELINE=false BRANCH=configuring-plans-155326294 make dev pipelines
```

## ⚠️ Before merge

Ensure that https://github.com/alphagov/paas-billing/pull/23 is merged first and then replace the [TMP] commit in this commit with the proper release tag.

## Who can review

Not @chrisfarms or @camelpunch 
