### PR TITLE
[#162303736] Deploy the yace CloudWatch exporter and scrape it with Prometheus

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -377,6 +377,12 @@ resources:
     source:
       service_key: ((pagerduty_integration_key))
 
+  - name: paas-yet-another-cloudwatch-exporter
+    type: git
+    source:
+      uri: https://github.com/alphagov/paas-yet-another-cloudwatch-exporter
+      tag_filter: 0.10.0
+
 jobs:
   - name: pipeline-lock
     serial: true
@@ -1215,6 +1221,7 @@ jobs:
           - get: bosh-CA-crt
           - get: cf-vars-store
           - get: cf-tfstate
+          - get: paas-yet-another-cloudwatch-exporter
 
       - task: extract-terraform-outputs
         config:
@@ -1234,6 +1241,35 @@ jobs:
                 ./paas-cf/concourse/scripts/extract_terraform_state_to_yaml.rb \
                   < cf-tfstate/cf.tfstate \
                   > terraform-outputs/cf.yml
+
+      - task: retrieve-config
+        config:
+          platform: linux
+          inputs:
+            - name: paas-cf
+            - name: cf-vars-store
+            - name: terraform-outputs
+          outputs:
+            - name: config
+          params:
+            SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+          image_resource: *ruby-slim-image-resource
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
+
+                cat << EOT > config/config.sh
+                export CF_ADMIN=admin
+                export CF_PASS=$($VAL_FROM_YAML cf_admin_password cf-vars-store/cf-vars-store.yml)
+                export API_ENDPOINT="https://api.${SYSTEM_DNS_ZONE_NAME}"
+                export YACE_AWS_ACCESS_KEY_ID=$($VAL_FROM_YAML terraform_outputs_yace_aws_access_key_id terraform-outputs/cf.yml)
+                export YACE_AWS_SECRET_ACCESS_KEY=$($VAL_FROM_YAML terraform_outputs_yace_aws_secret_access_key terraform-outputs/cf.yml)
+                EOT
+
 
       - task: generate-prometheus-manifest
         config:
@@ -1336,6 +1372,48 @@ jobs:
                 export BOSH_CLIENT_SECRET
 
                 bosh -n deploy prometheus-manifest/prometheus-manifest.yml
+
+      - task: deploy-cloudwatch-exporter
+        config:
+          platform: linux
+          image_resource: *cf-cli-image-resource
+          params:
+            DEPLOY_ENV: ((deploy_env))
+            AWS_REGION: ((aws_region))
+          inputs:
+            - name: paas-cf
+            - name: config
+            - name: paas-yet-another-cloudwatch-exporter
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                . ./config/config.sh
+                echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}" -o admin -s monitoring
+
+                spruce merge paas-cf/config/cloudwatch-exporter/config.yml > paas-yet-another-cloudwatch-exporter/src/config.yml
+
+                cd paas-yet-another-cloudwatch-exporter/src
+
+                cat << EOF > manifest.yml
+                ---
+                applications:
+                  - name: cloudwatch-exporter
+                    memory: 128M
+                    disk_quota: 100M
+                    instances: 1
+                    buildpack: go_buildpack
+                    health-check-type: http
+                    env:
+                      GOPACKAGENAME: github.com/alphagov/paas-yet-another-cloudwatch-exporter/src
+                      AWS_ACCESS_KEY_ID: "${YACE_AWS_ACCESS_KEY_ID}"
+                      AWS_SECRET_ACCESS_KEY: "${YACE_AWS_SECRET_ACCESS_KEY}"
+                    command: "src -listen-address=0.0.0.0:\$PORT"
+                EOF
+
+                cf zero-downtime-push cloudwatch-exporter -f manifest.yml
 
   - name: post-deploy
     serial: true

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2499,7 +2499,7 @@ jobs:
                 cf blue-green-deploy paas-uaa-assets
                 cf delete -f paas-uaa-assets-old
 
-      - task: remove-unused-ses-smtp-access-keys
+      - task: remove-unused-iam-access-keys
         config:
           platform: linux
           image_resource: *awscli-image-resource
@@ -2542,6 +2542,7 @@ jobs:
 
                 delete_unused_keys ses_smtp_aws_access_key_id "ses-smtp-${DEPLOY_ENV}"
                 delete_unused_keys metrics_exporter_aws_access_key_id "metrics-exporter-${DEPLOY_ENV}"
+                delete_unused_keys yace_aws_access_key_id "yace-${DEPLOY_ENV}"
 
   - name: smoke-tests
     serial_groups: [smoke-tests]

--- a/concourse/tasks/forget-access-keys.yml
+++ b/concourse/tasks/forget-access-keys.yml
@@ -26,4 +26,8 @@ run:
         aws_iam_access_key.metrics_exporter
       echo "metrics exporter access key no longer managed by terraform."
 
+      terraform state rm -state=updated-tfstate/cf.tfstate \
+        aws_iam_access_key.yace
+      echo "yace access key no longer managed by terraform."
+
       echo "next successful deployment run will delete the unused keys"

--- a/config/cloudwatch-exporter/config.yml
+++ b/config/cloudwatch-exporter/config.yml
@@ -1,0 +1,35 @@
+---
+discovery:
+  exportedTagsOnMetrics:
+    ec2:
+      - Name
+    rds:
+      - Name
+  jobs:
+    - type: "ec2"
+      region: (( grab $AWS_REGION ))
+      searchTags:
+        - Key: deploy_env
+          Value: (( concat "^" $DEPLOY_ENV "$" ))
+      metrics:
+        - name: CPUCreditBalance
+          statistics:
+            - Minimum
+          period: 60
+          length: 600
+    - type: "rds"
+      region: (( grab $AWS_REGION ))
+      searchTags:
+        - Key: deploy_env
+          Value: (( concat "^" $DEPLOY_ENV "$" ))
+      metrics:
+        - name: FreeStorageSpace
+          statistics:
+            - Minimum
+          period: 60
+          length: 600
+        - name: CPUCreditBalance
+          statistics:
+            - Minimum
+          period: 60
+          length: 600

--- a/manifests/prometheus/operations.d/301-scrape-cloudwatch-exporter.yml
+++ b/manifests/prometheus/operations.d/301-scrape-cloudwatch-exporter.yml
@@ -1,0 +1,11 @@
+---
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  value:
+    job_name: cloudwatch-exporter
+    scrape_interval: 5m
+    scheme: https
+    static_configs:
+      - targets:
+        - cloudwatch-exporter.((app_domain))

--- a/terraform/cloudfoundry/outputs.tf
+++ b/terraform/cloudfoundry/outputs.tf
@@ -177,3 +177,11 @@ output "metrics_exporter_aws_access_key_id" {
 output "metrics_exporter_aws_secret_access_key" {
   value = "${aws_iam_access_key.metrics_exporter.secret}"
 }
+
+output "yace_aws_access_key_id" {
+  value = "${aws_iam_access_key.yace.id}"
+}
+
+output "yace_aws_secret_access_key" {
+  value = "${aws_iam_access_key.yace.secret}"
+}

--- a/terraform/cloudfoundry/yace.tf
+++ b/terraform/cloudfoundry/yace.tf
@@ -1,0 +1,14 @@
+resource "aws_iam_user" "yace" {
+  name = "yace-${var.env}"
+
+  force_destroy = true
+}
+
+resource "aws_iam_user_group_membership" "yace" {
+  user   = "${aws_iam_user.yace.name}"
+  groups = ["cloudwatch-exporter"]
+}
+
+resource "aws_iam_access_key" "yace" {
+  user = "${aws_iam_user.yace.name}"
+}


### PR DESCRIPTION
# What

Deploy https://github.com/alphagov/paas-yet-another-cloudwatch-exporter to collect CloudWatch metrics and make them available for Prometheus.

Additional changes:
 - add the `deploy_env` tag to all EC2 instances in the CF and Prometheus Bosh deployments (this is not used yet as the instances needs to be recreated to get the new tag)

For now we use the `deployment` EC2 tag for filtering, but in dev one env will get the metrics from all Prometheus, Concourse and Bosh instances. Later if a stemcell update recreates all instances we can depend on the new `deploy_env` tag.

# How to review

❕ https://github.com/alphagov/paas-aws-account-wide-terraform/pull/144 - already reviewed and merged.

1. Review: https://github.com/alphagov/paas-bootstrap/pull/225
2. Run the create-cloudfoundry pipeline from this branch
3. You should see new metrics, like `aws_ec2_cpucreditbalance_minimum` in your Prometheus
4. Check if all relevant RDS/EC2 instance metrics are reported
5. Test the key rotation by running the "expire-aws-keys" job and run the pipeline. In the cf-terraform job a new key pair should be generated and the app should be redeployed successfully.

# Who can review

Anyone