### PR TITLE
Require Notify secrets to run `make pipelines`

### DIFF
--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -73,7 +73,13 @@ prepare_environment() {
 
   # shellcheck disable=SC2154
   if [ -z "${compose_api_key+x}" ] ; then
-    echo "Could not retrieve access token for compose. Did you do run \`make ${AWS_ACCOUNT} upload-compose-secrets\`?"
+    echo "Could not retrieve access token for Compose. Did you run \`make ${AWS_ACCOUNT} upload-compose-secrets\`?"
+    exit 1
+  fi
+
+  # shellcheck disable=SC2154
+  if [ -z "${notify_api_key+x}" ] ; then
+    echo "Could not retrieve api key for Notify. Did you run \`make ${AWS_ACCOUNT} upload-notify-secrets\`?"
     exit 1
   fi
 


### PR DESCRIPTION
## What

See commit message.

## How to review

* Delete the Notify secrets from your S3 bucket and check that `make dev pipelines` fails with the expected message
* Upload the Notify secrets (following instructions in the message) and check that `make dev pipelines` succeeds

## Who can review

Not @46bit