### PR TITLE
[#159174283] Deploy Metric Exporter

### DIFF
--- a/manifests/cf-manifest/operations.d/750-metric-exporter.yml
+++ b/manifests/cf-manifest/operations.d/750-metric-exporter.yml
@@ -1,0 +1,57 @@
+- type: replace
+  path: /releases/-
+  value:
+    name: metric-exporter
+    version: 0.1.6
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/metric-exporter-0.1.6.tgz
+    sha1: e749ff9dff2f16db7d0e85da59b233c76ea636d4
+
+- type: replace
+  path: /variables/-
+  value:
+    name: uaa_clients_metric_exporter_password
+    type: password
+
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/metric-exporter?
+  value:
+    override: true
+    access-token-validity: 1209600
+    authorities: oauth.login,doppler.firehose,cloud_controller.admin_read_only
+    authorized-grant-types: authorization_code,client_credentials,refresh_token
+    redirect-uri: https://login.((system_domain))/login
+    scope: openid,oauth.approvals,doppler.firehose
+    secret: ((uaa_clients_metric_exporter_password))
+
+- type: replace
+  path: /instance_groups/name=log-api/jobs/-
+  value:
+    name: metric-exporter
+    release: metric-exporter
+    properties:
+      metric-exporter:
+        cf_api_url: https://api.((terraform_outputs_cf_root_domain))
+        client_id: metric-exporter
+        client_secret: "((uaa_clients_metric_exporter_password))"
+        loggregator:
+          ca_cert: "((loggregator_ca.certificate))((loggregator_ca_old.certificate))"
+          client_cert: "((loggregator_metric_exporter.certificate))"
+          client_key: "((loggregator_metric_exporter.private_key))"
+        locket:
+          api_location: "locket.service.cf.internal:8891"
+          ca_cert: "((service_cf_internal_ca.certificate))((service_cf_internal_ca_old.certificate))"
+          client_cert: "((diego_locket_client.certificate))"
+          client_key: "((diego_locket_client.private_key))"
+        metric_whitelist: "responseTime,requests"
+
+- type: replace
+  path: /variables/-
+  value:
+    name: loggregator_metric_exporter
+    type: certificate
+    options:
+      ca: loggregator_ca
+      common_name: loggregator_metric_exporter
+      extended_key_usage:
+        - client_auth
+        - server_auth

--- a/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
@@ -163,6 +163,7 @@ RSpec.describe "base properties" do
           "paas-admin",
           "user_invitation",
           "network-policy",
+          "metric-exporter",
         )
       }
 


### PR DESCRIPTION
What
----

This deploys the metric exporter to pull event data for all apps and parse them into useful HTTP metrics. It then feeds the metrics into Loggregator via a local Metron Agent.

It is colocated with the log-api VM for cost-saving purposes.

How to review
-------------

Ultimately we want users of Prometheus to be able to scrape the app metrics from `metrics.<system-domain>/metrics`. You can deploy from this branch and follow [the docs](https://docs.cloud.service.gov.uk/monitoring_apps.html) for getting a Dockerised Prometheus up and running.

Note: the response time metrics are currently not working. This only delivers a partial solution. We should just verify if the timing metrics are getting to log-cache, we can fix the Prometheus adapter in a follow-up story if required.

## Before merging ⚠️ 

Review and merge https://github.com/alphagov/paas-metric-exporter-boshrelease/pull/1 and amend this commit to point to the final version of the Bosh release.

Who can review
--------------

Anyone but me.
