### PR TITLE
[#160479583] Fix password reset in London

### DIFF
--- a/terraform/cloudfoundry/outputs.tf
+++ b/terraform/cloudfoundry/outputs.tf
@@ -155,7 +155,7 @@ output "nat_public_ips_csv" {
 }
 
 output "ses_smtp_host" {
-  value = "email-smtp.${var.region}.amazonaws.com"
+  value = "email-smtp.eu-west-1.amazonaws.com"
 }
 
 output "ses_smtp_aws_access_key_id" {


### PR DESCRIPTION
## What

We were interpolating the AWS region into the hostname being used here,
but SES is only available in 3 regions globally[1] - London isn't one of
them.  email-smtp.eu-west-2.amazonaws.com does not resolve.

This causes the password reset flow to fail with a 500 error because UAA
is unable to mail the reset link to the user.

We address this by hardcoding eu-west-1 (Ireland) as that's the closest
available region for all our deployments

[1] https://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html

How to review
-------------

To test this, you'll need a dev environment deployed in London. Test the password reset flow after deploying from this branch. (You'll need to verify the recipient address before email sending will work because dev SES is in sandbox mode. `aws --region=eu-west-1 ses verify-email-identity --email-address <email>`)

or you could take my word for it that I've tested this in my dev environment.

Who can review
--------------

Not me.