### PR TITLE
[#162013441] Fine-tune "Cloud Controller latency as reported by gorouter" DataDog monitor

### DIFF
--- a/terraform/datadog/cloud_controller.tf
+++ b/terraform/datadog/cloud_controller.tf
@@ -99,11 +99,11 @@ resource "datadog_monitor" "cc_gorouter_latency" {
   message             = "${format("Average latency of cloud controller calls is high - this may be due to a high proportion of expensive API calls or it may indicate that the API servers need to be scaled up @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   require_full_window = false
 
-  query = "${format("avg(last_10m):max:cf.gorouter.latency.CloudController{deployment:%s} by {ip} > 200", var.env)}"
+  query = "${format("avg(last_10m):avg:cf.gorouter.latency.CloudController{deployment:%s} > 250", var.env)}"
 
   thresholds {
-    warning  = "150"
-    critical = "200"
+    warning  = "200"
+    critical = "250"
   }
 
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:api"]


### PR DESCRIPTION
# What

The first version of the monitor was too sensitive and was making a lot of
noise.

We decided to increase the thresholds by 50 ms and only consider the average of
all gorouter latencies.

# How to review

Code review should be enough.

# Who can review

Not me.