### PR TITLE
[#158944131] Collect aiven estimated cost and add datadog monitor

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2526,6 +2526,8 @@ jobs:
             APPS_DNS_ZONE_NAME: ((apps_dns_zone_name))
             SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
             AWS_REGION: ((aws_region))
+            AIVEN_API_TOKEN: ((aiven_api_token))
+            AIVEN_PROJECT: paas-cf-((aws_account))
           inputs:
             - name: paas-cf
             - name: config
@@ -2569,6 +2571,8 @@ jobs:
                     'AWS_REGION' => '${AWS_REGION}',
                     'AWS_ACCESS_KEY_ID' => '${METRICS_AWS_ACCESS_KEY_ID}',
                     'AWS_SECRET_ACCESS_KEY' => '${METRICS_AWS_SECRET_ACCESS_KEY}',
+                    'AIVEN_API_TOKEN' => '${AIVEN_API_TOKEN}',
+                    'AIVEN_PROJECT' => '${AIVEN_PROJECT}'
                   }
                   manifest = YAML.load_file('manifest.yml')
                   manifest['applications'].each { |app|

--- a/terraform/datadog/aiven.tf
+++ b/terraform/datadog/aiven.tf
@@ -1,0 +1,16 @@
+resource "datadog_monitor" "aiven_cost_threshold" {
+  name                = "${format("%s aiven cost is high", var.env)}"
+  type                = "metric alert"
+  message             = "${format("Aiven cost is high, possibly need to alert finance. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
+  no_data_timeframe   = "7"
+  require_full_window = true
+
+  query = "${format("max(last_1h):max:aiven.estimated.cost{deploy_env:%s} > 3100.0", var.env)}"
+
+  thresholds {
+    warning  = "2600.00"
+    critical = "3100.00"
+  }
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors"]
+}

--- a/tools/metrics/aiven.go
+++ b/tools/metrics/aiven.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+type AivenClient struct {
+	BaseURL    *url.URL
+	Project    string
+	Token      string
+	httpClient *http.Client
+}
+
+type AivenInvoice struct {
+	Currency       string `json:"currency"`
+	Invoice_number string `json:"invoice_number"`
+	State          string `json:"state"`
+	Cost           string `json:"total_vat_zero"`
+}
+
+type AivenInvoiceResponse struct {
+	Invoices []AivenInvoice `json:"invoices"`
+}
+
+func NewAivenClient(project string, token string) (*AivenClient, error) {
+	httpClient := http.DefaultClient
+	baseurl, err := url.Parse("https://api.aiven.io/v1beta/")
+	if err != nil {
+		return nil, err
+	}
+
+	return &AivenClient{BaseURL: baseurl, Project: project, Token: token, httpClient: httpClient}, nil
+}
+
+func (c *AivenClient) GetInvoices() ([]AivenInvoice, error) {
+	path := &url.URL{Path: fmt.Sprintf("project/%s/invoice", c.Project)}
+	apiurl := c.BaseURL.ResolveReference(path)
+	req, err := http.NewRequest("GET", apiurl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("aivenv1 %s", c.Token))
+
+	resp, err := c.httpClient.Do(req)
+
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+    if resp.StatusCode != http.StatusOK {
+    	return nil, fmt.Errorf("Returned statuscode from aiven %d", resp.StatusCode)
+	}
+	bodyBuffer, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var invoiceResponse AivenInvoiceResponse
+	err = json.Unmarshal(bodyBuffer, &invoiceResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return invoiceResponse.Invoices, nil
+}
+
+func AivenCostGauge(client *AivenClient, interval time.Duration) MetricReadCloser {
+	return NewMetricPoller(interval, func(w MetricWriter) error {
+		metrics := []Metric{}
+		invoices, err := client.GetInvoices()
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(invoices)
+		for _, invoice := range invoices {
+			if invoice.State == "estimate" {
+				currentCost, err := strconv.ParseFloat(invoice.Cost, 64)
+				if err != nil {
+					return err
+				}
+				metrics = append(metrics, Metric{
+					Kind:  Gauge,
+					Time:  time.Now(),
+					Name:  "aiven.estimated.cost",
+					Value: currentCost,
+				})
+			}
+		}
+
+		return w.WriteMetrics(metrics)
+	})
+}

--- a/tools/metrics/aiven_test.go
+++ b/tools/metrics/aiven_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"github.com/alphagov/paas-cf/tools/metrics/fakes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+			"net/url"
+	"time"
+)
+
+var _ = Describe("Aiven", func() {
+	var (
+		aivenClient *AivenClient
+		fakeAivenServer *fakes.FakeAivenServer
+	)
+
+	BeforeEach(func() {
+		var err error
+		fakeAivenServer = fakes.NewFakeAivenServer("123456")
+		aivenClient, err = NewAivenClient("test", "123456")
+		Expect(err).ToNot(HaveOccurred())
+		aivenClient.BaseURL, err = url.Parse(fakeAivenServer.Server.URL)
+		Expect(err).ToNot(HaveOccurred())
+
+	})
+
+	It("returns all invoices", func() {
+		invoices, err := aivenClient.GetInvoices()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(invoices).To(HaveLen(2))
+	})
+
+	It("returns error of auth token is invalid", func() {
+		aivenClient.Token = "boaty mcboatface"
+		_, err := aivenClient.GetInvoices()
+		Expect(err).To(HaveOccurred())
+	})
+
+	Context("selects value from estimated invoice", func() {
+		It("lists all custom domains", func() {
+			gauge := AivenCostGauge(aivenClient, 1*time.Second)
+			defer gauge.Close()
+			var metric Metric
+			Eventually(func() string {
+				var err error
+				metric, err = gauge.ReadMetric()
+				Expect(err).NotTo(HaveOccurred())
+				return metric.Name
+			}, 3*time.Second).Should(Equal("aiven.estimated.cost"))
+
+			Expect(metric.Value).To(Equal(10.88))
+			Expect(metric.Kind).To(Equal(Gauge))
+		})
+	})
+})

--- a/tools/metrics/fakes/fake_aiven.go
+++ b/tools/metrics/fakes/fake_aiven.go
@@ -1,0 +1,59 @@
+package fakes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"fmt"
+)
+
+type FakeAivenServer struct {
+	Server *httptest.Server
+	Mux *http.ServeMux
+}
+
+func NewFakeAivenServer(validToken string) (aivenServer *FakeAivenServer) {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/project/test/invoice", func(w http.ResponseWriter, r *http.Request) {
+		auth:= r.Header.Get("Authorization")
+		validTokenHeader := fmt.Sprintf("aivenv1 %s", validToken )
+		if auth != validTokenHeader {
+			w.WriteHeader(http.StatusForbidden)
+		} else {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			w.Write([]byte(`
+			{
+				"invoices": [
+					{
+						"currency": "GBP",
+						"download_cookie": "123456789",
+						"invoice_number": "2dd1-1",
+						"period_begin": "2018-07-01T00:00:00Z",
+						"period_end": "2018-07-31T23:59:59Z",
+						"state": "mailed",
+						"total_inc_vat": "76.90",
+						"total_vat_zero": "64.08"
+					},
+					{
+						"currency": "GBP",
+						"download_cookie": "123456790",
+						"invoice_number": "2dd1-2",
+						"period_begin": "2018-08-01T00:00:00Z",
+						"period_end": "2018-08-01T23:59:59Z",
+						"state": "estimate",
+						"total_inc_vat": "13.06",
+						"total_vat_zero": "10.88"
+					}
+				]
+			}
+			`))
+		}
+	})
+
+	return &FakeAivenServer{
+		Mux:        mux,
+		Server:     httptest.NewServer(mux),
+	}
+}

--- a/tools/metrics/main.go
+++ b/tools/metrics/main.go
@@ -54,6 +54,13 @@ func Main() error {
 	if err != nil {
 		return errors.Wrap(err, "failed to connect to cloud foundry api")
 	}
+	a, err := NewAivenClient(
+		os.Getenv("AIVEN_PROJECT"),
+		os.Getenv("AIVEN_API_TOKEN"),
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to get Aiven connection data")
+	}
 	sess, err := session.NewSession()
 	if err != nil {
 		return errors.Wrap(err, "failed to connect to AWS API")
@@ -71,6 +78,7 @@ func Main() error {
 		SpaceCountGauge(c, 5*time.Minute),               // poll number of spaces
 		UserCountGauge(c, 5*time.Minute),                // poll number of users
 		QuotaGauge(c, 5*time.Minute),                    // poll quota usage
+		AivenCostGauge(a, 5*time.Minute),                // poll aiven cost
 		EventCountGauge(c, "app.crash", 10*time.Minute), // count number of times an event is seen within the interval
 		ELBNodeFailureCountGauge(logger, pingdumb.ReportConfig{
 			Target:  os.Getenv("ELB_ADDRESS"),


### PR DESCRIPTION
What
----

Monitor how much we are spending with Aiven and alert if necessary.

We want to know if we reach the limit internally agreed with
accounting, so that we can discuss what to do on time.


How to review
-------------

 - Code review

Check that works, either by yourself:

 - Deploy with datadog enabled (tip: you comment out or remove the addon in the
 `manifests/cf-manifest/operations/datadog.yml` in a tmp commit so it does not re deploy
 all VMs, you only need the nozzle)
 - Check that the metric is there in datadog

Or check that works on the `leeporte` environment in datadog directly.


Who can review
--------------

Anyone. @leeporte can merge, as we paired and I am happy with the
implementation.