### PR TITLE
[#SUPPORT] Ignore "overlay" device in disk-space alert

### DIFF
--- a/terraform/datadog/general.tf
+++ b/terraform/datadog/general.tf
@@ -3,7 +3,7 @@ resource "datadog_monitor" "disk-space" {
   type           = "query alert"
   message        = "${format("More than {{threshold}}%% disk used. @govpaas-alerting-%s@digital.cabinet-office.gov.uk", var.aws_account)}"
   notify_no_data = false
-  query          = "${format("max(last_5m):max:system.disk.in_use{deploy_env:%s,!device:/dev/loop0,!device:tmpfs,!device:cgroup,!device:udev,!device:/var/vcap/data/root_log,!device:/var/vcap/data/root_tmp} by {bosh-job,device,bosh-index} * 100 > 85", var.env)}"
+  query          = "${format("max(last_5m):max:system.disk.in_use{deploy_env:%s,!device:overlay,!device:/dev/loop0,!device:tmpfs,!device:cgroup,!device:udev,!device:/var/vcap/data/root_log,!device:/var/vcap/data/root_tmp} by {bosh-job,device,bosh-index} * 100 > 85", var.env)}"
 
   thresholds {
     warning  = "75.0"


### PR DESCRIPTION
What
----

The "overlay" device is for the containers of the applications, and
the space is restricted to the allowed disk for the application.

We do not want to alert if an application runs out of space, that
is up for the tenant to monitor.

Because that, we also ignore the overlay device.

Example output of a df command:

   overlay             1024   998        27  98% /var/vcap/data/grootfs/store/unprivileged/images/ab308816-7857-4c76-5020-9114/rootfs

How to review
-------------

Code review

Who can review
--------------

Not me