### PR TITLE
[SUPPORT] Increase prod cells to 33

### DIFF
--- a/manifests/cf-manifest/env-specific/cf-prod.yml
+++ b/manifests/cf-manifest/env-specific/cf-prod.yml
@@ -1,5 +1,5 @@
 ---
-cell_instances: 30
+cell_instances: 33
 router_instances: 3
 elasticsearch_master_disk_size: 3072000
 elasticsearch_master_instance_type: c4.2xlarge


### PR DESCRIPTION
What
----

We are hovering around 33% advertised capacity remaining on the
cells, which is below the threshold we're aiming for in ARD021[1].
Adding 3 cells beings this back up to around 40%.

[1] https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision

How to review
-------------

Code review

Who can review
--------------

Not @LeePorte
