### PR TITLE
[#SUPPORT] Update cflinuxfs2 to 1.242.0 to fix git CVE

### DIFF
--- a/manifests/cf-manifest/operations.d/260-cf-upgrade-cflinuxfs2.yml
+++ b/manifests/cf-manifest/operations.d/260-cf-upgrade-cflinuxfs2.yml
@@ -4,6 +4,6 @@
   path: /releases/name=cflinuxfs2
   value:
     name: cflinuxfs2
-    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.241.0
-    version: 1.241.0
-    sha1: adce7383e1eb8d60351c1204d0d947a235893c39
+    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.242.0
+    version: 1.242.0
+    sha1: 99821c729c05646c203a684a15a0971a5af08e35


### PR DESCRIPTION
What
----


Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.

Update to latest version of cflinuxfs2 to cover CVE USN-3791-1[1]

Git vulnerability

It was discovered that git did not properly validate git submodule urls
or paths. A remote attacker could possibly use this to craft a git
repository that causes arbitrary code execution when recursive
operations are used.

CVEs contained in this USN include: CVE-2018-17456

[1] https://www.cloudfoundry.org/blog/usn-3791-1/

How to review
-------------

Code review. Check the checksum at https://bosh.io/releases/github.com/cloudfoundry/cflinuxfs2-release?all=1

Any issue should be catched in staging, I think it is safe to merge.

Who can review
--------------

Not me