### PR TITLE
[#157803606] Bump garden-runc to fix Docker layer bug

### DIFF
--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -8,4 +8,4 @@
       version: "3468.42"
     - alias: default
       os: ubuntu-trusty
-      version: "3541.25"
+      version: "3541.26"

--- a/manifests/cf-manifest/operations.d/240-cf-upgrade-garden-runc.yml
+++ b/manifests/cf-manifest/operations.d/240-cf-upgrade-garden-runc.yml
@@ -1,0 +1,9 @@
+---
+
+- type: replace
+  path: /releases/name=garden-runc
+  value:
+    name: garden-runc
+    url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.13.3
+    version: 1.13.3
+    sha1: 8868157d567c0e51eb19d3ccadeed951c7616975


### PR DESCRIPTION
What
----

This upgrades garden-runc to 1.13.3 which includes the fix for the [Docker image layer bug](https://github.com/cloudfoundry/garden-runc-release/issues/77).

To fully apply the fix it's necessary to recreate all the cell VMs. I've therefore included a stemcell bump in this PR as that seems like the easiest, and most tested way we have for achieving this.

How to review
-------------

* Push an app using a docker image that demonstrates the problem:
```
cf push docker-test --docker-image cfgarden/opaque-whiteouts-regression-image --no-route --health-check-type none
cf ssh docker-test
ls /test/foo # Will cause "No such file or directory" errors
```
* Deploy from this branch
* Observe that the above test app now no longer exhibits these errors.
* Verify all other tests pass

Who can review
--------------

Not me.