### PR TITLE
[#156154997] Separate TLS expiry and validity metrics

### DIFF
--- a/terraform/datadog/certificates.tf
+++ b/terraform/datadog/certificates.tf
@@ -17,20 +17,37 @@ resource "datadog_monitor" "invalid_tls_cert" {
   tags = ["deployment:${var.env}", "service:${var.env}_monitors"]
 }
 
-resource "datadog_monitor" "invalid_cdn_tls_cert" {
-  name              = "${format("%s Invalid CloudFront TLS/SSL Certificate", var.env)}"
-  type              = "metric alert"
-  message           = "${format("{{hostname.name}} CloudFront certificate {{#is_alert}}is invalid!{{/is_alert}}{{#is_warning}}expires in {{value}} days{{/is_warning}}\n\nSee [Team Manual > Responding to alerts > Invalid Certificates](%s#invalid-certificates) for more info.", var.datadog_documentation_url)}"
-  notify_no_data    = true
-  no_data_timeframe = 480
+resource "datadog_monitor" "cdn_tls_cert_expiry" {
+  name    = "${format("%s CloudFront TLS/SSL Certificates expiry", var.env)}"
+  type    = "metric alert"
+  message = "${format("{{hostname.name}} CloudFront certificate {{#is_alert}}is almost expired!{{/is_alert}}{{#is_warning}}expires in {{value}} days{{/is_warning}}\n\nSee [Team Manual > Responding to alerts > Invalid Certificates](%s#invalid-certificates) for more info.", var.datadog_documentation_url)}"
 
-  query = "${format("min(last_4h):min:cdn.tls.certificates.validity{deploy_env:%s} by {hostname} <= 7", var.env)}"
+  query = "${format("min(last_4h):min:cdn.tls.certificates.expiry{deploy_env:%s} by {hostname} <= 7", var.env)}"
 
   require_full_window = false
 
   thresholds {
     warning  = 21
     critical = 7
+  }
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors"]
+}
+
+resource "datadog_monitor" "cdn_tls_cert_validity" {
+  name              = "${format("%s CloudFront TLS/SSL Certificate validity", var.env)}"
+  type              = "metric alert"
+  message           = "${format("A high number of CloudFront certificates are invalid.\n\nSee [Team Manual > Responding to alerts > Invalid Certificates](%s#invalid-certificates) for more info.", var.datadog_documentation_url)}"
+  notify_no_data    = true
+  no_data_timeframe = 480
+
+  query = "${format("min(last_4h):min:cdn.tls.certificates.validity{deploy_env:%s}.rollup(avg) <= 0.5", var.env)}"
+
+  require_full_window = false
+
+  thresholds {
+    warning  = 0.75
+    critical = 0.5
   }
 
   tags = ["deployment:${var.env}", "service:${var.env}_monitors"]

--- a/tools/metrics/gauges_tls.go
+++ b/tools/metrics/gauges_tls.go
@@ -62,14 +62,27 @@ func CDNTLSValidityGauge(logger lager.Logger, certChecker tlscheck.CertChecker, 
 					"alias_domain":      customDomain.AliasDomain,
 					"cloudfront_domain": customDomain.CloudFrontDomain,
 				})
-				continue
+			}
+
+			var validity int
+			if err == nil {
+				validity = 1
+				metrics = append(metrics, Metric{
+					Kind:  Gauge,
+					Time:  time.Now(),
+					Name:  "cdn.tls.certificates.expiry",
+					Value: daysUntilExpiry,
+					Tags: []string{
+						fmt.Sprintf("hostname:%s", customDomain.AliasDomain),
+					},
+				})
 			}
 
 			metrics = append(metrics, Metric{
 				Kind:  Gauge,
 				Time:  time.Now(),
 				Name:  "cdn.tls.certificates.validity",
-				Value: daysUntilExpiry,
+				Value: float64(validity),
 				Tags: []string{
 					fmt.Sprintf("hostname:%s", customDomain.AliasDomain),
 				},

--- a/tools/metrics/gauges_tls.go
+++ b/tools/metrics/gauges_tls.go
@@ -62,7 +62,7 @@ func CDNTLSValidityGauge(logger lager.Logger, certChecker tlscheck.CertChecker, 
 					"alias_domain":      customDomain.AliasDomain,
 					"cloudfront_domain": customDomain.CloudFrontDomain,
 				})
-				return err
+				continue
 			}
 
 			metrics = append(metrics, Metric{

--- a/tools/metrics/metrics_test.go
+++ b/tools/metrics/metrics_test.go
@@ -57,7 +57,7 @@ func TestMetricBuffer(t *testing.T) {
 				t.Fatal(err)
 			}
 			if m.Value != metrics[i].Value {
-				t.Fatalf("expected metric.Value to be %d got %d", metrics[i].Value, m.Value)
+				t.Fatalf("expected metric.Value to be %f got %f", metrics[i].Value, m.Value)
 			}
 		})
 	}
@@ -102,7 +102,7 @@ func TestMetricPoller(t *testing.T) {
 			}
 		}
 		if len(metrics) > 11 || len(metrics) < 9 {
-			t.Fatal("expected to collect roughly ~10 metrics over ~1 second got %v", len(metrics))
+			t.Fatalf("expected to collect roughly ~10 metrics over ~1 second got %d", len(metrics))
 		}
 	})
 	t.Run("close should end polling", func(t *testing.T) {

--- a/tools/metrics/tlscheck/tls_test.go
+++ b/tools/metrics/tlscheck/tls_test.go
@@ -30,28 +30,24 @@ var _ = Describe("TLSCheck", func() {
 			Expect(daysUntilExpiry).To(Equal(float64(0)))
 		})
 
-		It("returns 0 for certificate with incorrect common name", func() {
-			daysUntilExpiry, err := checker.DaysUntilExpiry("wrong.host.badssl.com:443", &tls.Config{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(daysUntilExpiry).To(Equal(float64(0)))
+		It("returns error for certificate with incorrect common name", func() {
+			_, err := checker.DaysUntilExpiry("wrong.host.badssl.com:443", &tls.Config{})
+			Expect(err).To(HaveOccurred())
 		})
 
-		It("returns 0 for certificate with untrusted root CA", func() {
-			daysUntilExpiry, err := checker.DaysUntilExpiry("untrusted-root.badssl.com:443", &tls.Config{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(daysUntilExpiry).To(Equal(float64(0)))
+		It("returns error for certificate with untrusted root CA", func() {
+			_, err := checker.DaysUntilExpiry("untrusted-root.badssl.com:443", &tls.Config{})
+			Expect(err).To(HaveOccurred())
 		})
 
-		It("returns 0 for certificate with self-signed CA", func() {
-			daysUntilExpiry, err := checker.DaysUntilExpiry("self-signed.badssl.com:443", &tls.Config{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(daysUntilExpiry).To(Equal(float64(0)))
+		It("returns error for certificate with self-signed CA", func() {
+			_, err := checker.DaysUntilExpiry("self-signed.badssl.com:443", &tls.Config{})
+			Expect(err).To(HaveOccurred())
 		})
 
-		It("returns 0 for certificate with null cipher suite", func() {
-			daysUntilExpiry, err := checker.DaysUntilExpiry("null.badssl.com:443", &tls.Config{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(daysUntilExpiry).To(Equal(float64(0)))
+		It("returns error for certificate with null cipher suite", func() {
+			_, err := checker.DaysUntilExpiry("null.badssl.com:443", &tls.Config{})
+			Expect(err).To(HaveOccurred())
 		})
 
 		It("returns err when cannot connect", func() {


### PR DESCRIPTION
## What

We'll report expiry and validity metrics separately.

Also don't stop reporting domain metrics when any of the domain TLS check fails.

When any of the domain TLS check has an error we just log it and continue with the next one.
Also we changed the DaysUntilExpiry method so it always returns an error when a certificate has a non-expiry related issues.

We only want to be alerted when correctly set up domains are near expiry.

When tenants don't set up DNS for their domain, or point it to the wrong domain we shouldn't get an alert.

Separate monitors to check expiry and validity.

## How to review

For the metrics reporter I think a code review should be enough.

Deploy CF from this branch and with Datadog enabled and check the new monitors (it's quicker if you set ENABLED_DATADOG to true in the datadog-terraform-apply job temporarily).

## Who can review

Not me.
