### PR TITLE
[#157032509] Fix CA certification rotation

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -156,7 +156,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli-v2
-              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+              tag: c88f3e0b03558c987693fad3f180d9052b77342c
           run:
             path: sh
             args:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -48,6 +48,7 @@ groups:
       - expire-aws-keys
       - rotate-cf-certs-cas
       - rotate-cf-certs-leafs
+      - regenerate-cf-certs-cas-with-skis
       - delete-old-cf-certs
 resource_types:
 - name: s3-iam
@@ -3332,6 +3333,48 @@ jobs:
             - -c
             - |
               ./paas-cf/manifests/cf-manifest/scripts/rotate-cf-certs.rb --delete \
+                --manifest cf-manifest-pre-vars/cf-manifest-pre-vars.yml \
+                --vars-store cf-vars-store/cf-vars-store.yml \
+                > updated-cf-certs/cf-vars-store.yml
+      on_success:
+        put: cf-vars-store
+        params:
+          file: updated-cf-certs/cf-vars-store.yml
+
+  - name: regenerate-cf-certs-cas-with-skis
+    serial: true
+    plan:
+    - aggregate:
+      - get: paas-cf
+      - get: cf-manifest-pre-vars
+      - get: cf-vars-store
+    - task: regenerate-cf-certs-cas-with-skis
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: ruby
+            tag: 2.5-slim
+        inputs:
+          - name: paas-cf
+          - name: cf-manifest-pre-vars
+          - name: cf-vars-store
+        outputs:
+          - name: updated-cf-certs
+        run:
+          path: sh
+          args:
+            - -e
+            - -c
+            - |
+              apt-get update -qq && apt-get install -yqq wget --no-install-recommends
+              wget -nv https://github.com/square/certstrap/releases/download/v1.1.1/certstrap-v1.1.1-linux-amd64
+              echo "274c3e746761014df4b014103a36f8e8adad26a282fdd294d886a1e305cbfaa7  certstrap-v1.1.1-linux-amd64" | sha256sum -c
+              chmod +x certstrap-v1.1.1-linux-amd64
+              mv certstrap-v1.1.1-linux-amd64 /usr/local/bin/certstrap
+
+              ./paas-cf/manifests/cf-manifest/scripts/rotate-cf-certs.rb --ca-add-ski \
                 --manifest cf-manifest-pre-vars/cf-manifest-pre-vars.yml \
                 --vars-store cf-vars-store/cf-vars-store.yml \
                 > updated-cf-certs/cf-vars-store.yml

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1149,7 +1149,7 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/bosh-cli-v2
-                tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+                tag: c88f3e0b03558c987693fad3f180d9052b77342c
             inputs:
               - name: paas-cf
               - name: terraform-outputs
@@ -1179,7 +1179,7 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/bosh-cli-v2
-                tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+                tag: c88f3e0b03558c987693fad3f180d9052b77342c
             inputs:
               - name: cf-vars-store
               - name: paas-cf
@@ -1252,7 +1252,7 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/bosh-cli-v2
-                tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+                tag: c88f3e0b03558c987693fad3f180d9052b77342c
             inputs:
               - name: bosh-secrets
               - name: paas-cf
@@ -1293,7 +1293,7 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/bosh-cli-v2
-                tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+                tag: c88f3e0b03558c987693fad3f180d9052b77342c
             inputs:
               - name: cloud-config
               - name: bosh-secrets
@@ -1370,7 +1370,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli-v2
-              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+              tag: c88f3e0b03558c987693fad3f180d9052b77342c
           inputs:
             - name: paas-cf
             - name: cf-manifest
@@ -2343,7 +2343,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli-v2
-              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+              tag: c88f3e0b03558c987693fad3f180d9052b77342c
           inputs:
             - name: paas-cf
             - name: bosh-secrets
@@ -2848,7 +2848,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli-v2
-              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+              tag: c88f3e0b03558c987693fad3f180d9052b77342c
           inputs:
             - name: paas-cf
             - name: cf-manifest

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -193,7 +193,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli-v2
-              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+              tag: c88f3e0b03558c987693fad3f180d9052b77342c
           inputs:
             - name: bosh-secrets
             - name: paas-cf

--- a/concourse/scripts/check-certificates.rb
+++ b/concourse/scripts/check-certificates.rb
@@ -10,7 +10,7 @@ certs = YAML.safe_load(STDIN)
 alert = false
 
 unless certs.nil?
-  certs.each { |variable, value|
+  certs.each do |variable, value|
     next unless value.is_a?(Hash) && value.has_key?('certificate')
     next if variable =~ /_old$/
     certificate = OpenSSL::X509::Certificate.new value['certificate']
@@ -22,7 +22,12 @@ unless certs.nil?
       puts "#{variable}: #{days_to_expire} days to expire. ERROR! less than #{ALERT_DAYS} days."
       alert = true
     end
-  }
+
+    unless certificate.extensions.find { |e| e.oid == 'subjectKeyIdentifier' }
+      puts "#{variable}: ERROR! Missing Subject Key Identifier"
+      alert = true
+    end
+  end
 end
 
 exit 1 if alert

--- a/concourse/tasks/generate-test-config.yml
+++ b/concourse/tasks/generate-test-config.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/bosh-cli-v2
-    tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+    tag: c88f3e0b03558c987693fad3f180d9052b77342c
 inputs:
   - name: paas-cf
   - name: admin-creds

--- a/manifests/cf-manifest/operations.d/540-log-cache.yml
+++ b/manifests/cf-manifest/operations.d/540-log-cache.yml
@@ -189,19 +189,6 @@
     name: log-cache-scheduler
     release: log-cache
 
-# Add certification rotation support
-- type: replace
-  path: /instance_groups/name=doppler/jobs/name=log-cache-cf-auth-proxy/properties/uaa/ca_cert
-  value: ((uaa_ca.certificate))((uaa_ca_old.certificate))
-- type: replace
-  path: /variables/-
-  value:
-    name: log_cache_ca_old
-    options:
-      common_name: log-cache
-      is_ca: true
-    type: certificate
-
 # FIXME: Rename the doppler secrets to our legacy secrets variables
 - type: replace
   path: /instance_groups/name=doppler/jobs/name=log-cache-cf-auth-proxy/properties/uaa/client_secret

--- a/manifests/cf-manifest/operations.d/900-cf-cert-rotation.yml
+++ b/manifests/cf-manifest/operations.d/900-cf-cert-rotation.yml
@@ -68,6 +68,22 @@
   value: ((loggregator_ca.certificate))((loggregator_ca_old.certificate))
 
 - type: replace
+  path: /instance_groups/name=doppler/jobs/name=log-cache/properties/tls/ca_cert
+  value: ((log_cache_ca.certificate))((log_cache_ca_old.certificate))
+
+- type: replace
+  path: /instance_groups/name=doppler/jobs/name=log-cache-nozzle/properties/logs_provider/tls/ca_cert
+  value: ((loggregator_ca.certificate))((loggregator_ca_old.certificate))
+
+- type: replace
+  path: /instance_groups/name=doppler/jobs/name=log-cache-cf-auth-proxy/properties/cc/ca_cert
+  value: ((service_cf_internal_ca.certificate))((service_cf_internal_ca_old.certificate))
+
+- type: replace
+  path: /instance_groups/name=doppler/jobs/name=log-cache-cf-auth-proxy/properties/uaa/ca_cert
+  value: ((uaa_ca.certificate))((uaa_ca_old.certificate))
+
+- type: replace
   path: /instance_groups/name=log-api/jobs/name=loggregator_trafficcontroller/properties/cc/mutual_tls/ca_cert
   value: ((service_cf_internal_ca.certificate))((service_cf_internal_ca_old.certificate))
 
@@ -232,6 +248,15 @@
     name: loggregator_ca_old
     options:
       common_name: loggregatorCA
+      is_ca: true
+    type: certificate
+
+- type: replace
+  path: /variables/-
+  value:
+    name: log_cache_ca_old
+    options:
+      common_name: log-cache
       is_ca: true
     type: certificate
 

--- a/manifests/cf-manifest/scripts/rotate-cf-certs.rb
+++ b/manifests/cf-manifest/scripts/rotate-cf-certs.rb
@@ -2,6 +2,8 @@
 
 require 'optparse'
 require 'yaml'
+require 'open3'
+require 'tmpdir'
 
 BLANK_CERT = {
   "ca" => "",
@@ -16,6 +18,7 @@ def parse_args
   parser.on("--ca", "Rotate CA certs") { options[:ca] = true }
   parser.on("--leaf", "Rotate leaf certs") { options[:leaf] = true }
   parser.on("--delete", "Delete _old certificates") { options[:delete] = true }
+  parser.on("--ca-add-ski", "Regenerate CA certs to include a Subject Key Identifier") { options[:ca_add_ski] = true }
   parser.on("--manifest MANIFEST", "BOSH manifest") { |v| options[:manifest] = v }
   parser.on("--vars-store VARS", "BOSH variable store") { |v| options[:vars_store] = v }
   parser.parse!
@@ -65,7 +68,45 @@ def delete_old(vars, certs)
   certs
 end
 
-def rotate(manifest, certs, ca: false, leaf: false, delete: false)
+def regenerate_cas(vars, certs)
+  STDERR.puts "Regenerating CA certificates with Subject Key Identifiers"
+
+  workdir = Dir.mktmpdir('rotate-cf-certs')
+
+  vars.each do |var|
+    next unless var.fetch("options", {}).fetch("is_ca", false)
+    name = var.fetch("name")
+    next unless certs.is_a?(Hash) && certs.has_key?(name)
+    next if name.end_with?("_old")
+
+    common_name = var.fetch("options").fetch("common_name")
+    private_key = certs.fetch(name).fetch("private_key")
+
+    STDERR.puts "Generating #{name} with common name #{common_name}"
+
+    private_key_path = File.join(workdir, "private.key")
+    File.open(private_key_path, 'w') { |file| file.write(private_key) }
+
+    output = `certstrap init --expires "12 months" --common-name "#{common_name}" --passphrase "" --key "#{private_key_path}" --c "USA" -o "Cloud Foundry"`
+    STDERR.puts output
+    status = $?
+    raise "certstrap exited #{status}" if status != 0
+
+    cert = File.read("out/#{common_name}.crt")
+    certs[name]["ca"] = cert
+    certs[name]["certificate"] = cert
+
+    `rm -rf out/#{common_name}.*`
+  end
+
+  if !workdir.nil?
+    FileUtils.rm_rf(workdir)
+  end
+
+  certs
+end
+
+def rotate(manifest, certs, ca: false, leaf: false, delete: false, ca_add_ski: false)
   vars = manifest.fetch("variables").select { |v| v["type"] == 'certificate' }
 
   if delete
@@ -74,6 +115,7 @@ def rotate(manifest, certs, ca: false, leaf: false, delete: false)
 
   certs = rotate_cas(vars, certs) if ca
   certs = rotate_leafs(vars, certs) if leaf
+  certs = regenerate_cas(vars, certs) if ca_add_ski
 
   certs
 end

--- a/manifests/cf-manifest/spec/manifest/rotate_certs_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/rotate_certs_spec.rb
@@ -38,5 +38,16 @@ RSpec.describe "Certificate rotation" do
 
     expect(rotable_ca_certs_not_patched).to be_empty,
       "CA certificates referred without appending '_old.certificate' to support rotation: #{rotable_ca_certs_not_patched.join('; ')}"
+
+    # When indirectly referencing the ca via `certificate.ca` it's not possible to add the _old version of the CA cert.
+    indirect_ca_references = manifest.inject([]) do |acum, v, path|
+      if v =~ /\(\(([^\.]*).ca\)\)/
+        acum << path
+      end
+      acum
+    end
+
+    expect(indirect_ca_references).to be_empty,
+      "CA certificates referred to indirectly meaning the _old version can't be used: #{indirect_ca_references.join('; ')}"
   end
 end


### PR DESCRIPTION
## What

We use the BOSH cli to generate certificates into a variable stare - based on the manifest variable definitons.
There is a known issue if you try to rotate the CA certificates outlined in [1].

The root of the problem is that when OpenSSL is configured to trust multiple CAs, and two of them have the same subject name, OpenSSL will only verify certificates against the first one (see [2] in OpenSSL code).

One solution for the CA certificate rotation problem is to set the Subject Key Identifiers so OpenSSL will be able to handle multiple certificates with the same subject name.

We patched the bosh-cli to generate certificates with an SKI. This will solve the problem long-term but the first rotation _would_ still cause downtime as OpenSSL is still not able to find the right CA unless all CAs with the same common name have SKIs.

To achieve the first rotation without downtime (when old CAs don't have SKIs but new CAs have it) we've created a Concourse job `credentials/regenerate-cf-certs-cas-with-skis` which needs to be run once (+ a CF deploy).

[1] https://docs.google.com/document/d/1vKxziTEvIgKHubukoyAGaJzGqrMBjun7JffbunlLBPg/edit#heading=h.wftyivqbaag4
[2] https://github.com/openssl/openssl/blob/49f6cb968ff63793f6671d9026fb2a7034dad79a/crypto/x509/x509_lu.c#L613-L617

## How to review

1. Review the following PRs first
    * https://github.com/alphagov/paas-config-server/pull/2
    * https://github.com/alphagov/paas-bosh-cli/pull/1
    * https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/131

1. Make sure you've updated for CF env from the latest master and this PR is rebased from master

1. Follow the `How to deploy instructions` on your dev env

1. Make sure all tests pass at every stage.

## How to deploy

### 1. Regenerate the existing certificates with SKIs

1. Run the `credentials/regenerate-cf-certs-cas-with-skis`
1. Run create-cloudfoundry to deploy the updated CAs with SKIs
1. Run the `rotate-cf-certs-leafs` delete existing non-CA certs
1. Run create-cloudfoundry to generate new non-CA certs with SKIs against the new CAs and deploy them

### 2. Run the regular CA rotation process

1. Run rotate-cf-certs-cas to copy existing CAs into _old suffixes
1. Run create-cloudfoundry to generate new CAs and deploy them alongside the old CAs
1. Run rotate-cf-certs-leafs to delete existing non-CA certs
1. Run create-cloudfoundry to generate new non-CA certs against the new CAs and deploy them
1. Run delete-old-cf-certs to delete old CAs
1. Run create-cloudfoundry to remove the old CAs

## How to merge

❗️ The TMP commit needs to be udpated with the final Docker image tags for bosh-cli-v2.

1. Merge https://github.com/alphagov/paas-config-server/pull/2
1. Update and merge https://github.com/alphagov/paas-bosh-cli/pull/1
1. Build a final BOSH cli binary (instructions in the PR)
1. Update and merge https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/131
1. Update the Docker image tags in the TMP commit and merge this PR.

## Who can review

Not me