### PR TITLE
[#161146691] Split kick-off wait task from main one

### DIFF
--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -17,13 +17,12 @@ resources:
       stop: 7:30 AM
 
 jobs:
-  - name: kick-off
+  - name: await-kick-off
     serial: true
     plan:
       - get: deployment-timer
         trigger: true
       - get: paas-cf
-
       - task: await-turn
         config:
           platform: linux
@@ -39,6 +38,14 @@ jobs:
             DEPLOY_ENV: ((deploy_env))
           run:
             path: ./paas-cf/concourse/scripts/sleep_for_deploy_env.sh
+
+  - name: kick-off
+    serial: true
+    plan:
+      - get: deployment-timer
+        trigger: true
+        passed: [await-kick-off]
+      - get: paas-cf
 
       - task: startup-rds-instances
         config:


### PR DESCRIPTION
What
----

Now the automatic kick-off is an opt-in feature[1], and our
environments won't we started unless the developer actively
sets it so.

But now we want to be able to trigger the kick-off to start
the DBs and the deployment without having to wait the
safe sleep time added to prevent all environments starting
at the same time and avoid rate limits.

To do so, we split the two parts: await and perform the kick-off.
The developer can trigger the kick-off at any time of the day.

The only restriction, due how concourse dependencies work,
is that the await-kick-off job has to be execute at least
once since the first bootstrap, but we can accept that.

[1] https://github.com/alphagov/paas-cf/pull/1583

How to review
-------------

Code review

Who can review
--------------

Not me