### PR TITLE
[#159790813] Bump paas-billing to 0.39.0

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -351,7 +351,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-billing
-      tag_filter: v0.38.0
+      tag_filter: v0.39.0
 
   - name: paas-accounts
     type: git


### PR DESCRIPTION
What
----

Bump paas-billing to 0.39.0.

Why
----

The new version **stops** enforcing a minimum 1p charge per resource.

How to review
-------------

This **is** the review of https://github.com/alphagov/paas-billing/pull/46.

Who can review
--------------

@richardTowers and myself are doing&reviewing.