### PR TITLE
Remove Cloudfoundry group from pipeline

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1,25 +1,8 @@
 ---
 groups:
-  - name: all
+  - name: deploy
     jobs:
       - pipeline-lock
-      - pre-deploy
-      - generate-secrets
-      - app-availability-tests
-      - api-availability-tests
-      - cf-terraform
-      - generate-cf-config
-      - cf-deploy
-      - post-deploy
-      - smoke-tests
-      - acceptance-tests
-      - custom-acceptance-tests
-      - bosh-tests
-      - performance-tests
-      - tag-release
-      - pipeline-unlock
-  - name: cloudfoundry
-    jobs:
       - pre-deploy
       - generate-secrets
       - app-availability-tests


### PR DESCRIPTION
What
----

This was identical to the 'All' group except for the pipeline-lock job
which isn't included. It therefore doesn't offer much value, so let's
remove it.

This also renames the 'all' group to 'depoly' because it doesn't contain
all jobs, so the name is misleading.

This is leftover from when this pipeline used to deploy both bosh and
cloudfoundry.

How to review
-------------

* Deploy the pipelines (`make dev pipelines`)
* Verify the new layout looks good and you can see/access everything

Who can review
--------------

Not me.