### PR TITLE
[#157189960] Set token expiry for CF CLI UAA client

### DIFF
--- a/manifests/cf-manifest/operations.d/330-uaa.yml
+++ b/manifests/cf-manifest/operations.d/330-uaa.yml
@@ -164,7 +164,7 @@
 
 - type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/cf/refresh-token-validity
-  value: 604800
+  value: 72000
 
 - type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/cf/scope

--- a/manifests/cf-manifest/spec/manifest/uaa_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/uaa_spec.rb
@@ -38,4 +38,19 @@ uaa_jwt_signing_key_old:
       expect(default_key).not_to eq(previous_key)
     end
   end
+
+  context "when setting the cf cli token validity" do
+    let(:manifest) { manifest_with_defaults }
+    let(:cf_client) { manifest.fetch("instance_groups.uaa.jobs.uaa.properties.uaa.clients.cf") }
+    let(:refresh_token_validity) { cf_client.fetch("refresh-token-validity") }
+    let(:access_token_validity) { cf_client.fetch("access-token-validity") }
+
+    it "sets the refresh token validity to 20 hours" do
+      expect(refresh_token_validity).to equal(72000)
+    end
+
+    it "doesn't set the access token validity to higher than the refresh validity" do
+      expect(access_token_validity).to be <= refresh_token_validity
+    end
+  end
 end


### PR DESCRIPTION
What
-----

We want to force login sessions to last no longer than a day, due to a
recommendation in a recent penetration test. The access token validity
is set via cf-deployment, but we set the refresh token validity via our
own ops files, so we add a test to make sure the value is set correctly
and cf-deployment does not override our value.

How to review
-------------

Code review.

If you want you can deploy from this branch, login with the CF CLI, and inspect the token to see what access and refresh expiries it has:

The access token expiry token should be 10 minutes from when the token was issued:

```bash
date -r $(cf oauth-token | awk '{ print $2 }' | cut -d. -f2 | base64 -D | jq '.exp')
```

And the refresh token expiry should be 20 hours from when the token was issued.

You can grab the refresh token from your `~/.cf/config.json` and check the `exp` like the above example. I tried to script it but it was truncated when I decoded it with base64 for some reason so I gave up. You can do it manually.

Who can review
--------------

Anyone but me.
