### PR TITLE
[#162475243] Block pipeline on prometheus-deploy failures

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2470,11 +2470,11 @@ jobs:
     plan:
       - aggregate:
           - get: pipeline-trigger
-            passed: ['post-deploy','app-availability-tests','api-availability-tests']
+            passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
             trigger: true
           - get: cf-smoke-tests-release
           - get: paas-cf
-            passed: ['post-deploy','app-availability-tests','api-availability-tests']
+            passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
           - get: cf-manifest
             passed: ['post-deploy']
           - get: cf-vars-store
@@ -2509,11 +2509,11 @@ jobs:
     plan:
       - aggregate:
           - get: pipeline-trigger
-            passed: ['post-deploy','app-availability-tests','api-availability-tests']
+            passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
             trigger: true
           - get: cf-acceptance-tests
           - get: paas-cf
-            passed: ['post-deploy','app-availability-tests','api-availability-tests']
+            passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
           - get: cf-manifest
             passed: ['post-deploy']
           - get: cf-vars-store
@@ -2564,10 +2564,10 @@ jobs:
     plan:
       - aggregate:
           - get: pipeline-trigger
-            passed: ['post-deploy','app-availability-tests','api-availability-tests']
+            passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
             trigger: true
           - get: paas-cf
-            passed: ['post-deploy','app-availability-tests','api-availability-tests']
+            passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
           - get: cf-manifest
             passed: ['post-deploy']
           - get: cf-vars-store
@@ -2714,10 +2714,10 @@ jobs:
     plan:
       - aggregate:
           - get: pipeline-trigger
-            passed: ['post-deploy','app-availability-tests','api-availability-tests']
+            passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
             trigger: true
           - get: paas-cf
-            passed: ['post-deploy','app-availability-tests','api-availability-tests']
+            passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
           - get: cf-manifest
           - get: bosh-secrets
           - get: bosh-CA-crt


### PR DESCRIPTION
## What

We initially introduced this job without it blocking the pipeline
because prometheus was an experimental thing. It's now something we rely
on, so we should block the pipeline on the job so that we catch broken
config in staging before it reaches prod.

How to review
-------------

Code review should be enough. I've pushed this change to my dev env.

Who can review
--------------

Not me.