### PR TITLE
[Support] cf_subshell_scoped_login: export target env variable.

### DIFF
--- a/scripts/cf_subshell_scoped_login.sh
+++ b/scripts/cf_subshell_scoped_login.sh
@@ -32,6 +32,7 @@ cleanup() {
 trap 'cleanup' EXIT
 
 export CF_HOME
+export CF_SUBSHELL_TARGET=$TARGET
 
 cf api "${API_URL}"
 cf login --sso


### PR DESCRIPTION
## What

This can then be used to add an indicator to your shell prompt to
indicate which CF env you're targetting. eg:

```sh
PS1='\u@\h:\w${CF_SUBSHELL_TARGET+ (cf-$CF_SUBSHELL_TARGET)}\$ '
```
## How to review

* Code review
* Does the name of the new variable make sense?
* Verify that the variable is present in the subshell created by this script

## Who can review

Not me