### PR TITLE
[#163730761] Deploy paas-uaa-assets to system domain (part1)

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2498,6 +2498,9 @@ jobs:
           inputs:
             - name: paas-cf
             - name: config
+          params:
+            APPS_DNS_ZONE_NAME: ((apps_dns_zone_name))
+            SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
           run:
             path: sh
             args:
@@ -2510,8 +2513,18 @@ jobs:
 
                 cd paas-cf/tools/paas-uaa-assets
 
-                cf blue-green-deploy paas-uaa-assets
-                cf delete -f paas-uaa-assets-old
+                ruby -ryaml -e "
+                  manifest = YAML.load_file('manifest.yml')
+                  manifest['applications'].each do |app|
+                    app['routes'] = [
+                      { 'route' => 'paas-uaa-assets.${SYSTEM_DNS_ZONE_NAME}' },
+                      { 'route' => 'paas-uaa-assets.${APPS_DNS_ZONE_NAME}' },
+                    ]
+                  end
+                  File.write('manifest.yml', manifest.to_yaml)
+                "
+
+                cf zero-downtime-push paas-uaa-assets -f ./manifest.yml
 
       - task: remove-unused-iam-access-keys
         config:

--- a/tools/paas-uaa-assets/manifest.yml
+++ b/tools/paas-uaa-assets/manifest.yml
@@ -5,3 +5,4 @@ applications:
    disk_quota: 100M
    instances: 2
    stack: cflinuxfs3
+   buildpack: staticfile_buildpack


### PR DESCRIPTION
What
----

It's better for the assets used by UAA to be served from the same parent
domain that UAA itself uses. This avoids issues with one domain potentially impacting the other domain.

This is part one to make the assets available on a new route as well as the existing route. Once this is deployed, we'll update UAA to point at the new route, and remove the existing one.

I've also updated the uaa-assets app to specify the buildpack so that it doesn't need to go through the buildpack detection process.

How to review
-------------

* Deploy from this branch, verify that UAA login page is still styled correctly.

Who can review
--------------

Not me.
