### PR TITLE
[#158179141] Implement rotation of DB encryption keys for CC and UAA

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2310,32 +2310,58 @@ jobs:
                 export BOSH_CLIENT_SECRET
 
                 bosh -n clean-up --all
+      - do:
+        - task: rotate-cc-db-encryption-keys
+          config:
+            platform: linux
+            image_resource: *gov-paas-bosh-cli-v2-image-resource
+            inputs:
+              - name: paas-cf
+              - name: bosh-secrets
+              - name: bosh-CA-crt
+            params:
+              BOSH_ENVIRONMENT: ((bosh_fqdn))
+              BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
+              BOSH_DEPLOYMENT: ((deploy_env))
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
+                  BOSH_CLIENT=admin
+                  BOSH_CLIENT_SECRET=$($VAL_FROM_YAML secrets.bosh_admin_password bosh-secrets/bosh-secrets.yml)
+                  export BOSH_CLIENT
+                  export BOSH_CLIENT_SECRET
 
-      - task: rotate-cc-db-encryption-keys
-        config:
-          platform: linux
-          image_resource: *gov-paas-bosh-cli-v2-image-resource
-          inputs:
-            - name: paas-cf
-            - name: bosh-secrets
-            - name: bosh-CA-crt
-          params:
-            BOSH_ENVIRONMENT: ((bosh_fqdn))
-            BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
-            BOSH_DEPLOYMENT: ((deploy_env))
-          run:
-            path: sh
-            args:
-              - -e
-              - -c
-              - |
-                VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
-                BOSH_CLIENT=admin
-                BOSH_CLIENT_SECRET=$($VAL_FROM_YAML secrets.bosh_admin_password bosh-secrets/bosh-secrets.yml)
-                export BOSH_CLIENT
-                export BOSH_CLIENT_SECRET
+                  bosh run-errand rotate-cc-database-key --when-changed
 
-                bosh run-errand rotate-cc-database-key --when-changed
+        - task: rotate-uaa-db-encryption-keys
+          config:
+            platform: linux
+            image_resource: *gov-paas-bosh-cli-v2-image-resource
+            inputs:
+              - name: paas-cf
+              - name: bosh-secrets
+              - name: bosh-CA-crt
+            params:
+              BOSH_ENVIRONMENT: ((bosh_fqdn))
+              BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
+              BOSH_DEPLOYMENT: ((deploy_env))
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
+                  BOSH_CLIENT=admin
+                  BOSH_CLIENT_SECRET=$($VAL_FROM_YAML secrets.bosh_admin_password bosh-secrets/bosh-secrets.yml)
+                  export BOSH_CLIENT
+                  export BOSH_CLIENT_SECRET
+
+                  bosh run-errand rotate-uaa-database-key --when-changed
 
     - aggregate:
       - do:
@@ -3134,6 +3160,7 @@ jobs:
                 --preserve uaa_clients_tcp_emitter_secret \
                 --preserve uaa_clients_tcp_router_secret \
                 --preserve uaa_default_encryption_passphrase \
+                --preserve uaa_default_encryption_passphrase_id \
                 > modified-cf-vars-store/cf-vars-store.yml
       on_success:
         do:
@@ -3183,6 +3210,8 @@ jobs:
                 --passwords \
                 --rotate cc_db_encryption_key \
                 --rotate cc_db_encryption_key_id \
+                --rotate uaa_default_encryption_passphrase \
+                --rotate uaa_default_encryption_passphrase_id \
                 > modified-cf-vars-store/cf-vars-store.yml
       on_success:
         put: cf-vars-store

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -88,6 +88,7 @@ groups:
     jobs:
       - rotate-cf-admin-password
       - rotate-cloudfoundry-credentials
+      - rotate-database-encryption-keys
       - rotate-prometheus-credentials
       - expire-aws-keys
       - rotate-cf-certs-cas
@@ -3101,6 +3102,7 @@ jobs:
                 --rsa \
                 --preserve cc_bulk_api_password \
                 --preserve cc_db_encryption_key \
+                --preserve cc_db_encryption_key_id \
                 --preserve cc_internal_api_password \
                 --preserve cc_staging_upload_password \
                 --preserve cf_admin_password \
@@ -3150,6 +3152,42 @@ jobs:
         put: cf-tfstate
         params:
           file: updated-tfstate/cf.tfstate
+
+  - name: rotate-database-encryption-keys
+    serial: true
+    plan:
+    - aggregate:
+      - get: paas-cf
+      - get: cf-vars-store
+      - get: cf-manifest-pre-vars
+
+    - task: rotate-db-encryption-key
+      config:
+        platform: linux
+        image_resource: *ruby-slim-image-resource
+        inputs:
+          - name: paas-cf
+          - name: cf-vars-store
+          - name: cf-manifest-pre-vars
+        outputs:
+          - name: modified-cf-vars-store
+        run:
+          path: sh
+          args:
+            - -e
+            - -c
+            - |
+              ./paas-cf/manifests/cf-manifest/scripts/rotate-vars-store-secrets.rb \
+                --vars-store cf-vars-store/cf-vars-store.yml \
+                --manifest cf-manifest-pre-vars/cf-manifest-pre-vars.yml \
+                --passwords \
+                --rotate cc_db_encryption_key \
+                --rotate cc_db_encryption_key_id \
+                > modified-cf-vars-store/cf-vars-store.yml
+      on_success:
+        put: cf-vars-store
+        params:
+          file: modified-cf-vars-store/cf-vars-store.yml
 
   - name: rotate-prometheus-credentials
     serial: true

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2310,6 +2310,32 @@ jobs:
 
                 bosh -n clean-up --all
 
+      - task: rotate-cc-db-encryption-keys
+        config:
+          platform: linux
+          image_resource: *gov-paas-bosh-cli-v2-image-resource
+          inputs:
+            - name: paas-cf
+            - name: bosh-secrets
+            - name: bosh-CA-crt
+          params:
+            BOSH_ENVIRONMENT: ((bosh_fqdn))
+            BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
+            BOSH_DEPLOYMENT: ((deploy_env))
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
+                BOSH_CLIENT=admin
+                BOSH_CLIENT_SECRET=$($VAL_FROM_YAML secrets.bosh_admin_password bosh-secrets/bosh-secrets.yml)
+                export BOSH_CLIENT
+                export BOSH_CLIENT_SECRET
+
+                bosh run-errand rotate-cc-database-key --when-changed
+
     - aggregate:
       - do:
         - task: deploy-aiven-service-broker

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1052,6 +1052,20 @@ jobs:
                   tar -xzf ./ipsec-CA/ipsec-CA.tar.gz -C ./ipsec-CA
                   cp cf-vars-store/cf-vars-store.yml cf-vars-store-updated/
 
+                  # FIXME: populate the old value of 'encryption_key_0' for CC
+                  # and 'default_key' for UAA.
+                  # These keys should be removed after the first deployment
+                  # of this code.
+                  if ! grep -e '^cc_db_encryption_key_encryption_key_0:' cf-vars-store/cf-vars-store.yml; then
+                    awk '
+                      /^cc_db_encryption_key:/ {print "cc_db_encryption_key_encryption_key_0:", $2}
+                      /^uaa_default_encryption_passphrase:/ {print "uaa_default_encryption_passphrase_default_key:", $2}
+                      {print}
+                    ' \
+                    < cf-vars-store/cf-vars-store.yml \
+                    > cf-vars-store-updated/cf-vars-store.yml
+                  fi
+
                   VARS_STORE=cf-vars-store-updated/cf-vars-store.yml \
                     ./paas-cf/manifests/cf-manifest/scripts/generate-manifest.sh \
                       > cf-manifest/cf-manifest.yml
@@ -3161,6 +3175,8 @@ jobs:
                 --preserve uaa_clients_tcp_router_secret \
                 --preserve uaa_default_encryption_passphrase \
                 --preserve uaa_default_encryption_passphrase_id \
+                --preserve cc_db_encryption_key_encryption_key_0 \
+                --preserve uaa_default_encryption_passphrase_default_key \
                 > modified-cf-vars-store/cf-vars-store.yml
       on_success:
         do:

--- a/manifests/cf-manifest/operations.d/320-cc-database-key-rotation.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-database-key-rotation.yml
@@ -1,0 +1,38 @@
+---
+- type: replace
+  path: /instance_groups/name=rotate-cc-database-key/vm_extensions?/-
+  value: cf_rds_client_sg
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/database_encryption?
+  value: &cc-database-encryption
+    current_key_label: "((cc_db_encryption_key_id))"
+    keys:
+      ((cc_db_encryption_key_id)): "((cc_db_encryption_key))"
+      ((cc_db_encryption_key_id_old)): "((cc_db_encryption_key_old))"
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/database_encryption?
+  value: *cc-database-encryption
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/database_encryption?
+  value: *cc-database-encryption
+
+- type: replace
+  path: /variables/-
+  value:
+    name: cc_db_encryption_key_old
+    type: password
+
+- type: replace
+  path: /variables/-
+  value:
+    name: cc_db_encryption_key_id
+    type: password
+
+- type: replace
+  path: /variables/-
+  value:
+    name: cc_db_encryption_key_id_old
+    type: password

--- a/manifests/cf-manifest/operations.d/320-cc-database-key-rotation.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-database-key-rotation.yml
@@ -10,6 +10,8 @@
     keys:
       ((cc_db_encryption_key_id)): "((cc_db_encryption_key))"
       ((cc_db_encryption_key_id_old)): "((cc_db_encryption_key_old))"
+      # FIXME: remove this key once we have deployed and rotated this once
+      encryption_key_0: "((cc_db_encryption_key_encryption_key_0))"
 
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/database_encryption?
@@ -35,4 +37,11 @@
   path: /variables/-
   value:
     name: cc_db_encryption_key_id_old
+    type: password
+
+# FIXME: remove this key once we have deployed and rotated this once
+- type: replace
+  path: /variables/-
+  value:
+    name: cc_db_encryption_key_encryption_key_0
     type: password

--- a/manifests/cf-manifest/operations.d/331-uaa-database-key-rotation.yml
+++ b/manifests/cf-manifest/operations.d/331-uaa-database-key-rotation.yml
@@ -26,6 +26,9 @@
       passphrase: ((uaa_default_encryption_passphrase))
     - label: ((uaa_default_encryption_passphrase_id_old))
       passphrase: ((uaa_default_encryption_passphrase_old))
+    # FIXME: remove this key once we have deployed and rotated this once
+    - label: default_key
+      passphrase: ((uaa_default_encryption_passphrase_default_key))
 
 - type: replace
   path: /variables/-
@@ -43,4 +46,11 @@
   path: /variables/-
   value:
     name: uaa_default_encryption_passphrase_id_old
+    type: password
+
+# FIXME: remove this key once we have deployed and rotated this once
+- type: replace
+  path: /variables/-
+  value:
+    name: uaa_default_encryption_passphrase_default_key
     type: password

--- a/manifests/cf-manifest/operations.d/331-uaa-database-key-rotation.yml
+++ b/manifests/cf-manifest/operations.d/331-uaa-database-key-rotation.yml
@@ -1,0 +1,46 @@
+---
+- type: replace
+  path: /instance_groups/-
+  value:
+    name: rotate-uaa-database-key
+    instances: 1
+    azs: [z1]
+    lifecycle: errand
+    vm_type: errand
+    stemcell: default
+    networks:
+    - name: ((network_name))
+    vm_extensions:
+    - cf_rds_client_sg
+    jobs:
+    - name: uaa_key_rotator
+      release: uaa
+      properties: {}
+
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/encryption
+  value:
+    active_key_label: ((uaa_default_encryption_passphrase_id))
+    encryption_keys:
+    - label: ((uaa_default_encryption_passphrase_id))
+      passphrase: ((uaa_default_encryption_passphrase))
+    - label: ((uaa_default_encryption_passphrase_id_old))
+      passphrase: ((uaa_default_encryption_passphrase_old))
+
+- type: replace
+  path: /variables/-
+  value:
+    name: uaa_default_encryption_passphrase_old
+    type: password
+
+- type: replace
+  path: /variables/-
+  value:
+    name: uaa_default_encryption_passphrase_id
+    type: password
+
+- type: replace
+  path: /variables/-
+  value:
+    name: uaa_default_encryption_passphrase_id_old
+    type: password

--- a/manifests/cf-manifest/operations.d/400-errands.yml
+++ b/manifests/cf-manifest/operations.d/400-errands.yml
@@ -1,5 +1,0 @@
----
-
-- type: replace
-  path: /instance_groups/name=rotate-cc-database-key/vm_extensions?/-
-  value: cf_rds_client_sg

--- a/manifests/cf-manifest/spec/manifest/database_encryption_keys_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/database_encryption_keys_spec.rb
@@ -1,0 +1,48 @@
+RSpec.describe "database encryption keys" do
+  let(:manifest) { manifest_without_vars_store }
+
+  describe "CC database encryption key" do
+    %w{
+      instance_groups.api.jobs.cloud_controller_ng.properties
+      instance_groups.cc-worker.jobs.cloud_controller_worker.properties
+      instance_groups.scheduler.jobs.cloud_controller_clock.properties
+    }.each do |job_properties_path|
+
+      it "has a default encryption key configured" do
+        properties = manifest.fetch(job_properties_path)
+
+        current_key_label = properties.fetch("cc").fetch("database_encryption").fetch("current_key_label")
+        keys = properties.fetch("cc").fetch("database_encryption").fetch("keys")
+
+        expect(current_key_label).to eq("((cc_db_encryption_key_id))")
+        expect(keys[current_key_label]).to eq("((cc_db_encryption_key))")
+      end
+
+      it "it keeps the _old key as key" do
+        properties = manifest.fetch(job_properties_path)
+
+        keys = properties.fetch("cc").fetch("database_encryption").fetch("keys")
+
+        expect(keys).to include("((cc_db_encryption_key_id))" => "((cc_db_encryption_key))")
+        expect(keys).to include("((cc_db_encryption_key_id_old))" => "((cc_db_encryption_key_old))")
+      end
+    end
+
+    it "only has ((cc_db_encryption_key)) in the expected locations" do
+      found_locations = manifest.inject([]) { |acum, v, path|
+        new_acum = acum
+        new_acum << path if v.is_a?(String) && v.include?('((cc_db_encryption_key))')
+        new_acum
+      }
+      expected_locations = %w{
+        /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/database_encryption/keys/((cc_db_encryption_key_id))
+        /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/db_encryption_key
+        /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/database_encryption/keys/((cc_db_encryption_key_id))
+        /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/db_encryption_key
+        /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/database_encryption/keys/((cc_db_encryption_key_id))
+        /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/db_encryption_key
+      }
+      expect(found_locations).to contain_exactly(*expected_locations)
+    end
+  end
+end

--- a/manifests/cf-manifest/spec/manifest/database_encryption_keys_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/database_encryption_keys_spec.rb
@@ -45,4 +45,35 @@ RSpec.describe "database encryption keys" do
       expect(found_locations).to contain_exactly(*expected_locations)
     end
   end
+
+  describe "UAA database encryption key" do
+    it "has a default encryption key configured" do
+      properties = manifest.fetch("instance_groups.uaa.jobs.uaa.properties")
+
+      active_key_label = properties.fetch("encryption").fetch("active_key_label")
+      keys = properties.fetch("encryption").fetch("encryption_keys")
+
+      expect(active_key_label).to eq("((uaa_default_encryption_passphrase_id))")
+
+      expect(keys).to include(
+        "label" => "((uaa_default_encryption_passphrase_id))",
+        "passphrase" => "((uaa_default_encryption_passphrase))",
+      )
+    end
+
+    it "it keeps the _old key as key" do
+      properties = manifest.fetch("instance_groups.uaa.jobs.uaa.properties")
+
+      keys = properties.fetch("encryption").fetch("encryption_keys")
+
+      expect(keys).to include(
+        "label" => "((uaa_default_encryption_passphrase_id))",
+        "passphrase" => "((uaa_default_encryption_passphrase))",
+      )
+      expect(keys).to include(
+        "label" => "((uaa_default_encryption_passphrase_id_old))",
+        "passphrase" => "((uaa_default_encryption_passphrase_old))",
+      )
+    end
+  end
 end

--- a/manifests/cf-manifest/spec/manifest/database_encryption_keys_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/database_encryption_keys_spec.rb
@@ -26,6 +26,16 @@ RSpec.describe "database encryption keys" do
         expect(keys).to include("((cc_db_encryption_key_id))" => "((cc_db_encryption_key))")
         expect(keys).to include("((cc_db_encryption_key_id_old))" => "((cc_db_encryption_key_old))")
       end
+
+      # FIXME: this key 'encryption_key_0' should be after the first deployment
+      # with the new ((cc_db_encryption_key_id))
+      it "the cf-deployment 'encryption_key_0' key is being temporary set" do
+        properties = manifest.fetch(job_properties_path)
+
+        keys = properties.fetch("cc").fetch("database_encryption").fetch("keys")
+
+        expect(keys).to include("encryption_key_0" => "((cc_db_encryption_key_encryption_key_0))")
+      end
     end
 
     it "only has ((cc_db_encryption_key)) in the expected locations" do
@@ -73,6 +83,19 @@ RSpec.describe "database encryption keys" do
       expect(keys).to include(
         "label" => "((uaa_default_encryption_passphrase_id_old))",
         "passphrase" => "((uaa_default_encryption_passphrase_old))",
+      )
+    end
+
+    # FIXME: this key 'encryption_key_0' should be after the first deployment
+    # with the new ((cc_db_encryption_key_id))
+    it "the cf-deployment 'default_key' key is being temporary set" do
+      properties = manifest.fetch("instance_groups.uaa.jobs.uaa.properties")
+
+      keys = properties.fetch("encryption").fetch("encryption_keys")
+
+      expect(keys).to include(
+        "label" => "default_key",
+        "passphrase" => "((uaa_default_encryption_passphrase_default_key))",
       )
     end
   end

--- a/manifests/cf-manifest/spec/scripts/rotate-vars-store-secrets_spec.rb
+++ b/manifests/cf-manifest/spec/scripts/rotate-vars-store-secrets_spec.rb
@@ -2,74 +2,74 @@ require_relative '../../scripts/rotate-vars-store-secrets.rb'
 
 RSpec.describe "rotate-cf-certs" do
   let(:manifest) {
-    YAML.safe_load <<EOS
-variables:
-- name: ca_one
-  type: certificate
-  options:
-    is_ca: true
-    common_name: internalCA1
-- name: ca_one_old
-  type: certificate
-  options:
-    is_ca: true
-    common_name: internalCA1
-- name: ca_two
-  type: certificate
-  options:
-    is_ca: true
-    common_name: internalCA2
-- name: ca_to_keep
-  type: certificate
-  options:
-    is_ca: true
-    common_name: internalCA3
-- name: leaf_one
-  type: certificate
-  options:
-    ca: ca_one
-    common_name: leaf_one.cf.internal
-- name: leaf_one_old
-  type: certificate
-  options:
-    ca: ca_one
-    common_name: leaf_one.cf.internal
-- name: leaf_two
-  type: certificate
-  options:
-    ca: ca_one
-    common_name: leaf_two.cf.internal
-- name: leaf_to_keep
-  type: certificate
-  options:
-    ca: ca_one
-    common_name: leaf_to_keep.cf.internal
-- name: passwords_one
-  type: password
-- name: passwords_one_old
-  type: password
-- name: passwords_two
-  type: password
-- name: passwords_to_keep
-  type: password
-- name: ssh_one
-  type: ssh
-- name: ssh_one_old
-  type: ssh
-- name: ssh_to_keep
-  type: ssh
-- name: ssh_two
-  type: ssh
-- name: rsa_one
-  type: rsa
-- name: rsa_one_old
-  type: rsa
-- name: rsa_two
-  type: rsa
-- name: rsa_to_keep
-  type: rsa
+    YAML.safe_load <<~FIXTURE
+      variables:
+      - name: ca_one
+        type: certificate
+        options:
+          is_ca: true
+          common_name: internalCA1
+      - name: ca_one_old
+        type: certificate
+        options:
+          is_ca: true
+          common_name: internalCA1
+      - name: ca_two
+        type: certificate
+        options:
+          is_ca: true
+          common_name: internalCA2
+      - name: ca_to_keep
+        type: certificate
+        options:
+          is_ca: true
+          common_name: internalCA3
+      - name: leaf_one
+        type: certificate
+        options:
+          ca: ca_one
+          common_name: leaf_one.cf.internal
+      - name: leaf_one_old
+        type: certificate
+        options:
+          ca: ca_one
+          common_name: leaf_one.cf.internal
+      - name: leaf_two
+        type: certificate
+        options:
+          ca: ca_one
+          common_name: leaf_two.cf.internal
+      - name: leaf_to_keep
+        type: certificate
+        options:
+          ca: ca_one
+          common_name: leaf_to_keep.cf.internal
+      - name: passwords_one
+        type: password
+      - name: passwords_one_old
+        type: password
+      - name: passwords_two
+        type: password
+      - name: passwords_to_keep
+        type: password
+      - name: ssh_one
+        type: ssh
+      - name: ssh_one_old
+        type: ssh
+      - name: ssh_to_keep
+        type: ssh
+      - name: ssh_two
+        type: ssh
+      - name: rsa_one
+        type: rsa
+      - name: rsa_one_old
+        type: rsa
+      - name: rsa_two
+        type: rsa
+      - name: rsa_to_keep
+        type: rsa
 
-EOS
+FIXTURE
   }
 
   let(:empty_vars_store) {
@@ -77,96 +77,96 @@ EOS
   }
 
   let(:vars_store) {
-    YAML.safe_load <<EOS
-ca_one:
-  ca: |
-    one
-  certificate: |
-    one
-  private_key: |
-    one
-ca_one_old:
-  ca: |
-    two
-  certificate: |
-    two
-  private_key: |
-    two
-ca_to_keep:
-  ca: |
-    to_keep
-  certificate: |
-    to_keep
-  private_key: |
-    to_keep
-ca_two:
-  ca: |
-    two
-  certificate: |
-    two
-  private_key: |
-    two
-leaf_one:
-  ca: |
-    one
-  certificate: |
-    one
-  private_key: |
-    one
-leaf_one_old:
-  ca: |
-    one_old
-  certificate: |
-    one_old
-  private_key: |
-    one_old
-leaf_one_to_keep:
-  ca: |
-    one
-  certificate: |
-    one
-  private_key: |
-    one
-leaf_two:
-  ca: |
-    two
-  certificate: |
-    two
-  private_key: |
-    two
-passwords_one: foo
-passwords_one_old: foo_old
-passwords_two: foo2
-passwords_to_keep: foo_keep
-rsa_one:
-  private_key: rsa_priv
-  public_key: rsa_pub
-rsa_one_old:
-  private_key: rsa_priv_old
-  public_key: rsa_pub_old
-rsa_two:
-  private_key: rsa_priv2
-  public_key: rsa_pub2
-rsa_to_keep:
-  private_key: rsa_priv_keep
-  public_key: rsa_pub_keep
-ssh_one:
-  private_key: Private key
-  public_key: Public key
-  public_key_fingerprint: Public key's MD5 fingerprint
-ssh_one_old:
-  private_key: Private key old
-  public_key: Public key old
-  public_key_fingerprint: Public key's MD5 fingerprint old
-ssh_two:
-  private_key: Private key 2
-  public_key: Public key 2
-  public_key_fingerprint: Public key's MD5 fingerprint 2
-ssh_to_keep:
-  private_key: Private key keep
-  public_key: Public key keep
-  public_key_fingerprint: Public key's MD5 fingerprint keep
-EOS
+    YAML.safe_load <<~FIXTURE
+      ca_one:
+        ca: |
+          one
+        certificate: |
+          one
+        private_key: |
+          one
+      ca_one_old:
+        ca: |
+          two
+        certificate: |
+          two
+        private_key: |
+          two
+      ca_to_keep:
+        ca: |
+          to_keep
+        certificate: |
+          to_keep
+        private_key: |
+          to_keep
+      ca_two:
+        ca: |
+          two
+        certificate: |
+          two
+        private_key: |
+          two
+      leaf_one:
+        ca: |
+          one
+        certificate: |
+          one
+        private_key: |
+          one
+      leaf_one_old:
+        ca: |
+          one_old
+        certificate: |
+          one_old
+        private_key: |
+          one_old
+      leaf_one_to_keep:
+        ca: |
+          one
+        certificate: |
+          one
+        private_key: |
+          one
+      leaf_two:
+        ca: |
+          two
+        certificate: |
+          two
+        private_key: |
+          two
+      passwords_one: foo
+      passwords_one_old: foo_old
+      passwords_two: foo2
+      passwords_to_keep: foo_keep
+      rsa_one:
+        private_key: rsa_priv
+        public_key: rsa_pub
+      rsa_one_old:
+        private_key: rsa_priv_old
+        public_key: rsa_pub_old
+      rsa_two:
+        private_key: rsa_priv2
+        public_key: rsa_pub2
+      rsa_to_keep:
+        private_key: rsa_priv_keep
+        public_key: rsa_pub_keep
+      ssh_one:
+        private_key: Private key
+        public_key: Public key
+        public_key_fingerprint: Public key's MD5 fingerprint
+      ssh_one_old:
+        private_key: Private key old
+        public_key: Public key old
+        public_key_fingerprint: Public key's MD5 fingerprint old
+      ssh_two:
+        private_key: Private key 2
+        public_key: Public key 2
+        public_key_fingerprint: Public key's MD5 fingerprint 2
+      ssh_to_keep:
+        private_key: Private key keep
+        public_key: Public key keep
+        public_key_fingerprint: Public key's MD5 fingerprint keep
+FIXTURE
   }
 
   let(:vars_to_preserve) {
@@ -220,6 +220,25 @@ EOS
 
         expect(rotated_vars_store).to include("#{type}_one_old" => vars_store["#{type}_one"])
       end
+
+      it "should delete only passwords set to rotate" do
+        vars_to_rotate = vars_store.keys.select { |k| (k == "#{type}_one") }
+
+        args = {
+          type.to_sym => true,
+          vars_to_preserve: vars_to_preserve,
+          vars_to_rotate: vars_to_rotate,
+        }
+        rotated_vars_store = rotate(manifest, vars_store, **args)
+
+        expect(rotated_vars_store).to_not include("#{type}_one")
+
+        remaining_secrets = vars_store.keys.reject { |k| (k == "#{type}_one") }
+        expect(rotated_vars_store.keys).to include(*remaining_secrets)
+
+        expect(rotated_vars_store).to include("#{type}_one_old" => vars_store["#{type}_one"])
+        expect(rotated_vars_store).to include("#{type}_two" => vars_store["#{type}_two"])
+      end
     end
   end
 
@@ -227,14 +246,14 @@ EOS
     it "should delete _old secrets that are not certs" do
       rotated_vars_store = rotate(manifest, vars_store, delete: true)
 
-      rotated_vars_store.each { |k, _v|
+      rotated_vars_store.each_key { |k, _v|
         unless (k.start_with? "ca_", "leaf_") && k.end_with?("_old")
           expect(k).to_not end_with "_old"
         end
       }
     end
 
-    it "should ablank existing _old certs so that they are not regenerated and kept empty" do
+    it "should blank existing _old certs so that they are not regenerated and kept empty" do
       rotated_vars_store = rotate(manifest, vars_store, delete: true)
 
       rotated_vars_store.each { |k, v|
@@ -245,6 +264,35 @@ EOS
             "private_key" => "",
           )
         end
+      }
+    end
+
+    it "should only delete _old secrets for secrets set to rotate" do
+      vars_to_rotate = vars_store.keys.select { |k| k.end_with? "_one" }
+
+      rotated_vars_store = rotate(manifest, vars_store, vars_to_rotate: vars_to_rotate, delete: true)
+
+      vars_to_rotate.each { |k|
+        if k.start_with? "ca_", "leaf_"
+          expect(rotated_vars_store["#{k}_old"]).to include(
+            "ca" => "",
+            "certificate" => "",
+            "private_key" => "",
+          )
+        else
+          expect(rotated_vars_store).to_not include("#{k}_old")
+        end
+      }
+    end
+
+    it "should not delete _old secrets for secrets not set to rotate" do
+      vars_to_rotate = vars_store.keys.select { |k| k.end_with? "_two" }
+      expected_vars_to_keep = vars_store.keys.select { |k| k.end_with? "_one" }
+
+      rotated_vars_store = rotate(manifest, vars_store, vars_to_rotate: vars_to_rotate, delete: true)
+
+      expected_vars_to_keep.each { |k|
+        expect(rotated_vars_store).to include("#{k}_old" => vars_store["#{k}_old"])
       }
     end
   end


### PR DESCRIPTION
What
----

Cloud Foundry is gradually starting to support multiple encryption keys for easier rotation. There are two types of encryption key for which this is supported we know of:

1. [UAA 4.13.0 introduced a new, required, passphrase for encryption keys used to encrypt UAA's MFA tokens](https://github.com/cloudfoundry/uaa-release/releases/tag/v58).
2. [CF release 2.9.0 changed](https://github.com/cloudfoundry/cf-deployment/releases/tag/v2.9.0) how the cloudcontroller database encryption key is specified.

Both of these support specifying multiple keys.

In this PR we implement what is needed to support the rotation of these
credentials:

 1. We add a new dedicated job `rotate-db-encryption-key`
 2. Configure the required errands to rotate the secrets in DB.
 3. Configure the manifest to support multiple encryption keys (old and new)
 4. Add logic to migrated from the default keys provided by cf-deplyoment.

To support the rotation, we use a strategy similar to the one used for
jwt verification keys for UAA[1], where the label/name of each key
is a password itself. That way we rotate both the label/name and
the value of the key in the rotation scripts.

Comments:

 - We add a dedicated job for rotation of DB keys, as it would be run
   less frequently and might be more complicated to troubleshoot. We
   had to extend the rotate-vars-store script.

 - CC rotation keys are configured in several jobs/vms. We change all
   and we add a test to double check that the key is not used in any
   new place.

 - For UAA we still do not have any encrypted value, as it is used for
   MFA. Because that I do not provide any way to check that the values
   are updated in DB, it should be checked in the future when MFA are
   implemented.

 - The rotation would be done with dedicated errands, that would
   create a VM in each run. But the bosh flag `--when-changed` is used
   so the errand only runs on config changes.

[1] https://github.com/alphagov/paas-cf/pull/1184

How to review
-------------

Code review.

Also testing it your environment. You can check how the keys change
in DB for the API DB.

The easiest is hijack the `init-db` job when `cf-terraform` is running

```
cd paas-cf
./bin/fly -t hector hijack -j create-cloudfoundry/cf-terraform -s init-db sh

# Then run
. ./cf-terraform-outputs/cf.tfstate.sh

. ./terraform-variables/cf-secrets.tfvars.sh

export PGPASSWORD=${TF_VAR_secrets_cf_db_master_password}


psql -h "${TF_VAR_cf_db_address}" -U dbadmin -d postgres <<EOF
\connect api

SELECT encryption_key_label, count(*) FROM "apps" group by encryption_key_label;

\connect uaa

select encryption_key_label, count(*) FROM user_google_mfa_credentials group by encryption_key_label;

EOF

```

As said, UAA would have no entries.

To test it:

 1. check the state in DB. It should be using the default keys.
 2. Deploy this pipeline once. Check how the errands run in
 `post-deploy`
 3. Check that the state in DB changed and it is using new keys.
 4. rerun `post-deploy`, the errands should not run.
 5. Run the  `rotate-db-encryption-keys` job in `credentials` group.
 6. Rerun all the pipeline, the errands should run.
 7. Check that the state in DB has changed again.


Dependencies
------------

A follow up PR is required to stop using the default keys from
cf-deployment. It would basically revert the latest commit.

https://github.com/alphagov/paas-cf/pull/1693

Who can review
--------------

Not me
