### PR TITLE
[#158180318] Update the chrome plugin

### DIFF
--- a/misc/chrome_plugins/clean_concourse_pipeline/src/inject.user.js
+++ b/misc/chrome_plugins/clean_concourse_pipeline/src/inject.user.js
@@ -8,27 +8,25 @@
 // @version     1
 // @grant       none
 // ==/UserScript==
-var readyStateCheckInterval = setInterval(function() {
-    if (document.readyState === "complete") {
-        clearInterval(readyStateCheckInterval);
+const readyStateCheckInterval = setInterval(() => {
+  if (document.readyState === 'complete') {
+    clearInterval(readyStateCheckInterval);
 
-        console.log("Monitor mode is go");
-        var element = document.getElementsByClassName("legend")[0];
-        element.parentNode.removeChild(element);
+    console.log('Monitor mode is go');
+    const $legend = document.querySelector('.legend');
+    $legend.style.display = 'none';
 
-        var element = document.getElementsByClassName("lower-right-info")[0];
-        element.parentNode.removeChild(element);
+    const $infoBox = document.querySelector('.lower-right-info');
+    $infoBox.style.display = 'none';
 
-        var hostname = location.hostname.replace("deployer.", "").replace(".cloudpipeline.digital","");
+    const $topBar = document.querySelector('#top-bar-app');
+    $topBar.style.display = 'none';
 
-        var element = document.getElementById("top-bar-app");
-        element.innerHTML = "&nbsp;<font size=5>" + hostname + "</font>";
-        // Move it to the bottom because there's more space there.
-        element.style.position = "absolute";
-        element.style.bottom = "0";
+    const $bottom = document.querySelector('.bottom');
+    // Remove the padding because the top bar isn't there any more.
+    $bottom.style.paddingTop = '0';
 
-        var element = document.getElementsByClassName("bottom")[0];
-        // Remove the padding because the top bar isn't there any more.
-        element.style.paddingTop = "0";
-    }
+    const hostname = window.location.hostname.replace('deployer.', '').replace('.cloudpipeline.digital', '');
+    document.body.insertAdjacentHTML('beforeend', `<div style="bottom: 0; font-size: 24px; padding: 16px; position: absolute;">${hostname}</div>`);
+  }
 }, 2000);

--- a/misc/chrome_plugins/clean_concourse_pipeline/src/inject.user.js
+++ b/misc/chrome_plugins/clean_concourse_pipeline/src/inject.user.js
@@ -22,6 +22,9 @@ const readyStateCheckInterval = setInterval(() => {
     const $topBar = document.querySelector('#top-bar-app');
     $topBar.style.display = 'none';
 
+    const $groupsBar = document.querySelector('.groups-bar');
+    $groupsBar.style.display = 'none';
+
     const $bottom = document.querySelector('.bottom');
     // Remove the padding because the top bar isn't there any more.
     $bottom.style.paddingTop = '0';


### PR DESCRIPTION
What
----

Now that we have upgraded concourse, some of the frontend has changed.
This means our plugin is out of date and should be updated if we'd like
to keep on using it on our dashboard TV.

In the new concourse version, upstream has decided to separate the
grouping bar into it's own place. This is a simple change really and
requires some minimal effort to hide new additional element.

Some other changes have been made, purely as a maintenance task to
keep the linter happy as well as the code more modern.

See commit for more details.

How to review
-------------

- Code review
- Copy contents of the file
- Open the deployer concourse on staging
- Open the `Inspect` console on Chrome (Cmd + Alt + J)
- Paste the contents of the file
- See no errors and expect the dashboard to be clean

After merge
-----------

Make sure to update the plugin on the TV's Chrome. See README for more details.