### PR TITLE
[#162446918] Creates a handful of Prometheus alert tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   global:
     - TF_VERSION="0.11.1"
     - BOSH_CLI_VERSION="2.0.48"
-    - PROMETHEUS_VERSION="2.3.2"
+    - PROMETHEUS_VERSION="2.6.1"
     - DEPLOY_ENV="travis"
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   global:
     - TF_VERSION="0.11.1"
     - BOSH_CLI_VERSION="2.0.48"
+    - PROMETHEUS_VERSION="2.3.2"
     - DEPLOY_ENV="travis"
 
 addons:
@@ -38,6 +39,17 @@ before_install:
     set -e
     wget https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-${BOSH_CLI_VERSION}-linux-amd64
     mv bosh-cli-${BOSH_CLI_VERSION}-linux-amd64 ~/bin/bosh && chmod +x ~/bin/bosh
+    set +e
+  - |
+    echo "Fetching Promtool ${PROMETHEUS_VERSION}"
+    set -e
+    wget -O prometheus.tgz "https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.linux-amd64.tar.gz"
+    tar xzf "prometheus.tgz" \
+       -C $HOME/bin/ \
+       --wildcards \
+       --wildcards-match-slash \
+       --strip-components=1 \
+       '*promtool'
     set +e
   - pip install --user yamllint
   - GIMME_OUTPUT=$(gimme 1.11 | tee -a $HOME/.bashrc) && eval "$GIMME_OUTPUT"

--- a/manifests/prometheus/alerts.d/gorouter-latency.yml
+++ b/manifests/prometheus/alerts.d/gorouter-latency.yml
@@ -14,8 +14,8 @@
           severity: warning
         annotations:
           summary: Gorouter latency
-          description: "Gorouter latency is too high ({{ $value | printf \"%.0f\" }}ms) on {{ $labels.bosh_job_ip }}"
-          url: https://team-manual.cloud.service.gov.uk/incident_management/responding_to_alerts/#gorouter-high-latency-alerts"
+          description: "All Gorouter latencies are too high (min {{ $value | printf \"%.0f\" }}ms)"
+          url: https://team-manual.cloud.service.gov.uk/incident_management/responding_to_alerts/#gorouter-high-latency-alerts
 
       - <<: *alert
         alert: GorouterLatency_Critical

--- a/manifests/prometheus/spec/alerts/bosh-high-cpu-utilisation.test.yml
+++ b/manifests/prometheus/spec/alerts/bosh-high-cpu-utilisation.test.yml
@@ -1,0 +1,45 @@
+---
+rule_files:
+  # See alerts_validation_spec.rb for details of how stdin gets set:
+  - /dev/stdin
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1h
+    input_series:
+      - series: "bosh_job_cpu_sys{bosh_job_name='test',bosh_job_index='0'}"
+        values: 60 80 95
+
+      - series: "bosh_job_cpu_user{bosh_job_name='test',bosh_job_index='0'}"
+        values: 0 0 0 0 0
+
+      - series: "bosh_job_cpu_wait{bosh_job_name='test',bosh_job_index='0'}"
+        values: 0 0 0 0 0
+
+
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: BoshHighCPUUtilisation_Warning
+      - eval_time: 61m
+        alertname: BoshHighCPUUtilisation_Warning
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              bosh_job_name: 'test'
+              bosh_job_index: '0'
+            exp_annotations:
+              summary: "High cpu utilisation on test/0"
+              description: "test/0 CPU utilisation was over 80% in the last hour on average"
+      - eval_time: 121m
+        alertname: BoshHighCPUUtilisation_Critical
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              bosh_job_name: 'test'
+              bosh_job_index: '0'
+            exp_annotations:
+              summary: "High cpu utilisation on test/0"
+              description: "test/0 CPU utilisation was over 95% in the last hour on average"
+
+         

--- a/manifests/prometheus/spec/alerts/bosh-high-cpu-utilisation.test.yml
+++ b/manifests/prometheus/spec/alerts/bosh-high-cpu-utilisation.test.yml
@@ -41,5 +41,3 @@ tests:
             exp_annotations:
               summary: "High cpu utilisation on test/0"
               description: "test/0 CPU utilisation was over 95% in the last hour on average"
-
-         

--- a/manifests/prometheus/spec/alerts/concourse-smoketests-errors.test.yml
+++ b/manifests/prometheus/spec/alerts/concourse-smoketests-errors.test.yml
@@ -1,0 +1,24 @@
+---
+rule_files:
+  # See alerts_validation_spec.rb for details of how stdin gets set:
+  - /dev/stdin
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 15m
+    input_series:
+      - series: 'concourse_builds_finished{exported_job="continuous-smoke-tests",pipeline="create-cloudfoundry",status="errored"}'
+        values: 10 11 12 13 14
+
+    alert_rule_test:
+      - alertname: ConcourseSmoketestsErrors
+        eval_time: 10m
+      - alertname: ConcourseSmoketestsErrors
+        eval_time: 1h
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+            exp_annotations:
+              summary: Concourse continuous-smoke-tests errors
+              description: The continuous-smoke-tests Concourse job has been erroring for a while now.

--- a/manifests/prometheus/spec/alerts/gorouter-latency.test.yml
+++ b/manifests/prometheus/spec/alerts/gorouter-latency.test.yml
@@ -1,0 +1,29 @@
+---
+rule_files:
+  # See alerts_validation_spec.rb for details of how stdin gets set:
+  - /dev/stdin
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 5m
+    input_series:
+      - series: 'firehose_value_metric_gorouter_latency{bosh_job_ip="0.0.0.1"}'
+        values: 600 600 600 800 800 800 800
+      - series: 'firehose_value_metric_gorouter_latency{bosh_job_ip="0.0.0.2"}'
+        values: 900 900 900 900 900 900 900    
+      - series: 'firehose_value_metric_gorouter_latency{bosh_job_ip="0.0.0.3"}'
+        values: 900 900 900 900 900 900 900
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: GorouterLatency_Warning
+      - eval_time: 31m
+        alertname: GorouterLatency_Warning
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              description: "All Gorouter latencies are too high (min 800ms)"
+              summary: "Gorouter latency"
+              url: https://team-manual.cloud.service.gov.uk/incident_management/responding_to_alerts/#gorouter-high-latency-alerts

--- a/manifests/prometheus/spec/alerts_validation_spec.rb
+++ b/manifests/prometheus/spec/alerts_validation_spec.rb
@@ -1,0 +1,24 @@
+require 'open3'
+
+RSpec.describe "prometheus alerts" do
+
+    prom_alerts = nil
+
+    before(:all) do
+        prom_alerts = YAML.dump({
+            "groups" =>
+                manifest_with_defaults["instance_groups"]
+                    .select{|ig|ig["name"] == 'prometheus2'}
+                    .first["jobs"]
+                    .select{|j|j["name"]=='prometheus2'}
+                    .first.dig("properties", "prometheus", "custom_rules")
+        })
+    end
+
+    Dir.each_child('spec/alerts') do |filename|
+        it "runs #{filename}" do
+            out, err, status = Open3.capture3("promtool test rules spec/alerts/#{filename}", stdin_data: prom_alerts)
+            expect(status.success?).to be(true), "`promtool test rules ...` should pass. #{err}"
+        end
+    end
+end

--- a/manifests/prometheus/spec/alerts_validation_spec.rb
+++ b/manifests/prometheus/spec/alerts_validation_spec.rb
@@ -1,24 +1,23 @@
 require 'open3'
 
-RSpec.describe "prometheus alerts" do
+RSpec.describe 'prometheus alerts' do
+  prom_alerts = nil
 
-    prom_alerts = nil
+  before(:all) do
+    prom_alerts = YAML.dump(
+      'groups' =>
+        manifest_with_defaults['instance_groups']
+          .select { |ig| ig['name'] == 'prometheus2' }
+          .first['jobs']
+          .select { |j| j['name'] == 'prometheus2' }
+          .first.dig('properties', 'prometheus', 'custom_rules')
+    )
+  end
 
-    before(:all) do
-        prom_alerts = YAML.dump({
-            "groups" =>
-                manifest_with_defaults["instance_groups"]
-                    .select{|ig|ig["name"] == 'prometheus2'}
-                    .first["jobs"]
-                    .select{|j|j["name"]=='prometheus2'}
-                    .first.dig("properties", "prometheus", "custom_rules")
-        })
+  Dir.glob('*.test.yml', base: 'spec/alerts/') do |filename|
+    it "runs #{filename}" do
+      _, err, status = Open3.capture3("promtool test rules spec/alerts/#{filename}", stdin_data: prom_alerts)
+      expect(status.success?).to be(true), "`promtool test rules ...` should pass. #{err}"
     end
-
-    Dir.each_child('spec/alerts') do |filename|
-        it "runs #{filename}" do
-            out, err, status = Open3.capture3("promtool test rules spec/alerts/#{filename}", stdin_data: prom_alerts)
-            expect(status.success?).to be(true), "`promtool test rules ...` should pass. #{err}"
-        end
-    end
+  end
 end


### PR DESCRIPTION
What
----

Adds a handful of tests for Prometheus alerts using `promtool` https://prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules/

How to review
-------------

Code review (https://prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules/), check tests pass locally (`cd manifests/prometheus && bundle exec rspec`) and passes on Travis.

Who can review
--------------
Not me or @richardTowers 