### PR TITLE
[#158333555] Stop double emitting metrics

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -80,6 +80,11 @@
               ca_cert: "((loggregator_ca.certificate))((loggregator_ca_old.certificate))"
               client_cert: "((loggregator_rds_metrics_collector.certificate))"
               client_key: "((loggregator_rds_metrics_collector.private_key))"
+            locket:
+              api_location: "locket.service.cf.internal:8891"
+              ca_cert: "((service_cf_internal_ca.certificate))((service_cf_internal_ca_old.certificate))"
+              client_cert: "((diego_locket_client.certificate))"
+              client_key: "((diego_locket_client.private_key))"
       - name: rds-broker
         release: rds-broker
         properties:

--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -49,9 +49,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 0.1.39 
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.39.tgz
-    sha1: 736c5d04f566b0dcb3e3677c1fa758d3206fa725
+    version: 0.1.40
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.40.tgz
+    sha1: a65f445784614dceaa59d98ea23990d5f71326d1
 
 - type: replace
   path: /instance_groups/-


### PR DESCRIPTION
What
----

Deploy a new version of the rds-metric-collector which doesn't duplicate metrics.

How to review
-------------

* review https://github.com/alphagov/paas-rds-metric-collector/pull/7
* review https://github.com/alphagov/paas-rds-broker-boshrelease/pull/67
* code review this pull request
* ⚠️ update the temporary commit using the build details from: https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/rds-broker-release/jobs/build-final-release

If you want to deploy you can use:

```bash
BRANCH=stop-double-emitting-metrics ENABLE_DATADOG=true make dev pipelines
```

Who can review
--------------

Anyone but me or @richardTowers 
