### PR TITLE
bumps paas-billing to v0.29

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -341,7 +341,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-billing
-      tag_filter: v0.28.0
+      tag_filter: v0.29.0
 
   - name: paas-accounts
     type: git


### PR DESCRIPTION
What
-----

paas-billing v0.29 fixes issues with compose audit events that predate
the collection of cloudfoundry service_usage_events.

How to review
-------------

Code review

Who can review
--------------

Not @chrisfarms
