### PR TITLE
[#157470481] Rename service plans according ADR025

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1533,8 +1533,57 @@ jobs:
                 else
                   cf create-service-broker rds-broker rds-broker "${RDS_BROKER_PASS}" "https://${RDS_BROKER_SERVER}"
                 fi
-                cf enable-service-access postgres
-                cf enable-service-access mysql
+
+                # Enable supported plans
+                cat <<EOF | xargs -n1 cf enable-service-access mysql -p
+                tiny-5.7
+                small-5.7
+                small-ha-5.7
+                medium-ha-5.7
+                medium-5.7
+                large-ha-5.7
+                large-5.7
+                xlarge-ha-5.7
+                xlarge-5.7
+                EOF
+
+                cat <<EOF | xargs -n1 cf enable-service-access postgres -p
+                tiny-9.5
+                small-ha-9.5
+                small-9.5
+                medium-ha-9.5
+                medium-9.5
+                large-ha-9.5
+                large-9.5
+                xlarge-ha-9.5
+                xlarge-9.5
+                EOF
+
+                # Disable deprecated plans
+                cat <<EOF | xargs -n1 cf disable-service-access mysql -p
+                tiny-unencrypted-5.7
+                small-unencrypted-5.7
+                small-ha-unencrypted-5.7
+                medium-ha-unencrypted-5.7
+                medium-unencrypted-5.7
+                large-ha-unencrypted-5.7
+                large-unencrypted-5.7
+                xlarge-ha-unencrypted-5.7
+                xlarge-unencrypted-5.7
+                EOF
+
+                cat <<EOF | xargs -n1 cf disable-service-access postgres -p
+                tiny-unencrypted-9.5
+                small-ha-unencrypted-9.5
+                small-unencrypted-9.5
+                medium-ha-unencrypted-9.5
+                medium-unencrypted-9.5
+                large-ha-unencrypted-9.5
+                large-unencrypted-9.5
+                xlarge-ha-unencrypted-9.5
+                xlarge-unencrypted-9.5
+                EOF
+
 
       - task: register-cdn-broker
         config:

--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -27,7 +27,7 @@
       engine_version: "5.7"
       db_parameter_group_name: ((terraform_outputs_rds_broker_mysql57_db_parameter_group))
 
-    free_plan_rds_properties: &free_plan_rds_properties
+    tiny_plan_rds_properties: &tiny_plan_rds_properties
       db_instance_class: "db.t2.micro"
       allocated_storage: 5
       backup_retention_period: 0
@@ -115,7 +115,7 @@
                   plan_updateable: true
                   plans:
                     - id: "5f2eec8a-0cad-4ab9-b81e-d6adade2fd42"
-                      name: "Free"
+                      name: "tiny-unencrypted-9.5"
                       description: "5GB Storage, NOT BACKED UP, Dedicated Instance, Max 50 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t2.micro."
                       free: true
                       metadata:
@@ -124,10 +124,10 @@
                           - "AWS RDS"
                       rds_properties:
                         <<: *default_postgres_rds_properties # yamllint disable-line
-                        <<: *free_plan_rds_properties # yamllint disable-line
+                        <<: *tiny_plan_rds_properties # yamllint disable-line
 
                     - id: "b7d0a368-ac92-4eff-9b8d-ab4ba45bed0e"
-                      name: "S-dedicated-9.5"
+                      name: "small-unencrypted-9.5"
                       description: "20GB Storage, Dedicated Instance, Max 200 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t2.small."
                       free: false
                       metadata:
@@ -143,7 +143,7 @@
                         <<: *small_plan_rds_properties # yamllint disable-line
 
                     - id: "359bcb39-0264-46bd-9120-0182c3829067"
-                      name: "S-HA-dedicated-9.5"
+                      name: "small-ha-unencrypted-9.5"
                       description: "20GB Storage, Dedicated Instance, Highly Available, Max 200 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t2.small."
                       free: false
                       metadata:
@@ -160,7 +160,7 @@
                         multi_az: true
 
                     - id: "d9f1d61d-0a65-45ad-8fc9-88c921d038d2"
-                      name: "S-HA-enc-dedicated-9.5"
+                      name: "small-ha-9.5"
                       description: "20GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t2.small."
                       free: false
                       metadata:
@@ -178,7 +178,7 @@
                         storage_encrypted: true
 
                     - id: "9b882524-ab58-4c18-b501-d2a3f4619104"
-                      name: "M-dedicated-9.5"
+                      name: "medium-unencrypted-9.5"
                       description: "100GB Storage, Dedicated Instance, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.large."
                       free: false
                       metadata:
@@ -194,7 +194,7 @@
                         <<: *medium_plan_rds_properties # yamllint disable-line
 
                     - id: "bf5b99c2-7990-4b66-b341-1bb83566d76e"
-                      name: "M-HA-dedicated-9.5"
+                      name: "medium-ha-unencrypted-9.5"
                       description: "100GB Storage, Dedicated Instance, Highly Available, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.large."
                       free: false
                       metadata:
@@ -211,7 +211,7 @@
                         multi_az: true
 
                     - id: "8d50ccc5-707c-4306-be8f-f59a158eb736"
-                      name: "M-HA-enc-dedicated-9.5"
+                      name: "medium-ha-9.5"
                       description: "100GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.large."
                       free: false
                       metadata:
@@ -230,7 +230,7 @@
                         storage_encrypted: true
 
                     - id: "238a1328-4f77-4b70-9bd9-2cdbbfb999c8"
-                      name: "L-dedicated-9.5"
+                      name: "large-unencrypted-9.5"
                       description: "512GB Storage, Dedicated Instance, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.2xlarge."
                       free: false
                       metadata:
@@ -246,7 +246,7 @@
                         <<: *large_plan_rds_properties # yamllint disable-line
 
                     - id: "dfe4ab2b-2069-41a5-ba08-2be21b0c76d3"
-                      name: "L-HA-dedicated-9.5"
+                      name: "large-ha-unencrypted-9.5"
                       description: "512GB Storage, Dedicated Instance, Highly Available, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.2xlarge."
                       free: false
                       metadata:
@@ -263,7 +263,7 @@
                         multi_az: true
 
                     - id: "620055b3-fe7c-46fc-87ad-c7d8f4fe7f34"
-                      name: "L-HA-enc-dedicated-9.5"
+                      name: "large-ha-9.5"
                       description: "512GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.2xlarge."
                       free: false
                       metadata:
@@ -282,7 +282,7 @@
                         storage_encrypted: true
 
                     - id: "1065c353-54dd-4f6b-a5b4-a4b5aa4575c6"
-                      name: "XL-dedicated-9.5"
+                      name: "xlarge-unencrypted-9.5"
                       description: "2TB Storage, Dedicated Instance, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.4xlarge."
                       free: false
                       metadata:
@@ -298,7 +298,7 @@
                         <<: *xlarge_plan_rds_properties # yamllint disable-line
 
                     - id: "7119925f-518d-4263-96ac-16990295aad6"
-                      name: "XL-HA-dedicated-9.5"
+                      name: "xlarge-ha-unencrypted-9.5"
                       description: "2TB Storage, Dedicated Instance, Highly Available, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.4xlarge."
                       free: false
                       metadata:
@@ -315,7 +315,7 @@
                         multi_az: true
 
                     - id: "a91c8e59-8869-42fd-8a99-8989151d7353"
-                      name: "XL-HA-enc-dedicated-9.5"
+                      name: "xlarge-ha-9.5"
                       description: "2TB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.4xlarge."
                       free: false
                       metadata:
@@ -350,7 +350,7 @@
                   plan_updateable: true
                   plans:
                     - id: 69977068-8ef5-4172-bfdb-e8cea3c14d01
-                      name: "Free"
+                      name: "tiny-unencrypted-5.7"
                       description: "5GB Storage, NOT BACKED UP, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.t2.micro."
                       free: true
                       metadata:
@@ -359,10 +359,10 @@
                           - "AWS RDS"
                       rds_properties:
                         <<: *default_mysql_rds_properties # yamllint disable-line
-                        <<: *free_plan_rds_properties # yamllint disable-line
+                        <<: *tiny_plan_rds_properties # yamllint disable-line
 
                     - id: "7fdde6ea-cc27-466c-86aa-46181fc20d25"
-                      name: "S-dedicated-5.7"
+                      name: "small-unencrypted-5.7"
                       description: "20GB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.t2.small."
                       free: false
                       metadata:
@@ -378,7 +378,7 @@
                         <<: *small_plan_rds_properties # yamllint disable-line
 
                     - id: "72279ebd-6001-4e38-aaef-72b68c4fa6fd"
-                      name: "S-HA-dedicated-5.7"
+                      name: "small-ha-unencrypted-5.7"
                       description: "20GB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.t2.small."
                       free: false
                       metadata:
@@ -395,7 +395,7 @@
                         multi_az: true
 
                     - id: "6aa563c1-5aeb-46a1-9509-badcf5995c96"
-                      name: "S-HA-enc-dedicated-5.7"
+                      name: "small-ha-5.7"
                       description: "20GB Storage, Dedicated Instance, Highly Available. Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.t2.small."
                       free: false
                       metadata:
@@ -413,7 +413,7 @@
                         storage_encrypted: true
 
                     - id: "4eb35ca9-a7ec-46c6-b137-d819848536cd"
-                      name: "M-dedicated-5.7"
+                      name: "medium-unencrypted-5.7"
                       description: "100GB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.m4.large."
                       free: false
                       metadata:
@@ -429,7 +429,7 @@
                         <<: *medium_plan_rds_properties # yamllint disable-line
 
                     - id: "e60edf62-b701-4e38-846f-b0b3db728349"
-                      name: "M-HA-dedicated-5.7"
+                      name: "medium-ha-unencrypted-5.7"
                       description: "100GB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.m4.large."
                       free: false
                       metadata:
@@ -446,7 +446,7 @@
                         multi_az: true
 
                     - id: "8d139b9e-bc82-4749-8ad6-7733980292d6"
-                      name: "M-HA-enc-dedicated-5.7"
+                      name: "medium-ha-5.7"
                       description: "100GB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.large."
                       free: false
                       metadata:
@@ -465,7 +465,7 @@
                         storage_encrypted: true
 
                     - id: "6725bf1f-71e8-447a-b6a1-659247fcc03c"
-                      name: "L-dedicated-5.7"
+                      name: "large-unencrypted-5.7"
                       description: "512GB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.m4.2xlarge."
                       free: false
                       metadata:
@@ -481,7 +481,7 @@
                         <<: *large_plan_rds_properties # yamllint disable-line
 
                     - id: "63cdac92-9e44-42a6-ba3f-7be3dccf5dc6"
-                      name: "L-HA-dedicated-5.7"
+                      name: "large-ha-unencrypted-5.7"
                       description: "512GB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.m4.2xlarge."
                       free: false
                       metadata:
@@ -498,7 +498,7 @@
                         multi_az: true
 
                     - id: "d5efbf83-5e00-47a5-a668-2ef1307d5a23"
-                      name: "L-HA-enc-dedicated-5.7"
+                      name: "large-ha-5.7"
                       description: "512GB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.2xlarge."
                       free: false
                       metadata:
@@ -517,7 +517,7 @@
                         storage_encrypted: true
 
                     - id: "a37144bf-4e05-451b-87ba-0a2c57a23a91"
-                      name: "XL-dedicated-5.7"
+                      name: "xlarge-unencrypted-5.7"
                       description: "2TB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.m4.4xlarge."
                       free: false
                       metadata:
@@ -533,7 +533,7 @@
                         <<: *xlarge_plan_rds_properties # yamllint disable-line
 
                     - id: "065a7de5-28e8-4de1-8a39-4b4f752e2f2f"
-                      name: "XL-HA-dedicated-5.7"
+                      name: "xlarge-ha-unencrypted-5.7"
                       description: "2TB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.m4.4xlarge."
                       free: false
                       metadata:
@@ -550,7 +550,7 @@
                         multi_az: true
 
                     - id: "4edc975c-3f07-46f1-bd87-ecb35b76298f"
-                      name: "XL-HA-enc-dedicated-5.7"
+                      name: "xlarge-ha-5.7"
                       description: "2TB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.4xlarge."
                       free: false
                       metadata:

--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -126,6 +126,20 @@
                         <<: *default_postgres_rds_properties # yamllint disable-line
                         <<: *tiny_plan_rds_properties # yamllint disable-line
 
+                    - id: "8332f409-4689-4614-a6bc-64dec6e2faae"
+                      name: "tiny-9.5"
+                      description: "5GB Storage, NOT BACKED UP, Dedicated Instance, Storage Encrypted, Max 50 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t2.micro."
+                      free: true
+                      metadata:
+                        bullets:
+                          - "Dedicated Postgres 9.5 server"
+                          - "Storage Encrypted"
+                          - "AWS RDS"
+                      rds_properties:
+                        <<: *default_postgres_rds_properties # yamllint disable-line
+                        <<: *tiny_plan_rds_properties # yamllint disable-line
+                        storage_encrypted: true
+
                     - id: "b7d0a368-ac92-4eff-9b8d-ab4ba45bed0e"
                       name: "small-unencrypted-9.5"
                       description: "20GB Storage, Dedicated Instance, Max 200 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t2.small."
@@ -141,6 +155,24 @@
                       rds_properties:
                         <<: *default_postgres_rds_properties # yamllint disable-line
                         <<: *small_plan_rds_properties # yamllint disable-line
+
+                    - id: "2611d776-9991-4940-a755-880eafbc33a0"
+                      name: "small-9.5"
+                      description: "20GB Storage, Dedicated Instance, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t2.small."
+                      free: false
+                      metadata:
+                        costs:
+                          - amount:
+                              usd: 0.039
+                            unit: "HOUR"
+                        bullets:
+                          - "Dedicated Postgres 9.5 server"
+                          - "Storage Encrypted"
+                          - "AWS RDS"
+                      rds_properties:
+                        <<: *default_postgres_rds_properties # yamllint disable-line
+                        <<: *small_plan_rds_properties # yamllint disable-line
+                        storage_encrypted: true
 
                     - id: "359bcb39-0264-46bd-9120-0182c3829067"
                       name: "small-ha-unencrypted-9.5"
@@ -192,6 +224,24 @@
                       rds_properties:
                         <<: *default_postgres_rds_properties # yamllint disable-line
                         <<: *medium_plan_rds_properties # yamllint disable-line
+
+                    - id: "17ef8670-5134-4ae6-b7fc-9ee8e52394c5"
+                      name: "medium-9.5"
+                      description: "100GB Storage, Dedicated Instance, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.large."
+                      free: false
+                      metadata:
+                        costs:
+                          - amount:
+                              usd: 0.201
+                            unit: "HOUR"
+                        bullets:
+                          - "Dedicated Postgres 9.5 server"
+                          - "Storage Encrypted"
+                          - "AWS RDS"
+                      rds_properties:
+                        <<: *default_postgres_rds_properties # yamllint disable-line
+                        <<: *medium_plan_rds_properties # yamllint disable-line
+                        storage_encrypted: true
 
                     - id: "bf5b99c2-7990-4b66-b341-1bb83566d76e"
                       name: "medium-ha-unencrypted-9.5"
@@ -245,6 +295,24 @@
                         <<: *default_postgres_rds_properties # yamllint disable-line
                         <<: *large_plan_rds_properties # yamllint disable-line
 
+                    - id: "8ea15f55-fbd2-41a3-a679-482d67a3d9ea"
+                      name: "large-9.5"
+                      description: "512GB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.2xlarge."
+                      free: false
+                      metadata:
+                        costs:
+                          - amount:
+                              usd: 0.806
+                            unit: "HOUR"
+                        bullets:
+                          - "Dedicated Postgres 9.5 server"
+                          - "Storage Encrypted"
+                          - "AWS RDS"
+                      rds_properties:
+                        <<: *default_postgres_rds_properties # yamllint disable-line
+                        <<: *large_plan_rds_properties # yamllint disable-line
+                        storage_encrypted: true
+
                     - id: "dfe4ab2b-2069-41a5-ba08-2be21b0c76d3"
                       name: "large-ha-unencrypted-9.5"
                       description: "512GB Storage, Dedicated Instance, Highly Available, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.2xlarge."
@@ -296,6 +364,24 @@
                       rds_properties:
                         <<: *default_postgres_rds_properties # yamllint disable-line
                         <<: *xlarge_plan_rds_properties # yamllint disable-line
+
+                    - id: "3cb1947e-1df5-4483-8e9e-07c9294f9347"
+                      name: "xlarge-9.5"
+                      description: "2TB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.4xlarge."
+                      free: false
+                      metadata:
+                        costs:
+                          - amount:
+                              usd: 1.612
+                            unit: "HOUR"
+                        bullets:
+                          - "Dedicated Postgres 9.5 server"
+                          - "Storage Encrypted"
+                          - "AWS RDS"
+                      rds_properties:
+                        <<: *default_postgres_rds_properties # yamllint disable-line
+                        <<: *xlarge_plan_rds_properties # yamllint disable-line
+                        storage_encrypted: true
 
                     - id: "7119925f-518d-4263-96ac-16990295aad6"
                       name: "xlarge-ha-unencrypted-9.5"
@@ -361,6 +447,20 @@
                         <<: *default_mysql_rds_properties # yamllint disable-line
                         <<: *tiny_plan_rds_properties # yamllint disable-line
 
+                    - id: 05a741b5-e86a-4d36-a37a-04c8173381a6
+                      name: "tiny-5.7"
+                      description: "5GB Storage, NOT BACKED UP, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.t2.micro."
+                      free: true
+                      metadata:
+                        bullets:
+                          - "Dedicated MySQL 5.7 server"
+                          - "Storage Encryped"
+                          - "AWS RDS"
+                      rds_properties:
+                        <<: *default_mysql_rds_properties # yamllint disable-line
+                        <<: *tiny_plan_rds_properties # yamllint disable-line
+                        storage_encrypted: true
+
                     - id: "7fdde6ea-cc27-466c-86aa-46181fc20d25"
                       name: "small-unencrypted-5.7"
                       description: "20GB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.t2.small."
@@ -376,6 +476,24 @@
                       rds_properties:
                         <<: *default_mysql_rds_properties # yamllint disable-line
                         <<: *small_plan_rds_properties # yamllint disable-line
+
+                    - id: "b0ccc8c9-09b0-4c3e-9880-091cc41c2ab5"
+                      name: "small-5.7"
+                      description: "20GB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.t2.small."
+                      free: false
+                      metadata:
+                        costs:
+                          - amount:
+                              usd: 0.036
+                            unit: "HOUR"
+                        bullets:
+                          - "Dedicated MySQL 5.7 server"
+                          - "Storage Encrypted"
+                          - "AWS RDS"
+                      rds_properties:
+                        <<: *default_mysql_rds_properties # yamllint disable-line
+                        <<: *small_plan_rds_properties # yamllint disable-line
+                        storage_encrypted: true
 
                     - id: "72279ebd-6001-4e38-aaef-72b68c4fa6fd"
                       name: "small-ha-unencrypted-5.7"
@@ -427,6 +545,24 @@
                       rds_properties:
                         <<: *default_mysql_rds_properties # yamllint disable-line
                         <<: *medium_plan_rds_properties # yamllint disable-line
+
+                    - id: "29cdedeb-e910-4a7a-b606-2c4e42eea478"
+                      name: "medium-5.7"
+                      description: "100GB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.large."
+                      free: false
+                      metadata:
+                        costs:
+                          - amount:
+                              usd: 0.193
+                            unit: "HOUR"
+                        bullets:
+                          - "Dedicated MySQL 5.7 server"
+                          - "Storage Encrypted"
+                          - "AWS RDS"
+                      rds_properties:
+                        <<: *default_mysql_rds_properties # yamllint disable-line
+                        <<: *medium_plan_rds_properties # yamllint disable-line
+                        storage_encrypted: true
 
                     - id: "e60edf62-b701-4e38-846f-b0b3db728349"
                       name: "medium-ha-unencrypted-5.7"
@@ -480,6 +616,24 @@
                         <<: *default_mysql_rds_properties # yamllint disable-line
                         <<: *large_plan_rds_properties # yamllint disable-line
 
+                    - id: "98a9b7cf-e067-4915-8190-ce8224dd04dc"
+                      name: "large-5.7"
+                      description: "512GB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.2xlarge."
+                      free: false
+                      metadata:
+                        costs:
+                          - amount:
+                              usd: 0.772
+                            unit: "HOUR"
+                        bullets:
+                          - "Dedicated MySQL 5.7 server"
+                          - "Storage Encrypted"
+                          - "AWS RDS"
+                      rds_properties:
+                        <<: *default_mysql_rds_properties # yamllint disable-line
+                        <<: *large_plan_rds_properties # yamllint disable-line
+                        storage_encrypted: true
+
                     - id: "63cdac92-9e44-42a6-ba3f-7be3dccf5dc6"
                       name: "large-ha-unencrypted-5.7"
                       description: "512GB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.m4.2xlarge."
@@ -531,6 +685,24 @@
                       rds_properties:
                         <<: *default_mysql_rds_properties # yamllint disable-line
                         <<: *xlarge_plan_rds_properties # yamllint disable-line
+
+                    - id: "e03020e8-eaed-49c2-bd58-23b7cb871c22"
+                      name: "xlarge-5.7"
+                      description: "2TB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.4xlarge."
+                      free: false
+                      metadata:
+                        costs:
+                          - amount:
+                              usd: 1.545
+                            unit: "HOUR"
+                        bullets:
+                          - "Dedicated MySQL 5.7 server"
+                          - "Storage Encrypted"
+                          - "AWS RDS"
+                      rds_properties:
+                        <<: *default_mysql_rds_properties # yamllint disable-line
+                        <<: *xlarge_plan_rds_properties # yamllint disable-line
+                        storage_encrypted: true
 
                     - id: "065a7de5-28e8-4de1-8a39-4b4f752e2f2f"
                       name: "xlarge-ha-unencrypted-5.7"

--- a/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
+++ b/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
@@ -60,13 +60,13 @@
                   plan_updateable: true
                   plans:
                     - id: 3a51701c-eef3-447c-882b-907ad2bcb7ab
-                      name: tiny-clustered
+                      name: tiny-clustered-3.2
                       description: 568MB RAM, clustered (1 shard), single node, no failover, daily backups
                       free: true
                       metadata:
                         displayName: Redis Clustered Tiny
                     - id: c84d1bef-9500-4ce9-88b2-c0bd421bbf8a
-                      name: tiny-unclustered
+                      name: tiny-unclustered-3.2
                       description: 568MB RAM, non-clustered, single node, no failover, no backups
                       free: true
                       metadata:

--- a/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
@@ -160,7 +160,26 @@ RSpec.describe "RDS broker properties" do
 
       it "contains only specific plans" do
         pg_plan_names = pg_plans.map { |p| p["name"] }
-        expect(pg_plan_names).to contain_exactly("tiny-unencrypted-9.5", "small-unencrypted-9.5", "small-ha-unencrypted-9.5", "small-ha-9.5", "medium-unencrypted-9.5", "medium-ha-unencrypted-9.5", "medium-ha-9.5", "large-unencrypted-9.5", "large-ha-unencrypted-9.5", "large-ha-9.5", "xlarge-unencrypted-9.5", "xlarge-ha-unencrypted-9.5", "xlarge-ha-9.5")
+        expect(pg_plan_names).to contain_exactly(
+          "tiny-unencrypted-9.5",
+          "tiny-9.5",
+          "small-unencrypted-9.5",
+          "small-9.5",
+          "small-ha-unencrypted-9.5",
+          "small-ha-9.5",
+          "medium-unencrypted-9.5",
+          "medium-9.5",
+          "medium-ha-unencrypted-9.5",
+          "medium-ha-9.5",
+          "large-unencrypted-9.5",
+          "large-9.5",
+          "large-ha-unencrypted-9.5",
+          "large-ha-9.5",
+          "xlarge-unencrypted-9.5",
+          "xlarge-9.5",
+          "xlarge-ha-unencrypted-9.5",
+          "xlarge-ha-9.5",
+        )
       end
 
       describe "plan rds_properties" do
@@ -181,6 +200,34 @@ RSpec.describe "RDS broker properties" do
           end
         end
 
+        describe "tiny-unencrypted-9.5" do
+          subject { pg_plans.find { |p| p["name"] == "tiny-unencrypted-9.5" } }
+
+          it "is marked as free" do
+            expect(subject.fetch("free")).to eq(true)
+          end
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "tiny sized plans"
+          it_behaves_like "backup disabled plans"
+          it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption disabled plans"
+        end
+
+        describe "tiny-9.5" do
+          subject { pg_plans.find { |p| p["name"] == "tiny-9.5" } }
+
+          it "is marked as free" do
+            expect(subject.fetch("free")).to eq(true)
+          end
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "tiny sized plans"
+          it_behaves_like "backup disabled plans"
+          it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption enabled plans"
+        end
+
         describe "small-unencrypted-9.5" do
           subject { pg_plans.find { |p| p["name"] == "small-unencrypted-9.5" } }
 
@@ -189,6 +236,16 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "backup enabled plans"
           it_behaves_like "non-HA plans"
           it_behaves_like "Encryption disabled plans"
+        end
+
+        describe "small-9.5" do
+          subject { pg_plans.find { |p| p["name"] == "small-9.5" } }
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "small sized plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption enabled plans"
         end
 
         describe "small-ha-unencrypted-9.5" do
@@ -221,6 +278,16 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption disabled plans"
         end
 
+        describe "medium-9.5" do
+          subject { pg_plans.find { |p| p["name"] == "medium-9.5" } }
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "medium sized plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption enabled plans"
+        end
+
         describe "medium-ha-unencrypted-9.5" do
           subject { pg_plans.find { |p| p["name"] == "medium-ha-unencrypted-9.5" } }
 
@@ -249,6 +316,16 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "backup enabled plans"
           it_behaves_like "non-HA plans"
           it_behaves_like "Encryption disabled plans"
+        end
+
+        describe "large-9.5" do
+          subject { pg_plans.find { |p| p["name"] == "large-9.5" } }
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "large sized plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption enabled plans"
         end
 
         describe "large-ha-unencrypted-9.5" do
@@ -281,6 +358,16 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption disabled plans"
         end
 
+        describe "xlarge-9.5" do
+          subject { pg_plans.find { |p| p["name"] == "xlarge-9.5" } }
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "xlarge sized plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption enabled plans"
+        end
+
         describe "xlarge-ha-unencrypted-9.5" do
           subject { pg_plans.find { |p| p["name"] == "xlarge-ha-unencrypted-9.5" } }
 
@@ -300,20 +387,6 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "HA plans"
           it_behaves_like "Encryption enabled plans"
         end
-
-        describe "tiny plan" do
-          subject { pg_plans.find { |p| p["name"] == "tiny-unencrypted-9.5" } }
-
-          it "is marked as free" do
-            expect(subject.fetch("free")).to eq(true)
-          end
-
-          it_behaves_like "all postgres plans"
-          it_behaves_like "tiny sized plans"
-          it_behaves_like "backup disabled plans"
-          it_behaves_like "non-HA plans"
-          it_behaves_like "Encryption disabled plans"
-        end
       end
     end
 
@@ -323,7 +396,26 @@ RSpec.describe "RDS broker properties" do
 
       it "contains only specific plans" do
         my_plan_names = my_plans.map { |p| p["name"] }
-        expect(my_plan_names).to contain_exactly("tiny-unencrypted-5.7", "small-unencrypted-5.7", "small-ha-unencrypted-5.7", "small-ha-5.7", "medium-unencrypted-5.7", "medium-ha-unencrypted-5.7", "medium-ha-5.7", "large-unencrypted-5.7", "large-ha-unencrypted-5.7", "large-ha-5.7", "xlarge-unencrypted-5.7", "xlarge-ha-unencrypted-5.7", "xlarge-ha-5.7")
+        expect(my_plan_names).to contain_exactly(
+          "tiny-unencrypted-5.7",
+          "tiny-5.7",
+          "small-unencrypted-5.7",
+          "small-5.7",
+          "small-ha-unencrypted-5.7",
+          "small-ha-5.7",
+          "medium-unencrypted-5.7",
+          "medium-5.7",
+          "medium-ha-unencrypted-5.7",
+          "medium-ha-5.7",
+          "large-unencrypted-5.7",
+          "large-5.7",
+          "large-ha-unencrypted-5.7",
+          "large-ha-5.7",
+          "xlarge-unencrypted-5.7",
+          "xlarge-5.7",
+          "xlarge-ha-unencrypted-5.7",
+          "xlarge-ha-5.7",
+        )
       end
 
       describe "plan rds_properties" do
@@ -344,6 +436,34 @@ RSpec.describe "RDS broker properties" do
           end
         end
 
+        describe "tiny-unencrypted-5.7" do
+          subject { my_plans.find { |p| p["name"] == "tiny-unencrypted-5.7" } }
+
+          it "is marked as free" do
+            expect(subject.fetch("free")).to eq(true)
+          end
+
+          it_behaves_like "all mysql plans"
+          it_behaves_like "tiny sized plans"
+          it_behaves_like "backup disabled plans"
+          it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption disabled plans"
+        end
+
+        describe "tiny-5.7" do
+          subject { my_plans.find { |p| p["name"] == "tiny-5.7" } }
+
+          it "is marked as free" do
+            expect(subject.fetch("free")).to eq(true)
+          end
+
+          it_behaves_like "all mysql plans"
+          it_behaves_like "tiny sized plans"
+          it_behaves_like "backup disabled plans"
+          it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption enabled plans"
+        end
+
         describe "small-unencrypted-5.7" do
           subject { my_plans.find { |p| p["name"] == "small-unencrypted-5.7" } }
 
@@ -352,6 +472,16 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "backup enabled plans"
           it_behaves_like "non-HA plans"
           it_behaves_like "Encryption disabled plans"
+        end
+
+        describe "small-5.7" do
+          subject { my_plans.find { |p| p["name"] == "small-5.7" } }
+
+          it_behaves_like "all mysql plans"
+          it_behaves_like "small sized plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption enabled plans"
         end
 
         describe "small-ha-unencrypted-5.7" do
@@ -384,6 +514,16 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption disabled plans"
         end
 
+        describe "medium-5.7" do
+          subject { my_plans.find { |p| p["name"] == "medium-5.7" } }
+
+          it_behaves_like "all mysql plans"
+          it_behaves_like "medium sized plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption enabled plans"
+        end
+
         describe "medium-ha-unencrypted-5.7" do
           subject { my_plans.find { |p| p["name"] == "medium-ha-unencrypted-5.7" } }
 
@@ -412,6 +552,16 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "backup enabled plans"
           it_behaves_like "non-HA plans"
           it_behaves_like "Encryption disabled plans"
+        end
+
+        describe "large-5.7" do
+          subject { my_plans.find { |p| p["name"] == "large-5.7" } }
+
+          it_behaves_like "all mysql plans"
+          it_behaves_like "large sized plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption enabled plans"
         end
 
         describe "large-ha-unencrypted-5.7" do
@@ -444,6 +594,16 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption disabled plans"
         end
 
+        describe "xlarge-5.7" do
+          subject { my_plans.find { |p| p["name"] == "xlarge-5.7" } }
+
+          it_behaves_like "all mysql plans"
+          it_behaves_like "xlarge sized plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption enabled plans"
+        end
+
         describe "xlarge-ha-unencrypted-5.7" do
           subject { my_plans.find { |p| p["name"] == "xlarge-ha-unencrypted-5.7" } }
 
@@ -462,20 +622,6 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "backup enabled plans"
           it_behaves_like "HA plans"
           it_behaves_like "Encryption enabled plans"
-        end
-
-        describe "tiny plan" do
-          subject { my_plans.find { |p| p["name"] == "tiny-unencrypted-5.7" } }
-
-          it "is marked as free" do
-            expect(subject.fetch("free")).to eq(true)
-          end
-
-          it_behaves_like "all mysql plans"
-          it_behaves_like "tiny sized plans"
-          it_behaves_like "backup disabled plans"
-          it_behaves_like "non-HA plans"
-          it_behaves_like "Encryption disabled plans"
         end
       end
     end

--- a/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "RDS broker properties" do
       }
     end
 
-    shared_examples "free sized plans" do
+    shared_examples "tiny sized plans" do
       let(:rds_properties) { subject.fetch("rds_properties") }
 
       it { expect(rds_properties).to include("allocated_storage" => 5) }
@@ -160,7 +160,7 @@ RSpec.describe "RDS broker properties" do
 
       it "contains only specific plans" do
         pg_plan_names = pg_plans.map { |p| p["name"] }
-        expect(pg_plan_names).to contain_exactly("Free", "S-dedicated-9.5", "S-HA-dedicated-9.5", "S-HA-enc-dedicated-9.5", "M-dedicated-9.5", "M-HA-dedicated-9.5", "M-HA-enc-dedicated-9.5", "L-dedicated-9.5", "L-HA-dedicated-9.5", "L-HA-enc-dedicated-9.5", "XL-dedicated-9.5", "XL-HA-dedicated-9.5", "XL-HA-enc-dedicated-9.5")
+        expect(pg_plan_names).to contain_exactly("tiny-unencrypted-9.5", "small-unencrypted-9.5", "small-ha-unencrypted-9.5", "small-ha-9.5", "medium-unencrypted-9.5", "medium-ha-unencrypted-9.5", "medium-ha-9.5", "large-unencrypted-9.5", "large-ha-unencrypted-9.5", "large-ha-9.5", "xlarge-unencrypted-9.5", "xlarge-ha-unencrypted-9.5", "xlarge-ha-9.5")
       end
 
       describe "plan rds_properties" do
@@ -181,8 +181,8 @@ RSpec.describe "RDS broker properties" do
           end
         end
 
-        describe "S-dedicated-9.5" do
-          subject { pg_plans.find { |p| p["name"] == "S-dedicated-9.5" } }
+        describe "small-unencrypted-9.5" do
+          subject { pg_plans.find { |p| p["name"] == "small-unencrypted-9.5" } }
 
           it_behaves_like "all postgres plans"
           it_behaves_like "small sized plans"
@@ -191,8 +191,8 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption disabled plans"
         end
 
-        describe "S-HA-dedicated-9.5" do
-          subject { pg_plans.find { |p| p["name"] == "S-HA-dedicated-9.5" } }
+        describe "small-ha-unencrypted-9.5" do
+          subject { pg_plans.find { |p| p["name"] == "small-ha-unencrypted-9.5" } }
 
           it_behaves_like "all postgres plans"
           it_behaves_like "small sized plans"
@@ -201,8 +201,8 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption disabled plans"
         end
 
-        describe "S-HA-enc-dedicated-9.5" do
-          subject { pg_plans.find { |p| p["name"] == "S-HA-enc-dedicated-9.5" } }
+        describe "small-ha-9.5" do
+          subject { pg_plans.find { |p| p["name"] == "small-ha-9.5" } }
 
           it_behaves_like "all postgres plans"
           it_behaves_like "small sized plans"
@@ -211,8 +211,8 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption enabled plans"
         end
 
-        describe "M-dedicated-9.5" do
-          subject { pg_plans.find { |p| p["name"] == "M-dedicated-9.5" } }
+        describe "medium-unencrypted-9.5" do
+          subject { pg_plans.find { |p| p["name"] == "medium-unencrypted-9.5" } }
 
           it_behaves_like "all postgres plans"
           it_behaves_like "medium sized plans"
@@ -221,8 +221,8 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption disabled plans"
         end
 
-        describe "M-HA-dedicated-9.5" do
-          subject { pg_plans.find { |p| p["name"] == "M-HA-dedicated-9.5" } }
+        describe "medium-ha-unencrypted-9.5" do
+          subject { pg_plans.find { |p| p["name"] == "medium-ha-unencrypted-9.5" } }
 
           it_behaves_like "all postgres plans"
           it_behaves_like "medium sized plans"
@@ -231,8 +231,8 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption disabled plans"
         end
 
-        describe "M-HA-enc-dedicated-9.5" do
-          subject { pg_plans.find { |p| p["name"] == "M-HA-enc-dedicated-9.5" } }
+        describe "medium-ha-9.5" do
+          subject { pg_plans.find { |p| p["name"] == "medium-ha-9.5" } }
 
           it_behaves_like "all postgres plans"
           it_behaves_like "medium sized plans"
@@ -241,8 +241,8 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption enabled plans"
         end
 
-        describe "L-dedicated-9.5" do
-          subject { pg_plans.find { |p| p["name"] == "L-dedicated-9.5" } }
+        describe "large-unencrypted-9.5" do
+          subject { pg_plans.find { |p| p["name"] == "large-unencrypted-9.5" } }
 
           it_behaves_like "all postgres plans"
           it_behaves_like "large sized plans"
@@ -251,8 +251,8 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption disabled plans"
         end
 
-        describe "L-HA-dedicated-9.5" do
-          subject { pg_plans.find { |p| p["name"] == "L-HA-dedicated-9.5" } }
+        describe "large-ha-unencrypted-9.5" do
+          subject { pg_plans.find { |p| p["name"] == "large-ha-unencrypted-9.5" } }
 
           it_behaves_like "all postgres plans"
           it_behaves_like "large sized plans"
@@ -261,8 +261,8 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption disabled plans"
         end
 
-        describe "L-HA-enc-dedicated-9.5" do
-          subject { pg_plans.find { |p| p["name"] == "L-HA-enc-dedicated-9.5" } }
+        describe "large-ha-9.5" do
+          subject { pg_plans.find { |p| p["name"] == "large-ha-9.5" } }
 
           it_behaves_like "all postgres plans"
           it_behaves_like "large sized plans"
@@ -271,8 +271,8 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption enabled plans"
         end
 
-        describe "XL-dedicated-9.5" do
-          subject { pg_plans.find { |p| p["name"] == "XL-dedicated-9.5" } }
+        describe "xlarge-unencrypted-9.5" do
+          subject { pg_plans.find { |p| p["name"] == "xlarge-unencrypted-9.5" } }
 
           it_behaves_like "all postgres plans"
           it_behaves_like "xlarge sized plans"
@@ -281,8 +281,8 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption disabled plans"
         end
 
-        describe "XL-HA-dedicated-9.5" do
-          subject { pg_plans.find { |p| p["name"] == "XL-HA-dedicated-9.5" } }
+        describe "xlarge-ha-unencrypted-9.5" do
+          subject { pg_plans.find { |p| p["name"] == "xlarge-ha-unencrypted-9.5" } }
 
           it_behaves_like "all postgres plans"
           it_behaves_like "xlarge sized plans"
@@ -291,8 +291,8 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption disabled plans"
         end
 
-        describe "XL-HA-enc-dedicated-9.5" do
-          subject { pg_plans.find { |p| p["name"] == "XL-HA-enc-dedicated-9.5" } }
+        describe "xlarge-ha-9.5" do
+          subject { pg_plans.find { |p| p["name"] == "xlarge-ha-9.5" } }
 
           it_behaves_like "all postgres plans"
           it_behaves_like "xlarge sized plans"
@@ -301,15 +301,15 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption enabled plans"
         end
 
-        describe "free plan" do
-          subject { pg_plans.find { |p| p["name"] == "Free" } }
+        describe "tiny plan" do
+          subject { pg_plans.find { |p| p["name"] == "tiny-unencrypted-9.5" } }
 
           it "is marked as free" do
             expect(subject.fetch("free")).to eq(true)
           end
 
           it_behaves_like "all postgres plans"
-          it_behaves_like "free sized plans"
+          it_behaves_like "tiny sized plans"
           it_behaves_like "backup disabled plans"
           it_behaves_like "non-HA plans"
           it_behaves_like "Encryption disabled plans"
@@ -323,7 +323,7 @@ RSpec.describe "RDS broker properties" do
 
       it "contains only specific plans" do
         my_plan_names = my_plans.map { |p| p["name"] }
-        expect(my_plan_names).to contain_exactly("Free", "S-dedicated-5.7", "S-HA-dedicated-5.7", "S-HA-enc-dedicated-5.7", "M-dedicated-5.7", "M-HA-dedicated-5.7", "M-HA-enc-dedicated-5.7", "L-dedicated-5.7", "L-HA-dedicated-5.7", "L-HA-enc-dedicated-5.7", "XL-dedicated-5.7", "XL-HA-dedicated-5.7", "XL-HA-enc-dedicated-5.7")
+        expect(my_plan_names).to contain_exactly("tiny-unencrypted-5.7", "small-unencrypted-5.7", "small-ha-unencrypted-5.7", "small-ha-5.7", "medium-unencrypted-5.7", "medium-ha-unencrypted-5.7", "medium-ha-5.7", "large-unencrypted-5.7", "large-ha-unencrypted-5.7", "large-ha-5.7", "xlarge-unencrypted-5.7", "xlarge-ha-unencrypted-5.7", "xlarge-ha-5.7")
       end
 
       describe "plan rds_properties" do
@@ -344,8 +344,8 @@ RSpec.describe "RDS broker properties" do
           end
         end
 
-        describe "S-dedicated-5.7" do
-          subject { my_plans.find { |p| p["name"] == "S-dedicated-5.7" } }
+        describe "small-unencrypted-5.7" do
+          subject { my_plans.find { |p| p["name"] == "small-unencrypted-5.7" } }
 
           it_behaves_like "all mysql plans"
           it_behaves_like "small sized plans"
@@ -354,8 +354,8 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption disabled plans"
         end
 
-        describe "S-HA-dedicated-5.7" do
-          subject { my_plans.find { |p| p["name"] == "S-HA-dedicated-5.7" } }
+        describe "small-ha-unencrypted-5.7" do
+          subject { my_plans.find { |p| p["name"] == "small-ha-unencrypted-5.7" } }
 
           it_behaves_like "all mysql plans"
           it_behaves_like "small sized plans"
@@ -364,8 +364,8 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption disabled plans"
         end
 
-        describe "S-HA-enc-dedicated-5.7" do
-          subject { my_plans.find { |p| p["name"] == "S-HA-enc-dedicated-5.7" } }
+        describe "small-ha-5.7" do
+          subject { my_plans.find { |p| p["name"] == "small-ha-5.7" } }
 
           it_behaves_like "all mysql plans"
           it_behaves_like "small sized plans"
@@ -374,8 +374,8 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption enabled plans"
         end
 
-        describe "M-dedicated-5.7" do
-          subject { my_plans.find { |p| p["name"] == "M-dedicated-5.7" } }
+        describe "medium-unencrypted-5.7" do
+          subject { my_plans.find { |p| p["name"] == "medium-unencrypted-5.7" } }
 
           it_behaves_like "all mysql plans"
           it_behaves_like "medium sized plans"
@@ -384,8 +384,8 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption disabled plans"
         end
 
-        describe "M-HA-dedicated-5.7" do
-          subject { my_plans.find { |p| p["name"] == "M-HA-dedicated-5.7" } }
+        describe "medium-ha-unencrypted-5.7" do
+          subject { my_plans.find { |p| p["name"] == "medium-ha-unencrypted-5.7" } }
 
           it_behaves_like "all mysql plans"
           it_behaves_like "medium sized plans"
@@ -394,8 +394,8 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption disabled plans"
         end
 
-        describe "M-HA-enc-dedicated-5.7" do
-          subject { my_plans.find { |p| p["name"] == "M-HA-enc-dedicated-5.7" } }
+        describe "medium-ha-5.7" do
+          subject { my_plans.find { |p| p["name"] == "medium-ha-5.7" } }
 
           it_behaves_like "all mysql plans"
           it_behaves_like "medium sized plans"
@@ -404,8 +404,8 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption enabled plans"
         end
 
-        describe "L-dedicated-5.7" do
-          subject { my_plans.find { |p| p["name"] == "L-dedicated-5.7" } }
+        describe "large-unencrypted-5.7" do
+          subject { my_plans.find { |p| p["name"] == "large-unencrypted-5.7" } }
 
           it_behaves_like "all mysql plans"
           it_behaves_like "large sized plans"
@@ -414,8 +414,8 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption disabled plans"
         end
 
-        describe "L-HA-dedicated-5.7" do
-          subject { my_plans.find { |p| p["name"] == "L-HA-dedicated-5.7" } }
+        describe "large-ha-unencrypted-5.7" do
+          subject { my_plans.find { |p| p["name"] == "large-ha-unencrypted-5.7" } }
 
           it_behaves_like "all mysql plans"
           it_behaves_like "large sized plans"
@@ -424,8 +424,8 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption disabled plans"
         end
 
-        describe "L-HA-enc-dedicated-5.7" do
-          subject { my_plans.find { |p| p["name"] == "L-HA-enc-dedicated-5.7" } }
+        describe "large-ha-5.7" do
+          subject { my_plans.find { |p| p["name"] == "large-ha-5.7" } }
 
           it_behaves_like "all mysql plans"
           it_behaves_like "large sized plans"
@@ -434,8 +434,8 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption enabled plans"
         end
 
-        describe "XL-dedicated-5.7" do
-          subject { my_plans.find { |p| p["name"] == "XL-dedicated-5.7" } }
+        describe "xlarge-unencrypted-5.7" do
+          subject { my_plans.find { |p| p["name"] == "xlarge-unencrypted-5.7" } }
 
           it_behaves_like "all mysql plans"
           it_behaves_like "xlarge sized plans"
@@ -444,8 +444,8 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption disabled plans"
         end
 
-        describe "XL-HA-dedicated-5.7" do
-          subject { my_plans.find { |p| p["name"] == "XL-HA-dedicated-5.7" } }
+        describe "xlarge-ha-unencrypted-5.7" do
+          subject { my_plans.find { |p| p["name"] == "xlarge-ha-unencrypted-5.7" } }
 
           it_behaves_like "all mysql plans"
           it_behaves_like "xlarge sized plans"
@@ -454,8 +454,8 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption disabled plans"
         end
 
-        describe "XL-HA-enc-dedicated-5.7" do
-          subject { my_plans.find { |p| p["name"] == "XL-HA-enc-dedicated-5.7" } }
+        describe "xlarge-ha-5.7" do
+          subject { my_plans.find { |p| p["name"] == "xlarge-ha-5.7" } }
 
           it_behaves_like "all mysql plans"
           it_behaves_like "xlarge sized plans"
@@ -464,15 +464,15 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption enabled plans"
         end
 
-        describe "free plan" do
-          subject { my_plans.find { |p| p["name"] == "Free" } }
+        describe "tiny plan" do
+          subject { my_plans.find { |p| p["name"] == "tiny-unencrypted-5.7" } }
 
           it "is marked as free" do
             expect(subject.fetch("free")).to eq(true)
           end
 
           it_behaves_like "all mysql plans"
-          it_behaves_like "free sized plans"
+          it_behaves_like "tiny sized plans"
           it_behaves_like "backup disabled plans"
           it_behaves_like "non-HA plans"
           it_behaves_like "Encryption disabled plans"

--- a/platform-tests/src/platform/acceptance/init_test.go
+++ b/platform-tests/src/platform/acceptance/init_test.go
@@ -31,8 +31,9 @@ const (
 )
 
 var (
-	testConfig *config.Config
-	httpClient *http.Client
+	testConfig  *config.Config
+	httpClient  *http.Client
+	testContext *workflowhelpers.ReproducibleTestSuiteSetup
 )
 
 func TestSuite(t *testing.T) {
@@ -47,7 +48,7 @@ func TestSuite(t *testing.T) {
 		},
 	}
 
-	testContext := workflowhelpers.NewTestSuiteSetup(testConfig)
+	testContext = workflowhelpers.NewTestSuiteSetup(testConfig)
 
 	BeforeSuite(func() {
 		testContext.Setup()

--- a/platform-tests/src/platform/acceptance/mysql_service_test.go
+++ b/platform-tests/src/platform/acceptance/mysql_service_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/generator"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
+	"github.com/cloudfoundry-incubator/cf-test-helpers/workflowhelpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gbytes"
@@ -16,7 +17,7 @@ import (
 var _ = Describe("MySQL backing service", func() {
 	const (
 		serviceName  = "mysql"
-		testPlanName = "tiny-unencrypted-5.7"
+		testPlanName = "tiny-5.7"
 	)
 
 	It("should have registered the mysql service", func() {
@@ -25,27 +26,30 @@ var _ = Describe("MySQL backing service", func() {
 		Expect(plans).To(Say(serviceName))
 	})
 
-	It("has the expected plans available", func() {
-		plans := cf.Cf("marketplace", "-s", serviceName).Wait(testConfig.DefaultTimeoutDuration())
-		Expect(plans).To(Exit(0))
-		Expect(plans.Out.Contents()).To(ContainSubstring("tiny-unencrypted-5.7"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("tiny-5.7"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("small-unencrypted-5.7"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("small-5.7"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("small-ha-unencrypted-5.7"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("small-ha-5.7"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("medium-unencrypted-5.7"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("medium-5.7"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("medium-ha-unencrypted-5.7"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("medium-ha-5.7"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("large-unencrypted-5.7"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("large-5.7"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("large-ha-unencrypted-5.7"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("large-ha-5.7"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("xlarge-unencrypted-5.7"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("xlarge-5.7"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("xlarge-ha-unencrypted-5.7"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("xlarge-ha-5.7"))
+	It("has only the expected plans available to the user", func() {
+		workflowhelpers.AsUser(testContext.RegularUserContext(), testContext.ShortTimeout(), func() {
+			plans := cf.Cf("marketplace", "-s", serviceName).Wait(testConfig.DefaultTimeoutDuration())
+			Expect(plans).To(Exit(0))
+			cfMarketplaceOutput := string(plans.Out.Contents())
+			Expect(cfMarketplaceOutput).To(ContainSubstring("tiny-5.7"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("small-5.7"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("small-ha-5.7"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("medium-5.7"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("medium-ha-5.7"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("large-5.7"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("large-ha-5.7"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("xlarge-5.7"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("xlarge-ha-5.7"))
+			Expect(cfMarketplaceOutput).ToNot(ContainSubstring("tiny-unencrypted-5.7"))
+			Expect(cfMarketplaceOutput).ToNot(ContainSubstring("small-unencrypted-5.7"))
+			Expect(cfMarketplaceOutput).ToNot(ContainSubstring("small-ha-unencrypted-5.7"))
+			Expect(cfMarketplaceOutput).ToNot(ContainSubstring("medium-unencrypted-5.7"))
+			Expect(cfMarketplaceOutput).ToNot(ContainSubstring("medium-ha-unencrypted-5.7"))
+			Expect(cfMarketplaceOutput).ToNot(ContainSubstring("large-unencrypted-5.7"))
+			Expect(cfMarketplaceOutput).ToNot(ContainSubstring("large-ha-unencrypted-5.7"))
+			Expect(cfMarketplaceOutput).ToNot(ContainSubstring("xlarge-unencrypted-5.7"))
+			Expect(cfMarketplaceOutput).ToNot(ContainSubstring("xlarge-ha-unencrypted-5.7"))
+		})
 	})
 
 	Context("creating a database instance", func() {

--- a/platform-tests/src/platform/acceptance/mysql_service_test.go
+++ b/platform-tests/src/platform/acceptance/mysql_service_test.go
@@ -16,7 +16,7 @@ import (
 var _ = Describe("MySQL backing service", func() {
 	const (
 		serviceName  = "mysql"
-		testPlanName = "Free"
+		testPlanName = "tiny-unencrypted-5.7"
 	)
 
 	It("should have registered the mysql service", func() {
@@ -28,13 +28,24 @@ var _ = Describe("MySQL backing service", func() {
 	It("has the expected plans available", func() {
 		plans := cf.Cf("marketplace", "-s", serviceName).Wait(testConfig.DefaultTimeoutDuration())
 		Expect(plans).To(Exit(0))
-		Expect(plans.Out.Contents()).To(ContainSubstring("Free"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("S-dedicated-5.7"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("S-HA-dedicated-5.7"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("M-dedicated-5.7"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("M-HA-dedicated-5.7"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("L-dedicated-5.7"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("L-HA-dedicated-5.7"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("tiny-unencrypted-5.7"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("tiny-5.7"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("small-unencrypted-5.7"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("small-5.7"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("small-ha-unencrypted-5.7"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("small-ha-5.7"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("medium-unencrypted-5.7"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("medium-5.7"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("medium-ha-unencrypted-5.7"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("medium-ha-5.7"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("large-unencrypted-5.7"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("large-5.7"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("large-ha-unencrypted-5.7"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("large-ha-5.7"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("xlarge-unencrypted-5.7"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("xlarge-5.7"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("xlarge-ha-unencrypted-5.7"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("xlarge-ha-5.7"))
 	})
 
 	Context("creating a database instance", func() {

--- a/platform-tests/src/platform/acceptance/postgres_service_test.go
+++ b/platform-tests/src/platform/acceptance/postgres_service_test.go
@@ -16,7 +16,7 @@ import (
 var _ = Describe("Postgres backing service", func() {
 	const (
 		serviceName  = "postgres"
-		testPlanName = "Free"
+		testPlanName = "tiny-unencrypted-9.5"
 	)
 
 	It("should have registered the postgres service", func() {
@@ -28,13 +28,24 @@ var _ = Describe("Postgres backing service", func() {
 	It("has the expected plans available", func() {
 		plans := cf.Cf("marketplace", "-s", serviceName).Wait(testConfig.DefaultTimeoutDuration())
 		Expect(plans).To(Exit(0))
-		Expect(plans.Out.Contents()).To(ContainSubstring("Free"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("S-dedicated-9.5"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("S-HA-dedicated-9.5"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("M-dedicated-9.5"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("M-HA-dedicated-9.5"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("L-dedicated-9.5"))
-		Expect(plans.Out.Contents()).To(ContainSubstring("L-HA-dedicated-9.5"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("tiny-unencrypted-9.5"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("tiny-9.5"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("small-unencrypted-9.5"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("small-9.5"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("small-ha-unencrypted-9.5"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("small-ha-9.5"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("medium-unencrypted-9.5"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("medium-9.5"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("medium-ha-unencrypted-9.5"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("medium-ha-9.5"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("large-9.5"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("large-unencrypted-9.5"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("large-ha-unencrypted-9.5"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("large-ha-9.5"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("xlarge-unencrypted-9.5"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("xlarge-9.5"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("xlarge-ha-unencrypted-9.5"))
+		Expect(plans.Out.Contents()).To(ContainSubstring("xlarge-ha-9.5"))
 	})
 
 	Context("creating a database instance", func() {

--- a/platform-tests/src/platform/acceptance/redis_service_test.go
+++ b/platform-tests/src/platform/acceptance/redis_service_test.go
@@ -15,7 +15,7 @@ import (
 var _ = Describe("Redis backing service", func() {
 	const (
 		serviceName  = "redis"
-		testPlanName = "tiny-clustered"
+		testPlanName = "tiny-clustered-3.2"
 	)
 
 	It("is registered in the marketplace", func() {


### PR DESCRIPTION
What
----

We want to consolidate the naming convention for all the backing services
we offer, as it is described in ADR025: https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR025-service-plan-naming-conventions/

We also want to only offer encrypted plans and deprecate the non
encrypted ones. We will not remove them, but make them unavailable

To disable the plans, we add a script in the task that enable the broker to
specifically disable those.

How to review
-------------

 - Code review
 - Deploy this, let the tests pass
 - Check the marketplace as a normal (non admin) user:

```
cf create-user testuser password123
cf set-org-role testuser govuk-paas OrgManager
cf auth testuser password123
cf marketplace
cf marketplace mysql
cf marketplace postgres
cf marketplace redis
```


Who can review
--------------

Anyone but @keymon or @paroxp