### PR TITLE
[#159732085] Add smaller non-HA elasticsearch plans

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -346,7 +346,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-billing
-      tag_filter: v0.42.0
+      tag_filter: v0.43.0
 
   - name: paas-accounts
     type: git

--- a/config/service-brokers/aiven/config.json
+++ b/config/service-brokers/aiven/config.json
@@ -16,6 +16,26 @@
         },
         "plans": [
           {
+            "id": "07264114-c666-440b-934a-015508be4475",
+            "name": "tiny-5.x",
+            "aiven_plan": "startup-4",
+            "elasticsearch_version": "5",
+            "description": "NOT Highly Available, 1 dedicated VM, 1 CPU per VM, 4GB RAM per VM, 80GB disk space.",
+            "metadata": {
+              "displayName": "Tiny, NOT Highly Available single-node Elasticsearch 5 cluster"
+            }
+          },
+          {
+            "id": "7c0e6f6a-e443-41a0-83df-981bd35923a9",
+            "name": "tiny-6.x",
+            "aiven_plan": "startup-4",
+            "elasticsearch_version": "6",
+            "description": "NOT Highly Available, 1 dedicated VM, 1 CPU per VM, 4GB RAM per VM, 80GB disk space.",
+            "metadata": {
+              "displayName": "Tiny, NOT Highly Available single-node Elasticsearch 6 cluster"
+            }
+          },
+          {
             "id": "0eee9e10-db37-4cc3-bc9b-39e378ff3a5f",
             "name": "small-ha-5.x",
             "aiven_plan": "business-4",

--- a/config/service-brokers/aiven/config.json
+++ b/config/service-brokers/aiven/config.json
@@ -21,6 +21,7 @@
             "aiven_plan": "startup-4",
             "elasticsearch_version": "5",
             "description": "NOT Highly Available, 1 dedicated VM, 1 CPU per VM, 4GB RAM per VM, 80GB disk space.",
+            "free": true,
             "metadata": {
               "displayName": "Tiny, NOT Highly Available single-node Elasticsearch 5 cluster"
             }
@@ -31,6 +32,7 @@
             "aiven_plan": "startup-4",
             "elasticsearch_version": "6",
             "description": "NOT Highly Available, 1 dedicated VM, 1 CPU per VM, 4GB RAM per VM, 80GB disk space.",
+            "free": true,
             "metadata": {
               "displayName": "Tiny, NOT Highly Available single-node Elasticsearch 6 cluster"
             }
@@ -41,6 +43,7 @@
             "aiven_plan": "business-4",
             "elasticsearch_version": "5",
             "description": "3 dedicated VMs, 1 CPU per VM, 4GB RAM per VM, 240GB disk space.",
+            "free": false,
             "metadata": {
               "displayName": "Small, highly available Elasticsearch 5 cluster"
             }
@@ -51,6 +54,7 @@
             "aiven_plan": "business-4",
             "elasticsearch_version": "6",
             "description": "3 dedicated VMs, 1 CPU per VM, 4GB RAM per VM, 240GB disk space.",
+            "free": false,
             "metadata": {
               "displayName": "Small, highly available Elasticsearch 6 cluster"
             }

--- a/platform-tests/src/platform/acceptance/elasticsearch_service_test.go
+++ b/platform-tests/src/platform/acceptance/elasticsearch_service_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Elasticsearch backing service", func() {
 	)
 
 	var (
-		planNames = [2]string{"small-ha-5.x", "small-ha-6.x"}
+		planNames = []string{"tiny-5.x", "tiny-6.x", "small-ha-5.x", "small-ha-6.x"}
 	)
 
 	It("is registered in the marketplace", func() {


### PR DESCRIPTION
What
----

For many use-cases tenants don't need a HA elasticsearch instance, and
therefore want one that's smaller and cheaper. This adds these
instances.

This also updates our integration tests to use one of these smaller
plans so that we spend less testing the platform.

Now that we have some smaller plans, this marks the larger ones as non-free as we don't want them to be available for trial orgs.

How to review
-------------

* Deploy the pipeline from this branch.
* Verify the custom acceptance tests pass.
* Verify the new plans appear in the pricing calculator (`https://admin.${DEPLOY_ENV}.dev.cloudpipeline.digital/calculator`)

## :rotating_light: Before merging :rotating_light: 

Merge https://github.com/alphagov/paas-billing/pull/54 and update the TMP commit here accordingly.

Who can review
--------------

Not me.