### PR TITLE
[SUPPORT] Set the nginx_z2 instance count to 0

### DIFF
--- a/manifests/prometheus/operations.d/120-add-nginx-per-az.yml
+++ b/manifests/prometheus/operations.d/120-add-nginx-per-az.yml
@@ -41,6 +41,8 @@
     name: nginx_z2
     azs:
       - z2
+    # TODO: remove this line when the Prometheus cluster can be HA again
+    instances: 0
     vm_extensions:
       - prometheus_lb_z2
     jobs:


### PR DESCRIPTION
What
----

This commit sets the instance count for nginx_z2 to 0.

Currently all firehose instances are scraped by all Prometheus instances and we
have some metrics/alerts which only expect one set of data.

For now we scale back so we can decide how to fix this issue.

How to review
-------------

Code review, maybe a run of prometheus-deploy.

Who can review
--------------

Not me.
