### PR TITLE
[#161544435] Upgrade to cf-deployment v6.0.0

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -372,12 +372,6 @@ resources:
       uri: https://github.com/alphagov/paas-admin
       tag_filter: v0.48.0
 
-  - name: paas-log-cache-adapter
-    type: git
-    source:
-      uri: https://github.com/alphagov/paas-log-cache-adapter
-      tag_filter: v0.6.0
-
   - name: prometheus-vars-store
     type: s3-iam
     source:
@@ -1392,7 +1386,6 @@ jobs:
       - get: paas-billing
       - get: paas-accounts
       - get: paas-admin
-      - get: paas-log-cache-adapter
 
     - task: retrieve-config
       config:
@@ -2104,13 +2097,12 @@ jobs:
                   cf zero-downtime-push paas-admin -f ../paas-admin-manifest/manifest.yml
 
       - do:
-        - task: deploy-paas-log-cache-adapter
+        - task: remove-paas-log-cache-adapter
           config:
             platform: linux
             image_resource: *cf-cli-image-resource
             inputs:
               - name: paas-cf
-              - name: paas-log-cache-adapter
               - name: config
             params:
               SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
@@ -2126,24 +2118,7 @@ jobs:
                   cf auth "${CF_ADMIN}" "${CF_PASS}"
                   cf target -o admin -s monitoring
 
-                  cd paas-log-cache-adapter
-
-                  ruby -ryaml -e "
-                    env = {
-                      'LOG_CACHE_API' => 'https://log-cache.${SYSTEM_DNS_ZONE_NAME}',
-                    }
-                    manifest = YAML.load_file('manifest.yml')
-                    manifest['applications'].each { |app|
-                      app['env'] = {} unless app['env']
-                      app['env'].merge!(env)
-                      app['routes'] = [
-                        { 'route' => 'metrics.${SYSTEM_DNS_ZONE_NAME}' }
-                      ]
-                    }
-                    File.write('manifest.yml', manifest.to_yaml)
-                  "
-
-                  cf zero-downtime-push paas-log-cache-adapter -f manifest.yml
+                  cf delete paas-log-cache-adapter -r -f
 
       - task: run-bosh-cleanup
         config:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -52,7 +52,6 @@ groups:
       - post-deploy
       - smoke-tests
       - acceptance-tests
-      - log-cache-acceptance-tests
       - custom-acceptance-tests
       - bosh-tests
       - performance-tests
@@ -73,7 +72,6 @@ groups:
       - api-availability-tests
       - smoke-tests
       - acceptance-tests
-      - log-cache-acceptance-tests
       - custom-acceptance-tests
       - bosh-tests
       - performance-tests
@@ -2536,55 +2534,6 @@ jobs:
             params:
               DISABLE_ADMIN_USER_CREATION: ((disable_cf_acceptance_tests))
 
-  - name: log-cache-acceptance-tests
-    plan:
-      - aggregate:
-          - get: pipeline-trigger
-            passed: ['post-deploy','app-availability-tests','api-availability-tests']
-            trigger: true
-          - get: cf-acceptance-tests
-          - get: paas-cf
-            passed: ['post-deploy','app-availability-tests','api-availability-tests']
-          - get: cf-manifest
-            passed: ['post-deploy']
-          - get: cf-vars-store
-            passed: ['post-deploy']
-
-      - do:
-        - task: create-temp-user
-          file: paas-cf/concourse/tasks/create_admin.yml
-          params:
-            PREFIX: acceptance-test-user
-            DISABLE_ADMIN_USER_CREATION: ((disable_cf_acceptance_tests))
-
-        - do:
-          - task: generate-test-config
-            file: paas-cf/concourse/tasks/generate-test-config.yml
-            params:
-              TEST_PROPERTIES: acceptance_log_cache_tests
-              APP_DOMAIN: ((apps_dns_zone_name))
-              SYSTEM_DOMAIN: ((system_dns_zone_name))
-          - task: run-log-cache-tests
-            timeout: 20m
-            config:
-              platform: linux
-              image_resource: *cf-acceptance-tests-image-resource
-              params:
-                DISABLE_CF_ACCEPTANCE_TESTS: ((disable_cf_acceptance_tests))
-                SKIP_REGEX: "exercises basic loggregator behavior|applies default environment variables while running apps and tasks|applies default environment variables while staging apps"
-              inputs:
-                - name: paas-cf
-                - name: cf-acceptance-tests
-                  path: src/github.com/cloudfoundry/cf-acceptance-tests
-                - name: test-config
-              run:
-                path: ./paas-cf/platform-tests/upstream/run_acceptance_tests.sh
-          ensure:
-            task: remove-temp-user
-            file: paas-cf/concourse/tasks/delete_admin.yml
-            params:
-              DISABLE_ADMIN_USER_CREATION: ((disable_cf_acceptance_tests))
-
   - name: custom-acceptance-tests
     plan:
       - aggregate:
@@ -2785,10 +2734,10 @@ jobs:
     plan:
       - aggregate:
           - get: pipeline-trigger
-            passed: ['smoke-tests', 'acceptance-tests', 'log-cache-acceptance-tests', 'custom-acceptance-tests', 'bosh-tests']
+            passed: ['smoke-tests', 'acceptance-tests', 'custom-acceptance-tests', 'bosh-tests']
             trigger: true
           - get: paas-cf
-            passed: ['smoke-tests', 'acceptance-tests', 'log-cache-acceptance-tests', 'custom-acceptance-tests', 'bosh-tests']
+            passed: ['smoke-tests', 'acceptance-tests', 'custom-acceptance-tests', 'bosh-tests']
           - get: cf-manifest
             passed: ['smoke-tests', 'acceptance-tests', 'custom-acceptance-tests']
           - get: cf-vars-store

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -299,13 +299,13 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-acceptance-tests
-      branch: cf4.5
+      branch: cf6.0
 
   - name: cf-smoke-tests-release
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-smoke-tests-release
-      tag_filter: "40.0.9"
+      tag_filter: "40.0.17"
       submodules:
       - "src/smoke_tests"
 

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -15,7 +15,7 @@ meta:
       type: docker-image
       source:
         repository: governmentpaas/cf-acceptance-tests
-        tag: 51c4648c56a18e28a295e73963b65fdbfe76e52f
+        tag: a4abdc079caf1eccb11a6bd2c486469cd9d0362a
     cf-cli: &cf-cli-image-resource
       type: docker-image
       source:

--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -4,5 +4,6 @@
   path: /stemcells
   value:
     - alias: default
-      os: ubuntu-trusty
-      version: "3586.52"
+      os: ubuntu-xenial
+      version: "170.3"
+

--- a/manifests/cf-manifest/operations.d/260-cf-upgrade-cflinuxfs2.yml
+++ b/manifests/cf-manifest/operations.d/260-cf-upgrade-cflinuxfs2.yml
@@ -1,9 +1,0 @@
----
-
-- type: replace
-  path: /releases/name=cflinuxfs2
-  value:
-    name: cflinuxfs2
-    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.244.0
-    version: 1.244.0
-    sha1: 67f473bb1296b1faf598bceef2a36e9584b510f0

--- a/manifests/cf-manifest/operations.d/329-custom-capi-release.yml
+++ b/manifests/cf-manifest/operations.d/329-custom-capi-release.yml
@@ -1,0 +1,8 @@
+---
+- type: replace
+  path: /releases/name=capi
+  value:
+    name: capi
+    version: 0.1.1
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/capi-0.1.1.tgz
+    sha1: d0072aa5990eeb055e95379299ab67a2b7f28275

--- a/manifests/cf-manifest/operations.d/350-diego-cell.yml
+++ b/manifests/cf-manifest/operations.d/350-diego-cell.yml
@@ -13,16 +13,16 @@
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs2-rootfs-setup/properties/cflinuxfs2-rootfs/trusted_certs
   value: |
-    ((application_ca.certificate))
     ((aws_rds_combined_ca_bundle))
-    ((uaa_ca.certificate))
+    ((application_ca.certificate))((application_ca_old.certificate))
+    ((uaa_ca.certificate))((uaa_ca_old.certificate))
 
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs3-rootfs-setup/properties/cflinuxfs3-rootfs/trusted_certs
   value: |
-    ((application_ca.certificate))
     ((aws_rds_combined_ca_bundle))
-    ((uaa_ca.certificate))
+    ((application_ca.certificate))((application_ca_old.certificate))
+    ((uaa_ca.certificate))((uaa_ca_old.certificate))
 
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden?/log_level

--- a/manifests/cf-manifest/operations.d/350-diego-cell.yml
+++ b/manifests/cf-manifest/operations.d/350-diego-cell.yml
@@ -12,7 +12,17 @@
 
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs2-rootfs-setup/properties/cflinuxfs2-rootfs/trusted_certs
-  value: ((aws_rds_combined_ca_bundle))
+  value: |
+    ((application_ca.certificate))
+    ((aws_rds_combined_ca_bundle))
+    ((uaa_ca.certificate))
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs3-rootfs-setup/properties/cflinuxfs3-rootfs/trusted_certs
+  value: |
+    ((application_ca.certificate))
+    ((aws_rds_combined_ca_bundle))
+    ((uaa_ca.certificate))
 
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden?/log_level

--- a/manifests/cf-manifest/operations.d/900-cf-cert-rotation.yml
+++ b/manifests/cf-manifest/operations.d/900-cf-cert-rotation.yml
@@ -267,6 +267,9 @@
   path: /addons/name=bosh-dns/jobs/name=bosh-dns/properties/health/server/tls/ca
   value: ((dns_healthcheck_tls_ca.certificate))((dns_healthcheck_tls_ca_old.certificate))
 
+# /instance_groups/name=diego-cell/jobs/name=cflinuxfs2-rootfs-setup/properties/cflinuxfs2-rootfs/trusted_certs
+# /instance_groups/name=diego-cell/jobs/name=cflinuxfs3-rootfs-setup/properties/cflinuxfs3-rootfs/trusted_certs
+
 - type: replace
   path: /variables/-
   value:

--- a/manifests/cf-manifest/operations/datadog.yml
+++ b/manifests/cf-manifest/operations/datadog.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: datadog-agent
-    version: 0.1.5
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-agent-0.1.5.tgz
-    sha1: 573bed2ab7960eb97dafff4b7c6111e7ad72b39c
+    version: 0.1.7
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-agent-0.1.7.tgz
+    sha1: 09a2a37e492ff77a8362eb1269b78775b30099af
 
 - type: replace
   path: /addons/-

--- a/manifests/cf-manifest/scripts/generate-manifest.sh
+++ b/manifests/cf-manifest/scripts/generate-manifest.sh
@@ -9,9 +9,8 @@ WORKDIR=${WORKDIR:-.}
 
 opsfile_args=""
 
-slim_dev_deployment=""
 if [ "${SLIM_DEV_DEPLOYMENT-}" = "true" ]; then
-  slim_dev_deployment="--ops-file=${CF_DEPLOYMENT_DIR}/operations/scale-to-one-az.yml"
+  opsfile_args="$opsfile_args -o ${CF_DEPLOYMENT_DIR}/operations/scale-to-one-az.yml"
 fi
 
 for i in "${PAAS_CF_DIR}"/manifests/cf-manifest/operations.d/*.yml; do
@@ -26,7 +25,7 @@ if [ "${ENABLE_DATADOG}" = "true" ] ; then
 fi
 
 if [ "${DISABLE_USER_CREATION}" = "false" ] ; then
-   opsfile_args="$opsfile_args -o ${PAAS_CF_DIR}/manifests/cf-manifest/operations/uaa-add-google-oauth.yml"
+  opsfile_args="$opsfile_args -o ${PAAS_CF_DIR}/manifests/cf-manifest/operations/uaa-add-google-oauth.yml"
 fi
 
 if [ "${SLIM_DEV_DEPLOYMENT-}" = "true" ]; then
@@ -55,7 +54,6 @@ bosh interpolate \
   --ops-file="${CF_DEPLOYMENT_DIR}/operations/stop-skipping-tls-validation.yml" \
   --ops-file="${CF_DEPLOYMENT_DIR}/operations/enable-service-discovery.yml" \
   --ops-file="${PROMETHEUS_DEPLOYMENT_DIR}/manifests/operators/cf/add-prometheus-uaa-clients.yml" \
-  ${slim_dev_deployment} \
   ${opsfile_args} \
   --ops-file="${WORKDIR}/vpc-peering-opsfile/vpc-peers.yml" \
   "$@" \

--- a/manifests/cf-manifest/scripts/generate-manifest.sh
+++ b/manifests/cf-manifest/scripts/generate-manifest.sh
@@ -56,7 +56,6 @@ bosh interpolate \
   --ops-file="${CF_DEPLOYMENT_DIR}/operations/enable-service-discovery.yml" \
   --ops-file="${PROMETHEUS_DEPLOYMENT_DIR}/manifests/operators/cf/add-prometheus-uaa-clients.yml" \
   ${slim_dev_deployment} \
-  --ops-file="${CF_DEPLOYMENT_DIR}/operations/experimental/disable-consul.yml" \
   ${opsfile_args} \
   --ops-file="${WORKDIR}/vpc-peering-opsfile/vpc-peers.yml" \
   "$@" \

--- a/manifests/cf-manifest/spec/manifest/env_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/env_spec.rb
@@ -1,6 +1,6 @@
 
 RSpec.describe "Environment specific configuration" do
-  let(:default_manifest) { manifest_with_defaults }
+  let(:default_manifest) { manifest_without_vars_store }
   let(:prod_manifest) { manifest_for_prod }
 
   def get_instance_group_instances(manifest, instance_group_name)

--- a/manifests/cf-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/cf-manifest/spec/support/manifest_helpers.rb
@@ -67,19 +67,21 @@ module ManifestHelpers
   end
 
   def manifest_for_prod
-    render_manifest_with_vars_store(
+    render_manifest(
       environment: "prod",
       enable_datadog: "false",
       disable_user_creation: "true",
       env_specific_manifest: "prod",
+      extra_args: [],
     )
   end
 
   def manifest_for_dev
-    render_manifest_with_vars_store(
+    render_manifest(
       environment: "dev",
       enable_datadog: "false",
       disable_user_creation: "true",
+      extra_args: [],
     )
   end
 


### PR DESCRIPTION
What
----

We want to catchup our deployment and:

 - upgrade to cf-deployment v6.0.0 [1] (now we are on v4.5.0
 - upgrade the stemcell from Trusty to Xenial

We did not identify any major breaking change in the deployment.

During this upgrade:

 - We had to update the datadog agent to work on Xenial. See https://github.com/alphagov/paas-datadog-agent-boshrelease/pull/14
 - We had to create our own capi-release tarball (without changes) to workaround some issue with the upstream release. See https://github.com/cloudfoundry/cf-deployment/issues/663 and https://github.com/alphagov/paas-release-ci/pull/81

See commits for more info

[1] https://github.com/cloudfoundry/cf-deployment/releases/tag/v6.0.0


Related
--------

Bosh and stemcells upgrade: https://github.com/alphagov/paas-bootstrap/pull/210
and https://github.com/alphagov/paas-bootstrap/pull/214

How to review
-------------

This has been deployed on `towers` and `hector` dev environments.

We tested:
 - [x] deploy from scratch
 - [x] upgrade from master
 - [x] rotate certs (ca and leaf)
 - [x] rotate secrets

We run with an upgraded version of bosh.

Note: tehre were some errors of api availability, warnings due the stats
not being available. between 10 and 22. We assume them.

To review: Just double check the code and that the right stuff has been
deployed.


Who can review
--------------

Not me or @towers