### PR TITLE
[#157510099] Bump paas-billing to v0.30.0

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -334,7 +334,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-billing
-      tag_filter: v0.29.0
+      tag_filter: v0.30.0
 
   - name: paas-accounts
     type: git


### PR DESCRIPTION


What
----

paas-billing v0.30.0 updates the pricing formulas for Compose-hosted
services to calculate prices based on a fraction of the total cluster
memory usage.

How to review
-------------

Code review

Who can review
--------------

Not @chrisfarms
