### PR TITLE
[#161412619] Prometheus monitor dns

### DIFF
--- a/manifests/cf-manifest/operations.d/510-add-prometheus-blackbox-exporter.yml
+++ b/manifests/cf-manifest/operations.d/510-add-prometheus-blackbox-exporter.yml
@@ -1,0 +1,26 @@
+---
+- type: replace
+  path: /releases/-
+  value:
+    name: "prometheus"
+    version: "23.1.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=23.1.0"
+    sha1: "23e5f469c2e290efefde1166107f874c32374ff7"
+
+- type: replace
+  path: /addons?/-
+  value:
+    name: prometheus-blackbox-exporter
+    jobs:
+      - name: blackbox_exporter
+        release: prometheus
+        properties:
+          blackbox_exporter:
+            config:
+              modules:
+                dns_canary:
+                  prober: dns
+                  timeout: 1s
+                  dns:
+                    query_name: __canary.((system_domain))
+                    query_type: "A"

--- a/manifests/prometheus/alerts.d/dns-resolution-time.yml
+++ b/manifests/prometheus/alerts.d/dns-resolution-time.yml
@@ -1,0 +1,24 @@
+# Source: blackbox-exporter
+---
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: DNSResolutionTime
+    rules:
+    - &alert
+      alert: DNSResolutionTime_Warning
+      expr: avg_over_time(dns_resolution_probe_dns_lookup_time_seconds[5m]) > 0.1
+      labels:
+        severity: warning
+        notify: email
+      annotations:
+        summary: "DNS Resolution is slow on {{ $labels.address }}"
+        description: "If this persisists, consider contacting AWS Support."
+
+    - <<: *alert
+      alert: DNSResolutionTime_Critical
+      expr: avg_over_time(dns_resolution_probe_dns_lookup_time_seconds[5m]) > 0.2
+      labels:
+        severity: critical
+        notify: email

--- a/manifests/prometheus/alerts.d/dns-resolution-working.yml
+++ b/manifests/prometheus/alerts.d/dns-resolution-working.yml
@@ -1,0 +1,24 @@
+# Source: blackbox-exporter
+---
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: DNSResolutionWorking
+    rules:
+    - &alert
+      alert: DNSResolutionWorking_Warning
+      expr: (count_over_time(dns_resolution_probe_success[5m]) - sum_over_time(dns_resolution_probe_success[5m])) / count_over_time(dns_resolution_probe_success[5m]) > 0.25
+      labels:
+        severity: warning
+        notify: email
+      annotations:
+        summary: "DNS Resolution is failing on {{ $labels.address }}"
+        description: "If this persisists, consider contacting AWS Support."
+
+    - <<: *alert
+      alert: DNSResolutionWorking_Critical
+      expr: (count_over_time(dns_resolution_probe_success[5m]) - sum_over_time(dns_resolution_probe_success[5m])) / count_over_time(dns_resolution_probe_success[5m]) > 0.75
+      labels:
+        severity: critical
+        notify: email

--- a/manifests/prometheus/operations.d/512-scrape-dns-resolution.yml
+++ b/manifests/prometheus/operations.d/512-scrape-dns-resolution.yml
@@ -3,6 +3,7 @@
   path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
   value:
     job_name: dns_resolution
+    scrape_interval: 10s
     metrics_path: /probe
     params:
       module:

--- a/manifests/prometheus/operations.d/512-scrape-dns-resolution.yml
+++ b/manifests/prometheus/operations.d/512-scrape-dns-resolution.yml
@@ -1,0 +1,35 @@
+---
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  value:
+    job_name: dns_resolution
+    metrics_path: /probe
+    params:
+      module:
+        - dns_canary
+      target:
+        - 169.254.0.2 # hardcoded to the default bosh-dns address
+    file_sd_configs:
+      - files:
+        - "/var/vcap/store/bosh_exporter/bosh_target_groups.json"
+    relabel_configs:
+      - source_labels:
+        - __meta_bosh_job_process_name
+        regex: ^bosh-dns$
+        action: keep
+      - source_labels:
+          - __address__
+        regex: "(.*)"
+        target_label: address
+        replacement: "${1}"
+      - source_labels:
+          - __address__
+        regex: "(.*)"
+        target_label: __address__
+        replacement: "${1}:9115"
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: "(.*)"
+        target_label: __name__
+        replacement: "dns_resolution_${1}"


### PR DESCRIPTION
What
----

- Added blackbox-exporter to cloudfoundry deployment
- Configured prometheus to scrape blackbox-exporter for DNS metrics (against bosh-dns endpoint)
- Added alerts to trigger when DNS is failing / slow
  - Response time:
     - 0.1s (Warning)
     - 0.2s (Critical)
  - Workingness:
    - 25% fail over 5 minutes (Warning)
    - 75% fail over 5 minutes (Critical)

See commits for more details.

How to review
-------------

- Code Review
- Run branch down a dev pipeline
  - Ensure Alerts (`DNS.*`) are present in prometheus
  - Run `monit stop bosh-dns` on any cf VM, and ensure alert fires within 5 minutes.

Who can review
--------------

Not @tnwhitwell / @richardTowers 
