### PR TITLE
[#156721553] Version pin paas-admin

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -355,9 +355,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-admin
-      # FIXME: Use tags once paas-admin has a automated pipeline to
-      # test, release and tag the project.
-      branch: master
+      tag_filter: v0.1.0
 
 jobs:
   - name: pipeline-lock


### PR DESCRIPTION
What
----

We're implementing the version bumping for that application from the
build pipeline. We should fully make use of it in order to avoid any
incompatibilities in the future and run the desired version of the
application across all of our environments.

This does however introduces the inconvenience of the need to come into
this repo, and manually bump the version as we go.

How to review
-------------

- Make sure this version exists in build CI

Dependencies
-------------

This PR is the last one in the chain of PRs.

Before merging, make sure the following are already merged:

- alphagov/paas-admin#61
- alphagov/paas-release-ci#70