### PR TITLE
[#156164640] Create staging and prod London deployments.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ showenv: check-env ## Display environment information
 .PHONY: upload-datadog-secrets
 upload-datadog-secrets: check-env ## Decrypt and upload Datadog credentials to S3
 	$(eval export DATADOG_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
-	$(if ${AWS_ACCOUNT},,$(error Must set environment to staging/prod))
+	$(if ${MAKEFILE_ENV_TARGET},,$(error Must set MAKEFILE_ENV_TARGET))
 	$(if ${DATADOG_PASSWORD_STORE_DIR},,$(error Must pass DATADOG_PASSWORD_STORE_DIR=<path_to_password_store>))
 	$(if $(wildcard ${DATADOG_PASSWORD_STORE_DIR}),,$(error Password store ${DATADOG_PASSWORD_STORE_DIR} does not exist))
 	@scripts/upload-datadog-secrets.sh
@@ -212,7 +212,7 @@ upload-datadog-secrets: check-env ## Decrypt and upload Datadog credentials to S
 .PHONY: upload-compose-secrets
 upload-compose-secrets: check-env ## Decrypt and upload Compose credentials to S3
 	$(eval export COMPOSE_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
-	$(if ${AWS_ACCOUNT},,$(error Must set environment to dev/staging/prod))
+	$(if ${MAKEFILE_ENV_TARGET},,$(error Must set MAKEFILE_ENV_TARGET))
 	$(if ${COMPOSE_PASSWORD_STORE_DIR},,$(error Must pass COMPOSE_PASSWORD_STORE_DIR=<path_to_password_store>))
 	$(if $(wildcard ${COMPOSE_PASSWORD_STORE_DIR}),,$(error Password store ${COMPOSE_PASSWORD_STORE_DIR} does not exist))
 	@scripts/upload-compose-secrets.sh
@@ -220,7 +220,7 @@ upload-compose-secrets: check-env ## Decrypt and upload Compose credentials to S
 .PHONY: upload-google-oauth-secrets
 upload-google-oauth-secrets: check-env ## Decrypt and upload Google Admin Console credentials to S3
 	$(eval export OAUTH_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
-	$(if ${AWS_ACCOUNT},,$(error Must set environment to staging/prod))
+	$(if ${MAKEFILE_ENV_TARGET},,$(error Must set MAKEFILE_ENV_TARGET))
 	$(if ${OAUTH_PASSWORD_STORE_DIR},,$(error Must pass OAUTH_PASSWORD_STORE_DIR=<path_to_password_store>))
 	$(if $(wildcard ${OAUTH_PASSWORD_STORE_DIR}),,$(error Password store ${OAUTH_PASSWORD_STORE_DIR} does not exist))
 	@scripts/upload-google-oauth-secrets.sh
@@ -228,7 +228,7 @@ upload-google-oauth-secrets: check-env ## Decrypt and upload Google Admin Consol
 .PHONY: upload-notify-secrets
 upload-notify-secrets: check-env ## Decrypt and upload Notify Credentials to S3
 	$(eval export NOTIFY_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
-	$(if ${AWS_ACCOUNT},,$(error Must set environment))
+	$(if ${MAKEFILE_ENV_TARGET},,$(error Must set MAKEFILE_ENV_TARGET))
 	$(if ${NOTIFY_PASSWORD_STORE_DIR},,$(error Must pass NOTIFY_PASSWORD_STORE_DIR=<path_to_password_store>))
 	$(if $(wildcard ${NOTIFY_PASSWORD_STORE_DIR}),,$(error Password store ${NOTIFY_PASSWORD_STORE_DIR} does not exist))
 	@scripts/upload-notify-secrets.sh

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ help:
 DEPLOY_ENV_MAX_LENGTH=8
 DEPLOY_ENV_VALID_LENGTH=$(shell if [ $$(printf "%s" $(DEPLOY_ENV) | wc -c) -gt $(DEPLOY_ENV_MAX_LENGTH) ]; then echo ""; else echo "OK"; fi)
 DEPLOY_ENV_VALID_CHARS=$(shell if echo $(DEPLOY_ENV) | grep -q '^[a-zA-Z0-9-]*$$'; then echo "OK"; else echo ""; fi)
-AWS_DEFAULT_REGION ?= eu-west-1
 
 check-env:
 	$(if ${DEPLOY_ENV},,$(error Must pass DEPLOY_ENV=<name>))
@@ -77,12 +76,12 @@ list_merge_keys: ## List all GPG keys allowed to sign merge commits.
 .PHONY: globals
 PASSWORD_STORE_DIR?=${HOME}/.paas-pass
 globals:
-	$(eval export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION})
 	$(eval export PASSWORD_STORE_DIR=${PASSWORD_STORE_DIR})
 	@true
 
 .PHONY: dev
 dev: globals ## Set Environment to DEV
+	$(eval export AWS_DEFAULT_REGION ?= eu-west-1)
 	$(eval export AWS_ACCOUNT=dev)
 	$(eval export PERSISTENT_ENVIRONMENT=false)
 	$(eval export ENABLE_DESTROY=true)
@@ -115,6 +114,7 @@ staging: globals ## Set Environment to Staging
 	$(eval export DEPLOY_ENV=staging)
 	$(eval export TEST_HEAVY_LOAD=true)
 	$(eval export COMPOSE_PASSWORD_STORE_HIGH_DIR?=${HOME}/.paas-pass-high)
+	$(eval export AWS_DEFAULT_REGION=eu-west-1)
 	@true
 
 .PHONY: stg-lon
@@ -132,6 +132,7 @@ stg-lon: globals ## Set Environment to stg-lon
 	$(eval export DEPLOY_ENV=stg-lon)
 	$(eval export TEST_HEAVY_LOAD=true)
 	$(eval export COMPOSE_PASSWORD_STORE_HIGH_DIR?=${HOME}/.paas-pass-high)
+	$(eval export AWS_DEFAULT_REGION=eu-west-2)
 	@true
 
 .PHONY: prod
@@ -149,6 +150,7 @@ prod: globals ## Set Environment to Production
 	$(eval export ENABLE_DATADOG=true)
 	$(eval export DEPLOY_ENV=prod)
 	$(eval export COMPOSE_PASSWORD_STORE_HIGH_DIR?=${HOME}/.paas-pass-high)
+	$(eval export AWS_DEFAULT_REGION=eu-west-1)
 	@true
 
 .PHONY: prod-lon
@@ -166,6 +168,7 @@ prod-lon: globals ## Set Environment to prod-lon
 	$(eval export ENABLE_DATADOG=true)
 	$(eval export DEPLOY_ENV=prod-lon)
 	$(eval export COMPOSE_PASSWORD_STORE_HIGH_DIR?=${HOME}/.paas-pass-high)
+	$(eval export AWS_DEFAULT_REGION=eu-west-2)
 	@true
 
 .PHONY: bosh-cli

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,23 @@ staging: globals ## Set Environment to Staging
 	$(eval export COMPOSE_PASSWORD_STORE_HIGH_DIR?=${HOME}/.paas-pass-high)
 	@true
 
+.PHONY: stg-lon
+stg-lon: globals ## Set Environment to stg-lon
+	$(eval export AWS_ACCOUNT=staging)
+	$(eval export PERSISTENT_ENVIRONMENT=true)
+	$(eval export ENABLE_AUTO_DEPLOY=true)
+	$(eval export OUTPUT_TAG_PREFIX=prod-lon-)
+	$(eval export SYSTEM_DNS_ZONE_NAME=london.staging.cloudpipeline.digital)
+	$(eval export APPS_DNS_ZONE_NAME=london.staging.cloudpipelineapps.digital)
+	$(eval export ALERT_EMAIL_ADDRESS=the-multi-cloud-paas-team+stg-lon@digital.cabinet-office.gov.uk)
+	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS=${ALERT_EMAIL_ADDRESS})
+	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-stg-lon.yml)
+	$(eval export ENABLE_DATADOG=true)
+	$(eval export DEPLOY_ENV=stg-lon)
+	$(eval export TEST_HEAVY_LOAD=true)
+	$(eval export COMPOSE_PASSWORD_STORE_HIGH_DIR?=${HOME}/.paas-pass-high)
+	@true
+
 .PHONY: prod
 prod: globals ## Set Environment to Production
 	$(eval export AWS_ACCOUNT=prod)
@@ -131,6 +148,23 @@ prod: globals ## Set Environment to Production
 	$(eval export DISABLE_CF_ACCEPTANCE_TESTS=true)
 	$(eval export ENABLE_DATADOG=true)
 	$(eval export DEPLOY_ENV=prod)
+	$(eval export COMPOSE_PASSWORD_STORE_HIGH_DIR?=${HOME}/.paas-pass-high)
+	@true
+
+.PHONY: prod-lon
+prod-lon: globals ## Set Environment to prod-lon
+	$(eval export AWS_ACCOUNT=prod)
+	$(eval export PERSISTENT_ENVIRONMENT=true)
+	$(eval export ENABLE_AUTO_DEPLOY=true)
+	$(eval export INPUT_TAG_PREFIX=prod-lon-)
+	$(eval export SYSTEM_DNS_ZONE_NAME=london.cloud.service.gov.uk)
+	$(eval export APPS_DNS_ZONE_NAME=london.cloudapps.digital)
+	$(eval export ALERT_EMAIL_ADDRESS=the-multi-cloud-paas-team+prod-lon@digital.cabinet-office.gov.uk)
+	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS=${ALERT_EMAIL_ADDRESS})
+	$(eval export ENV_SPECIFIC_CF_MANIFEST=cf-prod-lon.yml)
+	$(eval export DISABLE_CF_ACCEPTANCE_TESTS=true)
+	$(eval export ENABLE_DATADOG=true)
+	$(eval export DEPLOY_ENV=prod-lon)
 	$(eval export COMPOSE_PASSWORD_STORE_HIGH_DIR?=${HOME}/.paas-pass-high)
 	@true
 

--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,9 @@ showenv: check-env ## Display environment information
 		--filters 'Name=tag:Name,Values=concourse/*' "Name=key-name,Values=${DEPLOY_ENV}_concourse_key_pair" \
 		--query 'Reservations[].Instances[].PublicIpAddress' --output text)
 
+.PHONY: upload-all-secrets
+upload-all-secrets: upload-datadog-secrets upload-compose-secrets upload-google-oauth-secrets upload-notify-secrets
+
 .PHONY: upload-datadog-secrets
 upload-datadog-secrets: check-env ## Decrypt and upload Datadog credentials to S3
 	$(eval export DATADOG_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ globals:
 dev: globals ## Set Environment to DEV
 	$(eval export AWS_DEFAULT_REGION ?= eu-west-1)
 	$(eval export AWS_ACCOUNT=dev)
+	$(eval export MAKEFILE_ENV_TARGET=dev)
 	$(eval export PERSISTENT_ENVIRONMENT=false)
 	$(eval export ENABLE_DESTROY=true)
 	$(eval export ENABLE_AUTODELETE=true)
@@ -102,6 +103,7 @@ dev: globals ## Set Environment to DEV
 .PHONY: staging
 staging: globals ## Set Environment to Staging
 	$(eval export AWS_ACCOUNT=staging)
+	$(eval export MAKEFILE_ENV_TARGET=staging)
 	$(eval export PERSISTENT_ENVIRONMENT=true)
 	$(eval export ENABLE_AUTO_DEPLOY=true)
 	$(eval export OUTPUT_TAG_PREFIX=prod-)
@@ -120,6 +122,7 @@ staging: globals ## Set Environment to Staging
 .PHONY: stg-lon
 stg-lon: globals ## Set Environment to stg-lon
 	$(eval export AWS_ACCOUNT=staging)
+	$(eval export MAKEFILE_ENV_TARGET=stg-lon)
 	$(eval export PERSISTENT_ENVIRONMENT=true)
 	$(eval export ENABLE_AUTO_DEPLOY=true)
 	$(eval export OUTPUT_TAG_PREFIX=prod-lon-)
@@ -138,6 +141,7 @@ stg-lon: globals ## Set Environment to stg-lon
 .PHONY: prod
 prod: globals ## Set Environment to Production
 	$(eval export AWS_ACCOUNT=prod)
+	$(eval export MAKEFILE_ENV_TARGET=prod)
 	$(eval export PERSISTENT_ENVIRONMENT=true)
 	$(eval export ENABLE_AUTO_DEPLOY=true)
 	$(eval export INPUT_TAG_PREFIX=prod-)
@@ -156,6 +160,7 @@ prod: globals ## Set Environment to Production
 .PHONY: prod-lon
 prod-lon: globals ## Set Environment to prod-lon
 	$(eval export AWS_ACCOUNT=prod)
+	$(eval export MAKEFILE_ENV_TARGET=prod-lon)
 	$(eval export PERSISTENT_ENVIRONMENT=true)
 	$(eval export ENABLE_AUTO_DEPLOY=true)
 	$(eval export INPUT_TAG_PREFIX=prod-lon-)

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -893,7 +893,7 @@ jobs:
               - -e
               - -c
               - |
-                ruby paas-cf/terraform/scripts/generate_vpc_peering_tfvars.rb "paas-cf/terraform/((aws_account)).vpc_peering.json" \
+                ruby paas-cf/terraform/scripts/generate_vpc_peering_tfvars.rb "paas-cf/terraform/((deploy_env)).vpc_peering.json" \
                 > vpc-peering-tfvars/vpc-peers.tfvars
 
                 cat vpc-peering-tfvars/vpc-peers.tfvars
@@ -1080,7 +1080,7 @@ jobs:
                 - -e
                 - -c
                 - |
-                  ruby paas-cf/terraform/scripts/generate_vpc_peering_opsfile.rb "paas-cf/terraform/((aws_account)).vpc_peering.json" \
+                  ruby paas-cf/terraform/scripts/generate_vpc_peering_opsfile.rb "paas-cf/terraform/((deploy_env)).vpc_peering.json" \
                   > vpc-peering-opsfile/vpc-peers.yml
 
                   cat vpc-peering-opsfile/vpc-peers.yml

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -438,7 +438,7 @@ jobs:
           params:
             DEPLOY_ENV: ((deploy_env))
             BRANCH: ((branch_name))
-            AWS_ACCOUNT: ((aws_account))
+            MAKEFILE_ENV_TARGET: ((makefile_env_target))
             AWS_DEFAULT_REGION: ((aws_region))
             SELF_UPDATE_PIPELINE: ((self_update_pipeline))
             PIPELINES_TO_UPDATE: ((pipeline_name))

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1927,7 +1927,7 @@ jobs:
 
                   if ! cf service healthcheck-db > /dev/null; then
                     cf create-service postgres tiny-unencrypted-9.5 healthcheck-db
-                    while ! cf service healthcheck-db | grep -q 'Status: create succeeded'; do
+                    while ! cf service healthcheck-db | grep -q 'create succeeded'; do
                       echo "Waiting for creation of service to complete..."
                       sleep 30
                     done

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -118,7 +118,7 @@ jobs:
           params:
             DEPLOY_ENV: ((deploy_env))
             BRANCH: ((branch_name))
-            AWS_ACCOUNT: ((aws_account))
+            MAKEFILE_ENV_TARGET: ((makefile_env_target))
             AWS_DEFAULT_REGION: ((aws_region))
             SELF_UPDATE_PIPELINE: ((self_update_pipeline))
             PIPELINES_TO_UPDATE: ((pipeline_name))

--- a/concourse/scripts/environment.sh
+++ b/concourse/scripts/environment.sh
@@ -11,8 +11,6 @@ if [ -z "${DEPLOY_ENV}" ]; then
   exit 1
 fi
 
-AWS_ACCOUNT=${AWS_ACCOUNT:-dev}
-
 case $TARGET_CONCOURSE in
   deployer)
     CONCOURSE_URL="${CONCOURSE_URL:-https://deployer.${SYSTEM_DNS_ZONE_NAME}}"

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -93,6 +93,7 @@ pipeline_name: ${pipeline_name}
 enable_destroy: ${ENABLE_DESTROY:-}
 self_update_pipeline: ${SELF_UPDATE_PIPELINE:-true}
 aws_account: ${AWS_ACCOUNT:-dev}
+makefile_env_target: ${MAKEFILE_ENV_TARGET}
 deploy_env: ${DEPLOY_ENV}
 state_bucket: ${state_bucket}
 test_artifacts_bucket: gds-paas-${DEPLOY_ENV}-test-artifacts

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -66,20 +66,20 @@ prepare_environment() {
   if [ "${ENABLE_DATADOG}" = "true" ] ; then
     # shellcheck disable=SC2154
     if [ -z "${datadog_api_key+x}" ] || [ -z "${datadog_app_key+x}" ] ; then
-      echo "Datadog enabled but could not retrieve api or app key. Did you do run \`make dev upload-datadog-secrets\`?"
+      echo "Datadog enabled but could not retrieve api or app key. Did you do run \`make ${MAKEFILE_ENV_TARGET} upload-datadog-secrets\`?"
       exit 1
     fi
   fi
 
   # shellcheck disable=SC2154
   if [ -z "${compose_api_key+x}" ] ; then
-    echo "Could not retrieve access token for Compose. Did you run \`make ${AWS_ACCOUNT} upload-compose-secrets\`?"
+    echo "Could not retrieve access token for Compose. Did you run \`make ${MAKEFILE_ENV_TARGET} upload-compose-secrets\`?"
     exit 1
   fi
 
   # shellcheck disable=SC2154
   if [ -z "${notify_api_key+x}" ] ; then
-    echo "Could not retrieve api key for Notify. Did you run \`make ${AWS_ACCOUNT} upload-notify-secrets\`?"
+    echo "Could not retrieve api key for Notify. Did you run \`make ${MAKEFILE_ENV_TARGET} upload-notify-secrets\`?"
     exit 1
   fi
 

--- a/concourse/scripts/self-update-pipeline.sh
+++ b/concourse/scripts/self-update-pipeline.sh
@@ -2,7 +2,7 @@
 #
 # Required variables are:
 # - DEPLOY_ENV
-# - AWS_ACCOUNT
+# - MAKEFILE_ENV_TARGET
 # - SELF_UPDATE_PIPELINE
 #
 # Optional variables:
@@ -22,5 +22,5 @@ if [ "${SELF_UPDATE_PIPELINE}" != "true" ]; then
 else
   echo "Self update pipeline is enabled. Updating. (set SELF_UPDATE_PIPELINE=false to disable)"
 
-  make -C ./paas-cf "${AWS_ACCOUNT}" pipelines
+  make -C ./paas-cf "${MAKEFILE_ENV_TARGET}" pipelines
 fi

--- a/concourse/scripts/tag_release.sh
+++ b/concourse/scripts/tag_release.sh
@@ -9,7 +9,7 @@ DEPLOY_ENV="${3}"
 INPUT_TAG_PREFIX="${4:-""}"
 
 GIT_EMAIL="the-multi-cloud-paas-team+deployer-ci@digital.cabinet-office.gov.uk"
-GIT_USER="gov-paas-${AWS_ACCOUNT}"
+GIT_USER="gov-paas-${DEPLOY_ENV}"
 GIT_REPO_URL="${GIT_REPO_URL:-git@github.com:alphagov/paas-cf.git}"
 
 echo Configure SSH

--- a/manifests/cf-manifest/env-specific/cf-prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/cf-prod-lon.yml
@@ -1,0 +1,7 @@
+---
+cell_instances: 6
+router_instances: 3
+elasticsearch_master_disk_size: 460800
+elasticsearch_master_instance_type: c4.2xlarge
+parser_instance_type: c4.xlarge
+queue_vm_type: small

--- a/manifests/cf-manifest/env-specific/cf-stg-lon.yml
+++ b/manifests/cf-manifest/env-specific/cf-stg-lon.yml
@@ -1,0 +1,7 @@
+---
+cell_instances: 6
+router_instances: 3
+elasticsearch_master_disk_size: 460800
+elasticsearch_master_instance_type: c4.2xlarge
+parser_instance_type: c4.xlarge
+queue_vm_type: small

--- a/scripts/cf_subshell_scoped_login.sh
+++ b/scripts/cf_subshell_scoped_login.sh
@@ -13,8 +13,14 @@ case $TARGET in
   prod)
     API_URL="https://api.cloud.service.gov.uk"
     ;;
+  prod-lon)
+    API_URL="https://api.london.cloud.service.gov.uk"
+    ;;
   staging)
     API_URL="https://api.staging.cloudpipeline.digital"
+    ;;
+  stg-lon)
+    API_URL="https://api.london.staging.cloudpipeline.digital"
     ;;
   *)
     echo "Unrecognised target '${TARGET}'" 1>&2

--- a/scripts/upload-compose-secrets.sh
+++ b/scripts/upload-compose-secrets.sh
@@ -9,7 +9,7 @@ COMPOSE_BILLING_PASSWORD=$(pass "compose/billing/password")
 if [ -n "${COMPOSE_PASSWORD_STORE_HIGH_DIR:-}" ]; then
   export PASSWORD_STORE_DIR=${COMPOSE_PASSWORD_STORE_HIGH_DIR}
 fi
-COMPOSE_API_KEY=$(pass "compose/${AWS_ACCOUNT}/access_token")
+COMPOSE_API_KEY=$(pass "compose/${MAKEFILE_ENV_TARGET}/access_token")
 
 SECRETS=$(mktemp secrets.yml.XXXXXX)
 trap 'rm  "${SECRETS}"' EXIT

--- a/scripts/upload-datadog-secrets.sh
+++ b/scripts/upload-datadog-secrets.sh
@@ -4,8 +4,8 @@ set -eu
 
 export PASSWORD_STORE_DIR=${DATADOG_PASSWORD_STORE_DIR}
 
-DATADOG_API_KEY=$(pass "datadog/${AWS_ACCOUNT}/datadog_api_key")
-DATADOG_APP_KEY=$(pass "datadog/${AWS_ACCOUNT}/datadog_app_key")
+DATADOG_API_KEY=$(pass "datadog/${MAKEFILE_ENV_TARGET}/datadog_api_key")
+DATADOG_APP_KEY=$(pass "datadog/${MAKEFILE_ENV_TARGET}/datadog_app_key")
 
 SECRETS=$(mktemp secrets.yml.XXXXXX)
 trap 'rm  "${SECRETS}"' EXIT

--- a/scripts/upload-google-oauth-secrets.sh
+++ b/scripts/upload-google-oauth-secrets.sh
@@ -4,8 +4,8 @@ set -eu
 
 export PASSWORD_STORE_DIR=${OAUTH_PASSWORD_STORE_DIR}
 
-OAUTH_CLIENT_ID=$(pass "google/${AWS_ACCOUNT}/oauth/client_id")
-OAUTH_CLIENT_SECRET=$(pass "google/${AWS_ACCOUNT}/oauth/client_secret")
+OAUTH_CLIENT_ID=$(pass "google/${MAKEFILE_ENV_TARGET}/oauth/client_id")
+OAUTH_CLIENT_SECRET=$(pass "google/${MAKEFILE_ENV_TARGET}/oauth/client_secret")
 
 SECRETS=$(mktemp secrets.yml.XXXXXX)
 trap 'rm  "${SECRETS}"' EXIT

--- a/scripts/upload-notify-secrets.sh
+++ b/scripts/upload-notify-secrets.sh
@@ -4,7 +4,7 @@ set -eu -o pipefail
 
 export PASSWORD_STORE_DIR=${NOTIFY_PASSWORD_STORE_DIR}
 
-NOTIFY_API_KEY="$(pass "notify/${AWS_ACCOUNT}/api_key")"
+NOTIFY_API_KEY="$(pass "notify/${MAKEFILE_ENV_TARGET}/api_key")"
 
 aws s3 cp - "s3://gds-paas-${DEPLOY_ENV}-state/notify-secrets.yml" << EOF
 ---


### PR DESCRIPTION
What
----

This adds the targets etc for deploying the staging and prod environments in the London region.

How to review
-------------

As per the paas-bootstrap PR, other than code review, the best way to test this is probably to try deploying the London staging deployment. Given the fiddly nature of this process it's probably best to pair with @henrytk or myself while deploying.

* Perform review steps from https://github.com/alphagov/paas-bootstrap/pull/168 to get a deployer concourse
* checkout this branch
* Load staging AWS keys (if you haven't already)
* Checkout the credstore branches: https://github.com/alphagov/paas-credentials/pull/121 and https://github.com/alphagov/paas-credentials-high/pull/37
* Upload the secrets: `COMPOSE_PASSWORD_STORE_HIGH_DIR=/path/to/paas-credentials-high make stg-lon upload-all-secrets`
* Push the pipelines pinned to this branch: `BRANCH=london make stg-lon pipelines`, the `create-cloudfoundry` pipeline should trigger automatically
* While it's running, trigger the `generate-git-keys` job from the operator tab, and then add the generated ssh public key (included in the job output) to the deploy keys for paas-cf.
* Verify the pipeline runs to completion, and that the deployed environment works.
* Create the Pingdom checks: `make stg-lon pingdom ACTION=apply`

## After merging

* Checkout master
* Point the pipeline back at the master branch again: `make stg-lon pipelines`
* Deploy the `prod-lon` environment as above, except don't point the branch at london when pushing the pipelines.

Who can review
--------------

Not @alext or @henrytk 
