### PR TITLE
Re-enable the self-signed ssl test.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,8 @@ lint_ruby:
 
 .PHONY: lint_posix_newlines
 lint_posix_newlines:
-	git ls-files | grep -v vendor/ | xargs ./scripts/test_posix_newline.sh
+	@# for some reason `git ls-files` is including 'manifests/cf-deployment' in its output...which is a directory
+	git ls-files | grep -v vendor/ | grep -v manifests/cf-deployment | xargs ./scripts/test_posix_newline.sh
 
 GPG = $(shell command -v gpg2 || command -v gpg)
 

--- a/scripts/test_posix_newline.sh
+++ b/scripts/test_posix_newline.sh
@@ -2,9 +2,15 @@
 RET_CODE=0
 
 test_posix_newline() {
+  if [ ! -f "$1" ]; then
+    echo "$1 is not a regular file" 1>&2
+    RET_CODE=1
+    return
+  fi
   if [ ! -r "$1" ]; then
     echo "File $1 not found or not readable" 1>&2
     RET_CODE=1
+    return
   fi
   if grep -Iq . "$1" ; then
     final_char=$(tail -q -c 1 "$1")

--- a/tools/metrics/tlscheck/tls_test.go
+++ b/tools/metrics/tlscheck/tls_test.go
@@ -40,13 +40,10 @@ var _ = Describe("TLSCheck", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
-		// FIXME: This should be reverted back, once the https://github.com/chromium/badssl.com/issues/359
-		// has been resolved.
-		//
-		//		It("returns error for certificate with self-signed CA", func() {
-		//			_, err := checker.DaysUntilExpiry("self-signed.badssl.com:443", &tls.Config{})
-		//			Expect(err).To(HaveOccurred())
-		//		})
+		It("returns error for certificate with self-signed CA", func() {
+			_, err := checker.DaysUntilExpiry("self-signed.badssl.com:443", &tls.Config{})
+			Expect(err).To(HaveOccurred())
+		})
 
 		It("returns error for certificate with null cipher suite", func() {
 			_, err := checker.DaysUntilExpiry("null.badssl.com:443", &tls.Config{})


### PR DESCRIPTION
What
----

The issue has been fixed by the 3rd party maintainers of the site:
https://github.com/chromium/badssl.com/issues/359
This test can now be re-enabled.

How to review
-------------

1. Code review
1. Run the tests locally (`make test`)

Who can review
--------------

Anyone but me.