### PR TITLE
[#157084165] Add RDS broker metrics collector

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -49,9 +49,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 0.1.27
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.27.tgz
-    sha1: 17c6ae4825225292c24760ac8ec47f104fe986ed
+    version: 0.1.28
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.28.tgz
+    sha1: 1398e27b7e55a0bcc59be4b40586def21fa4ba19
 
 - type: replace
   path: /instance_groups/-

--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -54,12 +54,6 @@
     sha1: 17c6ae4825225292c24760ac8ec47f104fe986ed
 
 - type: replace
-  path: /addons/name=metron_agent/exclude/jobs/-
-  value:
-    name: rds-broker
-    release: rds-broker
-
-- type: replace
   path: /instance_groups/-
   value:
     name: rds_broker

--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -76,6 +76,16 @@
             broker_name: "((terraform_outputs_environment))"
             cron_schedule: "0 0 * * *"
             keep_snapshots_for_days: 35
+      - name: rds-metric-collector
+        release: rds-broker
+        properties:
+          rds-metric-collector:
+            aws:
+              aws_region: "((terraform_outputs_region))"
+            rds-broker:
+              broker_name: "((terraform_outputs_environment))"
+              db_prefix: "rdsbroker"
+              master_password_seed: ((secrets_rds_broker_master_password_seed))
       - name: rds-broker
         release: rds-broker
         properties:

--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -735,3 +735,13 @@
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/default_staging_security_groups/-
   value: rds_broker_instances
+
+- type: replace
+  path: /instance_groups/name=rds_broker/jobs/0:before
+  value:
+    name: consul_agent
+    release: consul
+    consumes:
+      consul_common: {from: consul_common_link}
+      consul_server: nil
+      consul_client: {from: consul_client_link}


### PR DESCRIPTION
What
----

We want to install the [paas-rds-metrics-collector](https://github.com/alphagov/paas-rds-metric-collector/)
to get metrics from the tenant's RDS instances created by the [RDS broker](https://github.com/alphagov/paas-rds-broker)
into loggregator.

The user can then consume them using loggregator, or, probably, the
log-cache service added in https://github.com/alphagov/paas-cf/pull/1371

Dependencies
------------

Review with:

 - https://github.com/alphagov/paas-rds-metric-collector/pull/1
 - https://github.com/alphagov/paas-rds-broker-boshrelease/pull/58


How to review
-------------

 - Code review
 - Deploy the instance
 - Create a RDS instance (or use the billing one for instance) and get
 the guid with `cf service <name> --guid`
 - Install the log-cache-cli plugin (see below)
 - Query metrics from the service with `cf tail <guid>`.
   - Only users with permissions can see it. Try with admin, other user
   without permissions and one with permissions.
   - you shall see the metrics for connections

Example:

```
$ cf tail 89431d2a-f4a0-40c6-8822-f5a80237eb83
Retrieving logs for source 89431d2a-f4a0-40c6-8822-f5a80237eb83 as admin...

   2018-06-11T09:31:47.16+0100 [89431d2a-f4a0-40c6-8822-f5a80237eb83/0] GAUGE connections:3.000000 conn
   2018-06-11T09:32:13.33+0100 [89431d2a-f4a0-40c6-8822-f5a80237eb83/0] GAUGE connections:3.000000 conn
   2018-06-11T09:32:47.16+0100 [89431d2a-f4a0-40c6-8822-f5a80237eb83/0] GAUGE connections:3.000000 conn
   2018-06-11T09:33:13.33+0100 [89431d2a-f4a0-40c6-8822-f5a80237eb83/0] GAUGE connections:3.000000 conn
   2018-06-11T09:33:47.16+0100 [89431d2a-f4a0-40c6-8822-f5a80237eb83/0] GAUGE connections:3.000000 conn
   2018-06-11T09:34:13.33+0100 [89431d2a-f4a0-40c6-8822-f5a80237eb83/0] GAUGE connections:3.000000 conn
   2018-06-11T09:34:47.16+0100 [89431d2a-f4a0-40c6-8822-f5a80237eb83/0] GAUGE connections:3.000000 conn
   2018-06-11T09:35:13.33+0100 [89431d2a-f4a0-40c6-8822-f5a80237eb83/0] GAUGE connections:3.000000 conn
   2018-06-11T09:35:47.16+0100 [89431d2a-f4a0-40c6-8822-f5a80237eb83/0] GAUGE connections:3.000000 conn
   2018-06-11T09:36:13.33+0100 [89431d2a-f4a0-40c6-8822-f5a80237eb83/0] GAUGE connections:3.000000 conn

```



Test it with the cf log-cache-cli plugin  https://github.com/cloudfoundry/log-cache-cli:

```
go get code.cloudfoundry.org/log-cache-cli/...
go build -o  $GOPATH/bin/log-cache-cli code.cloudfoundry.org/log-cache-cli/cmd/cf-lc-plugin/
cf install-plugin $GOPATH/bin/log-cache-cli
```

Before merge
------------------

Update the WIP commit after the final bosh release is created.

Who can review
--------------

Anyone but @keymon @paroxp or @leeporte