### PR TITLE
[#157053149] Revert "Remove Compose API token from paas-billing"

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2055,9 +2055,6 @@ jobs:
                   File.write('manifest.yml', manifest.to_yaml)
                 "
 
-                # FIXME: remove once this has reached prod
-                cf unset-env paas-billing COMPOSE_API_KEY
-
                 cf push paas-billing
 
       - task: deploy-paas-accounts


### PR DESCRIPTION
## What

This has now been removed in persistent environments, so we no longer
need it.

This reverts commit de3a0d6e72b2e498462e1d32e52c1ef9718228e9.

How to review
-------------

* Check this makes sense
* Check that #1515 has been deployed in all persistent envs.

Who can review
--------------

Not me.