### PR TITLE
[#155856825] Move Cloud Controller behind GoRouter - Part 2: The Return of the Router

### DIFF
--- a/platform-tests/src/platform/availability/api/api_test.go
+++ b/platform-tests/src/platform/availability/api/api_test.go
@@ -2,6 +2,7 @@ package api_availability
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"regexp"
@@ -39,6 +40,11 @@ var _ = Describe("API Availability Monitoring", func() {
 			Username:          helpers.MustGetenv("CF_USER"),
 			Password:          helpers.MustGetenv("CF_PASS"),
 			SkipSslValidation: helpers.MustGetenv("SKIP_SSL_VALIDATION") == "true",
+			HttpClient: &http.Client{
+				Transport: &http.Transport{
+					DisableKeepAlives: true,
+				},
+			},
 		}
 		monitor := monitor.NewMonitor(cfConfig, os.Stdout, numWorkers, warningMatchers, taskRatePerSecond)
 		deployment := helpers.ConcourseDeployment()

--- a/terraform/cloudfoundry/dns-records.tf
+++ b/terraform/cloudfoundry/dns-records.tf
@@ -1,11 +1,3 @@
-resource "aws_route53_record" "cf_cc" {
-  zone_id = "${var.system_dns_zone_id}"
-  name    = "api.${var.system_dns_zone_name}."
-  type    = "CNAME"
-  ttl     = "60"
-  records = ["${aws_elb.cf_cc.dns_name}"]
-}
-
 resource "aws_route53_record" "cf_doppler" {
   zone_id = "${var.system_dns_zone_id}"
   name    = "doppler.${var.system_dns_zone_name}."


### PR DESCRIPTION
## What

Now that the ELB is configured we can switch DNS over to serve via GoRouter.

## How to review

* Deploy on top of https://github.com/alphagov/paas-cf/pull/1314
* Make sure all tests pass, particularly availlability tests.

### Before merging

* Merge https://github.com/alphagov/paas-cf/pull/1314
* Rebase on master

## Who can review

Anyone but me, @46bit or @chrisfarms 
