### PR TITLE
Update rds-broker - blank AWS keys no longer needed.

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -49,9 +49,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 0.1.33
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.33.tgz
-    sha1: bbdf8ed4c29adb1f6aa526c934f8bac8abdcad6d
+    version: 0.1.34
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.34.tgz
+    sha1: ba2e2bfa40d740555850f59851ab30b8bb20b3e8
 
 - type: replace
   path: /instance_groups/-
@@ -70,8 +70,6 @@
         release: rds-broker
         properties:
           rds-broker:
-            aws_access_key_id: ""
-            aws_secret_access_key: ""
             aws_region: "((terraform_outputs_region))"
             broker_name: "((terraform_outputs_environment))"
             cron_schedule: "0 0 * * *"
@@ -92,8 +90,6 @@
           rds-broker:
             allow_user_provision_parameters: true
             allow_user_update_parameters: true
-            aws_access_key_id: ""
-            aws_secret_access_key: ""
             aws_region: "((terraform_outputs_region))"
             password: ((secrets_rds_broker_admin_password))
             state_encryption_key: ((secrets_rds_broker_state_encryption_key))


### PR DESCRIPTION
## What

This includes https://github.com/alphagov/paas-rds-broker-boshrelease/pull/60 which
makes these properties optional, so we can remove them from the
manifest.

How to review
-------------

Deploy from this branch. Verify all the tests pass.

Who can review
--------------

Not me.