### PR TITLE
[Support] Fix cert monitor query to match critical threshold.

### DIFF
--- a/terraform/datadog/certificates.tf
+++ b/terraform/datadog/certificates.tf
@@ -41,7 +41,7 @@ resource "datadog_monitor" "cdn_tls_cert_validity" {
   notify_no_data    = true
   no_data_timeframe = 480
 
-  query = "${format("min(last_4h):avg:cdn.tls.certificates.validity{deploy_env:%s} <= 0.85", var.env)}"
+  query = "${format("min(last_4h):avg:cdn.tls.certificates.validity{deploy_env:%s} <= 0.75", var.env)}"
 
   require_full_window = false
 


### PR DESCRIPTION
## What

I got it wrong in the previous commit and used the wrong threshold value
in the query, which causes Datadog to return an error.

How to review
-------------

* Code review.
* Verify that the value in the query matches the critical threshold.

Who can review
--------------

Not me.