### PR TITLE
[#161146691] Fix the pipeline kick-off pausing in London

### DIFF
--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -69,6 +69,7 @@ jobs:
           inputs:
             - name: paas-cf
           params:
+            AWS_DEFAULT_REGION: ((aws_region))
             DEPLOY_ENV: ((deploy_env))
             SKIP_AWS_CREDENTIAL_VALIDATION: true
           run:
@@ -98,6 +99,7 @@ jobs:
           inputs:
             - name: paas-cf
           params:
+            AWS_DEFAULT_REGION: ((aws_region))
             DEPLOY_ENV: ((deploy_env))
             SKIP_AWS_CREDENTIAL_VALIDATION: true
           run:


### PR DESCRIPTION
## What

When the pipeline pausing was introduced in d3fee14, the
`AWS_DEFAULT_REGION` param was removed from these 2 tasks. This causes
them to fail when not in eu-west-1 (Ireland) as the s3 API returns a 400
error when trying to access the bucket in the wrong region (called from
the `environment.sh` script to get the concourse password[1]). This is
because the Makefile defaults this to eu-west-1 if it's not set[2].

[1]https://github.com/alphagov/paas-cf/blob/bb5bf1e/concourse/scripts/environment.sh#L33
[2]https://github.com/alphagov/paas-cf/blob/bb5bf1e/Makefile#L95

How to review
-------------

Code review. I've tested this change in my environment (which is in London).

Who can review
--------------

Not me.