### PR TITLE
[Support] Pin a specific version of the Alpine containers.

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -131,7 +131,7 @@ jobs:
             type: docker-image
             source:
               repository: alpine
-              tag: latest
+              tag: 3.7
           inputs:
             - name: paas-cf
           params:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -406,7 +406,7 @@ jobs:
               type: docker-image
               source:
                 repository: alpine
-                tag: latest
+                tag: 3.7
             platform: linux
             params:
               DISABLE_PIPELINE_LOCKING: ((disable_pipeline_locking))
@@ -1184,7 +1184,7 @@ jobs:
               type: docker-image
               source:
                 repository: alpine
-                tag: latest
+                tag: 3.7
             inputs:
               - name: paas-cf
             outputs:
@@ -3090,7 +3090,7 @@ jobs:
               type: docker-image
               source:
                 repository: alpine
-                tag: latest
+                tag: 3.7
             platform: linux
             params:
               DISABLE_PIPELINE_LOCKING: ((disable_pipeline_locking))
@@ -3531,7 +3531,7 @@ jobs:
             type: docker-image
             source:
               repository: alpine
-              tag: latest
+              tag: 3.7
           inputs:
             - name: deployed-healthcheck
           params:

--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -31,7 +31,7 @@ jobs:
             type: docker-image
             source:
               repository: alpine
-              tag: latest
+              tag: 3.7
           inputs:
             - name: paas-cf
             - name: deployment-timer


### PR DESCRIPTION
## What

The latest tag was recently updated to point to the 3.8 release, but
this release was broken[1]. attempting to pull the container locally
resulted in the error:
```
$ docker pull alpine:latest
latest: Pulling from library/alpine
no matching manifest for linux/amd64 in the manifest list entries
```
This has caused the continuous smoke tests to fail to start in all
environments as of around 9:40 today.  Pinning this to the version we
were previously using (3.7) should help avoid this sort of issue in
future.

[1]https://github.com/gliderlabs/docker-alpine/issues/418

How to review
-------------

Code review.  I've already tested this in my dev env, so that's probably enough.

Who can review
--------------

Not me.