### PR TITLE
Move CC unregistry alerts from datadog to prometheus

### DIFF
--- a/manifests/prometheus/alerts.d/700-cloud_controller_unregistry.yml
+++ b/manifests/prometheus/alerts.d/700-cloud_controller_unregistry.yml
@@ -1,0 +1,14 @@
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: cloud-controller-unregistry
+    rules:
+    - alert: CFCloudControllerUnregistry
+      expr: avg(rate(firehose_counter_event_gorouter_unregistry_message_cloud_controller_total[10m])*60*10) or vector(0) > 1.5
+      for: 10m
+      labels:
+        deployment: ((metrics_environment))
+        severity: critical
+      annotations:
+        summary: Cloud Controller is unregistering from gorouter
+        description: Cloud Controller is unregistering from gorouter, this probably means it is failing its route_registrar healthcheck. This could be due to high load, and may indicate that the API servers need to be scaled up.

--- a/terraform/datadog/cloud_controller.tf
+++ b/terraform/datadog/cloud_controller.tf
@@ -108,19 +108,3 @@ resource "datadog_monitor" "cc_gorouter_latency" {
 
   tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:api"]
 }
-
-resource "datadog_monitor" "cc_gorouter_unregistry" {
-  name                = "${format("%s Cloud Controller is unregistering from gorouter", var.env)}"
-  type                = "query alert"
-  message             = "${format("Cloud Controller is unregistering from gorouter, this probably means it is failing its route_registrar healthcheck. This could be due to high load, and may indicate that the API servers need to be scaled up @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
-  require_full_window = false
-
-  query = "${format("max(last_10m):per_hour(avg:cf.gorouter.unregistry_message.CloudController{deployment:%s}) > 10", var.env)}"
-
-  thresholds {
-    warning  = "5"
-    critical = "10"
-  }
-
-  tags = ["deployment:${var.env}", "service:${var.env}_monitors", "job:api"]
-}


### PR DESCRIPTION
What
----

Datadog doesn't like sparse metrics, so we were unable to write this
alert there.

Hopefully with the `or vector(0)` thing in Prometheus this should be
more reliable.

How to review
-------------

* Code review
* Run it down a dev pipeline
* `monit stop cloud_controller_ng` to see the alert fire.

Who can review
--------------

Not @richardtowers