### PR TITLE
[#161412619] Switch metric used for DNS resolution

### DIFF
--- a/manifests/prometheus/alerts.d/dns-resolution-time.yml
+++ b/manifests/prometheus/alerts.d/dns-resolution-time.yml
@@ -8,7 +8,7 @@
     rules:
     - &alert
       alert: DNSResolutionTime_Warning
-      expr: avg_over_time(dns_resolution_probe_dns_lookup_time_seconds[5m]) > 0.1
+      expr: avg_over_time(dns_resolution_probe_duration_seconds[5m]) > 0.1
       labels:
         severity: warning
         notify: email
@@ -18,7 +18,7 @@
 
     - <<: *alert
       alert: DNSResolutionTime_Critical
-      expr: avg_over_time(dns_resolution_probe_dns_lookup_time_seconds[5m]) > 0.2
+      expr: avg_over_time(dns_resolution_probe_duration_seconds[5m]) > 0.2
       labels:
         severity: critical
         notify: email


### PR DESCRIPTION
What
----

The previous metric was concerned with lookup time from the bosh DNS
cache rather than the full resolution process.


How to review
-------------

Code review and compare graphs in story

Who can review
--------------

anyone
