### PR TITLE
[#163285897] - Add timeout to automatic smoke tests

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -3457,11 +3457,13 @@ jobs:
               fi
       - do:
         - task: create-temp-user
+          timeout: 5m
           file: paas-cf/concourse/tasks/create_admin.yml
           params:
             PREFIX: cont-smoketest-user
 
         - task: smoke-tests-config
+          timeout: 1m
           file: paas-cf/concourse/tasks/generate-test-config.yml
           params:
             TEST_PROPERTIES: smoke_tests
@@ -3470,6 +3472,7 @@ jobs:
 
         - task: smoke-tests-run
           attempts: 3
+          timeout: 10m
           file: paas-cf/concourse/tasks/smoke-tests-run.yml
           params:
             AWS_DEFAULT_REGION: ((aws_region))


### PR DESCRIPTION
What
----

Multiple timeouts have been added to the steps of this job, selected based on the average total job time over the last 14k automatic smoke test runs:

| minimum time    | maximum time    | mean time       |
|-----------------|-----------------|-----------------|
| 2.8166666666667 | 9.7666666666667 | 3.1423720930233 |

Retries are being ignored at this point, as we will be removing those as part of #162014355 - with the retries still there, this will still be a significant improvement over the tests never completing.

How to review
-------------

* BAU: Deploy to pipeline, ensure smoke tests continue as normal

* Test timeout functionality: create branch from this, change timeout of `smoke-tests-run` task to 1 minute, ensure that smoke tests are aborted at 1 minute.

Who can review
--------------

Anyone but @tnwhitwell
