### PR TITLE
[#158938536] Update cf-deployment to 2.6.0

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -264,7 +264,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-cf-acceptance-tests
-      branch: cf1.38-gds
+      branch: cf2.6-gds
 
   - name: cf-smoke-tests-release
     type: git

--- a/manifests/cf-manifest/operations.d/230-cf-set-metron-agent-deployment.yml
+++ b/manifests/cf-manifest/operations.d/230-cf-set-metron-agent-deployment.yml
@@ -1,5 +1,5 @@
 ---
 
 - type: replace
-  path: /addons/name=metron_agent/jobs/name=metron_agent/properties/metron_agent?/deployment
+  path: /addons/name=loggregator_agent/jobs/name=loggregator_agent/properties/loggregator_agent?/deployment
   value: ((environment))

--- a/manifests/cf-manifest/operations.d/299-cf-rename-vars-to-terraform.yml
+++ b/manifests/cf-manifest/operations.d/299-cf-rename-vars-to-terraform.yml
@@ -17,10 +17,10 @@
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/system_domain
   value: ((terraform_outputs_cf_root_domain))
 - type: replace
-  path: /instance_groups/name=api/jobs/name=policy-server/properties/cf_networking/policy_server/database/host
+  path: /instance_groups/name=api/jobs/name=policy-server/properties/database/host
   value: ((terraform_outputs_cf_db_address))
 - type: replace
-  path: /instance_groups/name=diego-api/jobs/name=silk-controller/properties/cf_networking/silk_controller/database/host
+  path: /instance_groups/name=diego-api/jobs/name=silk-controller/properties/database/host
   value: ((terraform_outputs_cf_db_address))
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/buildpacks/fog_connection/region

--- a/manifests/cf-manifest/operations.d/710-logsearch.yml
+++ b/manifests/cf-manifest/operations.d/710-logsearch.yml
@@ -17,7 +17,7 @@
     sha1: dee838e3a9c317c406ae1bcb84ae42ae862829c2
 
 - type: replace
-  path: /addons/name=metron_agent/exclude/jobs/-
+  path: /addons/name=loggregator_agent/exclude/jobs/-
   value:
     name: queue
     release: logsearch
@@ -42,7 +42,7 @@
     persistent_disk_type: queue
 
 - type: replace
-  path: /addons/name=metron_agent/exclude/jobs/-
+  path: /addons/name=loggregator_agent/exclude/jobs/-
   value:
     name: parser
     release: logsearch
@@ -141,7 +141,7 @@
     - name: cf
 
 - type: replace
-  path: /addons/name=metron_agent/exclude/jobs/-
+  path: /addons/name=loggregator_agent/exclude/jobs/-
   value:
     name: elasticsearch
     release: logsearch
@@ -179,7 +179,7 @@
       serial: true
 
 - type: replace
-  path: /addons/name=metron_agent/exclude/jobs/-
+  path: /addons/name=loggregator_agent/exclude/jobs/-
   value:
     name: elasticsearch_config
     release: logsearch
@@ -226,7 +226,7 @@
     - name: cf
 
 - type: replace
-  path: /addons/name=metron_agent/exclude/jobs/-
+  path: /addons/name=loggregator_agent/exclude/jobs/-
   value:
     name: kibana
     release: logsearch
@@ -265,7 +265,7 @@
     - name: cf
 
 - type: replace
-  path: /addons/name=metron_agent/exclude/jobs/-
+  path: /addons/name=loggregator_agent/exclude/jobs/-
   value:
     name: ingestor_syslog
     release: logsearch

--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -76,6 +76,10 @@
               broker_name: "((terraform_outputs_environment))"
               db_prefix: "rdsbroker"
               master_password_seed: ((secrets_rds_broker_master_password_seed))
+            loggregator:
+              ca_cert: "/var/vcap/jobs/loggregator_agent/config/certs/loggregator_ca.crt"
+              client_cert: "/var/vcap/jobs/loggregator_agent/config/certs/loggregator_agent.crt"
+              client_key: "/var/vcap/jobs/loggregator_agent/config/certs/loggregator_agent.key"
       - name: rds-broker
         release: rds-broker
         properties:

--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -49,9 +49,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 0.1.37
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.37.tgz
-    sha1: 7c224a33e028c05f4e518b7bc79323fbaac74f35
+    version: 0.1.38
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.38.tgz
+    sha1: 4dd361c256e6d80554014823811fa81aa50bf731
 
 - type: replace
   path: /instance_groups/-
@@ -77,9 +77,9 @@
               db_prefix: "rdsbroker"
               master_password_seed: ((secrets_rds_broker_master_password_seed))
             loggregator:
-              ca_cert: "/var/vcap/jobs/loggregator_agent/config/certs/loggregator_ca.crt"
-              client_cert: "/var/vcap/jobs/loggregator_agent/config/certs/loggregator_agent.crt"
-              client_key: "/var/vcap/jobs/loggregator_agent/config/certs/loggregator_agent.key"
+              ca_cert: "((loggregator_ca.certificate))((loggregator_ca_old.certificate))"
+              client_cert: "((loggregator_rds_metrics_collector.certificate))"
+              client_key: "((loggregator_rds_metrics_collector.private_key))"
       - name: rds-broker
         release: rds-broker
         properties:
@@ -755,3 +755,15 @@
   value:
     name: secrets_rds_broker_state_encryption_key
     type: password
+- type: replace
+  path: /variables/-
+  value:
+    name: loggregator_rds_metrics_collector
+    type: certificate
+    options:
+      ca: loggregator_ca
+      common_name: loggregator_rds_metrics_collector
+      extended_key_usage:
+        - client_auth
+        - server_auth
+

--- a/manifests/cf-manifest/operations.d/720-cdn-broker.yml
+++ b/manifests/cf-manifest/operations.d/720-cdn-broker.yml
@@ -9,7 +9,7 @@
     sha1: 1d9e2c202192c2d4c726d82de2a46e73ad0177be
 
 - type: replace
-  path: /addons/name=metron_agent/exclude/jobs/-
+  path: /addons/name=loggregator_agent/exclude/jobs/-
   value:
     name: cdn-broker
     release: cdn-broker

--- a/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
+++ b/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
@@ -9,7 +9,7 @@
     sha1: a1b83e8f8972b71756bc622442590f34ff72a551
 
 - type: replace
-  path: /addons/name=metron_agent/exclude/jobs/-
+  path: /addons/name=loggregator_agent/exclude/jobs/-
   value:
     name: elasticache-broker
     release: elasticache-broker

--- a/manifests/cf-manifest/operations.d/900-cf-cert-rotation.yml
+++ b/manifests/cf-manifest/operations.d/900-cf-cert-rotation.yml
@@ -196,27 +196,31 @@
   value: ((service_cf_internal_ca.certificate))((service_cf_internal_ca_old.certificate))
 
 - type: replace
-  path: /instance_groups/name=api/jobs/name=policy-server/properties/cf_networking/policy_server/uaa_ca
+  path: /instance_groups/name=api/jobs/name=policy-server/properties/uaa_ca
   value: ((uaa_ca.certificate))((uaa_ca_old.certificate))
 
 - type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=silk-daemon/properties/cf_networking/silk_daemon/ca_cert
+  path: /instance_groups/name=diego-cell/jobs/name=silk-daemon/properties/ca_cert
   value: ((silk_ca.certificate))((silk_ca_old.certificate))
 
 - type: replace
-  path: /instance_groups/name=diego-api/jobs/name=silk-controller/properties/cf_networking/silk_controller/ca_cert
+  path: /instance_groups/name=diego-api/jobs/name=silk-controller/properties/ca_cert
   value: ((silk_ca.certificate))((silk_ca_old.certificate))
 
 - type: replace
-  path: /instance_groups/name=diego-api/jobs/name=silk-controller/properties/cf_networking/silk_daemon/ca_cert
+  path: /instance_groups/name=diego-api/jobs/name=silk-controller/properties/silk_daemon/ca_cert
   value: ((silk_ca.certificate))((silk_ca_old.certificate))
 
 - type: replace
-  path: /instance_groups/name=api/jobs/name=policy-server-internal/properties/cf_networking/policy_server_internal/ca_cert
+  path: /instance_groups/name=diego-api/jobs/name=silk-controller/properties/ca_cert
+  value: ((silk_ca.certificate))((silk_ca_old.certificate))
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=policy-server-internal/properties/ca_cert
   value: ((network_policy_ca.certificate))((network_policy_ca_old.certificate))
 
 - type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=vxlan-policy-agent/properties/cf_networking/vxlan_policy_agent/ca_cert
+  path: /instance_groups/name=diego-cell/jobs/name=vxlan-policy-agent/properties/ca_cert
   value: ((network_policy_ca.certificate))((network_policy_ca_old.certificate))
 
 - type: replace

--- a/manifests/cf-manifest/operations.d/900-cf-cert-rotation.yml
+++ b/manifests/cf-manifest/operations.d/900-cf-cert-rotation.yml
@@ -1,6 +1,6 @@
 ---
 - type: replace
-  path: /addons/name=metron_agent/jobs/name=metron_agent/properties/loggregator/tls/ca_cert
+  path: /addons/name=loggregator_agent/jobs/name=loggregator_agent/properties/loggregator/tls/ca_cert
   value: ((loggregator_ca.certificate))((loggregator_ca_old.certificate))
 
 - type: replace

--- a/manifests/cf-manifest/operations/datadog.yml
+++ b/manifests/cf-manifest/operations/datadog.yml
@@ -45,7 +45,7 @@
     sha1: b358712488c44a09e815f278d6b767f3e82cd3e3
 
 - type: replace
-  path: /addons/name=metron_agent/exclude/jobs/-
+  path: /addons/name=loggregator_agent/exclude/jobs/-
   value:
     name: datadog-firehose-nozzle
     release: datadog-firehose-nozzle

--- a/manifests/cf-manifest/scripts/generate-manifest.sh
+++ b/manifests/cf-manifest/scripts/generate-manifest.sh
@@ -37,6 +37,7 @@ bosh interpolate \
   --vars-file="${WORKDIR}/environment-variables/environment-variables.yml" \
   --ops-file="${CF_DEPLOYMENT_DIR}/operations/rename-network.yml" \
   --ops-file="${CF_DEPLOYMENT_DIR}/operations/aws.yml" \
+  --ops-file="${CF_DEPLOYMENT_DIR}/operations/use-external-blobstore.yml" \
   --ops-file="${CF_DEPLOYMENT_DIR}/operations/use-s3-blobstore.yml" \
   --ops-file="${CF_DEPLOYMENT_DIR}/operations/use-external-dbs.yml" \
   --ops-file="${CF_DEPLOYMENT_DIR}/operations/stop-skipping-tls-validation.yml" \


### PR DESCRIPTION
What
----

Upgrade cf-deployment from 1.38 to 2.6.0.

This was mostly pain free, but we had to do a few things to support the
new version:

- Removed the override on the version of cflinuxfs as the version in cf
is newer
- Fixed a bunch of yaml paths which had changed
- Updated the rds-broker not to depend on certificate files on disk -
  the location of these had changed
- Added use-external-blobstore.yml to the manifest - required in the
  newer version

How to review
-------------

See also https://github.com/alphagov/paas-rds-broker-boshrelease/pull/64
which is the update in rds-broker.

Who can review
--------------

Anyone