### PR TITLE
[#162611438]Update Logstash filters to deserialize JSON messages

### DIFF
--- a/config/logit/output/generated_logit_filters.conf
+++ b/config/logit/output/generated_logit_filters.conf
@@ -747,7 +747,7 @@ filter {
   ##--------------------------
   # Uaa conf. Parses uaa logs.|
   ##--------------------------
-  if [@source][component] == "vcap.uaa" {
+  if [@source][component] == "uaa" {
 
       # ---- Parse UAA events (general)
 
@@ -816,7 +816,7 @@ filter {
   ##-----------------------------
   # Vcap conf. Parses vcap* logs.|
   ##-----------------------------
-  if [@source][component] != "vcap.uaa" and [@source][component] =~ /vcap\..*/ {
+  if [@source][component] != "uaa" {
 
       # minus vcap. prefix
       mutate {

--- a/scripts/generate_logit_filters.sh
+++ b/scripts/generate_logit_filters.sh
@@ -51,3 +51,11 @@ echo "filter {" > /output/generated_logit_filters.conf
 } >> /output/generated_logit_filters.conf
 
 sed -i 's/^ *$//g' /output/generated_logit_filters.conf
+
+sed -i \
+    "s/if \[@source\]\[component\] != \"vcap.uaa\".*/if [@source][component] != \"uaa\" {/" \
+    /output/generated_logit_filters.conf
+
+sed -i \
+    "s/vcap\.uaa/uaa/" \
+    /output/generated_logit_filters.conf	


### PR DESCRIPTION
What
----
Logstash filters were looking for component names beginning with "vcap." before
deserializing JSON. No components had this prefix.

Removes "vcap" from generated Logstash filters file inside the make task using
sed.

How to review
-------------

Check paas-dev ELK stack for events whose original JSON message (see `@raw`) has been broken down in to a field whose name matches the value of `@source.component`.

To deploy, copy and past `config/logit/output/generated_logit_filters.conf` to the relevant ELK stack logstash filters in Logit.

Who can review
--------------
Not @mogds or @AP-Hunt 