### PR TITLE
[#159730005] Ensure current buildpacks are installed.

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2819,6 +2819,74 @@ jobs:
                     ACCOUNTS_PASSWORD="$(awk '/^secrets_paas_accounts_admin_password:/ { print $2 }' < ../cf-vars-store/cf-vars-store.yml)" \
                       npm run test:acceptance
 
+          - task: ensure-buildpacks-exist
+            config:
+              platform: linux
+              image_resource:
+                type: docker-image
+                source:
+                  repository: governmentpaas/cf-cli
+                  tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+              inputs:
+                - name: paas-cf
+                - name: cf-vars-store
+              params:
+                CF_ADMIN: admin
+                SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+              run:
+                path: bash
+                args:
+                  - -c
+                  - |
+                    set -ueo pipefail
+
+                    CF_PASS=$(awk '/cf_admin_password/ {print $2}' cf-vars-store/cf-vars-store.yml | tr -d '"')
+                    API_ENDPOINT="https://api.${SYSTEM_DNS_ZONE_NAME}"
+                    echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}" > /dev/null
+
+                    SORT="sort"
+
+                    cat <<-BUILDPACKS | "$SORT" > desired_buildpacks.txt
+                    binary_buildpack
+                    staticfile_buildpack
+                    java_buildpack
+                    ruby_buildpack
+                    nodejs_buildpack
+                    go_buildpack
+                    python_buildpack
+                    php_buildpack
+                    BUILDPACKS
+
+                    cf buildpacks \
+                       | awk '/_buildpack/ {print $1}' \
+                       | "$SORT" \
+                       > actual_buildpacks.txt
+
+                    # comm is a utility to get common lines between files
+                    # -2 will hide the lines only present in the second file
+                    # -3 will hide the lines common in both
+                    # Therefore -23 will show only lines in the first, which
+                    # should be empty becase we expect `cf buildpacks` to be a
+                    # superset of those defined here
+                    #
+                    # We do not care about buildpack versions for this test
+                    comm -23 \
+                         desired_buildpacks.txt \
+                         actual_buildpacks.txt \
+                         > buildpacks_not_found.txt
+
+                    if grep -q . buildpacks_not_found.txt; then
+                      echo 'Could not find one of the following buildpacks:'
+                      cat buildpacks_not_found.txt
+                      echo '-----'
+                      echo 'List of buildpacks found:'
+                      cat actual_buildpacks.txt
+                      exit 1
+                    else
+                      echo 'All buildpacks present'
+                      exit 0
+                    fi
+
         ensure:
           task: remove-temp-user
           file: paas-cf/concourse/tasks/delete_admin.yml

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2830,6 +2830,7 @@ jobs:
               inputs:
                 - name: paas-cf
                 - name: cf-vars-store
+                - name: cf-manifest
               params:
                 CF_ADMIN: admin
                 SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
@@ -2844,48 +2845,41 @@ jobs:
                     API_ENDPOINT="https://api.${SYSTEM_DNS_ZONE_NAME}"
                     echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}" > /dev/null
 
-                    SORT="sort"
-
-                    cat <<-BUILDPACKS | "$SORT" > desired_buildpacks.txt
-                    binary_buildpack
-                    staticfile_buildpack
-                    java_buildpack
-                    ruby_buildpack
-                    nodejs_buildpack
-                    go_buildpack
-                    python_buildpack
-                    php_buildpack
-                    BUILDPACKS
-
                     cf buildpacks \
                        | awk '/_buildpack/ {print $1}' \
-                       | "$SORT" \
                        > actual_buildpacks.txt
 
-                    # comm is a utility to get common lines between files
-                    # -2 will hide the lines only present in the second file
-                    # -3 will hide the lines common in both
-                    # Therefore -23 will show only lines in the first, which
-                    # should be empty becase we expect `cf buildpacks` to be a
-                    # superset of those defined here
-                    #
-                    # We do not care about buildpack versions for this test
-                    comm -23 \
-                         desired_buildpacks.txt \
-                         actual_buildpacks.txt \
-                         > buildpacks_not_found.txt
+                    ruby <<-RUBY
+                    require 'yaml'
+                    YAML
+                      .load_file('cf-manifest/cf-manifest.yml')
+                      .fetch('instance_groups', [])
+                      .find { |g| g['name'] == 'api' }
+                      .fetch('jobs', [])
+                      .find { |j| j['name'] == 'cloud_controller_ng' }
+                      .dig('properties', 'cc', 'install_buildpacks')
+                      .map { |buildpack| buildpack['name'] }
+                      .tap do |expected|
+                        actual = File
+                          .read('actual_buildpacks.txt')
+                          .lines
+                          .map(&:strip)
+                          .to_a
 
-                    if grep -q . buildpacks_not_found.txt; then
-                      echo 'Could not find one of the following buildpacks:'
-                      cat buildpacks_not_found.txt
-                      echo '-----'
-                      echo 'List of buildpacks found:'
-                      cat actual_buildpacks.txt
-                      exit 1
-                    else
-                      echo 'All buildpacks present'
-                      exit 0
-                    fi
+                        puts 'Expected', '-----', expected, '-----'
+                        puts 'Actual',   '-----', actual,   '-----'
+
+                        buildpacks_not_found = expected - actual
+
+                        if buildpacks_not_found.empty?
+                          puts 'Found all buildpacks'
+                          exit 0
+                        else
+                          puts "Could not find #{buildpacks_not_found.inspect}"
+                          exit 1
+                        end
+                      end
+                    RUBY
 
         ensure:
           task: remove-temp-user

--- a/manifests/cf-manifest/operations.d/230-rename-buildpack-packages.yml
+++ b/manifests/cf-manifest/operations.d/230-rename-buildpack-packages.yml
@@ -1,0 +1,19 @@
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks
+  value:
+  - name: staticfile_buildpack
+    package: staticfile-buildpack
+  - name: java_buildpack
+    package: java-buildpack
+  - name: ruby_buildpack
+    package: ruby-buildpack
+  - name: nodejs_buildpack
+    package: nodejs-buildpack
+  - name: go_buildpack
+    package: go-buildpack
+  - name: python_buildpack
+    package: python-buildpack
+  - name: php_buildpack
+    package: php-buildpack
+  - name: binary_buildpack
+    package: binary-buildpack

--- a/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
@@ -208,6 +208,16 @@ RSpec.describe "base properties" do
           "install_buildpacks entry #{pack.fetch('name')} references non-existent package #{pack.fetch('package')}"
       end
     end
+
+    it "install_buildpacks contains certain named buildpacks" do
+      expected = %w[
+        staticfile_buildpack java_buildpack ruby_buildpack nodejs_buildpack
+        go_buildpack python_buildpack php_buildpack binary_buildpack
+      ]
+      actual = install_buildpacks_property.map { |b| b.fetch('name') }
+
+      expect(expected - actual).to be_empty
+    end
   end
 
   describe "router" do

--- a/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
@@ -202,26 +202,10 @@ RSpec.describe "base properties" do
       manifest["instance_groups.api.jobs.cloud_controller_ng.properties.cc.install_buildpacks"]
     }
 
-    it "install_buildpacks reference jobs which may include the required packages" do
-      # Previously job name implied a similar package name:
-      #
-      # e.g. the release staticfile-buildpack
-      #      contained the job staticfile_buildpack
-      #      which contained package staticfile-buildpack
-      #
-      # Now the release staticfile-buildpack
-      #     contains the job staticfile_buildpack
-      #     which contains two packages
-      #     - staticfile-buildpack-cflinuxfs2
-      #     - staticfile-buildpack-cflinuxfs3
-      #
-      # We cannot assert that these packages exist without pulling the tarballs
-      # for each, however acceptance tests will catch this, and upstream has
-      # responsibility to stick to this implicit contract
+    it "install_buildpacks reference packages that exist" do
       install_buildpacks_property.each do |pack|
-        job_name = pack.fetch("package").gsub(/-cflinuxfs2$/, '')
-        expect(api_job_names).to include(job_name),
-          "install_buildpacks entry #{pack.fetch('name')} references non-existent job #{job_name}"
+        expect(api_job_names).to include(pack.fetch("package")),
+          "install_buildpacks entry #{pack.fetch('name')} references non-existent package #{pack.fetch('package')}"
       end
     end
   end


### PR DESCRIPTION
In 88ad0226095eafc4c969828d3d98446065551247 we "fixed" a test which asserted
the wrong thing, in cf-deployment v3.6.0 they changed the package names,
however we override these because we pin our buildpack versions (because we
like our tenants).

The result of this was that creating a new environment left us with a grand
total of 1 buildpack (where the buildpack version we had pinned was the same as
v3.6.0 - binary_buildpack: they had the same package name)

This PR does three things:

- Revert the test which we fixed, this can be reverted in one weeks time when
we have upgraded the buildpacks (after we have notified our tenants).

- Add an ops file which changes the package names that we look for to be the
same as they were pre v3.6.0 upgrade. This means that they will be installed
when creating a new environment.

- Adds a test which blindly asserts that the buildpacks that we expect to exist
do, in fact, exist.


Either code review, or:

- Spin up a new CF
- It goes green


Not @tlwr @jpluscplusm