### PR TITLE
[#160950252] Upgrade cf networking release PART 2

### DIFF
--- a/manifests/cf-manifest/operations.d/260-cf-networking-release-upgrade.yml
+++ b/manifests/cf-manifest/operations.d/260-cf-networking-release-upgrade.yml
@@ -4,6 +4,6 @@
   path: /releases/name=cf-networking
   value:
     name: "cf-networking"
-    version: "2.15.1"
-    url: "https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.15.1"
-    sha1: "14a958518194ae6922dfa50f868f177a34b13794"
+    version: "2.16.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.16.0"
+    sha1: "9f34333f6a41c66b39fdde1971b03ed466a248d3"


### PR DESCRIPTION
What
----

Upgrade to the latest version of cf-networking-release

This resolves the following CVE:

 - https://www.cloudfoundry.org/blog/cve-2018-15755/

How to review
-------------

Merge #1568 first.

I've run it through my dev environment and it went green—I tihnk it's probably good to just merge.

Who can review
--------------

Anyone.