### PR TITLE
[#160175665] Add job to rotate prometheus credentials

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1120,10 +1120,11 @@ jobs:
 
                   tar -xzf ./ipsec-CA/ipsec-CA.tar.gz -C ./ipsec-CA
                   cp cf-vars-store/cf-vars-store.yml cf-vars-store-updated/
-                  ./paas-cf/manifests/cf-manifest/scripts/generate-manifest.sh \
-                    --var-errs \
-                    --vars-store cf-vars-store-updated/cf-vars-store.yml \
-                    > cf-manifest/cf-manifest.yml
+
+                  VARS_STORE=cf-vars-store-updated/cf-vars-store.yml \
+                    ./paas-cf/manifests/cf-manifest/scripts/generate-manifest.sh \
+                      > cf-manifest/cf-manifest.yml
+
                   ./paas-cf/manifests/cf-manifest/scripts/generate-manifest.sh \
                     > cf-manifest-pre-vars/cf-manifest-pre-vars.yml
 

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -83,6 +83,7 @@ groups:
     jobs:
       - rotate-cf-admin-password
       - rotate-cloudfoundry-credentials
+      - rotate-prometheus-credentials
       - expire-aws-keys
       - rotate-cf-certs-cas
       - rotate-cf-certs-leafs
@@ -363,6 +364,13 @@ resources:
       region_name: ((aws_region))
       versioned_file: prometheus-vars-store.yml
       initial_version: "-"
+
+  - name: prometheus-manifest-pre-vars
+    type: s3-iam
+    source:
+      bucket: ((state_bucket))
+      region_name: ((aws_region))
+      versioned_file: prometheus-manifest-pre-vars.yml
 
   - name: pagerduty-notify
     type: pagerduty-notification-resource
@@ -1292,12 +1300,12 @@ jobs:
             - name: terraform-outputs
           outputs:
             - name: prometheus-manifest
+            - name: prometheus-manifest-pre-vars
             - name: prometheus-vars-store-updated
           params:
             SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
             CF_DEPLOYMENT_NAME: ((deploy_env))
             BOSH_URL: https://((bosh_fqdn)):25555
-            VARS_STORE: prometheus-vars-store-updated/prometheus-vars-store.yml
             METRON_DEPLOYMENT_NAME: ((deploy_env))
           run:
             path: sh
@@ -1306,7 +1314,6 @@ jobs:
               - -u
               - -c
               - |
-                cp prometheus-vars-store/prometheus-vars-store.yml "${VARS_STORE}"
 
                 export VARS_FILES="
                   ./prometheus-vars-file.yml
@@ -1335,12 +1342,23 @@ jobs:
                 aws_account: ((aws_account))
                 EOF
 
+                cp prometheus-vars-store/prometheus-vars-store.yml prometheus-vars-store-updated/
+
+                VARS_STORE=prometheus-vars-store-updated/prometheus-vars-store.yml \
+                  ./paas-cf/manifests/prometheus/scripts/generate-manifest.sh \
+                    > prometheus-manifest/prometheus-manifest.yml
+
                 ./paas-cf/manifests/prometheus/scripts/generate-manifest.sh \
-                  > prometheus-manifest/prometheus-manifest.yml
+                  > prometheus-manifest-pre-vars/prometheus-manifest-pre-vars.yml
+
         on_success:
-          put: prometheus-vars-store
-          params:
-            file: prometheus-vars-store-updated/prometheus-vars-store.yml
+          aggregate:
+          - put: prometheus-vars-store
+            params:
+              file: prometheus-vars-store-updated/prometheus-vars-store.yml
+          - put: prometheus-manifest-pre-vars
+            params:
+              file: prometheus-manifest-pre-vars/prometheus-manifest-pre-vars.yml
 
       - task: prometheus-deploy
         config:
@@ -3144,6 +3162,42 @@ jobs:
         put: cf-tfstate
         params:
           file: updated-tfstate/cf.tfstate
+
+  - name: rotate-prometheus-credentials
+    serial: true
+    plan:
+    - aggregate:
+      - get: paas-cf
+      - get: prometheus-vars-store
+      - get: prometheus-manifest-pre-vars
+
+    - task: rotate-credentials
+      config:
+        platform: linux
+        image_resource: *ruby-slim-image-resource
+        inputs:
+          - name: paas-cf
+          - name: prometheus-vars-store
+          - name: prometheus-manifest-pre-vars
+        outputs:
+          - name: modified-prometheus-vars-store
+        run:
+          path: sh
+          args:
+            - -e
+            - -c
+            - |
+              ./paas-cf/manifests/cf-manifest/scripts/rotate-vars-store-secrets.rb \
+                --vars-store prometheus-vars-store/prometheus-vars-store.yml \
+                --manifest prometheus-manifest-pre-vars/prometheus-manifest-pre-vars.yml \
+                --passwords \
+                --ssh \
+                --rsa \
+                > modified-prometheus-vars-store/prometheus-vars-store.yml
+      on_success:
+        put: prometheus-vars-store
+        params:
+          file: modified-prometheus-vars-store/prometheus-vars-store.yml
 
   - name: expire-aws-keys
     serial: true

--- a/manifests/cf-manifest/scripts/generate-manifest.sh
+++ b/manifests/cf-manifest/scripts/generate-manifest.sh
@@ -32,6 +32,11 @@ if [ "${SLIM_DEV_DEPLOYMENT-}" = "true" ]; then
   opsfile_args="$opsfile_args -o ${PAAS_CF_DIR}/manifests/cf-manifest/operations/scale-down-dev.yml"
 fi
 
+vars_store_args=""
+if [ -n "${VARS_STORE:-}" ]; then
+  vars_store_args=" --var-errs --vars-store ${VARS_STORE}"
+fi
+
 # shellcheck disable=SC2086
 bosh interpolate \
   --var-file ipsec_ca.private_key="${WORKDIR}/ipsec-CA/ipsec-CA.key" \
@@ -56,5 +61,5 @@ bosh interpolate \
   --ops-file="${PROMETHEUS_DEPLOYMENT_DIR}/manifests/operators/cf/add-prometheus-uaa-clients.yml" \
   ${opsfile_args} \
   --ops-file="${WORKDIR}/vpc-peering-opsfile/vpc-peers.yml" \
-  "$@" \
+  ${vars_store_args} \
   "${CF_DEPLOYMENT_DIR}/cf-deployment.yml"

--- a/manifests/prometheus/scripts/generate-manifest.sh
+++ b/manifests/prometheus/scripts/generate-manifest.sh
@@ -21,11 +21,15 @@ for i in ${VARS_FILES}; do
   varsfile_args+="--vars-file $i "
 done
 
+vars_store_args=""
+if [ -n "${VARS_STORE:-}" ]; then
+  vars_store_args=" --var-errs --vars-store ${VARS_STORE}"
+fi
+
 # shellcheck disable=SC2086
 bosh interpolate \
-  --var-errs \
-  --vars-store "${VARS_STORE}" \
   ${varsfile_args} \
   ${opsfile_args} \
   ${alerts_opsfile_args} \
+  ${vars_store_args} \
   "${PROM_BOSHRELEASE_DIR}/manifests/prometheus.yml"


### PR DESCRIPTION
What
----

We want to be able to rotate the prometheus secrets generated
by bosh during the prometheus deployment.

As we store the secrets in a vars-store.yml file,
we reuse the script used for the cf-manifest:

   manifests/cf-manifest/scripts/rotate-vars-store-secrets.rb

This script requires a version of the manifest without the variables
expanded, so we update the render-manifest.sh script to be able
to render the manifest without variables, and we pass the
right arguments as needed.

The rendered manifest without variables is stored as a resource
in the S3 bucket.

Note that currently the prometheus-vars-store only contains a set
of plain passwords, we do not use the `*_old` vars, and we do not
keep any variable. That is effectivelly like deleting all the
vars-store.yml file. But we decided to use the
rotate-vars-store-secrets.rb script as it is more flexible.

How to review
-------------

For the UAA secrets:
 - Not really required, but you can rotate the cf secrets and then
 redeploy prometheus.

For the prometheus secrets:
 1. Rerun prometheus-deploy
 2. Run `rotate-prometheus-credentials`
 3. Rerun prometheus-deploy to change the secrets
 4. Check that you can login in all services, and that metrics carry on
 working.

Who can review
--------------

Not me