### PR TITLE
Bump `rds_broker` VM instance size

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -59,7 +59,7 @@
     name: rds_broker
     azs: [z1, z2]
     instances: 2
-    vm_type: small
+    vm_type: medium
     vm_extensions:
       - rds_broker
     stemcell: default


### PR DESCRIPTION
What
----

Even after the bump to `t2.small` we're exhausting all the available CPU
credits. Bumping again.

How to review
-------------

Just merge it #yolo.

Who can review
--------------

Anyone.
