### PR TITLE
[#163596794] Set a unique subscription id for the firehose-exporters

### DIFF
--- a/manifests/prometheus/operations.d/000-custom-prometheus-bosh-release.yml
+++ b/manifests/prometheus/operations.d/000-custom-prometheus-bosh-release.yml
@@ -4,6 +4,6 @@
   path: /releases/name=prometheus
   value:
     name: prometheus
-    version: 0.1.2
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/prometheus-0.1.2.tgz
-    sha1: d21096352b113d089e95d4e1921bd7a4b44143d9
+    version: 0.1.3
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/prometheus-0.1.3.tgz
+    sha1: a19681ffac93bc36fc274fc3daead794f965f7b5

--- a/manifests/prometheus/operations.d/223-unique-firehose-subscription-id.yml
+++ b/manifests/prometheus/operations.d/223-unique-firehose-subscription-id.yml
@@ -1,0 +1,5 @@
+---
+
+- type: replace
+  path: /instance_groups/name=firehose/jobs/name=firehose_exporter/properties/firehose_exporter/doppler/use_unique_subscription_id?
+  value: true


### PR DESCRIPTION
What
----

Set a unique subscription id for the firehose-exporters, otherwise the exporters will receive only 50% of the data because of the same subscription id. (This is how Firehose works).

❗️ Make sure the WIP commit is replaced before merge.

How to review
-------------

1. Review https://github.com/alphagov/paas-prometheus-boshrelease/pull/2 first
1. Update your pipelines with `SLIM_DEV_DEPLOYMENT=false` and run the prometheus-deploy job
1. If you ssh onto the firehose nodes (prometheus deployment), you should see the firehose exporter runs with a unique subscription id flag

Who can review
--------------

Not me.
