### PR TITLE
[#156224014] Don't disable the uaa.require_https flag.

### DIFF
--- a/manifests/cf-manifest/operations.d/330-uaa.yml
+++ b/manifests/cf-manifest/operations.d/330-uaa.yml
@@ -86,10 +86,6 @@
   value: 8
 
 - type: replace
-  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/require_https?
-  value: false
-
-- type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/login?
   value:
     authorities: oauth.login,scim.write,clients.read,notifications.write,critical_notifications.write,emails.write,scim.userids,password.write


### PR DESCRIPTION
What
----

The default is true upstream but we've set it to false in [1].

If require_https is disabled the Current-User cookie won't have the secure flag which came up in our latest pentest.

There is no reason to disable this anymore. Whatever caused issues previously it doesn't seem to be present anymore.

[1] https://github.com/alphagov/paas-cf/commit/9a4dda67ead70bd39d811cc373d8fd10dbb9df44

How to review
-------------

1. Deploy your CF from this branch

2. Make sure the tests pass. Log in to UAA on the web.

Who can review
--------------

Not me.
