### PR TITLE
[#160021128] Bump paas-admin to version 0.34.0

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -363,7 +363,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-admin
-      tag_filter: v0.33.0
+      tag_filter: v0.34.0
 
   - name: paas-log-cache-adapter
     type: git


### PR DESCRIPTION
What
----


The new version contains upgrade of dependencies to fix a minor
problem running acceptance tests.

https://github.com/alphagov/paas-admin/pull/93

How to review
-------------

Check the version number

Who can review
--------------

not me