### PR TITLE
[#158108798] Upgrade the buildpacks to the latest versions

### DIFF
--- a/manifests/cf-manifest/operations.d/240-cf-set-buildpack-release.yml
+++ b/manifests/cf-manifest/operations.d/240-cf-set-buildpack-release.yml
@@ -4,62 +4,62 @@
   path: /releases/name=binary-buildpack
   value:
     name: binary-buildpack
-    url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.18
-    version: 1.0.18
-    sha1: e903612106b20b6cf969be83dfb2bdd0bb4d9db2
+    url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.19
+    version: 1.0.19
+    sha1: fa71efbd352c11f31ab12b91c7542b8e930ec4b1
 
 - type: replace
   path: /releases/name=go-buildpack
   value:
     name: go-buildpack
-    url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.8.21
-    version: 1.8.21
-    sha1: 7ed54d5d1449c946eead324089e79faadf87a87a
+    url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.8.23
+    version: 1.8.23
+    sha1: 937b84449f7203266f9cb5f44941cc96a2b9d05a
 
 - type: replace
   path: /releases/name=java-buildpack
   value:
     name: java-buildpack
-    url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.10
-    version: "4.10"
-    sha1: 811866eff83751c12e06eef2af4ac33e91d193fd
+    url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.12
+    version: "4.12"
+    sha1: 4932d769feb5987fdd6fcc60c9c132746e14dade
 
 - type: replace
   path: /releases/name=nodejs-buildpack
   value:
     name: nodejs-buildpack
-    url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.6.22
-    version: 1.6.22
-    sha1: 527ca54f9d3fd836a8f689eb0c77b32ea66b98d6
+    url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.6.25
+    version: 1.6.25
+    sha1: 70b7cf1267ef2df2ce5d6bff54ac312e2f441813
 
 - type: replace
   path: /releases/name=php-buildpack
   value:
     name: php-buildpack
-    version: 4.3.53
-    url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.3.53
-    sha1: fd6eaec4090066a0cee8953da8edab58e4e7983a
+    version: 4.3.56
+    url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.3.56
+    sha1: 29db7c0ad6fb939d43dff16af19263a0b534d3a2
 
 - type: replace
   path: /releases/name=python-buildpack
   value:
     name: python-buildpack
-    version: 1.6.14
-    url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.6.14
-    sha1: 8e4f68197f78aa5ef2e5ba4a25b1a80991b8ed27
+    version: 1.6.17
+    url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.6.17
+    sha1: 8dec8296ad14ddbee0a5335e1397644f115037a5
 
 - type: replace
   path: /releases/name=ruby-buildpack
   value:
     name: ruby-buildpack
-    version: 1.7.16
-    url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.7.16
-    sha1: 1ca144320e7fcdb072603a5aa0d224d73237fd87
+    version: 1.7.19
+    url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.7.19
+    sha1: 07d3353f5ab9af26be10790f0a440dee2ae7a643
 
 - type: replace
   path: /releases/name=staticfile-buildpack
   value:
     name: staticfile-buildpack
-    version: 1.4.27
-    url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.4.27
-    sha1: b4abd75f2b34e4eac2ee9814a8405f580c193a07
+    version: 1.4.28
+    url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.4.28
+    sha1: ba9d9e68cf41029e2aec6a6acd3e5d578f6dd298


### PR DESCRIPTION
## What

Upgrade the buildpacks to the latest versions

These versions are the same as in cf-deployment v1.40.0: https://github.com/cloudfoundry/cf-deployment/blob/2118b5d8ac09feed153f6eea552fd561dd6aa999/cf-deployment.yml#L1623

See commit for detailed buildpack changes.

The tenant notification draft is attached to the story: https://www.pivotaltracker.com/story/show/158108798/comments/190615158

❗️ This PR should not be merged before 20th June.

## How to review

Deploy your CF from this branch and make sure all tests pass.

## Who can review

Not me.