### PR TITLE
Scale API instances in production to 4

### DIFF
--- a/manifests/cf-manifest/env-specific/cf-default.yml
+++ b/manifests/cf-manifest/env-specific/cf-default.yml
@@ -1,3 +1,4 @@
 ---
 cell_instances: 3
 router_instances: 2
+api_instances: 2

--- a/manifests/cf-manifest/env-specific/cf-prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/cf-prod-lon.yml
@@ -1,3 +1,4 @@
 ---
 cell_instances: 6
 router_instances: 3
+api_instances: 2

--- a/manifests/cf-manifest/env-specific/cf-prod.yml
+++ b/manifests/cf-manifest/env-specific/cf-prod.yml
@@ -1,3 +1,4 @@
 ---
 cell_instances: 39
 router_instances: 3
+api_instances: 4

--- a/manifests/cf-manifest/env-specific/cf-stg-lon.yml
+++ b/manifests/cf-manifest/env-specific/cf-stg-lon.yml
@@ -1,3 +1,4 @@
 ---
 cell_instances: 6
 router_instances: 3
+api_instances: 2

--- a/manifests/cf-manifest/operations.d/370-scale-api.yml
+++ b/manifests/cf-manifest/operations.d/370-scale-api.yml
@@ -1,0 +1,9 @@
+---
+- type: replace
+  path: /instance_groups/name=api/azs/-
+  value: z3
+
+- type: replace
+  path: /instance_groups/name=api/instances
+  value: ((api_instances))
+

--- a/manifests/cf-manifest/operations/scale-down-dev.yml
+++ b/manifests/cf-manifest/operations/scale-down-dev.yml
@@ -29,3 +29,6 @@
 - type: replace
   path: /instance_groups/name=elasticache_broker/instances
   value: 1
+- type: replace
+  path: /instance_groups/name=api/instances
+  value: 1

--- a/manifests/cf-manifest/spec/manifest/env_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/env_spec.rb
@@ -13,4 +13,11 @@ RSpec.describe "Environment specific configuration" do
 
     expect(default_cell_instances).to be < prod_cell_instances
   end
+
+  it "should allow a higher number of instances of API servers in production" do
+    default_api_instances = get_instance_group_instances(default_manifest, "api")
+    prod_api_instances = get_instance_group_instances(prod_manifest, "api")
+
+    expect(default_api_instances).to be < prod_api_instances
+  end
 end


### PR DESCRIPTION
What
----

... and make sure they span three AZs.

We had an incident recently where enabling the prometheus cf_exporter
caused some API requests to time out. We think this wouldn't have been a
problem if the API instances had been scaled up.

We're going with 4 instances (rather than 3) so that there's enough
of a difference for us to notice any changes in our metrics.

We're not planning on re-enabling the cf_exporter as part of this story.

How to review
-------------

* Code review
* Observe that [`towers` has four API instances](https://deployer.towers.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/cf-deploy/builds/156)

Who can review
--------------

* Not @richardtowers