### PR TITLE
[#SUPPORT] post-deploy removes access-keys first

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1558,6 +1558,54 @@ jobs:
               ls -l config/*
 
     - aggregate:
+      - task: remove-unused-ses-smtp-access-keys
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/awscli
+              tag: b2495d6ed07f680125d19aa7d1701da7efabb289
+          inputs:
+            - name: cf-tfstate
+          params:
+            DEPLOY_ENV: ((deploy_env))
+            AWS_DEFAULT_REGION: ((aws_region))
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                delete_unused_keys() {
+                  terraform_outputs_key=$1
+                  username=$2
+
+                  jq_path=".modules[].outputs.${terraform_outputs_key}.value"
+                  ACCESS_KEY_ID=$(jq -r "$jq_path" cf-tfstate/cf.tfstate)
+                  if [ -z "$ACCESS_KEY_ID" ]; then
+                    echo "could not find $terraform_outputs_key in terraform outputs"
+                    exit 1
+                  fi
+
+                  UNUSED_ACCESS_KEYS=$(\
+                    aws iam list-access-keys --user-name "$username" \
+                    --query "AccessKeyMetadata[?AccessKeyId!=\`${ACCESS_KEY_ID}\`].AccessKeyId" \
+                    --output text \
+                  )
+                  if [ -z "$UNUSED_ACCESS_KEYS" ]; then
+                    echo "no access keys to revoke"
+                  else
+                    for key in $UNUSED_ACCESS_KEYS; do
+                      echo "deleting key $key for user $username"
+                      aws iam delete-access-key --user-name "$username" --access-key-id "$key"
+                    done
+                  fi
+                }
+
+                delete_unused_keys ses_smtp_aws_access_key_id "ses-smtp-${DEPLOY_ENV}"
+                delete_unused_keys metrics_exporter_aws_access_key_id "metrics-exporter-${DEPLOY_ENV}"
+
       - task: create-orgs
         config:
           platform: linux
@@ -2644,54 +2692,6 @@ jobs:
 
                 cf blue-green-deploy paas-uaa-assets
                 cf delete -f paas-uaa-assets-old
-
-      - task: remove-unused-ses-smtp-access-keys
-        config:
-          platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/awscli
-              tag: b2495d6ed07f680125d19aa7d1701da7efabb289
-          inputs:
-            - name: cf-tfstate
-          params:
-            DEPLOY_ENV: ((deploy_env))
-            AWS_DEFAULT_REGION: ((aws_region))
-          run:
-            path: sh
-            args:
-              - -e
-              - -c
-              - |
-                delete_unused_keys() {
-                  terraform_outputs_key=$1
-                  username=$2
-
-                  jq_path=".modules[].outputs.${terraform_outputs_key}.value"
-                  ACCESS_KEY_ID=$(jq -r "$jq_path" cf-tfstate/cf.tfstate)
-                  if [ -z "$ACCESS_KEY_ID" ]; then
-                    echo "could not find $terraform_outputs_key in terraform outputs"
-                    exit 1
-                  fi
-
-                  UNUSED_ACCESS_KEYS=$(\
-                    aws iam list-access-keys --user-name "$username" \
-                    --query "AccessKeyMetadata[?AccessKeyId!=\`${ACCESS_KEY_ID}\`].AccessKeyId" \
-                    --output text \
-                  )
-                  if [ -z "$UNUSED_ACCESS_KEYS" ]; then
-                    echo "no access keys to revoke"
-                  else
-                    for key in $UNUSED_ACCESS_KEYS; do
-                      echo "deleting key $key for user $username"
-                      aws iam delete-access-key --user-name "$username" --access-key-id "$key"
-                    done
-                  fi
-                }
-
-                delete_unused_keys ses_smtp_aws_access_key_id "ses-smtp-${DEPLOY_ENV}"
-                delete_unused_keys metrics_exporter_aws_access_key_id "metrics-exporter-${DEPLOY_ENV}"
 
   - name: smoke-tests
     serial_groups: [smoke-tests]


### PR DESCRIPTION
What
----

post-deploy has a task to remove not managed AWS access keys, but
it runs it later in the job.

If there is any problem in other task in the post-deploy, this
task would not be executed, so the old keys won't be deleted.

As we frequently delete the aws-keys from the terraform state,
next terraform run would create new keys, and we will reach
the maximum of 2x keys per using, making terraform fail:

   2 error(s) occurred:

   * aws_iam_access_key.metrics_exporter: 1 error(s) occurred:
   * aws_iam_access_key.metrics_exporter: Error creating access key for user metrics-exporter-hector: LimitExceeded: Cannot exceed quota for AccessKeysPerUser: 2
         status code: 409, request id: 5444db5e-7f75-11e8-8585-b3cfdf7af00c

   * aws_iam_access_key.ses_smtp: 1 error(s) occurred:
   * aws_iam_access_key.ses_smtp: Error creating access key for user ses-smtp-hector: LimitExceeded: Cannot exceed quota for AccessKeysPerUser: 2
         status code: 409, request id: 5444dbfc-7f75-11e8-b8c9-0f4f651e0f50

If we put the task to run the very first time, it is less likely
we end in this situaton.

See https://github.com/alphagov/paas-cf/pull/1174 for more info

How to review
-------------

Code review

Who can review
--------------

Not me