### PR TITLE
[#155854402] Use the right CN for cert validation in adapter

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -1338,7 +1338,7 @@ instance_groups:
             ca: "((loggregator_ca.certificate))"
             cert: "((adapter_rlp_tls.certificate))"
             key: "((adapter_rlp_tls.private_key))"
-            cn: reverse_log_proxy
+            cn: "reverselogproxy"
 
 variables:
 - name: service_cf_internal_ca


### PR DESCRIPTION
[#155854402 Restructure internal certs to match cf-deployment](https://www.pivotaltracker.com/story/show/155854402)

What
----

the adapter service verifies the CN of the certificate of
the reverse log proxy. In cf-deployment it is used reverselogproxy
and we generated the certs using that name.

We must update the adapter service to use the same.

How to test?
------------

Deploy, check that the adapter service is not logging:


```
2018/04/04 14:15:01 Failed to connect to loggregator API: x509: certificate is valid for reverselogproxy, not reverse_log_proxy
```

Who?
---

Anyone but @keymon