### PR TITLE
[#156570305] Remove datadog rep health monitor

### DIFF
--- a/manifests/cf-manifest/operations.d/520-datadog-add-instance-group-checks.yml
+++ b/manifests/cf-manifest/operations.d/520-datadog-add-instance-group-checks.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: datadog-for-cloudfoundry
-    sha1: 09f70cbd87ec6045d44aa346e23fd6dd9bf14bfa
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.1.23.tgz
-    version: 0.1.23
+    version: 0.1.24
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.1.24.tgz
+    sha1: 75b4e4e76508e730b3c62a1ac76992a85467a6c5
 
 - type: replace
   path: /instance_groups/name=consul/jobs/-

--- a/terraform/datadog/cell.tf
+++ b/terraform/datadog/cell.tf
@@ -53,25 +53,6 @@ resource "datadog_monitor" "rep_process_running" {
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:diego-cell"]
 }
 
-# FIXME: Re-enable this once the check has been fixed - https://www.pivotaltracker.com/story/show/156570305
-#
-#resource "datadog_monitor" "rep_healthy" {
-#  name                = "${format("%s Cell rep healthy", var.env)}"
-#  type                = "service check"
-#  message             = "Large portion of Cell reps unhealthy. Check deployment state."
-#  escalation_message  = "Large portion of Cell reps still unhealthy. Check deployment state."
-#  no_data_timeframe   = "7"
-#  require_full_window = true
-#
-#  query = "${format("'http.can_connect'.over('deploy_env:%s','instance:rep_service_endpoint').by('*').last(1).pct_by_status()", var.env)}"
-#
-#  thresholds {
-#    critical = 50
-#  }
-#
-#  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:diego-cell"]
-#}
-
 resource "datadog_monitor" "rep-container-capacity" {
   name               = "${format("%s rep container capacity", var.env)}"
   type               = "query alert"


### PR DESCRIPTION
## What

Remove rep cell Datadog monitor and rep service endpoint check.

After the upgrade done in [1], the rep cell monitor is broken. The reason is that the datadog rep check does not work because it uses mutual TLS. [2]

The monitor was disabled in [3] while we decided what to do about it.

We've now decided that we should remove this, as we don't believe this offers much value above the existing process monitor that's in place.

[1] https://www.pivotaltracker.com/story/show/156299675
[2] https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/blob/8d8ae64cba528dc31d432f45699b3de8e100a92b/jobs/datadog-rep/templates/http_check.yaml.erb#L4-L7
[3] https://github.com/alphagov/paas-cf/pull/1317

## How to review

1. Review and merge https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/28

1. Code review should be enough. I don't think it's worth to do a full Datadog enabled dev deploy for this.

## Before merge

❗️ update the WIP commit with the final datadog-for-cloudfoundry release

## Who can review

Not me.