### PR TITLE
[#160383666] Enable Elsticsearch service for everyone.

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2350,6 +2350,7 @@ jobs:
                   else
                     cf create-service-broker aiven-broker aiven-broker "$AIVEN_BROKER_PASS" "https://aiven-broker.${APPS_DNS_ZONE_NAME}"
                   fi
+                  cf enable-service-access elasticsearch
 
         - task: register-elasticache-broker
           config:

--- a/platform-tests/src/platform/acceptance/init_test.go
+++ b/platform-tests/src/platform/acceptance/init_test.go
@@ -60,10 +60,6 @@ func TestSuite(t *testing.T) {
 			enableServiceAccess := cf.Cf("enable-service-access", "mongodb", "-o", org).Wait(testConfig.DefaultTimeoutDuration())
 			Expect(enableServiceAccess).To(Exit(0))
 			Expect(enableServiceAccess).To(Say("OK"))
-
-			enableServiceAccess = cf.Cf("enable-service-access", "elasticsearch", "-o", org).Wait(testConfig.DefaultTimeoutDuration())
-			Expect(enableServiceAccess).To(Exit(0))
-			Expect(enableServiceAccess).To(Say("OK"))
 		})
 	})
 


### PR DESCRIPTION
## What

We want to allow all users to be able to use this service. This adds the
call to the pipeline to enable it for everyone.

I've also updated the tests to not enable this service for the test org
so that we can verify it's on for all orgs by default.

How to review
-------------

* Run the pipeline
* Verify the tests pass
* Run `cf marketplace` after targetting an org/space and verify that the elasticsearch service is listed.

Who can review
--------------

Not me.