### PR TITLE
Fix validate_aws_credentials.sh for assumed roles

### DIFF
--- a/scripts/validate_aws_credentials.sh
+++ b/scripts/validate_aws_credentials.sh
@@ -15,7 +15,7 @@ if [ -z "$AWS_ACCOUNT" ]; then
   exit 255;
 fi
 
-if ! aws iam get-user > /dev/null 2>&1; then
+if ! aws sts get-caller-identity > /dev/null 2>&1; then
   echo "Current AWS credentials are invalid, please refresh them using create_sts_token.sh"
   exit 255;
 fi


### PR DESCRIPTION
What
----

`aws iam get-user` returns `Must specify userName when calling with
non-User credentials` when called with an assumed role.

We can use `aws sts get-caller-identity` instead, which will always
work.

See https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html

How to review
-------------

* Code review
* Check you can still run `make dev showenv` (for example) on this branch

Who can review
--------------

Not @richardTowers