### PR TITLE
[#163113585] Fix noisy alerts

### DIFF
--- a/manifests/prometheus/alerts.d/bosh-high-cpu-utilisation.yml
+++ b/manifests/prometheus/alerts.d/bosh-high-cpu-utilisation.yml
@@ -23,3 +23,12 @@
         expr: "bosh_job:bosh_job_cpu:avg1h > 90"
         labels:
           severity: critical
+
+# FIXME: there is no easy way currently to remove upstream alerts
+# This effectively disables the upstream CPU alert by increasing the threshold to a really high value
+# If a node has a really high load for a long time it's still useful to know about it
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=bosh_alerts/properties?/bosh_alerts/job_high_cpu_load
+  value:
+    threshold: 50
+    evaluation_time: 1h

--- a/manifests/prometheus/alerts.d/cc-latency-by-gorouter.yml
+++ b/manifests/prometheus/alerts.d/cc-latency-by-gorouter.yml
@@ -6,12 +6,9 @@
   value:
     name: CloudControllerLatencyByGorouter
     rules:
-      - record: "cc:firehose_value_metric_gorouter_latency_cloud_controller:avg10m"
-        expr: avg(avg_over_time(firehose_value_metric_gorouter_latency_cloud_controller[10m]))
-
       - &alert
         alert: CloudControllerLatencyByGorouter_Warning
-        expr: cc:firehose_value_metric_gorouter_latency_cloud_controller:avg10m > 200
+        expr: avg(avg_over_time(firehose_value_metric_gorouter_latency_cloud_controller[30m])) > 500
         labels:
           severity: warning
         annotations:
@@ -20,6 +17,6 @@
 
       - <<: *alert
         alert: CloudControllerLatencyByGorouter_Critical
-        expr: cc:firehose_value_metric_gorouter_latency_cloud_controller:avg10m > 250
+        expr: avg(avg_over_time(firehose_value_metric_gorouter_latency_cloud_controller[10m])) > 1000
         labels:
           severity: critical

--- a/manifests/prometheus/alerts.d/cloud-controller-unregistry.yml
+++ b/manifests/prometheus/alerts.d/cloud-controller-unregistry.yml
@@ -7,8 +7,7 @@
     name: CFCloudControllerUnregistry
     rules:
     - alert: CFCloudControllerUnregistry
-      expr: avg(rate(firehose_counter_event_gorouter_unregistry_message_cloud_controller_total[10m])*60*10) or vector(0) > 1.5
-      for: 10m
+      expr: avg(increase(firehose_counter_event_gorouter_unregistry_message_cloud_controller_total[10m])) >= 10
       labels:
         severity: critical
       annotations:

--- a/manifests/prometheus/alerts.d/dns-resolution-time.yml
+++ b/manifests/prometheus/alerts.d/dns-resolution-time.yml
@@ -8,7 +8,7 @@
     rules:
     - &alert
       alert: DNSResolutionTime_Warning
-      expr: avg_over_time(dns_resolution_probe_duration_seconds[5m]) > 0.1
+      expr: avg_over_time(dns_resolution_probe_duration_seconds[10m]) > 0.2
       labels:
         severity: warning
       annotations:
@@ -17,6 +17,6 @@
 
     - <<: *alert
       alert: DNSResolutionTime_Critical
-      expr: avg_over_time(dns_resolution_probe_duration_seconds[5m]) > 0.2
+      expr: avg_over_time(dns_resolution_probe_duration_seconds[10m]) > 0.5
       labels:
         severity: critical

--- a/manifests/prometheus/alerts.d/dns-resolution-working.yml
+++ b/manifests/prometheus/alerts.d/dns-resolution-working.yml
@@ -9,6 +9,7 @@
     - &alert
       alert: DNSResolutionWorking_Warning
       expr: (count_over_time(dns_resolution_probe_success[5m]) - sum_over_time(dns_resolution_probe_success[5m])) / count_over_time(dns_resolution_probe_success[5m]) > 0.25
+      for: 10m
       labels:
         severity: warning
       annotations:

--- a/manifests/prometheus/alerts.d/gorouter-latency.yml
+++ b/manifests/prometheus/alerts.d/gorouter-latency.yml
@@ -6,12 +6,10 @@
   value:
     name: GorouterLatency
     rules:
-      - record: "cc:firehose_value_metric_gorouter_latency:avg10m"
-        expr: avg_over_time(firehose_value_metric_gorouter_latency[10m])
-
       - &alert
         alert: GorouterLatency_Warning
-        expr: cc:firehose_value_metric_gorouter_latency:avg10m > 750
+        expr: min(avg_over_time(firehose_value_metric_gorouter_latency[5m])) > 750
+        for: 15m
         labels:
           severity: warning
         annotations:
@@ -21,6 +19,6 @@
 
       - <<: *alert
         alert: GorouterLatency_Critical
-        expr: cc:firehose_value_metric_gorouter_latency:avg10m > 1500
+        expr: min(avg_over_time(firehose_value_metric_gorouter_latency[5m])) > 1500
         labels:
           severity: critical

--- a/manifests/prometheus/alerts.d/router_total_routes.yml
+++ b/manifests/prometheus/alerts.d/router_total_routes.yml
@@ -43,7 +43,7 @@
           )
           / on() group_left() max(firehose_value_metric_gorouter_total_routes)
           > 3
-        for: 5m
+        for: 10m
         labels:
           severity: warning
         annotations:


### PR DESCRIPTION
What
----

The following alerts were amended so we'll get less noise:
* BOSHJobHighCPULoad
* GorouterLatency_Warning
* GorouterLatency_Critical
* CloudControllerLatencyByGorouter_Warning
* CloudControllerLatencyByGorouter_Critical
* CFCloudControllerUnregistry
* RouterTotalRoutesDiscrepancy
* DNSResolutionWorking_Warning
* DNSResolutionTime_Critical

How to review
-------------

1. Code review
1. Deploy your CF from this branch (running the prometheus-deploy with `make run_job` should be enough)

Who can review
--------------

Not me.
