### PR TITLE
[#162157392] Add alert for Syslog Drains in prometheus

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1251,7 +1251,9 @@ jobs:
               - |
                 cp prometheus-vars-store/prometheus-vars-store.yml "${VARS_STORE}"
 
-                export VARS_FILE=./prometheus-vars-file.yml
+                export VARS_FILES="
+                  ./prometheus-vars-file.yml
+                "
 
                 bosh interpolate - \
                   --var-errs \

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1222,6 +1222,26 @@ jobs:
           - get: bosh-secrets
           - get: bosh-CA-crt
           - get: cf-vars-store
+          - get: cf-tfstate
+
+      - task: extract-terraform-outputs
+        config:
+          platform: linux
+          image_resource: *ruby-slim-image-resource
+          inputs:
+            - name: paas-cf
+            - name: cf-tfstate
+          outputs:
+            - name: terraform-outputs
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                ./paas-cf/concourse/scripts/extract_terraform_state_to_yaml.rb \
+                  < cf-tfstate/cf.tfstate \
+                  > terraform-outputs/cf.yml
 
       - task: generate-prometheus-manifest
         config:
@@ -1233,6 +1253,7 @@ jobs:
             - name: bosh-secrets
             - name: bosh-CA-crt
             - name: cf-vars-store
+            - name: terraform-outputs
           outputs:
             - name: prometheus-manifest
             - name: prometheus-vars-store-updated
@@ -1253,6 +1274,7 @@ jobs:
 
                 export VARS_FILES="
                   ./prometheus-vars-file.yml
+                  ./terraform-outputs/cf.yml
                 "
 
                 bosh interpolate - \
@@ -1273,6 +1295,7 @@ jobs:
                 traffic_controller_external_port: 443
                 uaa_clients_cf_exporter_secret: ((uaa_clients_cf_exporter_secret))
                 uaa_clients_firehose_exporter_secret: ((uaa_clients_firehose_exporter_secret))
+                aws_account: ((aws_account))
                 EOF
 
 

--- a/manifests/prometheus/alerts.d/600-syslog_drains.yml
+++ b/manifests/prometheus/alerts.d/600-syslog_drains.yml
@@ -13,3 +13,13 @@
       annotations:
         summary: Syslog drains
         description: "Consider scaling the adapters to cope with the number of syslog drains."
+    - alert: CFSyslogDrainsCritical
+      expr: firehose_value_metric_cf_syslog_drain_scheduler_drains > 300
+      labels:
+        deployment: ((metrics_environment))
+        severity: critical
+        notify: email
+        runbook: "https://github.com/cloudfoundry/cf-syslog-drain-release/tree/v6.4#syslog-adapter"
+      annotations:
+        summary: Syslog drains
+        description: "Consider scaling the adapters to cope with the number of syslog drains."

--- a/manifests/prometheus/alerts.d/600-syslog_drains.yml
+++ b/manifests/prometheus/alerts.d/600-syslog_drains.yml
@@ -8,6 +8,7 @@
       labels:
         deployment: ((metrics_environment))
         severity: warning
+        notify: email
         runbook: "https://github.com/cloudfoundry/cf-syslog-drain-release/tree/v6.4#syslog-adapter"
       annotations:
         summary: Syslog drains

--- a/manifests/prometheus/alerts.d/600-syslog_drains.yml
+++ b/manifests/prometheus/alerts.d/600-syslog_drains.yml
@@ -1,0 +1,14 @@
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: syslog-drains
+    rules:
+    - alert: CFSyslogDrainsWarning
+      expr: firehose_value_metric_cf_syslog_drain_scheduler_drains > 250
+      labels:
+        deployment: ((metrics_environment))
+        severity: warning
+        runbook: "https://github.com/cloudfoundry/cf-syslog-drain-release/tree/v6.4#syslog-adapter"
+      annotations:
+        summary: Syslog drains
+        description: "Consider scaling the adapters to cope with the number of syslog drains."

--- a/manifests/prometheus/operations.d/300-alertmanager-smtp.yml
+++ b/manifests/prometheus/operations.d/300-alertmanager-smtp.yml
@@ -1,0 +1,7 @@
+- type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/smtp?
+  value:
+    smarthost:  ((terraform_outputs_ses_smtp_host)):587
+    auth_username: ((terraform_outputs_ses_smtp_aws_access_key_id))
+    auth_password: ((terraform_outputs_ses_smtp_password))
+    require_tls: true

--- a/manifests/prometheus/operations.d/310-alertmanager-routes.yml
+++ b/manifests/prometheus/operations.d/310-alertmanager-routes.yml
@@ -1,0 +1,31 @@
+- type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/route?
+  value:
+    receiver: default-receiver
+    group_by:
+    - deployment
+    group_wait: 30s
+    group_interval: 1m
+    repeat_interval: 1h
+
+- type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/route/routes?/-
+  value:
+    receiver: email-receiver
+    continue: true
+    match_re:
+      notify: ".*email.*"
+
+- type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers?/-
+  value:
+    name: default-receiver
+
+- type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers?/-
+  value:
+    name: 'email-receiver'
+    email_configs:
+    - send_resolved: true
+      from: govpaas-alerting-((aws_account))@digital.cabinet-office.gov.uk
+      to: govpaas-alerting-((aws_account))@digital.cabinet-office.gov.uk

--- a/manifests/prometheus/scripts/generate-manifest.sh
+++ b/manifests/prometheus/scripts/generate-manifest.sh
@@ -11,10 +11,21 @@ for i in "${PAAS_CF_DIR}"/manifests/prometheus/operations.d/*.yml; do
   opsfile_args+="-o $i "
 done
 
+alerts_opsfile_args=""
+for i in "${PAAS_CF_DIR}"/manifests/prometheus/alerts.d/*.yml; do
+  alerts_opsfile_args+="-o $i "
+done
+
+varsfile_args=""
+for i in ${VARS_FILES}; do
+  varsfile_args+="--vars-file $i "
+done
+
 # shellcheck disable=SC2086
 bosh interpolate \
   --var-errs \
   --vars-store "${VARS_STORE}" \
-  --vars-file "${VARS_FILE}" \
+  ${varsfile_args} \
   ${opsfile_args} \
+  ${alerts_opsfile_args} \
   "${PROM_BOSHRELEASE_DIR}/manifests/prometheus.yml"

--- a/manifests/prometheus/spec/fixtures/prometheus-vars-file.yml
+++ b/manifests/prometheus/spec/fixtures/prometheus-vars-file.yml
@@ -16,3 +16,4 @@ system_domain: example.com
 traffic_controller_external_port: 443
 uaa_clients_cf_exporter_secret: secret
 uaa_clients_firehose_exporter_secret: secret
+aws_account: dev

--- a/manifests/prometheus/spec/support/manifest_helpers.rb
+++ b/manifests/prometheus/spec/support/manifest_helpers.rb
@@ -22,7 +22,9 @@ private
     env = {
       'PAAS_CF_DIR' => root.to_s,
       'VARS_STORE' => vars_store.path,
-      'VARS_FILE' => "#{root}/manifests/prometheus/spec/fixtures/prometheus-vars-file.yml",
+      'VARS_FILES' => [
+        "#{root}/manifests/prometheus/spec/fixtures/prometheus-vars-file.yml",
+      ].join(' ')
     }
     output, error, status = Open3.capture3(env, "#{root}/manifests/prometheus/scripts/generate-manifest.sh")
     expect(status).to be_success, "generate-manifest.sh exited #{status.exitstatus}, stderr:\n#{error}"

--- a/manifests/prometheus/spec/support/manifest_helpers.rb
+++ b/manifests/prometheus/spec/support/manifest_helpers.rb
@@ -24,6 +24,7 @@ private
       'VARS_STORE' => vars_store.path,
       'VARS_FILES' => [
         "#{root}/manifests/prometheus/spec/fixtures/prometheus-vars-file.yml",
+        "#{root}/manifests/shared/spec/fixtures/terraform/cf.yml",
       ].join(' ')
     }
     output, error, status = Open3.capture3(env, "#{root}/manifests/prometheus/scripts/generate-manifest.sh")


### PR DESCRIPTION
What
----

Here we add a basic example of one alert using syslog drains on
prometheus and alertmanager.

We include a new directory `manifests/prometheus-manifest/alerts.d`
where one file per alert can be added.

We also setup receivers for email, that would allow to
configure notification for any alert. To do so, the alert must
add a new label `notify: ` including the words `email`.


How to review
-------------

Deploy this. Try to trigger the alert by, for instance, doing:

```
cf target -o admin -s billing
for i in $(seq 1 300); do
    cf cups test-syslog-$i -l syslog://127.0.0.1.xip.io
    cf bind-service paas-accounts test-syslog-$i
fone
```

To trigger alerts and test only the receivers, you can use
the following script:

https://gist.github.com/keymon/2dcfc653bd0e2099fda589cb19e983a3

Who can review
--------------

Anyone