### PR TITLE
[#159986104] Bump metric collector to v0.9.0

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -49,9 +49,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 0.1.43
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.43.tgz
-    sha1: 33a50f7d7ab870a5b6cec3d6a19558bde9f39ba7
+    version: 0.1.44
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.44.tgz
+    sha1: 33a2b8e72e92111b785884859b486b43e160df87
 
 - type: replace
   path: /instance_groups/-


### PR DESCRIPTION
## What

This bumps the collector to the version which continues to collect
metrics when it hits an error[1].

[1] https://github.com/alphagov/paas-rds-metric-collector/pull/11

How to review
-------------

This has been code reviewed and merged without deployment, so if the reviewer thinks it is low risk enough they can merge this. Otherwise, at least deploy from this branch and check the custom acceptance tests pass.

Who can review
--------------

@tlwr 
