### PR TITLE
[#162507264] Add timestamp support to the cloudwatch-exporter

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -364,7 +364,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-yet-another-cloudwatch-exporter
-      tag_filter: 0.10.0
+      branch: gds_master 
 
 jobs:
   - name: pipeline-lock

--- a/manifests/prometheus/alerts.d/ec2_cpu_credits.yml
+++ b/manifests/prometheus/alerts.d/ec2_cpu_credits.yml
@@ -8,7 +8,7 @@
     rules:
       - &alert
         alert: EC2CPUCreditsLow_Warning
-        expr: avg_over_time(aws_ec2_cpucreditbalance_minimum[30m]) <= 20
+        expr: avg_over_time(aws_ec2_cpucredit_balance_minimum[30m]) <= 20
         labels:
           severity: warning
         annotations:
@@ -18,6 +18,6 @@
 
       - <<: *alert
         alert: EC2CPUCreditsLow_Critical
-        expr: avg_over_time(aws_ec2_cpucreditbalance_minimum[30m]) <= 1
+        expr: avg_over_time(aws_ec2_cpucredit_balance_minimum[30m]) <= 1
         labels:
           severity: critical

--- a/manifests/prometheus/alerts.d/rds_cpu_credits.yml
+++ b/manifests/prometheus/alerts.d/rds_cpu_credits.yml
@@ -8,7 +8,7 @@
     rules:
       - &alert
         alert: RDSCPUCreditsLow_Warning
-        expr: avg_over_time(aws_rds_cpucreditbalance_minimum[30m]) <= 20
+        expr: avg_over_time(aws_rds_cpucredit_balance_minimum[30m]) <= 20
         labels:
           severity: warning
         annotations:
@@ -18,6 +18,6 @@
 
       - <<: *alert
         alert: RDSCPUCreditsLow_Critical
-        expr: avg_over_time(aws_rds_cpucreditbalance_minimum[30m]) <= 1
+        expr: avg_over_time(aws_rds_cpucredit_balance_minimum[30m]) <= 1
         labels:
           severity: critical

--- a/manifests/prometheus/alerts.d/rds_disk_utilisation.yml
+++ b/manifests/prometheus/alerts.d/rds_disk_utilisation.yml
@@ -8,7 +8,7 @@
     rules:
       - &alert
         alert: RDSCPUDiskUtilisation_Warning
-        expr: aws_rds_freestoragespace_minimum <= 2 * 1024 ^ 3
+        expr: aws_rds_free_storage_space_minimum <= 2 * 1024 ^ 3
         labels:
           severity: warning
         annotations:
@@ -18,6 +18,6 @@
 
       - <<: *alert
         alert: RDSCPUDiskUtilisation_Critical
-        expr: aws_rds_freestoragespace_minimum <= 1 * 1024 ^ 3
+        expr: aws_rds_free_storage_space_minimum <= 1 * 1024 ^ 3
         labels:
           severity: critical


### PR DESCRIPTION
What
----

* we've upgraded yace (https://github.com/ivx/yet-another-cloudwatch-exporter) to 0.11.1
* we added timestamps to yace, so Prometheus can scrape the AWS metrics with the correct timestamps
* we amended the existing AWS related Prometheus alerts as the metric names have changed

How to review
-------------

1. Review https://github.com/alphagov/paas-yet-another-cloudwatch-exporter/pull/1 first
1. Deploy your CF from this branch
1. Check if you still get data for: `aws_ec2_cpucredit_balance_minimum`, `aws_rds_cpucredit_balance_minimum`, `aws_rds_free_storage_space_minimum`
1. Check `https://cloudwatch-exporter.${DEPLOY_ENV}.dev.cloudpipelineapps.digital/metrics` whether the metrics have the promised timestamps (excluding the `*_info` ones and `yace_cloudwatch_requests_total`)

How to merge
----------

Update the WIP commit with the final yace tag.

Who can review
--------------

Not me.
