### PR TITLE
[Support] Exclude parsers from EC2 CPU usage alert

### DIFF
--- a/terraform/datadog/aws.tf
+++ b/terraform/datadog/aws.tf
@@ -62,7 +62,7 @@ resource "datadog_monitor" "rds-failure" {
 resource "datadog_monitor" "ec2-cpu-utilisation" {
   name                = "${format("%s EC2 high CPU utilisation", var.env)}"
   type                = "metric alert"
-  query               = "${format("avg(last_1h):avg:aws.ec2.cpuutilization{deploy_env:%s,!bosh-job:diego-cell,!bosh-job:elasticsearch_master} by {bosh-job,bosh-index} > 90", var.env)}"
+  query               = "${format("avg(last_1h):avg:aws.ec2.cpuutilization{deploy_env:%s,!bosh-job:diego-cell,!bosh-job:elasticsearch_master,!bosh-job:parser_z1,!bosh-job:parser_z2} by {bosh-job,bosh-index} > 90", var.env)}"
   message             = "{{bosh-job.name}}/{{bosh-index.name}} CPU utilisation has been over {{#is_warning}}{{warn_threshold}}{{/is_warning}}{{#is_alert}}{{threshold}}{{/is_alert}}% for 1h"
   notify_no_data      = false
   require_full_window = false


### PR DESCRIPTION
## What

The parsers are continually loaded due to the log volumes. It doesn't
therefore make sense to alert on these, and doing so actually masks
alerts for other VMs.

## How to review

Code review is probably enough.

## Who can review

Not me.