### PR TITLE
[#161146691 ] Small fixes to auto-kickoff process and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ trigger-deploy: check-env ## Trigger a run of the create-cloudfoundry pipeline.
 pause-kick-off: check-env ## Pause the morning kick-off of deployment.
 	concourse/scripts/pause-kick-off.sh pause
 
-.PHONY: pause-kick-off
+.PHONY: unpause-kick-off
 unpause-kick-off: check-env ## Unpause the morning kick-off of deployment.
 	concourse/scripts/pause-kick-off.sh unpause
 

--- a/README.md
+++ b/README.md
@@ -216,14 +216,14 @@ The pipeline `deployment-kick-off` can trigger for you the deployment in
 the morning, so the environment is ready for you before you start work.
 
 This feature is opt-in and must be enable **every day** by unpausing the
-`deployer-timer` resource in `deployment-kick-off`, either manually or
+`deployment-timer` resource in `deployment-kick-off`, either manually or
 by running:
 
 ```
 make dev unpause-kick-off
 ```
 
-The `deployer-timer` would be disabled automatically just after the
+The `deployment-timer` would be disabled automatically just after the
 deployment is kick-off, to prevent the next day to happen again. You can
 avoid this by pausing the job `pause-kick-off`
 


### PR DESCRIPTION
What
----

Fixes:

- The `unpause-kick-off` Makefile target should be phony. This is almost certainly a typo from a copy/paste.
- The docs refer to the triggering resource by a slightly wrong name.

Both of these should be uncontroversial.

How to review
-------------

Code review.

Who can review
--------------

Anyone. @henrytk reviewed the previous PR, so the context of that process would probably be handy.