### PR TITLE
Fix firing alerts N/A on prometheus dashboard

### DIFF
--- a/manifests/prometheus/dashboards.d/user-impact.json
+++ b/manifests/prometheus/dashboards.d/user-impact.json
@@ -619,11 +619,7 @@
                 "postfixFontSize": "50%",
                 "prefix": "",
                 "prefixFontSize": "50%",
-                "rangeMaps": [{
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }],
+                "rangeMaps": [],
                 "sparkline": {
                     "fillColor": "rgba(31, 118, 189, 0.18)",
                     "full": false,
@@ -632,13 +628,13 @@
                 },
                 "tableColumn": "",
                 "targets": [{
-                    "expr": "count(ALERTS{alertstate=\"firing\"})",
+                    "expr": "count(ALERTS{alertstate=\"firing\"}) or vector(0)",
                     "format": "time_series",
                     "instant": true,
                     "intervalFactor": 1,
                     "refId": "A"
                 }],
-                "thresholds": "0,1",
+                "thresholds": "1,1",
                 "title": "Firing Alerts",
                 "type": "singlestat",
                 "valueFontSize": "200%",


### PR DESCRIPTION
What
----

We originally set up the "Firing alerts" panel to replace "no data" with
"N/A". This is a bit confusing, because really when there's no data it
means "0 alerts". To make matters worse, if the alerts fire the panel
goes red, but the transition from firing to not firing doesn't reset the
color.

Much better to set the panel to 0 if there's no data (which can be done
with `or vector(0)`). I also noticed that the thresholds were wrong (it
was showing as orange when there were 0 alerts).

How to review
-------------

* Code review
* See my dashboard (which was deployed through the pipeline) -
https://grafana.towers.dev.cloudpipeline.digital/d/paas-user-impact/user-impact-towers

Who can review
--------------

Not @richardtowers