### PR TITLE
[#162755282] Fix the RouterTotalRoutesDrop alert

### DIFF
--- a/manifests/prometheus/alerts.d/router_total_routes.yml
+++ b/manifests/prometheus/alerts.d/router_total_routes.yml
@@ -9,8 +9,8 @@
         expr: avg_over_time(firehose_value_metric_gorouter_total_routes[5m])
       - record: gorouter:total_routes:delta5m
         expr: delta(firehose_value_metric_gorouter_total_routes[5m])
-      - &alert
-        alert: RouterTotalRoutesDrop_Warning
+
+      - alert: RouterTotalRoutesDrop
         expr: >
           100 *
           min_over_time(gorouter:total_routes:delta5m[30m])
@@ -24,15 +24,6 @@
             {{ $labels.bosh_job_name }}/{{ $labels.bosh_job_id }}
             Router total routes count has dropped {{ $value | printf "%.0f" }}% in 5m
             within the last 30m.
-      - <<: *alert
-        alert: RouterTotalRoutesDrop_Critical
-        expr: >
-          100 *
-          min_over_time(gorouter:total_routes:delta5m[30m])
-          / on() group_left() gorouter:total_routes:mean5m
-          < -20
-        labels:
-          severity: critical
 
       - alert: RouterTotalRoutesDiscrepancy
         expr: >

--- a/manifests/prometheus/alerts.d/router_total_routes.yml
+++ b/manifests/prometheus/alerts.d/router_total_routes.yml
@@ -14,7 +14,7 @@
         expr: >
           100 *
           min_over_time(gorouter:total_routes:delta5m[30m])
-          / on() group_left() gorouter:total_routes:mean5m
+          / gorouter:total_routes:mean5m
           < -20
         labels:
           severity: warning

--- a/manifests/prometheus/alerts.d/router_total_routes.yml
+++ b/manifests/prometheus/alerts.d/router_total_routes.yml
@@ -5,16 +5,11 @@
   value:
     name: RouterTotalRoutesDrop
     rules:
-      - record: gorouter:total_routes:mean5m
-        expr: avg_over_time(firehose_value_metric_gorouter_total_routes[5m])
-      - record: gorouter:total_routes:delta5m
-        expr: delta(firehose_value_metric_gorouter_total_routes[5m])
-
       - alert: RouterTotalRoutesDrop
         expr: >
           100 *
-          min_over_time(gorouter:total_routes:delta5m[30m])
-          / gorouter:total_routes:mean5m
+          delta(firehose_value_metric_gorouter_total_routes[5m])
+          / avg_over_time(firehose_value_metric_gorouter_total_routes[5m])
           < -20
         labels:
           severity: warning
@@ -22,8 +17,7 @@
           summary: Router total routes drop
           description: >
             {{ $labels.bosh_job_name }}/{{ $labels.bosh_job_id }}
-            Router total routes count has dropped {{ $value | printf "%.0f" }}% in 5m
-            within the last 30m.
+            Router total routes count has dropped {{ $value | printf "%.0f" }}% in 5m.
 
       - alert: RouterTotalRoutesDiscrepancy
         expr: >


### PR DESCRIPTION
What
----

The existing expresion was causing the following error in Prometheus:

> Error executing query: many-to-many matching not allowed: matching
> labels must be unique on one side

In fact because we're using the same series on both sides of the /
operator, there's no need for the on() group_left() functions at all.

I initially fixed this by adding 'bosh_job_name,bosh_job_id' to the on()
function, but then realised that the whole thing was unnecessary.

How to review
-------------

* Code review.
* Try viewing the updated expression in the prometheus console in a production env.

Who can review
--------------

Not me.