### PR TITLE
Fix unbound variable

### DIFF
--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -67,7 +67,7 @@ prepare_environment() {
   get_google_oauth_secrets
   get_notify_secrets
 
-  if [ -n "${SLIM_DEV_DEPLOYMENT}" ] && [ "${MAKEFILE_ENV_TARGET}" != "dev" ]; then
+  if [ -n "${SLIM_DEV_DEPLOYMENT:-}" ] && [ "${MAKEFILE_ENV_TARGET}" != "dev" ]; then
     echo "SLIM_DEV_DEPLOYMENT set for non-dev deployment. Aborting!"
     exit 1
   fi


### PR DESCRIPTION
What
----

Now that we have implemented the slim dev deployment functionality, we
should make sure it doesn't break any of our persisting environments.

Falling back to nothing with bash should ensure the desired behaviour,
where it has failed on us in previous staging deployment.

How to review
-------------

- See if the thing makes sense
- Probably no need to deployment to dev. The only way to find out if it works, is to deploy it :D