### PR TITLE
[#157470481] Remove invalid tiny encrypted RDS plans

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1536,7 +1536,7 @@ jobs:
 
                 # Enable supported plans
                 cat <<EOF | xargs -n1 cf enable-service-access mysql -p
-                tiny-5.7
+                tiny-unencrypted-5.7
                 small-5.7
                 small-ha-5.7
                 medium-ha-5.7
@@ -1548,7 +1548,7 @@ jobs:
                 EOF
 
                 cat <<EOF | xargs -n1 cf enable-service-access postgres -p
-                tiny-9.5
+                tiny-unencrypted-9.5
                 small-ha-9.5
                 small-9.5
                 medium-ha-9.5
@@ -1561,7 +1561,6 @@ jobs:
 
                 # Disable deprecated plans
                 cat <<EOF | xargs -n1 cf disable-service-access mysql -p
-                tiny-unencrypted-5.7
                 small-unencrypted-5.7
                 small-ha-unencrypted-5.7
                 medium-ha-unencrypted-5.7
@@ -1573,7 +1572,6 @@ jobs:
                 EOF
 
                 cat <<EOF | xargs -n1 cf disable-service-access postgres -p
-                tiny-unencrypted-9.5
                 small-ha-unencrypted-9.5
                 small-unencrypted-9.5
                 medium-ha-unencrypted-9.5
@@ -1968,7 +1966,7 @@ jobs:
                 if  [ "${DISABLE_HEALTHCHECK_DB:-}" != "true" ] ; then
 
                   if ! cf service healthcheck-db > /dev/null; then
-                    cf create-service postgres tiny-9.5 healthcheck-db
+                    cf create-service postgres tiny-unencrypted-9.5 healthcheck-db
                     while ! cf service healthcheck-db | grep -q 'Status: create succeeded'; do
                       echo "Waiting for creation of service to complete..."
                       sleep 30
@@ -2016,7 +2014,7 @@ jobs:
               - -u
               - -c
               - |
-                BILLING_DB_PLAN="tiny-9.5"
+                BILLING_DB_PLAN="tiny-unencrypted-9.5"
                 if [ "${DEPLOY_ENV}" = "prod" ]; then
                   BILLING_DB_PLAN="medium-9.5"
                 fi
@@ -2082,7 +2080,7 @@ jobs:
               - -u
               - -c
               - |
-                DB_PLAN="tiny-9.5"
+                DB_PLAN="tiny-unencrypted-9.5"
 
                 VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
                 BASIC_AUTH_PASSWORD=$($VAL_FROM_YAML secrets_paas_accounts_admin_password cf-secrets/cf-secrets.yml)

--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -126,20 +126,6 @@
                         <<: *default_postgres_rds_properties # yamllint disable-line
                         <<: *tiny_plan_rds_properties # yamllint disable-line
 
-                    - id: "8332f409-4689-4614-a6bc-64dec6e2faae"
-                      name: "tiny-9.5"
-                      description: "5GB Storage, NOT BACKED UP, Dedicated Instance, Storage Encrypted, Max 50 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t2.micro."
-                      free: true
-                      metadata:
-                        bullets:
-                          - "Dedicated Postgres 9.5 server"
-                          - "Storage Encrypted"
-                          - "AWS RDS"
-                      rds_properties:
-                        <<: *default_postgres_rds_properties # yamllint disable-line
-                        <<: *tiny_plan_rds_properties # yamllint disable-line
-                        storage_encrypted: true
-
                     - id: "b7d0a368-ac92-4eff-9b8d-ab4ba45bed0e"
                       name: "small-unencrypted-9.5"
                       description: "20GB Storage, Dedicated Instance, Max 200 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t2.small."
@@ -446,20 +432,6 @@
                       rds_properties:
                         <<: *default_mysql_rds_properties # yamllint disable-line
                         <<: *tiny_plan_rds_properties # yamllint disable-line
-
-                    - id: 05a741b5-e86a-4d36-a37a-04c8173381a6
-                      name: "tiny-5.7"
-                      description: "5GB Storage, NOT BACKED UP, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.t2.micro."
-                      free: true
-                      metadata:
-                        bullets:
-                          - "Dedicated MySQL 5.7 server"
-                          - "Storage Encryped"
-                          - "AWS RDS"
-                      rds_properties:
-                        <<: *default_mysql_rds_properties # yamllint disable-line
-                        <<: *tiny_plan_rds_properties # yamllint disable-line
-                        storage_encrypted: true
 
                     - id: "7fdde6ea-cc27-466c-86aa-46181fc20d25"
                       name: "small-unencrypted-5.7"

--- a/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
@@ -162,7 +162,6 @@ RSpec.describe "RDS broker properties" do
         pg_plan_names = pg_plans.map { |p| p["name"] }
         expect(pg_plan_names).to contain_exactly(
           "tiny-unencrypted-9.5",
-          "tiny-9.5",
           "small-unencrypted-9.5",
           "small-9.5",
           "small-ha-unencrypted-9.5",
@@ -212,20 +211,6 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "backup disabled plans"
           it_behaves_like "non-HA plans"
           it_behaves_like "Encryption disabled plans"
-        end
-
-        describe "tiny-9.5" do
-          subject { pg_plans.find { |p| p["name"] == "tiny-9.5" } }
-
-          it "is marked as free" do
-            expect(subject.fetch("free")).to eq(true)
-          end
-
-          it_behaves_like "all postgres plans"
-          it_behaves_like "tiny sized plans"
-          it_behaves_like "backup disabled plans"
-          it_behaves_like "non-HA plans"
-          it_behaves_like "Encryption enabled plans"
         end
 
         describe "small-unencrypted-9.5" do
@@ -398,7 +383,6 @@ RSpec.describe "RDS broker properties" do
         my_plan_names = my_plans.map { |p| p["name"] }
         expect(my_plan_names).to contain_exactly(
           "tiny-unencrypted-5.7",
-          "tiny-5.7",
           "small-unencrypted-5.7",
           "small-5.7",
           "small-ha-unencrypted-5.7",
@@ -448,20 +432,6 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "backup disabled plans"
           it_behaves_like "non-HA plans"
           it_behaves_like "Encryption disabled plans"
-        end
-
-        describe "tiny-5.7" do
-          subject { my_plans.find { |p| p["name"] == "tiny-5.7" } }
-
-          it "is marked as free" do
-            expect(subject.fetch("free")).to eq(true)
-          end
-
-          it_behaves_like "all mysql plans"
-          it_behaves_like "tiny sized plans"
-          it_behaves_like "backup disabled plans"
-          it_behaves_like "non-HA plans"
-          it_behaves_like "Encryption enabled plans"
         end
 
         describe "small-unencrypted-5.7" do

--- a/platform-tests/src/platform/acceptance/mysql_service_test.go
+++ b/platform-tests/src/platform/acceptance/mysql_service_test.go
@@ -17,7 +17,7 @@ import (
 var _ = Describe("MySQL backing service", func() {
 	const (
 		serviceName  = "mysql"
-		testPlanName = "tiny-5.7"
+		testPlanName = "tiny-unencrypted-5.7"
 	)
 
 	It("should have registered the mysql service", func() {
@@ -31,7 +31,7 @@ var _ = Describe("MySQL backing service", func() {
 			plans := cf.Cf("marketplace", "-s", serviceName).Wait(testConfig.DefaultTimeoutDuration())
 			Expect(plans).To(Exit(0))
 			cfMarketplaceOutput := string(plans.Out.Contents())
-			Expect(cfMarketplaceOutput).To(ContainSubstring("tiny-5.7"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("tiny-unencrypted-5.7"))
 			Expect(cfMarketplaceOutput).To(ContainSubstring("small-5.7"))
 			Expect(cfMarketplaceOutput).To(ContainSubstring("small-ha-5.7"))
 			Expect(cfMarketplaceOutput).To(ContainSubstring("medium-5.7"))
@@ -40,7 +40,6 @@ var _ = Describe("MySQL backing service", func() {
 			Expect(cfMarketplaceOutput).To(ContainSubstring("large-ha-5.7"))
 			Expect(cfMarketplaceOutput).To(ContainSubstring("xlarge-5.7"))
 			Expect(cfMarketplaceOutput).To(ContainSubstring("xlarge-ha-5.7"))
-			Expect(cfMarketplaceOutput).ToNot(ContainSubstring("tiny-unencrypted-5.7"))
 			Expect(cfMarketplaceOutput).ToNot(ContainSubstring("small-unencrypted-5.7"))
 			Expect(cfMarketplaceOutput).ToNot(ContainSubstring("small-ha-unencrypted-5.7"))
 			Expect(cfMarketplaceOutput).ToNot(ContainSubstring("medium-unencrypted-5.7"))

--- a/platform-tests/src/platform/acceptance/postgres_service_test.go
+++ b/platform-tests/src/platform/acceptance/postgres_service_test.go
@@ -17,7 +17,7 @@ import (
 var _ = Describe("Postgres backing service", func() {
 	const (
 		serviceName  = "postgres"
-		testPlanName = "tiny-9.5"
+		testPlanName = "tiny-unencrypted-9.5"
 	)
 
 	It("should have registered the postgres service", func() {
@@ -31,7 +31,7 @@ var _ = Describe("Postgres backing service", func() {
 			plans := cf.Cf("marketplace", "-s", serviceName).Wait(testConfig.DefaultTimeoutDuration())
 			Expect(plans).To(Exit(0))
 			cfMarketplaceOutput := string(plans.Out.Contents())
-			Expect(cfMarketplaceOutput).To(ContainSubstring("tiny-9.5"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("tiny-unencrypted-9.5"))
 			Expect(cfMarketplaceOutput).To(ContainSubstring("small-9.5"))
 			Expect(cfMarketplaceOutput).To(ContainSubstring("small-ha-9.5"))
 			Expect(cfMarketplaceOutput).To(ContainSubstring("medium-9.5"))
@@ -40,7 +40,6 @@ var _ = Describe("Postgres backing service", func() {
 			Expect(cfMarketplaceOutput).To(ContainSubstring("large-ha-9.5"))
 			Expect(cfMarketplaceOutput).To(ContainSubstring("xlarge-9.5"))
 			Expect(cfMarketplaceOutput).To(ContainSubstring("xlarge-ha-9.5"))
-			Expect(cfMarketplaceOutput).ToNot(ContainSubstring("tiny-unencrypted-9.5"))
 			Expect(cfMarketplaceOutput).ToNot(ContainSubstring("small-unencrypted-9.5"))
 			Expect(cfMarketplaceOutput).ToNot(ContainSubstring("small-ha-unencrypted-9.5"))
 			Expect(cfMarketplaceOutput).ToNot(ContainSubstring("medium-unencrypted-9.5"))


### PR DESCRIPTION
What
----

In PRs #1377 #1376 and #1375 we renamed the RDS services to the
new convention and added some `tiny-*` ones using t2.micro with
encryption.

But AWS RDS does not support t2.micro RDS instances with encryption.
Creating an instance tiny-* would result in a error:

    Server error, status code: 502, error code: 10001, message: Service broker error: InvalidParameterCombination: DB Instance class db.t2.micro does not support encryption at rest

We remove tiny-5.7 and tiny-9.5, and enable the unencrypted ones
to everybody.


How to review
-------------

 - Code review
 - Optionally: Deploy this and check the tests pass



Who can review
--------------

Anyone but me