### PR TITLE
[#SUPPORT] Set monitor threshold for gorouter health to 55%

### DIFF
--- a/terraform/datadog/router.tf
+++ b/terraform/datadog/router.tf
@@ -129,7 +129,7 @@ resource "datadog_monitor" "gorouter_healthy" {
   query = "${format("'http.can_connect'.over('deploy_env:%s','instance:gorouter','url:http://localhost:80/').by('*').last(1).pct_by_status()", var.env)}"
 
   thresholds {
-    critical = 50
+    critical = 55
   }
 
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:router"]


### PR DESCRIPTION
What
----


This monitor triggers when the % of gorouters marked as unhealthy
is >= 50%.

But it is incorrectly triggered sometimes when we do a change
that redeploys the VMs, for instance for a stemcell changes:

 - BOSH would create new VMs which will replace the previous
   ones, with different hostname.
 - From the point of view of datadog, they are different instances.
 - When this happens, if during the stop of the old VMs the check
   failed (ie. haproxy stopped after gorouter and then the check run),
   datadog would keep record of the failure on the VM for 24h
 - In that case 3 instances would be marked as failed (old ones) and
   3 instances would be marked as OK.
 - If the threshold is >= 50%, the monitor would be incorrectly
   triggered for 24h until the old VMs metrics are gone.

We opened tickets with datadog but with not a sastifactory answer:

https://help.datadoghq.com/hc/en-us/requests/148727

As a workaround, we change the threshold to something slightly over
50%. The Datadog UI allows to set 55%, so 55% will be. With this
number, under the circunstances described above, the monitor won't
be incorrectly trigger (unless there is other deployment within 24h)

How to review
-------------

Code review


Who can review
--------------

Not me