### PR TITLE
[Support] Switch back to upstream acceptance tests.

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -272,8 +272,8 @@ resources:
   - name: cf-acceptance-tests
     type: git
     source:
-      uri: https://github.com/alphagov/paas-cf-acceptance-tests
-      branch: cf2.6-gds
+      uri: https://github.com/cloudfoundry/cf-acceptance-tests
+      branch: cf2.6
 
   - name: cf-smoke-tests-release
     type: git


### PR DESCRIPTION
## What

The issue[1] that we encountered has been fixed upstream as of version
2.2, so we no longer need to use our fork of these with the workaround.

[1]https://github.com/cloudfoundry/cf-acceptance-tests/pull/312

How to review
-------------

Run the pipeline, verify that the acceptance tests pass.

You could go as far as checking out the referenced version of the tests and running locally with the loggregator test focussed to confirm that it's not flakey, or you could take my word for it that I've already done this testing.

Who can review
--------------

Not me.