### PR TITLE
WIP: [#162157392] Add alert for Syslog Drains in prometheus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,6 +262,13 @@ upload-pagerduty-secrets: check-env ## Decrypt and upload pagerduty credentials 
 	$(if $(wildcard ${PAGERDUTY_PASSWORD_STORE_DIR}),,$(error Password store ${PAGERDUTY_PASSWORD_STORE_DIR} does not exist))
 	@scripts/upload-pagerduty-secrets.sh
 
+.PHONY: upload-alertmanager-pagerduty-secrets
+upload-alertmanager-pagerduty-secrets: check-env ## Decrypt and upload pagerduty credentials to S3
+	$(eval export ALERTMANAGER_PAGERDUTY_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
+	$(if ${MAKEFILE_ENV_TARGET},,$(error Must set MAKEFILE_ENV_TARGET))
+	$(if $(wildcard ${ALERTMANAGER_PAGERDUTY_PASSWORD_STORE_DIR}),,$(error Password store ${ALERTMANAGER_PAGERDUTY_PASSWORD_STORE_DIR} does not exist))
+	@scripts/upload-alertmanager-pagerduty-secrets.sh
+
 .PHONY: pingdom
 pingdom: check-env ## Use custom Terraform provider to set up Pingdom check
 	$(if ${ACTION},,$(error Must pass ACTION=<plan|apply|...>))

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1222,6 +1222,28 @@ jobs:
           - get: bosh-secrets
           - get: bosh-CA-crt
           - get: cf-vars-store
+          - get: cf-tfstate
+
+      - task: extract-terraform-outputs
+        config:
+          platform: linux
+          image_resource: *ruby-slim-image-resource
+          inputs:
+            - name: paas-cf
+            - name: cf-tfstate
+          outputs:
+            - name: terraform-outputs
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                for state in cf; do
+                  ./paas-cf/concourse/scripts/extract_terraform_state_to_yaml.rb \
+                    < ${state}-tfstate/${state}.tfstate \
+                    > terraform-outputs/${state}.yml
+                done
 
       - task: generate-prometheus-manifest
         config:
@@ -1233,6 +1255,7 @@ jobs:
             - name: bosh-secrets
             - name: bosh-CA-crt
             - name: cf-vars-store
+            - name: terraform-outputs
           outputs:
             - name: prometheus-manifest
             - name: prometheus-vars-store-updated
@@ -1253,6 +1276,7 @@ jobs:
 
                 export VARS_FILES="
                   ./prometheus-vars-file.yml
+                  ./terraform-outputs/cf.yml
                 "
 
                 bosh interpolate - \
@@ -1273,6 +1297,7 @@ jobs:
                 traffic_controller_external_port: 443
                 uaa_clients_cf_exporter_secret: ((uaa_clients_cf_exporter_secret))
                 uaa_clients_firehose_exporter_secret: ((uaa_clients_firehose_exporter_secret))
+                aws_account: ((aws_account))
                 EOF
 
 

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1251,7 +1251,9 @@ jobs:
               - |
                 cp prometheus-vars-store/prometheus-vars-store.yml "${VARS_STORE}"
 
-                export VARS_FILE=./prometheus-vars-file.yml
+                export VARS_FILES="
+                  ./prometheus-vars-file.yml
+                "
 
                 bosh interpolate - \
                   --var-errs \

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1297,6 +1297,7 @@ jobs:
                 traffic_controller_external_port: 443
                 uaa_clients_cf_exporter_secret: ((uaa_clients_cf_exporter_secret))
                 uaa_clients_firehose_exporter_secret: ((uaa_clients_firehose_exporter_secret))
+                alertmanager_pagerduty_service_key: ((alertmanager_pagerduty_integration_key))
                 aws_account: ((aws_account))
                 EOF
 

--- a/concourse/scripts/lib/alertmanager-pagerduty.sh
+++ b/concourse/scripts/lib/alertmanager-pagerduty.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+set -u
+
+get_alertmanager_pagerduty_secrets() {
+  # shellcheck disable=SC2154
+  secrets_uri="s3://${state_bucket}/alertmanager-pagerduty-secrets.yml"
+  export alertmanager_pagerduty_integration_key
+  if aws s3 ls "$secrets_uri" > /dev/null ; then
+    secrets_file=$(mktemp -t alertmanager-pagerduty-secrets.XXXXXX)
+
+    aws s3 cp "$secrets_uri" "$secrets_file"
+    alertmanager_pagerduty_integration_key=$("${SCRIPT_DIR}/val_from_yaml.rb" alertmanager_pagerduty_service_key "$secrets_file")
+
+    rm -f "$secrets_file"
+  fi
+}

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -24,6 +24,9 @@ $("${SCRIPT_DIR}/environment.sh" "$@")
 # shellcheck disable=SC1090
 . "${SCRIPT_DIR}/lib/pagerduty.sh"
 
+# shellcheck disable=SC1090
+. "${SCRIPT_DIR}/lib/alertmanager-pagerduty.sh"
+
 download_git_id_rsa() {
   git_id_rsa_file=$(mktemp -t id_rsa.XXXXXX)
 
@@ -64,6 +67,7 @@ prepare_environment() {
   get_notify_secrets
   get_logit_ca_cert
   get_pagerduty_secrets
+  get_alertmanager_pagerduty_secrets
 
   if [ -n "${SLIM_DEV_DEPLOYMENT:-}" ] && [ "${MAKEFILE_ENV_TARGET}" != "dev" ]; then
     echo "SLIM_DEV_DEPLOYMENT set for non-dev deployment. Aborting!"
@@ -93,6 +97,12 @@ prepare_environment() {
   # shellcheck disable=SC2154
   if [ -z "${pagerduty_integration_key+x}" ] && [ "${MAKEFILE_ENV_TARGET}" != "dev" ]; then
     echo "Could not retrieve integration key for Pagerduty. Did you run \`make ${MAKEFILE_ENV_TARGET} upload-pagerduty-secrets\`?"
+    exit 1
+  fi
+
+  # shellcheck disable=SC2154
+  if [ -z "${alertmanager_pagerduty_integration_key+x}" ] && [ "${MAKEFILE_ENV_TARGET}" != "dev" ]; then
+    echo "Could not retrieve integration key for Pagerduty. Did you run \`make ${MAKEFILE_ENV_TARGET} upload-alertmanager-pagerduty-secrets\`?"
     exit 1
   fi
 
@@ -143,6 +153,7 @@ datadog_api_key: "${datadog_api_key:-}"
 datadog_app_key: "${datadog_app_key:-}"
 aiven_api_token: ${aiven_api_token:-}
 pagerduty_integration_key: "${pagerduty_integration_key:-this-is-not-a-pagerduty-key}"
+alertmanager_pagerduty_integration_key: "${alertmanager_pagerduty_integration_key:-this-is-not-a-pagerduty-key}"
 enable_datadog: ${ENABLE_DATADOG}
 concourse_atc_password: ${CONCOURSE_ATC_PASSWORD}
 oauth_client_id: "${oauth_client_id:-}"

--- a/manifests/prometheus/alerts.d/600-syslog_drains.yml
+++ b/manifests/prometheus/alerts.d/600-syslog_drains.yml
@@ -13,3 +13,13 @@
       annotations:
         summary: Syslog drains
         description: "Consider scaling the adapters to cope with the number of syslog drains."
+    - alert: CFSyslogDrainsCritical
+      expr: firehose_value_metric_cf_syslog_drain_scheduler_drains > 300
+      labels:
+        deployment: ((metrics_environment))
+        severity: critical
+        notify: email,pagerduty
+        runbook: "https://github.com/cloudfoundry/cf-syslog-drain-release/tree/v6.4#syslog-adapter"
+      annotations:
+        summary: Syslog drains
+        description: "Consider scaling the adapters to cope with the number of syslog drains."

--- a/manifests/prometheus/alerts.d/600-syslog_drains.yml
+++ b/manifests/prometheus/alerts.d/600-syslog_drains.yml
@@ -1,0 +1,14 @@
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: syslog-drains
+    rules:
+    - alert: CFSyslogDrainsWarning
+      expr: firehose_value_metric_cf_syslog_drain_scheduler_drains > 250
+      labels:
+        deployment: ((metrics_environment))
+        severity: warning
+        runbook: "https://github.com/cloudfoundry/cf-syslog-drain-release/tree/v6.4#syslog-adapter"
+      annotations:
+        summary: Syslog drains
+        description: "Consider scaling the adapters to cope with the number of syslog drains."

--- a/manifests/prometheus/alerts.d/600-syslog_drains.yml
+++ b/manifests/prometheus/alerts.d/600-syslog_drains.yml
@@ -8,6 +8,7 @@
       labels:
         deployment: ((metrics_environment))
         severity: warning
+        notify: email,pagerduty
         runbook: "https://github.com/cloudfoundry/cf-syslog-drain-release/tree/v6.4#syslog-adapter"
       annotations:
         summary: Syslog drains

--- a/manifests/prometheus/alerts.d/600-syslog_drains.yml
+++ b/manifests/prometheus/alerts.d/600-syslog_drains.yml
@@ -3,21 +3,20 @@
   value:
     name: syslog-drains
     rules:
-    - alert: CFSyslogDrainsWarning
-      expr: firehose_value_metric_cf_syslog_drain_scheduler_drains > 250
+    - record: CFSyslogDrains_threshold
+      expr: 300
       labels:
-        deployment: ((metrics_environment))
-        severity: warning
-        notify: email,pagerduty
-        runbook: "https://github.com/cloudfoundry/cf-syslog-drain-release/tree/v6.4#syslog-adapter"
-      annotations:
-        summary: Syslog drains
-        description: "Consider scaling the adapters to cope with the number of syslog drains."
-    - alert: CFSyslogDrainsCritical
-      expr: firehose_value_metric_cf_syslog_drain_scheduler_drains > 300
-      labels:
-        deployment: ((metrics_environment))
         severity: critical
+    - record: CFSyslogDrains_threshold
+      expr: 250
+      labels:
+        severity: warning
+    - alert: CFSyslogDrains
+      expr: |
+          firehose_value_metric_cf_syslog_drain_scheduler_drains
+          > on (severity) group_left CFSyslogDrains_threshold
+      labels:
+        deployment: ((metrics_environment))
         notify: email,pagerduty
         runbook: "https://github.com/cloudfoundry/cf-syslog-drain-release/tree/v6.4#syslog-adapter"
       annotations:

--- a/manifests/prometheus/operations.d/300-alertmanager-smtp.yml
+++ b/manifests/prometheus/operations.d/300-alertmanager-smtp.yml
@@ -1,0 +1,7 @@
+- type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/smtp?
+  value:
+    smarthost:  ((terraform_outputs_ses_smtp_host)):587
+    auth_username: ((terraform_outputs_ses_smtp_aws_access_key_id))
+    auth_password: ((terraform_outputs_ses_smtp_password))
+    require_tls: true

--- a/manifests/prometheus/operations.d/310-alertmanager-routes.yml
+++ b/manifests/prometheus/operations.d/310-alertmanager-routes.yml
@@ -1,0 +1,32 @@
+- type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/route?
+  value:
+    receiver: default-receiver
+    group_by:
+    # FIXME: not sure about these values
+    - deployment
+    group_wait: 30s
+    group_interval: 1m
+    repeat_interval: 1h
+
+- type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/route/routes?/-
+  value:
+    receiver: email-receiver
+    continue: true
+    match_re:
+      notify: ".*email.*"
+
+- type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers?/-
+  value:
+    name: default-receiver
+
+- type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers?/-
+  value:
+    name: 'email-receiver'
+    email_configs:
+    - send_resolved: true
+      from: govpaas-alerting-((aws_account))@digital.cabinet-office.gov.uk
+      to: govpaas-alerting-((aws_account))@digital.cabinet-office.gov.uk

--- a/manifests/prometheus/operations.d/310-alertmanager-routes.yml
+++ b/manifests/prometheus/operations.d/310-alertmanager-routes.yml
@@ -18,6 +18,14 @@
       notify: ".*email.*"
 
 - type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/route/routes?/-
+  value:
+    receiver: pagerduty-receiver
+    continue: true
+    match_re:
+      notify: ".*pagerduty.*"
+
+- type: replace
   path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers?/-
   value:
     name: default-receiver
@@ -30,3 +38,10 @@
     - send_resolved: true
       from: govpaas-alerting-((aws_account))@digital.cabinet-office.gov.uk
       to: govpaas-alerting-((aws_account))@digital.cabinet-office.gov.uk
+
+- type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers?/-
+  value:
+    name: 'pagerduty-receiver'
+    pagerduty_configs:
+    - service_key: "((alertmanager_pagerduty_service_key))"

--- a/manifests/prometheus/scripts/generate-manifest.sh
+++ b/manifests/prometheus/scripts/generate-manifest.sh
@@ -11,10 +11,21 @@ for i in "${PAAS_CF_DIR}"/manifests/prometheus/operations.d/*.yml; do
   opsfile_args+="-o $i "
 done
 
+alerts_opsfile_args=""
+for i in "${PAAS_CF_DIR}"/manifests/prometheus/alerts.d/*.yml; do
+  alerts_opsfile_args+="-o $i "
+done
+
+vars_files=""
+for i in ${VARS_FILES}; do
+  vars_files+="--vars-file $i "
+done
+
 # shellcheck disable=SC2086
 bosh interpolate \
   --var-errs \
   --vars-store "${VARS_STORE}" \
-  --vars-file "${VARS_FILE}" \
+  ${vars_files} \
   ${opsfile_args} \
+  ${alerts_opsfile_args} \
   "${PROM_BOSHRELEASE_DIR}/manifests/prometheus.yml"

--- a/manifests/prometheus/scripts/generate-manifest.sh
+++ b/manifests/prometheus/scripts/generate-manifest.sh
@@ -17,6 +17,7 @@ for i in "${PAAS_CF_DIR}"/manifests/prometheus/alerts.d/*.yml; do
 done
 
 vars_files=""
+# shellcheck disable=SC2153
 for i in ${VARS_FILES}; do
   vars_files+="--vars-file $i "
 done

--- a/manifests/prometheus/spec/fixtures/prometheus-vars-file.yml
+++ b/manifests/prometheus/spec/fixtures/prometheus-vars-file.yml
@@ -16,3 +16,5 @@ system_domain: example.com
 traffic_controller_external_port: 443
 uaa_clients_cf_exporter_secret: secret
 uaa_clients_firehose_exporter_secret: secret
+alertmanager_pagerduty_service_key: 1234567890
+aws_account: dev

--- a/manifests/prometheus/spec/support/manifest_helpers.rb
+++ b/manifests/prometheus/spec/support/manifest_helpers.rb
@@ -22,7 +22,9 @@ private
     env = {
       'PAAS_CF_DIR' => root.to_s,
       'VARS_STORE' => vars_store.path,
-      'VARS_FILE' => "#{root}/manifests/prometheus/spec/fixtures/prometheus-vars-file.yml",
+      'VARS_FILES' => [
+        "#{root}/manifests/prometheus/spec/fixtures/prometheus-vars-file.yml",
+      ].join(' ')
     }
     output, error, status = Open3.capture3(env, "#{root}/manifests/prometheus/scripts/generate-manifest.sh")
     expect(status).to be_success, "generate-manifest.sh exited #{status.exitstatus}, stderr:\n#{error}"

--- a/manifests/prometheus/spec/support/manifest_helpers.rb
+++ b/manifests/prometheus/spec/support/manifest_helpers.rb
@@ -24,6 +24,7 @@ private
       'VARS_STORE' => vars_store.path,
       'VARS_FILES' => [
         "#{root}/manifests/prometheus/spec/fixtures/prometheus-vars-file.yml",
+        "#{root}/manifests/shared/spec/fixtures/terraform/cf.yml",
       ].join(' ')
     }
     output, error, status = Open3.capture3(env, "#{root}/manifests/prometheus/scripts/generate-manifest.sh")

--- a/scripts/upload-alertmanager-pagerduty-secrets.sh
+++ b/scripts/upload-alertmanager-pagerduty-secrets.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -eu
+
+export PASSWORD_STORE_DIR=${ALERTMANAGER_PAGERDUTY_PASSWORD_STORE_DIR}
+
+KEY=$(pass "pagerduty/${MAKEFILE_ENV_TARGET}/alertmanager_pagerduty_service_key")
+
+SECRETS=$(mktemp secrets.yml.XXXXXX)
+trap 'rm  "${SECRETS}"' EXIT
+
+cat > "${SECRETS}" << EOF
+---
+alertmanager_pagerduty_service_key: ${KEY}
+EOF
+
+aws s3 cp "${SECRETS}" "s3://gds-paas-${DEPLOY_ENV}-state/alertmanager-pagerduty-secrets.yml"


### PR DESCRIPTION
What
----

Here we add a basic example of one alert using syslog drains on
prometheus and alertmanager.

We include a new directory `manifests/prometheus-manifest/alerts.d`
where one file per alert can be added.

We also setup receivers for email and pagerduty, that would allow to
configure notification for any alert. To do so, the alert must
add a new label `notify: ` including the words `email` or `pagerduty`
or both.


How to review
-------------

Deploy this. Try to trigger the alert by, for instance, doing:

```
cf target -o admin -s billing
for i in $(seq 1..300); do
    cf cups test-syslog-$i -l syslog://127.0.0.1.xip.io
    cf bind-service test-syslog-$i paas-accounts
fone
```

To trigger alerts and test only the receivers, you can use
the following script:

https://gist.github.com/keymon/2dcfc653bd0e2099fda589cb19e983a3

Who can review
--------------

Anyone