### PR TITLE
[#161146691] Add logic to pause the kick-off after kick-off

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,14 @@ pipelines: check-env ## Upload pipelines to Concourse
 trigger-deploy: check-env ## Trigger a run of the create-cloudfoundry pipeline.
 	concourse/scripts/trigger-deploy.sh
 
+.PHONY: pause-kick-off
+pause-kick-off: check-env ## Pause the morning kick-off of deployment.
+	concourse/scripts/pause-kick-off.sh pause
+
+.PHONY: pause-kick-off
+unpause-kick-off: check-env ## Unpause the morning kick-off of deployment.
+	concourse/scripts/pause-kick-off.sh unpause
+
 .PHONY: showenv
 showenv: check-env ## Display environment information
 	$(eval export TARGET_CONCOURSE=deployer)

--- a/README.md
+++ b/README.md
@@ -210,6 +210,23 @@ pipelines or its resources or jobs.
 
 Note that the *Deployer Concourse* and *MicroBOSH* VMs will be kept running.
 
+## Morning kick-off of deployment
+
+The pipeline `deployment-kick-off` can trigger for you the deployment in
+the morning, so the environment is ready for you before you start work.
+
+This feature is opt-in and must be enable **every day** by unpausing the
+`deployer-timer` resource in `deployment-kick-off`, either manually or
+by running:
+
+```
+make dev unpause-kick-off
+```
+
+The `deployer-timer` would be disabled automatically just after the
+deployment is kick-off, to prevent the next day to happen again. You can
+avoid this by pausing the job `pause-kick-off`
+
 ## aws-cli
 
 You might need [aws-cli][] installed on your machine to debug a deployment.

--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -69,8 +69,6 @@ jobs:
           inputs:
             - name: paas-cf
           params:
-            AWS_ACCOUNT: ((aws_account))
-            AWS_DEFAULT_REGION: ((aws_region))
             DEPLOY_ENV: ((deploy_env))
             SKIP_AWS_CREDENTIAL_VALIDATION: true
           run:
@@ -81,4 +79,31 @@ jobs:
               - |
                 echo "Pipeline kick-off is enabled. Updating. (set ENABLE_MORNING_DEPLOYMENT=false to disable)"
 
-                make -C ./paas-cf "${AWS_ACCOUNT}" trigger-deploy
+                make -C ./paas-cf "((makefile_env_target))" trigger-deploy
+
+  - name: pause-kick-off
+    serial: true
+    plan:
+      - get: deployment-timer
+        trigger: true
+      - get: paas-cf
+      - task: pause-kick-off
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/self-update-pipelines
+              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+          inputs:
+            - name: paas-cf
+          params:
+            DEPLOY_ENV: ((deploy_env))
+            SKIP_AWS_CREDENTIAL_VALIDATION: true
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                make -C ./paas-cf "((makefile_env_target))" pause-kick-off

--- a/concourse/scripts/pause-kick-off.sh
+++ b/concourse/scripts/pause-kick-off.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Required variables are:
+# - DEPLOY_ENV
+# - AWS_ACCOUNT
+
+set -u
+set -e
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+case "${1:-}" in
+  pause)
+    echo "Pausing pipeline kick-off."
+    action=pause
+    ;;
+  unpause)
+    echo "Unpausing pipeline kick-off."
+    action=unpause
+    ;;
+  *)
+    echo "Usage $0 <pause|unpause>"
+    exit 1
+    ;;
+esac
+
+export TARGET_CONCOURSE=deployer
+# shellcheck disable=SC2091
+$("${SCRIPT_DIR}/environment.sh")
+"${SCRIPT_DIR}/fly_sync_and_login.sh"
+FLY="$FLY_CMD -t ${FLY_TARGET}"
+
+${FLY} "${action}-resource" -r "deployment-kick-off/deployment-timer"


### PR DESCRIPTION
What
----

We want to not trigger the deploy pipeline automatically for every
environment unless the developer opts in the day before.

To do so, we simply add an additional job that would pause the
timer that triggers the kick-off after the timer is triggered.

The developer must unpause the resource manually to get the deployment
the next day.

Known flaws: 
 - The first time you deploy from scratch, the feature is not disabled by default. I think we can accept this instead of add more complexity.

How to review
-------------

Code review.

To test: Change the branch in concourse/pipelines/deployment-kick-off.yml and
   the time window of the trigger to test it.


Who can review
--------------

Not me