### PR TITLE
Increase the collection interval

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -85,6 +85,8 @@
               ca_cert: "((service_cf_internal_ca.certificate))((service_cf_internal_ca_old.certificate))"
               client_cert: "((diego_locket_client.certificate))"
               client_key: "((diego_locket_client.private_key))"
+            scheduler:
+              metrics_collector_interval: 600
       - name: rds-broker
         release: rds-broker
         properties:


### PR DESCRIPTION
What
----

We're now scraping a lot of metrics every 1 minute. We presume that's
OK, however this includes querying the AWS CloudWatch, which is really
expensive. For the time being in order to save some moneys, we'd like to
run the queries every 10 minutes. A downside is that at the current
state of an application it has to apply these for all metric collectors.

This should be a temporary change, and ideally be reverted back and
sorted in a different way.

How to review
-------------

- Make sure the change makes sense

I haven't tested this. Base on https://github.com/alphagov/paas-rds-broker-boshrelease/blob/master/jobs/rds-metric-collector/spec#L40-L42