### PR TITLE
[#158386152] Add missing datadog notifications

### DIFF
--- a/terraform/datadog/auctioneer.tf
+++ b/terraform/datadog/auctioneer.tf
@@ -1,7 +1,7 @@
 resource "datadog_monitor" "auctioneer_lock_held_once" {
   name                = "${format("%s auctioneer lock held exactly once (%s)", var.env, element(list("upper", "lower"), count.index))}"
   type                = "query alert"
-  message             = "There is not exactly one auctioneer holding the lock."
+  message             = "${format("There is not exactly one auctioneer holding the lock. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message  = "There is still not exactly one auctioneer holding the lock."
   notify_no_data      = false
   require_full_window = true

--- a/terraform/datadog/auctioneer.tf
+++ b/terraform/datadog/auctioneer.tf
@@ -2,7 +2,6 @@ resource "datadog_monitor" "auctioneer_lock_held_once" {
   name                = "${format("%s auctioneer lock held exactly once (%s)", var.env, element(list("upper", "lower"), count.index))}"
   type                = "query alert"
   message             = "${format("There is not exactly one auctioneer holding the lock. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message  = "There is still not exactly one auctioneer holding the lock."
   notify_no_data      = false
   require_full_window = true
 

--- a/terraform/datadog/aws.tf
+++ b/terraform/datadog/aws.tf
@@ -63,7 +63,7 @@ resource "datadog_monitor" "ec2-cpu-utilisation" {
   name                = "${format("%s EC2 high CPU utilisation", var.env)}"
   type                = "metric alert"
   query               = "${format("avg(last_1h):avg:aws.ec2.cpuutilization{deploy_env:%s,!bosh-job:diego-cell,!bosh-job:elasticsearch_master,!bosh-job:parser} by {bosh-job,bosh-index} > 90", var.env)}"
-  message             = "{{bosh-job.name}}/{{bosh-index.name}} CPU utilisation has been over {{#is_warning}}{{warn_threshold}}{{/is_warning}}{{#is_alert}}{{threshold}}{{/is_alert}}% for 1h"
+  message             = "${format("{{bosh-job.name}}/{{bosh-index.name}} CPU utilisation has been over {{#is_warning}}{{warn_threshold}}{{/is_warning}}{{#is_alert}}{{threshold}}{{/is_alert}}%% for 1h @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   notify_no_data      = false
   require_full_window = false
 
@@ -79,7 +79,7 @@ resource "datadog_monitor" "ec2-cpu-utilisation-es" {
   name                = "${format("%s EC2 high CPU utilisation - ElasticSearch", var.env)}"
   type                = "metric alert"
   query               = "${format("avg(last_1h):avg:aws.ec2.cpuutilization{deploy_env:%s,bosh-job:elasticsearch_master} by {bosh-job,bosh-index} > 95", var.env)}"
-  message             = "{{bosh-job.name}}/{{bosh-index.name}} CPU utilisation has been over {{#is_warning}}{{warn_threshold}}{{/is_warning}}{{#is_alert}}{{threshold}}{{/is_alert}}% for 1h"
+  message             = "${format("{{bosh-job.name}}/{{bosh-index.name}} CPU utilisation has been over {{#is_warning}}{{warn_threshold}}{{/is_warning}}{{#is_alert}}{{threshold}}{{/is_alert}}%% for 1h @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   notify_no_data      = false
   require_full_window = false
 
@@ -95,7 +95,7 @@ resource "datadog_monitor" "elasticache-node-limit" {
   name                = "${format("%s Number of elasticache nodes is close to the limit", var.env)}"
   type                = "metric alert"
   query               = "${format("avg(last_1h):avg:aws.elasticache.node.count{deploy_env:%s} > %d", var.env, (var.aws_limits_elasticache_nodes * 90) / 100)}"
-  message             = "Number of elasticache nodes has been over {{#is_warning}}{{warn_threshold}}{{/is_warning}}{{#is_alert}}{{threshold}}{{/is_alert}}% for 1h"
+  message             = "${format("Number of elasticache nodes has been over {{#is_warning}}{{warn_threshold}}{{/is_warning}}{{#is_alert}}{{threshold}}{{/is_alert}}%% for 1h @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   notify_no_data      = false
   require_full_window = false
 
@@ -111,7 +111,7 @@ resource "datadog_monitor" "elasticache-cache-parameter-groups-limit" {
   name                = "${format("%s Number of elasticache cache parameter groups is close to the limit", var.env)}"
   type                = "metric alert"
   query               = "${format("avg(last_1h):avg:aws.elasticache.cache_parameter_group.count{deploy_env:%s} > %d", var.env, (var.aws_limits_elasticache_cache_parameter_groups * 90) / 100)}"
-  message             = "Number of elasticache cache parameter groups has been over {{#is_warning}}{{warn_threshold}}{{/is_warning}}{{#is_alert}}{{threshold}}{{/is_alert}}% for 1h"
+  message             = "${format("Number of elasticache cache parameter groups has been over {{#is_warning}}{{warn_threshold}}{{/is_warning}}{{#is_alert}}{{threshold}}{{/is_alert}}%% for 1h @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   notify_no_data      = false
   require_full_window = false
 

--- a/terraform/datadog/bbs.tf
+++ b/terraform/datadog/bbs.tf
@@ -2,7 +2,6 @@ resource "datadog_monitor" "bbs_lock_held_once" {
   name                = "${format("%s bbs lock held exactly once (%s)", var.env, element(list("upper", "lower"), count.index))}"
   type                = "query alert"
   message             = "${format("There is not exactly one bbs holding the lock. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message  = "There is still not exactly one bbs holding the lock."
   notify_no_data      = false
   require_full_window = true
 
@@ -27,7 +26,6 @@ resource "datadog_monitor" "bbs_healthy" {
   name                = "${format("%s bbs healthy", var.env)}"
   type                = "query alert"
   message             = "${format("BBS health check failed. Check BBS status immediately. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message  = "BBS health check still failing. Check BBS status immediately."
   notify_no_data      = true
   require_full_window = false
 

--- a/terraform/datadog/bbs.tf
+++ b/terraform/datadog/bbs.tf
@@ -1,7 +1,7 @@
 resource "datadog_monitor" "bbs_lock_held_once" {
   name                = "${format("%s bbs lock held exactly once (%s)", var.env, element(list("upper", "lower"), count.index))}"
   type                = "query alert"
-  message             = "There is not exactly one bbs holding the lock."
+  message             = "${format("There is not exactly one bbs holding the lock. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message  = "There is still not exactly one bbs holding the lock."
   notify_no_data      = false
   require_full_window = true

--- a/terraform/datadog/bosh-jobs.tf
+++ b/terraform/datadog/bosh-jobs.tf
@@ -24,11 +24,6 @@ resource "datadog_monitor" "job_healthy" {
     element(null_resource.parsed_job_instances.*.triggers.job_name, count.index), var.aws_account
   )}"
 
-  escalation_message = "${format(
-    "%s bosh job has still too many unhealthy instances",
-    element(null_resource.parsed_job_instances.*.triggers.job_name, count.index)
-  )}"
-
   no_data_timeframe   = "30"
   require_full_window = true
 

--- a/terraform/datadog/bosh-jobs.tf
+++ b/terraform/datadog/bosh-jobs.tf
@@ -20,8 +20,8 @@ resource "datadog_monitor" "job_healthy" {
   type = "metric alert"
 
   message = "${format(
-    "%s bosh job has too many unhealthy instances",
-    element(null_resource.parsed_job_instances.*.triggers.job_name, count.index)
+    "%s bosh job has too many unhealthy instances @govpaas-alerting-%s@digital.cabinet-office.gov.uk",
+    element(null_resource.parsed_job_instances.*.triggers.job_name, count.index), var.aws_account
   )}"
 
   escalation_message = "${format(

--- a/terraform/datadog/cdn_broker.tf
+++ b/terraform/datadog/cdn_broker.tf
@@ -2,7 +2,6 @@ resource "datadog_monitor" "cdn_broker_healthy" {
   name                = "${format("%s cdn_broker healthy", var.env)}"
   type                = "service check"
   message             = "${format("Large portion of cdn brokers unhealthy. Check deployment state. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message  = "Large portion of cdn brokers still unhealthy. Check deployment state."
   no_data_timeframe   = "7"
   require_full_window = true
 

--- a/terraform/datadog/cdn_broker.tf
+++ b/terraform/datadog/cdn_broker.tf
@@ -1,7 +1,7 @@
 resource "datadog_monitor" "cdn_broker_healthy" {
   name                = "${format("%s cdn_broker healthy", var.env)}"
   type                = "service check"
-  message             = "Large portion of cdn brokers unhealthy. Check deployment state."
+  message             = "${format("Large portion of cdn brokers unhealthy. Check deployment state. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message  = "Large portion of cdn brokers still unhealthy. Check deployment state."
   no_data_timeframe   = "7"
   require_full_window = true

--- a/terraform/datadog/cell.tf
+++ b/terraform/datadog/cell.tf
@@ -37,7 +37,7 @@ resource "datadog_monitor" "cell-idle-cpu" {
 resource "datadog_monitor" "rep_process_running" {
   name                = "${format("%s Cell rep process running", var.env)}"
   type                = "service check"
-  message             = "Cell rep process not running."
+  message             = "${format("Cell rep process not running. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message  = "Cell rep process still not running."
   notify_no_data      = false
   require_full_window = true
@@ -92,7 +92,7 @@ resource "datadog_monitor" "rep-memory-capacity" {
 resource "datadog_monitor" "garden_process_running" {
   name                = "${format("%s Cell garden process running", var.env)}"
   type                = "service check"
-  message             = "Cell garden process not running."
+  message             = "${format("Cell garden process not running. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message  = "Cell garden process still not running."
   notify_no_data      = false
   require_full_window = true

--- a/terraform/datadog/cell.tf
+++ b/terraform/datadog/cell.tf
@@ -1,10 +1,9 @@
 resource "datadog_monitor" "cell-available-memory" {
-  name               = "${format("%s cell available memory", var.env)}"
-  type               = "query alert"
-  message            = "${format("Less than {{threshold}}%% memory free on cells. There is only {{value}}%% memory free on average on cells. Review if we need to scale... @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message = "There is only {{value}}% memory free on average on cells. Check the deployment!"
-  no_data_timeframe  = "7"
-  query              = "${format("avg(last_2h):ewma_5(avg:system.mem.pct_usable{bosh-job:diego-cell,deploy_env:%s}) * 100 < 50", var.env)}"
+  name              = "${format("%s cell available memory", var.env)}"
+  type              = "query alert"
+  message           = "${format("Less than {{threshold}}%% memory free on cells. There is only {{value}}%% memory free on average on cells. Review if we need to scale... @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
+  no_data_timeframe = "7"
+  query             = "${format("avg(last_2h):ewma_5(avg:system.mem.pct_usable{bosh-job:diego-cell,deploy_env:%s}) * 100 < 50", var.env)}"
 
   thresholds {
     warning  = "55.0"
@@ -17,12 +16,11 @@ resource "datadog_monitor" "cell-available-memory" {
 }
 
 resource "datadog_monitor" "cell-idle-cpu" {
-  name               = "${format("%s cell idle CPU", var.env)}"
-  type               = "query alert"
-  message            = "${format("Less than {{threshold}}%% CPU idle on cells. There is only {{value}}%% CPU idle on average on cells. Review if we need to scale... @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message = "There is only {{value}}% CPU idle on average on cells. Check the deployment!"
-  no_data_timeframe  = "7"
-  query              = "${format("avg(last_1d):ewma_5(avg:system.cpu.idle{deploy_env:%s,bosh-job:diego-cell}) < 33", var.env)}"
+  name              = "${format("%s cell idle CPU", var.env)}"
+  type              = "query alert"
+  message           = "${format("Less than {{threshold}}%% CPU idle on cells. There is only {{value}}%% CPU idle on average on cells. Review if we need to scale... @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
+  no_data_timeframe = "7"
+  query             = "${format("avg(last_1d):ewma_5(avg:system.cpu.idle{deploy_env:%s,bosh-job:diego-cell}) < 33", var.env)}"
 
   thresholds {
     warning  = "37.0"
@@ -38,7 +36,6 @@ resource "datadog_monitor" "rep_process_running" {
   name                = "${format("%s Cell rep process running", var.env)}"
   type                = "service check"
   message             = "${format("Cell rep process not running. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message  = "Cell rep process still not running."
   notify_no_data      = false
   require_full_window = true
 
@@ -54,12 +51,11 @@ resource "datadog_monitor" "rep_process_running" {
 }
 
 resource "datadog_monitor" "rep-container-capacity" {
-  name               = "${format("%s rep container capacity", var.env)}"
-  type               = "query alert"
-  message            = "${format("More than {{threshold}}%% of container capacity across reps is utilised. There is {{value}}%% of container capacity in use. Review if we need to scale... @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message = "There is {{value}}% container capacity in use. Check the deployment!"
-  no_data_timeframe  = "7"
-  query              = "${format("avg(last_2h):( ewma_5(sum:cf.rep.ContainerCount{deployment:%s,job:diego-cell}) / ewma_5(sum:cf.rep.CapacityTotalContainers{deployment:%s,job:diego-cell}) ) * 100 > 80", var.env, var.env)}"
+  name              = "${format("%s rep container capacity", var.env)}"
+  type              = "query alert"
+  message           = "${format("More than {{threshold}}%% of container capacity across reps is utilised. There is {{value}}%% of container capacity in use. Review if we need to scale... @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
+  no_data_timeframe = "7"
+  query             = "${format("avg(last_2h):( ewma_5(sum:cf.rep.ContainerCount{deployment:%s,job:diego-cell}) / ewma_5(sum:cf.rep.CapacityTotalContainers{deployment:%s,job:diego-cell}) ) * 100 > 80", var.env, var.env)}"
 
   thresholds {
     warning  = "75.0"
@@ -72,12 +68,11 @@ resource "datadog_monitor" "rep-container-capacity" {
 }
 
 resource "datadog_monitor" "rep-memory-capacity" {
-  name               = "${format("%s rep advertised memory capacity", var.env)}"
-  type               = "query alert"
-  message            = "${format("Less than {{threshold}}%% of rep advertised memory capacity. There is {{value}}%% of rep advertised remaining memory capacity. Review if we need to scale... @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message = "There is only {{value}}% of rep advertised memory capacity. Check the deployment!"
-  no_data_timeframe  = "7"
-  query              = "${format("avg(last_2h):( ewma_5(sum:cf.rep.CapacityRemainingMemory{deployment:%s,job:diego-cell}) / ewma_5(sum:cf.rep.CapacityTotalMemory{deployment:%s,job:diego-cell}) ) * 100 < 33", var.env, var.env)}"
+  name              = "${format("%s rep advertised memory capacity", var.env)}"
+  type              = "query alert"
+  message           = "${format("Less than {{threshold}}%% of rep advertised memory capacity. There is {{value}}%% of rep advertised remaining memory capacity. Review if we need to scale... @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
+  no_data_timeframe = "7"
+  query             = "${format("avg(last_2h):( ewma_5(sum:cf.rep.CapacityRemainingMemory{deployment:%s,job:diego-cell}) / ewma_5(sum:cf.rep.CapacityTotalMemory{deployment:%s,job:diego-cell}) ) * 100 < 33", var.env, var.env)}"
 
   thresholds {
     warning  = "35.0"
@@ -93,7 +88,6 @@ resource "datadog_monitor" "garden_process_running" {
   name                = "${format("%s Cell garden process running", var.env)}"
   type                = "service check"
   message             = "${format("Cell garden process not running. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message  = "Cell garden process still not running."
   notify_no_data      = false
   require_full_window = true
 

--- a/terraform/datadog/certificates.tf
+++ b/terraform/datadog/certificates.tf
@@ -1,7 +1,7 @@
 resource "datadog_monitor" "invalid_tls_cert" {
   name              = "${format("%s Invalid TLS/SSL Certificate", var.env)}"
   type              = "metric alert"
-  message           = "${format("{{hostname.name}} certificate {{#is_alert}}is invalid!{{/is_alert}}{{#is_warning}}expires in {{value}} days{{/is_warning}}\n\nSee [Team Manual > Responding to alerts > Invalid Certificates](%s#invalid-certificates) for more info.", var.datadog_documentation_url)}"
+  message           = "${format("{{hostname.name}} certificate {{#is_alert}}is invalid!{{/is_alert}}{{#is_warning}}expires in {{value}} days{{/is_warning}}\n\nSee [Team Manual > Responding to alerts > Invalid Certificates](%s#invalid-certificates) for more info. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_documentation_url, var.aws_account)}"
   notify_no_data    = true
   no_data_timeframe = 120
 
@@ -20,7 +20,7 @@ resource "datadog_monitor" "invalid_tls_cert" {
 resource "datadog_monitor" "cdn_tls_cert_expiry" {
   name    = "${format("%s CloudFront TLS/SSL Certificates expiry", var.env)}"
   type    = "metric alert"
-  message = "${format("{{hostname.name}} CloudFront certificate {{#is_alert}}is almost expired!{{/is_alert}}{{#is_warning}}expires in {{value}} days{{/is_warning}}\n\nSee [Team Manual > Responding to alerts > Invalid Certificates](%s#invalid-certificates) for more info.", var.datadog_documentation_url)}"
+  message = "${format("{{hostname.name}} CloudFront certificate {{#is_alert}}is almost expired!{{/is_alert}}{{#is_warning}}expires in {{value}} days{{/is_warning}}\n\nSee [Team Manual > Responding to alerts > Invalid Certificates](%s#invalid-certificates) for more info. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_documentation_url, var.aws_account)}"
 
   query = "${format("min(last_4h):min:cdn.tls.certificates.expiry{deploy_env:%s} by {hostname} <= 7", var.env)}"
 
@@ -37,7 +37,7 @@ resource "datadog_monitor" "cdn_tls_cert_expiry" {
 resource "datadog_monitor" "cdn_tls_cert_validity" {
   name              = "${format("%s CloudFront TLS/SSL Certificate validity", var.env)}"
   type              = "metric alert"
-  message           = "${format("A high number of CloudFront certificates are invalid.\n\nSee [Team Manual > Responding to alerts > Invalid Certificates](%s#invalid-certificates) for more info.", var.datadog_documentation_url)}"
+  message           = "${format("A high number of CloudFront certificates are invalid.\n\nSee [Team Manual > Responding to alerts > Invalid Certificates](%s#invalid-certificates) for more info. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_documentation_url, var.aws_account)}"
   notify_no_data    = true
   no_data_timeframe = 480
 

--- a/terraform/datadog/cloud_controller.tf
+++ b/terraform/datadog/cloud_controller.tf
@@ -1,7 +1,7 @@
 resource "datadog_monitor" "cc_api_master_process_running" {
   name                = "${format("%s Cloud Controller API master process running", var.env)}"
   type                = "service check"
-  message             = "Cloud Controller API master process is not running. Check deployment state."
+  message             = "${format("Cloud Controller API master process is not running. Check deployment state. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message  = "Cloud Controller API master process is still not running. Check deployment state."
   notify_no_data      = false
   require_full_window = true
@@ -20,7 +20,7 @@ resource "datadog_monitor" "cc_api_master_process_running" {
 resource "datadog_monitor" "cc_api_worker_process_running" {
   name                = "${format("%s Cloud Controller API worker process running", var.env)}"
   type                = "service check"
-  message             = "Cloud Controller API worker process is not running. Check deployment state."
+  message             = "${format("Cloud Controller API worker process is not running. Check deployment state. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message  = "Cloud Controller API worker process is still not running. Check deployment state."
   notify_no_data      = false
   require_full_window = true
@@ -39,7 +39,7 @@ resource "datadog_monitor" "cc_api_worker_process_running" {
 resource "datadog_monitor" "cc_api_healthy" {
   name                = "${format("%s Cloud Controller API healthy", var.env)}"
   type                = "service check"
-  message             = "Large portion of Cloud Controller API master unhealthy. Check deployment state."
+  message             = "${format("Large portion of Cloud Controller API master unhealthy. Check deployment state. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message  = "Large portion of Cloud Controller API master still unhealthy. Check deployment state."
   no_data_timeframe   = "7"
   require_full_window = true
@@ -56,7 +56,7 @@ resource "datadog_monitor" "cc_api_healthy" {
 resource "datadog_monitor" "cc_failed_job_count_total_increase" {
   name                = "${format("%s Cloud Controller API failed job count", var.env)}"
   type                = "query alert"
-  message             = "${format("Amount of failed jobs in Cloud Controller API grew considerably. See logsearch: '@source.component:cloud_controller_worker AND @level:ERROR' {{#is_alert}}%s{{/is_alert}}", var.datadog_notification_in_hours)}"
+  message             = "${format("Amount of failed jobs in Cloud Controller API grew considerably. See logsearch: '@source.component:cloud_controller_worker AND @level:ERROR' {{#is_alert}}%s{{/is_alert}} @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_notification_in_hours, var.aws_account)}"
   escalation_message  = "Amount of failed jobs in Cloud Controller API still growing considerably. See logsearch: '@source.component:cloud_controller_worker AND @level:ERROR'"
   require_full_window = false
 
@@ -73,7 +73,7 @@ resource "datadog_monitor" "cc_failed_job_count_total_increase" {
 resource "datadog_monitor" "cc_log_count_error_increase" {
   name               = "${format("%s Cloud Controller API log error count", var.env)}"
   type               = "query alert"
-  message            = "${format("Amount of logged errors in Cloud Controller API grew considerably. See logsearch: '@source.component:cloud_controller_ng AND @level:ERROR' {{#is_alert}}%s{{/is_alert}}", var.datadog_notification_in_hours)}"
+  message            = "${format("Amount of logged errors in Cloud Controller API grew considerably. See logsearch: '@source.component:cloud_controller_ng AND @level:ERROR' {{#is_alert}}%s{{/is_alert}} @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_notification_in_hours, var.aws_account)}"
   escalation_message = "Amount of logged errors in Cloud Controller API still growing considerably. See logsearch: '@source.component:cloud_controller_ng AND @level:ERROR'"
 
   query               = "${format("avg(last_30m):anomalies(sum:cf.cc.log_count.error{deployment:%s}, 'agile', 2, direction='above') >= 0.5", var.env)}"
@@ -85,7 +85,7 @@ resource "datadog_monitor" "cc_log_count_error_increase" {
 resource "datadog_monitor" "cc_job_queue_length" {
   name                = "${format("%s Cloud Controller API job queue length", var.env)}"
   type                = "query alert"
-  message             = "Job queue in Cloud Controller API grew considerably, check the API health."
+  message             = "${format("Job queue in Cloud Controller API grew considerably, check the API health. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message  = "Job queue in Cloud Controller API still too big, check the API health."
   require_full_window = false
 

--- a/terraform/datadog/cloud_controller.tf
+++ b/terraform/datadog/cloud_controller.tf
@@ -2,7 +2,6 @@ resource "datadog_monitor" "cc_api_master_process_running" {
   name                = "${format("%s Cloud Controller API master process running", var.env)}"
   type                = "service check"
   message             = "${format("Cloud Controller API master process is not running. Check deployment state. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message  = "Cloud Controller API master process is still not running. Check deployment state."
   notify_no_data      = false
   require_full_window = true
 
@@ -21,7 +20,6 @@ resource "datadog_monitor" "cc_api_worker_process_running" {
   name                = "${format("%s Cloud Controller API worker process running", var.env)}"
   type                = "service check"
   message             = "${format("Cloud Controller API worker process is not running. Check deployment state. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message  = "Cloud Controller API worker process is still not running. Check deployment state."
   notify_no_data      = false
   require_full_window = true
 
@@ -40,7 +38,6 @@ resource "datadog_monitor" "cc_api_healthy" {
   name                = "${format("%s Cloud Controller API healthy", var.env)}"
   type                = "service check"
   message             = "${format("Large portion of Cloud Controller API master unhealthy. Check deployment state. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message  = "Large portion of Cloud Controller API master still unhealthy. Check deployment state."
   no_data_timeframe   = "7"
   require_full_window = true
 
@@ -57,7 +54,6 @@ resource "datadog_monitor" "cc_failed_job_count_total_increase" {
   name                = "${format("%s Cloud Controller API failed job count", var.env)}"
   type                = "query alert"
   message             = "${format("Amount of failed jobs in Cloud Controller API grew considerably. See logsearch: '@source.component:cloud_controller_worker AND @level:ERROR' {{#is_alert}}%s{{/is_alert}} @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_notification_in_hours, var.aws_account)}"
-  escalation_message  = "Amount of failed jobs in Cloud Controller API still growing considerably. See logsearch: '@source.component:cloud_controller_worker AND @level:ERROR'"
   require_full_window = false
 
   query = "${format("change(max(last_1m),last_30m):max:cf.cc.failed_job_count.total{deployment:%s}.rollup(avg, 30) > 5", var.env)}"
@@ -71,10 +67,9 @@ resource "datadog_monitor" "cc_failed_job_count_total_increase" {
 }
 
 resource "datadog_monitor" "cc_log_count_error_increase" {
-  name               = "${format("%s Cloud Controller API log error count", var.env)}"
-  type               = "query alert"
-  message            = "${format("Amount of logged errors in Cloud Controller API grew considerably. See logsearch: '@source.component:cloud_controller_ng AND @level:ERROR' {{#is_alert}}%s{{/is_alert}} @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_notification_in_hours, var.aws_account)}"
-  escalation_message = "Amount of logged errors in Cloud Controller API still growing considerably. See logsearch: '@source.component:cloud_controller_ng AND @level:ERROR'"
+  name    = "${format("%s Cloud Controller API log error count", var.env)}"
+  type    = "query alert"
+  message = "${format("Amount of logged errors in Cloud Controller API grew considerably. See logsearch: '@source.component:cloud_controller_ng AND @level:ERROR' {{#is_alert}}%s{{/is_alert}} @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_notification_in_hours, var.aws_account)}"
 
   query               = "${format("avg(last_30m):anomalies(sum:cf.cc.log_count.error{deployment:%s}, 'agile', 2, direction='above') >= 0.5", var.env)}"
   require_full_window = true
@@ -86,7 +81,6 @@ resource "datadog_monitor" "cc_job_queue_length" {
   name                = "${format("%s Cloud Controller API job queue length", var.env)}"
   type                = "query alert"
   message             = "${format("Job queue in Cloud Controller API grew considerably, check the API health. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message  = "Job queue in Cloud Controller API still too big, check the API health."
   require_full_window = false
 
   query = "${format("avg(last_30m):max:cf.cc.job_queue_length.total{deployment:%s} > 25", var.env)}"

--- a/terraform/datadog/compose_scraper.tf
+++ b/terraform/datadog/compose_scraper.tf
@@ -1,7 +1,7 @@
 resource "datadog_monitor" "compose_host_ram_in_use" {
   name              = "${format("%s High memory utilisation on a Compose cluster host", var.env)}"
   type              = "metric alert"
-  message           = "Host {{host.name}} in the Compose cluster is using {{value}}% of RAM. As this is above {{#is_alert}}{{threshold}}%{{/is_alert}}{{#is_warning}}{{warn_threshold}}%{{/is_warning}} the cluster may need scaling."
+  message           = "${format("Host {{host.name}} in the Compose cluster is using {{value}}%% of RAM. As this is above {{#is_alert}}{{threshold}}%%{{/is_alert}}{{#is_warning}}{{warn_threshold}}%%{{/is_warning}} the cluster may need scaling. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   no_data_timeframe = "20"
   notify_no_data    = true
   renotify_interval = "20"
@@ -15,7 +15,7 @@ resource "datadog_monitor" "compose_host_ram_in_use" {
 resource "datadog_monitor" "compose_host_disk_in_use" {
   name              = "${format("%s High disk utilisation on a Compose cluster host", var.env)}"
   type              = "metric alert"
-  message           = "Host {{host.name}} in the Compose cluster is using {{value}}% of disk. As this is above {{#is_alert}}{{threshold}}%{{/is_alert}}{{#is_warning}}{{warn_threshold}}%{{/is_warning}} the cluster may need scaling."
+  message           = "${format("Host {{host.name}} in the Compose cluster is using {{value}}%% of disk. As this is above {{#is_alert}}{{threshold}}%%{{/is_alert}}{{#is_warning}}{{warn_threshold}}%%{{/is_warning}} the cluster may need scaling. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   no_data_timeframe = "20"
   notify_no_data    = true
   renotify_interval = "20"

--- a/terraform/datadog/concourse.tf
+++ b/terraform/datadog/concourse.tf
@@ -1,10 +1,9 @@
 resource "datadog_monitor" "concourse-load" {
-  name               = "${format("%s concourse load", var.env)}"
-  type               = "query alert"
-  message            = "${format("Concourse load is too high: {{value}}. Check VM health. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message = "Concourse load still too high: {{value}}."
-  notify_no_data     = false
-  query              = "${format("max(last_1m):max:system.load.1{bosh-job:concourse,deploy_env:%s} > 200", var.env)}"
+  name           = "${format("%s concourse load", var.env)}"
+  type           = "query alert"
+  message        = "${format("Concourse load is too high: {{value}}. Check VM health. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
+  notify_no_data = false
+  query          = "${format("max(last_1m):max:system.load.1{bosh-job:concourse,deploy_env:%s} > 200", var.env)}"
 
   thresholds {
     warning  = "150.0"
@@ -17,12 +16,11 @@ resource "datadog_monitor" "concourse-load" {
 }
 
 resource "datadog_monitor" "continuous-smoketests" {
-  name               = "${format("%s concourse continuous smoketests runtime", var.env)}"
-  type               = "query alert"
-  message            = "${format("Continuous smoketests too slow: {{value}} ms. Check concourse VM health. {{#is_alert}}%s{{/is_alert}} {{#is_warning}}%s{{/is_warning}} {{#is_no_data}}The continuous smoke tests have not reported any metrics for a while. Check concourse status. %s{{/is_no_data}} @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_notification_24x7, var.datadog_notification_in_hours, var.datadog_notification_24x7, var.aws_account)}"
-  escalation_message = "Continuous smoketests still too slow: {{value}} ms."
-  no_data_timeframe  = "20"
-  query              = "${format("max(last_1m):avg:concourse.build.finished{job:continuous-smoke-tests,deploy_env:%s} > 1200000", var.env)}"
+  name              = "${format("%s concourse continuous smoketests runtime", var.env)}"
+  type              = "query alert"
+  message           = "${format("Continuous smoketests too slow: {{value}} ms. Check concourse VM health. {{#is_alert}}%s{{/is_alert}} {{#is_warning}}%s{{/is_warning}} {{#is_no_data}}The continuous smoke tests have not reported any metrics for a while. Check concourse status. %s{{/is_no_data}} @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_notification_24x7, var.datadog_notification_in_hours, var.datadog_notification_24x7, var.aws_account)}"
+  no_data_timeframe = "20"
+  query             = "${format("max(last_1m):avg:concourse.build.finished{job:continuous-smoke-tests,deploy_env:%s} > 1200000", var.env)}"
 
   thresholds {
     warning  = "720000.0"
@@ -35,10 +33,9 @@ resource "datadog_monitor" "continuous-smoketests" {
 }
 
 resource "datadog_monitor" "continuous-smoketests-failures" {
-  name               = "${format("%s concourse continuous smoketests failures", var.env)}"
-  type               = "query alert"
-  escalation_message = "Smoke test failures"
-  query              = "${format("sum(last_15m):count_nonzero(max:concourse.build.finished{build_status:failed,deploy_env:%s,job:continuous-smoke-tests}) >= 3", var.env)}"
+  name  = "${format("%s concourse continuous smoketests failures", var.env)}"
+  type  = "query alert"
+  query = "${format("sum(last_15m):count_nonzero(max:concourse.build.finished{build_status:failed,deploy_env:%s,job:continuous-smoke-tests}) >= 3", var.env)}"
 
   message = "${format("{{#is_alert}}The `continuous-smoke-tests` have been failing for a while now. We need to investigate. Notify: %s{{/is_alert}} @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_notification_24x7, var.aws_account)}"
 
@@ -53,10 +50,9 @@ resource "datadog_monitor" "continuous-smoketests-failures" {
 }
 
 resource "datadog_monitor" "check-certificates-failures" {
-  name               = "${format("%s concourse check certificates failures", var.env)}"
-  type               = "query alert"
-  escalation_message = "Cloud Foundry certificate check failed"
-  query              = "${format("sum(last_1d):count_nonzero(max:concourse.build.finished{build_status:failed,deploy_env:%s,job:check-certificates}) >= 1", var.env)}"
+  name  = "${format("%s concourse check certificates failures", var.env)}"
+  type  = "query alert"
+  query = "${format("sum(last_1d):count_nonzero(max:concourse.build.finished{build_status:failed,deploy_env:%s,job:check-certificates}) >= 1", var.env)}"
 
   message = "${format("{{#is_alert}}Some of the Cloud Foundry certificates might be expiring soon. Check the health/check-certificates job on Concourse.\n\nVisit the [Team Manual > Responding to alerts > Cloud Foundry internal certificates](%s#cloud-foundry-internal-certificates) for more info.{{/is_alert}} @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_documentation_url, var.aws_account)}"
 

--- a/terraform/datadog/concourse.tf
+++ b/terraform/datadog/concourse.tf
@@ -19,7 +19,7 @@ resource "datadog_monitor" "concourse-load" {
 resource "datadog_monitor" "continuous-smoketests" {
   name               = "${format("%s concourse continuous smoketests runtime", var.env)}"
   type               = "query alert"
-  message            = "${format("Continuous smoketests too slow: {{value}} ms. Check concourse VM health. {{#is_alert}}%s{{/is_alert}} {{#is_warning}}%s{{/is_warning}} {{#is_no_data}}The continuous smoke tests have not reported any metrics for a while. Check concourse status. %s{{/is_no_data}}", var.datadog_notification_24x7, var.datadog_notification_in_hours, var.datadog_notification_24x7)}"
+  message            = "${format("Continuous smoketests too slow: {{value}} ms. Check concourse VM health. {{#is_alert}}%s{{/is_alert}} {{#is_warning}}%s{{/is_warning}} {{#is_no_data}}The continuous smoke tests have not reported any metrics for a while. Check concourse status. %s{{/is_no_data}} @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_notification_24x7, var.datadog_notification_in_hours, var.datadog_notification_24x7, var.aws_account)}"
   escalation_message = "Continuous smoketests still too slow: {{value}} ms."
   no_data_timeframe  = "20"
   query              = "${format("max(last_1m):avg:concourse.build.finished{job:continuous-smoke-tests,deploy_env:%s} > 1200000", var.env)}"
@@ -40,7 +40,7 @@ resource "datadog_monitor" "continuous-smoketests-failures" {
   escalation_message = "Smoke test failures"
   query              = "${format("sum(last_15m):count_nonzero(max:concourse.build.finished{build_status:failed,deploy_env:%s,job:continuous-smoke-tests}) >= 3", var.env)}"
 
-  message = "${format("{{#is_alert}}The `continuous-smoke-tests` have been failing for a while now. We need to investigate. Notify: %s{{/is_alert}}", var.datadog_notification_24x7)}"
+  message = "${format("{{#is_alert}}The `continuous-smoke-tests` have been failing for a while now. We need to investigate. Notify: %s{{/is_alert}} @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_notification_24x7, var.aws_account)}"
 
   require_full_window = false
   notify_no_data      = false
@@ -58,7 +58,7 @@ resource "datadog_monitor" "check-certificates-failures" {
   escalation_message = "Cloud Foundry certificate check failed"
   query              = "${format("sum(last_1d):count_nonzero(max:concourse.build.finished{build_status:failed,deploy_env:%s,job:check-certificates}) >= 1", var.env)}"
 
-  message = "${format("{{#is_alert}}Some of the Cloud Foundry certificates might be expiring soon. Check the health/check-certificates job on Concourse.\n\nVisit the [Team Manual > Responding to alerts > Cloud Foundry internal certificates](%s#cloud-foundry-internal-certificates) for more info.{{/is_alert}}", var.datadog_documentation_url)}"
+  message = "${format("{{#is_alert}}Some of the Cloud Foundry certificates might be expiring soon. Check the health/check-certificates job on Concourse.\n\nVisit the [Team Manual > Responding to alerts > Cloud Foundry internal certificates](%s#cloud-foundry-internal-certificates) for more info.{{/is_alert}} @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_documentation_url, var.aws_account)}"
 
   require_full_window = false
   notify_no_data      = true

--- a/terraform/datadog/consul.tf
+++ b/terraform/datadog/consul.tf
@@ -20,7 +20,7 @@ resource "datadog_monitor" "consul" {
 resource "datadog_monitor" "consul_connect_to_port" {
   name                = "${format("%s consul cluster service is accepting connections", var.env)}"
   type                = "service check"
-  message             = "Large portion of consul service are not accepting connections. Check deployment state."
+  message             = "${format("Large portion of consul service are not accepting connections. Check deployment state. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message  = "Large portion of consul service are still not accepting connections. Check deployment state."
   no_data_timeframe   = "7"
   require_full_window = true
@@ -37,7 +37,7 @@ resource "datadog_monitor" "consul_connect_to_port" {
 resource "datadog_monitor" "consul_has_leader" {
   name                = "${format("%s consul cluster has at least one leader", var.env)}"
   type                = "service check"
-  message             = "No consul cluster servers are repoted as leader"
+  message             = "${format("No consul cluster servers are repoted as leader @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message  = "Still no consul cluster servers are repoted as leader. Check deployment state."
   no_data_timeframe   = "7"
   require_full_window = true

--- a/terraform/datadog/consul.tf
+++ b/terraform/datadog/consul.tf
@@ -1,10 +1,9 @@
 resource "datadog_monitor" "consul" {
-  name               = "${format("%s Consul process running", var.env)}"
-  type               = "service check"
-  message            = "${format("Consul process not running on this host in environment {{host.environment}}. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message = "Consul process not running! Check VM state."
-  notify_no_data     = false
-  query              = "${format("'process.up'.over('deploy_env:%s','process:consul').last(6).count_by_status()", var.env)}"
+  name           = "${format("%s Consul process running", var.env)}"
+  type           = "service check"
+  message        = "${format("Consul process not running on this host in environment {{host.environment}}. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
+  notify_no_data = false
+  query          = "${format("'process.up'.over('deploy_env:%s','process:consul').last(6).count_by_status()", var.env)}"
 
   thresholds {
     ok       = 1
@@ -21,7 +20,6 @@ resource "datadog_monitor" "consul_connect_to_port" {
   name                = "${format("%s consul cluster service is accepting connections", var.env)}"
   type                = "service check"
   message             = "${format("Large portion of consul service are not accepting connections. Check deployment state. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message  = "Large portion of consul service are still not accepting connections. Check deployment state."
   no_data_timeframe   = "7"
   require_full_window = true
 
@@ -38,7 +36,6 @@ resource "datadog_monitor" "consul_has_leader" {
   name                = "${format("%s consul cluster has at least one leader", var.env)}"
   type                = "service check"
   message             = "${format("No consul cluster servers are repoted as leader @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message  = "Still no consul cluster servers are repoted as leader. Check deployment state."
   no_data_timeframe   = "7"
   require_full_window = true
 

--- a/terraform/datadog/dns.tf
+++ b/terraform/datadog/dns.tf
@@ -16,7 +16,7 @@ resource "datadog_monitor" "dns_can_resolve" {
 resource "datadog_monitor" "dns_response_time" {
   name                = "${format("%s DNS resolution response time", var.env)}"
   type                = "metric alert"
-  message             = "${format("DNS resolution is slow on {{host.name}} @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
+  message             = "DNS resolution is slow on {{host.name}}"
   notify_no_data      = false
   require_full_window = true
 

--- a/terraform/datadog/dns.tf
+++ b/terraform/datadog/dns.tf
@@ -1,7 +1,7 @@
 resource "datadog_monitor" "dns_can_resolve" {
   name    = "${format("%s DNS resolution working", var.env)}"
   type    = "service check"
-  message = "DNS resolution is failing on {{host.name}}"
+  message = "${format("DNS resolution is failing on {{host.name}} @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
 
   query = "${format("'dns.can_resolve'.over('deploy_env:%s').by('bosh-job','bosh-index').last(4).count_by_status()", var.env)}"
 
@@ -16,7 +16,7 @@ resource "datadog_monitor" "dns_can_resolve" {
 resource "datadog_monitor" "dns_response_time" {
   name                = "${format("%s DNS resolution response time", var.env)}"
   type                = "metric alert"
-  message             = "DNS resolution is slow on {{host.name}}"
+  message             = "${format("DNS resolution is slow on {{host.name}} @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   notify_no_data      = false
   require_full_window = true
 

--- a/terraform/datadog/elb.tf
+++ b/terraform/datadog/elb.tf
@@ -1,7 +1,7 @@
 resource "datadog_monitor" "abnormal_api_latency_cc" {
   name    = "${format("%s Abnormal API Latency - CC", var.env)}"
   type    = "query alert"
-  message = "${format("{{#is_alert}}We're experiencing >= {{threshold}} change in ELB Latency.{{/is_alert}} \n{{#is_warning}}We're experiencing >= {{warn_threshold}} change in ELB Latency.{{/is_warning}} \n\nVisit the [Team Manual > Responding to alerts > API Latency](%s#api-latency) for more info.", var.datadog_documentation_url)}"
+  message = "${format("{{#is_alert}}We're experiencing >= {{threshold}} change in ELB Latency.{{/is_alert}} \n{{#is_warning}}We're experiencing >= {{warn_threshold}} change in ELB Latency.{{/is_warning}} \n\nVisit the [Team Manual > Responding to alerts > API Latency](%s#api-latency) for more info. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_documentation_url, var.aws_account)}"
 
   query = "${format("max(last_1h):avg:aws.elb.latency{name:%s-cf-cc} > 2", var.env)}"
 
@@ -18,7 +18,7 @@ resource "datadog_monitor" "abnormal_api_latency_cc" {
 resource "datadog_monitor" "abnormal_api_latency_doppler" {
   name    = "${format("%s Abnormal API Latency - Doppler", var.env)}"
   type    = "query alert"
-  message = "${format("{{#is_alert}}We're experiencing >= {{threshold}} change in ELB Latency.{{/is_alert}} \n{{#is_warning}}We're experiencing >= {{warn_threshold}} change in ELB Latency.{{/is_warning}} \n\nVisit the [Team Manual > Responding to alerts > API Latency](%s#api-latency) for more info.", var.datadog_documentation_url)}"
+  message = "${format("{{#is_alert}}We're experiencing >= {{threshold}} change in ELB Latency.{{/is_alert}} \n{{#is_warning}}We're experiencing >= {{warn_threshold}} change in ELB Latency.{{/is_warning}} \n\nVisit the [Team Manual > Responding to alerts > API Latency](%s#api-latency) for more info. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_documentation_url, var.aws_account)}"
 
   query = "${format("avg(last_1h):anomalies(avg:aws.elb.latency{name:%s-cf-doppler}, 'basic', 2, direction='above') > 0.3", var.env)}"
 
@@ -35,7 +35,7 @@ resource "datadog_monitor" "abnormal_api_latency_doppler" {
 resource "datadog_monitor" "abnormal_api_latency_uaa" {
   name    = "${format("%s Abnormal API Latency - UAA", var.env)}"
   type    = "query alert"
-  message = "${format("{{#is_alert}}We're experiencing >= {{threshold}} change in ELB Latency.{{/is_alert}} \n{{#is_warning}}We're experiencing >= {{warn_threshold}} change in ELB Latency.{{/is_warning}} \n\nVisit the [Team Manual > Responding to alerts > API Latency](%s#api-latency) for more info.", var.datadog_documentation_url)}"
+  message = "${format("{{#is_alert}}We're experiencing >= {{threshold}} change in ELB Latency.{{/is_alert}} \n{{#is_warning}}We're experiencing >= {{warn_threshold}} change in ELB Latency.{{/is_warning}} \n\nVisit the [Team Manual > Responding to alerts > API Latency](%s#api-latency) for more info. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_documentation_url, var.aws_account)}"
 
   query = "${format("avg(last_1h):anomalies(avg:aws.elb.latency{name:%s-cf-uaa}, 'basic', 2, direction='above') > 0.3", var.env)}"
 
@@ -52,7 +52,7 @@ resource "datadog_monitor" "abnormal_api_latency_uaa" {
 resource "datadog_monitor" "unhealthy_elb_node" {
   name           = "${format("%s At least one ELB node is not responding", var.env)}"
   type           = "metric alert"
-  message        = "${format("Requests to the healthcheck app via {{value}} of the ELB IP addresses failed.\n\nSee [Team Manual > Responding to alerts > Intermittent ELB failures](%s#intermittent-elb-failures) for more info.", var.datadog_documentation_url)}"
+  message        = "${format("Requests to the healthcheck app via {{value}} of the ELB IP addresses failed.\n\nSee [Team Manual > Responding to alerts > Intermittent ELB failures](%s#intermittent-elb-failures) for more info. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_documentation_url, var.aws_account)}"
   notify_no_data = true
 
   query = "${format("min(last_1m):max:aws.elb.unhealthy_node_count{deploy_env:%s} > 0", var.env)}"

--- a/terraform/datadog/general.tf
+++ b/terraform/datadog/general.tf
@@ -1,10 +1,9 @@
 resource "datadog_monitor" "disk-space" {
-  name               = "${format("%s disk space", var.env)}"
-  type               = "query alert"
-  message            = "${format("More than {{threshold}}%% disk used. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message = "There is still {{value}} % disk used. Check the VM!"
-  notify_no_data     = false
-  query              = "${format("max(last_5m):max:system.disk.in_use{deploy_env:%s,!device:/dev/loop0,!device:tmpfs,!device:cgroup,!device:udev,!device:/var/vcap/data/root_log,!device:/var/vcap/data/root_tmp} by {bosh-job,device,bosh-index} * 100 > 85", var.env)}"
+  name           = "${format("%s disk space", var.env)}"
+  type           = "query alert"
+  message        = "${format("More than {{threshold}}%% disk used. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
+  notify_no_data = false
+  query          = "${format("max(last_5m):max:system.disk.in_use{deploy_env:%s,!device:/dev/loop0,!device:tmpfs,!device:cgroup,!device:udev,!device:/var/vcap/data/root_log,!device:/var/vcap/data/root_tmp} by {bosh-job,device,bosh-index} * 100 > 85", var.env)}"
 
   thresholds {
     warning  = "75.0"

--- a/terraform/datadog/ipsec.tf
+++ b/terraform/datadog/ipsec.tf
@@ -1,7 +1,7 @@
 resource "datadog_monitor" "ipsec_daemon_running" {
   name                = "${format("%s racoon ipsec daemon running", var.env)}"
   type                = "service check"
-  message             = "Racoon ipsec daemon not running. Check VM state."
+  message             = "${format("Racoon ipsec daemon not running. Check VM state. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message  = "Racoon ipsec daemon still not running. Check the VM!"
   notify_no_data      = false
   require_full_window = false

--- a/terraform/datadog/ipsec.tf
+++ b/terraform/datadog/ipsec.tf
@@ -2,7 +2,6 @@ resource "datadog_monitor" "ipsec_daemon_running" {
   name                = "${format("%s racoon ipsec daemon running", var.env)}"
   type                = "service check"
   message             = "${format("Racoon ipsec daemon not running. Check VM state. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message  = "Racoon ipsec daemon still not running. Check the VM!"
   notify_no_data      = false
   require_full_window = false
 

--- a/terraform/datadog/nats.tf
+++ b/terraform/datadog/nats.tf
@@ -2,7 +2,6 @@ resource "datadog_monitor" "nats_process_running" {
   name                = "${format("%s NATS process running", var.env)}"
   type                = "service check"
   message             = "${format("nats process not running. Check nats state. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message  = "nats process still not running. Check nats state."
   notify_no_data      = false
   require_full_window = true
 
@@ -21,7 +20,6 @@ resource "datadog_monitor" "nats_service_open" {
   name                = "${format("%s NATS service is accepting connections", var.env)}"
   type                = "service check"
   message             = "${format("Large portion of NATS service are not accepting connections. Check deployment state. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message  = "Large portion of NATS service are still not accepting connections. Check deployment state."
   no_data_timeframe   = "7"
   require_full_window = true
 
@@ -38,7 +36,6 @@ resource "datadog_monitor" "nats_cluster_service_open" {
   name                = "${format("%s NATS cluster service is accepting connections", var.env)}"
   type                = "service check"
   message             = "${format("Large portion of NATS cluster service are not accepting connections. Check deployment state. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message  = "Large portion of NATS cluster service are still not accepting connections. Check deployment state."
   no_data_timeframe   = "7"
   require_full_window = true
 

--- a/terraform/datadog/nats.tf
+++ b/terraform/datadog/nats.tf
@@ -1,7 +1,7 @@
 resource "datadog_monitor" "nats_process_running" {
   name                = "${format("%s NATS process running", var.env)}"
   type                = "service check"
-  message             = "nats process not running. Check nats state."
+  message             = "${format("nats process not running. Check nats state. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message  = "nats process still not running. Check nats state."
   notify_no_data      = false
   require_full_window = true
@@ -20,7 +20,7 @@ resource "datadog_monitor" "nats_process_running" {
 resource "datadog_monitor" "nats_service_open" {
   name                = "${format("%s NATS service is accepting connections", var.env)}"
   type                = "service check"
-  message             = "Large portion of NATS service are not accepting connections. Check deployment state."
+  message             = "${format("Large portion of NATS service are not accepting connections. Check deployment state. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message  = "Large portion of NATS service are still not accepting connections. Check deployment state."
   no_data_timeframe   = "7"
   require_full_window = true
@@ -37,7 +37,7 @@ resource "datadog_monitor" "nats_service_open" {
 resource "datadog_monitor" "nats_cluster_service_open" {
   name                = "${format("%s NATS cluster service is accepting connections", var.env)}"
   type                = "service check"
-  message             = "Large portion of NATS cluster service are not accepting connections. Check deployment state."
+  message             = "${format("Large portion of NATS cluster service are not accepting connections. Check deployment state. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message  = "Large portion of NATS cluster service are still not accepting connections. Check deployment state."
   no_data_timeframe   = "7"
   require_full_window = true

--- a/terraform/datadog/queue.tf
+++ b/terraform/datadog/queue.tf
@@ -2,7 +2,7 @@ resource "datadog_monitor" "queue_logsearch_redis_queue_length" {
   name                = "${format("%s Logsearch Redis queue length", var.env)}"
   type                = "metric alert"
   query               = "${format("max(last_5m):max:redis.key.length{deploy_env:%s,bosh-job:queue,key:logstash} by {host} > 1000000", var.env)}"
-  message             = "${format("Logsearch Redis queue length is over {{#is_warning}}{{warn_threshold}}{{/is_warning}}{{#is_alert}}{{threshold}}, Logsearch started to drop log messages.{{/is_alert}}. See [Team Manual > Responding to alerts > Logsearch/ELK queue threshold limits](%s#logsearchelk-queue-threshold-limits) for more info.", var.datadog_documentation_url)}"
+  message             = "${format("Logsearch Redis queue length is over {{#is_warning}}{{warn_threshold}}{{/is_warning}}{{#is_alert}}{{threshold}}, Logsearch started to drop log messages.{{/is_alert}}. See [Team Manual > Responding to alerts > Logsearch/ELK queue threshold limits](%s#logsearchelk-queue-threshold-limits) for more info. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_documentation_url, var.aws_account)}"
   notify_no_data      = true
   require_full_window = true
 

--- a/terraform/datadog/route-emitter.tf
+++ b/terraform/datadog/route-emitter.tf
@@ -1,7 +1,7 @@
 resource "datadog_monitor" "route_emitter_process_running" {
   name                = "${format("%s route-emitter process running", var.env)}"
   type                = "service check"
-  message             = "route-emitter process not running. Check router state."
+  message             = "${format("route-emitter process not running. Check router state. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message  = "route-emitter rep process still not running. Check router state."
   notify_no_data      = false
   require_full_window = true
@@ -20,7 +20,7 @@ resource "datadog_monitor" "route_emitter_process_running" {
 resource "datadog_monitor" "route_emitter_healthy" {
   name                = "${format("%s route-emitter healthy", var.env)}"
   type                = "service check"
-  message             = "Large portion of route-emitter unhealthy. Check deployment state."
+  message             = "${format("Large portion of route-emitter unhealthy. Check deployment state. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message  = "Large portion of route-emitter still unhealthy. Check deployment state."
   no_data_timeframe   = "7"
   require_full_window = true

--- a/terraform/datadog/route-emitter.tf
+++ b/terraform/datadog/route-emitter.tf
@@ -2,7 +2,6 @@ resource "datadog_monitor" "route_emitter_process_running" {
   name                = "${format("%s route-emitter process running", var.env)}"
   type                = "service check"
   message             = "${format("route-emitter process not running. Check router state. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message  = "route-emitter rep process still not running. Check router state."
   notify_no_data      = false
   require_full_window = true
 
@@ -21,7 +20,6 @@ resource "datadog_monitor" "route_emitter_healthy" {
   name                = "${format("%s route-emitter healthy", var.env)}"
   type                = "service check"
   message             = "${format("Large portion of route-emitter unhealthy. Check deployment state. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message  = "Large portion of route-emitter still unhealthy. Check deployment state."
   no_data_timeframe   = "7"
   require_full_window = true
 

--- a/terraform/datadog/router.tf
+++ b/terraform/datadog/router.tf
@@ -48,7 +48,6 @@ resource "datadog_monitor" "route_update_latency" {
   name                = "${format("%s route update latency", var.env)}"
   type                = "metric alert"
   message             = "${format("Route update latency too high, possibly serving stale routes. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message  = "Route update latency still too high. Check the deployment."
   no_data_timeframe   = "7"
   require_full_window = true
 
@@ -72,7 +71,6 @@ resource "datadog_monitor" "total_routes_drop" {
   name                = "${format("%s total routes difference", var.env)}"
   type                = "query alert"
   message             = "${format("Amount of the routes has decreased considerably, check deployment status. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message  = "Total routes still dropping quickly. Check the deployment."
   no_data_timeframe   = "7"
   require_full_window = true
 
@@ -93,7 +91,6 @@ resource "datadog_monitor" "total_routes_discrepancy" {
   name                = "${format("%s total routes discrepancy", var.env)}"
   type                = "query alert"
   message             = "${format("Discrepancy in the amount of routes on routers. Check deployment status. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message  = "Routers still have considerably different amount of total routes!"
   no_data_timeframe   = "7"
   require_full_window = true
 
@@ -108,7 +105,6 @@ resource "datadog_monitor" "gorouter_process_running" {
   name                = "${format("%s gorouter process running", var.env)}"
   type                = "service check"
   message             = "${format("gorouter process not running. Check router state. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message  = "gorouter process still not running. Check router state."
   notify_no_data      = false
   require_full_window = true
 
@@ -127,7 +123,6 @@ resource "datadog_monitor" "gorouter_healthy" {
   name                = "${format("%s gorouter healthy", var.env)}"
   type                = "service check"
   message             = "${format("Large portion of gorouters unhealthy. Check deployment state. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message  = "Large portion of gorouters still unhealthy. Check deployment state."
   no_data_timeframe   = "7"
   require_full_window = true
 
@@ -144,7 +139,6 @@ resource "datadog_monitor" "gorouter_latency" {
   name                = "${format("%s gorouter latency", var.env)}"
   type                = "metric alert"
   message             = "${format("Gorouter latency too high. See: %s#Gorouter-high-latency-alerts @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_documentation_url, var.aws_account)}"
-  escalation_message  = "Gorouter latency still too high. Check the deployment."
   no_data_timeframe   = "7"
   require_full_window = true
 

--- a/terraform/datadog/router.tf
+++ b/terraform/datadog/router.tf
@@ -47,7 +47,7 @@ resource "datadog_timeboard" "gorouter" {
 resource "datadog_monitor" "route_update_latency" {
   name                = "${format("%s route update latency", var.env)}"
   type                = "metric alert"
-  message             = "Route update latency too high, possibly serving stale routes."
+  message             = "${format("Route update latency too high, possibly serving stale routes. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message  = "Route update latency still too high. Check the deployment."
   no_data_timeframe   = "7"
   require_full_window = true
@@ -71,7 +71,7 @@ variable "datadog_monitor_total_routes_drop_enabled" {
 resource "datadog_monitor" "total_routes_drop" {
   name                = "${format("%s total routes difference", var.env)}"
   type                = "query alert"
-  message             = "Amount of the routes has decreased considerably, check deployment status."
+  message             = "${format("Amount of the routes has decreased considerably, check deployment status. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message  = "Total routes still dropping quickly. Check the deployment."
   no_data_timeframe   = "7"
   require_full_window = true
@@ -92,7 +92,7 @@ resource "datadog_monitor" "total_routes_drop" {
 resource "datadog_monitor" "total_routes_discrepancy" {
   name                = "${format("%s total routes discrepancy", var.env)}"
   type                = "query alert"
-  message             = "Discrepancy in the amount of routes on routers. Check deployment status."
+  message             = "${format("Discrepancy in the amount of routes on routers. Check deployment status. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message  = "Routers still have considerably different amount of total routes!"
   no_data_timeframe   = "7"
   require_full_window = true
@@ -107,7 +107,7 @@ resource "datadog_monitor" "total_routes_discrepancy" {
 resource "datadog_monitor" "gorouter_process_running" {
   name                = "${format("%s gorouter process running", var.env)}"
   type                = "service check"
-  message             = "gorouter process not running. Check router state."
+  message             = "${format("gorouter process not running. Check router state. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message  = "gorouter process still not running. Check router state."
   notify_no_data      = false
   require_full_window = true
@@ -126,7 +126,7 @@ resource "datadog_monitor" "gorouter_process_running" {
 resource "datadog_monitor" "gorouter_healthy" {
   name                = "${format("%s gorouter healthy", var.env)}"
   type                = "service check"
-  message             = "Large portion of gorouters unhealthy. Check deployment state."
+  message             = "${format("Large portion of gorouters unhealthy. Check deployment state. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message  = "Large portion of gorouters still unhealthy. Check deployment state."
   no_data_timeframe   = "7"
   require_full_window = true
@@ -143,7 +143,7 @@ resource "datadog_monitor" "gorouter_healthy" {
 resource "datadog_monitor" "gorouter_latency" {
   name                = "${format("%s gorouter latency", var.env)}"
   type                = "metric alert"
-  message             = "${format("Gorouter latency too high. See: %s#Gorouter-high-latency-alerts", var.datadog_documentation_url)}"
+  message             = "${format("Gorouter latency too high. See: %s#Gorouter-high-latency-alerts @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_documentation_url, var.aws_account)}"
   escalation_message  = "Gorouter latency still too high. Check the deployment."
   no_data_timeframe   = "7"
   require_full_window = true

--- a/terraform/datadog/syslog_drains.tf
+++ b/terraform/datadog/syslog_drains.tf
@@ -1,7 +1,7 @@
 resource "datadog_monitor" "syslog_drains" {
   name                = "${format("%s syslog drains", var.env)}"
   type                = "query alert"
-  message             = "Consider scaling the adapters to cope with the number of syslog drains. See https://github.com/cloudfoundry/cf-syslog-drain-release/tree/v6.4#syslog-adapter"
+  message             = "${format("Consider scaling the adapters to cope with the number of syslog drains. See https://github.com/cloudfoundry/cf-syslog-drain-release/tree/v6.4#syslog-adapter @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message  = "You must scale the adapter VMs to cope with the number of syslog drains. See https://github.com/cloudfoundry/cf-syslog-drain-release/tree/v6.4#syslog-adapter"
   require_full_window = true
 

--- a/terraform/datadog/syslog_drains.tf
+++ b/terraform/datadog/syslog_drains.tf
@@ -2,7 +2,6 @@ resource "datadog_monitor" "syslog_drains" {
   name                = "${format("%s syslog drains", var.env)}"
   type                = "query alert"
   message             = "${format("Consider scaling the adapters to cope with the number of syslog drains. See https://github.com/cloudfoundry/cf-syslog-drain-release/tree/v6.4#syslog-adapter @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message  = "You must scale the adapter VMs to cope with the number of syslog drains. See https://github.com/cloudfoundry/cf-syslog-drain-release/tree/v6.4#syslog-adapter"
   require_full_window = true
 
   query = "${format("avg(last_1d):avg:cf.cf_syslog_drain.scheduler.drains{deployment:%s} > 300", var.env)}"

--- a/terraform/datadog/tps.tf
+++ b/terraform/datadog/tps.tf
@@ -2,7 +2,6 @@ resource "datadog_monitor" "tps_watcher_lock_held_once" {
   name                = "${format("%s tps_watcher lock held exactly once (%s)", var.env, element(list("upper", "lower"), count.index))}"
   type                = "query alert"
   message             = "${format("There is not exactly one tps_watcher holding the lock. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  escalation_message  = "There is still not exactly one tps_watcher holding the lock."
   notify_no_data      = false
   require_full_window = true
 

--- a/terraform/datadog/tps.tf
+++ b/terraform/datadog/tps.tf
@@ -1,7 +1,7 @@
 resource "datadog_monitor" "tps_watcher_lock_held_once" {
   name                = "${format("%s tps_watcher lock held exactly once (%s)", var.env, element(list("upper", "lower"), count.index))}"
   type                = "query alert"
-  message             = "There is not exactly one tps_watcher holding the lock."
+  message             = "${format("There is not exactly one tps_watcher holding the lock. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   escalation_message  = "There is still not exactly one tps_watcher holding the lock."
   notify_no_data      = false
   require_full_window = true


### PR DESCRIPTION
## What

It seems we forgot to add the email notification for many alerts and we didn't get emails for alerts which should've been investigated, like the daily increase in the gorouter latency caused by a Verify perf test.

I didn't enable the email notifications for the DNS response time monitor as we know this monitor alerts a lot, so it would cause a lot of noise.

Also I removed the escalation_message field from the Datadog monitors. This field is only needed if we enable renotify_interval, but we don't use it (except for 2 Compose monitors).

## How to review

1. Code review

1. Deploy the Datadog monitors from this branch and check if they deploy cleanly (You can speed up review if you manually enable Datadog only for the datadog-terraform-apply in the pipeline)

## Who can review

Not me.