### PR TITLE
[#157470481] Check if healthcheck-db exists before creating

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1966,11 +1966,14 @@ jobs:
                 cd paas-cf/platform-tests/example-apps/healthcheck
 
                 if  [ "${DISABLE_HEALTHCHECK_DB:-}" != "true" ] ; then
-                  cf create-service postgres tiny-9.5 healthcheck-db
-                  while ! cf service healthcheck-db | grep -q 'Status: create succeeded'; do
-                    echo "Waiting for creation of service to complete..."
-                    sleep 30
-                  done
+
+                  if ! cf service healthcheck-db > /dev/null; then
+                    cf create-service postgres tiny-9.5 healthcheck-db
+                    while ! cf service healthcheck-db | grep -q 'Status: create succeeded'; do
+                      echo "Waiting for creation of service to complete..."
+                      sleep 30
+                    done
+                  fi
 
                   ruby -ryaml -e '
                     manifest = YAML.load_file("manifest.yml")


### PR DESCRIPTION
What
----

When creating the healthcheck-db We were relying on the behaviour that
`cf create-service` is a no-op when creating a plan with the exact same
name, plan and args.

However we recently renamed the plan which causes the create-service
call to fail.

To resolve this a guard is added to check for the existance of the
database before attempting to create it.

How to review
-------------

Code review

Who can review
--------------

Not @chrisfarms
