### PR TITLE
[#155783706] Add opsfile to create paas-admin UAA client

### DIFF
--- a/manifests/cf-manifest/manifest/operations/200-paas-admin-uaa-client.yml
+++ b/manifests/cf-manifest/manifest/operations/200-paas-admin-uaa-client.yml
@@ -1,0 +1,16 @@
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/paas-admin?
+  value:
+    override: true
+    authorized-grant-types: authorization_code,client_credentials,refresh_token
+    autoapprove: true
+    secret: "((uaa_clients_paas_admin_secret))"
+    scope: cloud_controller.read,cloud_controller.admin_read_only,cloud_controller.global_auditor,cloud_controller.write,scim.me,openid,profile,uaa.user,cloud_controller.admincloud_controller.read,cloud_controller.admin_read_only,cloud_controller.global_auditor,cloud_controller.write,scim.me,openid,profile,uaa.user,cloud_controller.admin
+    authorities: scim.userids,scim.invite,scim.read
+    redirect-uri: "https://admin.((system_domain))/auth/login/callback"
+
+- type: replace
+  path: /variables/-
+  value:
+    name: uaa_clients_paas_admin_secret
+    type: password

--- a/manifests/cf-manifest/scripts/generate-manifest.sh
+++ b/manifests/cf-manifest/scripts/generate-manifest.sh
@@ -35,6 +35,7 @@ bosh interpolate \
   --ops-file="${PAAS_CF_DIR}/manifests/cf-manifest/manifest/operations/060-cdn-broker.yml" \
   --ops-file="${PAAS_CF_DIR}/manifests/cf-manifest/manifest/operations/070-elasticache-broker.yml" \
   --ops-file="${PAAS_CF_DIR}/manifests/cf-manifest/manifest/operations/080-logsearch.yml" \
+  --ops-file="${PAAS_CF_DIR}/manifests/cf-manifest/manifest/operations/200-paas-admin-uaa-client.yml" \
   --ops-file="${WORKDIR}/grafana-dashboards-opsfile/grafana-dashboards-opsfile.yml" \
   --ops-file="${WORKDIR}/vpc-peering-opsfile/vpc-peers.yml" \
   --ops-file="${datadog_opsfile}" \


### PR DESCRIPTION
What?
-----

```
 ☻/ This is Bill.
/▌  Bill wants to deploy a application integrated with UAA.
/\  Bill creates a dedicated UAA client for this app.
    That's because Bill knows that federated login does not work
    without a client in UAA.

    Bill is smart

```

Be like Bill... review and merge this opsfile that would create a new UAA client so that our paas-admin app can be integrated with UAA and we can authenticate our tenants using the same creds than the platform.

How to review?
-------------

 - code review
 - tested in hector environment
 - as in https://github.com/alphagov/paas-admin#prerequisites

Who?
----

Anyone but @keymon or Bill