### PR TITLE
[SUPPORT] Bump the paas-billing to 0.49.0

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -326,7 +326,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-billing
-      tag_filter: v0.48.0
+      tag_filter: v0.49.0
 
   - name: paas-accounts
     type: git


### PR DESCRIPTION
What
----

Bump the paas-billing to 0.49.0

Increase the eventstore's init and refresh timeouts to 15 minutes

On prod it takes more than 5 minutes to initialise the database. The init
therefore timeouts and the application exits.

As a quickfix we'll increase the timeouts.

How to review
-------------

Code review.

Who can review
--------------

Not me.
