### PR TITLE
[#156729524] Enable the syslog drain test in cf-acceptance-tests.

### DIFF
--- a/concourse/scripts/pipecleaner_test.go
+++ b/concourse/scripts/pipecleaner_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var _ = Describe("PipeCleaner", func() {
-	const runTimeout = 2 * time.Second
+	const runTimeout = 5 * time.Second
 
 	var (
 		command *exec.Cmd

--- a/platform-tests/upstream/run_acceptance_tests.sh
+++ b/platform-tests/upstream/run_acceptance_tests.sh
@@ -14,7 +14,6 @@ SLOW_SPEC_THRESHOLD=120
 # Build Skip regex to ignore tests
 SKIP_REGEX='routing.API'
 SKIP_REGEX="${SKIP_REGEX}|Adding a wildcard route to a domain"
-SKIP_REGEX="${SKIP_REGEX}|forwards app messages to registered syslog drains"
 SKIP_REGEX="${SKIP_REGEX}|when app has multiple ports mapped"
 SKIP_REGEX="${SKIP_REGEX// /\\s}" # Replace ' ' with \s
 


### PR DESCRIPTION
## What

We originally disabled the test in [1] because it was incompatible with running CATS from a Concourse container (instead of a BOSH errand).

The test would have prevented us from breaking syslog drain functionality in the incident [2].

Also I increased the PipeCleaner timeout, because both @46bit and I had a timeout on Travis the last week.

[1] https://github.com/alphagov/paas-cf/commit/3a7d54a5c1f1e50283c16e99eb0a70e374984dbb
[2] https://www.pivotaltracker.com/story/show/156683943

## How to review

1. Deploy CF from this branch, the acceptance tests should pass. Also validate that there is a test saying `forwards app messages to registered syslog drains` really runs.

    ```BRANCH=enable_syslog_acc_tests_156729524 make dev pipelines```

## Who can review

Not me.
