### PR TITLE
[support] desensitize doppler elb latency monitor

### DIFF
--- a/terraform/datadog/elb.tf
+++ b/terraform/datadog/elb.tf
@@ -20,13 +20,13 @@ resource "datadog_monitor" "abnormal_api_latency_doppler" {
   type    = "query alert"
   message = "${format("{{#is_alert}}We're experiencing >= {{threshold}} change in ELB Latency.{{/is_alert}} \n{{#is_warning}}We're experiencing >= {{warn_threshold}} change in ELB Latency.{{/is_warning}} \n\nVisit the [Team Manual > Responding to alerts > API Latency](%s#api-latency) for more info. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_documentation_url, var.aws_account)}"
 
-  query = "${format("avg(last_1h):anomalies(avg:aws.elb.latency{name:%s-cf-doppler}, 'basic', 2, direction='above') > 0.3", var.env)}"
+  query = "${format("avg(last_1h):anomalies(avg:aws.elb.latency{name:%s-cf-doppler}, 'agile', 2, direction='above', alert_window='last_5m', interval=20, count_default_zero='false', seasonality='weekly') > 0.5", var.env)}"
 
   require_full_window = true
 
   thresholds {
-    warning  = 0.15
-    critical = 0.3
+    warning  = 0.25
+    critical = 0.5
   }
 
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:doppler"]


### PR DESCRIPTION
# What

We are constantly seeing our Doppler ELB Latency monitor triggered as
a result of the anomaly detection algorithm noticing large %-changes of
what are ultimately very small values.

This alters the monitor configuration to use the 'agile' detection
algorithm (which takes into account a larger history of data), uses a
smaller window for sampling and uses warning/alert thresholds at a
25%-change and 50%-change respectfully.

The result should be a monitor that is less sentitive to short spikes of
%-change but still trigger on more sustained deviations.

This may mean that it takes a bit longer for an alert to trigger and may
potentially be prone to miscalculation if the value rises very slowly over
say a few weeks. However we have not seen such behaviour and that could
be caught using a more traditional "alert if value > x" style monitor.

# How to review

* If you want to test in dev you will need to set ENABLE_DATADOG=true
* code review
* consider: this monitor is prone to a failing if the value rises very slowly over a period of weeks... is that an issue?

# Who can review

Not @chrisfarms