### PR TITLE
Upgrade uaa-release to v60

### DIFF
--- a/manifests/cf-manifest/operations.d/260-cf-upgrade-uaa.yml
+++ b/manifests/cf-manifest/operations.d/260-cf-upgrade-uaa.yml
@@ -1,0 +1,9 @@
+---
+
+- type: replace
+  path: /releases/name=uaa
+  value:
+    name: "uaa"
+    version: "60"
+    url: "https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=60"
+    sha1: "a7c14357ae484e89e547f4f207fb8de36d2b0966"


### PR DESCRIPTION
What
----

We are bumping uaa-release to v60 separate from cf-deployment to address
a [CVE](https://www.cloudfoundry.org/blog/cve-2018-11041/). 

How to review
-------------

* Review code
* Test deployment

Who can review
--------------

Not @chrisfarms
