### PR TITLE
Redirect to Paas Admin on Login

### DIFF
--- a/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
+++ b/manifests/cf-manifest/manifest/000-base-cf-deployment.yml
@@ -422,7 +422,7 @@ instance_groups:
             override: true
             authorities: oauth.login,scim.write,emails.write,scim.userids
             authorized-grant-types: password,refresh_token
-            redirect-uri: "https://www.cloud.service.gov.uk/next-steps?success"
+            redirect-uri: "https://admin.((system_domain))/"
             scope: openid,password.write,scim.read,scim.write,scim.invite,uaa.user
             secret: ((secrets_uaa_clients_login_secret))
         zones:
@@ -449,7 +449,7 @@ instance_groups:
         links:
           passwd: "https://login.((system_domain))/forgot_password"
           signup: "https://www.cloud.service.gov.uk/signup"
-          homeRedirect: "https://www.cloud.service.gov.uk/next-steps?account-updated"
+          homeRedirect: "https://admin.((system_domain))/"
         branding:
           company_name: "GOV.UK PaaS"
         asset_base_url: "https://paas-uaa-assets.((terraform_outputs_cf_apps_domain))"

--- a/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe "base properties" do
 
       it { is_expected.to include("passwd" => "https://login.#{terraform_fixture(:cf_root_domain)}/forgot_password") }
       it { is_expected.to include("signup" => "https://www.cloud.service.gov.uk/signup") }
-      it { is_expected.to include("homeRedirect" => "https://www.cloud.service.gov.uk/next-steps?account-updated") }
+      it { is_expected.to include("homeRedirect" => "https://admin.#{terraform_fixture(:cf_root_domain)}/") }
     end
   end
 

--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -23,7 +23,7 @@ https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!managemembers/
 As a welcome message you can use the text from here:
 https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/gov-uk-paas-announce
 '
-REDIRECT_URI="https://www.cloud.service.gov.uk/next-steps?success"
+REDIRECT_URI="https://admin.cloud.service.gov.uk/"
 
 ###########################################################################
 usage() {


### PR DESCRIPTION
## What

Redirect to Paas Admin as previously on login the user would have been directed to next steps on the product page.  However this content has now been moved to Paas Admin, so redirect to the new location of next steps.

Depends on https://github.com/alphagov/paas-product-page/pull/63

## How to review

Make sure the pages are redirected.

## Who can review

Anyone who isn't me or @paroxp 
