### PR TITLE
[#161388997] Set BOSH_CLIENT* vars when using bosh

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -164,7 +164,12 @@ jobs:
               - -e
               - -c
               - |
-                ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
+                VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
+                BOSH_CLIENT=admin
+                BOSH_CLIENT_SECRET=$($VAL_FROM_YAML secrets.bosh_admin_password bosh-secrets/bosh-secrets.yml)
+                export BOSH_CLIENT
+                export BOSH_CLIENT_SECRET
+
                 bosh -n delete-deployment --force --deployment "((deploy_env))"
                 bosh -n delete-deployment --force --deployment prometheus
 

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1230,6 +1230,11 @@ jobs:
                 - |
                   VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
 
+                  BOSH_CLIENT=admin
+                  BOSH_CLIENT_SECRET=$($VAL_FROM_YAML secrets.bosh_admin_password bosh-secrets/bosh-secrets.yml)
+                  export BOSH_CLIENT
+                  export BOSH_CLIENT_SECRET
+
                   stemcell_index=0
                   while true; do
                     if ! $VAL_FROM_YAML "stemcells.${stemcell_index}" cf-manifest/cf-manifest.yml > /dev/null 2>&1; then
@@ -1240,7 +1245,7 @@ jobs:
                     STEMCELL_OS=$($VAL_FROM_YAML "stemcells.${stemcell_index}.os" cf-manifest/cf-manifest.yml)
 
                     wget "https://bosh.io/d/stemcells/bosh-aws-xen-hvm-${STEMCELL_OS}-go_agent?v=${STEMCELL_VERSION}" -O stemcell.tgz
-                    ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
+
                     bosh -n upload-stemcell stemcell.tgz
 
                     stemcell_index=$((stemcell_index + 1))
@@ -1265,7 +1270,12 @@ jobs:
                 - -e
                 - -c
                 - |
-                  ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
+                  VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
+                  BOSH_CLIENT=admin
+                  BOSH_CLIENT_SECRET=$($VAL_FROM_YAML secrets.bosh_admin_password bosh-secrets/bosh-secrets.yml)
+                  export BOSH_CLIENT
+                  export BOSH_CLIENT_SECRET
+
                   bosh -n update-cloud-config cloud-config/cloud-config.yml
 
       - task: cf-deploy
@@ -1287,7 +1297,12 @@ jobs:
               - -e
               - -c
               - |
-                ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
+                VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
+                BOSH_CLIENT=admin
+                BOSH_CLIENT_SECRET=$($VAL_FROM_YAML secrets.bosh_admin_password bosh-secrets/bosh-secrets.yml)
+                export BOSH_CLIENT
+                export BOSH_CLIENT_SECRET
+
                 bosh -n deploy cf-manifest/cf-manifest.yml
 
   - name: prometheus-deploy
@@ -1352,8 +1367,13 @@ jobs:
               - -e
               - -c
               - |
-               ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
-               bosh -n deploy prometheus-manifest/prometheus-manifest.yml
+                VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
+                BOSH_CLIENT=admin
+                BOSH_CLIENT_SECRET=$($VAL_FROM_YAML secrets.bosh_admin_password bosh-secrets/bosh-secrets.yml)
+                export BOSH_CLIENT
+                export BOSH_CLIENT_SECRET
+
+                bosh -n deploy prometheus-manifest/prometheus-manifest.yml
 
   - name: post-deploy
     serial: true
@@ -2144,7 +2164,12 @@ jobs:
               - -e
               - -c
               - |
-                ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
+                VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
+                BOSH_CLIENT=admin
+                BOSH_CLIENT_SECRET=$($VAL_FROM_YAML secrets.bosh_admin_password bosh-secrets/bosh-secrets.yml)
+                export BOSH_CLIENT
+                export BOSH_CLIENT_SECRET
+
                 bosh -n clean-up --all
 
     - aggregate:
@@ -2739,7 +2764,12 @@ jobs:
               - -e
               - -c
               - |
-                ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
+                VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
+                BOSH_CLIENT=admin
+                BOSH_CLIENT_SECRET=$($VAL_FROM_YAML secrets.bosh_admin_password bosh-secrets/bosh-secrets.yml)
+                export BOSH_CLIENT
+                export BOSH_CLIENT_SECRET
+
                 bosh deployment
                 bosh vms | tee vms.txt
                 vms_not_running=$(grep '|' vms.txt | grep -cEv '(\-\-|VM|running)' || true)

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -218,7 +218,12 @@ jobs:
               - -e
               - -c
               - |
-                ./paas-cf/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
+                VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
+                BOSH_CLIENT=admin
+                BOSH_CLIENT_SECRET=$($VAL_FROM_YAML secrets.bosh_admin_password bosh-secrets/bosh-secrets.yml)
+                export BOSH_CLIENT
+                export BOSH_CLIENT_SECRET
+
                 bosh -n delete-deployment --force --deployment "((deploy_env))"
                 bosh -n delete-deployment --force --deployment prometheus
                 echo "no" > deployed-healthcheck/healthcheck-deployed

--- a/concourse/scripts/bosh_login.sh
+++ b/concourse/scripts/bosh_login.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-set -eu
-
-bosh_secrets_file=$1
-
-SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
-bosh_password=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.bosh_admin_password "${bosh_secrets_file}")
-
-bosh login --client="admin" --client-secret="${bosh_password}"


### PR DESCRIPTION
What
----

We want to start using bosh with UAA. But using it seems to have
problem when we do a login first with `bosh login` and then
do not pass the `client` and `client-secret` to every command.

To workaround this, we decided to set the variables `BOSH_CLIENT` and
`BOSH_CLIENT_SECRET` in every job that uses bosh.

To fix this, we replace the script `bosh_login.sh` with the
corresponding snippet that sets the environment variables.

How to review
-------------

 - Code review
 - Run the pipeline


Who can review
--------------

anyone