### PR TITLE
[#158553839] Fix broken links in the create user email

### DIFF
--- a/scripts/templates/create_user_html.erb
+++ b/scripts/templates/create_user_html.erb
@@ -15,16 +15,13 @@
 </p>
 <p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;"><%= org %></p>
 <p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">
-  Read more about <a href="https://docs.cloud.service.gov.uk/#organisations" target="_blank">organisations</a>.
+  Read more about <a href="https://docs.cloud.service.gov.uk/#managing-organisations-spaces-and-users" target="_blank">organisations</a>.
 </p>
 <p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">
-  You can find advice about <a href="https://docs.cloud.service.gov.uk/#choosing-passwords">choosing a password</a>.
+  Check out our documentation on how to <a href="https://docs.cloud.service.gov.uk/#get-started">get started</a>.
 </p>
 <p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">
-  To get started, look at our <a href="https://docs.cloud.service.gov.uk/#quick-setup-guide">Quick Setup Guide</a>.
-</p>
-<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">
-  You can find our privacy policy <a href="https://docs.cloud.service.gov.uk/#privacy-policy">here</a>.
+  You can find our privacy notice <a href="https://www.cloud.service.gov.uk/privacy-notice">here</a>.
 </p>
 <p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">
   To check the status of GOV.UK PaaS, and see the availability of live applications and database connectivity, visit our <a href="https://status.cloud.service.gov.uk">status page</a>. We recommend you sign up to this service to get alerts and incident updates.

--- a/scripts/templates/create_user_plain.erb
+++ b/scripts/templates/create_user_plain.erb
@@ -13,16 +13,13 @@ We’ve added your account to the following organisation:
 <%= org %>
 
 Read more about organisations:
-https://docs.cloud.service.gov.uk/#organisations
+https://docs.cloud.service.gov.uk/#managing-organisations-spaces-and-users
 
-You can find advice about choosing a password:
-https://docs.cloud.service.gov.uk/#choosing-passwords
+Check out our documentation on how to get started:
+https://docs.cloud.service.gov.uk/#get-started
 
-To get started, look at our Quick Setup Guide:
-https://docs.cloud.service.gov.uk/#quick-setup-guide
-
-You can find our privacy policy here:
-https://docs.cloud.service.gov.uk/#privacy-policy
+You can find our privacy notice here:
+https://www.cloud.service.gov.uk/privacy-notice
 
 To check the status of GOV.UK PaaS, and see the availability of live
 applications and database connectivity, visit


### PR DESCRIPTION
## What

* Remove the how to choose password link as it doesn't exist anymore
* Update the privacy policy link as it was removed from the tech docs
* Update the guick started guide link to point to get started
* Update the organisations link to point to the main section

## How to review

I think code review is enough. Check the links whether they are correct.

## Who can review

Not me.