### PR TITLE
[#161655766] Upgrade uaa-release to v64.0

### DIFF
--- a/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
+++ b/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
@@ -1,0 +1,8 @@
+---
+- type: replace
+  path: /releases/name=uaa
+  value:
+    name: "uaa"
+    version: "64.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=64.0"
+    sha1: "f10caefdd136675975bfc88d6409f322c68209d4"


### PR DESCRIPTION
What
----

There is a new CVE-2018-15761[1] that gets fixed wit the version v64.0

[1] https://www.cloudfoundry.org/blog/cve-2018-15761/

How to review
-------------

Code review.

Test in stating should be enough

Who can review
--------------

anyone