### PR TITLE
[#162275131] cf-networking-release hotfix for paginated spaces

### DIFF
--- a/manifests/cf-manifest/operations.d/319-custom-networking-release.yml
+++ b/manifests/cf-manifest/operations.d/319-custom-networking-release.yml
@@ -1,0 +1,8 @@
+---
+- type: replace
+  path: /releases/name=cf-networking
+  value:
+    name: cf-networking
+    version: 0.1.1
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cf-networking-0.1.1.tgz
+    sha1: a5666172d8c595acafd17155ff1e3e68b46e4915

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -30,7 +30,11 @@ RSpec.describe "release versions" do
       "capi" => {
         local: "0.1.1",
         upstream: "1.71.0"
-      }
+      },
+      "cf-networking" => {
+        local: "0.1.1",
+        upstream: "2.18.0"
+      },
     }
 
     manifest_releases = manifest_without_vars_store.fetch("releases").map { |release|


### PR DESCRIPTION
What
----

Our deployment is affected by the bug described in

https://github.com/cloudfoundry/cf-networking-release/issues/59

some tenants assigned to more than 50 spaces cannot see some policies
in some specific spaces.

In this PR we want to deploy a forked version with a proposed patch
as in:

https://github.com/cloudfoundry/cf-networking-release/pull/60

Additionally, as it seems common to add new releases, I refactored the test to check the release versions to make it easier to pin older versions. 

How to review
-------------

Code review

Try to reproduce the issue as described in:

https://github.com/cloudfoundry/cf-networking-release/issues/59

Deploy this, and check that fixes the issue.


Who can review
--------------

Not me