### PR TITLE
[#156925097] Fix CF API url used by destroy-cloudfoundry

### DIFF
--- a/concourse/tasks/get-cf-cli-config.yml
+++ b/concourse/tasks/get-cf-cli-config.yml
@@ -15,6 +15,7 @@ run:
   path: sh
   args:
     - -e
+    - -u
     - -c
     - |
       VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
@@ -22,5 +23,11 @@ run:
       cat << EOT > config/config.sh
       export CF_ADMIN=admin
       export CF_PASS=$($VAL_FROM_YAML secrets_uaa_admin_password cf-secrets/cf-secrets.yml)
-      export API_ENDPOINT=$($VAL_FROM_YAML properties.cc.srv_api_uri cf-manifest/cf-manifest.yml)
+
+      SYSTEM_DNS_ZONE_NAME=$($VAL_FROM_YAML instance_groups.api.jobs.cloud_controller_ng.properties.system_domain cf-manifest/cf-manifest.yml)
+      export API_ENDPOINT="https://api.\${SYSTEM_DNS_ZONE_NAME}"
+
       EOT
+
+      . ./config/config.sh
+      echo "API_ENDPOINT: ${API_ENDPOINT}"


### PR DESCRIPTION
## What

See commit message. This should fix the `remove-healthcheck-db` and `remove-billing-db` tasks of the `destroy-cloudfoundry` pipeline's `delete-deployment` job.

I am not certain if this fully fixes the `destroy-cloudfoundry`. This works fine in my temporary dev environment `mikie`, but it [fails in my permanent `miki` dev environment](https://deployer.miki.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/custom-acceptance-tests/builds/18) even when I thought I'd cleared out RDS instances beforehand.

## How to review

* Code review
* Try it in your dev environment (use `BRANCH=fix-destroy-cloudfoundry-api-url-156925097 make dev pipelines` to push these custom pipelines.) Check the `destroy-cloudfoundry` entirely succeeds (you'll need to destroy any service instances you've created manually, but not the billing or healthcheck DBs)

## Who can review

Not @46bit