### PR TITLE
Downgrade log-cache 1.3.0 to avoid memory leak

### DIFF
--- a/manifests/cf-manifest/operations.d/540-log-cache.yml
+++ b/manifests/cf-manifest/operations.d/540-log-cache.yml
@@ -8,10 +8,10 @@
 - type: replace
   path: /releases/-
   value:
-    name: log-cache
-    sha: 8330eee7454c27790869aacdf5b58d497c3007b0
-    url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=1.4.1
-    version: 1.4.1
+    name: "log-cache"
+    version: "1.3.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=1.3.0"
+    sha1: "2fee0f51c4093091d33eb117202f7476f1a4ebcf"
 
 - type: replace
   path: /instance_groups/name=doppler/jobs/-


### PR DESCRIPTION
What
----

The log-cache 1.4.1 has some problems freeing memory in the store[1][2]

This has caused some problems in production to us, where log-cache
grew to consume all the memory and swap of the doppler nodes.

This is meant to be fixed in 1.4.2 from comments in slack #log-cache[3]
but it is not ready yet.

The most recent stable version is 1.3.0, it is not as performant but
more stable.

[1] https://www.pivotaltracker.com/story/show/159699403
[2] https://www.pivotaltracker.com/story/show/157700747
[3] https://cloudfoundry.slack.com/archives/CBFB7NP9B/p1534518013000100

How to review
-------------

Code review, check the version in https://bosh.io/releases/github.com/cloudfoundry/log-cache-release?version=1.3.0

No point to test it, let it run in staging and if there are problems we
revert.

Who can review
--------------

Anyone