### PR TITLE
[#157470481] Bump paas-billing to v0.28.0

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -342,7 +342,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-billing
-      tag_filter: v0.27.0
+      tag_filter: v0.28.0
 
   - name: paas-accounts
     type: git


### PR DESCRIPTION
What
----

New plans have been added to paas-billing for the new plans that were
added to the cf marketplace offering.

This bumps paas-billing to latest version.

How to review
-------------

Code review should suffice

Who can review
--------------

Not @chrisfarms
