### PR TITLE
[#161511720] Apps Apex domain DNS and Cert SAN checks

### DIFF
--- a/platform-tests/src/platform/acceptance/apps_domain_dns_tls_test.go
+++ b/platform-tests/src/platform/acceptance/apps_domain_dns_tls_test.go
@@ -1,0 +1,31 @@
+package acceptance_test
+
+import (
+	"crypto/tls"
+	"net"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("The apps apex domain", func() {
+
+	It("should have the same DNS records as the healthcheck app", func() {
+		apexIPs, err := net.LookupIP(testConfig.GetAppsDomain())
+		Expect(err).NotTo(HaveOccurred())
+		healthcheckIPs, err := net.LookupIP("healthcheck." + testConfig.GetAppsDomain())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(apexIPs).To(ConsistOf(healthcheckIPs))
+	})
+
+	It("should have a valid TLS certificate with the apps domain as SAN", func() {
+		conn, err := tls.Dial("tcp", testConfig.GetAppsDomain()+":443", nil)
+		Expect(err).NotTo(HaveOccurred())
+		defer conn.Close()
+		peerCertificates := conn.ConnectionState().PeerCertificates
+		Expect(len(peerCertificates)).To(BeNumerically(">", 0))
+		cert := peerCertificates[0]
+		Expect(cert.DNSNames).To(ContainElement(testConfig.GetAppsDomain()))
+	})
+
+})

--- a/platform-tests/src/platform/acceptance/init_test.go
+++ b/platform-tests/src/platform/acceptance/init_test.go
@@ -41,7 +41,9 @@ func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	testConfig, err = config.NewCatsConfig(os.Getenv("CONFIG"))
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	httpClient = &http.Client{
 		Transport: &http.Transport{


### PR DESCRIPTION
What
----

Added some tests to check that the CDN broker's assumptions about the apps apex domain are valid:
  - DNS A records are the same as the `apps.` domain
  - Certificate for apex domain is valid, and contains the correct SAN

How to review
-------------

- Code Review
- Ensure tests pass in pipeline (Use [this](https://deployer.tnw.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/custom-acceptance-tests/builds/8) as an example if you want!)

Who can review
--------------

Not @tnwhitwell / @richardTowers 