### PR TITLE
[#155783706] Deploy paas-admin as part of the PaaS deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,11 +180,18 @@ upload-compose-secrets: check-env ## Decrypt and upload Compose credentials to S
 .PHONY: upload-google-oauth-secrets
 upload-google-oauth-secrets: check-env ## Decrypt and upload Google Admin Console credentials to S3
 	$(eval export OAUTH_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
-	# FIXME After it has been tested, we'd like to restrict its usage in dev.
-	# $(if ${AWS_ACCOUNT},,$(error Must set environment to staging/prod))
+	$(if ${AWS_ACCOUNT},,$(error Must set environment to staging/prod))
 	$(if ${OAUTH_PASSWORD_STORE_DIR},,$(error Must pass OAUTH_PASSWORD_STORE_DIR=<path_to_password_store>))
 	$(if $(wildcard ${OAUTH_PASSWORD_STORE_DIR}),,$(error Password store ${OAUTH_PASSWORD_STORE_DIR} does not exist))
 	@scripts/upload-google-oauth-secrets.sh
+
+.PHONY: upload-notify-secrets
+upload-notify-secrets: check-env ## Decrypt and upload Notify Credentials to S3
+	$(eval export NOTIFY_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
+	$(if ${AWS_ACCOUNT},,$(error Must set environment))
+	$(if ${NOTIFY_PASSWORD_STORE_DIR},,$(error Must pass NOTIFY_PASSWORD_STORE_DIR=<path_to_password_store>))
+	$(if $(wildcard ${NOTIFY_PASSWORD_STORE_DIR}),,$(error Password store ${NOTIFY_PASSWORD_STORE_DIR} does not exist))
+	@scripts/upload-notify-secrets.sh
 
 .PHONY: pingdom
 pingdom: check-env ## Use custom Terraform provider to set up Pingdom check

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -12,7 +12,6 @@ groups:
       - generate-cf-config
       - cf-deploy
       - post-deploy
-      - deploy-paas-admin
       - smoke-tests
       - acceptance-tests
       - custom-acceptance-tests
@@ -30,7 +29,6 @@ groups:
       - generate-cf-config
       - cf-deploy
       - post-deploy
-      - deploy-paas-admin
       - smoke-tests
       - acceptance-tests
       - custom-acceptance-tests
@@ -2077,8 +2075,8 @@ jobs:
               - name: paas-admin-manifest
             params:
               SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
-              NOTIFY_API_KEY: foo # FIXME: Inject credentials
-              NOTIFY_WELCOME_TEMPLATE_ID: bar # FIXME: Inject credentials
+              NOTIFY_API_KEY: ((notify_api_key))
+              NOTIFY_WELCOME_TEMPLATE_ID: 1859ce68-f133-4218-ac6e-a8ef32a41292
             run:
               path: sh
               args:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -12,6 +12,7 @@ groups:
       - generate-cf-config
       - cf-deploy
       - post-deploy
+      - deploy-paas-admin
       - smoke-tests
       - acceptance-tests
       - custom-acceptance-tests
@@ -29,6 +30,7 @@ groups:
       - generate-cf-config
       - cf-deploy
       - post-deploy
+      - deploy-paas-admin
       - smoke-tests
       - acceptance-tests
       - custom-acceptance-tests
@@ -287,6 +289,14 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-billing
       tag_filter: v0.17.0
+
+  - name: paas-admin
+    type: git
+    source:
+      uri: https://github.com/alphagov/paas-admin
+      # FIXME: Use tags once paas-admin has a automated pipeline to
+      # test, release and tag the project.
+      branch: master
 
 jobs:
   - name: pipeline-lock
@@ -1359,12 +1369,15 @@ jobs:
         passed: ['cf-deploy']
       - get: cf-secrets
         passed: ['generate-cf-config']
+      - get: cf-vars-store
+        passed: ['generate-cf-config']
       - get: bosh-CA-crt
       - get: graphite-nozzle
       - get: datadog-tfstate
       - get: paas-compose-broker
       - get: paas-compose-scraper
       - get: paas-billing
+      - get: paas-admin
 
     - task: retrieve-config
       config:
@@ -2022,6 +2035,115 @@ jobs:
                 "
 
                 cf push paas-compose-scraper
+
+      - do:
+        - task: build-paas-admin
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: node
+                tag: 8-alpine
+            inputs:
+              - name: paas-admin
+            outputs:
+              - name: paas-admin-dist
+            run:
+              path: sh
+              args:
+                - -e
+                - -u
+                - -c
+                - |
+                  cd paas-admin
+                  npm install
+                  NODE_ENV=production npm run build
+
+                  cp -Ra . ../paas-admin-dist
+
+        - task: render-manifest-paas-admin
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/spruce
+                tag: c735581beb174ecc95ca1a7b57eff444af3bf099
+            inputs:
+              - name: paas-admin-dist
+              - name: cf-vars-store
+            outputs:
+              - name: paas-admin-manifest
+            params:
+              SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+              NOTIFY_API_KEY: foo # FIXME: Inject credentials
+              NOTIFY_WELCOME_TEMPLATE_ID: bar # FIXME: Inject credentials
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  cat <<EOF > paas-admin-env-and-routes.yml
+                  applications:
+                  - name: paas-admin
+                    routes:
+                    - route: "admin.${SYSTEM_DNS_ZONE_NAME}"
+                    env:
+                      OAUTH_AUTHORIZATION_URL: "https://login.${SYSTEM_DNS_ZONE_NAME}/oauth/authorize"
+                      OAUTH_TOKEN_URL: "https://uaa.${SYSTEM_DNS_ZONE_NAME}/oauth/token"
+                      OAUTH_CLIENT_ID: "paas-admin"
+                      OAUTH_CLIENT_SECRET: "(( grab uaa_clients_paas_admin_secret ))"
+                      API_URL: "https://api.${SYSTEM_DNS_ZONE_NAME}"
+                      UAA_URL: "https://uaa.${SYSTEM_DNS_ZONE_NAME}"
+                      NOTIFY_API_KEY: "${NOTIFY_API_KEY}"
+                      NOTIFY_WELCOME_TEMPLATE_ID: "${NOTIFY_WELCOME_TEMPLATE_ID}"
+                  EOF
+
+                  spruce merge \
+                    paas-admin-dist/manifest.yml \
+                    paas-admin-env-and-routes.yml \
+                    cf-vars-store/cf-vars-store.yml \
+                    | spruce merge --cherry-pick applications \
+                      > paas-admin-manifest/manifest.yml
+
+        - task: deploy-paas-admin
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/cf-cli
+                tag: b70af5321b8c80994add887c94827aa583f95541
+            inputs:
+              - name: paas-cf
+              - name: paas-admin-dist
+              - name: paas-admin-manifest
+              - name: config
+              - name: cf-secrets
+            params:
+              SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+            run:
+              path: sh
+              args:
+                - -e
+                - -u
+                - -c
+                - -x
+                - |
+                  VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
+                  export CF_CLIENT_SECRET
+                  CF_CLIENT_SECRET=$($VAL_FROM_YAML secrets_uaa_clients_paas_billing_secret cf-secrets/cf-secrets.yml)
+
+                  . ./config/config.sh
+                  cf api "${API_ENDPOINT}"
+                  cf auth "${CF_ADMIN}" "${CF_PASS}"
+                  cf target -o admin -s public
+
+                  cd paas-admin-dist
+
+                  cf zero-downtime-push paas-admin -f ../paas-admin-manifest/manifest.yml
 
       - task: run-bosh-cleanup
         config:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1450,6 +1450,7 @@ jobs:
                 cf create-space service-brokers -o admin
                 cf create-space healthchecks -o admin
                 cf create-space billing -o admin
+                cf create-space public -o admin
                 cf create-space assets -o admin
 
                 cf create-org govuk-paas

--- a/concourse/scripts/lib/notify.sh
+++ b/concourse/scripts/lib/notify.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+set -u
+
+get_notify_secrets() {
+  # shellcheck disable=SC2154
+  secrets_uri="s3://${state_bucket}/notify-secrets.yml"
+  export notify_api_key
+  secrets_size=$(aws s3 ls "${secrets_uri}" | awk '{print $3}')
+  if [ "${secrets_size}" != 0 ] && [ -n "${secrets_size}" ]  ; then
+    secrets_file=$(mktemp -t notify-secrets.XXXXXX)
+
+    aws s3 cp "${secrets_uri}" "${secrets_file}"
+    notify_api_key=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.notify_api_key "${secrets_file}")
+
+    rm -f "${secrets_file}"
+  fi
+}

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -15,6 +15,9 @@ $("${SCRIPT_DIR}/environment.sh" "$@")
 # shellcheck disable=SC1090
 . "${SCRIPT_DIR}/lib/google-oauth.sh"
 
+# shellcheck disable=SC1090
+. "${SCRIPT_DIR}/lib/notify.sh"
+
 download_git_id_rsa() {
   git_id_rsa_file=$(mktemp -t id_rsa.XXXXXX)
 
@@ -58,6 +61,7 @@ prepare_environment() {
   get_datadog_secrets
   get_compose_secrets
   get_google_oauth_secrets
+  get_notify_secrets
 
   if [ "${ENABLE_DATADOG}" = "true" ] ; then
     # shellcheck disable=SC2154
@@ -115,6 +119,7 @@ enable_datadog: ${ENABLE_DATADOG}
 concourse_atc_password: ${CONCOURSE_ATC_PASSWORD}
 oauth_client_id: ${oauth_client_id:-}
 oauth_client_secret: ${oauth_client_secret:-}
+notify_api_key: ${notify_api_key:-}
 enable_billing_app: ${ENABLE_BILLING_APP}
 auto_deploy: $([ "${ENABLE_AUTO_DEPLOY:-}" ] && echo "true" || echo "false")
 persistent_environment: ${PERSISTENT_ENVIRONMENT}

--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -406,14 +406,6 @@ instance_groups:
             scope: openid,oauth.approvals,cloud_controller.admin_read_only,cloud_controller.read,cloud_controller.global_auditor,cloud_controller.admin
             authorities: cloud_controller.admin_read_only,uaa.resource
             redirect-uri: https://billing.((system_domain))/oauth/callback
-          paas-admin:
-            override: true
-            authorized-grant-types: authorization_code,refresh_token
-            autoapprove: true
-            secret: ((secrets_uaa_clients_paas_admin_secret))
-            scope: openid,oauth.approvals,cloud_controller.read,cloud_controller.admin_read_only,cloud_controller.global_auditor
-            authorities: uaa.none
-            redirect-uri: https://paas-admin.((app_domain))/auth/cloudfoundry/callback
           cc-service-dashboards:
             override: true
             secret: ((secrets_uaa_clients_cc_service_dashboards_password))

--- a/manifests/cf-manifest/manifest/operations/200-paas-admin-uaa-client.yml
+++ b/manifests/cf-manifest/manifest/operations/200-paas-admin-uaa-client.yml
@@ -1,0 +1,16 @@
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/paas-admin?
+  value:
+    override: true
+    authorized-grant-types: authorization_code,client_credentials,refresh_token
+    autoapprove: true
+    secret: "((uaa_clients_paas_admin_secret))"
+    scope: cloud_controller.read,cloud_controller.admin_read_only,cloud_controller.global_auditor,cloud_controller.write,scim.me,openid,profile,uaa.user,cloud_controller.admincloud_controller.read,cloud_controller.admin_read_only,cloud_controller.global_auditor,cloud_controller.write,scim.me,openid,profile,uaa.user,cloud_controller.admin
+    authorities: scim.userids,scim.invite,scim.read
+    redirect-uri: "https://admin.((system_domain))/auth/login/callback"
+
+- type: replace
+  path: /variables/-
+  value:
+    name: uaa_clients_paas_admin_secret
+    type: password

--- a/manifests/cf-manifest/scripts/generate-cf-secrets.rb
+++ b/manifests/cf-manifest/scripts/generate-cf-secrets.rb
@@ -48,7 +48,6 @@ generator = SecretGenerator.new(
   "secrets_uaa_clients_notifications_secret" => :simple,
   "secrets_uaa_clients_paas_metrics_secret" => :simple,
   "secrets_uaa_clients_paas_billing_secret" => :simple,
-  "secrets_uaa_clients_paas_admin_secret" => :simple,
   "secrets_uaa_clients_ssh_proxy_secret" => :simple,
   "secrets_vcap_password" => :sha512_crypted,
 )

--- a/manifests/cf-manifest/scripts/generate-manifest.sh
+++ b/manifests/cf-manifest/scripts/generate-manifest.sh
@@ -35,6 +35,7 @@ bosh interpolate \
   --ops-file="${PAAS_CF_DIR}/manifests/cf-manifest/manifest/operations/060-cdn-broker.yml" \
   --ops-file="${PAAS_CF_DIR}/manifests/cf-manifest/manifest/operations/070-elasticache-broker.yml" \
   --ops-file="${PAAS_CF_DIR}/manifests/cf-manifest/manifest/operations/080-logsearch.yml" \
+  --ops-file="${PAAS_CF_DIR}/manifests/cf-manifest/manifest/operations/200-paas-admin-uaa-client.yml" \
   --ops-file="${WORKDIR}/grafana-dashboards-opsfile/grafana-dashboards-opsfile.yml" \
   --ops-file="${WORKDIR}/vpc-peering-opsfile/vpc-peers.yml" \
   --ops-file="${datadog_opsfile}" \

--- a/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
@@ -145,7 +145,6 @@ RSpec.describe "base properties" do
           "tcp_router",
           "ssh-proxy",
           "graphite-nozzle",
-          "paas-admin",
           "paas-metrics",
           "cc-service-dashboards",
           "cc_service_key_client",

--- a/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
@@ -150,6 +150,7 @@ RSpec.describe "base properties" do
           "cc_service_key_client",
           "cdn_broker",
           "paas-billing",
+          "paas-admin",
           "user_invitation",
         )
       }

--- a/scripts/upload-notify-secrets.sh
+++ b/scripts/upload-notify-secrets.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+export PASSWORD_STORE_DIR=${NOTIFY_PASSWORD_STORE_DIR}
+
+NOTIFY_API_KEY="$(pass "notify/${AWS_ACCOUNT}/api_key")"
+
+aws s3 cp - "s3://gds-paas-${DEPLOY_ENV}-state/notify-secrets.yml" << EOF
+---
+secrets:
+  notify_api_key: ${NOTIFY_API_KEY}
+EOF


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/155783706

What?
-----

We want to deploy the paas-admin application for the tenants.

We consider that the admin tool is part of every platform, so we decided to add the deployment as part of the paas-cf deployment pipeline.

The deployment requires:
 - A new UAA client to integrate with UAA oauth for tenants.
 - Deploy the app from master
 - Inject secrets from notify.

> We follow the same pattern than other secrets, although I personally consider it extremely   overcomplicated and difficult to maintain

How to review?
--------------

 1. Code review
 2. Go to `http://admin.${DEPLOY_ENV}.dev.cloudpipeline.digital/`, try to login and use the app.
 3. try to invite a user. You shall receive notifications.

Related
--------

https://github.com/alphagov/paas-credentials/pull/110

Who?
----

Anyone but @keymon