### PR TITLE
Do not use the external url for the Prometheus data source in Grafana

### DIFF
--- a/manifests/prometheus/operations.d/050-set-external-urls.yml
+++ b/manifests/prometheus/operations.d/050-set-external-urls.yml
@@ -9,3 +9,7 @@
 - type: replace
   path: /instance_groups/name=grafana/jobs/name=grafana/properties/grafana/server?/root_url
   value: https://grafana.((system_domain))
+
+- type: replace
+  path: /instance_groups/name=grafana/jobs/name=grafana/properties/grafana/prometheus?/use_external_url?
+  value: false


### PR DESCRIPTION
What
----

Grafana is not allowed to access Prometheus through the ELB, so we should still
use the internal address.


How to review
-------------

Quick deploy test

Who can review
--------------

Not me.