### PR TITLE
[#159620811] rds-broker to 0.1.42 (v0.20.0 of paas-rds-broker)

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -49,9 +49,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 0.1.41
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.41.tgz
-    sha1: f7d6b9e9ac43849ad9c8dbb21f46b5acf88acb17
+    version: 0.1.42
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.42.tgz
+    sha1: 2715059cde500904bb5dcd084c04a4db1896ee68
 
 - type: replace
   path: /instance_groups/-


### PR DESCRIPTION
What
----

This is to fix the bug where RDS instances would have some flags
overwritten during operations like master password resets.

How to review
-------------

See:

* the [bosh-release build](https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/rds-broker-release/jobs/build-final-release/builds/42?)
* the [rds-broker build](https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/rds-broker/jobs/tag-releases/builds/24)
* the [PR](https://github.com/alphagov/paas-rds-broker/pull/85)

Who can review
--------------

Anyone