### PR TITLE
[#157965597] Upgrade cf-deployment and loggregator

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -3403,7 +3403,7 @@ jobs:
         - get: deployed-healthcheck
         - get: cf-smoke-tests-release
         - get: paas-cf
-          passed: ['post-deploy']
+          passed: ['pipeline-lock']
         - get: cf-manifest
           passed: ['post-deploy']
         - get: cf-secrets

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -267,12 +267,8 @@ resources:
   - name: cf-acceptance-tests
     type: git
     source:
-      #FIXME: We have forked the acceptance tests due to:
-      # https://github.com/cloudfoundry/cf-acceptance-tests/pull/290
-      # Remove this once we are using a version of the acceptance
-      # tests that include the above fix.
-      uri: https://github.com/alphagov/paas-cf-acceptance-tests/
-      branch: cf1.28-allow-http-redirect
+      uri: https://github.com/cloudfoundry/cf-acceptance-tests
+      branch: cf1.38
 
   - name: cf-smoke-tests
     type: git

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -270,11 +270,13 @@ resources:
       uri: https://github.com/cloudfoundry/cf-acceptance-tests
       branch: cf1.38
 
-  - name: cf-smoke-tests
+  - name: cf-smoke-tests-release
     type: git
     source:
-      uri: https://github.com/alphagov/paas-cf-smoke-tests
-      branch: gds-cf-deployment-v1.28.0
+      uri: https://github.com/cloudfoundry/cf-smoke-tests-release
+      tag_filter: "40.0.5"
+      submodules:
+      - "src/smoke_tests"
 
   - name: git-keys
     type: s3-iam
@@ -2653,7 +2655,7 @@ jobs:
           - get: pipeline-trigger
             passed: ['post-deploy','app-availability-tests','api-availability-tests']
             trigger: true
-          - get: cf-smoke-tests
+          - get: cf-smoke-tests-release
           - get: paas-cf
             passed: ['post-deploy','app-availability-tests','api-availability-tests']
           - get: cf-manifest
@@ -3399,7 +3401,7 @@ jobs:
         - get: smoke-tests-timer
           trigger: true
         - get: deployed-healthcheck
-        - get: cf-smoke-tests
+        - get: cf-smoke-tests-release
         - get: paas-cf
           passed: ['post-deploy']
         - get: cf-manifest

--- a/concourse/tasks/smoke-tests-run.yml
+++ b/concourse/tasks/smoke-tests-run.yml
@@ -7,7 +7,7 @@ image_resource:
     tag: 4aff7d1fd0fa27ff9910a77b39cbcaedb4455f0c
 inputs:
   - name: paas-cf
-  - name: cf-smoke-tests
+  - name: cf-smoke-tests-release
   - name: test-config
 outputs:
   - name: artifacts

--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -8,4 +8,4 @@
       version: "3468.42"
     - alias: default
       os: ubuntu-trusty
-      version: "3541.26"
+      version: "3586.16"

--- a/manifests/cf-manifest/operations.d/240-cf-upgrade-garden-runc.yml
+++ b/manifests/cf-manifest/operations.d/240-cf-upgrade-garden-runc.yml
@@ -1,9 +1,0 @@
----
-
-- type: replace
-  path: /releases/name=garden-runc
-  value:
-    name: garden-runc
-    url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.13.3
-    version: 1.13.3
-    sha1: 8868157d567c0e51eb19d3ccadeed951c7616975

--- a/manifests/cf-manifest/operations.d/240-cf-upgrade-loggregator.yml
+++ b/manifests/cf-manifest/operations.d/240-cf-upgrade-loggregator.yml
@@ -1,0 +1,9 @@
+---
+
+- type: replace
+  path: /releases/name=loggregator
+  value:
+    name: loggregator
+    url: "https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=102.2"
+    version: "102.2"
+    sha1: "1ff4ad235be2720ed119cbb775f6ffdb712e53ea"

--- a/platform-tests/upstream/run_smoke_tests.sh
+++ b/platform-tests/upstream/run_smoke_tests.sh
@@ -8,7 +8,7 @@ CONFIG="$(pwd)/test-config/config.json"
 echo "Linking smoke-tests directory inside $GOPATH"
 CF_GOPATH=/go/src/github.com/cloudfoundry
 mkdir -p $CF_GOPATH
-ln -s "$(pwd)/cf-smoke-tests" "${CF_GOPATH}/cf-smoke-tests"
+ln -s "$(pwd)/cf-smoke-tests-release/src/smoke_tests" "${CF_GOPATH}/cf-smoke-tests"
 
 echo "Linking test artifacts directory"
 ln -s "$(pwd)/artifacts" /tmp/artifacts


### PR DESCRIPTION
What
----

- We've upgraded to cf-deployment v1.38.0
- We've upgraded to the latest loggregator release to resolve multiple CVEs (see commit).

How to review
-------------

We've deployed this a couple of times to dev environments. You can do so too if you want, however it probably isn't necessary and you can just eyeball the changes and lean on staging.

Who can review
--------------

Not me. Not Henry.
