### PR TITLE
[Support] Scope RDS disk utilisation monitor to region

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -118,6 +118,7 @@ jobs:
           TF_VAR_datadog_app_key: ((datadog_app_key))
           TF_VAR_env: ((deploy_env))
           TF_VAR_aws_account: ((aws_account))
+          TF_VAR_region: ((aws_region))
           ENABLE_DATADOG: ((enable_datadog))
         ensure:
           put: datadog-tfstate

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2343,6 +2343,7 @@ jobs:
             TF_VAR_datadog_api_key: ((datadog_api_key))
             TF_VAR_datadog_app_key: ((datadog_app_key))
             TF_VAR_aws_account: ((aws_account))
+            TF_VAR_region: ((aws_region))
             ENABLE_DATADOG: ((enable_datadog))
           run:
             path: sh

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -188,6 +188,7 @@ jobs:
           TF_VAR_datadog_app_key: ((datadog_app_key))
           TF_VAR_env: ((deploy_env))
           TF_VAR_aws_account: ((aws_account))
+          TF_VAR_region: ((aws_region))
           ENABLE_DATADOG: ((enable_datadog))
         ensure:
           put: datadog-tfstate

--- a/terraform/datadog/aws.tf
+++ b/terraform/datadog/aws.tf
@@ -37,7 +37,7 @@ resource "datadog_monitor" "rds-disk-utilisation" {
   type           = "query alert"
   message        = "${format("Instance is {{#is_warning}}low on{{/is_warning}}{{#is_alert}}critically low on{{/is_alert}} storage space. See: %s#rds-disk-utilisation @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_documentation_url, var.aws_account)}"
   notify_no_data = false
-  query          = "${format("min(last_1h):min:aws.rds.free_storage_space{aws_account:%s} by {hostname} / min:aws.rds.total_storage_space{aws_account:%s} by {hostname} <= 0.1", var.aws_account, var.aws_account)}"
+  query          = "${format("min(last_1h):min:aws.rds.free_storage_space{aws_account:%s,region:%s} by {hostname} / min:aws.rds.total_storage_space{aws_account:%s,region:%s} by {hostname} <= 0.1", var.aws_account, var.region, var.aws_account, var.region)}"
 
   thresholds {
     warning  = "0.2"

--- a/terraform/datadog/datadog.tf
+++ b/terraform/datadog/datadog.tf
@@ -6,6 +6,8 @@ variable "env" {}
 
 variable "aws_account" {}
 
+variable "region" {}
+
 provider "datadog" {
   api_key = "${var.datadog_api_key}"
   app_key = "${var.datadog_app_key}"


### PR DESCRIPTION
What
----

Currently if the RDS ultilisation monitor is triggered it will show for
both "prod" and "prod-lon". This is because it was only scoped to the
aws-account and we now have multiple things in each account.

To make this more intuitive, this change scopes the monitor to the same
region as the deploy_env. Since we do not expect to have multiple
deploy_envs within the same region this should result in alerts being
triggered for their respective deploy_env.

How to review
-------------

I have not tested this change as I didn't have a dev-env handy, so **please check/deploy to a dev env before merging**.

Who can review
--------------

Not @chrisfarms
