### PR TITLE
Remove CC and UAA ELB latency monitors from Datadog.

### DIFF
--- a/terraform/datadog/elb.tf
+++ b/terraform/datadog/elb.tf
@@ -1,20 +1,3 @@
-resource "datadog_monitor" "abnormal_api_latency_cc" {
-  name    = "${format("%s Abnormal API Latency - CC", var.env)}"
-  type    = "query alert"
-  message = "${format("{{#is_alert}}We're experiencing >= {{threshold}} change in ELB Latency.{{/is_alert}} \n{{#is_warning}}We're experiencing >= {{warn_threshold}} change in ELB Latency.{{/is_warning}} \n\nVisit the [Team Manual > Responding to alerts > API Latency](%s#api-latency) for more info. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_documentation_url, var.aws_account)}"
-
-  query = "${format("max(last_1h):avg:aws.elb.latency{name:%s-cf-cc} > 2", var.env)}"
-
-  thresholds {
-    warning  = 1
-    critical = 2
-  }
-
-  require_full_window = true
-
-  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:cc"]
-}
-
 resource "datadog_monitor" "abnormal_api_latency_doppler" {
   name    = "${format("%s Abnormal API Latency - Doppler", var.env)}"
   type    = "query alert"
@@ -30,23 +13,6 @@ resource "datadog_monitor" "abnormal_api_latency_doppler" {
   }
 
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:doppler"]
-}
-
-resource "datadog_monitor" "abnormal_api_latency_uaa" {
-  name    = "${format("%s Abnormal API Latency - UAA", var.env)}"
-  type    = "query alert"
-  message = "${format("{{#is_alert}}We're experiencing >= {{threshold}} change in ELB Latency.{{/is_alert}} \n{{#is_warning}}We're experiencing >= {{warn_threshold}} change in ELB Latency.{{/is_warning}} \n\nVisit the [Team Manual > Responding to alerts > API Latency](%s#api-latency) for more info. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_documentation_url, var.aws_account)}"
-
-  query = "${format("avg(last_1h):anomalies(avg:aws.elb.latency{name:%s-cf-uaa}, 'basic', 2, direction='above') > 0.3", var.env)}"
-
-  require_full_window = true
-
-  thresholds {
-    warning  = 0.15
-    critical = 0.3
-  }
-
-  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:uaa"]
 }
 
 resource "datadog_monitor" "unhealthy_elb_node" {


### PR DESCRIPTION
## What

These ELBs no longer exist, so these monitors no longer apply. They're
currently reporting no data in London because the ELBs have never
existed there. In other environments, they aren't alerting because
they're not set to alert on no data.

How to review
-------------

* Code review.
* Verify that my assertion about these monitors applying to a non-existent ELB is correct

Who can review
--------------

Not me.