### PR TITLE
[#161387517] Concourse to alert PagerDuty on 24x7 continuous-smoke-test failures 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ showenv: check-env ## Display environment information
 	@scripts/show-vars-store-secrets.sh prometheus-vars-store alertmanager_password grafana_password prometheus_password
 
 .PHONY: upload-all-secrets
-upload-all-secrets: upload-datadog-secrets upload-google-oauth-secrets upload-notify-secrets upload-aiven-secrets upload-logit-secrets
+upload-all-secrets: upload-datadog-secrets upload-google-oauth-secrets upload-notify-secrets upload-aiven-secrets upload-logit-secrets upload-pagerduty-secrets
 
 .PHONY: upload-datadog-secrets
 upload-datadog-secrets: check-env ## Decrypt and upload Datadog credentials to S3
@@ -254,6 +254,13 @@ upload-logit-secrets: check-env ## Decrypt and upload Logit credentials to S3
 	$(if ${LOGIT_PASSWORD_STORE_DIR},,$(error Must pass LOGIT_PASSWORD_STORE_DIR=<path_to_password_store>))
 	$(if $(wildcard ${LOGIT_PASSWORD_STORE_DIR}),,$(error Password store ${LOGIT_PASSWORD_STORE_DIR} does not exist))
 	@scripts/upload-logit-secrets.sh
+
+.PHONY: upload-pagerduty-secrets
+upload-pagerduty-secrets: check-env ## Decrypt and upload pagerduty credentials to S3
+	$(eval export PAGERDUTY_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
+	$(if ${MAKEFILE_ENV_TARGET},,$(error Must set MAKEFILE_ENV_TARGET))
+	$(if $(wildcard ${PAGERDUTY_PASSWORD_STORE_DIR}),,$(error Password store ${PAGERDUTY_PASSWORD_STORE_DIR} does not exist))
+	@scripts/upload-pagerduty-secrets.sh
 
 .PHONY: pingdom
 pingdom: check-env ## Use custom Terraform provider to set up Pingdom check

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -105,8 +105,8 @@ resource_types:
 - name: pagerduty-notification-resource
   type: docker-image
   source:
-    repository: fidelityinternational/pagerduty-notification-resource
-    tag: latest
+    repository: governmentpaas/pagerduty-notification-resource
+    tag: 2018-11-15
 
 resources:
   - name: pipeline-trigger

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -102,6 +102,12 @@ resource_types:
     repository: governmentpaas/semver-resource
     tag: ecbdd201e122b44de99a40ac9f24407c1a43b9a2
 
+- name: pagerduty-notification-resource
+  type: docker-image
+  source:
+    repository: fidelityinternational/pagerduty-notification-resource
+    tag: latest
+
 resources:
   - name: pipeline-trigger
     type: semver-iam
@@ -381,6 +387,11 @@ resources:
       region_name: ((aws_region))
       versioned_file: prometheus-vars-store.yml
       initial_version: "-"
+
+  - name: pagerduty-notify
+    type: pagerduty-notification-resource
+    source:
+      service_key: ((pagerduty_integration_key))
 
 jobs:
   - name: pipeline-lock
@@ -3345,27 +3356,19 @@ jobs:
             SYSTEM_DOMAIN: ((system_dns_zone_name))
 
         - task: smoke-tests-run
+          attempts: 3
           file: paas-cf/concourse/tasks/smoke-tests-run.yml
+          params:
+            AWS_DEFAULT_REGION: ((aws_region))
+            DEPLOY_ENV: ((deploy_env))
+            SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+            ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
+            EMAIL_ON_SMOKE_TEST_FAILURE: true
           on_failure:
-            task: alert
-            config:
-              platform: linux
-              image_resource: *awscli-image-resource
-              params:
-                AWS_DEFAULT_REGION: ((aws_region))
-                DEPLOY_ENV: ((deploy_env))
-                SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
-                ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
-              inputs:
-                - name: paas-cf
-              run:
-                path: sh
-                args:
-                - -e
-                - -c
-                - |
-                  paas-cf/concourse/scripts/smoke_tests_email.sh \
-                    "${DEPLOY_ENV}" "${SYSTEM_DNS_ZONE_NAME}" "${ALERT_EMAIL_ADDRESS}"
+            put: pagerduty-notify
+            params:
+              action: trigger
+              description: "((deploy_env)) concourse continuous smoketests errors"
           ensure:
             task: upload-test-artifacts
             file: paas-cf/concourse/tasks/upload-test-artifacts.yml

--- a/concourse/scripts/lib/pagerduty.sh
+++ b/concourse/scripts/lib/pagerduty.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+set -u
+
+get_pagerduty_secrets() {
+  # shellcheck disable=SC2154
+  secrets_uri="s3://${state_bucket}/pagerduty-secrets.yml"
+  export pagerduty_spike_integration_key
+  if aws s3 ls "$secrets_uri" > /dev/null ; then
+    secrets_file=$(mktemp -t pagerduty-secrets.XXXXXX)
+
+    aws s3 cp "$secrets_uri" "$secrets_file"
+    pagerduty_spike_integration_key=$("${SCRIPT_DIR}/val_from_yaml.rb" pagerduty_spike_integration_key "$secrets_file")
+
+    rm -f "$secrets_file"
+  fi
+}

--- a/concourse/scripts/lib/pagerduty.sh
+++ b/concourse/scripts/lib/pagerduty.sh
@@ -5,12 +5,12 @@ set -u
 get_pagerduty_secrets() {
   # shellcheck disable=SC2154
   secrets_uri="s3://${state_bucket}/pagerduty-secrets.yml"
-  export pagerduty_spike_integration_key
+  export pagerduty_integration_key
   if aws s3 ls "$secrets_uri" > /dev/null ; then
     secrets_file=$(mktemp -t pagerduty-secrets.XXXXXX)
 
     aws s3 cp "$secrets_uri" "$secrets_file"
-    pagerduty_spike_integration_key=$("${SCRIPT_DIR}/val_from_yaml.rb" pagerduty_spike_integration_key "$secrets_file")
+    pagerduty_integration_key=$("${SCRIPT_DIR}/val_from_yaml.rb" pagerduty_integration_key "$secrets_file")
 
     rm -f "$secrets_file"
   fi

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -21,6 +21,9 @@ $("${SCRIPT_DIR}/environment.sh" "$@")
 # shellcheck disable=SC1090
 . "${SCRIPT_DIR}/lib/logit.sh"
 
+# shellcheck disable=SC1090
+. "${SCRIPT_DIR}/lib/pagerduty.sh"
+
 download_git_id_rsa() {
   git_id_rsa_file=$(mktemp -t id_rsa.XXXXXX)
 
@@ -60,6 +63,7 @@ prepare_environment() {
   get_google_oauth_secrets
   get_notify_secrets
   get_logit_ca_cert
+  get_pagerduty_secrets
 
   if [ -n "${SLIM_DEV_DEPLOYMENT:-}" ] && [ "${MAKEFILE_ENV_TARGET}" != "dev" ]; then
     echo "SLIM_DEV_DEPLOYMENT set for non-dev deployment. Aborting!"
@@ -84,6 +88,14 @@ prepare_environment() {
   if [ -z "${notify_api_key+x}" ] ; then
     echo "Could not retrieve api key for Notify. Did you run \`make ${MAKEFILE_ENV_TARGET} upload-notify-secrets\`?"
     exit 1
+  fi
+
+  # shellcheck disable=SC2154
+  if [ -z "${pagerduty_spike_integration_key+x}" ] && [ "${MAKEFILE_ENV_TARGET}" != "dev" ]; then
+    echo "Could not retrieve intgration key for Pagerduty. Did you run \`make ${MAKEFILE_ENV_TARGET} upload-pagerduty-secrets\`?"
+    exit 1
+  else
+    echo "Could not retrieve intgration key for Pagerduty. Using default"
   fi
 
   # Note: this credential is not interpolated into the pipeline. It is used as a guard against forgetting
@@ -132,6 +144,7 @@ disable_pipeline_locking: ${DISABLE_PIPELINE_LOCKING:-}
 datadog_api_key: "${datadog_api_key:-}"
 datadog_app_key: "${datadog_app_key:-}"
 aiven_api_token: ${aiven_api_token:-}
+pagerduty_spike_integration_key: "${pagerduty_spike_integration_key:-this-is-not-a-pagerduty-key}"
 enable_datadog: ${ENABLE_DATADOG}
 concourse_atc_password: ${CONCOURSE_ATC_PASSWORD}
 oauth_client_id: "${oauth_client_id:-}"

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -91,11 +91,9 @@ prepare_environment() {
   fi
 
   # shellcheck disable=SC2154
-  if [ -z "${pagerduty_spike_integration_key+x}" ] && [ "${MAKEFILE_ENV_TARGET}" != "dev" ]; then
-    echo "Could not retrieve intgration key for Pagerduty. Did you run \`make ${MAKEFILE_ENV_TARGET} upload-pagerduty-secrets\`?"
+  if [ -z "${pagerduty_integration_key+x}" ] && [ "${MAKEFILE_ENV_TARGET}" != "dev" ]; then
+    echo "Could not retrieve integration key for Pagerduty. Did you run \`make ${MAKEFILE_ENV_TARGET} upload-pagerduty-secrets\`?"
     exit 1
-  else
-    echo "Could not retrieve intgration key for Pagerduty. Using default"
   fi
 
   # Note: this credential is not interpolated into the pipeline. It is used as a guard against forgetting
@@ -144,7 +142,7 @@ disable_pipeline_locking: ${DISABLE_PIPELINE_LOCKING:-}
 datadog_api_key: "${datadog_api_key:-}"
 datadog_app_key: "${datadog_app_key:-}"
 aiven_api_token: ${aiven_api_token:-}
-pagerduty_spike_integration_key: "${pagerduty_spike_integration_key:-this-is-not-a-pagerduty-key}"
+pagerduty_integration_key: "${pagerduty_integration_key:-this-is-not-a-pagerduty-key}"
 enable_datadog: ${ENABLE_DATADOG}
 concourse_atc_password: ${CONCOURSE_ATC_PASSWORD}
 oauth_client_id: "${oauth_client_id:-}"

--- a/concourse/tasks/smoke-tests-run.yml
+++ b/concourse/tasks/smoke-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/cf-acceptance-tests
-    tag: 51c4648c56a18e28a295e73963b65fdbfe76e52f
+    tag: cd404e5f6e7b96082c586e80921189769131f593
 inputs:
   - name: paas-cf
   - name: cf-smoke-tests-release
@@ -12,4 +12,16 @@ inputs:
 outputs:
   - name: artifacts
 run:
-  path: ./paas-cf/platform-tests/upstream/run_smoke_tests.sh
+  path: sh
+  args:
+  - -c
+  - |
+    paas-cf/platform-tests/upstream/run_smoke_tests.sh
+    TEST_EXIT_CODE=$?
+    if [ "$EMAIL_ON_SMOKE_TEST_FAILURE" = "true" ]; then
+      if [ "$TEST_EXIT_CODE" -gt 0 ]; then
+        paas-cf/concourse/scripts/smoke_tests_email.sh \
+          "${DEPLOY_ENV}" "${SYSTEM_DNS_ZONE_NAME}" "${ALERT_EMAIL_ADDRESS}"
+      fi
+    fi
+    exit $TEST_EXIT_CODE

--- a/scripts/upload-pagerduty-secrets.sh
+++ b/scripts/upload-pagerduty-secrets.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -eu
+
+export PASSWORD_STORE_DIR=${PAGERDUTY_PASSWORD_STORE_DIR}
+
+KEY=$(pass "pagerduty/${MAKEFILE_ENV_TARGET}/pagerduty_integration_key")
+
+SECRETS=$(mktemp secrets.yml.XXXXXX)
+trap 'rm  "${SECRETS}"' EXIT
+
+cat > "${SECRETS}" << EOF
+---
+pagerduty_integration_key: ${KEY}
+EOF
+
+aws s3 cp "${SECRETS}" "s3://gds-paas-${DEPLOY_ENV}-state/pagerduty-secrets.yml"

--- a/terraform/datadog/concourse.tf
+++ b/terraform/datadog/concourse.tf
@@ -32,23 +32,6 @@ resource "datadog_monitor" "continuous-smoketests" {
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:concourse"]
 }
 
-resource "datadog_monitor" "continuous-smoketests-failures" {
-  name  = "${format("%s concourse continuous smoketests failures", var.env)}"
-  type  = "query alert"
-  query = "${format("sum(last_15m):count_nonzero(max:concourse.build.finished{build_status:failed,deploy_env:%s,job:continuous-smoke-tests}) >= 3", var.env)}"
-
-  message = "${format("{{#is_alert}}The `continuous-smoke-tests` have been failing for a while now. We need to investigate. Notify: %s{{/is_alert}} @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.datadog_notification_24x7, var.aws_account)}"
-
-  require_full_window = false
-  notify_no_data      = false
-
-  thresholds {
-    critical = "3"
-  }
-
-  tags = ["deployment:${var.env}", "service:${var.env}_monitors"]
-}
-
 resource "datadog_monitor" "continuous-smoketests-errors" {
   name  = "${format("%s concourse continuous smoketests errors", var.env)}"
   type  = "query alert"


### PR DESCRIPTION
What
----

This PR modifies the pipeline to run the smoke tests in an attempts group with a email fired on each unsuccessful run of the tests. if 3 unsuccessful tests occur in a row Concourse will alert PagerDuty.

How to review
-------------

Code review

Upload PagerDuty secrets to your dev environment and run the pipeline on top of current master.

You should have emails on the paas-dev-alerts email address and then a followup from PagerDuty after 3 successive failures.

Before merging
--------------

Delete commit `7c99ba3` as this is only there for the purpose of reviewing.

Who can review
--------------

Not @LeePorte or @jpluscplusm 