### PR TITLE
[#159173326] Bump paas-log-cache-adapter v0.4.0

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -370,7 +370,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-log-cache-adapter
-      tag_filter: v0.3.0
+      tag_filter: v0.4.0
 
   - name: prometheus-vars-store
     type: s3-iam


### PR DESCRIPTION
What
----

Bumps the version of paas-log-cache-adapter to v0.4.0

v0.4.0 contains improvements that causes promtool to complain less when scraping metrics, now it only complains about HELP annotations and naming

How to review
-------------

Version bump

Who can review
--------------

Not me
