### PR TITLE
[#157737884] Add check for Aiven API token in pipelines script

### DIFF
--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -82,6 +82,12 @@ prepare_environment() {
   fi
 
   # shellcheck disable=SC2154
+  if [ -z "${aiven_api_token+x}" ] ; then
+    echo "Could not retrieve API token for Aiven. Did you run \`make ${MAKEFILE_ENV_TARGET} upload-aiven-secrets\`?"
+    exit 1
+  fi
+
+  # shellcheck disable=SC2154
   if [ -z "${notify_api_key+x}" ] ; then
     echo "Could not retrieve api key for Notify. Did you run \`make ${MAKEFILE_ENV_TARGET} upload-notify-secrets\`?"
     exit 1


### PR DESCRIPTION
## What

This means that the pipeline will fail early if the API token hasn't
been uploaded, instead of waiting until the post-deploy task before
failing.

How to review
-------------

* Run `make dev pipelines` without aiven secrets uploaded, and verify you get a helpful error message.
* Upload the secrets (`make dev upload-aiven-secrets`), and repeat. Verify it now works.

Who can review
--------------

Not me.