### PR TITLE
[#162551292] Grafana monitoring board user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ showenv: check-env ## Display environment information
 	@echo export CONCOURSE_IP=$$(aws ec2 describe-instances \
 		--filters 'Name=tag:Name,Values=concourse/*' "Name=key-name,Values=$(DEPLOY_ENV)_concourse_key_pair" \
 		--query 'Reservations[].Instances[].PublicIpAddress' --output text)
-	@scripts/show-vars-store-secrets.sh prometheus-vars-store alertmanager_password grafana_password prometheus_password
+	@scripts/show-vars-store-secrets.sh prometheus-vars-store alertmanager_password grafana_password grafana_mon_password prometheus_password
 
 .PHONY: upload-all-secrets
 upload-all-secrets: upload-datadog-secrets upload-google-oauth-secrets upload-notify-secrets upload-aiven-secrets upload-logit-secrets upload-pagerduty-secrets

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -3260,6 +3260,7 @@ jobs:
                 --passwords \
                 --ssh \
                 --rsa \
+                --preserve grafana_mon_password \
                 > modified-prometheus-vars-store/prometheus-vars-store.yml
       on_success:
         put: prometheus-vars-store

--- a/manifests/prometheus/operations.d/240-grafana-monitoring-user.yml
+++ b/manifests/prometheus/operations.d/240-grafana-monitoring-user.yml
@@ -1,0 +1,12 @@
+- type: replace
+  path: /variables/-
+  value:
+    name: grafana_mon_password
+    type: password
+- type: replace
+  path: /instance_groups/name=grafana/jobs/name=grafana/properties/grafana/users?/seeded_global_users/-
+  value:
+    name: mon
+    email: mon
+    login: mon
+    password: ((grafana_mon_password))


### PR DESCRIPTION
What
----

Added the pre-seeding of a `mon` user to grafana, to remove the need for monitoring screens to be logged in to the grafana dashboard as _admin_.

How to review
-------------

1. Run the pipeline from this branch
1. Retrieve the `GRAFANA_MON_PASSWORD` with `make dev showenv`
1. Login to grafana with `mon`/`$GRAFANA_MON_PASSWORD`
1. Ensure you can view "User Impact - $env" dashboard with r/o permissions

Who can review
--------------

Not me
