### PR TITLE
[#162381976] Cleanup Temporary task to cleanup datadog state from bucket

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2363,24 +2363,6 @@ jobs:
                   fi
                   cf enable-service-access redis
 
-      # FIXME: remove this when it's been run everywhere
-      - task: remove-datadog-state
-        config:
-          platform: linux
-          image_resource: *awscli-image-resource
-          params:
-            DEPLOY_ENV: ((deploy_env))
-            AWS_DEFAULT_REGION: ((aws_region))
-          run:
-            path: sh
-            args:
-              - -e
-              - -u
-              - -c
-              - |
-                aws s3 rm "s3://gds-paas-${DEPLOY_ENV}-state/datadog.tfstate"
-                aws s3 rm "s3://gds-paas-${DEPLOY_ENV}-state/datadog-secrets.yml"
-
       - task: deploy-paas-metrics
         config:
           platform: linux


### PR DESCRIPTION
## What

This has been run everywhere, so is no longer needed.

This reverts commit c84b8ba66074021ee03574df88c6fc72e5e4702f from #1688 

How to review
-------------

* Code review
* Verify that #1688 has been deployed everywhere

Who can review
--------------

Not me.
