### PR TITLE
[#SUPPORT] Decrease SQL metric collection interval to 60s

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -43,7 +43,7 @@
           client_cert: "((diego_locket_client.certificate))"
           client_key: "((diego_locket_client.private_key))"
         scheduler:
-          sql_metrics_collector_interval: 150
+          sql_metrics_collector_interval: 60
           cloudwatch_metrics_collector_interval: 300
 
 - type: replace


### PR DESCRIPTION
What
----

It was originally 1 minute, no need to be more, and we can get
better resolution.

Cloudwatch is still 300s because it is expensive.

How to review
-------------

Code review

Who can review
--------------

not me