### PR TITLE
[#159136460] Bump datadog BOSH release

### DIFF
--- a/manifests/cf-manifest/operations.d/520-datadog-add-instance-group-checks.yml
+++ b/manifests/cf-manifest/operations.d/520-datadog-add-instance-group-checks.yml
@@ -4,10 +4,9 @@
   path: /releases/-
   value:
     name: datadog-for-cloudfoundry
-    version: 0.1.26
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.1.26.tgz
-    sha1: c47959e19137a2f6420422baa6f8b1f1abe25879
-
+    version: 0.1.27
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-for-cloudfoundry-0.1.27.tgz
+    sha1: 53b108f7e1a36df064e6d264c4e447d0fbb9f9de
 
 - type: replace
   path: /instance_groups/name=consul/jobs/-


### PR DESCRIPTION
What
----

Bump the datadog Bosh release to include a BAU change which tests Consul's reporting of its leader against IPs, not against DNS names.

How to review
-------------

- Merge https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/31
- Update the WIP commit in this PR's branch referencing the final BOSH release
- Deploy a dev env on this branch with datadog integrations enabled
- Check that the `<env name> consul cluster has at least one leader` datadog monitor is not red

Who can review
--------------

Anyone except myself.