### PR TITLE
[#162381973] Prometheus user impact dashboard 

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1430,6 +1430,7 @@ jobs:
           image_resource: *curl-ssl-image-resource
           params:
             SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+            DEPLOY_ENV: ((deploy_env))
           inputs:
             - name: paas-cf
             - name: config
@@ -1443,6 +1444,7 @@ jobs:
                 . ./config/config.sh
                 for f in "$(pwd)/paas-cf/manifests/prometheus/dashboards.d/"*.json; do
                   sed "s/__SYSTEM_DNS_ZONE_NAME__/${SYSTEM_DNS_ZONE_NAME}/g" "${f}" \
+                  | sed "s/__DEPLOY_ENV__/${DEPLOY_ENV}/g" \
                   | curl "https://grafana.${SYSTEM_DNS_ZONE_NAME}/api/dashboards/db" \
                     --user "admin:$GRAFANA_PASS" \
                     --header 'Content-Type: application/json' \

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -36,6 +36,11 @@ meta:
       source:
         repository: governmentpaas/terraform
         tag: 6efea7a479f9336019155cc039ad33d2c8845cb0
+    curl-ssl: &curl-ssl-image-resource
+      type: docker-image
+      source:
+        repository: governmentpaas/curl-ssl
+        tag: 6efea7a479f9336019155cc039ad33d2c8845cb0
 
 groups:
   - name: deploy
@@ -1242,33 +1247,7 @@ jobs:
                   < cf-tfstate/cf.tfstate \
                   > terraform-outputs/cf.yml
 
-      - task: retrieve-config
-        config:
-          platform: linux
-          inputs:
-            - name: paas-cf
-            - name: cf-vars-store
-            - name: terraform-outputs
-          outputs:
-            - name: config
-          params:
-            SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
-          image_resource: *ruby-slim-image-resource
-          run:
-            path: sh
-            args:
-              - -e
-              - -c
-              - |
-                VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
 
-                cat << EOT > config/config.sh
-                export CF_ADMIN=admin
-                export CF_PASS=$($VAL_FROM_YAML cf_admin_password cf-vars-store/cf-vars-store.yml)
-                export API_ENDPOINT="https://api.${SYSTEM_DNS_ZONE_NAME}"
-                export YACE_AWS_ACCESS_KEY_ID=$($VAL_FROM_YAML terraform_outputs_yace_aws_access_key_id terraform-outputs/cf.yml)
-                export YACE_AWS_SECRET_ACCESS_KEY=$($VAL_FROM_YAML terraform_outputs_yace_aws_secret_access_key terraform-outputs/cf.yml)
-                EOT
 
 
       - task: generate-prometheus-manifest
@@ -1346,6 +1325,36 @@ jobs:
             params:
               file: prometheus-manifest-pre-vars/prometheus-manifest-pre-vars.yml
 
+      - task: retrieve-config
+        config:
+          platform: linux
+          inputs:
+            - name: paas-cf
+            - name: cf-vars-store
+            - name: terraform-outputs
+            - name: prometheus-vars-store
+          outputs:
+            - name: config
+          params:
+            SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+          image_resource: *ruby-slim-image-resource
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
+
+                cat << EOT > config/config.sh
+                export CF_ADMIN=admin
+                export CF_PASS=$($VAL_FROM_YAML cf_admin_password cf-vars-store/cf-vars-store.yml)
+                export API_ENDPOINT="https://api.${SYSTEM_DNS_ZONE_NAME}"
+                export YACE_AWS_ACCESS_KEY_ID=$($VAL_FROM_YAML terraform_outputs_yace_aws_access_key_id terraform-outputs/cf.yml)
+                export YACE_AWS_SECRET_ACCESS_KEY=$($VAL_FROM_YAML terraform_outputs_yace_aws_secret_access_key terraform-outputs/cf.yml)
+                export GRAFANA_PASS=$($VAL_FROM_YAML grafana_password prometheus-vars-store/prometheus-vars-store.yml)
+                EOT
+
       - task: prometheus-deploy
         config:
           platform: linux
@@ -1414,6 +1423,33 @@ jobs:
                 EOF
 
                 cf zero-downtime-push cloudwatch-exporter -f manifest.yml
+
+      - task: upload-grafana-dashboards
+        config:
+          platform: linux
+          image_resource: *curl-ssl-image-resource
+          params:
+            SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+          inputs:
+            - name: paas-cf
+            - name: config
+          run:
+            path: sh
+            args:
+              - -e
+              - -u
+              - -c
+              - |
+                . ./config/config.sh
+                for f in "$(pwd)/paas-cf/manifests/prometheus/dashboards.d/"*.json; do
+                  sed "s/__SYSTEM_DNS_ZONE_NAME__/${SYSTEM_DNS_ZONE_NAME}/g" "${f}" \
+                  | curl "https://grafana.${SYSTEM_DNS_ZONE_NAME}/api/dashboards/db" \
+                    --user "admin:$GRAFANA_PASS" \
+                    --header 'Content-Type: application/json' \
+                    --data "@-" \
+                    --fail \
+                    --include
+                done
 
   - name: post-deploy
     serial: true

--- a/manifests/prometheus/dashboards.d/user-impact.json
+++ b/manifests/prometheus/dashboards.d/user-impact.json
@@ -687,7 +687,7 @@
             ]
         },
         "timezone": "UTC",
-        "title": "User Impact",
+        "title": "User Impact - __DEPLOY_ENV__",
         "uid": "paas-user-impact"
     },
     "folderId": 0,

--- a/manifests/prometheus/dashboards.d/user-impact.json
+++ b/manifests/prometheus/dashboards.d/user-impact.json
@@ -1,0 +1,695 @@
+{
+    "dashboard": {
+        "annotations": {
+            "list": [{
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            }]
+        },
+        "editable": false,
+        "gnetId": null,
+        "graphTooltip": 0,
+        "id": null,
+        "links": [],
+        "panels": [{
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "prometheus",
+                "fill": 1,
+                "gridPos": {
+                    "h": 8,
+                    "w": 12,
+                    "x": 0,
+                    "y": 0
+                },
+                "id": 2,
+                "legend": {
+                    "alignAsTable": true,
+                    "avg": true,
+                    "current": true,
+                    "max": true,
+                    "min": true,
+                    "rightSide": false,
+                    "show": true,
+                    "total": false,
+                    "values": true
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [{
+                        "expr": "sum(rate(firehose_counter_event_gorouter_responses_total[2m]))",
+                        "format": "time_series",
+                        "intervalFactor": 1,
+                        "legendFormat": "All Responses",
+                        "refId": "A"
+                    },
+                    {
+                        "expr": "sum(rate(firehose_counter_event_gorouter_responses_4_xx_total[2m]))",
+                        "format": "time_series",
+                        "hide": false,
+                        "intervalFactor": 1,
+                        "legendFormat": "4xx Responses",
+                        "refId": "B"
+                    },
+                    {
+                        "expr": "sum(rate(firehose_counter_event_gorouter_responses_5_xx_total[2m]))",
+                        "format": "time_series",
+                        "intervalFactor": 1,
+                        "legendFormat": "5xx Responses",
+                        "refId": "C"
+                    }
+                ],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Gorouter requests/sec",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                },
+                "yaxes": [{
+                        "format": "reqps",
+                        "label": "",
+                        "logBase": 1,
+                        "max": null,
+                        "min": "0",
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ],
+                "yaxis": {
+                    "align": false,
+                    "alignLevel": null
+                }
+            },
+            {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "prometheus",
+                "fill": 1,
+                "gridPos": {
+                    "h": 8,
+                    "w": 12,
+                    "x": 12,
+                    "y": 0
+                },
+                "id": 3,
+                "legend": {
+                    "alignAsTable": true,
+                    "avg": true,
+                    "current": true,
+                    "max": true,
+                    "min": true,
+                    "rightSide": false,
+                    "show": true,
+                    "total": false,
+                    "values": true
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [{
+                        "expr": "sum(rate(firehose_value_metric_cc_http_status_2_xx[2m]))",
+                        "format": "time_series",
+                        "intervalFactor": 1,
+                        "legendFormat": "2xx Responses",
+                        "refId": "A"
+                    },
+                    {
+                        "expr": "sum(rate(firehose_value_metric_cc_http_status_4_xx[2m]))",
+                        "format": "time_series",
+                        "hide": false,
+                        "intervalFactor": 1,
+                        "legendFormat": "4xx Responses",
+                        "refId": "B"
+                    },
+                    {
+                        "expr": "sum(rate(firehose_value_metric_cc_http_status_5_xx[2m]))",
+                        "format": "time_series",
+                        "intervalFactor": 1,
+                        "legendFormat": "5xx Responses",
+                        "refId": "C"
+                    }
+                ],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "API requests/sec",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                },
+                "yaxes": [{
+                        "format": "reqps",
+                        "label": "",
+                        "logBase": 1,
+                        "max": null,
+                        "min": "0",
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ],
+                "yaxis": {
+                    "align": false,
+                    "alignLevel": null
+                }
+            },
+            {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "prometheus",
+                "fill": 1,
+                "gridPos": {
+                    "h": 8,
+                    "w": 12,
+                    "x": 0,
+                    "y": 8
+                },
+                "id": 7,
+                "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [{
+                        "expr": "firehose_value_metric_bbs_lr_ps_running",
+                        "format": "time_series",
+                        "interval": "",
+                        "intervalFactor": 1,
+                        "legendFormat": "LRPsRunning",
+                        "refId": "A"
+                    },
+                    {
+                        "expr": "firehose_value_metric_bbs_lr_ps_desired",
+                        "format": "time_series",
+                        "intervalFactor": 1,
+                        "legendFormat": "LRPsDesired",
+                        "refId": "B"
+                    }
+                ],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Application Instances",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                },
+                "yaxes": [{
+                        "decimals": 0,
+                        "format": "none",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": "0",
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ],
+                "yaxis": {
+                    "align": false,
+                    "alignLevel": null
+                }
+            },
+            {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "prometheus",
+                "fill": 1,
+                "gridPos": {
+                    "h": 8,
+                    "w": 12,
+                    "x": 12,
+                    "y": 8
+                },
+                "id": 9,
+                "legend": {
+                    "alignAsTable": true,
+                    "avg": true,
+                    "current": true,
+                    "max": true,
+                    "min": true,
+                    "show": true,
+                    "total": false,
+                    "values": true
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [{
+                        "expr": "sum(rate(firehose_value_metric_uaa_requests_global_status_2_xx_count[2m]))",
+                        "format": "time_series",
+                        "intervalFactor": 1,
+                        "legendFormat": "2xx Responses",
+                        "refId": "A"
+                    },
+                    {
+                        "expr": "sum(rate(firehose_value_metric_uaa_requests_global_status_4_xx_count[2m]))",
+                        "format": "time_series",
+                        "intervalFactor": 1,
+                        "legendFormat": "4xx Responses",
+                        "refId": "B"
+                    },
+                    {
+                        "expr": "sum(rate(firehose_value_metric_uaa_requests_global_status_5_xx_count[2m]))",
+                        "format": "time_series",
+                        "intervalFactor": 1,
+                        "legendFormat": "5xx Responses",
+                        "refId": "C"
+                    }
+                ],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "UAA requests/sec",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                },
+                "yaxes": [{
+                        "format": "reqps",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": "0",
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": "0",
+                        "show": false
+                    }
+                ],
+                "yaxis": {
+                    "align": false,
+                    "alignLevel": null
+                }
+            },
+            {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "prometheus",
+                "fill": 0,
+                "gridPos": {
+                    "h": 8,
+                    "w": 12,
+                    "x": 0,
+                    "y": 16
+                },
+                "id": 11,
+                "legend": {
+                    "alignAsTable": false,
+                    "avg": true,
+                    "current": true,
+                    "max": true,
+                    "min": true,
+                    "rightSide": false,
+                    "show": false,
+                    "total": false,
+                    "values": true
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [{
+                    "expr": "bosh_job_mem_percent{bosh_job_name=\"diego-cell\"}",
+                    "format": "time_series",
+                    "instant": false,
+                    "intervalFactor": 1,
+                    "legendFormat": "{{bosh_job_id}} ({{bosh_job_ip}})",
+                    "refId": "A"
+                }],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Cell Used Memory",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 2,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                },
+                "yaxes": [{
+                        "decimals": 0,
+                        "format": "percent",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": "0",
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ],
+                "yaxis": {
+                    "align": false,
+                    "alignLevel": null
+                }
+            },
+            {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "prometheus",
+                "fill": 1,
+                "gridPos": {
+                    "h": 8,
+                    "w": 8,
+                    "x": 12,
+                    "y": 16
+                },
+                "id": 13,
+                "legend": {
+                    "alignAsTable": true,
+                    "avg": true,
+                    "current": true,
+                    "max": true,
+                    "min": true,
+                    "show": true,
+                    "total": false,
+                    "values": true
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [{
+                    "expr": "max(firehose_value_metric_cc_job_queue_length_total)",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "CC Job Queue Length",
+                    "refId": "A"
+                }],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "CloudController Job Queue",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                },
+                "yaxes": [{
+                        "decimals": 0,
+                        "format": "none",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": "0",
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ],
+                "yaxis": {
+                    "align": false,
+                    "alignLevel": null
+                }
+            },
+            {
+                "cacheTimeout": null,
+                "colorBackground": true,
+                "colorValue": false,
+                "colors": [
+                    "#299c46",
+                    "rgba(237, 129, 40, 0.89)",
+                    "#d44a3a"
+                ],
+                "datasource": "prometheus",
+                "format": "none",
+                "gauge": {
+                    "maxValue": 100,
+                    "minValue": 0,
+                    "show": false,
+                    "thresholdLabels": false,
+                    "thresholdMarkers": true
+                },
+                "gridPos": {
+                    "h": 8,
+                    "w": 4,
+                    "x": 20,
+                    "y": 16
+                },
+                "id": 5,
+                "interval": null,
+                "links": [{
+                    "targetBlank": true,
+                    "title": "https://prometheus.__SYSTEM_DNS_ZONE_NAME__/alerts",
+                    "type": "absolute",
+                    "url": "https://prometheus.__SYSTEM_DNS_ZONE_NAME__/alerts"
+                }],
+                "mappingType": 1,
+                "mappingTypes": [{
+                        "name": "value to text",
+                        "value": 1
+                    },
+                    {
+                        "name": "range to text",
+                        "value": 2
+                    }
+                ],
+                "maxDataPoints": 100,
+                "nullPointMode": "connected",
+                "nullText": null,
+                "postfix": "",
+                "postfixFontSize": "50%",
+                "prefix": "",
+                "prefixFontSize": "50%",
+                "rangeMaps": [{
+                    "from": "null",
+                    "text": "N/A",
+                    "to": "null"
+                }],
+                "sparkline": {
+                    "fillColor": "rgba(31, 118, 189, 0.18)",
+                    "full": false,
+                    "lineColor": "rgb(31, 120, 193)",
+                    "show": false
+                },
+                "tableColumn": "",
+                "targets": [{
+                    "expr": "count(ALERTS{alertstate=\"firing\"})",
+                    "format": "time_series",
+                    "instant": true,
+                    "intervalFactor": 1,
+                    "refId": "A"
+                }],
+                "thresholds": "0,1",
+                "title": "Firing Alerts",
+                "type": "singlestat",
+                "valueFontSize": "200%",
+                "valueMaps": [{
+                    "op": "=",
+                    "text": "N/A",
+                    "value": "null"
+                }],
+                "valueName": "current"
+            }
+        ],
+        "refresh": "5s",
+        "schemaVersion": 16,
+        "style": "dark",
+        "tags": [],
+        "templating": {
+            "list": []
+        },
+        "time": {
+            "from": "now-24h",
+            "to": "now"
+        },
+        "timepicker": {
+            "refresh_intervals": [
+                "5s",
+                "10s",
+                "30s",
+                "1m",
+                "5m",
+                "15m",
+                "30m",
+                "1h",
+                "2h",
+                "1d"
+            ],
+            "time_options": [
+                "5m",
+                "15m",
+                "1h",
+                "6h",
+                "12h",
+                "24h",
+                "2d",
+                "7d",
+                "30d"
+            ]
+        },
+        "timezone": "UTC",
+        "title": "User Impact",
+        "uid": "paas-user-impact"
+    },
+    "folderId": 0,
+    "overwrite": true
+}

--- a/terraform/cloudfoundry/prometheus.tf
+++ b/terraform/cloudfoundry/prometheus.tf
@@ -25,6 +25,7 @@ resource "aws_security_group" "prometheus-lb" {
 
     cidr_blocks = [
       "${compact(var.admin_cidrs)}",
+      "${var.concourse_elastic_ip}/32",
     ]
   }
 


### PR DESCRIPTION
What
----

Added User Impact dashboard to Grafana to replace the current Datadog dashboard view

How to review
-------------

1. Run the pipeline against a deployment
2. In Grafana (https://grafana.${deployment_domain}), ensure "User Impact" dashboard is available to view (`/d/paas-user-impact/user-impact`) and shows the same information as the current Datadog one.

Who can review
--------------

Anyone but @tnwhitwell, @richardTowers & @jpluscplusm 
