### PR TITLE
[#158180318] Upgrade fly-login wrapper to cope with Concourse 4 upgrade

### DIFF
--- a/concourse/scripts/fly_sync_and_login.sh
+++ b/concourse/scripts/fly_sync_and_login.sh
@@ -8,13 +8,40 @@ set -euo pipefail
 # FLY_CMD
 # FLY_TARGET
 
-FLY_CMD_URL="${CONCOURSE_URL}/api/v1/cli?arch=amd64&platform=$(uname | tr '[:upper:]' '[:lower:]')"
-echo "Downloading fly command..."
-curl "$FLY_CMD_URL" -# -L -f -z "$FLY_CMD" -o "$FLY_CMD" -u "${CONCOURSE_ATC_USER}:${CONCOURSE_ATC_PASSWORD}"
-chmod +x "$FLY_CMD"
+fetch_fly() {
+  echo "Downloading fly .."
+  FLY_CMD_URL="${CONCOURSE_URL}/api/v1/cli?arch=amd64&platform=$(uname | tr '[:upper:]' '[:lower:]')"
+  curl \
+    --progress-bar \
+    --location \
+    --fail \
+    --output "$FLY_CMD" \
+    "$FLY_CMD_URL"
+  chmod +x "$FLY_CMD"
+}
 
-echo "Doing fly login"
-$FLY_CMD -t "${FLY_TARGET}" login --concourse-url "${CONCOURSE_URL}" -u "${CONCOURSE_ATC_USER}" -p "${CONCOURSE_ATC_PASSWORD}"
+fly_sync() {
+  echo "Doing fly sync .."
+  $FLY_CMD -t "${FLY_TARGET}" sync
+}
 
-echo "Doing fly sync"
-$FLY_CMD -t "${FLY_TARGET}" sync
+fly_login() {
+  echo "Doing fly login .."
+  $FLY_CMD -t "${FLY_TARGET}" login --concourse-url "${CONCOURSE_URL}" -u "${CONCOURSE_ATC_USER}" -p "${CONCOURSE_ATC_PASSWORD}"
+}
+
+fly_is_runnable() {
+  [ -x "${FLY_CMD}" ]
+}
+
+if fly_is_runnable; then
+  if fly_login; then
+    fly_sync
+  else
+    fetch_fly
+    fly_login
+  fi
+else
+  fetch_fly
+  fly_login
+fi

--- a/concourse/scripts/fly_sync_and_login.sh
+++ b/concourse/scripts/fly_sync_and_login.sh
@@ -2,11 +2,12 @@
 set -euo pipefail
 
 # Required env vars
-# CONCOURSE_URL
-# CONCOURSE_ATC_USER
-# CONCOURSE_ATC_PASSWORD
-# FLY_CMD
-# FLY_TARGET
+# shellcheck disable=SC2086
+: $CONCOURSE_URL \
+  $CONCOURSE_ATC_USER \
+  $CONCOURSE_ATC_PASSWORD \
+  $FLY_CMD \
+  $FLY_TARGET
 
 fetch_fly() {
   echo "Downloading fly .."


### PR DESCRIPTION
What
----

This PR make our fly login+sync wrapper capable of upgrading a fly binary over the v3/v4 major version boundary, in a way which the Concourse 4.0.0 release notes correctly say that `fly sync` can't do by itself. [1]

To make the different possible flows through the code clearer, the code is wrapped up in some shell functions which do what they say on the tin [2]. 

The script also exits early if any required envvars aren't set.

[1] https://concourse-ci.org/download.html#v400
[2] https://en.wikipedia.org/wiki/Does_exactly_what_it_says_on_the_tin

How to review
-------------

- Check out the branch
- Use your `$PAAS_CF/bin/fly` binary to log into a Concourse 3.8 instance
- Setting the envars appropriately (see Makefile:pipelines and its deps), use this script to log in to a Concourse 4.2.1 instance (e.g. `jonmtest` or `leeporte`)
- Observe that, with perhaps just a single re-start, you end up where you were aiming for, and don't get stuck on the 3.8 side of the process.

Who can review
--------------

@jpluscplusm wrote this, and probably shouldn't review it.