### PR TITLE
[#158520831] Only run RDS broker housekeeping on one instance.

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -88,7 +88,7 @@
             db_prefix: "rdsbroker"
             master_password_seed: ((secrets_rds_broker_master_password_seed))
             broker_name: "((terraform_outputs_environment))"
-            cron_schedule: "0 0 * * *"
+            cron_schedule: "@daily"
             keep_snapshots_for_days: 35
             catalog:
               services:

--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -49,9 +49,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 0.1.36
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.36.tgz
-    sha1: e899f2ed8fe8b80ef060fff483d22ba5ec4848cb
+    version: 0.1.37
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.37.tgz
+    sha1: 7c224a33e028c05f4e518b7bc79323fbaac74f35
 
 - type: replace
   path: /instance_groups/-
@@ -66,14 +66,6 @@
     networks:
       - name: cf
     jobs:
-      - name: rds-broker-cron
-        release: rds-broker
-        properties:
-          rds-broker:
-            aws_region: "((terraform_outputs_region))"
-            broker_name: "((terraform_outputs_environment))"
-            cron_schedule: "0 0 * * *"
-            keep_snapshots_for_days: 35
       - name: rds-metric-collector
         release: rds-broker
         properties:
@@ -96,6 +88,8 @@
             db_prefix: "rdsbroker"
             master_password_seed: ((secrets_rds_broker_master_password_seed))
             broker_name: "((terraform_outputs_environment))"
+            cron_schedule: "0 0 * * *"
+            keep_snapshots_for_days: 35
             catalog:
               services:
                 - id: "ce71b484-d542-40f7-9dd4-5526e38c81ba"


### PR DESCRIPTION
What
----

This updates the broker so that the startup credential check and rotate only runs on a single instance. This is to reduce the number of AWS API calls we make, and hopefully help prevent us hitting the rate-limits.

This also updates the cron schedule to only run the stale snapshot cleanup job daily.

How to review
-------------

* Deploy from this branch.
* Verify all still works
* Verify the check-and-rotate still runs, and only runs on a single instance (easiest way is probably to check the logs)
* Verify the cron process still runs, and only runs on one instance (again the logs are probably the easiest way to check this)

## 🚨 Before merging 🚨 

Merge https://github.com/alphagov/paas-rds-broker-boshrelease/pull/63 and update the TMP commit with the resulting boshrelease build.

Who can review
--------------

Not me.