### PR TITLE
[#157205103] Bump paas-billing to 0.38.0

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -351,7 +351,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-billing
-      tag_filter: v0.37.0
+      tag_filter: v0.38.0
 
   - name: paas-accounts
     type: git


### PR DESCRIPTION
What
----

Bump paas-billing to 0.38.0 to enable historical record of names for
org/space GUIDs.

How to review
-------------

If you really want to you can have a look at
https://github.com/alphagov/paas-billing/pull/45

Who can review
--------------

Anyone