### PR TITLE
[#157438891] Bump paas-billing to v0.32.0

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -336,7 +336,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-billing
-      tag_filter: v0.31.0
+      tag_filter: v0.32.0
 
   - name: paas-accounts
     type: git


### PR DESCRIPTION


What
----

paas-billing v0.32.0 collects service_plans and service records from the
CF API and versions them to allow for queries against historic data.

How to review
-------------

Check the paas-billing tag matches the one produced by build ci

Who can review
--------------

Not @chrisfarms
