### PR TITLE
[SUPPORT] Increase prod cells to 30

### DIFF
--- a/manifests/cf-manifest/env-specific/cf-prod.yml
+++ b/manifests/cf-manifest/env-specific/cf-prod.yml
@@ -1,5 +1,5 @@
 ---
-cell_instances: 27
+cell_instances: 30
 router_instances: 3
 elasticsearch_master_disk_size: 3072000
 elasticsearch_master_instance_type: c4.2xlarge


### PR DESCRIPTION
What
----
We're currently hovering around 32% advertised capacity remaining on the
cells, which is below the threshold we're aiming for in ARD021[1].
Adding 3 cells beings this back up to around 40%.

Same than [2]

[1] https://alphagov.github.io/paas-team-manual/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision
[2] 5cf3323d5773a245dd9406f65824dde8342b0a99


How to review
-------------

Code review.

Who can review
--------------

not @keymon