### PR TITLE
[SUPPORT] Use the $CF_HOME env var in org-usage-report.sh

### DIFF
--- a/scripts/org-usage-report.sh
+++ b/scripts/org-usage-report.sh
@@ -2,13 +2,14 @@
 
 set -eu
 
+CF_HOME=${CF_HOME:-~}
 UAA_TOKEN=$(cf oauth-token)
-UAA_API=$(jq -r '.UaaEndpoint' < ~/.cf/config.json)
+UAA_API=$(jq -r '.UaaEndpoint' < "${CF_HOME}/.cf/config.json")
 
 # Assert logged in
 cf target > /dev/null
 
-TARGET=$(jq -r '.Target' < ~/.cf/config.json)
+TARGET=$(jq -r '.Target' < "${CF_HOME}/.cf/config.json")
 echo "Targetting CF API: $TARGET" 1>&2
 
 paginate() {


### PR DESCRIPTION
What
----

Use the $CF_HOME env var in org-usage-report.sh.

This way we can run the script from a subshell created by the cf_subshell_scoped_login.sh script.

How to review
-------------

Code review and/or run the script

How to merge
---------

It’s okay to merge it from the Github UI by adding `[skip ci]` to the merge commit message

Who can review
--------------

Anyone