### PR TITLE
[#156299675] Fix properties for loggregator in bbs service

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -228,11 +228,11 @@ instance_groups:
             db_schema: bbs
             db_driver: postgres
           require_ssl: true
-        loggregator: &diego_loggregator_client_properties
-          use_v2_api: true
-          ca_cert: "((loggregator_ca.certificate))"
-          cert: "((loggregator_tls_metron.certificate))"
-          key: "((loggregator_tls_metron.private_key))"
+      loggregator: &diego_loggregator_client_properties
+        use_v2_api: true
+        ca_cert: "((loggregator_ca.certificate))"
+        cert: "((loggregator_tls_metron.certificate))"
+        key: "((loggregator_tls_metron.private_key))"
   - name: cfdot
     <<: *cfdot_job
   - name: metron_agent

--- a/manifests/cf-manifest/manifest/operations/010-cert-rotation.yml
+++ b/manifests/cf-manifest/manifest/operations/010-cert-rotation.yml
@@ -208,7 +208,7 @@
   value: ((loggregator_ca.certificate))((loggregator_ca_old.certificate))
 
 - type: replace
-  path: /instance_groups/name=diego-api/jobs/name=bbs/properties/diego/loggregator/ca_cert
+  path: /instance_groups/name=diego-api/jobs/name=bbs/properties/loggregator/ca_cert
   value: ((loggregator_ca.certificate))((loggregator_ca_old.certificate))
 
 - type: replace


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1275640/stories/156299675

What?
-----

We configured the bbs service incorrectly in the PR alphagov/paas-cf#1306. The properties must be under `loggregator.*`, not `diego.loggregator`.

Without this, the bbs service does not send the metrics to the metron agent.

This is causing some monitors fail in datadog, as metrics for the lock held by BBS are missing.

How to review?
------------

 - code review

 - deploy this
 - check that the files are populated in the vm `diego-api/0`: `/var/vcap/jobs/bbs/config/certs/loggregator/*` and `/var/vcap/jobs/bbs/config/bbs.json` has the property `loggregator_use_v2_api":false`

You can check in my deployment instead of deploying yours, ask me

Who?
---

Anyone but @keymon