### PR TITLE
[#162113648] UAA: allow emails with more than 4 domain parts

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1624,6 +1624,28 @@ jobs:
                   cf curl /v2/shared_domains -d '{"name": "apps.internal", "internal": true}'
                 fi
 
+      - task: set-uaa-idp-email-domains
+        config:
+          platform: linux
+          image_resource: *cf-cli-image-resource
+          inputs:
+            - name: paas-cf
+            - name: cf-vars-store
+          params:
+            LOGIN_URL: https://login.((system_dns_zone_name))
+            UAA_URL: https://uaa.((system_dns_zone_name))
+          run:
+            path: sh
+            args:
+              - -e
+              - -u
+              - -c
+              - |
+                export UAA_ADMIN_CLIENT_SECRET
+                UAA_ADMIN_CLIENT_SECRET=$(./paas-cf/concourse/scripts/val_from_yaml.rb uaa_admin_client_secret cf-vars-store/cf-vars-store.yml)
+
+                ./paas-cf/concourse/scripts/uaa_set_email_domains.sh '["*.*", "*.*.*", "*.*.*.*", "*.*.*.*.*", "*.*.*.*.*.*"]'
+
     - aggregate:
       - task: block-create-account-endpoints
         config:

--- a/concourse/scripts/uaa_set_email_domains.sh
+++ b/concourse/scripts/uaa_set_email_domains.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e -u -o pipefail
+
+# SCRIPT
+
+email_domains=${1}
+
+basic_auth_client_creds=$(echo -n "admin:${UAA_ADMIN_CLIENT_SECRET}" | base64)
+access_token="$(curl \
+  --silent \
+  --fail \
+  --header "Authorization: Basic ${basic_auth_client_creds}" \
+  --data 'grant_type=client_credentials' \
+  "${LOGIN_URL}/oauth/token" | jq -r '.access_token')"
+
+uaa_idp_json=$(curl --silent --fail --header "Authorization: bearer ${access_token}" "${UAA_URL}/identity-providers/" | jq -r '.[] | select(.type == "uaa")')
+uaa_idp_guid=$(jq -r '.id' <<< "$uaa_idp_json")
+uaa_idp_config=$(jq -r '.config' <<< "$uaa_idp_json")
+
+updated_uaa_idp_config=$(jq --compact-output ".emailDomain = ${email_domains}" <<< "${uaa_idp_config}")
+updated_uaa_idp_json=$(jq --compact-output --arg config "${updated_uaa_idp_config}" '.config = $config' <<< "${uaa_idp_json}")
+
+if curl --silent --fail \
+  --header "Content-Type: application/json" \
+  --header "Authorization: bearer ${access_token}" \
+  --request PUT \
+  --data "${updated_uaa_idp_json}" \
+  "${UAA_URL}/identity-providers/${uaa_idp_guid}"; then
+
+  echo -e '\n\nSuccessfully updated emailDomain for uaa identity provider'
+else
+  >&2 echo 'Failed to update emailDomain for uaa identity provider'
+  exit 1
+fi


### PR DESCRIPTION
## What

The default allowlist for UAA's internal IDP only allows users with 4
parts in their email domain[1]. This means that UAA returns an error
when we (or an Org Manager) attempts to invide a user with 5 or more
components in their email domain.

It doesn't appear to be possible to configure this via UAA's config file
(as per a conversation on CF slack[2]), and therefore via the manifest,
so instead we have to add a post-deploy job to update this via UAA's
API. This extends the list to allow up to 6 components in the domain.
This should be enough for now, and it's reasonably simple to extend
further if needed.

[1]https://github.com/cloudfoundry/uaa/blob/4.24.0/server/src/main/java/org/cloudfoundry/identity/uaa/util/DomainFilter.java#L103
[2]https://cloudfoundry.slack.com/archives/C03FXANBV/p1542628288065500

How to review
-------------

I've already done the following in my dev env:

* Attempt to invite a user with 5 components in the email (eg user@a.b.c.example.com), and see it fail.
* Deploy from this branch
* Repeat the attempt and see it succeed.

This script might be useful to manually invite a user:
```sh
#!/bin/bash

set -e -u -o pipefail

# INPUTS

uaa_admin_client_secret=<INSERT_HERE>
login_url=https://login.${DEPLOY_ENV}.dev.cloudpipeline.digital
uaa_url=https://uaa.${DEPLOY_ENV}.dev.cloudpipeline.digital
redirect_uri=https://admin.${DEPLOY_ENV}.dev.cloudpipeline.digital

# SCRIPT

basic_auth_client_creds=$(echo -n "admin:$uaa_admin_client_secret" | base64)
access_token="$(curl \
  --silent \
  --fail \
  --header "Authorization: Basic $basic_auth_client_creds" \
  --data 'grant_type=client_credentials' \
  "$login_url/oauth/token" | jq -r '.access_token')"

email=$1

curl --fail \
  -H "Authorization: bearer $access_token" \
  -H "Accept: application/json" -H "Content-Type: application/json" \
  -X POST \
  -d "{\"emails\": [\"${email}\"]}" \
  "${uaa_url}/invite_users?redirect_uri=${redirect_uri}&client_id=user_invitation"
```

Who can review
--------------

Not me.