### PR TITLE
[#SUPPORT] Add script to list all users

### DIFF
--- a/scripts/list-all-users.sh
+++ b/scripts/list-all-users.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e -u -o pipefail
+
+uaac_endpoint=$(cf curl /v2/info | jq -r '.authorization_endpoint')
+oauth_token=$(cf oauth-token)
+
+get_number_of_users() {
+  curl --silent --fail "$uaac_endpoint/Users?count=0" -H "Authorization: $oauth_token" | jq -r '.totalResults'
+}
+
+get_users() {
+  curl --silent --fail "$uaac_endpoint/Users?attributes=userName&startIndex=$1&count=500" -H "Authorization: $oauth_token" | jq -r '.resources[].userName'
+}
+
+for s in $(seq 0 500 "$(get_number_of_users)"); do
+  get_users "$s"
+done

--- a/scripts/list-all-users.sh
+++ b/scripts/list-all-users.sh
@@ -6,11 +6,17 @@ uaac_endpoint=$(cf curl /v2/info | jq -r '.authorization_endpoint')
 oauth_token=$(cf oauth-token)
 
 get_number_of_users() {
-  curl --silent --fail "$uaac_endpoint/Users?count=0" -H "Authorization: $oauth_token" | jq -r '.totalResults'
+  if ! curl --silent --fail "$uaac_endpoint/Users?count=0" -H "Authorization: $oauth_token" | jq -r '.totalResults'; then
+    >&2 echo 'Error talking to UAA - are you logged in as an admin?'
+    exit 1
+  fi
 }
 
 get_users() {
-  curl --silent --fail "$uaac_endpoint/Users?attributes=userName&startIndex=$1&count=500" -H "Authorization: $oauth_token" | jq -r '.resources[].userName'
+  if ! curl --silent --fail "$uaac_endpoint/Users?attributes=userName&startIndex=$1&count=500" -H "Authorization: $oauth_token" | jq -r '.resources[].userName'; then
+    >&2 echo 'Error getting users from UAA - aborting'
+    exit 2
+  fi
 }
 
 for s in $(seq 0 500 "$(get_number_of_users)"); do


### PR DESCRIPTION
What
----

Uses the current `cf-cli` user's oauth token to query the uaa API
directly.

Could have used the uaa client instead of calling the API, but it's a
bit of a pain to use.

How to review
-------------

* Code review
* Run the script

Who can review
--------------

PaaS admins