### PR TITLE
[ZD3454682] Set up VPC peering for DIT London

### DIFF
--- a/terraform/prod-lon.vpc_peering.json
+++ b/terraform/prod-lon.vpc_peering.json
@@ -1,0 +1,14 @@
+[
+    {
+        "peer_name": "dit-services_tap",
+        "account_id": "588284153815",
+        "vpc_id": "vpc-03378ac5a1be3218d",
+        "subnet_cidr": "172.16.0.0/22"
+    },
+    {
+        "peer_name": "dit-services_datasci",
+        "account_id": "604925858717",
+        "vpc_id": "vpc-0338ce744086cd767",
+        "subnet_cidr": "172.16.4.0/22"
+    }
+]


### PR DESCRIPTION
What
----

Set up two new VPC peerings for DIT in prod-long, as per
https://govuk.zendesk.com/agent/tickets/3454682:

> Thanks for your response, and these are the details:
>
> Account ID: 588284153815
> VPC ID: vpc-03378ac5a1be3218d
> VPC CIDR: 172.16.0.0/22
> Org/Space: dit-services / tap
>
> Account ID: 604925858717
> VPC ID: vpc-0338ce744086cd767
> VPC CIDR: 172.16.4.0/22
> Org/Space: dit-services / datasci

The concourse pipeline runs:

```
ruby \
  paas-cf/terraform/scripts/generate_vpc_peering_tfvars.rb \
  "paas-cf/terraform/((deploy_env)).vpc_peering.json"
```

So even though the `prod-lon.vpc_peering.json` file is new it should
Just Work(TM).

How to review
-------------

* JSON review
* Check the tests pass

Who can review
--------------

Not @richardTowers