### PR TITLE
[#156911499] "Revert Run paas-admin integration/acceptance tests in the pipeline"

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -363,7 +363,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-admin
-      tag_filter: v0.22.0
+      tag_filter: v0.21.0
 
   - name: paas-log-cache-adapter
     type: git
@@ -2819,8 +2819,6 @@ jobs:
           - get: cf-vars-store
             passed: ['post-deploy']
           - get: cf-acceptance-tests
-          - get: paas-admin
-            passed: ['post-deploy']
 
       - do:
         - task: create-temp-user
@@ -2836,55 +2834,19 @@ jobs:
             APP_DOMAIN: ((apps_dns_zone_name))
             SYSTEM_DOMAIN: ((system_dns_zone_name))
 
-        - aggregate:
-          - task: "Run custom acceptance tests"
-            file: paas-cf/concourse/tasks/custom-acceptance-tests-run.yml
+        - task: "Run custom acceptance tests"
+          file: paas-cf/concourse/tasks/custom-acceptance-tests-run.yml
+          params:
+            DISABLE_CUSTOM_ACCEPTANCE_TESTS: ((disable_custom_acceptance_tests))
+            DEPLOY_ENV: ((deploy_env))
+            AWS_REGION: ((aws_region))
+            SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+
+          ensure:
+            task: upload-test-artifacts
+            file: paas-cf/concourse/tasks/upload-test-artifacts.yml
             params:
-              DISABLE_CUSTOM_ACCEPTANCE_TESTS: ((disable_custom_acceptance_tests))
-              DEPLOY_ENV: ((deploy_env))
-              AWS_REGION: ((aws_region))
-              SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
-            ensure:
-              task: upload-test-artifacts
-              file: paas-cf/concourse/tasks/upload-test-artifacts.yml
-              params:
-                TEST_ARTIFACTS_BUCKET: ((test_artifacts_bucket))
-
-          - task: "Run paas-admin integration tests"
-            config:
-              platform: linux
-              image_resource:
-                type: docker-image
-                source:
-                  repository: node
-                  tag: 8-alpine
-              params:
-                DISABLE_CUSTOM_ACCEPTANCE_TESTS: ((disable_custom_acceptance_tests))
-                DEPLOY_ENV: ((deploy_env))
-                SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
-              inputs:
-                - name: paas-cf
-                - name: paas-admin
-                - name: admin-creds
-              run:
-                path: sh
-                args:
-                  - -e
-                  - -u
-                  - -c
-                  - |
-                    if [ "${DISABLE_CUSTOM_ACCEPTANCE_TESTS:-}" = "true" ]; then
-                      echo 'Skipping because DISABLE_CUSTOM_ACCEPTANCE_TESTS is set'
-                      exit 0
-                    fi
-                    cd paas-admin
-                    npm install
-
-                    ADMIN_USERNAME="$(cat ../admin-creds/username)" \
-                    ADMIN_PASSWORD="$(cat ../admin-creds/password)" \
-                    PAAS_ADMIN_BASE_URL="https://admin.${SYSTEM_DNS_ZONE_NAME}" \
-                    CF_API_BASE_URL="https://api.${SYSTEM_DNS_ZONE_NAME}" \
-                      npm run test:acceptance
+              TEST_ARTIFACTS_BUCKET: ((test_artifacts_bucket))
 
         ensure:
           task: remove-temp-user


### PR DESCRIPTION
What?
------

The PR in  alphagov/paas-cf#1463 does not had into account the agreements to accept after login. We need to revert this to unblock the pipeline

How to review?
--------------

No need

Who?
-----

Anyone