### PR TITLE
[#159200278] Fix elasticsearch plan names

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -345,13 +345,13 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-aiven-broker
-      tag_filter: v0.5.0
+      tag_filter: v0.6.0
 
   - name: paas-billing
     type: git
     source:
       uri: https://github.com/alphagov/paas-billing
-      tag_filter: v0.35.0
+      tag_filter: v0.36.0
 
   - name: paas-accounts
     type: git
@@ -2370,7 +2370,6 @@ jobs:
                     -o admin -s service-brokers
 
                   cp ./paas-cf/config/service-brokers/aiven/config.json ./paas-aiven-broker/
-                  cp ./paas-cf/config/service-brokers/aiven/manifest.yml ./paas-aiven-broker/
                   cd paas-aiven-broker/
 
                   ruby -ryaml -e "

--- a/config/service-brokers/aiven/config.json
+++ b/config/service-brokers/aiven/config.json
@@ -17,7 +17,7 @@
         "plans": [
           {
             "id": "0eee9e10-db37-4cc3-bc9b-39e378ff3a5f",
-            "name": "small-ha-es5",
+            "name": "small-ha-5.x",
             "aiven_plan": "business-4",
             "elasticsearch_version": "5",
             "description": "3 dedicated VMs, 1 CPU per VM, 4GB RAM per VM, 240GB disk space.",
@@ -27,7 +27,7 @@
           },
           {
             "id": "225e97cc-f786-408c-8b59-d2118248a53d",
-            "name": "small-ha-es6",
+            "name": "small-ha-6.x",
             "aiven_plan": "business-4",
             "elasticsearch_version": "6",
             "description": "3 dedicated VMs, 1 CPU per VM, 4GB RAM per VM, 240GB disk space.",

--- a/config/service-brokers/aiven/manifest.yml
+++ b/config/service-brokers/aiven/manifest.yml
@@ -1,9 +1,0 @@
----
-applications:
-- name: aiven-broker
-  memory: 128M
-  instances: 2
-  buildpack: go_buildpack
-  env:
-    GOVERSION: go1.10.2
-    GOPACKAGENAME: github.com/alphagov/paas-aiven-broker

--- a/platform-tests/src/platform/acceptance/elasticsearch_service_test.go
+++ b/platform-tests/src/platform/acceptance/elasticsearch_service_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Elasticsearch backing service", func() {
 	)
 
 	var (
-		planNames = [2]string{"small-ha-es5", "small-ha-es6"}
+		planNames = [2]string{"small-ha-5.x", "small-ha-6.x"}
 	)
 
 	It("is registered in the marketplace", func() {


### PR DESCRIPTION
What
----

The `es` suffix in the name doesn't confirm to the [naming ADR](https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR025-service-plan-naming-conventions/). This updates them to conform.

We had some debate as to whether the version should be expressed as 5.x
or merely 5. We decided to go with 5.x as that makes it more obvious
that this represents a version.

I've also taken the opportunity to move the app's base CF manifest into the app repo.

How to review
-------------

* Review https://github.com/alphagov/paas-aiven-broker/pull/6
* Update the broker pinning in the TMP commit.
* Verify this runs and the tests pass in the pipeline

Who can review
--------------

Not me.