### PR TITLE
[support task] Make Doppler ELB latency monitor more reliable

### DIFF
--- a/terraform/datadog/elb.tf
+++ b/terraform/datadog/elb.tf
@@ -3,7 +3,7 @@ resource "datadog_monitor" "abnormal_api_latency_doppler" {
   type    = "query alert"
   message = "${format("{{#is_alert}}We're experiencing >= {{threshold}} change in ELB Latency.{{/is_alert}} \n{{#is_warning}}We're experiencing >= {{warn_threshold}} change in ELB Latency.{{/is_warning}} \n\nVisit the [Team Manual > Responding to alerts > API Latency](%s#api-latency) for more info. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_documentation_url, var.aws_account)}"
 
-  query = "${format("avg(last_1h):anomalies(avg:aws.elb.latency{name:%s-cf-doppler}, 'agile', 2, direction='above', alert_window='last_5m', interval=20, count_default_zero='false', seasonality='weekly') > 0.5", var.env)}"
+  query = "${format("avg(last_1h):anomalies(avg:aws.elb.latency{name:%s-cf-doppler}, 'agile', 2, direction='above', alert_window='last_30m', interval=20, count_default_zero='false', seasonality='weekly') > 0.5", var.env)}"
 
   require_full_window = true
 


### PR DESCRIPTION
## What

We do not want this monitor to generate spurious alerts.

Currently this monitor is being triggered a few times a day for up to 10
minutes at a time. The current behaviour that leads me to think this is
spurious: looking at the `aws.elb.latency` metric it seems normal for
the value to be around 9µs, but regularly spiking up to 20-30µs for only
5 minutes or so. The spikes consistently return to normal levels and
are, in my opinion, not high latencies.

Given the current alert window is 5 minutes and only 50% of values need
to be above the threshold, it seems correct for the alert to trigger as
often as it does[1]. Since a typical spike lasts no longer than 15
minutes and we want to trigger when 50% of values are above the
threshold I have decided to make the alert window 30 minutes.

In the event of a real problem we will expect the monitor to trigger
after 15 minutes or so, which does increase our response time, but
should generate much less noise from the monitor.

[1] https://docs.datadoghq.com/monitors/monitor_types/anomaly/#advanced-options

How to review
-------------

Deploying this would take a long time. In my opinion code review and a manual check once in prod should be sufficient. Your call.

Who can review
--------------

Anyone but me.