### PR TITLE
[#160950252] Upgrade cf-networking-release  PART 1

### DIFF
--- a/manifests/cf-manifest/operations.d/260-cf-networking-release-upgrade.yml
+++ b/manifests/cf-manifest/operations.d/260-cf-networking-release-upgrade.yml
@@ -1,0 +1,9 @@
+---
+
+- type: replace
+  path: /releases/name=cf-networking
+  value:
+    name: "cf-networking"
+    version: "2.15.1"
+    url: "https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.15.1"
+    sha1: "14a958518194ae6922dfa50f868f177a34b13794"


### PR DESCRIPTION
What
----

In order to upgrade to the latest version of cf-networking-release we
first have to go via 2.15.1 in order to avoid downtime[1].

[1] https://github.com/cloudfoundry/cf-networking-release/releases/tag/2.16.0

How to review
-------------

I've deployed it to my dev environment and it went green. I think it's probably good to just merge.

Who can review
--------------
Anyone.
