### PR TITLE
Use autopilot for healthcheck app deployment

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1877,6 +1877,7 @@ jobs:
               tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
           params:
             DISABLE_HEALTHCHECK_DB: ((disable_healthcheck_db))
+            APPS_DNS_ZONE_NAME: ((apps_dns_zone_name))
           inputs:
             - name: paas-cf
             - name: config
@@ -1913,8 +1914,17 @@ jobs:
                   '
                 fi
 
-                cf blue-green-deploy healthcheck
-                cf delete -f healthcheck-old
+                ruby -ryaml -e "
+                  manifest = YAML.load_file('manifest.yml')
+                  manifest['applications'].each do |app|
+                    app['routes'] = [
+                      { 'route' => 'healthcheck.${APPS_DNS_ZONE_NAME}' }
+                    ]
+                  end
+                  File.write('manifest.yml', manifest.to_yaml)
+                "
+
+                cf zero-downtime-push healthcheck -f manifest.yml
 
                 cd "${BUILD_ROOT}"
                 echo "yes" > deployed-healthcheck/healthcheck-deployed


### PR DESCRIPTION
## What

We've seen several occasions where the blue-green plugin will fail to
detect that the app already exists when deploying a dev environment. The
deploy then fails at the step when it attempts to rename the -new app
because the target appname is already taken.

I've not got to the bottom of why this happens, but switching to
autopilot has removed the issue for me. This plugin also has the
advantage that it purely relies on the manifest.yml for details of the
app, and doesn't attempt to preserve any details from the existing
deployment.

How to review
-------------

* Code review
* Optionally run this down a pipeline to verify it works (I've tested it in my environment several times).

Who can review
--------------

Not me.