### PR TITLE
[#157510099] bump paas-admin to v0.4.0

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -346,7 +346,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-admin
-      tag_filter: v0.3.0
+      tag_filter: v0.4.0
 
 jobs:
   - name: pipeline-lock

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -346,7 +346,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-admin
-      tag_filter: v0.2.0
+      tag_filter: v0.3.0
 
 jobs:
   - name: pipeline-lock


### PR DESCRIPTION
What
----

Bump paas-admin to v0.4.0

 - paas-admin v0.3.0 implements the first version of the pricing calculator
 - v0.4.0 handles not allow remove the latest org manager
How to review
-------------

Code review

Who can review
--------------

Not @chrisfarms
