### PR TITLE
[#SUPPORT] Update elasticache_cache_parameter_groups in prod

### DIFF
--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -26,4 +26,4 @@ datadog_notification_in_hours = "@pagerduty-datadog-in-hours"
 
 # AWS Limits not accesible via API
 aws_limits_elasticache_nodes = 100
-aws_limits_elasticache_cache_parameter_groups = 60
+aws_limits_elasticache_cache_parameter_groups = 100


### PR DESCRIPTION
What
----

AWS support:

> [I can] confirm that your ElastiCache Parameter Groups per Region limit in the
Ireland region is 100.

https://console.aws.amazon.com/support/v1#/case/?displayId=5516588401&language=en

How to review
-------------

* Sanity check

Who can review
--------------

Not @richardTowers