### PR TITLE
[#157424419] Update cdn-broker release

### DIFF
--- a/manifests/cf-manifest/operations.d/720-cdn-broker.yml
+++ b/manifests/cf-manifest/operations.d/720-cdn-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: cdn-broker
-    version: 0.1.6
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.6.tgz
-    sha1: 7db1bf1d80707e56d257d813d5155ce3c6767127
+    version: 0.1.8
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.8.tgz
+    sha1: 1d9e2c202192c2d4c726d82de2a46e73ad0177be
 
 - type: replace
   path: /instance_groups/-


### PR DESCRIPTION
## What?

We fixed some error handling when deleting orphaned certificates.

Both the ListDistributions and ListCertificates errors were swallowed therefore we didn't see any errors in the logs. Because of this we spent more time debugging that deleting the certificates failed as the broker didn't have the proper IAM permissions to list the certificates.

We also added test cases to thoroughly check error handling.

## How to review?

1. https://github.com/alphagov/paas-aws-account-wide-terraform/pull/125 was already reviewed, merged and applied.

1. Review the following PRs first:
    * https://github.com/alphagov/paas-cdn-broker/pull/9
    * https://github.com/alphagov/paas-cdn-broker-boshrelease/pull/10

1. Deploy the cdn-broker to your dev env:

    ```
    BRANCH=delete_certs_fix_157424419 make dev pipelines
    ```

1. SSH onto the cdn_broker/0 and temporarily change the cron schedule to "0 * * * * *" to run it every minute (/var/vcap/jobs/cdn-cron/bin/job_properties.sh, CDN_SCHEDULE)

1. Restart the cdn_cron process, wait a minute and check the output, you should see no errors since the last start.

    ```
    sudo su -
    monit restart cdn-cron
    tail -f -n 100 /var/vcap/sys/log/cdn-croncdn-cron.stderr.log
    ```

## Before merge

❗️ Update the WIP commit with the final cdn-broker release

## Who?

Anyone but @keymon or @bandesz