### PR TITLE
WIP: [#156658598] Update link to the team manual for datadog alerts

### DIFF
--- a/terraform/datadog/variables.tf
+++ b/terraform/datadog/variables.tf
@@ -23,7 +23,7 @@ variable "datadog_notification_in_hours" {
 
 variable "datadog_documentation_url" {
   description = "URL that documents how to respond to specific DataDog alerts. Anchors can be appended to refer to specific alerts."
-  default     = "https://government-paas-team-manual.readthedocs.io/en/latest/support/responding_to_alerts/"
+  default     = "https://alphagov.github.io/paas-team-manual/support/responding_to_alerts/"
 }
 
 variable "aws_limits_elasticache_nodes" {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/156658598

What
----

We are deploying the team manual as a github page as in the PR[1]

We must update the urls to the runbooks set in the datadog alerts.

[1] https://github.com/alphagov/paas-team-manual/pull/195

How to review?
-------------

Code review

Who?
---

Anyone but @keymon or @bandesz