### PR TITLE
[support] Add logsearch query for CC failed jobs alert

### DIFF
--- a/terraform/datadog/cloud_controller.tf
+++ b/terraform/datadog/cloud_controller.tf
@@ -56,8 +56,8 @@ resource "datadog_monitor" "cc_api_healthy" {
 resource "datadog_monitor" "cc_failed_job_count_total_increase" {
   name                = "${format("%s Cloud Controller API failed job count", var.env)}"
   type                = "query alert"
-  message             = "${format("Amount of failed jobs in Cloud Controller API grew considerably, check the API health. {{#is_alert}}%s{{/is_alert}}", var.datadog_notification_in_hours)}"
-  escalation_message  = "Amount of failed jobs in Cloud Controller API still growing considerably, check the API health."
+  message             = "${format("Amount of failed jobs in Cloud Controller API grew considerably. See logsearch: '@source.component:cloud_controller_worker AND @level:ERROR' {{#is_alert}}%s{{/is_alert}}", var.datadog_notification_in_hours)}"
+  escalation_message  = "Amount of failed jobs in Cloud Controller API still growing considerably. See logsearch: '@source.component:cloud_controller_worker AND @level:ERROR'"
   require_full_window = false
 
   query = "${format("change(max(last_1m),last_30m):max:cf.cc.failed_job_count.total{deployment:%s}.rollup(avg, 30) > 5", var.env)}"


### PR DESCRIPTION
What
----

So that you can easily find out what jobs have failed. Similar to the CC
errors alert that's next to it.

I've removed the text about checking the API because I don't think it's
useful. Errors can happen even if CC API is fine. The error logs will
tell you the actual problem.

How to review
-------------

I haven't tested that this applies and I suggest you don't either because enabling DataDog takes too long. Check the changes for syntax and that the search query returns the right things in Logsearch.

Who can review
--------------

Anyone.
