### PR TITLE
[#158594217] Bump rds-broker release to disable table metrics

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -49,9 +49,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 0.1.31
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.31.tgz
-    sha1: 112e3183e67f20579c9cd93b4e3449d5e1023128
+    version: 0.1.32
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.32.tgz
+    sha1: d8afd212f706b21eb6921b010eb47eb143bc95e3
 
 - type: replace
   path: /instance_groups/-


### PR DESCRIPTION
What
----

We are worried of the overhead of having metrics per table from
RDS broker instance, so we disabled them in
https://github.com/alphagov/paas-rds-metric-collector/pull/4

Here we bump the corresponding bosh-release version.

How to review
-------------

Code review


Who can review
--------------

not me