### PR TITLE
[#159730005] Cert rotation and uaa_ca on gorouter for v3.6.0

### DIFF
--- a/manifests/cf-manifest/operations.d/310-router.yml
+++ b/manifests/cf-manifest/operations.d/310-router.yml
@@ -34,9 +34,14 @@
     enable_tls: true
     private_key: ((router_ssl.private_key))
 
+  # Upstream uses application_ca and service_cf_internal_ca
+  # We want to use these but also rotate them
+  #
+  # We also want to use the uaa_ca (and uaa_ca_old)
+  # so we can have TLS between gorouter and UAA
 - type: replace
   path: /instance_groups/name=router/jobs/name=gorouter/properties/router/ca_certs?
-  value: ((uaa_ca.certificate))((uaa_ca_old.certificate))
+  value: ((application_ca.certificate))((application_ca_old.certificate))((service_cf_internal_ca.certificate))((service_cf_internal_ca_old.certificate))((uaa_ca.certificate))((uaa_ca_old.certificate))
 
 - type: replace
   path: /instance_groups/name=router/jobs/name=gorouter/properties/router/drain_wait?


### PR DESCRIPTION
```
For cf-deployment v3.6.0

We have TLS between the gorouter and UAA, so we need tell the gorouter
to trust whatever CAs upstream has, AS WELL AS the CA that we use for
UAA.

We also do certificate rotations on all of these CA certs so we need to
add in the appropriate `${ca}_old` values.
```

What
----

We need to get gorouter to trust cloud controller (amongst others)

We're separating out our #159730005 v3.6.0 into separate releases so we do not get HTTP 526s when rolling out v3.6.0

How to review
-------------

Code review

Who can review
--------------

Not me or Richard
