### PR TITLE
[#162156376] Disable email alerts on development environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,7 @@ dev: globals ## Set Environment to DEV
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
 	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipelineapps.digital)
 	$(eval export ALERT_EMAIL_ADDRESS=govpaas-alerting-dev@digital.cabinet-office.gov.uk)
+	$(eval export ENABLE_ALERT_EMAILS=false)
 	$(eval export SKIP_COMMIT_VERIFICATION=true)
 	$(eval export ENV_SPECIFIC_BOSH_VARS_FILE=default.yml)
 	$(eval export DISABLE_HEALTHCHECK_DB=true)

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -448,6 +448,7 @@ jobs:
             AWS_DEFAULT_REGION: ((aws_region))
             SELF_UPDATE_PIPELINE: ((self_update_pipeline))
             PIPELINES_TO_UPDATE: ((pipeline_name))
+            ENABLE_ALERT_EMAILS: ((ENABLE_ALERT_EMAILS))
             BOSH_AZ: ((bosh_az))
             SKIP_AWS_CREDENTIAL_VALIDATION: true
             NEW_ACCOUNT_EMAIL_ADDRESS: ((NEW_ACCOUNT_EMAIL_ADDRESS))
@@ -1242,6 +1243,7 @@ jobs:
             CF_DEPLOYMENT_NAME: ((deploy_env))
             BOSH_URL: https://((bosh_fqdn)):25555
             METRON_DEPLOYMENT_NAME: ((deploy_env))
+            ENABLE_ALERT_EMAILS: ((ENABLE_ALERT_EMAILS))
           run:
             path: sh
             args:
@@ -3387,7 +3389,7 @@ jobs:
             DEPLOY_ENV: ((deploy_env))
             SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
             ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
-            EMAIL_ON_SMOKE_TEST_FAILURE: true
+            EMAIL_ON_SMOKE_TEST_FAILURE: ((ENABLE_ALERT_EMAILS))
           on_failure:
             put: pagerduty-notify
             params:

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -118,6 +118,7 @@ system_dns_zone_name: ${SYSTEM_DNS_ZONE_NAME}
 apps_dns_zone_name: ${APPS_DNS_ZONE_NAME}
 git_concourse_pool_clone_full_url_ssh: ${git_concourse_pool_clone_full_url_ssh}
 ALERT_EMAIL_ADDRESS: ${ALERT_EMAIL_ADDRESS:-}
+ENABLE_ALERT_EMAILS: ${ENABLE_ALERT_EMAILS:-true}
 NEW_ACCOUNT_EMAIL_ADDRESS: "${NEW_ACCOUNT_EMAIL_ADDRESS:-}"
 disable_healthcheck_db: ${DISABLE_HEALTHCHECK_DB:-}
 test_heavy_load: ${TEST_HEAVY_LOAD:-false}

--- a/manifests/prometheus/operations/disable-email.yml
+++ b/manifests/prometheus/operations/disable-email.yml
@@ -1,0 +1,6 @@
+---
+- type: remove
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers/name=warning-receiver/email_configs
+
+- type: remove
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers/name=critical-receiver/email_configs

--- a/manifests/prometheus/scripts/generate-manifest.sh
+++ b/manifests/prometheus/scripts/generate-manifest.sh
@@ -6,6 +6,7 @@ PAAS_CF_DIR=${PAAS_CF_DIR:-paas-cf}
 PROM_BOSHRELEASE_DIR=${PAAS_CF_DIR}/manifests/prometheus/upstream
 WORKDIR=${WORKDIR:-.}
 
+
 opsfile_args=""
 for i in "${PAAS_CF_DIR}"/manifests/prometheus/operations.d/*.yml; do
   opsfile_args+="-o $i "
@@ -24,6 +25,10 @@ done
 vars_store_args=""
 if [ -n "${VARS_STORE:-}" ]; then
   vars_store_args=" --var-errs --vars-store ${VARS_STORE}"
+fi
+
+if [ "${ENABLE_ALERT_EMAILS:-}" == "false" ]; then
+  opsfile_args+="-o ${PAAS_CF_DIR}/manifests/prometheus/operations/disable-email.yml"
 fi
 
 # shellcheck disable=SC2086


### PR DESCRIPTION
What
----

We want to stop the dev environments from sending email notifications
unless enabled.

We disable the notifications for the smoke tests and for the alert
manager, by adding a new parameter ENABLE_ALERT_EMAILS, that
is true by default and set to false in dev.

In prometheus, setting ENABLE_ALERT_EMAILS would add an opsfile
that removes the email_configs from the alert manager.

How to review
-------------

Code review

Who can review
--------------

Not me