### PR TITLE
[#156224236] Update the rds-broker release to use SHA256 for generating usernames/passwords and MySQL password reset.

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -49,9 +49,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 0.1.24
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.24.tgz
-    sha1: e060b260fb534a679de91a6305d62ecd3d181bed
+    version: 0.1.25
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.25.tgz
+    sha1: 7664f69cf92803dab195f1ea128502d1dfa86113
 
 - type: replace
   path: /instance_groups/-


### PR DESCRIPTION
## What

Update the rds-broker release to use SHA256 for generating usernames/passwords.

During the pentest it came up that MD5 isn't considered safe anymore and we
should use SHA256 instead.

We also found that the MySQL instances [were not reseting the Master Password when changing the seed or the algorithm](https://github.com/alphagov/paas-rds-broker/pull/75)

## How to review

1. ~~Review https://github.com/alphagov/paas-rds-broker/pull/74~~ already reviewed by @keymon 
1. Review https://github.com/alphagov/paas-rds-broker/pull/75
1. Review https://github.com/alphagov/paas-rds-broker-boshrelease/pull/54
1. Create one `mysql` and `psql` RDS instance in your environment. Create some binding creds with `cf create-service-key <service> key1`
1. Deploy your CF from this branch and wait for all tests to pass

```
BRANCH=password_generate_sha_156224236 make dev pipelines
```
 1. Check that you can still create credentials in the rds instances previously created with ``cf create-service-key <service> key2` 
 1. Delete these temporary services.
## How to merge

❗️ Please update the WIP commit with the final rds-broker release after merging https://github.com/alphagov/paas-rds-broker-boshrelease/pull/54


## Who can review it

Not @keymon

@bandesz can review, as he only worked on the SHA256 part and that has been merged in the broker.  