### PR TITLE
Add billing URL to PaaS Admin

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2102,11 +2102,10 @@ jobs:
                     routes:
                     - route: "admin.${SYSTEM_DNS_ZONE_NAME}"
                     env:
-                      OAUTH_AUTHORIZATION_URL: "https://login.${SYSTEM_DNS_ZONE_NAME}/oauth/authorize"
-                      OAUTH_TOKEN_URL: "https://uaa.${SYSTEM_DNS_ZONE_NAME}/oauth/token"
                       OAUTH_CLIENT_ID: "paas-admin"
                       OAUTH_CLIENT_SECRET: "(( grab uaa_clients_paas_admin_secret ))"
                       API_URL: "https://api.${SYSTEM_DNS_ZONE_NAME}"
+                      BILLING_URL: "https://billing.${SYSTEM_DNS_ZONE_NAME}"
                       UAA_URL: "https://uaa.${SYSTEM_DNS_ZONE_NAME}"
                       NOTIFY_API_KEY: "${NOTIFY_API_KEY}"
                       NOTIFY_WELCOME_TEMPLATE_ID: "${NOTIFY_WELCOME_TEMPLATE_ID}"


### PR DESCRIPTION
What
----

We've broken our pipelines, as we're deploying an application that is
going to fail due to missing environment variable.

This should be addressed in already backlogged story that will enable
tagging for that application.

How to review
-------------

- See if the changes make sense
- I'd say run through pipelines, but it's a blocker for staging. Perhaps unblock the pipeline and test on staging?