### PR TITLE
Add london domain to the match array

### DIFF
--- a/misc/chrome_plugins/clean_concourse_pipeline/manifest.json
+++ b/misc/chrome_plugins/clean_concourse_pipeline/manifest.json
@@ -4,13 +4,15 @@
   "manifest_version": 2,
   "permissions": [
     "https://*.cloudpipeline.digital/*",
-    "https://deployer.cloud.service.gov.uk/*"
+    "https://deployer.cloud.service.gov.uk/*",
+    "https://deployer.london.cloud.service.gov.uk/*"
   ],
   "content_scripts": [
     {
       "matches": [
         "https://*.cloudpipeline.digital/*",
-        "https://deployer.cloud.service.gov.uk/*"
+        "https://deployer.cloud.service.gov.uk/*",
+        "https://deployer.london.cloud.service.gov.uk/*"
       ],
       "js": [
         "src/inject.user.js"

--- a/misc/chrome_plugins/clean_concourse_pipeline/src/inject.user.js
+++ b/misc/chrome_plugins/clean_concourse_pipeline/src/inject.user.js
@@ -4,6 +4,7 @@
 // @description Strips away some of the cruft from the concourse pipeline view when showing it on monitoring screens.
 // @include     https://deployer.*.cloudpipeline.digital/*
 // @include     https://deployer.cloud.service.gov.uk/*
+// @include     https://deployer.london.cloud.service.gov.uk/*
 // @version     1
 // @grant       none
 // ==/UserScript==


### PR DESCRIPTION
What
----

Now that we're running PaaS in London, we've created a subdomain to
differentiate between both.

The plugin requires adding an extra string to the array the script
matches against.

How to review
-------------

- Test whether the plugin works
- Update the dashboard