### PR TITLE
[#160446591] Bump stemcell and cflinuxfs2 to fix USNs.

### DIFF
--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -5,4 +5,4 @@
   value:
     - alias: default
       os: ubuntu-trusty
-      version: "3586.36"
+      version: "3586.42"

--- a/manifests/cf-manifest/operations.d/260-cf-upgrade-cflinuxfs2.yml
+++ b/manifests/cf-manifest/operations.d/260-cf-upgrade-cflinuxfs2.yml
@@ -1,0 +1,9 @@
+---
+
+- type: replace
+  path: /releases/name=cflinuxfs2
+  value:
+    name: cflinuxfs2
+    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.235.0
+    version: 1.235.0
+    sha1: 1ed4e65bdb8ec4ba58060705f47c157663c23cfa


### PR DESCRIPTION
## What

Includes fixes for the following:

- USN-3755-1: GD vulnerabilities
- USN-3756-1: Intel Microcode vulnerabilities
- USN-3753-2: Linux kernel (Xenial HWE) vulnerabilities

How to review
-------------

I've already tested this in my dev environment, so core review is probably sufficient.

Who can review
--------------

Not me.