### PR TITLE
[Support task] Replace Doppler latency monitor

### DIFF
--- a/terraform/datadog/doppler.tf
+++ b/terraform/datadog/doppler.tf
@@ -1,0 +1,17 @@
+resource "datadog_monitor" "doppler_dropped_envelopes" {
+  name    = "${format("%s Doppler - dropped envelopes", var.env)}"
+  type    = "query alert"
+  message = "${format("{{#is_alert}}A Doppler VM is dropping >= {{threshold}} envelopes.{{/is_alert}} \n{{#is_warning}}A Doppler VM is dropping >= {{warn_threshold}} envelopes.{{/is_warning}} \n\nInvestigate whether this is a one-off or we need to scale our Dopplers. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
+
+  query = "${format("change(max(last_10m),last_1h):max:cf.loggregator.doppler.dropped{deployment:%s} by {index} > 1000", var.env)}"
+
+  require_full_window = false
+  notify_no_data      = false
+
+  thresholds {
+    warning  = 100
+    critical = 1000
+  }
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:doppler"]
+}

--- a/terraform/datadog/elb.tf
+++ b/terraform/datadog/elb.tf
@@ -1,20 +1,3 @@
-resource "datadog_monitor" "abnormal_api_latency_doppler" {
-  name    = "${format("%s Abnormal API Latency - Doppler", var.env)}"
-  type    = "query alert"
-  message = "${format("{{#is_alert}}We're experiencing >= {{threshold}} change in ELB Latency.{{/is_alert}} \n{{#is_warning}}We're experiencing >= {{warn_threshold}} change in ELB Latency.{{/is_warning}} \n\nVisit the [Team Manual > Responding to alerts > API Latency](%s#api-latency) for more info. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_documentation_url, var.aws_account)}"
-
-  query = "${format("avg(last_1h):anomalies(avg:aws.elb.latency{name:%s-cf-doppler}, 'agile', 2, direction='above', alert_window='last_30m', interval=20, count_default_zero='false', seasonality='weekly') > 0.5", var.env)}"
-
-  require_full_window = true
-
-  thresholds {
-    warning  = 0.25
-    critical = 0.5
-  }
-
-  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:doppler"]
-}
-
 resource "datadog_monitor" "unhealthy_elb_node" {
   name           = "${format("%s At least one ELB node is not responding", var.env)}"
   type           = "metric alert"


### PR DESCRIPTION
## What

Despite various previous attempts to make this monitor less noisy we
still get spurious alerts. I believe this is because the nature of the
metric we are monitoring: the ELB latency is a very small value (around
9µs) and is subject to high spikes, but not to a level where the latency
is something we would worry about.

This monitor achieves the same result: it gives us an indication of the
health of the Dopplers and whether they are coping with the log and
metric volumes.

The monitor is a change alert because the metric is a count (and will
therefore keep increasing for the lifecycle of the VM). It checks the
maximum count in the last 10 minutes and compares it to the value an
hour ago[1].

[1] https://docs.datadoghq.com/api/?lang=python#create-a-monitor

How to review
-------------

I've deployed this with Datadog to ensure it deploys correctly: it does. The rest is up to you.

Who can review
--------------

Anyone but me.
