### PR TITLE
Stemcell bumps for CVEs

### DIFF
--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -5,7 +5,7 @@
   value:
     - alias: "3468"
       os: ubuntu-trusty
-      version: "3468.42"
+      version: "3468.51"
     - alias: default
       os: ubuntu-trusty
-      version: "3586.16"
+      version: "3586.24"


### PR DESCRIPTION
# What

We bump stemcells to 3468.51/3586.23 ~~and bump cflinuxfs2 to 1.218.0~~ to
mitigate the following CVEs:

https://www.cloudfoundry.org/blog/usn-3676-2/
https://www.cloudfoundry.org/blog/usn-3686-1/
https://www.cloudfoundry.org/blog/usn-3675-1/
https://www.cloudfoundry.org/blog/usn-3684-1/

Describe what you have changed and why.

# How to review

* Check the versions picked mitigate the issues
* Code review (this is my first Opsfile/overriding cf-deployment change)
* Check it deploys cleanly in dev

# Who can review

Not @chrisfarms
