### PR TITLE
Update prometheus sha1 to use bosh.io

### DIFF
--- a/manifests/cf-manifest/operations.d/510-add-prometheus-blackbox-exporter.yml
+++ b/manifests/cf-manifest/operations.d/510-add-prometheus-blackbox-exporter.yml
@@ -5,7 +5,7 @@
     name: "prometheus"
     version: "23.1.0"
     url: "https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=23.1.0"
-    sha1: "23e5f469c2e290efefde1166107f874c32374ff7"
+    sha1: "d9ef31b8e57d8668de14cdf976cbaffa78a80897"
 
 - type: replace
   path: /addons?/-


### PR DESCRIPTION
What
----

We had the github sha1 in the manifest despite pulling the release from
bosh.io. This commit updates it to keep it in sync.

How to review
-------------

Check the sha1 against [the bosh.io release](https://bosh.io/releases/github.com/cloudfoundry-community/prometheus-boshrelease?version=23.1.0)

Who can review
--------------

Anyone
