### PR TITLE
[#162233928] Unbind splitted paas-billing before delete

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -93,7 +93,7 @@ jobs:
           ORG: admin
           SPACE: healthchecks
           DB_NAME: healthcheck-db
-          BOUND_APP: healthcheck
+          BOUND_APPS: healthcheck
 
       - task: remove-billing-db
         file: paas-cf/concourse/tasks/remove-db.yml
@@ -101,7 +101,7 @@ jobs:
           ORG: admin
           SPACE: billing
           DB_NAME: billing-db
-          BOUND_APP: paas-billing
+          BOUND_APPS: paas-billing-api paas-billing-collector
 
       - task: remove-accounts-db
         file: paas-cf/concourse/tasks/remove-db.yml
@@ -109,7 +109,7 @@ jobs:
           ORG: admin
           SPACE: billing
           DB_NAME: accounts-db
-          BOUND_APP: paas-accounts
+          BOUND_APPS: paas-accounts
 
       - task: datadog-TF-destroy
         file: paas-cf/concourse/tasks/terraform_destroy_datadog.yml

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -163,7 +163,7 @@ jobs:
           ORG: admin
           SPACE: healthchecks
           DB_NAME: healthcheck-db
-          BOUND_APP: healthcheck
+          BOUND_APPS: healthcheck
 
       - task: remove-billing-db
         file: paas-cf/concourse/tasks/remove-db.yml
@@ -171,7 +171,7 @@ jobs:
           ORG: admin
           SPACE: billing
           DB_NAME: billing-db
-          BOUND_APP: paas-billing
+          BOUND_APPS: paas-billing-api paas-billing-collector
 
       - task: remove-accounts-db
         file: paas-cf/concourse/tasks/remove-db.yml
@@ -179,7 +179,7 @@ jobs:
           ORG: admin
           SPACE: billing
           DB_NAME: accounts-db
-          BOUND_APP: paas-accounts
+          BOUND_APPS: paas-accounts
 
       - task: datadog-TF-destroy
         file: paas-cf/concourse/tasks/terraform_destroy_datadog.yml

--- a/concourse/tasks/remove-db.yml
+++ b/concourse/tasks/remove-db.yml
@@ -29,6 +29,9 @@ run:
         exit 0
       fi
       if cf services | grep -q "${DB_NAME}"; then
-        cf unbind-service "${BOUND_APP}" "${DB_NAME}" || true
+        # shellcheck disable=SC2153
+        for app in ${BOUND_APPS}; do
+          cf unbind-service "${app}" "${DB_NAME}" || true
+        done
         cf delete-service "${DB_NAME}" -f
       fi


### PR DESCRIPTION
What
----

On #1629 we splitted the paas-billing in two different deployed
apps, so that we can run the API in HA and the collectors as
single instance.

But the autodelete-deployment needs to unbind all the apps to
delete the service, and now we have two apps bound to the same
service.

We extend the remove-db.yml task to accept a list of BOUND_APPS
to unbind, instead of only one app.

How to review
-------------

Code review.

I run the autodelete here: https://deployer.hector.dev.cloudpipeline.digital/teams/main/pipelines/autodelete-cloudfoundry/jobs/delete/builds/161

You can run your own, but you need to update the paas-cf branch in the
pipeline for `autodelete-cloudfoundry.yml`

Who can review
--------------

Not me