### PR TITLE
[#160556015] Rotation for cc db encryption key - Part 1.1

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1290,6 +1290,28 @@ jobs:
                 ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
                 bosh -n deploy cf-manifest/cf-manifest.yml
 
+      - task: rotate-cc-db-encryption-keys
+        config:
+          platform: linux
+          image_resource: *gov-paas-bosh-cli-v2-image-resource
+          inputs:
+            - name: paas-cf
+            - name: cf-manifest
+            - name: bosh-secrets
+            - name: bosh-CA-crt
+          params:
+            BOSH_ENVIRONMENT: ((bosh_fqdn))
+            BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
+            BOSH_DEPLOYMENT: ((deploy_env))
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
+                bosh run-errand rotate-cc-database-key
+
   - name: prometheus-deploy
     serial: true
     plan:


### PR DESCRIPTION
## What

We want to be able to update the CC DB with the name of the key which
has been used to encrypt the values in it.

In the database's current state it is missing records for which key was
used to encrypt the values. This job is being added only temporarily to
fix the missing data. See [1,2] for more details.

Eventually, when we work out how we will do key rotations, the task in
this job should probably be run in the rotate-cloudfoundry-credentials
job. For now it is a standalone job to allow it to be run without
forcing you to do a full rotation.

[1] https://github.com/cloudfoundry/cf-deployment/pull/561
[2] https://github.com/cloudfoundry/cf-deployment/releases/tag/v2.9.0

This was split out from #1574 because the errand had a bug in it and we wanted to wait for the CF upgrade that included the fix before running it. This adds the job to the pipeline so that it updates the encryption keys in the CC DB correctly.

How to review
-------------

* Check the current state of the CC DB. There should be some missing values in the `encryption_key_label` field of the `apps` table.

  I don't know how you like to access the CC DB in a `psql` shell, but I do it with this script: https://gist.github.com/henrytk/2f60d592e169876dc758a3d4a6b7153e

  You can run the following to check:

  ```sql
  select name, encryption_key_label from apps;
  ```

* Push pipelines from this branch and trigger a deploy. The rotation task will run at the end of the cf-deploy job.
* Check the state of the CC DB again. The `encryption_key_label` field should not be blank for any app now.
* Run the pipeline to make sure all is healthy.

Who can review
--------------

Not @henrytk 