### PR TITLE
[#157047494] Migrate away from runtime config

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1123,13 +1123,6 @@ jobs:
               - name: paas-cf
             outputs:
               - name: environment-variables
-            params:
-              APPS_DNS_ZONE_NAME: ((apps_dns_zone_name))
-              SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
-              DEPLOY_ENV: ((deploy_env))
-              DATADOG_API_KEY: ((datadog_api_key))
-              OAUTH_CLIENT_ID: ((oauth_client_id))
-              OAUTH_CLIENT_SECRET: ((oauth_client_secret))
             run:
               path: sh
               args:
@@ -1138,12 +1131,12 @@ jobs:
                 - |
                   cat <<EOF > environment-variables/environment-variables.yml
                   ---
-                  system_domain: ${SYSTEM_DNS_ZONE_NAME}
-                  app_domain: ${APPS_DNS_ZONE_NAME}
-                  environment: ${DEPLOY_ENV}
-                  datadog_api_key: ${DATADOG_API_KEY}
-                  oauth_client_id: ${OAUTH_CLIENT_ID}
-                  oauth_client_secret: ${OAUTH_CLIENT_SECRET}
+                  system_domain: ((system_dns_zone_name))
+                  app_domain: ((apps_dns_zone_name))
+                  environment: ((deploy_env))
+                  datadog_api_key: ((datadog_api_key))
+                  oauth_client_id: ((oauth_client_id))
+                  oauth_client_secret: ((oauth_client_secret))
                   EOF
 
       - do:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1134,7 +1134,9 @@ jobs:
                   system_domain: ((system_dns_zone_name))
                   app_domain: ((apps_dns_zone_name))
                   environment: ((deploy_env))
+                  aws_account: ((aws_account))
                   datadog_api_key: ((datadog_api_key))
+                  datadog_app_key: ((datadog_app_key))
                   oauth_client_id: ((oauth_client_id))
                   oauth_client_secret: ((oauth_client_secret))
                   EOF

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -116,15 +116,15 @@ bosh_fqdn: bosh.${SYSTEM_DNS_ZONE_NAME}
 disable_cf_acceptance_tests: ${DISABLE_CF_ACCEPTANCE_TESTS:-}
 disable_custom_acceptance_tests: ${DISABLE_CUSTOM_ACCEPTANCE_TESTS:-}
 disable_pipeline_locking: ${DISABLE_PIPELINE_LOCKING:-}
-datadog_api_key: ${datadog_api_key:-}
-datadog_app_key: ${datadog_app_key:-}
+datadog_api_key: "${datadog_api_key:-}"
+datadog_app_key: "${datadog_app_key:-}"
 compose_api_key: ${compose_api_key:-}
 compose_billing_email: ${compose_billing_email:-}
 compose_billing_password: ${compose_billing_password:-}
 enable_datadog: ${ENABLE_DATADOG}
 concourse_atc_password: ${CONCOURSE_ATC_PASSWORD}
-oauth_client_id: ${oauth_client_id:-}
-oauth_client_secret: ${oauth_client_secret:-}
+oauth_client_id: "${oauth_client_id:-}"
+oauth_client_secret: "${oauth_client_secret:-}"
 notify_api_key: ${notify_api_key:-}
 auto_deploy: $([ "${ENABLE_AUTO_DEPLOY:-}" ] && echo "true" || echo "false")
 persistent_environment: ${PERSISTENT_ENVIRONMENT}

--- a/manifests/cf-manifest/operations.d/500-syslog-forwarder.yml
+++ b/manifests/cf-manifest/operations.d/500-syslog-forwarder.yml
@@ -1,0 +1,28 @@
+---
+
+- type: replace
+  path: /releases/-
+  value:
+    name: syslog
+    version: 0.1.3
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/syslog-0.1.3.tgz
+    sha1: d7048c6205929365b7de60c03b6dd16531c29d5d
+
+- type: replace
+  path: /addons/-
+  value:
+    name: syslog_forwarder
+    jobs:
+      - name: syslog_forwarder
+        release: syslog
+        properties:
+          syslog:
+            address: logsearch-ingestor.((system_domain))
+            port: 6514
+            transport: 'tcp'
+            tls_enabled: true
+            permitted_peer: "*.((system_domain))"
+            custom_rule: |
+              $MaxMessageSize 64k
+              if ($programname startswith "vcap.") then ~
+            use_tcp_for_file_forwarding_local_transport: true

--- a/manifests/cf-manifest/operations/datadog.yml
+++ b/manifests/cf-manifest/operations/datadog.yml
@@ -3,6 +3,42 @@
 - type: replace
   path: /releases/-
   value:
+    name: datadog-agent
+    version: 0.1.5
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-agent-0.1.5.tgz
+    sha1: 573bed2ab7960eb97dafff4b7c6111e7ad72b39c
+
+- type: replace
+  path: /addons/-
+  value:
+    name: datadog-agent
+    jobs:
+    - name: datadog-agent
+      release: datadog-agent
+    properties:
+      enabled: true
+      api_key: ((datadog_api_key))
+      application_key: ((datadog_app_key))
+      use_dogstatsd: false
+      include_bosh_tags: true
+      tags:
+        aws_account: ((aws_account))
+        deploy_env: ((terraform_outputs_environment))
+      integrations:
+        process:
+          init_config:
+          instances:
+            - name: btrfs
+              search_string: ["btrfs"]
+        dns_check:
+          init_config:
+          instances:
+            - name: Canary
+              hostname: __canary.((system_domain))
+
+- type: replace
+  path: /releases/-
+  value:
     name: datadog-firehose-nozzle
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/datadog-firehose-nozzle-release?v=51
     version: "51"

--- a/manifests/cf-manifest/scripts/generate-manifest.sh
+++ b/manifests/cf-manifest/scripts/generate-manifest.sh
@@ -8,7 +8,7 @@ WORKDIR=${WORKDIR:-.}
 
 datadog_opsfile=${PAAS_CF_DIR}/manifests/cf-manifest/operations/noop.yml
 if [ "${ENABLE_DATADOG}" = "true" ] ; then
-  datadog_opsfile="${PAAS_CF_DIR}/manifests/cf-manifest/operations/datadog-add-nozzle.yml"
+  datadog_opsfile="${PAAS_CF_DIR}/manifests/cf-manifest/operations/datadog.yml"
 fi
 
 oauth_opsfile=${PAAS_CF_DIR}/manifests/cf-manifest/operations/noop.yml

--- a/manifests/cf-manifest/spec/manifest/datadog_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/datadog_spec.rb
@@ -1,10 +1,13 @@
 RSpec.describe "Datadog" do
-  let(:properties) { manifest.fetch("instance_groups.uaa.jobs.uaa.properties") }
-
   describe "when Datadog is disabled" do
     let(:manifest) { manifest_with_defaults }
-    it "should not have the datadog release" do
+    it "should not have the datadog releases" do
+      expect(manifest.fetch('releases.datadog-agent', 'not_found')).to eq 'not_found'
       expect(manifest.fetch('releases.datadog-firehose-nozzle', 'not_found')).to eq 'not_found'
+    end
+
+    it "should not have the datadog-agent addon" do
+      expect(manifest.fetch('addons.datadog-agent', 'not_found')).to eq 'not_found'
     end
 
     it "should not have nozzle instance group" do
@@ -20,7 +23,12 @@ RSpec.describe "Datadog" do
   describe "when Datadog is enabled" do
     let(:manifest) { manifest_with_datadog_enabled }
     it "should have the datadog release" do
+      expect(manifest.fetch('releases.datadog-agent', 'not_found')).to_not eq 'not_found'
       expect(manifest.fetch('releases.datadog-firehose-nozzle', 'not_found')).to_not eq 'not_found'
+    end
+
+    it "should have the datadog-agent addon" do
+      expect(manifest.fetch('addons.datadog-agent', 'not_found')).to_not eq 'not_found'
     end
 
     it "should have nozzle instance group" do

--- a/manifests/cf-manifest/spec/manifest/syslog_forwarder_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/syslog_forwarder_spec.rb
@@ -1,0 +1,14 @@
+
+RSpec.describe "syslog forwarder config" do
+  let(:manifest) { manifest_with_defaults }
+  let(:syslog_addon) { manifest.fetch('addons').find { |a| a['name'] == 'syslog_forwarder' } }
+  let(:syslog_properties) { syslog_addon.fetch('jobs').find { |j| j['name'] == 'syslog_forwarder' }.fetch('properties') }
+
+  it "adds the syslog_forwarder addon" do
+    expect(syslog_addon).to be
+  end
+
+  it "configures the addon properties" do
+    expect(syslog_properties['syslog']['address']).to eq("logsearch-ingestor.unit-test.dev.paas.example.com")
+  end
+end

--- a/manifests/cf-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/cf-manifest/spec/support/manifest_helpers.rb
@@ -91,6 +91,7 @@ module ManifestHelpers
     attr_accessor :workdir
     attr_accessor :manifest_with_defaults
     attr_accessor :manifest_without_vars_store
+    attr_accessor :manifest_with_datadog_enabled
     attr_accessor :cf_deployment_manifest
     attr_accessor :cloud_config_with_defaults
     attr_accessor :terraform_fixture
@@ -117,7 +118,8 @@ module ManifestHelpers
   end
 
   def manifest_with_datadog_enabled
-    render_manifest_with_vars_store("default", "true", "true", nil)
+    Cache.instance.manifest_with_datadog_enabled ||= \
+      render_manifest_with_vars_store("default", "true", "true", nil)
   end
 
   def manifest_with_enable_user_creation

--- a/manifests/shared/spec/fixtures/environment-variables.yml
+++ b/manifests/shared/spec/fixtures/environment-variables.yml
@@ -2,6 +2,8 @@
 system_domain: unit-test.dev.paas.example.com
 app_domain: unit-test.dev-apps.paas.example.com
 environment: unit-test
+aws_account: dev
 datadog_api_key: abcd1234
+datadog_app_key: abcd1234
 oauth_client_id: abcd1234
 oauth_client_secret: abcd1234


### PR DESCRIPTION
What
----

This is the companion PR to alphagov/paas-bootstrap#166.

We want to move away from using runtime-config to reduce the coupling between this repo and paas-bootstrap.

This adds the configure that used to be provided by the runtime config to the CF manifest.

How to review
-------------

* Deploy alphagov/paas-bootstrap#166
* Deploy CF from this branch with Datadog enabled.
* Verify that metrics still appear in Datadog
* Verify that logs are still shipped to logsearch.

## :rotating_light: Notes on merging :rotating_light: 

This needs to be coordinated with alphagov/paas-bootstrap#166 when merging and applying. This needs to be deployed immediately after alphagov/paas-bootstrap#166 has been deployed to avoid a gap in metrics to Datadog.

Who can review
--------------

Not me