### PR TITLE
Remove prometheus scraping of concourse

### DIFF
--- a/manifests/prometheus/operations.d/230-do-not-monitor-concourse.yml
+++ b/manifests/prometheus/operations.d/230-do-not-monitor-concourse.yml
@@ -1,0 +1,5 @@
+# FIXME: remove this when we enable the concourse prometheus exporter
+---
+- type: remove
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/job_name=concourse
+


### PR DESCRIPTION
What
----

We're not currently running a prometheus exporter on concourse, so this
scraper is erroring.

We may decide to re-enable this once datadog is turned off and we can
enable the prometheus exporter on concourse.

How to review
-------------

* Code review
* Observe that the PrometheusScrape error does not fire *for Concourse* in
environments where this branch has been deployed (e.g.  https://prometheus.towers.dev.cloudpipeline.digital/alerts)

Who can review
--------------

Not @richardtowers