### PR TITLE
[#161316533] Deploy 2 separate apps from paas-billing

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -342,7 +342,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-billing
-      tag_filter: v0.44.0
+      tag_filter: v0.46.0
 
   - name: paas-accounts
     type: git
@@ -1897,19 +1897,38 @@ jobs:
                     'CF_CLIENT_REDIRECT_URL' => 'https://billing.${SYSTEM_DNS_ZONE_NAME}/oauth/callback',
                     'CF_API_ADDRESS' => '${API_ENDPOINT}',
                   }
-                  manifest = YAML.load_file('manifest.yml')
-                  manifest['applications'].each { |app|
+
+                  api = YAML.load_file('manifest-api.yml')
+                  api['applications'].each { |app|
                     app['env'] = {} unless app['env']
-                    app['env'].merge!(env)
+                    app['env'] = app['env'].merge(env)
                     app['services'] = ['billing-db']
                     app['routes'] = [
                       { 'route' => 'billing.${SYSTEM_DNS_ZONE_NAME}' }
                     ]
                   }
-                  File.write('manifest.yml', manifest.to_yaml)
+                  File.write('manifest-api.yml', api.to_yaml)
+
+                  collector = YAML.load_file('manifest-collector.yml')
+                  collector['applications'].each { |app|
+                    app['env'] = {} unless app['env']
+                    app['env'] = app['env'].merge(env)
+                    app['services'] = ['billing-db']
+                  }
+                  File.write('manifest-collector.yml', collector.to_yaml)
                 "
 
-                cf push paas-billing
+                # FIXME: remove this once all production envs have run this at
+                # least once. It's harmless to leave here, however.
+                cf rename paas-billing paas-billing-collector || true
+
+                cf zero-downtime-push \
+                  paas-billing-api \
+                  -f manifest-api.yml
+
+                cf push \
+                  paas-billing-collector \
+                  -f manifest-collector.yml
 
       - task: deploy-paas-accounts
         config:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1920,7 +1920,10 @@ jobs:
 
                 # FIXME: remove this once all production envs have run this at
                 # least once. It's harmless to leave here, however.
-                cf rename paas-billing paas-billing-collector || true
+                apps="$(cf apps)"
+                if echo "${apps}" | grep -qe '^paas-billing '; then
+                  cf rename paas-billing paas-billing-collector
+                fi
 
                 cf zero-downtime-push \
                   paas-billing-api \


### PR DESCRIPTION
What
----

As of https://github.com/alphagov/paas-billing/pull/56 there are 2 apps for the API and the data collector. This commit deploys both during `post-deploy`, using the appropriate strategy to deliver HA and non-HA uptime as required by the apps' consumers.

How to review
-------------

- Code review
- Run down a dev pipeline, probably as part of validating https://github.com/alphagov/paas-billing/pull/56 
- After this has run in prod, the `FIXME` line in the concourse pipeline can be PR'd away. It's harmless to leave there, however.

Who can review
--------------

Anyone except @jpluscplusm or @bandesz 