### PR TITLE
[#161716019] Pre-configure a wildcard hostname '*'

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1484,10 +1484,12 @@ jobs:
                 cf create-route docs "${APPS_DNS_ZONE_NAME}" --hostname www
                 cf create-route docs "${APPS_DNS_ZONE_NAME}" --hostname api
                 cf create-route docs "${APPS_DNS_ZONE_NAME}" --hostname status
+                cf create-route docs "${APPS_DNS_ZONE_NAME}" --hostname '*'
 
                 # Reserve the london app name so that we don't cause conflicts
                 # when we roll out the London region.
                 cf create-route docs "${APPS_DNS_ZONE_NAME}" --hostname london
+
 
       - task: register-rds-broker
         config:

--- a/platform-tests/src/platform/acceptance/routes_test.go
+++ b/platform-tests/src/platform/acceptance/routes_test.go
@@ -1,0 +1,92 @@
+package acceptance_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+
+	"encoding/json"
+
+	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
+	"github.com/cloudfoundry-incubator/cf-test-helpers/workflowhelpers"
+)
+
+var _ = Describe("Configured routes and domains", func() {
+	It("have a wildcard route configured for each non-internal shared domain", func() {
+		workflowhelpers.AsUser(testContext.AdminUserContext(), testConfig.DefaultTimeoutDuration(), func() {
+
+			sharedDomainsCommand := cf.Cf("curl", "/v2/shared_domains")
+			Expect(sharedDomainsCommand.Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
+
+			var sharedDomainsResp struct {
+				Resources []struct {
+					Metadata struct {
+						GUID string
+					}
+					Entity struct {
+						Name     string
+						Internal bool
+					}
+				}
+			}
+
+			err := json.Unmarshal(sharedDomainsCommand.Buffer().Contents(), &sharedDomainsResp)
+			Expect(err).NotTo(HaveOccurred())
+
+			for _, sharedDomain := range sharedDomainsResp.Resources {
+				if sharedDomain.Entity.Internal == true {
+					continue
+				}
+
+				routesCommand := cf.Cf("curl",
+					fmt.Sprintf("/v2/routes?q=host:*&q=domain_guid:%s", sharedDomain.Metadata.GUID),
+				)
+				Expect(routesCommand.Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
+				var routesResp struct {
+					TotalResults int `json:"total_results"`
+					Resources    []struct {
+						Entity struct {
+							SpaceURL string `json:"space_url"`
+						}
+					}
+				}
+
+				err := json.Unmarshal(routesCommand.Buffer().Contents(), &routesResp)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(routesResp.TotalResults).To(
+					BeNumerically("==", 1),
+					"No wildcard '*' route set for shared domain '%s'", sharedDomain.Entity.Name,
+				)
+
+				// Check that the route is in the desired org
+				spaceCommand := cf.Cf("curl", routesResp.Resources[0].Entity.SpaceURL)
+				Expect(spaceCommand.Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
+				var spaceResp struct {
+					Entity struct {
+						OrganizationURL string `json:"organization_url"`
+					}
+				}
+				err = json.Unmarshal(spaceCommand.Buffer().Contents(), &spaceResp)
+				Expect(err).NotTo(HaveOccurred())
+
+				orgCommand := cf.Cf("curl", spaceResp.Entity.OrganizationURL)
+				Expect(orgCommand.Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
+				var orgResp struct {
+					Entity struct {
+						Name string
+					}
+				}
+				err = json.Unmarshal(orgCommand.Buffer().Contents(), &orgResp)
+				Expect(err).NotTo(HaveOccurred())
+
+				expectedOrgName = "govuk-paas"
+				Expect(orgResp.Entity.Name).To(Equal(expectedOrgName),
+					"Expected org for wildcard '*' in shared domain '%s' to be '%s', got '%s'",
+					sharedDomain.Entity.Name, expectedOrgName, orgResp.Entity.Name,
+				)
+			}
+		})
+	})
+})


### PR DESCRIPTION
What
----

We want to pre-assign a host '*' route for the main shared domains
(non-internal) into our admin org, so that no other tenant would be able to
register the wildcard domain.

This would prevent a potential issue if someone registers the wildcard for
any other application, potentially hijacking the traffic of apps being
unavailable, or any route not mapped yet.

For the time being the route remains unmapped, in the future we might want
to assign this to a custom application with some message and custom HTTP
status code.

We also add a custom acceptance test for this case.


How to review
-------------

 - Code review
 - Run the pipeline
 - Check you cannot create a '*' route as a normal user:


```
DEPLOY_ENV=...
cf create-user testuser pass123
cf set-space-role testuser govuk-paas sandbox SpaceDeveloper

cf auth testuser pass123
cf target -o govuk-paas -s sandbox

cf create-route public ${DEPLOY_ENV}.dev.cloudpipelineapps.digital --hostname '*'
```

Who can review
--------------

Not me