### PR TITLE
[#159162443] Update UAA to 60.2 for CVE-2018-11047

### DIFF
--- a/manifests/cf-manifest/operations.d/260-cf-upgrade-uaa.yml
+++ b/manifests/cf-manifest/operations.d/260-cf-upgrade-uaa.yml
@@ -4,6 +4,6 @@
   path: /releases/name=uaa
   value:
     name: "uaa"
-    version: "60"
-    url: "https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=60"
-    sha1: "a7c14357ae484e89e547f4f207fb8de36d2b0966"
+    version: "60.2"
+    url: "https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=60.2"
+    sha1: "667af417997467681fddf13c78e5a11c6f4a9d15"


### PR DESCRIPTION
What
----

This commit updates UAA from 60 to 60.2 in order to mitigate against
accepting a refresh token as an access token.

How to review
-------------

Code review and deploy to dev on top of current master

Who can review
--------------

Not @LeePorte
