### PR TITLE
[#161591823] Consume bosh client password from bosh-vars-store.yml

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -43,12 +43,12 @@ resources:
       stop: 6:00 -0000
       interval: 2h
 
-  - name: bosh-secrets
+  - name: bosh-vars-store
     type: s3-iam
     source:
       bucket: ((state_bucket))
       region_name: ((aws_region))
-      versioned_file: bosh-secrets.yml
+      versioned_file: bosh-vars-store.yml
 
   - name: bosh-CA-crt
     type: s3-iam
@@ -70,7 +70,7 @@ jobs:
     plan:
       - get: delete-timer
         trigger: true
-      - get: bosh-secrets
+      - get: bosh-vars-store
       - get: paas-cf
       - get: cf-vars-store
       - get: cf-manifest
@@ -123,7 +123,7 @@ jobs:
           platform: linux
           inputs:
             - name: delete-timer
-            - name: bosh-secrets
+            - name: bosh-vars-store
             - name: paas-cf
             - name: bosh-CA-crt
           params:
@@ -144,9 +144,10 @@ jobs:
               - |
                 VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
                 BOSH_CLIENT=admin
-                BOSH_CLIENT_SECRET=$($VAL_FROM_YAML secrets.bosh_admin_password bosh-secrets/bosh-secrets.yml)
+                BOSH_CLIENT_SECRET=$($VAL_FROM_YAML admin_password bosh-vars-store/bosh-vars-store.yml)
                 export BOSH_CLIENT
                 export BOSH_CLIENT_SECRET
+
 
                 bosh -n delete-deployment --force --deployment "((deploy_env))"
                 bosh -n delete-deployment --force --deployment prometheus

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1054,20 +1054,6 @@ jobs:
                   tar -xzf ./ipsec-CA/ipsec-CA.tar.gz -C ./ipsec-CA
                   cp cf-vars-store/cf-vars-store.yml cf-vars-store-updated/
 
-                  # FIXME: populate the old value of 'encryption_key_0' for CC
-                  # and 'default_key' for UAA.
-                  # These keys should be removed after the first deployment
-                  # of this code.
-                  if ! grep -e '^cc_db_encryption_key_encryption_key_0:' cf-vars-store/cf-vars-store.yml; then
-                    awk '
-                      /^cc_db_encryption_key:/ {print "cc_db_encryption_key_encryption_key_0:", $2}
-                      /^uaa_default_encryption_passphrase:/ {print "uaa_default_encryption_passphrase_default_key:", $2}
-                      {print}
-                    ' \
-                    < cf-vars-store/cf-vars-store.yml \
-                    > cf-vars-store-updated/cf-vars-store.yml
-                  fi
-
                   VARS_STORE=cf-vars-store-updated/cf-vars-store.yml \
                     ./paas-cf/manifests/cf-manifest/scripts/generate-manifest.sh \
                       > cf-manifest/cf-manifest.yml
@@ -3306,8 +3292,6 @@ jobs:
                 --preserve uaa_clients_tcp_router_secret \
                 --preserve uaa_default_encryption_passphrase \
                 --preserve uaa_default_encryption_passphrase_id \
-                --preserve cc_db_encryption_key_encryption_key_0 \
-                --preserve uaa_default_encryption_passphrase_default_key \
                 > modified-cf-vars-store/cf-vars-store.yml
       on_success:
         do:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -151,12 +151,12 @@ resources:
       region_name: ((aws_region))
       versioned_file: bosh.tfstate
 
-  - name: bosh-secrets
+  - name: bosh-vars-store
     type: s3-iam
     source:
       bucket: ((state_bucket))
       region_name: ((aws_region))
-      versioned_file: bosh-secrets.yml
+      versioned_file: bosh-vars-store.yml
 
   - name: bosh-CA-crt
     type: s3-iam
@@ -1087,7 +1087,7 @@ jobs:
             passed: ['generate-cf-config']
           - get: cf-manifest
             passed: ['generate-cf-config']
-          - get: bosh-secrets
+          - get: bosh-vars-store
           - get: bosh-CA-crt
 
       - aggregate:
@@ -1096,7 +1096,7 @@ jobs:
             platform: linux
             image_resource: *gov-paas-bosh-cli-v2-image-resource
             inputs:
-              - name: bosh-secrets
+              - name: bosh-vars-store
               - name: paas-cf
               - name: cf-manifest
               - name: bosh-CA-crt
@@ -1113,7 +1113,7 @@ jobs:
                   VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
 
                   BOSH_CLIENT=admin
-                  BOSH_CLIENT_SECRET=$($VAL_FROM_YAML secrets.bosh_admin_password bosh-secrets/bosh-secrets.yml)
+                  BOSH_CLIENT_SECRET=$($VAL_FROM_YAML admin_password bosh-vars-store/bosh-vars-store.yml)
                   export BOSH_CLIENT
                   export BOSH_CLIENT_SECRET
 
@@ -1139,7 +1139,7 @@ jobs:
             image_resource: *gov-paas-bosh-cli-v2-image-resource
             inputs:
               - name: cloud-config
-              - name: bosh-secrets
+              - name: bosh-vars-store
               - name: paas-cf
               - name: bosh-CA-crt
             params:
@@ -1154,7 +1154,7 @@ jobs:
                 - |
                   VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
                   BOSH_CLIENT=admin
-                  BOSH_CLIENT_SECRET=$($VAL_FROM_YAML secrets.bosh_admin_password bosh-secrets/bosh-secrets.yml)
+                  BOSH_CLIENT_SECRET=$($VAL_FROM_YAML admin_password bosh-vars-store/bosh-vars-store.yml)
                   export BOSH_CLIENT
                   export BOSH_CLIENT_SECRET
 
@@ -1167,7 +1167,7 @@ jobs:
           inputs:
             - name: paas-cf
             - name: cf-manifest
-            - name: bosh-secrets
+            - name: bosh-vars-store
             - name: bosh-CA-crt
           params:
             BOSH_ENVIRONMENT: ((bosh_fqdn))
@@ -1181,7 +1181,7 @@ jobs:
               - |
                 VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
                 BOSH_CLIENT=admin
-                BOSH_CLIENT_SECRET=$($VAL_FROM_YAML secrets.bosh_admin_password bosh-secrets/bosh-secrets.yml)
+                BOSH_CLIENT_SECRET=$($VAL_FROM_YAML admin_password bosh-vars-store/bosh-vars-store.yml)
                 export BOSH_CLIENT
                 export BOSH_CLIENT_SECRET
 
@@ -1197,7 +1197,7 @@ jobs:
           - get: paas-cf
             passed: ['cf-deploy']
           - get: prometheus-vars-store
-          - get: bosh-secrets
+          - get: bosh-vars-store
           - get: bosh-CA-crt
           - get: cf-vars-store
           - get: cf-tfstate
@@ -1222,9 +1222,6 @@ jobs:
                   < cf-tfstate/cf.tfstate \
                   > terraform-outputs/cf.yml
 
-
-
-
       - task: generate-prometheus-manifest
         config:
           platform: linux
@@ -1232,7 +1229,7 @@ jobs:
           inputs:
             - name: paas-cf
             - name: prometheus-vars-store
-            - name: bosh-secrets
+            - name: bosh-vars-store
             - name: bosh-CA-crt
             - name: cf-vars-store
             - name: terraform-outputs
@@ -1253,7 +1250,6 @@ jobs:
               - -u
               - -c
               - |
-
                 VARS_FILES="
                   ./prometheus-vars-file.yml
                   ./terraform-outputs/cf.yml
@@ -1263,7 +1259,7 @@ jobs:
 
                 bosh interpolate - \
                   --var-errs \
-                  --vars-file bosh-secrets/bosh-secrets.yml \
+                  --vars-file bosh-vars-store/bosh-vars-store.yml \
                   --vars-file cf-vars-store/cf-vars-store.yml \
                   --var-file bosh_ca_cert=./bosh-CA-crt/bosh-CA.crt \
                 > ./prometheus-vars-file.yml \
@@ -1271,7 +1267,7 @@ jobs:
                 ---
                 metrics_environment: $CF_DEPLOYMENT_NAME
                 bosh_url: $BOSH_URL
-                uaa_bosh_exporter_client_secret: ((secrets.bosh_bosh_exporter_password))
+                uaa_bosh_exporter_client_secret: ((bosh_exporter_password))
                 bosh_ca_cert: ((bosh_ca_cert))
                 system_domain: $SYSTEM_DNS_ZONE_NAME
                 app_domain: ((apps_dns_zone_name))
@@ -1338,7 +1334,7 @@ jobs:
           inputs:
             - name: paas-cf
             - name: prometheus-manifest
-            - name: bosh-secrets
+            - name: bosh-vars-store
             - name: bosh-CA-crt
           params:
             BOSH_ENVIRONMENT: ((bosh_fqdn))
@@ -1352,7 +1348,7 @@ jobs:
               - |
                 VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
                 BOSH_CLIENT=admin
-                BOSH_CLIENT_SECRET=$($VAL_FROM_YAML secrets.bosh_admin_password bosh-secrets/bosh-secrets.yml)
+                BOSH_CLIENT_SECRET=$($VAL_FROM_YAML admin_password bosh-vars-store/bosh-vars-store.yml)
                 export BOSH_CLIENT
                 export BOSH_CLIENT_SECRET
 
@@ -1442,7 +1438,7 @@ jobs:
         passed: ['generate-cf-config']
       - get: cf-tfstate
         passed: ['generate-cf-config']
-      - get: bosh-secrets
+      - get: bosh-vars-store
         passed: ['cf-deploy']
       - get: cf-vars-store
         passed: ['generate-cf-config']
@@ -2420,7 +2416,7 @@ jobs:
           image_resource: *gov-paas-bosh-cli-v2-image-resource
           inputs:
             - name: paas-cf
-            - name: bosh-secrets
+            - name: bosh-vars-store
             - name: bosh-CA-crt
           params:
             BOSH_ENVIRONMENT: ((bosh_fqdn))
@@ -2434,7 +2430,7 @@ jobs:
               - |
                 VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
                 BOSH_CLIENT=admin
-                BOSH_CLIENT_SECRET=$($VAL_FROM_YAML secrets.bosh_admin_password bosh-secrets/bosh-secrets.yml)
+                BOSH_CLIENT_SECRET=$($VAL_FROM_YAML admin_password bosh-vars-store/bosh-vars-store.yml)
                 export BOSH_CLIENT
                 export BOSH_CLIENT_SECRET
 
@@ -2446,7 +2442,7 @@ jobs:
             image_resource: *gov-paas-bosh-cli-v2-image-resource
             inputs:
               - name: paas-cf
-              - name: bosh-secrets
+              - name: bosh-vars-store
               - name: bosh-CA-crt
             params:
               BOSH_ENVIRONMENT: ((bosh_fqdn))
@@ -2460,7 +2456,7 @@ jobs:
                 - |
                   VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
                   BOSH_CLIENT=admin
-                  BOSH_CLIENT_SECRET=$($VAL_FROM_YAML secrets.bosh_admin_password bosh-secrets/bosh-secrets.yml)
+                  BOSH_CLIENT_SECRET=$($VAL_FROM_YAML admin_password bosh-vars-store/bosh-vars-store.yml)
                   export BOSH_CLIENT
                   export BOSH_CLIENT_SECRET
 
@@ -2472,7 +2468,7 @@ jobs:
             image_resource: *gov-paas-bosh-cli-v2-image-resource
             inputs:
               - name: paas-cf
-              - name: bosh-secrets
+              - name: bosh-vars-store
               - name: bosh-CA-crt
             params:
               BOSH_ENVIRONMENT: ((bosh_fqdn))
@@ -2486,7 +2482,7 @@ jobs:
                 - |
                   VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
                   BOSH_CLIENT=admin
-                  BOSH_CLIENT_SECRET=$($VAL_FROM_YAML secrets.bosh_admin_password bosh-secrets/bosh-secrets.yml)
+                  BOSH_CLIENT_SECRET=$($VAL_FROM_YAML admin_password bosh-vars-store/bosh-vars-store.yml)
                   export BOSH_CLIENT
                   export BOSH_CLIENT_SECRET
 
@@ -2953,7 +2949,7 @@ jobs:
           - get: paas-cf
             passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
           - get: cf-manifest
-          - get: bosh-secrets
+          - get: bosh-vars-store
           - get: bosh-CA-crt
       - task: test-bosh-vms
         config:
@@ -2962,7 +2958,7 @@ jobs:
           inputs:
             - name: paas-cf
             - name: cf-manifest
-            - name: bosh-secrets
+            - name: bosh-vars-store
             - name: bosh-CA-crt
           params:
             BOSH_ENVIRONMENT: ((bosh_fqdn))
@@ -2976,7 +2972,7 @@ jobs:
               - |
                 VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
                 BOSH_CLIENT=admin
-                BOSH_CLIENT_SECRET=$($VAL_FROM_YAML secrets.bosh_admin_password bosh-secrets/bosh-secrets.yml)
+                BOSH_CLIENT_SECRET=$($VAL_FROM_YAML admin_password bosh-vars-store/bosh-vars-store.yml)
                 export BOSH_CLIENT
                 export BOSH_CLIENT_SECRET
 

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -49,12 +49,12 @@ resources:
       region_name: ((aws_region))
       key: ((pipeline_trigger_file))
 
-  - name: bosh-secrets
+  - name: bosh-vars-store
     type: s3-iam
     source:
       bucket: ((state_bucket))
       region_name: ((aws_region))
-      versioned_file: bosh-secrets.yml
+      versioned_file: bosh-vars-store.yml
 
   - name: bosh-CA-crt
     type: s3-iam
@@ -139,7 +139,7 @@ jobs:
           - get: pipeline-trigger
             passed: ['init']
             trigger: true
-          - get: bosh-secrets
+          - get: bosh-vars-store
           - get: paas-cf
           - get: cf-vars-store
           - get: cf-manifest
@@ -181,7 +181,7 @@ jobs:
               repository: governmentpaas/bosh-cli-v2
               tag: 4012d25ceb903b46908a830b8e05773ced1c8f86
           inputs:
-            - name: bosh-secrets
+            - name: bosh-vars-store
             - name: paas-cf
             - name: bosh-CA-crt
           params:
@@ -197,7 +197,7 @@ jobs:
               - |
                 VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
                 BOSH_CLIENT=admin
-                BOSH_CLIENT_SECRET=$($VAL_FROM_YAML secrets.bosh_admin_password bosh-secrets/bosh-secrets.yml)
+                BOSH_CLIENT_SECRET=$($VAL_FROM_YAML admin_password bosh-vars-store/bosh-vars-store.yml)
                 export BOSH_CLIENT
                 export BOSH_CLIENT_SECRET
 

--- a/manifests/cf-manifest/operations.d/320-cc-database-key-rotation.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-database-key-rotation.yml
@@ -10,8 +10,6 @@
     keys:
       ((cc_db_encryption_key_id)): "((cc_db_encryption_key))"
       ((cc_db_encryption_key_id_old)): "((cc_db_encryption_key_old))"
-      # FIXME: remove this key once we have deployed and rotated this once
-      encryption_key_0: "((cc_db_encryption_key_encryption_key_0))"
 
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/database_encryption?
@@ -37,11 +35,4 @@
   path: /variables/-
   value:
     name: cc_db_encryption_key_id_old
-    type: password
-
-# FIXME: remove this key once we have deployed and rotated this once
-- type: replace
-  path: /variables/-
-  value:
-    name: cc_db_encryption_key_encryption_key_0
     type: password

--- a/manifests/cf-manifest/operations.d/331-uaa-database-key-rotation.yml
+++ b/manifests/cf-manifest/operations.d/331-uaa-database-key-rotation.yml
@@ -26,9 +26,6 @@
       passphrase: ((uaa_default_encryption_passphrase))
     - label: ((uaa_default_encryption_passphrase_id_old))
       passphrase: ((uaa_default_encryption_passphrase_old))
-    # FIXME: remove this key once we have deployed and rotated this once
-    - label: default_key
-      passphrase: ((uaa_default_encryption_passphrase_default_key))
 
 - type: replace
   path: /variables/-
@@ -46,11 +43,4 @@
   path: /variables/-
   value:
     name: uaa_default_encryption_passphrase_id_old
-    type: password
-
-# FIXME: remove this key once we have deployed and rotated this once
-- type: replace
-  path: /variables/-
-  value:
-    name: uaa_default_encryption_passphrase_default_key
     type: password

--- a/manifests/cf-manifest/spec/manifest/database_encryption_keys_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/database_encryption_keys_spec.rb
@@ -26,16 +26,6 @@ RSpec.describe "database encryption keys" do
         expect(keys).to include("((cc_db_encryption_key_id))" => "((cc_db_encryption_key))")
         expect(keys).to include("((cc_db_encryption_key_id_old))" => "((cc_db_encryption_key_old))")
       end
-
-      # FIXME: this key 'encryption_key_0' should be after the first deployment
-      # with the new ((cc_db_encryption_key_id))
-      it "the cf-deployment 'encryption_key_0' key is being temporary set" do
-        properties = manifest.fetch(job_properties_path)
-
-        keys = properties.fetch("cc").fetch("database_encryption").fetch("keys")
-
-        expect(keys).to include("encryption_key_0" => "((cc_db_encryption_key_encryption_key_0))")
-      end
     end
 
     it "only has ((cc_db_encryption_key)) in the expected locations" do
@@ -83,19 +73,6 @@ RSpec.describe "database encryption keys" do
       expect(keys).to include(
         "label" => "((uaa_default_encryption_passphrase_id_old))",
         "passphrase" => "((uaa_default_encryption_passphrase_old))",
-      )
-    end
-
-    # FIXME: this key 'encryption_key_0' should be after the first deployment
-    # with the new ((cc_db_encryption_key_id))
-    it "the cf-deployment 'default_key' key is being temporary set" do
-      properties = manifest.fetch("instance_groups.uaa.jobs.uaa.properties")
-
-      keys = properties.fetch("encryption").fetch("encryption_keys")
-
-      expect(keys).to include(
-        "label" => "default_key",
-        "passphrase" => "((uaa_default_encryption_passphrase_default_key))",
       )
     end
   end


### PR DESCRIPTION
What
----

In https://github.com/alphagov/paas-bootstrap/pull/230 we migrated
to bosh-deployment and generate the secrets using `bosh interpolate`.

The bosh secrets are now stored in the file `bosh-vars-store.yml`

We update wherever we consume these secrets in the current project.

Dependencies
-------------


 - Based on: https://github.com/alphagov/paas-cf/pull/1693 and
   https://github.com/alphagov/paas-cf/pull/1692, rebase once merged.

 - Review and merge first https://github.com/alphagov/paas-bootstrap/pull/230

How to review
-------------

Code review
Test the pipeline

Who can review
--------------

Not me