### PR TITLE
[#157083954] Deploy Log Cache service

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2661,39 +2661,71 @@ jobs:
             PREFIX: acceptance-test-user
             DISABLE_ADMIN_USER_CREATION: ((disable_cf_acceptance_tests))
 
-        - task: generate-test-config
-          file: paas-cf/concourse/tasks/generate-test-config.yml
-          params:
-            TEST_PROPERTIES: acceptance_tests
-            APP_DOMAIN: ((apps_dns_zone_name))
-            SYSTEM_DOMAIN: ((system_dns_zone_name))
+        - aggregate:
+          - do:
+            - task: generate-test-config
+              file: paas-cf/concourse/tasks/generate-test-config.yml
+              params:
+                TEST_PROPERTIES: acceptance_tests
+                APP_DOMAIN: ((apps_dns_zone_name))
+                SYSTEM_DOMAIN: ((system_dns_zone_name))
+            - task: run-tests
+              config:
+                platform: linux
+                image_resource:
+                  type: docker-image
+                  source:
+                    repository: governmentpaas/cf-acceptance-tests
+                    tag: c599048c56cc1508314315552bd11f413fab1c78
+                params:
+                  DISABLE_CF_ACCEPTANCE_TESTS: ((disable_cf_acceptance_tests))
+                inputs:
+                  - name: paas-cf
+                  - name: cf-acceptance-tests
+                    path: src/github.com/cloudfoundry/cf-acceptance-tests
+                  - name: test-config
+                outputs:
+                  - name: artifacts
+                    path: /tmp/artifacts
+                run:
+                  path: ./paas-cf/platform-tests/upstream/run_acceptance_tests.sh
 
-        - task: run-tests
-          config:
-            platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: governmentpaas/cf-acceptance-tests
-                tag: c599048c56cc1508314315552bd11f413fab1c78
-            params:
-              DISABLE_CF_ACCEPTANCE_TESTS: ((disable_cf_acceptance_tests))
-            inputs:
-              - name: paas-cf
-              - name: cf-acceptance-tests
-                path: src/github.com/cloudfoundry/cf-acceptance-tests
-              - name: test-config
-            outputs:
-              - name: artifacts
-                path: /tmp/artifacts
-            run:
-              path: ./paas-cf/platform-tests/upstream/run_acceptance_tests.sh
+              ensure:
+                task: upload-test-artifacts
+                file: paas-cf/concourse/tasks/upload-test-artifacts.yml
+                params:
+                  TEST_ARTIFACTS_BUCKET: ((test_artifacts_bucket))
 
-          ensure:
-            task: upload-test-artifacts
-            file: paas-cf/concourse/tasks/upload-test-artifacts.yml
-            params:
-              TEST_ARTIFACTS_BUCKET: ((test_artifacts_bucket))
+          - do:
+            - task: generate-test-config
+              file: paas-cf/concourse/tasks/generate-test-config.yml
+              params:
+                TEST_PROPERTIES: acceptance_log_cache_tests
+                APP_DOMAIN: ((apps_dns_zone_name))
+                SYSTEM_DOMAIN: ((system_dns_zone_name))
+            - task: run-log-cache-tests
+              timeout: 20m
+              config:
+                platform: linux
+                image_resource:
+                  type: docker-image
+                  source:
+                    # FIXME: Use the right acceptance test container ID with the log-cach-cli plugin
+                    # https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/129
+                    repository: governmentpaas/cf-acceptance-tests
+                    tag: c599048c56cc1508314315552bd11f413fab1c78
+                params:
+                  DISABLE_CF_ACCEPTANCE_TESTS: ((disable_cf_acceptance_tests))
+                inputs:
+                  - name: paas-cf
+                  - name: cf-acceptance-tests
+                    path: src/github.com/cloudfoundry/cf-acceptance-tests
+                  - name: test-config
+                outputs:
+                  - name: artifacts
+                    path: /tmp/artifacts
+                run:
+                  path: ./paas-cf/platform-tests/upstream/run_acceptance_tests.sh
 
         ensure:
           task: remove-temp-user

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2714,6 +2714,7 @@ jobs:
                     tag: 52752f11595bab840402c22021d34c6ed6b41b70
                 params:
                   DISABLE_CF_ACCEPTANCE_TESTS: ((disable_cf_acceptance_tests))
+                  SKIP_REGEX: "exercises basic loggregator behavior"
                 inputs:
                   - name: paas-cf
                   - name: cf-acceptance-tests

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2714,7 +2714,7 @@ jobs:
                     tag: 52752f11595bab840402c22021d34c6ed6b41b70
                 params:
                   DISABLE_CF_ACCEPTANCE_TESTS: ((disable_cf_acceptance_tests))
-                  SKIP_REGEX: "exercises basic loggregator behavior"
+                  SKIP_REGEX: "exercises basic loggregator behavior|applies default environment variables while running apps and tasks"
                 inputs:
                   - name: paas-cf
                   - name: cf-acceptance-tests

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -691,7 +691,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/cf-acceptance-tests
-              tag: c599048c56cc1508314315552bd11f413fab1c78
+              tag: 52752f11595bab840402c22021d34c6ed6b41b70
           inputs:
             - name: paas-cf
             - name: pipeline-trigger
@@ -743,7 +743,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/cf-acceptance-tests
-              tag: c599048c56cc1508314315552bd11f413fab1c78
+              tag: 52752f11595bab840402c22021d34c6ed6b41b70
           inputs:
             - name: paas-cf
             - name: pipeline-trigger
@@ -2676,7 +2676,7 @@ jobs:
                   type: docker-image
                   source:
                     repository: governmentpaas/cf-acceptance-tests
-                    tag: c599048c56cc1508314315552bd11f413fab1c78
+                    tag: 52752f11595bab840402c22021d34c6ed6b41b70
                 params:
                   DISABLE_CF_ACCEPTANCE_TESTS: ((disable_cf_acceptance_tests))
                 inputs:
@@ -2710,10 +2710,8 @@ jobs:
                 image_resource:
                   type: docker-image
                   source:
-                    # FIXME: Use the right acceptance test container ID with the log-cach-cli plugin
-                    # https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/129
                     repository: governmentpaas/cf-acceptance-tests
-                    tag: c599048c56cc1508314315552bd11f413fab1c78
+                    tag: 52752f11595bab840402c22021d34c6ed6b41b70
                 params:
                   DISABLE_CF_ACCEPTANCE_TESTS: ((disable_cf_acceptance_tests))
                 inputs:
@@ -2859,7 +2857,7 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/cf-acceptance-tests
-                tag: c599048c56cc1508314315552bd11f413fab1c78
+                tag: 52752f11595bab840402c22021d34c6ed6b41b70
             inputs:
               - name: paas-cf
               - name: test-config

--- a/manifests/cf-manifest/operations.d/540-log-cache.yml
+++ b/manifests/cf-manifest/operations.d/540-log-cache.yml
@@ -189,6 +189,19 @@
     name: log-cache-scheduler
     release: log-cache
 
+# Add certification rotation support
+- type: replace
+  path: /instance_groups/name=doppler/jobs/name=log-cache-cf-auth-proxy/properties/uaa/ca_cert
+  value: ((uaa_ca.certificate))((uaa_ca_old.certificate))
+- type: replace
+  path: /variables/-
+  value:
+    name: log_cache_ca_old
+    options:
+      common_name: log-cache
+      is_ca: true
+    type: certificate
+
 # FIXME: Rename the doppler secrets to our legacy secrets variables
 - type: replace
   path: /instance_groups/name=doppler/jobs/name=log-cache-cf-auth-proxy/properties/uaa/client_secret

--- a/manifests/cf-manifest/operations.d/540-log-cache.yml
+++ b/manifests/cf-manifest/operations.d/540-log-cache.yml
@@ -1,0 +1,191 @@
+# FIXME: Copied from cf-deployment experimental opsfile in the latest
+# version of cf-deployment
+#
+# https://github.com/cloudfoundry/cf-deployment/blob/v1.31.0/operations/experimental/use-log-cache.yml
+#
+# Replace for the upstream opsfile once we upgrade cf-deployment > v1.31.0
+#
+- type: replace
+  path: /releases/-
+  value:
+    name: log-cache
+    sha: 87134510c23ce5facca665ac025f41a19340f5e9
+    url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=1.1.1
+    version: 1.1.1
+
+- type: replace
+  path: /instance_groups/name=doppler/jobs/-
+  value:
+    name: log-cache
+    properties:
+      egress_port: 8080
+      health_addr: localhost:6060
+      tls:
+        ca_cert: ((log_cache.ca))
+        cert: ((log_cache.certificate))
+        key: ((log_cache.private_key))
+    release: log-cache
+
+- type: replace
+  path: /instance_groups/name=doppler/jobs/-
+  value:
+    name: log-cache-gateway
+    properties:
+      gateway_addr: localhost:8081
+    release: log-cache
+
+- type: replace
+  path: /instance_groups/name=doppler/jobs/-
+  value:
+    name: log-cache-group-reader
+    properties:
+      port: 8084
+    release: log-cache
+
+- type: replace
+  path: /instance_groups/name=doppler/jobs/-
+  value:
+    consumes:
+      reverse_log_proxy:
+        from: reverse_log_proxy
+    name: log-cache-nozzle
+    properties:
+      logs_provider:
+        tls:
+          ca_cert: ((logs_provider.ca))
+          cert: ((logs_provider.certificate))
+          key: ((logs_provider.private_key))
+    release: log-cache
+
+- type: replace
+  path: /instance_groups/name=doppler/jobs/-
+  value:
+    name: log-cache-expvar-forwarder
+    properties:
+      counters:
+      - addr: http://localhost:6060/debug/vars
+        name: egress
+        source_id: log-cache
+        template: '{{.LogCache.Egress}}'
+      - addr: http://localhost:6060/debug/vars
+        name: ingress
+        source_id: log-cache
+        template: '{{.LogCache.Ingress}}'
+      - addr: http://localhost:6060/debug/vars
+        name: expired
+        source_id: log-cache
+        template: '{{.LogCache.Expired}}'
+      - addr: http://localhost:6061/debug/vars
+        name: egress
+        source_id: log-cache-nozzle
+        template: '{{.Nozzle.Egress}}'
+      - addr: http://localhost:6061/debug/vars
+        name: ingress
+        source_id: log-cache-nozzle
+        template: '{{.Nozzle.Ingress}}'
+      - addr: http://localhost:6061/debug/vars
+        name: err
+        source_id: log-cache-nozzle
+        template: '{{.Nozzle.Err}}'
+      gauges:
+      - addr: http://localhost:6060/debug/vars
+        name: cache-period
+        source_id: log-cache
+        template: '{{.LogCache.CachePeriod}}'
+      - addr: http://localhost:6060/debug/vars
+        name: store-size
+        source_id: log-cache
+        template: '{{.LogCache.StoreSize}}'
+      - addr: http://localhost:6060/debug/vars
+        name: total-system-memory
+        source_id: log-cache
+        template: '{{.LogCache.TotalSystemMemory}}'
+      - addr: http://localhost:6060/debug/vars
+        name: available-system-memory
+        source_id: log-cache
+        template: '{{.LogCache.AvailableSystemMemory}}'
+    release: log-cache
+
+- type: replace
+  path: /instance_groups/name=doppler/jobs/-
+  value:
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: log-cache-reverse-proxy
+          port: 8083
+          registration_interval: 20s
+          uris:
+          - log-cache.((system_domain))
+          - '*.log-cache.((system_domain))'
+    release: routing
+
+- type: replace
+  path: /instance_groups/name=doppler/jobs/-
+  value:
+    name: log-cache-cf-auth-proxy
+    properties:
+      cc:
+        ca_cert: ((log_cache_tls_cc_auth_proxy.ca))
+        capi_internal_addr: https://cloud-controller-ng.service.cf.internal:9023
+        cert: ((log_cache_tls_cc_auth_proxy.certificate))
+        common_name: cloud-controller-ng.service.cf.internal
+        key: ((log_cache_tls_cc_auth_proxy.private_key))
+      proxy_port: 8083
+      uaa:
+        ca_cert: ((uaa_ca.certificate))
+        client_id: doppler
+        client_secret: ((uaa_clients_doppler_secret))
+        internal_addr: https://uaa.service.cf.internal:8443
+    release: log-cache
+
+- type: replace
+  path: /variables/-
+  value:
+    name: logs_provider
+    options:
+      ca: loggregator_ca
+      common_name: log-cache
+      extended_key_usage:
+      - client_auth
+      - server_auth
+    type: certificate
+- type: replace
+  path: /variables/-
+  value:
+    name: log_cache_ca
+    options:
+      common_name: log-cache
+      is_ca: true
+    type: certificate
+- type: replace
+  path: /variables/-
+  value:
+    name: log_cache
+    options:
+      alternative_names:
+      - log_cache
+      - log-cache
+      - logcache
+      ca: log_cache_ca
+      common_name: log-cache
+      extended_key_usage:
+      - client_auth
+      - server_auth
+    type: certificate
+- type: replace
+  path: /variables/-
+  value:
+    name: log_cache_tls_cc_auth_proxy
+    options:
+      ca: service_cf_internal_ca
+      common_name: log-cache
+      extended_key_usage:
+      - client_auth
+    type: certificate
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=log-cache-scheduler?
+  value:
+    name: log-cache-scheduler
+    release: log-cache

--- a/manifests/cf-manifest/operations.d/540-log-cache.yml
+++ b/manifests/cf-manifest/operations.d/540-log-cache.yml
@@ -127,10 +127,9 @@
     name: log-cache-cf-auth-proxy
     properties:
       cc:
-        ca_cert: ((log_cache_tls_cc_auth_proxy.ca))
-        capi_internal_addr: https://cloud-controller-ng.service.cf.internal:9023
-        cert: ((log_cache_tls_cc_auth_proxy.certificate))
         common_name: cloud-controller-ng.service.cf.internal
+        ca_cert: ((log_cache_tls_cc_auth_proxy.ca))
+        cert: ((log_cache_tls_cc_auth_proxy.certificate))
         key: ((log_cache_tls_cc_auth_proxy.private_key))
       proxy_port: 8083
       uaa:
@@ -189,3 +188,23 @@
   value:
     name: log-cache-scheduler
     release: log-cache
+
+# FIXME: the log-cache release relies on bosh-dns https://github.com/cloudfoundry/bosh-dns-release
+# to discover the reverse-log-proxy address, but we don not use bosh-dns yet.
+#
+# We override the link information with the consul dns name and hardcoded port
+- type: replace
+  path: /instance_groups/name=doppler/jobs/name=log-cache-nozzle/consumes/reverse_log_proxy
+  value:
+    address: reverse-log-proxy.service.cf.internal
+    instances: []
+    properties:
+      reverse_log_proxy:
+        egress:
+          port: 8082
+
+- type: replace
+  path: /instance_groups/name=doppler/jobs/name=log-cache-cf-auth-proxy/consumes?/cloud_controller?
+  value:
+    address: cloud-controller-ng.service.cf.internal
+    instances: []

--- a/manifests/cf-manifest/operations.d/540-log-cache.yml
+++ b/manifests/cf-manifest/operations.d/540-log-cache.yml
@@ -189,6 +189,11 @@
     name: log-cache-scheduler
     release: log-cache
 
+# FIXME: Rename the doppler secrets to our legacy secrets variables
+- type: replace
+  path: /instance_groups/name=doppler/jobs/name=log-cache-cf-auth-proxy/properties/uaa/client_secret
+  value: ((secrets_uaa_clients_doppler_secret))
+
 # FIXME: the log-cache release relies on bosh-dns https://github.com/cloudfoundry/bosh-dns-release
 # to discover the reverse-log-proxy address, but we don not use bosh-dns yet.
 #

--- a/manifests/cf-manifest/test-config/acceptance_log_cache_tests.yml
+++ b/manifests/cf-manifest/test-config/acceptance_log_cache_tests.yml
@@ -1,0 +1,42 @@
+---
+api: api.((system_domain))
+apps_domain: ((app_domain))
+system_domain: ((system_domain))
+admin_user: ((admin_user))
+admin_password: ((admin_password))
+test_password: ((secrets_test_user_password))
+skip_ssl_validation: false
+backend: "diego"
+skip_diego_unsupported_tests: true
+artifacts_directory: "/tmp/artifacts"
+use_existing_user: false
+
+use_log_cache: true
+
+include_apps: true
+include_backend_compatibility: false
+include_capi_experimental: false
+include_capi_no_bridge: false
+include_container_networking: false
+include_credhub : false
+include_detect: false
+include_docker: false
+include_internet_dependent: false
+include_isolation_segments: false
+include_logging: false
+include_operator: false
+include_persistent_app: false
+include_private_docker_registry: false
+include_privileged_container_support: false
+include_route_services: false
+include_routing: false
+include_routing_isolation_segments: false
+include_security_groups: false
+include_service_discovery: false
+include_service_instance_sharing: false
+include_services: false
+include_ssh: false
+include_sso: false
+include_tasks: false
+include_v3: false
+include_zipkin: false

--- a/platform-tests/upstream/run_acceptance_tests.sh
+++ b/platform-tests/upstream/run_acceptance_tests.sh
@@ -12,7 +12,7 @@ NODES=5
 SLOW_SPEC_THRESHOLD=120
 
 # Build Skip regex to ignore tests
-SKIP_REGEX='routing.API'
+SKIP_REGEX="${SKIP_REGEX:+${SKIP_REGEX}|}routing.API"
 SKIP_REGEX="${SKIP_REGEX}|Adding a wildcard route to a domain"
 SKIP_REGEX="${SKIP_REGEX}|when app has multiple ports mapped"
 SKIP_REGEX="${SKIP_REGEX// /\\s}" # Replace ' ' with \s


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/157083954

What
----

We want to deploy log-cache https://github.com/cloudfoundry/log-cache to
transfer and cache tenants metrics. One of the harder problems with
collecting metrics (and logs) and exposing them to tenants is if/how to
cache them, transport them, drop them, and scale delivery of them to
authenticated tenants. Loggregator already solves this problem so it
would be nice to take advantage of that.

log-cache allows us to retrieve this metrics and cache them reducing the
overhead caused on the dopplers when there are several consumers. It is
proposed as a new addition to the loggregator for the normal log
shipping.

We tried this service in a previous spike [#156731599](https://www.pivotaltracker.com/n/projects/1275640/stories/156731599)
and it probably fits our needs.

In this PR we deploy the service, following the pattern in the latest
experimental opsfile in cf-deployment, which colocates the service
with the doppler instances.

We manually copy that opsfile (still not available in the cf-deployment version that we are tracking) and tune it for our deployment. We also had to add more config to override the links (`cloud_controller_ng` links). 

For testing, we will run the "apps" [cf-acceptance tests with log-cache enabled](https://github.com/cloudfoundry/cf-acceptance-tests/commit/923a0fe9335bf0a1e75286801e952f248491cd38), although a pair of tests had to been disabled as they were not working (reported upstream). 

Dependencies:
---------------

 1. Merge PR https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/129 first
 2. Wait for the new container https://hub.docker.com/r/governmentpaas/cf-acceptance-tests/ to be built
 2. Update the WIP commit with the right container tag


How to review
-------------

 - Code review
 - Tests should pass

Test it with the cf log-cache-cli plugin  https://github.com/cloudfoundry/log-cache-cli:

```
go get code.cloudfoundry.org/log-cache-cli/...
go build -o  $GOPATH/bin/log-cache-cli code.cloudfoundry.org/log-cache-cli/cmd/cf-lc-plugin/
cf install-plugin $GOPATH/bin/log-cache-cli
```

And then try log-cache:
 - tail the logs of any app `cf tail <appname>`
 - Get meta information of the metrics stored in log-cache: `cf log-meta`
Who can review
--------------

Anyone but @keymon or @paroxp 