### PR TITLE
[#163730761] Deploy paas-uaa-assets to system domain (part2)

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2499,7 +2499,6 @@ jobs:
             - name: paas-cf
             - name: config
           params:
-            APPS_DNS_ZONE_NAME: ((apps_dns_zone_name))
             SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
           run:
             path: sh
@@ -2518,7 +2517,6 @@ jobs:
                   manifest['applications'].each do |app|
                     app['routes'] = [
                       { 'route' => 'paas-uaa-assets.${SYSTEM_DNS_ZONE_NAME}' },
-                      { 'route' => 'paas-uaa-assets.${APPS_DNS_ZONE_NAME}' },
                     ]
                   end
                   File.write('manifest.yml', manifest.to_yaml)

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1556,6 +1556,10 @@ jobs:
                   cf update-user-provided-service logit-syslog-drain -l "${LOGIT_ADDRESS}"
                 fi
 
+                # FIXME: remove this when it's run everywhere.
+                cf target -o admin -s assets
+                cf delete-route -f "${APPS_DNS_ZONE_NAME}" --hostname paas-uaa-assets
+
       - task: register-rds-broker
         config:
           platform: linux

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2498,6 +2498,9 @@ jobs:
           inputs:
             - name: paas-cf
             - name: config
+          params:
+            APPS_DNS_ZONE_NAME: ((apps_dns_zone_name))
+            SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
           run:
             path: sh
             args:
@@ -2510,8 +2513,18 @@ jobs:
 
                 cd paas-cf/tools/paas-uaa-assets
 
-                cf blue-green-deploy paas-uaa-assets
-                cf delete -f paas-uaa-assets-old
+                ruby -ryaml -e "
+                  manifest = YAML.load_file('manifest.yml')
+                  manifest['applications'].each do |app|
+                    app['routes'] = [
+                      { 'route' => 'paas-uaa-assets.${SYSTEM_DNS_ZONE_NAME}' },
+                      { 'route' => 'paas-uaa-assets.${APPS_DNS_ZONE_NAME}' },
+                    ]
+                  end
+                  File.write('manifest.yml', manifest.to_yaml)
+                "
+
+                cf zero-downtime-push paas-uaa-assets -f ./manifest.yml
 
       - task: remove-unused-iam-access-keys
         config:

--- a/manifests/cf-manifest/operations.d/330-uaa.yml
+++ b/manifests/cf-manifest/operations.d/330-uaa.yml
@@ -35,7 +35,7 @@
 
 - type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/login/asset_base_url?
-  value: https://paas-uaa-assets.((terraform_outputs_cf_apps_domain))
+  value: https://paas-uaa-assets.((system_domain))
 
 - type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/login/branding?/company_name

--- a/platform-tests/src/platform/acceptance/uaa_styling_test.go
+++ b/platform-tests/src/platform/acceptance/uaa_styling_test.go
@@ -4,14 +4,15 @@ import (
 	"crypto/sha512"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/url"
+	"strings"
+
 	"github.com/PuerkitoBio/goquery"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
-	"io/ioutil"
-	"net/url"
-	"strings"
 )
 
 var _ = Describe("UAA authorization webpage styling", func() {
@@ -43,7 +44,7 @@ var _ = Describe("UAA authorization webpage styling", func() {
 
 		customAppURL = url.URL{
 			Scheme: "https",
-			Host:   "paas-uaa-assets." + testConfig.GetAppsDomain(),
+			Host:   "paas-uaa-assets." + GetConfigFromEnvironment("SYSTEM_DNS_ZONE_NAME"),
 		}
 		customLogoURL = customAppURL
 		customLogoURL.Path = "/images/product-logo.png"

--- a/tools/paas-uaa-assets/manifest.yml
+++ b/tools/paas-uaa-assets/manifest.yml
@@ -5,3 +5,4 @@ applications:
    disk_quota: 100M
    instances: 2
    stack: cflinuxfs3
+   buildpack: staticfile_buildpack


### PR DESCRIPTION
What
----

This is the second part of moving the UAA assets to the system domain.

It updates UAA to point at the system domain, and removes the apps domain from the app. These are safe to combine in the same PR because UAA gets updated in the cf-deploy job, and the uaa-assets app then gets updated in the post-deploy.

How to review
-------------

* Review along with #1742 (commits from that are also included here until it can be rebased)
* Deploy from this branch, and verify that `login.$SYSTEM_DOMAIN` doesn't load anything from the apps domain.

Who can review
--------------

Not me.