### PR TITLE
[#161647315] Self-Enable RDS Broker Extensions

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 0.1.50 
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.50.tgz
-    sha1: 3de23a9b34eab9c08d337613f594778642c67fa3
+    version: 0.1.51
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.51.tgz
+    sha1: 04d6e058e3f836cbeff044f74b7c505a3029e8f5
 
 - type: replace
   path: /instance_groups/-

--- a/manifests/cf-manifest/operations.d/711-rds-broker-postgres95-plans.yml
+++ b/manifests/cf-manifest/operations.d/711-rds-broker-postgres95-plans.yml
@@ -16,6 +16,7 @@
         - ((terraform_outputs_rds_broker_dbs_security_group_id))
       engine: "postgres"
       engine_version: "9.5"
+      engine_family: "postgres9.5"
       default_extensions: ["uuid-ossp", "postgis"]
       allowed_extensions: ["uuid-ossp", "postgis", "pg_stat_statements"]
 

--- a/manifests/cf-manifest/operations.d/711-rds-broker-postgres95-plans.yml
+++ b/manifests/cf-manifest/operations.d/711-rds-broker-postgres95-plans.yml
@@ -16,8 +16,8 @@
         - ((terraform_outputs_rds_broker_dbs_security_group_id))
       engine: "postgres"
       engine_version: "9.5"
-      db_parameter_group_name: ((terraform_outputs_rds_broker_postgres95_db_parameter_group))
-      postgres_extensions: ["uuid-ossp", "postgis"]
+      default_extensions: ["uuid-ossp", "postgis"]
+      allowed_extensions: ["uuid-ossp", "postgis", "pg_stat_statements"]
 
     tiny_plan_rds_properties: &tiny_plan_rds_properties
       db_instance_class: "db.t2.micro"

--- a/manifests/cf-manifest/operations.d/712-rds-broker-mysql-plans.yml
+++ b/manifests/cf-manifest/operations.d/712-rds-broker-mysql-plans.yml
@@ -16,7 +16,6 @@
         - ((terraform_outputs_rds_broker_dbs_security_group_id))
       engine: "mysql"
       engine_version: "5.7"
-      db_parameter_group_name: ((terraform_outputs_rds_broker_mysql57_db_parameter_group))
 
     tiny_plan_rds_properties: &tiny_plan_rds_properties
       db_instance_class: "db.t2.micro"

--- a/manifests/cf-manifest/operations.d/712-rds-broker-mysql-plans.yml
+++ b/manifests/cf-manifest/operations.d/712-rds-broker-mysql-plans.yml
@@ -16,6 +16,7 @@
         - ((terraform_outputs_rds_broker_dbs_security_group_id))
       engine: "mysql"
       engine_version: "5.7"
+      engine_family: "mysql5.7"
 
     tiny_plan_rds_properties: &tiny_plan_rds_properties
       db_instance_class: "db.t2.micro"

--- a/manifests/cf-manifest/operations.d/713-rds-broker-postgres10-plans.yml
+++ b/manifests/cf-manifest/operations.d/713-rds-broker-postgres10-plans.yml
@@ -16,8 +16,8 @@
         - ((terraform_outputs_rds_broker_dbs_security_group_id))
       engine: "postgres"
       engine_version: "10"
-      db_parameter_group_name: ((terraform_outputs_rds_broker_postgres10_db_parameter_group))
-      postgres_extensions: ["uuid-ossp", "postgis", "citext"]
+      default_extensions: ["uuid-ossp", "postgis", "citext"]
+      allowed_extensions: ["uuid-ossp", "postgis", "citext", "pg_stat_statements"]
 
     tiny_plan_rds_properties: &tiny_plan_rds_properties
       db_instance_class: "db.t2.micro"

--- a/manifests/cf-manifest/operations.d/713-rds-broker-postgres10-plans.yml
+++ b/manifests/cf-manifest/operations.d/713-rds-broker-postgres10-plans.yml
@@ -16,6 +16,7 @@
         - ((terraform_outputs_rds_broker_dbs_security_group_id))
       engine: "postgres"
       engine_version: "10"
+      engine_family: "postgres10"
       default_extensions: ["uuid-ossp", "postgis", "citext"]
       allowed_extensions: ["uuid-ossp", "postgis", "citext", "pg_stat_statements"]
 


### PR DESCRIPTION
What
----

The RDS broker has been updated so users have the option to enable supported extensions. This PR adds a Postgres pg_stat_statements enabled parameter group to be consumed by the RDS broker.

How to review
-------------

- Deploy this branch to a dev env and go through a database service lifecycle, with and without different extensions enabled, using the `-c '{"enabled_extensions": ["pg_stat_statements"]}'` argument to `cf create-service`
- Confirm the correct parameter group has been applied, and connect to the RDS instance to confirm the correct extensions have been enabled

**Merge Steps**

- Merge the [RDS broker PR](https://github.com/alphagov/paas-rds-broker/pull/95)
- Remove the [branch line](https://github.com/alphagov/paas-rds-broker-boshrelease/pull/77/files#diff-8903239df476d7401cf9e76af0252622R4) in `.gitsubmodules` for [the bosh release](https://github.com/alphagov/paas-rds-broker-boshrelease/pull/77) and update the submodule
- Update the WIP commit in this PR with the final rds broker bosh release and merge

Who can review
--------------

Not @mogds @AP-Hunt @LeePorte 
