### PR TITLE
Increase number of cells in London to meet demand

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -1,4 +1,4 @@
 ---
-cell_instances: 6
+cell_instances: 9
 router_instances: 3
 api_instances: 2


### PR DESCRIPTION
What
----

As tenants have been migrating from Ireland to London we've been using
more of the available capacity. We're now at the point where we need to
scale up.

See this graph:

https://prometheus.london.cloud.service.gov.uk/graph?g0.range_input=8w&g0.expr=rep_memory_capacity_pct%3Aavg5m&g0.tab=0

How to review
-------------

* Code review
* Check that you agree that we need to scale based on [the prometheus graph](https://prometheus.london.cloud.service.gov.uk/graph?g0.range_input=8w&g0.expr=rep_memory_capacity_pct%3Aavg5m&g0.tab=0)

Who can review
--------------

Not @richardtowers