### PR TITLE
[#157084165] Increase rds-broker instance type to small

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -59,7 +59,7 @@
     name: rds_broker
     azs: [z1, z2]
     instances: 2
-    vm_type: nano
+    vm_type: small
     vm_extensions:
       - rds_broker
     stemcell: default


### PR DESCRIPTION
What
----

We have added the rds-metrics-collector job in the rds-broker
instance-group to collect tenants metrics. But this job runs
periodically (every 1-5 minutes) instead of in a burst mode as
the broker use to. Because that the VM ends running out of credits.

We will try to increase with the `small` size, which is a
t2.small, and see if it behaves better with it.


How to review
-------------

Code review

Who can review
--------------

Anyone but me