### PR TITLE
[#156923083] Add configuration to wire paas-admin -> paas-accounts

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2181,6 +2181,7 @@ jobs:
                   - name: paas-admin
                     routes:
                     - route: "admin.${SYSTEM_DNS_ZONE_NAME}"
+                    instances: 2
                     env:
                       OAUTH_CLIENT_ID: "paas-admin"
                       OAUTH_CLIENT_SECRET: "(( grab uaa_clients_paas_admin_secret ))"


### PR DESCRIPTION
What
----

Updated the manifest for deploying paas-admin so that it can connect to paas-accounts for the work in https://github.com/alphagov/paas-admin/pull/52

How to review
-------------

Deploy to dev, check pazmin deploys and test out the terms signing as per https://github.com/alphagov/paas-admin/pull/52

Before merge
-------------

Ensure the TMP commit is removed so paas-admin deploys from master

Who can review
--------------

Not @chrisfarms
