### PR TITLE
[#161224612] Add `gds-non-chargeable` quota to quota sizes

### DIFF
--- a/manifests/cf-manifest/operations.d/320-cc-add-quotas.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-add-quotas.yml
@@ -12,6 +12,11 @@
       non_basic_services_allowed: false
       total_routes: 1000
       total_services: 10
+    gds-non-chargeable:
+      memory_limit: 5120
+      non_basic_services_allowed: false
+      total_routes: 1000
+      total_services: 10
     large:
       memory_limit: 102400
       non_basic_services_allowed: true


### PR DESCRIPTION
What
----

The `gds-non-chargeable` quota has been created in order to aid in the
process for filtering orgs that should either be in a billable state or
should have their trial account removed as part of the 3 month trial
period.

How to review
-------------

Code review
If you feel inclined deploy over a current master and chack `cf quotas` to see it in place

Who can review
--------------

Not @LeePorte
