### PR TITLE
[#163220697] Upgrade CF to 6.10.0

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -271,7 +271,7 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-smoke-tests-release
-      tag_filter: "40.0.17"
+      tag_filter: "40.0.44"
       submodules:
       - "src/smoke_tests"
 

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -265,7 +265,7 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-acceptance-tests
-      branch: cf6.0
+      branch: cf6.10
 
   - name: cf-smoke-tests-release
     type: git

--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-xenial
-      version: "170.15"
+      version: "170.19"

--- a/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
+++ b/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
@@ -3,15 +3,15 @@
 - type: replace
   path: /releases/name=cflinuxfs2
   value:
-    name: cflinuxfs2
-    version: "1.255.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.255.0"
-    sha1: "8fdfe5cfc1c961dbc385150e6008878e3572701d"
+    name: "cflinuxfs2"
+    version: "1.259.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.259.0"
+    sha1: "e439317c8e4cb7aa3c6980e98bf612054b9a3fb8"
 
 - type: replace
   path: /releases/name=cflinuxfs3
   value:
-    name: cflinuxfs3
-    version: "0.46.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.46.0"
-    sha1: "0dae6d614dec4dd5db40ec01e62c2e8c5470c2d9"
+    name: "cflinuxfs3"
+    version: "0.50.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.50.0"
+    sha1: "3d4935ea8a046c00ae98eee3fe9616ed584e0ad7"

--- a/manifests/cf-manifest/operations.d/319-custom-networking-release.yml
+++ b/manifests/cf-manifest/operations.d/319-custom-networking-release.yml
@@ -1,8 +1,0 @@
----
-- type: replace
-  path: /releases/name=cf-networking
-  value:
-    name: cf-networking
-    version: 0.1.1
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cf-networking-0.1.1.tgz
-    sha1: a5666172d8c595acafd17155ff1e3e68b46e4915

--- a/manifests/cf-manifest/operations.d/329-custom-capi-release.yml
+++ b/manifests/cf-manifest/operations.d/329-custom-capi-release.yml
@@ -1,8 +1,13 @@
 ---
+# FIXME: because of a BOSH compilation issue we couldn't use the upstream release,
+# so we use our own fork for now which points to 1.74.0.
+#
+# Revisit this when https://github.com/cloudfoundry/bosh/issues/2118 was fixed.
+#
 - type: replace
   path: /releases/name=capi
   value:
     name: capi
-    version: 0.1.1
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/capi-0.1.1.tgz
-    sha1: d0072aa5990eeb055e95379299ab67a2b7f28275
+    version: 0.1.2
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/capi-0.1.2.tgz
+    sha1: 47f2c40859533d4c808c7653f86231e9a996c744

--- a/manifests/cf-manifest/operations.d/330-uaa.yml
+++ b/manifests/cf-manifest/operations.d/330-uaa.yml
@@ -275,3 +275,7 @@
   value:
     name: secrets_uaa_clients_paas_billing_secret
     type: password
+
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/cf_smoke_tests/override?
+  value: true

--- a/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
+++ b/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
@@ -1,8 +1,0 @@
----
-- type: replace
-  path: /releases/name=uaa
-  value:
-    name: "uaa"
-    version: "66.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=66.0"
-    sha1: "2848d9fb65d2d556a918e8045359cf469c241123"

--- a/manifests/cf-manifest/operations.d/900-cf-cert-rotation.yml
+++ b/manifests/cf-manifest/operations.d/900-cf-cert-rotation.yml
@@ -267,6 +267,22 @@
   path: /addons/name=bosh-dns/jobs/name=bosh-dns/properties/health/server/tls/ca
   value: ((dns_healthcheck_tls_ca.certificate))((dns_healthcheck_tls_ca_old.certificate))
 
+- type: replace
+  path: /addons/name=loggregator_agent/jobs/name=loggr-expvar-forwarder/properties/log_agent/ca_cert
+  value: ((loggregator_ca.certificate))((loggregator_ca_old.certificate))
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=ssh_proxy/properties/backends/tls/ca_certificates/0
+  value: ((application_ca.certificate))((application_ca_old.certificate))
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=log-cache-expvar-forwarder/properties/loggregator_agent/tls/ca_cert
+  value: ((loggregator_ca.certificate))((loggregator_ca_old.certificate))
+
+- type: replace
+  path: /instance_groups/name=doppler/jobs/name=log-cache-expvar-forwarder/properties/loggregator_agent/tls/ca_cert
+  value: ((loggregator_ca.certificate))((loggregator_ca_old.certificate))
+
 # /instance_groups/name=diego-cell/jobs/name=cflinuxfs2-rootfs-setup/properties/cflinuxfs2-rootfs/trusted_certs
 # /instance_groups/name=diego-cell/jobs/name=cflinuxfs3-rootfs-setup/properties/cflinuxfs3-rootfs/trusted_certs
 

--- a/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
@@ -41,6 +41,14 @@ RSpec.describe "base properties" do
 
       expect(default["os"]).to eq(cf_deployment_default.fetch("os"))
     end
+
+    it "stemcell version is not older than the one in cf-deployment" do
+      default = stemcells.find { |s| s["alias"] == "default" }
+      cf_deployment_default = cf_deployment_manifest.fetch("stemcells").find { |s| s["alias"] == "default" }
+
+      expect(Gem::Version.new(default["version"])).to be >= Gem::Version.new(cf_deployment_default.fetch("version")),
+        "the stemcell version should not be older than in cf-deployment"
+    end
   end
 
   describe "api cloud_controller_ng" do

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe "release versions" do
 
     pinned_releases = {
       "capi" => {
-        local: "0.1.1",
-        upstream: "1.71.0"
+        local: "0.1.2",
+        upstream: "1.74.0"
       },
     }
 

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -63,6 +63,23 @@ RSpec.describe "release versions" do
     }
   end
 
+  specify "cf-smoke-tests-release version is not older than in upstream" do
+    cf_smoke_tests_release = cf_deployment_manifest
+      .fetch('releases')
+      .select { |v| v['name'] == 'cf-smoke-tests' }
+      .fetch(0)
+
+    cf_smoke_tests_resource = cf_pipeline
+      .fetch('resources')
+      .select { |v| v['name'] == 'cf-smoke-tests-release' }
+      .fetch(0)
+
+    upstream_version = Gem::Version.new(cf_smoke_tests_release['version'])
+    paas_version = Gem::Version.new(cf_smoke_tests_resource['source']['tag_filter'])
+
+    expect(paas_version).to be >= upstream_version, "we should upgrade the cf-smoke-tests-release's tag_filter in the create-cloundfoundry pipeline to #{upstream_version} or greater"
+  end
+
   specify "releases do not include buildpacks" do
     manifest_without_vars_store.fetch("releases").each do |release|
       expect(release.fetch('name')).not_to end_with('-buildpack')

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -31,10 +31,6 @@ RSpec.describe "release versions" do
         local: "0.1.1",
         upstream: "1.71.0"
       },
-      "cf-networking" => {
-        local: "0.1.1",
-        upstream: "2.18.0"
-      },
     }
 
     manifest_releases = manifest_without_vars_store.fetch("releases").map { |release|

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -80,6 +80,21 @@ RSpec.describe "release versions" do
     expect(paas_version).to be >= upstream_version, "we should upgrade the cf-smoke-tests-release's tag_filter in the create-cloundfoundry pipeline to #{upstream_version} or greater"
   end
 
+  specify "cf-acceptance-tests version should be the same as the CF manifest version" do
+    cf_manifest_version = cf_deployment_manifest
+      .fetch('manifest_version')
+
+    cf_acceptance_tests_resource = cf_pipeline
+      .fetch('resources')
+      .select { |v| v['name'] == 'cf-acceptance-tests' }
+      .fetch(0)
+
+    upstream_version = Gem::Version.new(cf_manifest_version.gsub(/^v/, '').gsub(/\.0$/, ''))
+    paas_version = Gem::Version.new(cf_acceptance_tests_resource['source']['branch'].gsub(/^cf/, ''))
+
+    expect(paas_version).to be >= upstream_version, "we should upgrade the cf-acceptance-tests' branch in the create-cloundfoundry pipeline to 'cf#{upstream_version}'"
+  end
+
   specify "releases do not include buildpacks" do
     manifest_without_vars_store.fetch("releases").each do |release|
       expect(release.fetch('name')).not_to end_with('-buildpack')

--- a/manifests/cf-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/cf-manifest/spec/support/manifest_helpers.rb
@@ -10,6 +10,7 @@ module ManifestHelpers
     attr_accessor :manifest_with_defaults
     attr_accessor :manifest_without_vars_store
     attr_accessor :cf_deployment_manifest
+    attr_accessor :cf_pipeline
     attr_accessor :vars_store
   end
 
@@ -66,6 +67,10 @@ module ManifestHelpers
 
   def cf_deployment_manifest
     Cache.instance.cf_deployment_manifest ||= YAML.load_file(root.join('manifests/cf-deployment/cf-deployment.yml'))
+  end
+
+  def cf_pipeline
+    Cache.instance.cf_pipeline ||= YAML.load_file(root.join('concourse/pipelines/create-cloudfoundry.yml'))
   end
 
   def property_tree(tree)


### PR DESCRIPTION
## What

* We've upgraded CF from 6.0.0 to 6.10.0
* We found a security notice in the stemcell changelogs, so we upgraded to 170.19 (both in paas-cf and paas-bootstrap)
* We found another security notice in the cflinuxfs* changelogs, so we upgraded these to 1.259.0 and 0.50.0
* There were some new ca_cert params in the Manifest, so we added those to the certificate rotation opsfile
* we've removed the custom cf-networking release as our last patch is now included in this CF release
* we couldn't remove the custom capi release as we still encountered the same packaging errors like the last time (Alex opened https://github.com/cloudfoundry/bosh/issues/2118)

### Notable CF changes

* The default runtime wrapper in Garden changed to containerd from garden-runc.
* Apps have annotations
* Spaces have experimental support for labels
* We finished our proof of concept for putting Envoy in the data path
* Log cache security event logging to file (needs to be enabled)
* Operator can specify HTTP headers to be added by Gorouter to responses details
* Operator can specify HTTP headers to be removed by Gorouter from responses details
* When an application instance crashes while processing a request Gorouter now returns an error and takes the backend out of the pool temporarily, without retrying another backend. This change may cause increased 502 rates for existing apps details.
* As a CF Operator I want to be able to run cf-smoke-tests using user or client credentials (if MFA will be enabled for us we have to run the smoke tests with the new UAA client)

## How to review

* Review and deploy https://github.com/alphagov/paas-bootstrap/pull/240 first
* run cf deploy from this branch (some errors in the api-availability tests are expected, mainly CF-StatsUnavailable ones, but more than usual, and will need to be restarted)
    * I've encountered one `Failed to fetch 'admin' org` error and a bbs connection error

I've done the following tests which you shouldn't repeat (especially the cert rotation)
 * test the CA rotation so we can make sure the new ca_cert params are set correctly and the affected components are available during the rotation
 * test whether `cf tail` works
 * test whether `cf ssh` works
 * test whether the firehose_counter_event_loggregator_metron* metrics still receive new data points in Prometheus (the *_delta ones are stopped coming, but the *_total ones are okay, and none of these are used in any of the alerts)

## Who can review

Not @mogds , @AP-Hunt or me.