### PR TITLE
[Support] Fix Application Instances graph on dashboard.

### DIFF
--- a/manifests/prometheus/dashboards.d/user-impact.json
+++ b/manifests/prometheus/dashboards.d/user-impact.json
@@ -250,7 +250,7 @@
                 "stack": false,
                 "steppedLine": false,
                 "targets": [{
-                        "expr": "firehose_value_metric_bbs_lr_ps_running",
+                        "expr": "max(firehose_value_metric_bbs_lr_ps_running)",
                         "format": "time_series",
                         "interval": "",
                         "intervalFactor": 1,
@@ -258,7 +258,7 @@
                         "refId": "A"
                     },
                     {
-                        "expr": "firehose_value_metric_bbs_lr_ps_desired",
+                        "expr": "max(firehose_value_metric_bbs_lr_ps_desired)",
                         "format": "time_series",
                         "intervalFactor": 1,
                         "legendFormat": "LRPsDesired",


### PR DESCRIPTION
## What

Currently because we're not aggregating the metrics at all, during a
deployment we end up with 2 series for each metric which makes the graph
look odd. Aggregating these prevents this from happening.

How to review
-------------

Code review is probably enough.

Who can review
--------------

Not me.