### PR TITLE
[#162753042] Use cf-deployment.yml manifest to check buildpacks

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2922,7 +2922,7 @@ jobs:
                     ruby <<-RUBY
                     require 'yaml'
                     YAML
-                      .load_file('cf-manifest/cf-manifest.yml')
+                      .load_file('paas-cf/manifests/cf-deployment/cf-deployment.yml')
                       .fetch('instance_groups', [])
                       .find { |g| g['name'] == 'api' }
                       .fetch('jobs', [])


### PR DESCRIPTION
What
----

We had a small script to check that all the expected buildpacks
defined in the manifest are deployed, but we do not install
the buildpacks using manifests anymore.

We will replace the manifest used for reference, and pull from
the upstream cf-deployment.yml. We expect the same buildpacks
are installed.

How to review
-------------

Code review

Who can review
--------------

Not me