### PR TITLE
[support] Change paas-admin UAA_URL to login.<system>

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2106,7 +2106,7 @@ jobs:
                       OAUTH_CLIENT_SECRET: "(( grab uaa_clients_paas_admin_secret ))"
                       API_URL: "https://api.${SYSTEM_DNS_ZONE_NAME}"
                       BILLING_URL: "https://billing.${SYSTEM_DNS_ZONE_NAME}"
-                      UAA_URL: "https://uaa.${SYSTEM_DNS_ZONE_NAME}"
+                      UAA_URL: "https://login.${SYSTEM_DNS_ZONE_NAME}"
                       NOTIFY_API_KEY: "${NOTIFY_API_KEY}"
                       NOTIFY_WELCOME_TEMPLATE_ID: "${NOTIFY_WELCOME_TEMPLATE_ID}"
                   EOF


### PR DESCRIPTION
What
----

In our deployments we were setting UAA_URL as
https://uaa<system>, which caused the IDP federation fail, as the
oauth2 clients were configured to work on the https://login.<system>
domain.

Because that, we were getting the following error when
authenticating with google:

                   Error: redirect_uri_mismatch

                   The redirect URI in the request, https://uaa.cloud.service.gov.uk/login/callback/google, does not match the ones authorized for the OAuth client. To update the authorized redirect URIs, visit: https://console.developers.google.com/apis/credentials/oauthclient/.......apps.google

The PR https://github.com/alphagov/paas-admin/pull/44 likely
fixes the issue, but changing the UAA_URL would also fix it
until that gets merged.

How to review
-------------

Code review. This setting has been changed in prod already

Who can review
--------------

Anyone but @keymon