### PR TITLE
[#160508552] Bump paas-admin to include location banner

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -354,7 +354,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-admin
-      tag_filter: v0.48.0
+      tag_filter: v0.49.0
 
   - name: prometheus-vars-store
     type: s3-iam


### PR DESCRIPTION
What
----

Version 0.49.0 includes the location banner in the header

[1] https://github.com/alphagov/paas-admin/pull/114


How to review
-------------

Code review.
Version tagged in: https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/paas-admin/jobs/tag-releases/builds/49

Who can review
--------------

Not me