### PR TITLE
[#162448351] Finalise Prometheus emails

### DIFF
--- a/manifests/prometheus/alerts.d/aiven-cost.yml
+++ b/manifests/prometheus/alerts.d/aiven-cost.yml
@@ -12,7 +12,6 @@
         for: 1h
         labels:
           severity: warning
-          notify: email
         annotations:
           summary: "Aiven estimated cost is high, possibly need to alert finance."
           description: "The estimated monthly cost of Aiven is currently £{{ $value | printf \"%.2f\" }}, possibly need to alert finance."
@@ -22,4 +21,3 @@
         expr: paas_aiven_estimated_cost_pounds > 3100
         labels:
           severity: critical
-          notify: email

--- a/manifests/prometheus/alerts.d/auctioneer-lock-held-once.yml
+++ b/manifests/prometheus/alerts.d/auctioneer-lock-held-once.yml
@@ -10,7 +10,5 @@
         expr: "sum(firehose_value_metric_auctioneer_lock_held) != 1"
         labels:
           severity: critical
-          notify: email
         annotations:
           summary: there is not exactly one auctioneer holding the lock.
-

--- a/manifests/prometheus/alerts.d/aws-elb-unhealthy-nodes.yml
+++ b/manifests/prometheus/alerts.d/aws-elb-unhealthy-nodes.yml
@@ -10,7 +10,6 @@
       expr: max_over_time(paas_aws_elb_unhealthy_node_count[5m]) > 0
       labels:
         severity: warning
-        notify: email
       annotations:
         summary: "At least one ELB node is not responding"
         description: Requests to the healthcheck app via {{ $value | printf \"%.0f\" }} of the ELB IP addresses failed.

--- a/manifests/prometheus/alerts.d/bbs-healthy.yml
+++ b/manifests/prometheus/alerts.d/bbs-healthy.yml
@@ -10,6 +10,5 @@
         expr: min(bosh_job_process_healthy{bosh_job_process_name="bbs"}) < 1
         labels:
           severity: critical
-          notify: email
         annotations:
           summary: BBS health check failed. Check BBS status immediately.

--- a/manifests/prometheus/alerts.d/bbs-lock-held-once.yml
+++ b/manifests/prometheus/alerts.d/bbs-lock-held-once.yml
@@ -10,7 +10,5 @@
         expr: "sum(firehose_value_metric_bbs_lock_held) != 1"
         labels:
           severity: critical
-          notify: email
         annotations:
           summary: there is not exactly one BBS holding the lock.
-

--- a/manifests/prometheus/alerts.d/bosh-high-cpu-utilisation.yml
+++ b/manifests/prometheus/alerts.d/bosh-high-cpu-utilisation.yml
@@ -14,7 +14,6 @@
         expr: "bosh_job:bosh_job_cpu:avg1h > 70"
         labels:
           severity: warning
-          notify: email
         annotations:
           summary: "High cpu utilisation on {{ $labels.bosh_job_name }}/{{ $labels.bosh_job_index }}"
           description: "{{ $labels.bosh_job_name }}/{{ $labels.bosh_job_index }} CPU utilisation was over {{ $value | printf \"%.0f\" }}% in the last hour on average"
@@ -24,4 +23,3 @@
         expr: "bosh_job:bosh_job_cpu:avg1h > 90"
         labels:
           severity: critical
-          notify: email

--- a/manifests/prometheus/alerts.d/bosh-swap-utilisation.yml
+++ b/manifests/prometheus/alerts.d/bosh-swap-utilisation.yml
@@ -10,7 +10,6 @@
         expr: "avg_over_time(bosh_job_swap_percent[30m]) >= 25"
         labels:
           severity: critical
-          notify: email
         annotations:
           summary: "High swap usage on {{ $labels.bosh_job_name }}{{ $labels.bosh_job_index }}"
           description: "{{ $labels.bosh_job_name }}/{{ $labels.bosh_job_index }} swap usage was {{ $value | printf \"%.0f\" }}% in the last 30m on average"

--- a/manifests/prometheus/alerts.d/cc-api-job-queue-length.yml
+++ b/manifests/prometheus/alerts.d/cc-api-job-queue-length.yml
@@ -11,7 +11,6 @@
         expr: avg_over_time(firehose_value_metric_cc_job_queue_length_total[30m]) > 20
         labels:
           severity: warning
-          notify: email
         annotations:
           summary: "Cloud Controller API job queue length"
           description: "Job queue in Cloud Controller API grew considerably, check the API health: {{ $value | printf \"%.0f\" }}. See logit.io: '@source.component:cloud_controller_ng AND @level:ERROR'"
@@ -21,4 +20,3 @@
         expr: avg_over_time(firehose_value_metric_cc_job_queue_length_total[30m]) > 25
         labels:
           severity: critical
-          notify: email

--- a/manifests/prometheus/alerts.d/cc-failed-job-count.yml
+++ b/manifests/prometheus/alerts.d/cc-failed-job-count.yml
@@ -14,7 +14,6 @@
         expr: max(delta(firehose_value_metric_cc_failed_job_count_total:avg30m[30m])) > 3
         labels:
           severity: warning
-          notify: email
         annotations:
           summary: "Cloud Controller API failed job count"
           description: "Amount of failed jobs in Cloud Controller API grew considerably in the last hour: {{ $value | printf \"%.0f\" }}. See logit.io: '@source.component:cloud_controller_worker AND @level:ERROR'"
@@ -24,4 +23,3 @@
         expr: max(delta(firehose_value_metric_cc_failed_job_count_total:avg30m[30m])) > 5
         labels:
           severity: critical
-          notify: email

--- a/manifests/prometheus/alerts.d/cc-latency-by-gorouter.yml
+++ b/manifests/prometheus/alerts.d/cc-latency-by-gorouter.yml
@@ -14,7 +14,6 @@
         expr: cc:firehose_value_metric_gorouter_latency_cloud_controller:avg10m > 200
         labels:
           severity: warning
-          notify: email
         annotations:
           summary: "Cloud Controller latency as reported by gorouter"
           description: "Average latency of cloud controller calls is high ({{ $value | printf \"%.0f\" }}ms) - this may be due to a high proportion of expensive API calls or it may indicate that the API servers need to be scaled up"
@@ -24,4 +23,3 @@
         expr: cc:firehose_value_metric_gorouter_latency_cloud_controller:avg10m > 250
         labels:
           severity: critical
-          notify: email

--- a/manifests/prometheus/alerts.d/cc-log-error-count.yml
+++ b/manifests/prometheus/alerts.d/cc-log-error-count.yml
@@ -11,7 +11,6 @@
         expr: sum(increase(firehose_value_metric_cc_log_count_error[1h])) > 20
         labels:
           severity: warning
-          notify: email
         annotations:
           summary: "Cloud Controller API log error count"
           description: "Amount of logged errors in Cloud Controller API grew considerably in the last hour: {{ $value | printf \"%.0f\" }}. See logit.io: '@source.component:cloud_controller_ng AND @level:ERROR'"
@@ -21,4 +20,3 @@
         expr: sum(increase(firehose_value_metric_cc_log_count_error[1h])) > 40
         labels:
           severity: critical
-          notify: email

--- a/manifests/prometheus/alerts.d/cf-syslog-drains.yml
+++ b/manifests/prometheus/alerts.d/cf-syslog-drains.yml
@@ -11,7 +11,6 @@
       expr: firehose_value_metric_cf_syslog_drain_scheduler_drains > 250
       labels:
         severity: warning
-        notify: email
       annotations:
         summary: "Syslog drain count is high"
         description: "Consider scaling the adapters to cope with the number of syslog drains."
@@ -22,4 +21,3 @@
       expr: firehose_value_metric_cf_syslog_drain_scheduler_drains > 300
       labels:
         severity: critical
-        notify: email

--- a/manifests/prometheus/alerts.d/cloud-controller-unregistry.yml
+++ b/manifests/prometheus/alerts.d/cloud-controller-unregistry.yml
@@ -11,7 +11,6 @@
       for: 10m
       labels:
         severity: critical
-        notify: email
       annotations:
         summary: "Cloud Controller is unregistering from gorouter"
         description: Cloud Controller is unregistering from gorouter, this probably means it is failing its route_registrar healthcheck. This could be due to high load, and may indicate that the API servers need to be scaled up.

--- a/manifests/prometheus/alerts.d/cloudfront_tls_certificates_expiry.yml
+++ b/manifests/prometheus/alerts.d/cloudfront_tls_certificates_expiry.yml
@@ -16,7 +16,6 @@
           url: "https://team-manual.cloud.service.gov.uk/incident_management/responding_to_alerts/#invalid-certificates"
         labels:
           severity: warning
-          notify: email
           service: cloudfront
 
       - alert: CloudFrontTLSCertificateExpiresSoon_Critical
@@ -28,5 +27,4 @@
           url: "https://team-manual.cloud.service.gov.uk/incident_management/responding_to_alerts/#invalid-certificates"
         labels:
           severity: critical
-          notify: email
           service: cloudfront

--- a/manifests/prometheus/alerts.d/cloudfront_tls_certificates_validity.yml
+++ b/manifests/prometheus/alerts.d/cloudfront_tls_certificates_validity.yml
@@ -16,7 +16,6 @@
           url: "https://team-manual.cloud.service.gov.uk/incident_management/responding_to_alerts/#invalid-certificates"
         labels:
           severity: warning
-          notify: email
           service: cloudfront
 
       - alert: CloudFrontInvalidTLSCertificates_Critical
@@ -28,5 +27,4 @@
           url: "https://team-manual.cloud.service.gov.uk/incident_management/responding_to_alerts/#invalid-certificates"
         labels:
           severity: critical
-          notify: email
           service: cloudfront

--- a/manifests/prometheus/alerts.d/concourse-load.yml
+++ b/manifests/prometheus/alerts.d/concourse-load.yml
@@ -14,7 +14,6 @@
         expr: "bosh_job:bosh_job_cpu:avg1h > 150"
         labels:
           severity: warning
-          notify: email
         annotations:
           summary: "High cpu utilisation on {{ $labels.bosh_job_name }}/{{ $labels.bosh_job_index }}"
           description: "{{ $labels.bosh_job_name }}/{{ $labels.bosh_job_index }} CPU utilisation was over {{ $value | printf \"%.0f\" }}% in the last hour on average"
@@ -24,7 +23,6 @@
         expr: "bosh_job:bosh_job_cpu:avg1h > 200"
         labels:
           severity: critical
-          notify: email
         annotations:
           summary: "Critical cpu utilisation on {{ $labels.bosh_job_name }}/{{ $labels.bosh_job_index }}"
           description: "{{ $labels.bosh_job_name }}/{{ $labels.bosh_job_index }} CPU utilisation was over {{ $value | printf \"%.0f\" }}% in the last hour on average"

--- a/manifests/prometheus/alerts.d/diego_cell_available_cpu_idle.yml
+++ b/manifests/prometheus/alerts.d/diego_cell_available_cpu_idle.yml
@@ -10,7 +10,6 @@
         expr: avg(avg_over_time(bosh_job_cpu_idle{bosh_job_name="diego-cell"}[1d])) < 37
         labels:
           severity: warning
-          notify: email
         annotations:
           summary: Cell idle CPU is low
           description: There is only {{ $value | printf "%.0f" }}% CPU idle on average on cells. Review if we need to scale...
@@ -21,4 +20,3 @@
         expr: avg(avg_over_time(bosh_job_cpu_idle{bosh_job_name="diego-cell"}[1d])) < 33
         labels:
           severity: critical
-          notify: email

--- a/manifests/prometheus/alerts.d/diego_cell_available_memory.yml
+++ b/manifests/prometheus/alerts.d/diego_cell_available_memory.yml
@@ -10,7 +10,6 @@
         expr: avg(avg_over_time(bosh_job_mem_percent{bosh_job_name="diego-cell"}[1d])) >= 45
         labels:
           severity: warning
-          notify: email
         annotations:
           summary: Cell available memory is low
           description: There is only {{ $value | printf "%.0f" }}% memory free on average on cells. Review if we need to scale...
@@ -21,4 +20,3 @@
         expr: avg(avg_over_time(bosh_job_mem_percent{bosh_job_name="diego-cell"}[1d])) >= 50
         labels:
           severity: critical
-          notify: email

--- a/manifests/prometheus/alerts.d/diego_cell_rep_container_capacity.yml
+++ b/manifests/prometheus/alerts.d/diego_cell_rep_container_capacity.yml
@@ -16,7 +16,6 @@
         for: 2h
         labels:
           severity: warning
-          notify: email
         annotations:
           summary: Rep Container Capacity
           description: >
@@ -30,4 +29,3 @@
         expr: rep_container_capacity_pct:avg5m > 80
         labels:
           severity: critical
-          notify: email

--- a/manifests/prometheus/alerts.d/diego_cell_rep_memory_capacity.yml
+++ b/manifests/prometheus/alerts.d/diego_cell_rep_memory_capacity.yml
@@ -16,7 +16,6 @@
         for: 2h
         labels:
           severity: warning
-          notify: email
         annotations:
           summary: Rep low free memory capacity
           description: >
@@ -30,4 +29,3 @@
         expr: rep_memory_capacity_pct:avg5m < 33
         labels:
           severity: critical
-          notify: email

--- a/manifests/prometheus/alerts.d/disk-space-low.yml
+++ b/manifests/prometheus/alerts.d/disk-space-low.yml
@@ -11,7 +11,6 @@
       expr: bosh_job_ephemeral_disk_percent > 75.0
       labels:
         severity: warning
-        notify: email
       annotations:
         summary: "Disk space low on {{ $labels.bosh_job_name }}/{{ $labels.bosh_job_index }}"
         description: "The disk usage is at {{ $value | printf \"%.0f\" }}% on {{ $labels.bosh_job_name }}/{{ $labels.bosh_job_index }}"
@@ -21,7 +20,6 @@
       expr: bosh_job_ephemeral_disk_percent > 85.0
       labels:
         severity: critical
-        notify: email
 
 - type: replace
   path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
@@ -33,7 +31,6 @@
       expr: bosh_job_ephemeral_disk_inode_percent > 75.0
       labels:
         severity: warning
-        notify: email
       annotations:
         summary: "Running out of inodes on {{ $labels.bosh_job_name }}/{{ $labels.bosh_job_index }}"
         description: "The inode usage is at {{ $value | printf \"%.0f\" }}% on {{ $labels.bosh_job_name }}/{{ $labels.bosh_job_index }}"
@@ -43,7 +40,6 @@
       expr: bosh_job_ephemeral_disk_inode_percent > 85.0
       labels:
         severity: critical
-        notify: email
 
 - type: replace
   path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
@@ -55,7 +51,6 @@
       expr: bosh_job_persistent_disk_percent > 75.0
       labels:
         severity: warning
-        notify: email
       annotations:
         summary: "Disk space low on {{ $labels.bosh_job_name }}/{{ $labels.bosh_job_index }}"
         description: "The disk usage is at {{ $value | printf \"%.0f\" }}% on {{ $labels.bosh_job_name }}/{{ $labels.bosh_job_index }}"
@@ -65,7 +60,6 @@
       expr: bosh_job_persistent_disk_percent > 85.0
       labels:
         severity: critical
-        notify: email
 
 - type: replace
   path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
@@ -77,7 +71,6 @@
       expr: bosh_job_persistent_disk_inode_percent > 75.0
       labels:
         severity: warning
-        notify: email
       annotations:
         summary: "Running out of inodes on {{ $labels.bosh_job_name }}/{{ $labels.bosh_job_index }}"
         description: "The inode usage is at {{ $value | printf \"%.0f\" }}% on {{ $labels.bosh_job_name }}/{{ $labels.bosh_job_index }}"
@@ -87,7 +80,6 @@
       expr: bosh_job_persistent_disk_inode_percent > 85.0
       labels:
         severity: critical
-        notify: email
 
 - type: replace
   path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
@@ -99,7 +91,6 @@
       expr: bosh_job_system_disk_percent > 75.0
       labels:
         severity: warning
-        notify: email
       annotations:
         summary: "Disk space low on {{ $labels.bosh_job_name }}/{{ $labels.bosh_job_index }}"
         description: "The disk usage is at {{ $value | printf \"%.0f\" }}% on {{ $labels.bosh_job_name }}/{{ $labels.bosh_job_index }}"
@@ -109,7 +100,6 @@
       expr: bosh_job_system_disk_percent > 85.0
       labels:
         severity: critical
-        notify: email
 
 - type: replace
   path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
@@ -121,7 +111,6 @@
       expr: bosh_job_system_disk_inode_percent > 75.0
       labels:
         severity: warning
-        notify: email
       annotations:
         summary: "Running out of inodes on {{ $labels.bosh_job_name }}/{{ $labels.bosh_job_index }}"
         description: "The inode usage is at {{ $value | printf \"%.0f\" }}% on {{ $labels.bosh_job_name }}/{{ $labels.bosh_job_index }}"
@@ -131,4 +120,3 @@
       expr: bosh_job_system_disk_inode_percent > 85.0
       labels:
         severity: critical
-        notify: email

--- a/manifests/prometheus/alerts.d/dns-resolution-time.yml
+++ b/manifests/prometheus/alerts.d/dns-resolution-time.yml
@@ -11,7 +11,6 @@
       expr: avg_over_time(dns_resolution_probe_dns_lookup_time_seconds[5m]) > 0.1
       labels:
         severity: warning
-        notify: email
       annotations:
         summary: "DNS Resolution is slow on {{ $labels.address }}"
         description: "If this persisists, consider contacting AWS Support."
@@ -21,4 +20,3 @@
       expr: avg_over_time(dns_resolution_probe_dns_lookup_time_seconds[5m]) > 0.2
       labels:
         severity: critical
-        notify: email

--- a/manifests/prometheus/alerts.d/dns-resolution-working.yml
+++ b/manifests/prometheus/alerts.d/dns-resolution-working.yml
@@ -11,7 +11,6 @@
       expr: (count_over_time(dns_resolution_probe_success[5m]) - sum_over_time(dns_resolution_probe_success[5m])) / count_over_time(dns_resolution_probe_success[5m]) > 0.25
       labels:
         severity: warning
-        notify: email
       annotations:
         summary: "DNS Resolution is failing on {{ $labels.address }}"
         description: "If this persisists, consider contacting AWS Support."
@@ -21,4 +20,3 @@
       expr: (count_over_time(dns_resolution_probe_success[5m]) - sum_over_time(dns_resolution_probe_success[5m])) / count_over_time(dns_resolution_probe_success[5m]) > 0.75
       labels:
         severity: critical
-        notify: email

--- a/manifests/prometheus/alerts.d/doppler-dropped-envelopes.yml
+++ b/manifests/prometheus/alerts.d/doppler-dropped-envelopes.yml
@@ -11,7 +11,6 @@
         expr: sum(increase(firehose_counter_event_loggregator_doppler_dropped_total[1h])) > 100
         labels:
           severity: warning
-          notify: email
         annotations:
           summary: "Doppler - dropped envelopes"
           description: "A Doppler VM dropped {{ $value | printf \"%.0f\" }} envelopes in an hour. Investigate whether this is a one-off or we need to scale our Dopplers."
@@ -21,4 +20,3 @@
         expr: sum(increase(firehose_counter_event_loggregator_doppler_dropped_total[1h])) > 1000
         labels:
           severity: critical
-          notify: email

--- a/manifests/prometheus/alerts.d/ec2_cpu_credits.yml
+++ b/manifests/prometheus/alerts.d/ec2_cpu_credits.yml
@@ -11,7 +11,6 @@
         expr: avg_over_time(aws_ec2_cpucreditbalance_minimum[30m]) <= 20
         labels:
           severity: warning
-          notify: email
         annotations:
           summary: "EC2 CPU credits are low on {{ $labels.tag_Name }}"
           description: "Instance {{ $labels.tag_Name }} has only {{ $value | printf \"%.0f\" }} CPU credits left and may perform badly."
@@ -22,4 +21,3 @@
         expr: avg_over_time(aws_ec2_cpucreditbalance_minimum[30m]) <= 1
         labels:
           severity: critical
-          notify: email

--- a/manifests/prometheus/alerts.d/elasticache-node-count.yml
+++ b/manifests/prometheus/alerts.d/elasticache-node-count.yml
@@ -12,7 +12,6 @@
         for: 1h
         labels:
           severity: warning
-          notify: email
         annotations:
           summary: "Number of elasticache nodes is close to the limit"
           description: "We are using {{ $value | printf \"%.0f\" }} of 100 Elasticache nodes. We might have to contact AWS support to raise the limit."
@@ -22,4 +21,3 @@
         expr: paas_aws_elasticache_node_count > 90
         labels:
           severity: critical
-          notify: email

--- a/manifests/prometheus/alerts.d/elasticache-parameter-group-count.yml
+++ b/manifests/prometheus/alerts.d/elasticache-parameter-group-count.yml
@@ -12,7 +12,6 @@
         for: 1h
         labels:
           severity: warning
-          notify: email
         annotations:
           summary: "Number of elasticache cache parameter groups is close to the limit"
           description: "We are using {{ $value | printf \"%.0f\" }} of ((aws_limits_elasticache_cache_parameter_groups)) Elasticache parameter groups. We might have to contact AWS support to raise the limit."
@@ -22,4 +21,3 @@
         expr: paas_aws_elasticache_cache_parameter_group_count > ((aws_limits_elasticache_cache_parameter_groups)) / 100 * 90
         labels:
           severity: critical
-          notify: email

--- a/manifests/prometheus/alerts.d/gorouter-latency.yml
+++ b/manifests/prometheus/alerts.d/gorouter-latency.yml
@@ -14,7 +14,6 @@
         expr: cc:firehose_value_metric_gorouter_latency:avg10m > 750
         labels:
           severity: warning
-          notify: email
         annotations:
           summary: Gorouter latency
           description: Gorouter latency is too high ({{ $value | printf \"%.0f\" }}ms") on {{ $labels.bosh_job_ip }}
@@ -25,4 +24,3 @@
         expr: cc:firehose_value_metric_gorouter_latency:avg10m > 1500
         labels:
           severity: critical
-          notify: email

--- a/manifests/prometheus/alerts.d/platform_tls_certificates_expiry.yml
+++ b/manifests/prometheus/alerts.d/platform_tls_certificates_expiry.yml
@@ -16,7 +16,6 @@
           url: "https://team-manual.cloud.service.gov.uk/incident_management/responding_to_alerts/#invalid-certificates"
         labels:
           severity: warning
-          notify: email
           service: elb
 
       - alert: PlatformTLSCertificateExpiresSoon_Critical
@@ -28,5 +27,4 @@
           url: "https://team-manual.cloud.service.gov.uk/incident_management/responding_to_alerts/#invalid-certificates"
         labels:
           severity: critical
-          notify: email
           service: elb

--- a/manifests/prometheus/alerts.d/rds_cpu_credits.yml
+++ b/manifests/prometheus/alerts.d/rds_cpu_credits.yml
@@ -11,7 +11,6 @@
         expr: avg_over_time(aws_rds_cpucreditbalance_minimum[30m]) <= 20
         labels:
           severity: warning
-          notify: email
         annotations:
           summary: "RDS CPU credits are low on {{ $labels.tag_Name }}"
           description: "RDS instance {{ $labels.tag_Name }} has only {{ $value | printf \"%.0f\" }} CPU credits left and may perform badly."
@@ -22,4 +21,3 @@
         expr: avg_over_time(aws_rds_cpucreditbalance_minimum[30m]) <= 1
         labels:
           severity: critical
-          notify: email

--- a/manifests/prometheus/alerts.d/rds_disk_utilisation.yml
+++ b/manifests/prometheus/alerts.d/rds_disk_utilisation.yml
@@ -11,7 +11,6 @@
         expr: aws_rds_freestoragespace_minimum <= 2 * 1024 ^ 3
         labels:
           severity: warning
-          notify: email
         annotations:
           summary: "RDS free storage space is low on {{ $labels.tag_Name }}"
           description: "RDS Instance {{ $labels.tag_Name }} has only {{ $value | humanize1024 }}B free storage."
@@ -22,4 +21,3 @@
         expr: aws_rds_freestoragespace_minimum <= 1 * 1024 ^ 3
         labels:
           severity: critical
-          notify: email

--- a/manifests/prometheus/alerts.d/router_total_routes.yml
+++ b/manifests/prometheus/alerts.d/router_total_routes.yml
@@ -18,7 +18,6 @@
           < -20
         labels:
           severity: warning
-          notify: email
         annotations:
           summary: Router total routes drop
           description: >
@@ -34,7 +33,6 @@
           < -20
         labels:
           severity: critical
-          notify: email
 
       - alert: RouterTotalRoutesDiscrepancy
         expr: >
@@ -48,7 +46,6 @@
         for: 5m
         labels:
           severity: warning
-          notify: email
         annotations:
           summary: Router total routes discrepancy
           description: >

--- a/manifests/prometheus/alerts.d/uaa-failed-login-user-not-found.yml
+++ b/manifests/prometheus/alerts.d/uaa-failed-login-user-not-found.yml
@@ -10,7 +10,6 @@
         expr: sum(increase(firehose_value_metric_uaa_audit_service_user_not_found_count[1h])) > 10
         labels:
           severity: warning
-          notify: email
         annotations:
           summary: "UAA - Failed login: user not found"
           description: "Anomalous levels of authentication attempts with a user name that does not exist. Number of failed login attempts per hour: {{ $value | printf \"%.0f\" }}"

--- a/manifests/prometheus/alerts.d/uaa-failed-login-wrong-password.yml
+++ b/manifests/prometheus/alerts.d/uaa-failed-login-wrong-password.yml
@@ -10,7 +10,6 @@
         expr: sum(increase(firehose_value_metric_uaa_audit_service_client_authentication_failure_count[1h])) > 10
         labels:
           severity: warning
-          notify: email
         annotations:
           summary: "UAA - Failed login: wrong password"
           description: "Anomalous levels of authentication attempts with an existing user name and wrong password. Number of failed login attempts per hour: {{ $value | printf \"%.0f\" }}"

--- a/manifests/prometheus/operations.d/050-set-external-urls.yml
+++ b/manifests/prometheus/operations.d/050-set-external-urls.yml
@@ -1,0 +1,11 @@
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/web?/external_url?
+  value: https://prometheus.((system_domain))
+
+- type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/web?/external_url
+  value: https://alertmanager.((system_domain))
+
+- type: replace
+  path: /instance_groups/name=grafana/jobs/name=grafana/properties/grafana/server?/root_url
+  value: https://grafana.((system_domain))

--- a/manifests/prometheus/operations.d/310-alertmanager-routes.yml
+++ b/manifests/prometheus/operations.d/310-alertmanager-routes.yml
@@ -24,6 +24,8 @@
     email_configs:
       - from: govpaas-alerting-((aws_account))@digital.cabinet-office.gov.uk
         to: govpaas-alerting-((aws_account))+warning@digital.cabinet-office.gov.uk
+        headers:
+          Subject: "[((metrics_environment))] [warning] {{ .GroupLabels.SortedPairs.Values | join \" \" }}"
 
 - type: replace
   path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers?/-
@@ -32,3 +34,5 @@
     email_configs:
       - from: govpaas-alerting-((aws_account))@digital.cabinet-office.gov.uk
         to: govpaas-alerting-((aws_account))+critical@digital.cabinet-office.gov.uk
+        headers:
+          Subject: "[((metrics_environment))] [critical] {{ .GroupLabels.SortedPairs.Values | join \" \" }}"

--- a/manifests/prometheus/operations.d/310-alertmanager-routes.yml
+++ b/manifests/prometheus/operations.d/310-alertmanager-routes.yml
@@ -8,7 +8,7 @@
       - alertname
     group_wait: 30s
     group_interval: 1m
-    repeat_interval: 1h
+    repeat_interval: 24h
     routes:
       - receiver: warning-receiver
         match:

--- a/manifests/prometheus/operations.d/310-alertmanager-routes.yml
+++ b/manifests/prometheus/operations.d/310-alertmanager-routes.yml
@@ -1,31 +1,34 @@
+---
+
 - type: replace
   path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/route?
   value:
-    receiver: default-receiver
+    receiver: critical-receiver
     group_by:
-    - deployment
+      - alertname
     group_wait: 30s
     group_interval: 1m
     repeat_interval: 1h
-
-- type: replace
-  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/route/routes?/-
-  value:
-    receiver: email-receiver
-    continue: true
-    match_re:
-      notify: ".*email.*"
-
-- type: replace
-  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers?/-
-  value:
-    name: default-receiver
+    routes:
+      - receiver: warning-receiver
+        match:
+          severity: "warning"
+      - receiver: critical-receiver
+        match:
+          severity: "critical"
 
 - type: replace
   path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers?/-
   value:
-    name: 'email-receiver'
+    name: warning-receiver
     email_configs:
-    - send_resolved: true
-      from: govpaas-alerting-((aws_account))@digital.cabinet-office.gov.uk
-      to: govpaas-alerting-((aws_account))@digital.cabinet-office.gov.uk
+      - from: govpaas-alerting-((aws_account))@digital.cabinet-office.gov.uk
+        to: govpaas-alerting-((aws_account))+warning@digital.cabinet-office.gov.uk
+
+- type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers?/-
+  value:
+    name: critical-receiver
+    email_configs:
+      - from: govpaas-alerting-((aws_account))@digital.cabinet-office.gov.uk
+        to: govpaas-alerting-((aws_account))+critical@digital.cabinet-office.gov.uk


### PR DESCRIPTION
# What

Changes:
 * Group the email alerts by alert name
 * Set the email subject to `[<env>] [<severity>] <alert name>`
 * Send alert emails by default
 * Separate receivers for warnings/critical alerts
 * Disable emails for resolved alerts
 * Remove the now unneeded `notify` labels from our alerts
 * Set the external urls for Prometheus/Alertmanager/Grafana which means the links in Alertmanager and the alert emails are working now 

What I didn't change:
 * I didn't touch the email body as it didn't seem to worth the effort for only some minor optimisations
 * I didn't add a way to disable email alerts - mostly because there is no need for it currently and maybe a more appropriate action is to remove the alert. (We can still silence one temporarily in alertmanager)

Up for debate:
 * All alerts should have the severity tag, but ones without one will trigger a critical alert to be on the safe side.
 * The alerts will be repeated only every 24h as an insurance.

# How to review

1. Deploy Prometheus from this branch
2. Trigger an alert (e.g. stop a process with monit on one of your instances and wait 5 minutes) and check if it looks ok (govpaas-alerting-dev list).
3. Check if all alert related links work correctly in Alertmanager and in the emails
4. Resolve the alert and check whether you get a resolve email (you shouldn't).

# Who can review

Not me.