### PR TITLE
[#162604166] Add a test to check we only offer TLS 1.2

### DIFF
--- a/platform-tests/src/platform/acceptance/tls_version_test.go
+++ b/platform-tests/src/platform/acceptance/tls_version_test.go
@@ -1,0 +1,83 @@
+package acceptance_test
+
+import (
+	"crypto/tls"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Checking the TLS version", func() {
+
+	testHostPortGetters := map[string]func() string{
+		"apps_apex": func() string {
+			return testConfig.GetAppsDomain() + ":443"
+		},
+		"apps": func() string {
+			return "healthcheck." + testConfig.GetAppsDomain() + ":443"
+		},
+		"system": func() string {
+			return testConfig.GetApiEndpoint() + ":443"
+		},
+	}
+
+	for domainClass, hostPortGetter := range testHostPortGetters {
+		domainClass, hostPortGetter := domainClass, hostPortGetter
+
+		Context(domainClass+" domain", func() {
+			It("should not allow SSL 3.0", func() {
+				tlsConfig := &tls.Config{
+					MinVersion: tls.VersionSSL30,
+					MaxVersion: tls.VersionSSL30,
+				}
+				hostPort := hostPortGetter()
+				conn, err := tls.Dial("tcp", hostPort, tlsConfig)
+				if err == nil {
+					defer conn.Close()
+				}
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError("EOF"))
+			})
+			It("should not allow TLS 1.0", func() {
+				tlsConfig := &tls.Config{
+					MinVersion: tls.VersionTLS10,
+					MaxVersion: tls.VersionTLS10,
+				}
+				hostPort := hostPortGetter()
+				conn, err := tls.Dial("tcp", hostPort, tlsConfig)
+				if err == nil {
+					defer conn.Close()
+				}
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError("EOF"))
+			})
+			It("should not allow TLS 1.1", func() {
+				tlsConfig := &tls.Config{
+					MinVersion: tls.VersionTLS11,
+					MaxVersion: tls.VersionTLS11,
+				}
+				hostPort := hostPortGetter()
+				conn, err := tls.Dial("tcp", hostPort, tlsConfig)
+				if err == nil {
+					defer conn.Close()
+				}
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError("EOF"))
+			})
+
+			It("should allow TLS 1.2", func() {
+				tlsConfig := &tls.Config{
+					MinVersion: tls.VersionTLS12,
+					MaxVersion: tls.VersionTLS12,
+				}
+				hostPort := hostPortGetter()
+				conn, err := tls.Dial("tcp", hostPort, tlsConfig)
+				if err == nil {
+					defer conn.Close()
+				}
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	}
+
+})


### PR DESCRIPTION
What
----

We want to ensure that our SSL endpoints for apps and system
only offer TLS 1.2.

We add a custom acceptance test that would check for all the old
disabled protocols, and expect failure.

How to review
-------------

Code review, test by changing the policy of the ELB in your environment.

Who can review
--------------

Not me