### PR TITLE
[#162265546] Clean up left-over CF users

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -71,6 +71,7 @@ groups:
       - bump-patch-version
       - pipeline-check-lock
       - pipeline-release-lock
+      - cleanup-deleted-cf-users
   - name: tests
     jobs:
       - app-availability-tests
@@ -3678,3 +3679,35 @@ jobs:
                 EOF
 
                 ./paas-cf/concourse/scripts/check-certificates.rb 30 < ipsec_cert.yml
+
+  - name: cleanup-deleted-cf-users
+    serial: true
+    plan:
+      - aggregate:
+        - get: paas-cf
+        - get: cf-vars-store
+
+      - task: cleanup-deleted-cf-users
+        config:
+          platform: linux
+          image_resource: *cf-cli-image-resource
+          inputs:
+            - name: paas-cf
+            - name: cf-vars-store
+          params:
+            SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+          run:
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
+
+              CF_USER=admin
+              CF_PASS=$($VAL_FROM_YAML cf_admin_password cf-vars-store/cf-vars-store.yml)
+              API_ENDPOINT="https://api.${SYSTEM_DNS_ZONE_NAME}"
+
+              echo | cf login -a "${API_ENDPOINT}" -u "${CF_USER}" -p "${CF_PASS}"
+
+              ./paas-cf/scripts/cleanup-deleted-cf-users.sh --delete

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -3167,6 +3167,7 @@ jobs:
 
   - name: rotate-cf-admin-password
     serial: true
+    serial_groups: [smoke-tests]
     plan:
     - aggregate:
       - get: paas-cf
@@ -3230,6 +3231,7 @@ jobs:
 
   - name: rotate-cloudfoundry-credentials
     serial: true
+    serial_groups: [smoke-tests]
     plan:
     - aggregate:
       - get: paas-cf

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -3577,7 +3577,6 @@ jobs:
         - get: cf-manifest
           passed: ['post-deploy']
         - get: cf-vars-store
-          passed: ['post-deploy']
 
       - task: assert-should-run
         config:

--- a/concourse/tasks/delete_admin.yml
+++ b/concourse/tasks/delete_admin.yml
@@ -9,6 +9,7 @@ inputs:
   - name: paas-cf
   - name: cf-manifest
   - name: admin-creds
+  - name: cf-vars-store
 run:
   path: sh
   args:
@@ -24,11 +25,12 @@ run:
       VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
       SYSTEM_DNS_ZONE_NAME=$($VAL_FROM_YAML instance_groups.api.jobs.cloud_controller_ng.properties.system_domain cf-manifest/cf-manifest.yml)
       API_ENDPOINT="https://api.${SYSTEM_DNS_ZONE_NAME}"
+      CF_ADMIN=admin
+      CF_PASS=$($VAL_FROM_YAML cf_admin_password cf-vars-store/cf-vars-store.yml)
       USERNAME=$(cat admin-creds/username)
-      PASSWORD=$(cat admin-creds/password)
 
       echo "Removing user ${USERNAME}"
 
-      echo | cf login -a "${API_ENDPOINT}" -u "${USERNAME}" -p "${PASSWORD}"
+      echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}"
 
       cf delete-user "${USERNAME}" -f

--- a/scripts/cleanup-deleted-cf-users.sh
+++ b/scripts/cleanup-deleted-cf-users.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+set -e -u -o pipefail
+
+delete=no
+
+for i in "$@"
+do
+  case $i in
+      --help)
+        echo "The script will gather users without usernames and will delete them"
+        echo "By default users to be deleted will only be printed, use the --delete option to really remove these users"
+        exit 1
+      ;;
+      --delete)
+      delete=yes
+      ;;
+      *)
+        echo "Unknown option: $i"
+        exit 1
+      ;;
+  esac
+done
+
+next_url="/v2/users?order-direction=desc&results-per-page=100"
+all_guids_to_delete=""
+
+while [ "${next_url}" != "null" ]; do
+  echo "Processing users from: ${next_url}"
+  cf_users=$(cf curl "${next_url}")
+  next_url=$(echo "${cf_users}" | jq '.next_url' -r)
+  length=$(echo "${cf_users}" | jq '.resources | length')
+
+  echo "Records: ${length}"
+
+  guids_to_delete=$(echo "${cf_users}" | jq '.resources[] | select(.metadata.guid|test("[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}")) | select(.entity|has("username") | not) | .metadata.guid' -r)
+
+  guids_not_uuid=$(echo "${cf_users}" | jq '.resources[] | select(.metadata.guid|test("[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}")|not) | .metadata.guid' -r)
+
+  usernames_to_keep=$(echo "${cf_users}" | jq '.resources[] | select(.metadata.guid|test("[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}")) | select(.entity|has("username")) | .entity.username' -r)
+
+  if [ -n "${guids_not_uuid}" ]; then
+    cnt=$(echo "${guids_not_uuid}" | wc -l | tr -d ' ')
+    echo "Keeping users with non-uuid guid (${cnt}): "
+    echo "${guids_not_uuid}"
+  fi
+
+  if [ -n "${usernames_to_keep}" ]; then
+    cnt=$(echo "${usernames_to_keep}" | wc -l | tr -d ' ')
+    echo "Keeping users with usernames: (${cnt})"
+    echo "${usernames_to_keep}"
+  fi
+
+  if [ -n "${guids_to_delete}" ]; then
+    cnt=$(echo "${guids_to_delete}" | wc -l | tr -d ' ')
+    echo "The following guids will be deleted: (${cnt})"
+    echo "${guids_to_delete}"
+
+    all_guids_to_delete="${all_guids_to_delete}${guids_to_delete}
+"
+  fi
+done
+
+if [ -z "${all_guids_to_delete}" ]; then
+  echo
+  echo "Nothing to delete"
+  echo
+  exit 0
+fi
+
+# This seemingly useless line strips the trailing new line from the end
+# shellcheck disable=SC2116
+all_guids_to_delete=$(echo "${all_guids_to_delete}")
+
+if [ "${delete}" == "yes" ]; then
+  cnt=$(echo "${all_guids_to_delete}" | wc -l | tr -d ' ')
+  echo
+  echo "Deleting ${cnt} users"
+  echo
+
+  while read -r guid; do
+    echo "Deleting ${guid}"
+    cf curl -X DELETE "/v2/users/${guid}"
+  done <<< "${all_guids_to_delete}"
+
+  echo
+  echo "Finished"
+  echo
+else
+  echo
+  echo "No users were deleted, use the --delete option"
+  echo
+fi


### PR DESCRIPTION
# What

We have a lot of users in CF which don't exist in UAA. These users don't have a username field in the CF API response.

Most of these users are created by the continuous smoke tests. When the tests finish we delete the user with itself but we failed to recognise that the user is not fully deleted.

We'll change the helper tasks to delete the temporary admin user with the global admin.

If the admin user's credentials are rotated the smoke tests could fail, therefore we make sure the creds rotation and the smoke tests don't run at the same time and also the continuous smoke tests always use the latest credentials/manifest variables.

I created a script to clean up the left-over users under `scripts/clean_up_cf_users.sh`.

A user:
 * will be skipped if a guid is not a UUID (some UAA clients)
 * will be skipped if it has a username
 * will be deleted otherwise

# How to review

1. Update your pipeline and run the continuous smoke tests
2. Run the script without any options on your dev and check if the numbers match.
3. Run the script with the `--delete` option on your dev env

After the clean up no left-over users should be present and no new ones should be created.

# Who can review

Not me.