### PR TITLE
[#156226677] Update elasticache broker (cleanup part)

### DIFF
--- a/manifests/cf-manifest/manifest/operations/070-elasticache-broker.yml
+++ b/manifests/cf-manifest/manifest/operations/070-elasticache-broker.yml
@@ -26,7 +26,6 @@
             broker_name: "elasticache-broker"
             broker_username: "elasticache-broker"
             broker_password: ((secrets_elasticache_broker_admin_password))
-            auth_token_seed: ((secrets_elasticache_broker_auth_token_seed))
             kms_key_id: alias/elasticache-broker
             secrets_manager_path: elasticache-broker/((environment))
             region: "eu-west-1"

--- a/manifests/cf-manifest/manifest/operations/070-elasticache-broker.yml
+++ b/manifests/cf-manifest/manifest/operations/070-elasticache-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: elasticache-broker
-    version: 0.1.7
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/elasticache-broker-0.1.7.tgz
-    sha1: d6a2a45c857a64c3f4962184d5163bfbb810fa9b
+    version: 0.1.8
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/elasticache-broker-0.1.8.tgz
+    sha1: a1b83e8f8972b71756bc622442590f34ff72a551
 
 - type: replace
   path: /instance_groups/-

--- a/manifests/cf-manifest/scripts/generate-cf-secrets.rb
+++ b/manifests/cf-manifest/scripts/generate-cf-secrets.rb
@@ -17,7 +17,6 @@ generator = SecretGenerator.new(
   "secrets_cf_db_uaa_password" => :simple,
   "secrets_compose_broker_admin_password" => :simple,
   "secrets_consul_encrypt_keys" => :simple_in_array,
-  "secrets_elasticache_broker_auth_token_seed" => :simple,
   "secrets_elasticache_broker_admin_password" => :simple,
   "secrets_grafana_admin_password" => :simple,
   "secrets_kibana_admin_password" => :simple,

--- a/manifests/cf-manifest/scripts/rotate-cf-secrets.rb
+++ b/manifests/cf-manifest/scripts/rotate-cf-secrets.rb
@@ -14,7 +14,6 @@ list_secrets_to_keep = %w{
   secrets_cf_db_uaa_password
   secrets_compose_broker_admin_password
   secrets_consul_encrypt_keys
-  secrets_elasticache_broker_auth_token_seed
   secrets_elasticache_broker_admin_password
   secrets_kibana_admin_password
   secrets_nats_password


### PR DESCRIPTION
## What

❗️ This PR should be merged only after the auth token migration was finished in prod.

In https://github.com/alphagov/paas-cf/pull/1318 we started to generate and store auth tokens in Secrets Manager.

This PR remove the auth token seed from the Elasticache Broker.

For details please see https://github.com/alphagov/paas-elasticache-broker/pull/14

The old auth token seed will be automatically removed at the next secret rotation.

❗️ This PR contains a temporary commit which needs to be updated with the final elasticache-broker release

## How to review

1. Review https://github.com/alphagov/paas-elasticache-broker/pull/14

1. Review https://github.com/alphagov/paas-elasticache-broker-boshrelease/pull/10

1. Deploy your CF from this branch and make sure all tests pass
    ```BRANCH=update_elasticache_broker_cleanup_156226677 make dev pipelines```
 
## How to merge

1. Merge https://github.com/alphagov/paas-elasticache-broker/pull/14

1. Update the tmp commit in https://github.com/alphagov/paas-elasticache-broker-boshrelease/pull/10 and merge

1. Update the tmp commit in this PR and merge

## Who can review

Not @46bit or me.
