### PR TITLE
[#156299675] Pin the smoke-tests and CATs to blessed versions

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -771,7 +771,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/cf-acceptance-tests
-              tag: 4aff7d1fd0fa27ff9910a77b39cbcaedb4455f0c
+              tag: c599048c56cc1508314315552bd11f413fab1c78
           inputs:
             - name: paas-cf
             - name: pipeline-trigger
@@ -827,7 +827,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/cf-acceptance-tests
-              tag: 4aff7d1fd0fa27ff9910a77b39cbcaedb4455f0c
+              tag: c599048c56cc1508314315552bd11f413fab1c78
           inputs:
             - name: paas-cf
             - name: pipeline-trigger
@@ -2577,7 +2577,7 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/cf-acceptance-tests
-                tag: 4aff7d1fd0fa27ff9910a77b39cbcaedb4455f0c
+                tag: c599048c56cc1508314315552bd11f413fab1c78
             params:
               DISABLE_CF_ACCEPTANCE_TESTS: ((disable_cf_acceptance_tests))
             inputs:
@@ -2732,7 +2732,7 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/cf-acceptance-tests
-                tag: 4aff7d1fd0fa27ff9910a77b39cbcaedb4455f0c
+                tag: c599048c56cc1508314315552bd11f413fab1c78
             inputs:
               - name: paas-cf
               - name: test-config

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -240,13 +240,13 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-acceptance-tests
-      branch: cf1.14
+      branch: cf1.21
 
   - name: cf-smoke-tests
     type: git
     source:
       uri: https://github.com/alphagov/paas-cf-smoke-tests
-      branch: gds-cf-deployment-v1.14.0
+      branch: gds-cf-deployment-v1.21.0
 
   - name: git-keys
     type: s3-iam

--- a/manifests/cf-manifest/test-config/acceptance_tests.yml
+++ b/manifests/cf-manifest/test-config/acceptance_tests.yml
@@ -9,7 +9,7 @@ skip_ssl_validation: false
 backend: "diego"
 skip_diego_unsupported_tests: true
 include_tasks: true
-include_v3: false
+include_v3: true
 include_security_groups: true
 include_routing: true
 include_internet_dependent: true

--- a/platform-tests/upstream/run_acceptance_tests.sh
+++ b/platform-tests/upstream/run_acceptance_tests.sh
@@ -37,6 +37,6 @@ cd src/github.com/cloudfoundry/cf-acceptance-tests
   -keepGoing \
   -randomizeAllSpecs \
   -skipPackage=helpers \
-  -skip=${SKIP_REGEX} \
+  -skip="${SKIP_REGEX}" \
   -slowSpecThreshold=${SLOW_SPEC_THRESHOLD} \
   -nodes="${NODES}"

--- a/platform-tests/upstream/run_acceptance_tests.sh
+++ b/platform-tests/upstream/run_acceptance_tests.sh
@@ -9,8 +9,16 @@ fi
 
 SLEEPTIME=90
 NODES=5
-SKIP_REGEX='routing.API|allows\spreviously-blocked\sip|Adding\sa\swildcard\sroute\sto\sa\sdomain|forwards\sapp\smessages\sto\sregistered\ssyslog\sdrains|when\sapp\shas\smultiple\sports\smapped'
 SLOW_SPEC_THRESHOLD=120
+
+# Build Skip regex to ignore tests
+SKIP_REGEX='routing.API'
+SKIP_REGEX="${SKIP_REGEX}|allows previously-blocked ip"
+SKIP_REGEX="${SKIP_REGEX}|Adding a wildcard route to a domain"
+SKIP_REGEX="${SKIP_REGEX}|forwards app messages to registered syslog drains"
+SKIP_REGEX="${SKIP_REGEX}|when app has multiple ports mapped"
+SKIP_REGEX="${SKIP_REGEX}|applies the associated app.s policies to the task"
+SKIP_REGEX="${SKIP_REGEX// /\\s}" # Replace ' ' with \s
 
 export CONFIG
 CONFIG="$(pwd)/test-config/config.json"


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1275640/stories/156299675

What?
-----

We are tracking the cf-deployment blessed version v1.21.0.

This version points to:
 - smoke-tests:
   - https://github.com/cloudfoundry/cf-smoke-tests-release/tree/40.0.1
   - submodule: https://github.com/cloudfoundry/cf-smoke-tests/tree/923e2a158722a37a9ed28c0216b3b5a4009e9ac9
 - CATS: https://github.com/cloudfoundry/cf-acceptance-tests/tree/cf1.21

I updated our fork https://github.com/alphagov/paas-cf-smoke-tests/tree/gds-cf-deployment-v1.21.0
and changed the references in the pipeline.

How to review?
-------------

Check that the pipeline ends OK.

Who?
----

Anyone but @keymon