### PR TITLE
[#SUPPORT] Use scaledDBSCAN rather than DBSCAN in datadog

### DIFF
--- a/terraform/datadog/router.tf
+++ b/terraform/datadog/router.tf
@@ -97,7 +97,7 @@ resource "datadog_monitor" "total_routes_discrepancy" {
   no_data_timeframe   = "7"
   require_full_window = true
 
-  query = "${format("avg(last_5m):outliers(avg:cf.gorouter.total_routes{deployment:%s,job:router} by {ip}, 'dbscan', 3.0) > 0", var.env)}"
+  query = "${format("avg(last_5m):outliers(avg:cf.gorouter.total_routes{deployment:%s,job:router} by {ip}, 'scaledDBSCAN', 3.0) > 0", var.env)}"
 
   thresholds {}
 


### PR DESCRIPTION
What
----

We are using DBSCAN[1] outlider monitoring on the number of registered
routes in the go routers. But since we added a third gorouter[2] this
monitor has been flapping, despite it does not seem to be outliers.

We opened a support case in datadog[3] and they suggested to use
scaledDBSCAN instead[4].

I tested the algorithms DBSCAN, MAD and scaledDBSCAN in cloned
monitors, and I confirmed that scaledDBSCAN did not flap, meanwhile
the other two did.

The scaledDBSCAN is still working, as I simulated a scenario by
blocking the traffic from one gorouter to NATS to prevent it from
receiving route updates, and adding some routes.

[1] https://docs.datadoghq.com/monitors/monitor_types/outlier/
[2] https://github.com/alphagov/paas-cf/pull/1336
[3] https://help.datadoghq.com/hc/en-us/requests/144344
[4] https://www.datadoghq.com/blog/scaling-outlier-algorithms/#introducing-scaleddbscan


How to review
-------------

Code review. You can check the monitors used for testing in datadog.
Check staging status yesterday afternoon to see how it failed when
simulating some downtime.


Dependencies
-------------

After merge, remove the unnecessary monitors in datadog.

Who can review
--------------

Anyone but @keymon