### PR TITLE
[#162869390] Update to stemcell 170.15 to cover usn-3840-1

### DIFF
--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-xenial
-      version: "170.12"
+      version: "170.15"


### PR DESCRIPTION
What
----

The CVE usn-3840-1 [1] affects stemcells prior 170.14. We update
to the latest available stemcell.

[1] https://www.cloudfoundry.org/blog/usn-3840-1/

How to review
-------------

Code review

Who can review
--------------

Not me