### PR TITLE
[#159559834] - Add the rsyslog impstats module

### DIFF
--- a/manifests/cf-manifest/operations.d/500-syslog-forwarder.yml
+++ b/manifests/cf-manifest/operations.d/500-syslog-forwarder.yml
@@ -26,4 +26,11 @@
             custom_rule: |
               $MaxMessageSize 64k
               if ($programname startswith "vcap.") then ~
+
+              module(load="impstats"
+                interval="60"
+                severity="7"
+                log.syslog="on"
+                format="json-elasticsearch")
+
             use_tcp_for_file_forwarding_local_transport: true


### PR DESCRIPTION
What
----

We've had some suspected issues with rsyslog using a lot of memory. If
this happens again it would be nice to have enough detail available in
the logs to diagnose the issue.

Adding the impstats module in this way causes rsyslog to log a set of
diagnostic information every one minute like the following:

```
2018-08-16T15:42:13.195272+00:00 localhost rsyslogd-pstats: { "name": "global", "origin": "dynstats", "values": { } }
2018-08-16T15:42:13.195290+00:00 localhost rsyslogd-pstats: { "name": "imuxsock", "origin": "imuxsock", "submitted": 8, "ratelimit!discarded": 0, "ratelimit!numratelimiters": 0 }
2018-08-16T15:42:13.195302+00:00 localhost rsyslogd-pstats: { "name": "action 1", "origin": "core.action", "processed": 328, "failed": 0, "suspended": 0, "suspended!duration": 0, "resumed": 0 }
2018-08-16T15:42:13.195311+00:00 localhost rsyslogd-pstats: { "name": "action 2", "origin": "core.action", "processed": 0, "failed": 0, "suspended": 0, "suspended!duration": 0, "resumed": 0 }
2018-08-16T15:42:13.195319+00:00 localhost rsyslogd-pstats: { "name": "action 3", "origin": "core.action", "processed": 258, "failed": 0, "suspended": 0, "suspended!duration": 0, "resumed": 0 }
2018-08-16T15:42:13.195342+00:00 localhost rsyslogd-pstats: { "name": "action 4", "origin": "core.action", "processed": 0, "failed": 0, "suspended": 0, "suspended!duration": 0, "resumed": 0 }
2018-08-16T15:42:13.195349+00:00 localhost rsyslogd-pstats: { "name": "action 5", "origin": "core.action", "processed": 0, "failed": 0, "suspended": 0, "suspended!duration": 0, "resumed": 0 }
2018-08-16T15:42:13.195354+00:00 localhost rsyslogd-pstats: { "name": "action 6", "origin": "core.action", "processed": 0, "failed": 0, "suspended": 0, "suspended!duration": 0, "resumed": 0 }
2018-08-16T15:42:13.195359+00:00 localhost rsyslogd-pstats: { "name": "action 7", "origin": "core.action", "processed": 0, "failed": 0, "suspended": 0, "suspended!duration": 0, "resumed": 0 }
2018-08-16T15:42:13.195363+00:00 localhost rsyslogd-pstats: { "name": "action 8", "origin": "core.action", "processed": 0, "failed": 0, "suspended": 0, "suspended!duration": 0, "resumed": 0 }
2018-08-16T15:42:13.195367+00:00 localhost rsyslogd-pstats: { "name": "action 9", "origin": "core.action", "processed": 0, "failed": 0, "suspended": 0, "suspended!duration": 0, "resumed": 0 }
2018-08-16T15:42:13.195371+00:00 localhost rsyslogd-pstats: { "name": "action 10", "origin": "core.action", "processed": 0, "failed": 0, "suspended": 0, "suspended!duration": 0, "resumed": 0 }
2018-08-16T15:42:13.195376+00:00 localhost rsyslogd-pstats: { "name": "action 11", "origin": "core.action", "processed": 0, "failed": 0, "suspended": 0, "suspended!duration": 0, "resumed": 0 }
2018-08-16T15:42:13.195382+00:00 localhost rsyslogd-pstats: { "name": "action 12", "origin": "core.action", "processed": 0, "failed": 0, "suspended": 0, "suspended!duration": 0, "resumed": 0 }
2018-08-16T15:42:13.195386+00:00 localhost rsyslogd-pstats: { "name": "action 13", "origin": "core.action", "processed": 0, "failed": 0, "suspended": 0, "suspended!duration": 0, "resumed": 0 }
2018-08-16T15:42:13.195390+00:00 localhost rsyslogd-pstats: { "name": "action 14", "origin": "core.action", "processed": 0, "failed": 0, "suspended": 0, "suspended!duration": 0, "resumed": 0 }
2018-08-16T15:42:13.195394+00:00 localhost rsyslogd-pstats: { "name": "action 15", "origin": "core.action", "processed": 27, "failed": 0, "suspended": 0, "suspended!duration": 0, "resumed": 0 }
2018-08-16T15:42:13.195398+00:00 localhost rsyslogd-pstats: { "name": "action 16", "origin": "core.action", "processed": 229, "failed": 0, "suspended": 0, "suspended!duration": 0, "resumed": 0 }
2018-08-16T15:42:13.195403+00:00 localhost rsyslogd-pstats: { "name": "action 17", "origin": "core.action", "processed": 0, "failed": 0, "suspended": 0, "suspended!duration": 0, "resumed": 0 }
2018-08-16T15:42:13.195408+00:00 localhost rsyslogd-pstats: { "name": "action 18", "origin": "core.action", "processed": 256, "failed": 243, "suspended": 1, "suspended!duration": 140, "resumed": 0 }
2018-08-16T15:42:13.195411+00:00 localhost rsyslogd-pstats: { "name": "imudp(127.0.0.1:514)", "origin": "imudp", "submitted": 225 }
2018-08-16T15:42:13.195414+00:00 localhost rsyslogd-pstats: { "name": "imtcp(514)", "origin": "imtcp", "submitted": 70 }
2018-08-16T15:42:13.195422+00:00 localhost rsyslogd-pstats: { "name": "resource-usage", "origin": "impstats", "utime": 60000, "stime": 20000, "maxrss": 5380, "minflt": 376, "majflt": 0, "inblock": 0, "oublock": 304, "nvcsw": 871, "nivcsw": 21 }
2018-08-16T15:42:13.195429+00:00 localhost rsyslogd-pstats: { "name": "action 1 queue[DA]", "origin": "core.queue", "size": 0, "enqueued": 0, "full": 0, "discarded!full": 0, "discarded!nf": 0, "maxqsize": 0 }
2018-08-16T15:42:13.195433+00:00 localhost rsyslogd-pstats: { "name": "action 1 queue", "origin": "core.queue", "size": 0, "enqueued": 328, "full": 0, "discarded!full": 0, "discarded!nf": 0, "maxqsize": 27 }
2018-08-16T15:42:13.195438+00:00 localhost rsyslogd-pstats: { "name": "main Q", "origin": "core.queue", "size": 25, "enqueued": 361, "full": 0, "discarded!full": 0, "discarded!nf": 0, "maxqsize": 25 }
2018-08-16T15:42:13.195442+00:00 localhost rsyslogd-pstats: { "name": "imudp(w0)", "origin": "imudp", "called!recvmmsg": 448, "called!recvmsg": 0, "msgs!received": 225 }
```

This is logged to syslog, so it will be available in /var/log/syslog and this is also shipped to Logit.

How to review
-------------

* See https://kibana.logit.io/s/c7358874-2b30-44a6-8271-554ad3996e50/goto/c65cf89b2753d3091357034f2e4fc494 for examples of the new logs being written
* Familiarise yourself with rsyslog impstats - https://www.rsyslog.com/doc/master/configuration/modules/impstats.html

Who can review
--------------

Anyone.