### PR TITLE
[#156924350] healthcheck/es: Content-Type request header

### DIFF
--- a/platform-tests/example-apps/healthcheck/elasticsearch.go
+++ b/platform-tests/example-apps/healthcheck/elasticsearch.go
@@ -129,6 +129,7 @@ func (e *esClient) doRequest(method, url string, body io.Reader, expectedStatus 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Add("Content-Type", "application/json")
 	resp, err := e.client.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
What
----

This appears to be required for newer Elasticsearch versions provided by
Aiven (which we're spiking against):

    {"error":"Content-Type header [] is not supported","status":406}

Adding it won't have any negative effect for older versions. Strictly
it may not be required for all requests, but it's correct for the
current set of requests and shouldn't cause harm in the future.

How to review
-------------

I haven't tested this against Compose, but I don't expect any problems. Code review should be sufficient. If you do want to test it in the pipeline then you'll need to un-pending the Compose custom acceptance tests.

Who can review
--------------

Anyone.