### PR TITLE
[support] Increase ElastiCache parameter group number

### DIFF
--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -23,3 +23,7 @@ pingdom_contact_ids = [ 14270737, 14270734 ]
 
 datadog_notification_24x7 = "@pagerduty-datadog-24x7"
 datadog_notification_in_hours = "@pagerduty-datadog-in-hours"
+
+# AWS Limits not accesible via API
+aws_limits_elasticache_nodes = 100
+aws_limits_elasticache_cache_parameter_groups = 35


### PR DESCRIPTION
What
----

This commit adds in the variables with the correct values that are used
for calculating the ElastiCache alerts in datadog.

How to review
-------------

Code review against patterns use in other env vars

Who can review
--------------

Not @LeePorte
