### PR TITLE
[#161184357] Upgrade AWS Terraform provider

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -879,23 +879,6 @@ jobs:
           params:
             file: updated-tfstate/cf.tfstate
 
-      # FIXME: Move this operation to Terraform when this feature is added:
-      # https://github.com/terraform-providers/terraform-provider-aws/issues/113
-      - task: add-aws-users-to-groups
-        config:
-          platform: linux
-          image_resource: *awscli-image-resource
-          params:
-            DEPLOY_ENV: ((deploy_env))
-          run:
-            path: sh
-            args:
-            - -e
-            - -c
-            - |
-              aws iam add-user-to-group --user-name "ses-smtp-${DEPLOY_ENV}" --group-name email-senders
-              aws iam add-user-to-group --user-name "metrics-exporter-${DEPLOY_ENV}" --group-name metrics-exporters
-
       - task: extract-cf-terraform-outputs
         config:
           platform: linux

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -35,7 +35,7 @@ meta:
       type: docker-image
       source:
         repository: governmentpaas/terraform
-        tag: f810666094e6c65eeb183f9833b231aa24df6811
+        tag: 6efea7a479f9336019155cc039ad33d2c8845cb0
 
 groups:
   - name: deploy

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -289,7 +289,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
-              tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
+              tag: 6efea7a479f9336019155cc039ad33d2c8845cb0
           inputs:
             - name: terraform-variables
             - name: paas-cf

--- a/concourse/tasks/forget-access-keys.yml
+++ b/concourse/tasks/forget-access-keys.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/terraform
-    tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
+    tag: 6efea7a479f9336019155cc039ad33d2c8845cb0
 inputs:
   - name: paas-cf
   - name: cf-tfstate

--- a/concourse/tasks/terraform_destroy_datadog.yml
+++ b/concourse/tasks/terraform_destroy_datadog.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/terraform
-    tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
+    tag: 6efea7a479f9336019155cc039ad33d2c8845cb0
 inputs:
   - name: paas-cf
   - name: datadog-tfstate

--- a/terraform/cloudfoundry/metrics-exporter.tf
+++ b/terraform/cloudfoundry/metrics-exporter.tf
@@ -4,17 +4,10 @@ resource "aws_iam_user" "metrics_exporter" {
   force_destroy = true
 }
 
-# Until this feature request is not solved https://github.com/terraform-providers/terraform-provider-aws/issues/113,
-# `aws_iam_group_membership` will wipe all the other members from the
-# shared group.
-#
-# The workaround is use aws cli:
-#
-#   aws iam add-user-to-group --user-name "metrics-exporter-${DEPLOY_ENV}" --group-name metrics-exporters
-#
-# We could do it using terraform provisioner local-exec calling out awscli
-# but we want to avoid this pattern so we will do it in a script in
-# the next step.
+resource "aws_iam_user_group_membership" "metrics_exporter" {
+  user   = "${aws_iam_user.metrics_exporter.name}"
+  groups = ["metrics-exporters"]
+}
 
 resource "aws_iam_access_key" "metrics_exporter" {
   user = "${aws_iam_user.metrics_exporter.name}"

--- a/terraform/cloudfoundry/prometheus.tf
+++ b/terraform/cloudfoundry/prometheus.tf
@@ -89,11 +89,14 @@ resource "aws_lb_listener" "prometheus" {
   ssl_policy        = "${var.default_elb_security_policy}"
   certificate_arn   = "${data.aws_acm_certificate.system.arn}"
 
-  # FIXME: use a fixed-response 404 when we've upgraded to a version of the AWS
-  # provider that supports this (1.6 does not).
   default_action {
-    type             = "forward"
-    target_group_arn = "${aws_lb_target_group.p8s_grafana.arn}"
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Hostname not known"
+      status_code  = "404"
+    }
   }
 }
 

--- a/terraform/cloudfoundry/smtp.tf
+++ b/terraform/cloudfoundry/smtp.tf
@@ -4,28 +4,10 @@ resource "aws_iam_user" "ses_smtp" {
   force_destroy = true
 }
 
-# Until this feature request is not solved https://github.com/terraform-providers/terraform-provider-aws/issues/113,
-# `aws_iam_group_membership` will wipe all the other members from the
-# shared group.
-#
-# The workaround is use aws cli:
-#
-#   aws iam add-user-to-group --user-name "ses-smtp-${DEPLOY_ENV}" --group-name ses-smtp
-#
-# We could do it using terraform provisioner local-exec calling out awscli
-# but we want to avoid this pattern so we will do it in a script in
-# the next step.
-#
-# Once they fix it upstream, we can replace it with this code:
-#
-# resource "aws_iam_group_membership" "ses_smtp" {
-#    name = "ses_smtp"
-#    group = "ses_smtp"
-#    users = [
-#        "${aws_iam_user.ses_smtp.name}",
-#    ]
-#    append = true
-#}
+resource "aws_iam_user_group_membership" "ses_smtp" {
+  user   = "${aws_iam_user.ses_smtp.name}"
+  groups = ["email-senders"]
+}
 
 resource "aws_iam_access_key" "ses_smtp" {
   user = "${aws_iam_user.ses_smtp.name}"


### PR DESCRIPTION
What
----

This upgrades the AWS Terraform provider, and also resolves a couple of FIXMEs relating to this.

This is a precursor to switching to using Terraform to generate ACM certs. The version of the provider we're currently running doesn't support the necessary resources to enable this.

How to review
-------------

* Run the pipeline from this branch.
* Verify everything works etc.

## 🚨 Before Merging 🚨 

* Merge https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/145
* Update the TMP commit to point the the relevant Docker image tag.

Who can review
--------------

Not me.