### PR TITLE
Remove verbose output when deploying paas-admin

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2164,7 +2164,6 @@ jobs:
                 - -e
                 - -u
                 - -c
-                - -x
                 - |
                   VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
                   export CF_CLIENT_SECRET
@@ -3388,7 +3387,7 @@ jobs:
               - |
                 log() { echo "$@" 1>&2; }
 
-                bosh_curl(){ 
+                bosh_curl(){
                   path="$1"
                   out="$2"
                   bosh_password=$(awk '/bosh_admin_password/ { print $2 }' < bosh-secrets/bosh-secrets.yml)


### PR DESCRIPTION
What
----

We are printing also credentials in the output and we shouldn't.

Also remove some spurious whitespaces.

How to review
-------------

Code review

Who can review
--------------

Not me