### PR TITLE
[#160197650] Prometheus ha fixes 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/cloudfoundry/cf-deployment
 [submodule "manifests/prometheus/upstream"]
 	path = manifests/prometheus/upstream
-	url = https://github.com/bosh-prometheus/prometheus-boshrelease
+	url = https://github.com/alphagov/paas-prometheus-boshrelease

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ dev: globals ## Set Environment to DEV
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
 	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipelineapps.digital)
 	$(eval export ALERT_EMAIL_ADDRESS=govpaas-alerting-dev@digital.cabinet-office.gov.uk)
-	$(eval export ENABLE_ALERT_EMAILS=false)
+	$(eval export ENABLE_ALERT_EMAILS ?= false)
 	$(eval export SKIP_COMMIT_VERIFICATION=true)
 	$(eval export ENV_SPECIFIC_BOSH_VARS_FILE=default.yml)
 	$(eval export DISABLE_HEALTHCHECK_DB=true)

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1412,8 +1412,7 @@ jobs:
               - -c
               - |
                 . ./config/config.sh
-                # FIXME: change this back to 2 when Prometheus can run again in an HA setup
-                AZ_COUNT=1
+                AZ_COUNT=2
                 if [ "${SLIM_DEV_DEPLOYMENT}" = "true" ]; then
                   AZ_COUNT=1
                 fi

--- a/manifests/prometheus/operations.d/000-custom-prometheus-bosh-release.yml
+++ b/manifests/prometheus/operations.d/000-custom-prometheus-bosh-release.yml
@@ -4,6 +4,6 @@
   path: /releases/name=prometheus
   value:
     name: prometheus
-    version: 0.0.1548085118
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/prometheus-0.0.1548085118.tgz
-    sha1: dead42725aeffcdaf9279818c3e8428e157feb90
+    version: 0.1.2
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/prometheus-0.1.2.tgz
+    sha1: d21096352b113d089e95d4e1921bd7a4b44143d9

--- a/manifests/prometheus/operations.d/050-set-external-urls.yml
+++ b/manifests/prometheus/operations.d/050-set-external-urls.yml
@@ -1,14 +1,10 @@
 - type: replace
   path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/web?/external_url?
-  value: https://prometheus.((system_domain))
+  value: https://prometheus-1.((system_domain))
 
 - type: replace
   path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/web?/external_url
-  value: https://alertmanager.((system_domain))
-
-- type: replace
-  path: /instance_groups/name=grafana/jobs/name=grafana/properties/grafana/server?/root_url
-  value: https://grafana.((system_domain))
+  value: https://alertmanager-1.((system_domain))
 
 - type: replace
   path: /instance_groups/name=grafana/jobs/name=grafana/properties/grafana/prometheus?/use_external_url?

--- a/manifests/prometheus/operations.d/120-add-nginx-per-az.yml
+++ b/manifests/prometheus/operations.d/120-add-nginx-per-az.yml
@@ -41,8 +41,6 @@
     name: nginx_z2
     azs:
       - z2
-    # TODO: remove this line when the Prometheus cluster can be HA again
-    instances: 0
     vm_extensions:
       - prometheus_lb_z2
     jobs:

--- a/manifests/prometheus/operations.d/230-enable-service-discovery-UPSTREAM.yml
+++ b/manifests/prometheus/operations.d/230-enable-service-discovery-UPSTREAM.yml
@@ -1,0 +1,1 @@
+../upstream/manifests/operators/enable-service-discovery.yml

--- a/manifests/prometheus/operations.d/231-scrape-instances-from-same-az.yml
+++ b/manifests/prometheus/operations.d/231-scrape-instances-from-same-az.yml
@@ -1,0 +1,19 @@
+---
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/job_name=firehose/file_sd_configs
+  value:
+    - files:
+      - "/var/vcap/jobs/service_discovery/firehose_exporter_target_groups.json"
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/job_name=grafana/file_sd_configs
+  value:
+    - files:
+      - "/var/vcap/jobs/service_discovery/grafana_target_groups.json"
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/job_name=prometheus/file_sd_configs
+  value:
+    - files:
+      - "/var/vcap/jobs/service_discovery/prometheus_target_groups.json"

--- a/manifests/prometheus/operations.d/400-set-instance-count.yml
+++ b/manifests/prometheus/operations.d/400-set-instance-count.yml
@@ -1,0 +1,39 @@
+- type: replace
+  path: /instance_groups/name=alertmanager/instances
+  value: 2
+
+- type: replace
+  path: /instance_groups/name=alertmanager/azs
+  value:
+    - z1
+    - z2
+
+- type: replace
+  path: /instance_groups/name=prometheus2/instances
+  value: 2
+
+- type: replace
+  path: /instance_groups/name=prometheus2/azs
+  value:
+    - z1
+    - z2
+
+- type: replace
+  path: /instance_groups/name=grafana/instances
+  value: 2
+
+- type: replace
+  path: /instance_groups/name=grafana/azs
+  value:
+    - z1
+    - z2
+
+- type: replace
+  path: /instance_groups/name=firehose/instances
+  value: 2
+
+- type: replace
+  path: /instance_groups/name=firehose/azs
+  value:
+    - z1
+    - z2


### PR DESCRIPTION
## What

This change re-enables the Prometheus HA setup.

In the forked Prometheus BOSH release I created a `service_discovery` job, which will generate JSON files containing instances only from the same AZ.

Also the Prometheus urls in the configs will point to the instances in the first AZ (this only matters for alert email links and links in the alertmanager).

❗️ There is a WIP commit which needs to be updated before merge.

## How to review

1. Review https://github.com/alphagov/paas-prometheus-boshrelease/pull/1 first
2. Deploy your env from this BRANCH, both with `SLIM_DEV_DEPLOYMENT` true/false. (to speed up things it's enough to run `make dev run_job JOB=prometheus-deploy`)

I tested what happens when Bosh is not available and the scrape configs based on the file service discovery still worked.

## Who can review

Not me.
