### PR TITLE
[#158791033] Bump stemcells to force NTP changes to apply.

### DIFF
--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -5,7 +5,7 @@
   value:
     - alias: "3468"
       os: ubuntu-trusty
-      version: "3468.51"
+      version: "3468.53"
     - alias: default
       os: ubuntu-trusty
-      version: "3586.24"
+      version: "3586.25"


### PR DESCRIPTION
## What

This is being done to force the changes in https://github.com/alphagov/paas-bootstrap/pull/171 to apply (they only
take effect the next time the VMs are recreated.

This includes a bunch of ubuntu trusty updates. Nothing specifically
significant.

How to review
-------------

Code review is probably enough. I've already tested this in my dev environment.

## Before merging

Ensure that https://github.com/alphagov/paas-bootstrap/pull/171 has been merged and applied in all persistent environments.

Who can review
--------------

Not me.