### PR TITLE
[#161184357] Use Terraform to create ACM certs.

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -839,6 +839,39 @@ jobs:
 
                 cat vpc-peering-tfvars/vpc-peers.tfvars
 
+      # FIXME: remove this when it's run everywhere.
+      - task: extract-acm-cert-arn
+        config:
+          platform: linux
+          image_resource: *awscli-image-resource
+          params:
+            AWS_DEFAULT_REGION: ((aws_region))
+          inputs:
+            - name: cf-tfstate
+          outputs:
+            - name: apps-cert
+          run:
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              tf_cert_details=$(jq -r '.modules[].resources."aws_acm_certificate.apps"' cf-tfstate/cf.tfstate)
+              if [ "${tf_cert_details}" = "null" ]; then
+                echo "Finding cert to import"
+                cert_arn=$(aws acm list-certificates \
+                  --query "CertificateSummaryList[?DomainName==\`*.((apps_dns_zone_name))\`].CertificateArn" \
+                  --output text)
+                if [ -n "${cert_arn}" ]; then
+                  echo "${cert_arn}" > apps-cert/import_arn.txt
+                  echo "Found cert to import: $(cat apps-cert/import_arn.txt)"
+                else
+                  echo "No existing cert found. Skipping import..."
+                fi
+              else
+                echo "TF state already includes a non-data cert resource. Skipping import..."
+              fi
+
       - task: terraform-apply
         config:
           platform: linux
@@ -848,6 +881,7 @@ jobs:
             - name: paas-cf
             - name: cf-tfstate
             - name: vpc-peering-tfvars
+            - name: apps-cert
           outputs:
             - name: updated-tfstate
           params:
@@ -867,6 +901,25 @@ jobs:
 
                 cp cf-tfstate/cf.tfstate updated-tfstate/cf.tfstate
                 terraform init paas-cf/terraform/cloudfoundry
+
+                # FIXME: remove this when it's run everywhere.
+                if [ -f apps-cert/import_arn.txt ]; then
+                  existing_cert_arn=$(cat apps-cert/import_arn.txt)
+                  echo "Importing existing cert with arn ${existing_cert_arn}"
+                  echo "Removing existing data resource"
+                  terraform state rm \
+                    -state=updated-tfstate/cf.tfstate \
+                    aws_acm_certificate.apps
+
+                  echo "Importing new resource"
+                  terraform import \
+                    -state=updated-tfstate/cf.tfstate \
+                    -config=paas-cf/terraform/cloudfoundry \
+                    aws_acm_certificate.apps \
+                    "${existing_cert_arn}"
+                fi
+
+
                 terraform apply \
                   -auto-approve=true \
                   -var-file="paas-cf/terraform/((aws_account)).tfvars" \

--- a/terraform/cloudfoundry/acm.tf
+++ b/terraform/cloudfoundry/acm.tf
@@ -1,9 +1,27 @@
+# Created in concourse-terraform
 data "aws_acm_certificate" "system" {
   domain   = "*.${var.system_dns_zone_name}"
   statuses = ["ISSUED"]
 }
 
-data "aws_acm_certificate" "apps" {
-  domain   = "*.${var.apps_dns_zone_name}"
-  statuses = ["ISSUED"]
+resource "aws_acm_certificate" "apps" {
+  domain_name               = "*.${var.apps_dns_zone_name}"
+  subject_alternative_names = ["${var.apps_dns_zone_name}"]
+  validation_method         = "DNS"
+}
+
+resource "aws_route53_record" "apps_cert_validation" {
+  name    = "${aws_acm_certificate.apps.domain_validation_options.0.resource_record_name}"
+  type    = "${aws_acm_certificate.apps.domain_validation_options.0.resource_record_type}"
+  zone_id = "${var.apps_dns_zone_id}"
+  records = ["${aws_acm_certificate.apps.domain_validation_options.0.resource_record_value}"]
+  ttl     = 60
+}
+
+resource "aws_acm_certificate_validation" "apps" {
+  certificate_arn = "${aws_acm_certificate.apps.arn}"
+
+  validation_record_fqdns = [
+    "${aws_route53_record.apps_cert_validation.fqdn}",
+  ]
 }

--- a/terraform/cloudfoundry/elbs.tf
+++ b/terraform/cloudfoundry/elbs.tf
@@ -118,7 +118,7 @@ resource "aws_elb" "cf_router" {
     instance_protocol  = "ssl"
     lb_port            = 443
     lb_protocol        = "ssl"
-    ssl_certificate_id = "${data.aws_acm_certificate.apps.arn}"
+    ssl_certificate_id = "${aws_acm_certificate_validation.apps.certificate_arn}"
   }
 
   listener {


### PR DESCRIPTION
What
----

This moves the ACM cert management into Terraform because it's much more robust than our set of scripts.

Previously, the apps cert was generated by paas-bootstrap so that we didn't need to duplicate the scripts into this repo. That's no longer a concern when using Terraform, so it makes sense for the apps cert to be generated here as this is where it's used...  The system domain cert is used by both this repo and paas-bootstrap, so that remains in paas-bootstrap.

This additionally includes a temporary commit to import the existing apps cert into Terraform to prevent it attempting to create a second one.

How to review
-------------

* https://github.com/alphagov/paas-bootstrap/pull/222 should be reviewed and merged/deployed first.
* Run the pipeline from this branch
* Verify terraform updates correctly and doesn't create a second apps domain cert.
* Run the pipeline a second time to verify the import process is idempotent.

Who can review
--------------

Not me.