### PR TITLE
[Support] Rename parameter group for shared_preload_libraries

### DIFF
--- a/terraform/cloudfoundry/rds_broker.tf
+++ b/terraform/cloudfoundry/rds_broker.tf
@@ -107,10 +107,10 @@ resource "aws_db_parameter_group" "rds_broker_postgres95" {
   }
 }
 
-resource "aws_db_parameter_group" "rds_broker_postgres95_pg_stat_statements" {
-  name        = "rdsbroker-postgres95-${var.env}-pg-stat-statements"
+resource "aws_db_parameter_group" "rds_broker_postgres95_shared_preload_libraries" {
+  name        = "rdsbroker-postgres95-${var.env}-shared-preload-libraries"
   family      = "postgres9.5"
-  description = "RDS Broker Postgres 9.5 parameter group with pg_stat_statments shared preload library"
+  description = "RDS Broker Postgres 9.5 parameter group with some shared_preload_libraries enabled"
 
   parameter {
     apply_method = "pending-reboot"


### PR DESCRIPTION
## What

There's already a manually created parameter group called
rdsbroker-postgres95-prod-pg-stat-statements in prod Ireland which was
conflicting with this. This group has instances using it, so can't be
deleted.

I initially attempted to import this into the tfstate, but terraform
needs to update the description, and AWS doesn't allow that, so
terraform still attempts to delete the group. It's therefore necessary
to use a different name for the group.

How to review
-------------

Code review should suffice.

Who can review
--------------

Not me.