### PR TITLE
[#159730005] upgrade upstream acceptance tests

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -274,7 +274,7 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-acceptance-tests
-      branch: cf2.6
+      branch: cf3.6
 
   - name: cf-smoke-tests-release
     type: git

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -280,7 +280,7 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-smoke-tests-release
-      tag_filter: "40.0.5"
+      tag_filter: "40.0.6"
       submodules:
       - "src/smoke_tests"
 


### PR DESCRIPTION
What
----

Upgrade the acceptance tests to the correct versions for cf-deployment 3.6, as per [the team manual](https://team-manual.cloud.service.gov.uk/guides/upgrading_CF,_bosh_and_stemcells/#before-upgrading).

How to review
-------------

* "Code review"
* Run the tests down a pipeline (they've been down `towers` already - had a failure in logcache-acceptance-tests which I think was just flakiness, so look out for that)

Who can review
--------------

Someone who:
* can count
* has a dev environment to test with