### PR TITLE
[#159268475] Bump paas-billing v0.37.0

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -351,7 +351,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-billing
-      tag_filter: v0.36.0
+      tag_filter: v0.37.0
 
   - name: paas-accounts
     type: git


### PR DESCRIPTION


What
----

paas-billing v0.37.0 [fixes an issue](https://github.com/alphagov/paas-billing/pull/44) with UPDATE events that alter plan guids of services.

How to review
-------------

* Code review (does the version look like the right one)

Who can review
--------------

Not @chrisfarms
