### PR TITLE
[#159136931] Stop relying on Consul

### DIFF
--- a/manifests/cf-manifest/scripts/generate-manifest.sh
+++ b/manifests/cf-manifest/scripts/generate-manifest.sh
@@ -53,6 +53,7 @@ bosh interpolate \
   --ops-file="${CF_DEPLOYMENT_DIR}/operations/stop-skipping-tls-validation.yml" \
   --ops-file="${CF_DEPLOYMENT_DIR}/operations/enable-uniq-consul-node-name.yml" \
   --ops-file="${CF_DEPLOYMENT_DIR}/operations/enable-service-discovery.yml" \
+  --ops-file="${CF_DEPLOYMENT_DIR}/operations/experimental/skip-consul-cell-registrations.yml" \
   ${opsfile_args} \
   --ops-file="${WORKDIR}/vpc-peering-opsfile/vpc-peers.yml" \
   "$@" \


### PR DESCRIPTION
## What

BBS had been using Consul for cell presence.  Therefore, despite Consul
not being the primary system for locks, its removal can still cause
problems.

How to review
-------------

Ensure this deploys with passing tests and no anticipated downtime.

Who can review
--------------

@tlwr 
