### PR TITLE
[#162501716] Bump Stemcell to 170.12 with fixes for some CVEs

### DIFF
--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -1,9 +1,7 @@
 ---
-
 - type: replace
   path: /stemcells
   value:
     - alias: default
       os: ubuntu-xenial
-      version: "170.9"
-
+      version: "170.12"

--- a/manifests/cf-manifest/operations.d/040-set-tags.yml
+++ b/manifests/cf-manifest/operations.d/040-set-tags.yml
@@ -1,0 +1,5 @@
+---
+
+- type: replace
+  path: /tags?/deploy_env
+  value: ((environment))

--- a/manifests/prometheus/operations.d/040-set-tags.yml
+++ b/manifests/prometheus/operations.d/040-set-tags.yml
@@ -1,0 +1,5 @@
+---
+
+- type: replace
+  path: /tags?/deploy_env
+  value: ((metrics_environment))

--- a/terraform/cloudfoundry/cdn_broker.tf
+++ b/terraform/cloudfoundry/cdn_broker.tf
@@ -122,7 +122,8 @@ resource "aws_db_instance" "cdn" {
   auto_minor_version_upgrade = true
 
   tags {
-    Name = "${var.env}-cdn"
+    Name       = "${var.env}-cdn"
+    deploy_env = "${var.env}"
   }
 }
 


### PR DESCRIPTION
What
----

We want to get the fixes for:

 - https://www.cloudfoundry.org/blog/usn-3816-2/
 - https://www.cloudfoundry.org/blog/usn-3816-3/
 - https://www.cloudfoundry.org/blog/usn-3836-2/

Andras edit: I also pulled in some minor changes that we add the `deploy_env` everywhere. The new tag will only be added when the EC2 instances are recreated. 

How to review
-------------

code review.

Who can review
--------------

not me