### PR TITLE
[BAU] Return 0 if an organization has no spaces

### DIFF
--- a/scripts/org-usage-report.sh
+++ b/scripts/org-usage-report.sh
@@ -67,7 +67,7 @@ apps_in_state() {
 services_in_org() {
   guid="$1"
   summary=$(cf curl "/v2/organizations/${guid}/summary")
-  echo "$summary" | jq -r "[.spaces[].service_count] | add"
+  echo "$summary" | jq -r "reduce .spaces[] as \$space (0; . + \$space.service_count)"
 }
 
 find_latest_login() {


### PR DESCRIPTION
What
----

If an organization as no spaces, then this script would return `null` as
the count of all services in that organization. If the input to `add` is
an empty array then it returns `null`.

How to review
-------------

Run the steps [from here](https://team-manual.cloud.service.gov.uk/guides/trial_accounts/#how-to-get-the-data), up to and including the database import. Before this change the data would error when importing into the database because of the `null` in the organization that had no spaces.

Who can review
--------------

Anyone.
