### PR TITLE
[SUPPORT] Improve error messages from tests

### DIFF
--- a/platform-tests/src/platform/acceptance/init_test.go
+++ b/platform-tests/src/platform/acceptance/init_test.go
@@ -81,7 +81,7 @@ func pollForServiceCreationCompletion(dbInstanceName string) {
 	Eventually(func() *Buffer {
 		fmt.Fprint(GinkgoWriter, ".")
 		command := quietCf("cf", "service", dbInstanceName).Wait(testConfig.DefaultTimeoutDuration())
-		Expect(command).To(Exit(0))
+		Expect(command).To(Exit(0), fmt.Sprint("Error calling cf service creation phase: ", string(command.Out.Contents())))
 		return command.Out
 	}, DB_CREATE_TIMEOUT, 15*time.Second).Should(Say("create succeeded"))
 	fmt.Fprint(GinkgoWriter, "done\n")
@@ -92,7 +92,7 @@ func pollForServiceUpdateCompletion(dbInstanceName string) {
 	Eventually(func() *Buffer {
 		fmt.Fprint(GinkgoWriter, ".")
 		command := quietCf("cf", "service", dbInstanceName).Wait(testConfig.DefaultTimeoutDuration())
-		Expect(command).To(Exit(0))
+		Expect(command).To(Exit(0), fmt.Sprint("Error calling cf service update phase: ", string(command.Out.Contents())))
 		return command.Out
 	}, DB_CREATE_TIMEOUT, 15*time.Second).Should(Say("update succeeded"))
 	fmt.Fprint(GinkgoWriter, "done\n")
@@ -103,7 +103,7 @@ func pollForServiceDeletionCompletion(dbInstanceName string) {
 	Eventually(func() *Buffer {
 		fmt.Fprint(GinkgoWriter, ".")
 		command := quietCf("cf", "services").Wait(testConfig.DefaultTimeoutDuration())
-		Expect(command).To(Exit(0))
+		Expect(command).To(Exit(0), fmt.Sprint("Error calling cf services: ", string(command.Out.Contents())))
 		return command.Out
 	}, DB_CREATE_TIMEOUT, 15*time.Second).ShouldNot(Say(dbInstanceName))
 	fmt.Fprint(GinkgoWriter, "done\n")


### PR DESCRIPTION
What
----

This commit improves the error output from a failed interaction with CF
during the running of the custom acceptance tests. We have been seeing some flakey tests and this should help in better understanding the cause.


How to review
-------------

Code review and optionally run through dev env.

Who can review
--------------

Not me
