### PR TITLE
Upgrade cflinuxfs2 to fix CVE-USN-3843-1

### DIFF
--- a/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
+++ b/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
@@ -4,9 +4,9 @@
   path: /releases/name=cflinuxfs2
   value:
     name: cflinuxfs2
-    version: "1.251.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.251.0"
-    sha1: "6d2954eb343b9aaaf23d38355fe0c3e85c2de36e"
+    version: "1.255.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.255.0"
+    sha1: "8fdfe5cfc1c961dbc385150e6008878e3572701d"
 
 - type: replace
   path: /releases/name=cflinuxfs3


### PR DESCRIPTION
What
----

### USN-3843-1: pixman vulnerability


#### Severity

Medium

#### Vendor

Canonical Ubuntu

#### Versions Affected

*   Canonical Ubuntu 14.04

#### Description

It was discovered that pixman incorrectly handled the general_composite_rect function. A remote attacker could use this issue to cause pixman to crash, resulting in a denial of service, or possibly execute arbitrary code.

CVEs contained in this USN include: CVE-2015-5297

#### Affected Cloud Foundry Products and Versions

_Severity is medium unless otherwise noted._

*   All versions of Cloud Foundry cflinuxfs2 prior to 1.255.0

#### Mitigation

Users of affected products are strongly encouraged to follow one of the mitigations below:

*   The Cloud Foundry project recommends that Cloud Foundry deployments run with cflinuxfs2 version 1.255.0 or later.

#### References

*   [USN-3843-1](https://usn.ubuntu.com/3843-1)
*   [CVE-2015-5297](https://people.canonical.com/~ubuntu-security/cve/CVE-2015-5297)


How to review
-------------

* Code review

Who can review
--------------

Not @richardTowers 