### PR TITLE
[#163558206] Update EC2 filters used for CONCOURSE_IP in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ showenv: check-env ## Display environment information
 	@concourse/scripts/environment.sh
 	@scripts/show-vars-store-secrets.sh cf-vars-store cf_admin_password
 	@echo export CONCOURSE_IP=$$(aws ec2 describe-instances \
-		--filters 'Name=tag:Name,Values=concourse/*' "Name=key-name,Values=$(DEPLOY_ENV)_concourse_key_pair" \
+		--filters "Name=tag:deploy_env,Values=${DEPLOY_ENV}" 'Name=tag:instance_group,Values=concourse' \
 		--query 'Reservations[].Instances[].PublicIpAddress' --output text)
 	@scripts/show-vars-store-secrets.sh prometheus-vars-store alertmanager_password grafana_password grafana_mon_password prometheus_password
 


### PR DESCRIPTION
## What

With the changes to ssh keypairs being made[1], this filter is no longer
matching correctly. Updating it to be based on the DEPLOY_ENV and
instance_group name makes it much more robust to any future changes.

[1]https://github.com/alphagov/paas-bootstrap/pull/244

How to review
-------------

* Code review
* Verify that `make dev showenv` continues to show the CONCOURSE_IP before and after https://github.com/alphagov/paas-bootstrap/pull/244 is deployed.

Who can review
--------------

Not me.