### PR TITLE
Aiven service instances cannot change plans

### DIFF
--- a/config/service-brokers/aiven/config.json
+++ b/config/service-brokers/aiven/config.json
@@ -8,7 +8,7 @@
         "name": "elasticsearch",
         "description": "Elasticsearch instances provisioned via Aiven",
         "bindable": true,
-        "plan_updateable": true,
+        "plan_updateable": false,
         "metadata": {
           "displayName": "Elasticsearch",
           "providerDisplayName": "GOV.UK PaaS",


### PR DESCRIPTION
What
----

The 2 Elasticsearch plans we're launching with are both the same size,
varied only by ES version (5 vs 6). Also, Aiven doesn't perform a
version upgrade when moving an existing service instance from the
small-ha-5 plan to the small-ha-6 plan.

Taken together, these two facts mean that there's no meaningful plan
change that can be made - so in this commit we mark these plans as
non-updatable.

The above holds, technically, for now, but may not be true in the
future.  We are choosing to delay the work to implement selective
update-ability until we actually introduce differently-sized plans.

Describe what you have changed and why.

How to review
-------------

- Point a dev env at this branch
- Update CF (possibly just the `post-deploy` job)
- Enable service access to `elasticsearch` for at least one org and space
- `cf create-service elasticsearch small-ha-5.x an-instance`
- `watch cf services` until it's created
- observe that `cf update-service an-instance -p small-ha-6.x` fails

If we don't do this 
-----------------

This PR is to enable the documentation story #154638140 to include "you can't update service instances". If we don't do this, then we'll have to document upgrade paths which *seem* to succeed, but don't really do anything, which seems sub-optimal at best.

Who can review
--------------

Anyone except me.