### PR TITLE
[Support] Temporarily disable the rep_healthy monitor.

### DIFF
--- a/terraform/datadog/cell.tf
+++ b/terraform/datadog/cell.tf
@@ -53,22 +53,24 @@ resource "datadog_monitor" "rep_process_running" {
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:diego-cell"]
 }
 
-resource "datadog_monitor" "rep_healthy" {
-  name                = "${format("%s Cell rep healthy", var.env)}"
-  type                = "service check"
-  message             = "Large portion of Cell reps unhealthy. Check deployment state."
-  escalation_message  = "Large portion of Cell reps still unhealthy. Check deployment state."
-  no_data_timeframe   = "7"
-  require_full_window = true
-
-  query = "${format("'http.can_connect'.over('deploy_env:%s','instance:rep_service_endpoint').by('*').last(1).pct_by_status()", var.env)}"
-
-  thresholds {
-    critical = 50
-  }
-
-  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:diego-cell"]
-}
+# FIXME: Re-enable this once the check has been fixed - https://www.pivotaltracker.com/story/show/156570305
+#
+#resource "datadog_monitor" "rep_healthy" {
+#  name                = "${format("%s Cell rep healthy", var.env)}"
+#  type                = "service check"
+#  message             = "Large portion of Cell reps unhealthy. Check deployment state."
+#  escalation_message  = "Large portion of Cell reps still unhealthy. Check deployment state."
+#  no_data_timeframe   = "7"
+#  require_full_window = true
+#
+#  query = "${format("'http.can_connect'.over('deploy_env:%s','instance:rep_service_endpoint').by('*').last(1).pct_by_status()", var.env)}"
+#
+#  thresholds {
+#    critical = 50
+#  }
+#
+#  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:diego-cell"]
+#}
 
 resource "datadog_monitor" "rep-container-capacity" {
   name               = "${format("%s rep container capacity", var.env)}"


### PR DESCRIPTION
## What

This is currently failing since rep was updated to require TLS and
client certs. This disables the monitor to avoid noise on the dashboards
until the story to fix it[1] is played.

[1]https://www.pivotaltracker.com/story/show/156570305

## How to review

Code review is probably enough.

## Who can review

Not me.