### PR TITLE
[#158943954] Bump pass-billing to 0.35

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -351,7 +351,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-billing
-      tag_filter: v0.33.0
+      tag_filter: v0.35.0
 
   - name: paas-accounts
     type: git


### PR DESCRIPTION
What
----

This commit bumps the version of PaaS-Billing to 0.35 in order to
include the Aiven Elasticsearch plans.

How to review
-------------

Code review

Who can review
--------------

Not @LeePorte
