### PR TITLE
[#159173326] Output metrics /w Prom exposition fmt

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -370,7 +370,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-log-cache-adapter
-      tag_filter: v0.1.0
+      tag_filter: v0.3.0
 
   - name: prometheus-vars-store
     type: s3-iam


### PR DESCRIPTION
What
----

Change the Prometheus metrics exporter to include TYPE annotations.

Interestingly `v0.2.0` was never deployed

How to review
-------------

See if https://github.com/alphagov/paas-log-cache-adapter/pull/4 looks legit

Who can review
--------------

Not me or Sam
