### PR TITLE
[Support] Fix CDN cert monitor to not alert for individual invalid certs

### DIFF
--- a/terraform/datadog/certificates.tf
+++ b/terraform/datadog/certificates.tf
@@ -41,13 +41,13 @@ resource "datadog_monitor" "cdn_tls_cert_validity" {
   notify_no_data    = true
   no_data_timeframe = 480
 
-  query = "${format("min(last_4h):min:cdn.tls.certificates.validity{deploy_env:%s}.rollup(avg) <= 0.5", var.env)}"
+  query = "${format("min(last_4h):avg:cdn.tls.certificates.validity{deploy_env:%s} <= 0.85", var.env)}"
 
   require_full_window = false
 
   thresholds {
-    warning  = 0.75
-    critical = 0.5
+    warning  = 0.85
+    critical = 0.75
   }
 
   tags = ["deployment:${var.env}", "service:${var.env}_monitors"]


### PR DESCRIPTION
## What

This was added in c3066ec with the intent of only alerting if a
significant number of certs were invalid, not when a single one was, so
that a cert that's in the process of being provisioned doesn't trigger
this monitor. It was intending to take the average of the values (which
are reported as 1 or 0 for each hostname), and alert if that fell below
a threshold.

However, because this was applying a `min` before doing the
`rollup(avg)`, it was taking the average of the minimum value, and hence
would always evaulate to 0 if any certs were invalid.

I've changed this to use the `avg` instead, and get rid of the rollup.
This results in a floating-point value representing the percentage of
certs that are valid. I've also changed the thresholds because a single
invalid cert in prod currently drops the value from 1 to 0.98, so these
thresholds seemed overly lenient

How to review
-------------

* Code review should be enough.
* I cloned the existing monitor to test these changes here: https://app.datadoghq.com/monitors/6364194

Who can review
--------------

Not me.