### PR TITLE
[#156164399] Reserve london.cloudapps.digital to prevent future conflicts

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1503,6 +1503,10 @@ jobs:
                 cf create-route docs "${APPS_DNS_ZONE_NAME}" --hostname api
                 cf create-route docs "${APPS_DNS_ZONE_NAME}" --hostname status
 
+                # Reserve the london app name so that we don't cause conflicts
+                # when we roll out the London region.
+                cf create-route docs "${APPS_DNS_ZONE_NAME}" --hostname london
+
       - task: register-rds-broker
         config:
           platform: linux


### PR DESCRIPTION
What
----

When we roll out the London region, we're going to host apps under this
subdomain there, so we want to ensure that tenants can't deploy an app
here in the Ireland region because that app would stop receiving traffic
when we rolled out London.

How to review
-------------

Code review is probably enough.

Who can review
--------------

Not me.
