### PR TITLE
[#162013441] Add monitors for cloud controller latency and unregistrys

### DIFF
--- a/terraform/datadog/cloud_controller.tf
+++ b/terraform/datadog/cloud_controller.tf
@@ -92,3 +92,20 @@ resource "datadog_monitor" "cc_job_queue_length" {
 
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:api"]
 }
+
+resource "datadog_monitor" "cc_gorouter_latency" {
+  name                = "${format("%s Cloud Controller latency as reported by gorouter", var.env)}"
+  type                = "query alert"
+  message             = "${format("Average latency of cloud controller calls is high - this may be due to a high proportion of expensive API calls or it may indicate that the API servers need to be scaled up @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
+  require_full_window = false
+
+  query = "${format("avg(last_10m):max:cf.gorouter.latency.CloudController{deployment:%s} by {ip} > 200", var.env)}"
+
+  thresholds {
+    warning  = "150"
+    critical = "200"
+  }
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:api"]
+}
+

--- a/terraform/datadog/cloud_controller.tf
+++ b/terraform/datadog/cloud_controller.tf
@@ -109,3 +109,18 @@ resource "datadog_monitor" "cc_gorouter_latency" {
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:api"]
 }
 
+resource "datadog_monitor" "cc_gorouter_unregistry" {
+  name                = "${format("%s Cloud Controller is unregistering from gorouter", var.env)}"
+  type                = "query alert"
+  message             = "${format("Cloud Controller is unregistering from gorouter, this probably means it is failing its route_registrar healthcheck. This could be due to high load, and may indicate that the API servers need to be scaled up @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
+  require_full_window = false
+
+  query = "${format("max(last_10m):per_hour(avg:cf.gorouter.unregistry_message.CloudController{deployment:%s}) > 10", var.env)}"
+
+  thresholds {
+    warning  = "5"
+    critical = "10"
+  }
+
+  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:api"]
+}


### PR DESCRIPTION
What
----

During a recent incident we had a monitor which overloaded the API.

Afterwards we could see that the latency was much higher than normal
during the incident, but we didn't have a monitor for this so we didn't notice.

Once the API's performance fell below a certain point it started failing
its healtcheck and getting unregistered from gorouter.

The thresholds we've chosen here were picked so that they would not warn
under average conditions but would have been critical during the incident

See https://app.datadoghq.com/notebook/63780/Cloud%20Controller%20outage%20metrics

How to review
-------------

* Code review
* See the monitors in datadog for `towers`:
  * https://app.datadoghq.com/monitors/7279410
  * https://app.datadoghq.com/monitors/7279438

Who can review
--------------

Not @richardtowers