### PR TITLE
[#162448881] Enable scraping Concourse metrics in Prometheus, add related missing alerts

### DIFF
--- a/manifests/prometheus/alerts.d/concourse-check-certificates-errors.yml
+++ b/manifests/prometheus/alerts.d/concourse-check-certificates-errors.yml
@@ -1,0 +1,18 @@
+# Source: concourse
+---
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: ConcourseCheckCertificatesErrors
+    rules:
+      - record: "concourse_check_certificates_errors"
+        expr: sum(concourse_builds_finished{exported_job="check-certificates",pipeline="create-cloudfoundry",status="errored"} or (absent(concourse_builds_finished{exported_job="check-certificates",pipeline="create-cloudfoundry",status="errored"})-1))
+
+      - alert: ConcourseCheckCertificatesErrors
+        expr: increase(concourse_check_certificates_errors[3d]) >= 2
+        labels:
+          severity: critical
+        annotations:
+          summary: Concourse check-certificates errors
+          description: The check-certificates Concourse job has been erroring for a while now. Check the health/check-certificates job on Concourse.

--- a/manifests/prometheus/alerts.d/concourse-check-certificates-failures.yml
+++ b/manifests/prometheus/alerts.d/concourse-check-certificates-failures.yml
@@ -1,0 +1,19 @@
+# Source: concourse
+---
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: ConcourseCheckCertificatesFailures
+    rules:
+      - record: "concourse_check_certificates_failures"
+        expr: sum(concourse_builds_finished{exported_job="check-certificates",pipeline="create-cloudfoundry",status="failed"} or (absent(concourse_builds_finished{exported_job="check-certificates",pipeline="create-cloudfoundry",status="failed"})-1))
+
+      - alert: ConcourseCheckCertificatesFailures
+        expr: increase(concourse_check_certificates_failures[1h]) >= 1
+        labels:
+          severity: critical
+        annotations:
+          summary: Concourse check-certificates failures
+          description: Some of the Cloud Foundry certificates might be expiring soon. Check the health/check-certificates job on Concourse.
+          url: https://team-manual.cloud.service.gov.uk/incident_management/responding_to_alerts/#cloud-foundry-internal-certificates

--- a/manifests/prometheus/alerts.d/concourse-check-certificates-no-data.yml
+++ b/manifests/prometheus/alerts.d/concourse-check-certificates-no-data.yml
@@ -1,0 +1,16 @@
+# Source: concourse
+---
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: ConcourseCheckCertificatesNoData
+    rules:
+      - alert: ConcourseCheckCertificatesNoData
+        expr: absent(concourse_builds_finished{pipeline="create-cloudfoundry",exported_job="check-certificates"})
+        for: 2d
+        labels:
+          severity: critical
+        annotations:
+          summary: Concourse check-certificates no data
+          description: The check-certificates Concourse job has not been reporting data for a while now. Check the health/check-certificates job on Concourse.

--- a/manifests/prometheus/alerts.d/concourse-smoketests-errors.yml
+++ b/manifests/prometheus/alerts.d/concourse-smoketests-errors.yml
@@ -1,0 +1,18 @@
+# Source: concourse
+---
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: ConcourseSmoketestsErrors
+    rules:
+      - record: "concourse_continuous_smoke_tests_errors"
+        expr: sum(concourse_builds_finished{exported_job="continuous-smoke-tests",pipeline="create-cloudfoundry",status="errored"} or (absent(concourse_builds_finished{exported_job="continuous-smoke-tests",pipeline="create-cloudfoundry",status="errored"})-1))
+
+      - alert: ConcourseSmoketestsErrors
+        expr: increase(concourse_continuous_smoke_tests_errors[1h]) >= 3
+        labels:
+          severity: critical
+        annotations:
+          summary: Concourse continuous-smoke-tests errors
+          description: The continuous-smoke-tests Concourse job has been erroring for a while now.

--- a/manifests/prometheus/alerts.d/concourse-smoketests-failures.yml
+++ b/manifests/prometheus/alerts.d/concourse-smoketests-failures.yml
@@ -1,0 +1,18 @@
+# Source: concourse
+---
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: ConcourseSmoketestsFailures
+    rules:
+      - record: "concourse_continuous_smoke_tests_failures"
+        expr: sum(concourse_builds_finished{exported_job="continuous-smoke-tests",pipeline="create-cloudfoundry",status="failed"} or (absent(concourse_builds_finished{exported_job="continuous-smoke-tests",pipeline="create-cloudfoundry",status="failed"})-1))
+
+      - alert: ConcourseSmoketestsFailures
+        expr: increase(concourse_continuous_smoke_tests_failures[1h]) >= 3
+        labels:
+          severity: critical
+        annotations:
+          summary: Concourse continuous-smoke-tests failures
+          description: The continuous-smoke-tests Concourse job has been failing for a while now.

--- a/manifests/prometheus/alerts.d/concourse-smoketests-no-data.yml
+++ b/manifests/prometheus/alerts.d/concourse-smoketests-no-data.yml
@@ -1,0 +1,16 @@
+# Source: concourse
+---
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: ConcourseSmoketestsNoData
+    rules:
+      - alert: ConcourseSmoketestsNoData
+        expr: absent(concourse_builds_finished{pipeline="create-cloudfoundry",exported_job="continuous-smoke-tests"})
+        for: 30m
+        labels:
+          severity: critical
+        annotations:
+          summary: Concourse continuous-smoke-tests no data
+          description: The continuous-smoke-tests Concourse job has not been reporting data for a while now.

--- a/manifests/prometheus/operations.d/230-do-not-monitor-concourse.yml
+++ b/manifests/prometheus/operations.d/230-do-not-monitor-concourse.yml
@@ -1,5 +1,0 @@
-# FIXME: remove this when we enable the concourse prometheus exporter
----
-- type: remove
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/job_name=concourse
-


### PR DESCRIPTION
# What

Reenable the Prometheus scraping for Concourse and migrate the continuous-smoke-tests and check-certificate monitors from DataDog.

The original `job` label collides with the Bosh job's `job` label, therefore it will be renamed to `exported_job`. See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#%3Cscrape_config%3E - `honor_labels ` to understand why.

I decided to record a more complex expression like:
```
sum(
  concourse_builds_finished{exported_job="check-certificates",pipeline="create-cloudfoundry",status="errored"}
  or
  (absent(concourse_builds_finished{exported_job="check-certificates",pipeline="create-cloudfoundry",status="errored"})-1)
)
```
as this way we'll have 0 values if Concourse doesn't report anything for a specific metric (it starts to report one after the first event only). This way we can consistently check the increase of any error/failure rate.

# How to review

1. Review and deploy https://github.com/alphagov/paas-bootstrap/pull/227 first
1. Deploy your CF from this branch
1. Check if Prometheus started scraping the Concourse metrics
1. You can verify the alerts by manually making the continuous-smoke-tests/check-certificates to fail/error (add an `exit 1` to any of these jobs and run the `pipelines` target)

# Who can review

Not me