### PR TITLE
[#160176077] Bump rds-broker release to 0.1.45 to fix restore from snapshots

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -49,9 +49,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 0.1.44
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.44.tgz
-    sha1: 33a2b8e72e92111b785884859b486b43e160df87
+    version: 0.1.45
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.45.tgz
+    sha1: 55be90acaf045442fbf41ad5ddf3c4dbd10eea4c
 
 - type: replace
   path: /instance_groups/-


### PR DESCRIPTION
What
----

This release fixes a bug restoring snapshots.

See  https://github.com/alphagov/paas-rds-broker/pull/87

How to review
-------------

 - Review & merge first https://github.com/alphagov/paas-rds-broker-boshrelease/pull/71
 - I guessed the version for the next in CI, check the release info in : https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/rds-broker-release/jobs/build-final-release/builds/45 and update with the right version.

Who can review
--------------

Not @keymon