### PR TITLE
[bugfix] Fix how SESSION_SECRET for paas-admin is generated

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2199,7 +2199,7 @@ jobs:
                       ACCOUNTS_SECRET: "(( grab secrets_paas_accounts_admin_password ))"
                       NOTIFY_API_KEY: "${NOTIFY_API_KEY}"
                       NOTIFY_WELCOME_TEMPLATE_ID: "${NOTIFY_WELCOME_TEMPLATE_ID}"
-                      SESSION_SECRET: "session-(( grab uaa_clients_paas_admin_secret ))"
+                      SESSION_SECRET: (( concat "session-" uaa_clients_paas_admin_secret ))
                   EOF
 
                   spruce merge \


### PR DESCRIPTION
What
----

We were generating the SESSION_SECRET env var for paas-admin wrong,
so it is always `session-(( grab ...`. This is because we use
spruce interpolation wrong

We fix it as the intention is use the UAA secret of the paas-admin
client.

To deploy this would logout all the users.

How to review
-------------

Code review shall be enough

Who can review
--------------

Anynone but me