### PR TITLE
[#158946642] Bump rds-broker to include MySQL stats collection

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -49,9 +49,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 0.1.38
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.38.tgz
-    sha1: 4dd361c256e6d80554014823811fa81aa50bf731
+    version: 0.1.39 
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.39.tgz
+    sha1: 736c5d04f566b0dcb3e3677c1fa758d3206fa725
 
 - type: replace
   path: /instance_groups/-


### PR DESCRIPTION
What
----

This PR bumps the RDS broker BOSH release to include the code PR'd at https://github.com/alphagov/paas-rds-metric-collector/pull/6, which exposes stats from MySQL instances.

How to review
-------------

- Take the release from the CI output produced by the merging of https://github.com/alphagov/paas-rds-broker-boshrelease/pull/66 (probably the latest green run of https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/rds-broker-release/jobs/build-final-release) and update this PR's WIP commit to reference the new final BOSH release at the bottom of the `build` step.
- Run this PR's branch's commit down your dev env.
- After the `cf-deploy` step, log into your CF and provision a mysql instance:
  - `cf create-service mysql large-5.7 test-stats`
- Install the log-cache CLI: https://github.com/cloudfoundry/log-cache-cli
- watch the metrics emerging from your instance:
  - `cf tail -f $(cf service test-stats --guid)`
- check that some `innodb_` prefixed stats emerge
- delete your test-stats DB instance

Who can review
--------------

Anyone except @keymon and I.