### PR TITLE
[#156313150] Split continuous smoke test assert and payload

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -3239,81 +3239,78 @@ jobs:
         - get: cf-secrets
           passed: ['post-deploy']
 
-      - try:
-          task: assert-should-run
-          config:
-            platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: alpine
-                tag: latest
-            inputs:
-              - name: deployed-healthcheck
+      - task: assert-should-run
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: alpine
+              tag: latest
+          inputs:
+            - name: deployed-healthcheck
+          params:
+            PERSISTENT_ENVIRONMENT: ((persistent_environment))
+          run:
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              HEALTHCHECK_DEPLOYED=$(cat deployed-healthcheck/healthcheck-deployed)
+              if [ "$HEALTHCHECK_DEPLOYED" = "no" ] && [ "$PERSISTENT_ENVIRONMENT" != "true" ]; then
+                echo "Healthcheck is not deployed and this is not a persistent environment"
+                echo "Skipping smoke tests"
+                exit 1
+              fi
+      - do:
+        - task: create-temp-user
+          file: paas-cf/concourse/tasks/create_admin.yml
+          params:
+            PREFIX: cont-smoketest-user
+
+        - task: smoke-tests-config
+          file: paas-cf/concourse/tasks/generate-test-config.yml
+          params:
+            TEST_PROPERTIES: smoke_tests
+            APP_DOMAIN: ((apps_dns_zone_name))
+            SYSTEM_DOMAIN: ((system_dns_zone_name))
+
+        - task: smoke-tests-run
+          file: paas-cf/concourse/tasks/smoke-tests-run.yml
+          on_failure:
+            task: alert
+            config:
+              platform: linux
+              image_resource:
+                type: docker-image
+                source:
+                  repository: governmentpaas/awscli
+                  tag: b2495d6ed07f680125d19aa7d1701da7efabb289
+              params:
+                AWS_DEFAULT_REGION: ((aws_region))
+                DEPLOY_ENV: ((deploy_env))
+                SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+                ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
+              inputs:
+                - name: paas-cf
+              run:
+                path: sh
+                args:
+                - -e
+                - -c
+                - |
+                  paas-cf/concourse/scripts/smoke_tests_email.sh \
+                    "${DEPLOY_ENV}" "${SYSTEM_DNS_ZONE_NAME}" "${ALERT_EMAIL_ADDRESS}"
+          ensure:
+            task: upload-test-artifacts
+            file: paas-cf/concourse/tasks/upload-test-artifacts.yml
             params:
-              PERSISTENT_ENVIRONMENT: ((persistent_environment))
-            run:
-              path: sh
-              args:
-              - -e
-              - -c
-              - |
-                HEALTHCHECK_DEPLOYED=$(cat deployed-healthcheck/healthcheck-deployed)
-                if [ "$HEALTHCHECK_DEPLOYED" = "no" ] && [ "$PERSISTENT_ENVIRONMENT" != "true" ]; then
-                  echo "Healthcheck is not deployed and this is not a persistent environment"
-                  echo "Skipping smoke tests"
-                  exit 1
-                fi
+              TEST_ARTIFACTS_BUCKET: ((test_artifacts_bucket))
 
-          on_success:
-            do:
-            - task: create-temp-user
-              file: paas-cf/concourse/tasks/create_admin.yml
-              params:
-                PREFIX: cont-smoketest-user
-
-            - task: smoke-tests-config
-              file: paas-cf/concourse/tasks/generate-test-config.yml
-              params:
-                TEST_PROPERTIES: smoke_tests
-                APP_DOMAIN: ((apps_dns_zone_name))
-                SYSTEM_DOMAIN: ((system_dns_zone_name))
-
-            - task: smoke-tests-run
-              file: paas-cf/concourse/tasks/smoke-tests-run.yml
-              on_failure:
-                task: alert
-                config:
-                  platform: linux
-                  image_resource:
-                    type: docker-image
-                    source:
-                      repository: governmentpaas/awscli
-                      tag: b2495d6ed07f680125d19aa7d1701da7efabb289
-                  params:
-                    AWS_DEFAULT_REGION: ((aws_region))
-                    DEPLOY_ENV: ((deploy_env))
-                    SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
-                    ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
-                  inputs:
-                    - name: paas-cf
-                  run:
-                    path: sh
-                    args:
-                    - -e
-                    - -c
-                    - |
-                      paas-cf/concourse/scripts/smoke_tests_email.sh \
-                        "${DEPLOY_ENV}" "${SYSTEM_DNS_ZONE_NAME}" "${ALERT_EMAIL_ADDRESS}"
-              ensure:
-                task: upload-test-artifacts
-                file: paas-cf/concourse/tasks/upload-test-artifacts.yml
-                params:
-                  TEST_ARTIFACTS_BUCKET: ((test_artifacts_bucket))
-
-            ensure:
-              task: remove-temp-user
-              file: paas-cf/concourse/tasks/delete_admin.yml
+        ensure:
+          task: remove-temp-user
+          file: paas-cf/concourse/tasks/delete_admin.yml
 
   - name: check-var-store-certs
     build_logs_to_retain: 50


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1275640/stories/156313150

What?
-----

During alphagov/paas-cf#1232 we added a task that would check
if the healthcheck is deployed and if the environment is a dev
environment, skipping the execution if it is not with a `try`
block.

But that semantically makes the job to always be "green" because
all the sequence is under a `try` block, even when the smoke test
actually fails. Although the email alert is sent, this prevents
our datadog monitor to be trigger because it checks if there
was a "green" build in the last X minutes.

We can rewrite the flow of the job so that the assertion runs first,
and if it fails, it stops all the execution of the task. The email
would be sent only if the smoke test fails.

In development we do not have datadog monitoring, so it is
fine to have this job as failed.

How to test?
------------

Code review

To test, check that the job runs as expected:
   1. Replace the continuous smoke test with a `true` command to test it quicker
   2. Run the test once, it should finish OK.
   3. Set the file `echo no | aws s3 cp - s3://gds-paas-${DEPLOY_ENV}-state/healthcheck-deployed` and rerun, it should fail, but not send emails.
   4. Set it back   `echo yes | aws s3 cp - s3://gds-paas-${DEPLOY_ENV}-state/healthcheck-deployed` and the task to run `false`. It should fail, and send the email.

Who?
----

Not me