### PR TITLE
[Support] Add RDS parameter group that includes pg_stat_statements

### DIFF
--- a/terraform/cloudfoundry/rds_broker.tf
+++ b/terraform/cloudfoundry/rds_broker.tf
@@ -107,6 +107,29 @@ resource "aws_db_parameter_group" "rds_broker_postgres95" {
   }
 }
 
+resource "aws_db_parameter_group" "rds_broker_postgres95_pg_stat_statements" {
+  name        = "rdsbroker-postgres95-${var.env}-pg-stat-statements"
+  family      = "postgres9.5"
+  description = "RDS Broker Postgres 9.5 parameter group with pg_stat_statments shared preload library"
+
+  parameter {
+    apply_method = "pending-reboot"
+    name         = "rds.force_ssl"
+    value        = "1"
+  }
+
+  parameter {
+    apply_method = "pending-reboot"
+    name         = "shared_preload_libraries"
+    value        = "pg_stat_statements"
+  }
+
+  parameter {
+    name  = "rds.log_retention_period"
+    value = "10080"                    // 7 days in minutes
+  }
+}
+
 resource "aws_db_parameter_group" "rds_broker_postgres10" {
   name        = "rdsbroker-postgres10-${var.env}"
   family      = "postgres10"


### PR DESCRIPTION
## What

We've had tenants requesting this extension be added. Unlike some
extensions, it can't merely be enabled using `CREATE EXTENSION`, it
requires a preload library. This therefore creates an additional
parameter group with this enabled. We'll use this to manually assign
instances to when requested.

How to review
-------------

* Code review.  I've already run this down my dev environment

Who can review
--------------

Not me.