### PR TITLE
[Support] Increase prod cells to 27

### DIFF
--- a/manifests/cf-manifest/env-specific/cf-prod.yml
+++ b/manifests/cf-manifest/env-specific/cf-prod.yml
@@ -1,5 +1,5 @@
 ---
-cell_instances: 24
+cell_instances: 27
 elasticsearch_master_disk_size: 3072000
 elasticsearch_master_instance_type: c4.2xlarge
 parser_instance_type: c4.xlarge


### PR DESCRIPTION
## What

We're currently hovering around 32% advertised capacity remaining on the
cells, which is below the threshold we're aiming for in ARD021[1].
Adding 3 cells beings this back up to around 40%.

[1]https://government-paas-team-manual.readthedocs.io/en/latest/architecture_decision_records/ADR021-cell-capacity-assignment-2/

## How to review

Code review is probably enough.

## Who can review

Not me.