### PR TITLE
Fix quoting in some alert descriptions

### DIFF
--- a/manifests/prometheus/alerts.d/aws-elb-unhealthy-nodes.yml
+++ b/manifests/prometheus/alerts.d/aws-elb-unhealthy-nodes.yml
@@ -12,5 +12,5 @@
         severity: warning
       annotations:
         summary: "At least one ELB node is not responding"
-        description: Requests to the healthcheck app via {{ $value | printf \"%.0f\" }} of the ELB IP addresses failed.
+        description: "Requests to the healthcheck app via {{ $value | printf \"%.0f\" }} of the ELB IP addresses failed."
         url: https://team-manual.cloud.service.gov.uk/incident_management/responding_to_alerts/#intermittent-elb-failures

--- a/manifests/prometheus/alerts.d/gorouter-latency.yml
+++ b/manifests/prometheus/alerts.d/gorouter-latency.yml
@@ -16,7 +16,7 @@
           severity: warning
         annotations:
           summary: Gorouter latency
-          description: Gorouter latency is too high ({{ $value | printf \"%.0f\" }}ms") on {{ $labels.bosh_job_ip }}
+          description: "Gorouter latency is too high ({{ $value | printf \"%.0f\" }}ms) on {{ $labels.bosh_job_ip }}"
           url: https://team-manual.cloud.service.gov.uk/incident_management/responding_to_alerts/#gorouter-high-latency-alerts"
 
       - <<: *alert


### PR DESCRIPTION
## What

They were producing the following error when rendering:
```
<error expanding template: error parsing template __alert_GorouterLatency_Warning: template: __alert_GorouterLatency_Warning:1: unexpected "\\" in operand>
```
The string isn't quoted, and yet the embedded quotes are escaped
resulting in them being rendered in the config file as:
```
Gorouter latency is too high ({{ $value | printf \\\"%.0f\\\" }} ms\") on {{ $labels.bosh_job_ip }}
```
There's also a spurious " in the GoRouter alert.

How to review
-------------

Code review is probably enough.

Who can review
--------------

Not me.