### PR TITLE
[#156924350] healthcheck: Allow CA cert to be empty

### DIFF
--- a/platform-tests/example-apps/healthcheck/main.go
+++ b/platform-tests/example-apps/healthcheck/main.go
@@ -42,6 +42,10 @@ func writeJson(w http.ResponseWriter, data interface{}) {
 }
 
 func buildTLSConfigWithCACert(caCertBase64 string) (*tls.Config, error) {
+	if caCertBase64 == "" {
+		return &tls.Config{}, nil
+	}
+
 	ca, err := base64.StdEncoding.DecodeString(caCertBase64)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
What
----

Return a default `tls.Config` when no CA cert is provided.

We're testing an Elasticsearch service from Aiven which uses publicly
trusted certs for service instances so we don't need to populate
`CACertBase64` in the bind credentials.

I considered changing the way that the client was constructed, to only
set `client.client.Transport.TLSClientConfig` when the CA is a non-empty
string but the code looked much more complicated than modifying
`buildTLSConfigWithCACert` and it wouldn't have applied to MongoDB which
also uses this function.

How to review
-------------

I haven't tested this against Compose, but I don't expect any problems. Code review should be sufficient. If you do want to test it in the pipeline then you'll need to un-pending the Compose custom acceptance tests.

Who can review
--------------

Anyone.