### PR TITLE
Check that platform tests compile in test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ check-env:
 	$(if ${DEPLOY_ENV_VALID_CHARS},,$(error Sorry, DEPLOY_ENV ($(DEPLOY_ENV)) must use only alphanumeric chars and hyphens, otherwise derived names will be malformatted))
 	@./scripts/validate_aws_credentials.sh
 
-test: spec lint_yaml lint_terraform lint_shellcheck lint_concourse lint_ruby lint_posix_newlines ## Run linting tests
+test: spec compile_platform_tests lint_yaml lint_terraform lint_shellcheck lint_concourse lint_ruby lint_posix_newlines ## Run linting tests
 
 spec:
 	cd scripts &&\
@@ -40,6 +40,16 @@ spec:
 		go test
 	cd platform-tests &&\
 		./run_tests.sh src/platform/availability/monitor/
+
+compile_platform_tests:
+	GOPATH="$$(pwd)/platform-tests:$${GOPATH}" \
+	go test -run ^$$ \
+		platform/acceptance \
+		platform/availability/api \
+		platform/availability/app \
+		platform/availability/helpers \
+		platform/availability/monitor \
+		platform/performance
 
 lint_yaml:
 	find . -name '*.yml' -not -path '*/vendor/*' -not -path './manifests/prometheus/upstream/*' | xargs yamllint -c yamllint.yml

--- a/platform-tests/src/platform/acceptance/routes_test.go
+++ b/platform-tests/src/platform/acceptance/routes_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Configured routes and domains", func() {
 				err = json.Unmarshal(orgCommand.Buffer().Contents(), &orgResp)
 				Expect(err).NotTo(HaveOccurred())
 
-				expectedOrgName = "govuk-paas"
+				expectedOrgName := "govuk-paas"
 				Expect(orgResp.Entity.Name).To(Equal(expectedOrgName),
 					"Expected org for wildcard '*' in shared domain '%s' to be '%s', got '%s'",
 					sharedDomain.Entity.Name, expectedOrgName, orgResp.Entity.Name,

--- a/platform-tests/src/platform/availability/helpers/concourse.go
+++ b/platform-tests/src/platform/availability/helpers/concourse.go
@@ -100,7 +100,7 @@ func buildsWithVersion(team concourse.Team, pipelineName, resourceName, resource
 	if err != nil {
 		return nil, err
 	} else if !resourceExists {
-		return nil, fmt.Errorf("Resource: %s did not exist in Concourse", resourceVersions)
+		return nil, fmt.Errorf("Resource: %v did not exist in Concourse", resourceVersions)
 	}
 
 	for _, version := range resourceVersions {


### PR DESCRIPTION
What
----

The staging pipeline failed because of a missing colon in the platform
tests - this sort of thing should be caught at unit test time. Because
we can't run the platform tests, we weren't even trying to compile them.

Using `go test -run ^$` makes go compile the test code, but doesn't run
any tests (because they don't match the empty string pattern).

Also fixing the missing colon that made the tests fail and an unrelated
error about `%s` that occurs with my version of the comiler.

How to review
-------------

* Code review
* Check the Travis build output to confirm it ran the new check

Who can review
--------------

Not @richardTowers