### PR TITLE
[#158459529] Ignore flaky acceptance test when testing logcache

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2721,7 +2721,7 @@ jobs:
                     tag: 52752f11595bab840402c22021d34c6ed6b41b70
                 params:
                   DISABLE_CF_ACCEPTANCE_TESTS: ((disable_cf_acceptance_tests))
-                  SKIP_REGEX: "exercises basic loggregator behavior|applies default environment variables while running apps and tasks"
+                  SKIP_REGEX: "exercises basic loggregator behavior|applies default environment variables while running apps and tasks|applies default environment variables while staging apps"
                 inputs:
                   - name: paas-cf
                   - name: cf-acceptance-tests


### PR DESCRIPTION
What
----

We have to ignore another test as we did in d141e72dci and
f8c5638151d999bcedd5eae62e8552d5f3607133, due the
bug in the cf-cli plugin for log-cache[1]

[1] https://github.com/cloudfoundry/log-cache-cli/issues/32

How to review
-------------

Code review. The ignored test is the one failing here:

https://deployer.staging.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/acceptance-tests/builds/1032


Who can review
--------------
Not me