### PR TITLE
[#157219548] Configure logsearch parse to consume both queues

### DIFF
--- a/manifests/cf-manifest/operations.d/710-logsearch.yml
+++ b/manifests/cf-manifest/operations.d/710-logsearch.yml
@@ -37,16 +37,23 @@
 - type: replace
   path: /instance_groups/-
   value:
-    name: parser_z1
+    name: parser
     release: logsearch
-    azs: [z1]
+    azs: [z1, z2]
     jobs:
     - name: parser
       release: logsearch
       properties:
         redis:
-          host: ((queue_static_ips_first))
+          host: dummy # This value would get overriden in each plugin below
         logstash_parser:
+          inputs:
+          - plugin: redis
+            options:
+              host: ((queue_static_ips_first))
+          - plugin: redis
+            options:
+              host: ((queue_static_ips_second))
           filters:
           - logstash: /var/vcap/packages/logsearch-config-logstash-filters/logstash-filters-default.conf
           - custom-filters: /var/vcap/jobs/parser-config-lfc/config/logstash-filters-custom.conf
@@ -116,41 +123,9 @@
 
     vm_type: parser
     stemcell: "3468"
-    instances: 1
+    instances: 2
     networks:
     - name: cf
-      static_ips:
-        - 10.0.16.14
-
-- type: replace
-  path: /instance_groups/-
-  value:
-    name: parser_z2
-    release: logsearch
-    azs: [z2]
-    jobs:
-    - name: parser
-      release: logsearch
-      properties:
-        redis:
-          host: ((queue_static_ips_second))
-        logstash_parser:
-          filters:
-          - logstash: /var/vcap/packages/logsearch-config-logstash-filters/logstash-filters-default.conf
-          - custom-filters: /var/vcap/jobs/parser-config-lfc/config/logstash-filters-custom.conf
-          elasticsearch:
-            data_hosts:
-            - ((terraform_outputs_logsearch_elastic_master_elb_dns_name))
-    - name: parser-config-lfc
-      release: logsearch-for-cloudfoundry
-      properties: *logstash_parser_config_lfc_properties
-    vm_type: parser
-    stemcell: "3468"
-    instances: 1
-    networks:
-    - name: cf
-      static_ips:
-        - 10.0.17.14
 
 - type: replace
   path: /instance_groups/-

--- a/manifests/cf-manifest/spec/manifest/logsearch_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/logsearch_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe "Logsearch properties" do
     }
 
     it "points the parsers at the correct queues" do
-      expect(manifest.fetch("instance_groups.parser_z1.jobs.parser.properties.redis.host")).to eq(queue_ips[0])
-      expect(manifest.fetch("instance_groups.parser_z2.jobs.parser.properties.redis.host")).to eq(queue_ips[1])
+      expect(manifest.fetch("instance_groups.parser.jobs.parser.properties.logstash_parser.inputs.0.options.host")).to eq(queue_ips[0])
+      expect(manifest.fetch("instance_groups.parser.jobs.parser.properties.logstash_parser.inputs.1.options.host")).to eq(queue_ips[1])
     end
   end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/157219548

What
----

We were configuring two different parsers consuming messages from
the specific redis queue of each AZ.

But there is no really a reason for this, and having this setup
can cause issues, as only one queue might start receiving messages
when the ingestors are redeployed and marked as unhealthy in the
ELBs. When this happens, one of the parsers will be really busy
and unable to cope with the backlog meanwhile the other is idle.

If the two parsers consume both queues, the load would be evenly
distributed across both of them and they will not be saturated.

Analysing the parser template[1], we found out that we might able
to define multiple redis "inputs" and override specific options in
each, specifically `host`.

With this change we
do not need to configure each parser differently and we can
merge the two instance groups `parser_z1` and `parser_z2` in
one `parser`.

[1] https://github.com/cloudfoundry-community/logsearch-boshrelease/blob/v205.0.0/jobs/parser/templates/config/input_and_output.conf.erb#L3-L21


**Note:** deploying this might cause somedowntime of the logs, but they will
be stored in the queue and processed later.

How to review
-------------

Code review. To test:

 1. Deploy this
 2. SSH into any parser and check the config `/var/vcap/jobs/parser/config/input_and_output.conf`. The parser logs report about the 2 inputs.
 3. Also check that the logs are still flowing Elasticsearch and available in kibana.


Who can review
--------------

Anyone but @keymon