### PR TITLE
[Support] Upgrade Go version for unit tests to 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
     mv bosh-cli-${BOSH_CLI_VERSION}-linux-amd64 ~/bin/bosh && chmod +x ~/bin/bosh
     set +e
   - pip install --user yamllint
-  - GIMME_OUTPUT=$(gimme 1.9 | tee -a $HOME/.bashrc) && eval "$GIMME_OUTPUT"
+  - GIMME_OUTPUT=$(gimme 1.11 | tee -a $HOME/.bashrc) && eval "$GIMME_OUTPUT"
   - export GOPATH=$HOME/gopath
   - export PATH=$HOME/gopath/bin:$PATH
   - mkdir -p $HOME/gopath/src/github.com/alphagov/paas-cf


### PR DESCRIPTION
What
----

We've just upgraded paas-bootstrap to 1.11[1] because it was still on 1.6
which doesn't work with recent gomega versions.

It makes sense to also upgrade this repo so that they're consistent.

[1]alphagov/paas-bootstrap#221

How to review
-------------

Code review. Verify Travis passes.

Who can review
--------------

Not me.