### PR TITLE
[#162540011] Set Prometheus data retention to 450 days

### DIFF
--- a/manifests/cf-manifest/cloud-config/000-base-cloud-config.yml
+++ b/manifests/cf-manifest/cloud-config/000-base-cloud-config.yml
@@ -23,6 +23,10 @@ disk_types:
   disk_size: 10240
   cloud_properties:
     type: gp2
+- name: 100GB
+  disk_size: 102400
+  cloud_properties:
+    type: gp2
 
 networks:
 - name: cf

--- a/manifests/prometheus/operations.d/001-set-retention.yml
+++ b/manifests/prometheus/operations.d/001-set-retention.yml
@@ -1,0 +1,5 @@
+---
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties?/prometheus/storage/tsdb/retention
+  value: 450d

--- a/manifests/prometheus/operations.d/001-set-retention.yml
+++ b/manifests/prometheus/operations.d/001-set-retention.yml
@@ -3,3 +3,7 @@
 - type: replace
   path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties?/prometheus/storage/tsdb/retention
   value: 450d
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties?/prometheus/storage/tsdb/max_block_duration
+  value: 7d

--- a/manifests/prometheus/operations.d/100-set-persistent-disks.yml
+++ b/manifests/prometheus/operations.d/100-set-persistent-disks.yml
@@ -13,6 +13,6 @@
 
 - type: replace
   path: /instance_groups/name=prometheus2/persistent_disk_type?
-  value: 10GB
+  value: 100GB
 - type: remove
   path: /instance_groups/name=prometheus2/persistent_disk

--- a/manifests/prometheus/spec/operations/set_persistent_disks_spec.rb
+++ b/manifests/prometheus/spec/operations/set_persistent_disks_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "setting persistent disks" do
   {
     "alertmanager" => "5GB",
     "grafana" => "5GB",
-    "prometheus2" => "10GB",
+    "prometheus2" => "100GB",
   }.each do |name, type|
     it "sets the persistent_disk_type for #{name} to #{type}" do
       expect(manifest_with_defaults.get("instance_groups.#{name}.persistent_disk_type")).to eq(type)


### PR DESCRIPTION
## What

We decided to have a data retention period of 15 months, so we can look back at least a year (and some).
Based on our current usage we store ~120Mb/day, which would be 54G for 15 months. We want to leave some room for growing, so we'll attach a 100Gb disk as data storage.

Also after reading [1] I decided to explicitly set the max-block-duration to 7 days, as the default 45 days seemed unnecessarily high.

[1] https://github.com/prometheus/prometheus/issues/4110

## How to review

1. Deploy Prometheus from your pipeline.
2. Check if the retention/max-block-duration values are correctly set (https://prometheus.$DEPLOY_ENV.dev.cloudpipeline.digital/flags)
3. Check that you didn't loose any data after the migration

## Who can review

Not me.
