### PR TITLE
[#163591232] Update log-cache to include CAPI pagination fix

### DIFF
--- a/manifests/cf-manifest/operations.d/400-upgrade-log-cache-version.yml
+++ b/manifests/cf-manifest/operations.d/400-upgrade-log-cache-version.yml
@@ -1,0 +1,8 @@
+- type: replace
+  path: /releases/name=log-cache
+  value:
+    name: log-cache
+    # This is v2.0.2 + a backported fix for a pagination issue - https://github.com/alphagov/paas-log-cache-release/pull/1
+    version: 0.1.3
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/log-cache-0.1.3.tgz
+    sha1: 64c599779c7e1efda39ffba306daf21d3361c852

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -29,7 +29,11 @@ RSpec.describe "release versions" do
     pinned_releases = {
       "capi" => {
         local: "0.1.2",
-        upstream: "1.74.0"
+        upstream: "1.74.0",
+      },
+      "log-cache" => {
+        local: "0.1.3",
+        upstream: "2.0.2",
       },
     }
 


### PR DESCRIPTION
## What

This pulls in our fork of log-cache-release which includes a backport of
the pagination fix.

How to review
-------------

TBC

Who can review
--------------

Not me.