### PR TITLE
[#162475628] Update the rds broker bosh release

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 0.1.47
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.47.tgz
-    sha1: 16f467a6ae0fa3994ed0dd8e4199b2cbcfebf314
+    version: 0.1.50 
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.50.tgz
+    sha1: 3de23a9b34eab9c08d337613f594778642c67fa3
 
 - type: replace
   path: /instance_groups/-
@@ -110,4 +110,3 @@
       extended_key_usage:
         - client_auth
         - server_auth
-


### PR DESCRIPTION
What
----

* update the rds-broker to support restarting RDS instances
* update the rds-broker-metrics-collector to be more resilient and handle sql query timeouts properly
* fix the bosh release so the `sql_metrics_collector_interval` and `cloudwatch_metrics_collector_interval` config values are correctly written into the config json (this fix will change the effective sql metrics collection interval to 1 minute)

How to review
-------------

Review the following PRs first (these were partially reviewed by me):
 * https://github.com/alphagov/paas-rds-broker/pull/94
 * https://github.com/alphagov/paas-rds-metric-collector/pull/16
 * https://github.com/alphagov/paas-rds-broker-boshrelease/pull/76

1. Deploy the pipeline from this branch
1. Check if the metrics collector still works as expected
1. Optionally you can re-check what happens if an RDS service (both Multi-AZ and simple) is restarted, with or without forcing a failover - there should be no more than a couple of minutes sql metrics missing

How to merge
-------------

1. Merge https://github.com/alphagov/paas-rds-broker/pull/94
1. Update and merge https://github.com/alphagov/paas-rds-metric-collector/pull/16
1. Update (both repos) and merge https://github.com/alphagov/paas-rds-broker-boshrelease/pull/76
1. Update this repo with the final release version and merge

Who can review
--------------

Not me.