### PR TITLE
[#159172134] Bump log-cache version

### DIFF
--- a/manifests/cf-manifest/operations.d/540-log-cache.yml
+++ b/manifests/cf-manifest/operations.d/540-log-cache.yml
@@ -9,9 +9,9 @@
   path: /releases/-
   value:
     name: log-cache
-    sha: 87134510c23ce5facca665ac025f41a19340f5e9
-    url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=1.1.1
-    version: 1.1.1
+    sha: 8330eee7454c27790869aacdf5b58d497c3007b0
+    url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=1.4.1
+    version: 1.4.1
 
 - type: replace
   path: /instance_groups/name=doppler/jobs/-


### PR DESCRIPTION
What
----

We're periodically experiencing responses with `502` on `/v1/meta`
endpoint, and before the issue is raised with the upstream, we'd like to
make sure it doesn't only happen to that specific version of log-cache.

The upgrade also involves other bug fixes and features, including:
- Fix data duplication bug
- Additional metrics for CFAuthProxy

This may solve one of our other stories we have in the backlog.

How to review
-------------

- Check if latest version has been used
- Optionally, run through pipeline