### PR TITLE
[#162199780] Alert on average total diego-cell memory used

### DIFF
--- a/manifests/prometheus/alerts.d/diego_cell_available_cpu_idle.yml
+++ b/manifests/prometheus/alerts.d/diego_cell_available_cpu_idle.yml
@@ -5,29 +5,21 @@
   value:
     name: BoshDiegoCellIdleCPU
     rules:
-      - record: bosh_job_cpu_idle
-        expr: 100 - (bosh_job_cpu_sys + bosh_job_cpu_user + bosh_job_cpu_wait)
-      - record: bosh_job:cpu_idle:diego_cell:avg5m
-        expr: avg_over_time(bosh_job_cpu_idle{environment="((metrics_environment))",bosh_job_name="diego-cell"}[5m])
       - &alert
         alert: BoshDiegoCellIdleCPU_Warning
-        expr:  bosh_job:cpu_idle:diego_cell:avg5m < 37
+        expr: avg(bosh_job_cpu_idle{bosh_job_name="diego-cell"}) < 37
         for: 1d
         labels:
           severity: warning
           notify: email
         annotations:
-          summary: Low CPU idle on {{ $labels.bosh_job_name }}.
-          description: >
-            {{ $labels.bosh_job_name }}/{{ $labels.bosh_job_id }}
-            CPU idle percentage was low {{ $value | printf "%.0f" }}%
-            in the last 1 day on average.
-            Review if we need to scale...
+          summary: Cell idle CPU is low
+          description: There is only {{ $value | printf "%.0f" }}% CPU idle on average on cells. Review if we need to scale...
           url: https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision
 
       - <<: *alert
         alert: BoshDiegoCellIdleCPU_Critical
-        expr: bosh_job:cpu_idle:diego_cell:avg5m < 33
+        expr: avg(bosh_job_cpu_idle{bosh_job_name="diego-cell"}) < 33
         labels:
           severity: critical
           notify: email

--- a/manifests/prometheus/alerts.d/diego_cell_available_cpu_idle.yml
+++ b/manifests/prometheus/alerts.d/diego_cell_available_cpu_idle.yml
@@ -7,8 +7,7 @@
     rules:
       - &alert
         alert: BoshDiegoCellIdleCPU_Warning
-        expr: avg(bosh_job_cpu_idle{bosh_job_name="diego-cell"}) < 37
-        for: 1d
+        expr: avg(avg_over_time(bosh_job_cpu_idle{bosh_job_name="diego-cell"}[1d])) < 37
         labels:
           severity: warning
           notify: email
@@ -19,7 +18,7 @@
 
       - <<: *alert
         alert: BoshDiegoCellIdleCPU_Critical
-        expr: avg(bosh_job_cpu_idle{bosh_job_name="diego-cell"}) < 33
+        expr: avg(avg_over_time(bosh_job_cpu_idle{bosh_job_name="diego-cell"}[1d])) < 33
         labels:
           severity: critical
           notify: email

--- a/manifests/prometheus/alerts.d/diego_cell_available_memory.yml
+++ b/manifests/prometheus/alerts.d/diego_cell_available_memory.yml
@@ -5,27 +5,21 @@
   value:
     name: BoshDiegoCellAvailableMemory
     rules:
-      - record: bosh_job:mem_percent:diego_cell:avg5m
-        expr: 100 - avg_over_time(bosh_job_mem_percent{environment="((metrics_environment))",bosh_job_name="diego-cell"}[5m])
       - &alert
         alert: BoshDiegoCellAvailableMemory_Warning
-        expr: bosh_job:mem_percent:diego_cell:avg5m < 55
+        expr: avg(bosh_job_mem_percent{bosh_job_name="diego-cell"}) >= 45
         for: 2h
         labels:
           severity: warning
           notify: email
         annotations:
-          summary: Low memory free on {{ $labels.bosh_job_name }}.
-          description: >
-            {{ $labels.bosh_job_name }}/{{ $labels.bosh_job_id }}
-            memory free was low {{ $value | printf "%.0f" }}%
-            in the last two hours on average.
-            Review if we need to scale...
+          summary: Cell available memory is low
+          description: There is only {{ $value | printf "%.0f" }}% memory free on average on cells. Review if we need to scale...
           url: https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision
 
       - <<: *alert
         alert: BoshDiegoCellAvailableMemory_Critical
-        expr: bosh_job:mem_percent:diego_cell:avg5m < 50
+        expr: avg(bosh_job_mem_percent{bosh_job_name="diego-cell"}) >= 50
         labels:
           severity: critical
           notify: email

--- a/manifests/prometheus/alerts.d/diego_cell_available_memory.yml
+++ b/manifests/prometheus/alerts.d/diego_cell_available_memory.yml
@@ -7,8 +7,7 @@
     rules:
       - &alert
         alert: BoshDiegoCellAvailableMemory_Warning
-        expr: avg(bosh_job_mem_percent{bosh_job_name="diego-cell"}) >= 45
-        for: 2h
+        expr: avg(avg_over_time(bosh_job_mem_percent{bosh_job_name="diego-cell"}[1d])) >= 45
         labels:
           severity: warning
           notify: email
@@ -19,7 +18,7 @@
 
       - <<: *alert
         alert: BoshDiegoCellAvailableMemory_Critical
-        expr: avg(bosh_job_mem_percent{bosh_job_name="diego-cell"}) >= 50
+        expr: avg(avg_over_time(bosh_job_mem_percent{bosh_job_name="diego-cell"}[1d])) >= 50
         labels:
           severity: critical
           notify: email


### PR DESCRIPTION
What
----

In `528417be` we record a metric and alert on it per-diego-cell, but we actually want to alert on the average *aggregate* memory that the cells have free.

We can do this by recording a new derived metric (per-VM, recorded for all VMs regardless of purpose), averaging it across all our diego cells and comparing the resulting percentage against the existing 50% and 55% thresholds.

NB This is only valid as long as our diego cells are (memory-)homogenous!

How to review
-------------

- code review
- push to a dev env (`jonmtest` has it running currently, if you want to speed this up)
  - maybe push a `[DELETE]` commit with 100%/99% thresholds to force it to fire. `jonmtest` env has already done this, however. Your call.

Who can review
--------------

Anyone except @jpluscplusm.