### PR TITLE
[Support] Make installed cf cli plugins available in subshell script

### DIFF
--- a/scripts/cf_subshell_scoped_login.sh
+++ b/scripts/cf_subshell_scoped_login.sh
@@ -34,6 +34,9 @@ cleanup() {
 }
 trap 'cleanup' EXIT
 
+mkdir -p "${HOME}/.cf/plugins" "${CF_HOME}/.cf"
+ln -s "${HOME}/.cf/plugins" "${CF_HOME}/.cf/plugins"
+
 export CF_HOME
 export CF_SUBSHELL_TARGET=$TARGET
 


### PR DESCRIPTION
## What

This script points CF_HOME to a temporary directory to create an
indipendent login for the subshell. This has the side-effect of hiding
any cli plugins that are installed. To avoid this, this PR adds a
symlink back to plugins directory so that they can be found.

How to review
-------------

* Code review
* use the cf_subshell_scoped_login scipt, and verify that `cf plugins` still returns any plugins you have installed.

Who can review
--------------

Not me.