### PR TITLE
[#162014355] Refactor the continuous-smoke-tests alerts.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ dev: globals ## Set Environment to DEV
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
 	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipelineapps.digital)
 	$(eval export ALERT_EMAIL_ADDRESS=govpaas-alerting-dev@digital.cabinet-office.gov.uk)
-	$(eval export ENABLE_ALERT_EMAILS ?= false)
+	$(eval export ENABLE_ALERT_NOTIFICATIONS ?= false)
 	$(eval export SKIP_COMMIT_VERIFICATION=true)
 	$(eval export ENV_SPECIFIC_BOSH_VARS_FILE=default.yml)
 	$(eval export DISABLE_HEALTHCHECK_DB=true)

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -453,7 +453,7 @@ jobs:
             AWS_DEFAULT_REGION: ((aws_region))
             SELF_UPDATE_PIPELINE: ((self_update_pipeline))
             PIPELINES_TO_UPDATE: ((pipeline_name))
-            ENABLE_ALERT_EMAILS: ((ENABLE_ALERT_EMAILS))
+            ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
             BOSH_AZ: ((bosh_az))
             SKIP_AWS_CREDENTIAL_VALIDATION: true
             NEW_ACCOUNT_EMAIL_ADDRESS: ((NEW_ACCOUNT_EMAIL_ADDRESS))
@@ -1247,7 +1247,7 @@ jobs:
             APPS_DNS_ZONE_NAME: ((apps_dns_zone_name))
             DEPLOY_ENV: ((deploy_env))
             BOSH_URL: https://((bosh_fqdn)):25555
-            ENABLE_ALERT_EMAILS: ((ENABLE_ALERT_EMAILS))
+            ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
             SLIM_DEV_DEPLOYMENT: ((slim_dev_deployment))
             ENV_SPECIFIC_BOSH_VARS_FILE: ((env_specific_bosh_vars_file))
           run:
@@ -3481,7 +3481,7 @@ jobs:
             DEPLOY_ENV: ((deploy_env))
             SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
             ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
-            EMAIL_ON_SMOKE_TEST_FAILURE: ((ENABLE_ALERT_EMAILS))
+            EMAIL_ON_SMOKE_TEST_FAILURE: ((ENABLE_ALERT_NOTIFICATIONS))
           ensure:
             task: upload-test-artifacts
             file: paas-cf/concourse/tasks/upload-test-artifacts.yml

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -108,12 +108,6 @@ resource_types:
     repository: governmentpaas/semver-resource
     tag: ecbdd201e122b44de99a40ac9f24407c1a43b9a2
 
-- name: pagerduty-notification-resource
-  type: docker-image
-  source:
-    repository: governmentpaas/pagerduty-notification-resource
-    tag: 2018-11-15
-
 resources:
   - name: pipeline-trigger
     type: semver-iam
@@ -362,16 +356,18 @@ resources:
       region_name: ((aws_region))
       versioned_file: prometheus-manifest-pre-vars.yml
 
-  - name: pagerduty-notify
-    type: pagerduty-notification-resource
-    source:
-      service_key: ((pagerduty_integration_key))
-
   - name: paas-yet-another-cloudwatch-exporter
     type: git
     source:
       uri: https://github.com/alphagov/paas-yet-another-cloudwatch-exporter
       branch: gds_master
+
+  - name: pagerduty-secrets
+    type: s3-iam
+    source:
+      bucket: ((state_bucket))
+      region_name: ((aws_region))
+      versioned_file: pagerduty-secrets.yml
 
 jobs:
   - name: pipeline-lock
@@ -1207,6 +1203,7 @@ jobs:
           - get: cf-vars-store
           - get: cf-tfstate
           - get: paas-yet-another-cloudwatch-exporter
+          - get: pagerduty-secrets
 
       - task: extract-terraform-outputs
         config:
@@ -1239,6 +1236,7 @@ jobs:
             - name: cf-vars-store
             - name: terraform-outputs
             - name: bosh-secrets
+            - name: pagerduty-secrets
           outputs:
             - name: prometheus-manifest
             - name: prometheus-manifest-pre-vars
@@ -3477,7 +3475,6 @@ jobs:
             SYSTEM_DOMAIN: ((system_dns_zone_name))
 
         - task: smoke-tests-run
-          attempts: 3
           file: paas-cf/concourse/tasks/smoke-tests-run.yml
           params:
             AWS_DEFAULT_REGION: ((aws_region))
@@ -3485,11 +3482,6 @@ jobs:
             SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
             ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
             EMAIL_ON_SMOKE_TEST_FAILURE: ((ENABLE_ALERT_EMAILS))
-          on_failure:
-            put: pagerduty-notify
-            params:
-              action: trigger
-              description: "((deploy_env)) concourse continuous smoketests errors"
           ensure:
             task: upload-test-artifacts
             file: paas-cf/concourse/tasks/upload-test-artifacts.yml

--- a/concourse/scripts/lib/pagerduty.sh
+++ b/concourse/scripts/lib/pagerduty.sh
@@ -5,12 +5,12 @@ set -u
 get_pagerduty_secrets() {
   # shellcheck disable=SC2154
   secrets_uri="s3://${state_bucket}/pagerduty-secrets.yml"
-  export pagerduty_integration_key
+  export alertmanager_pagerduty_service_key
   if aws s3 ls "$secrets_uri" > /dev/null ; then
     secrets_file=$(mktemp -t pagerduty-secrets.XXXXXX)
 
     aws s3 cp "$secrets_uri" "$secrets_file"
-    pagerduty_integration_key=$("${SCRIPT_DIR}/val_from_yaml.rb" pagerduty_integration_key "$secrets_file")
+    alertmanager_pagerduty_service_key=$("${SCRIPT_DIR}/val_from_yaml.rb" alertmanager_pagerduty_service_key "$secrets_file")
 
     rm -f "$secrets_file"
   fi

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -78,9 +78,11 @@ prepare_environment() {
     exit 1
   fi
 
+  # Note: this credential is not interpolated into the pipeline. It is used as a guard against forgetting
+  # to upload the credentials and has been placed here for consistency with the other credentials.
   # shellcheck disable=SC2154
-  if [ -z "${pagerduty_integration_key+x}" ] && [ "${MAKEFILE_ENV_TARGET}" != "dev" ]; then
-    echo "Could not retrieve integration key for Pagerduty. Did you run \`make ${MAKEFILE_ENV_TARGET} upload-pagerduty-secrets\`?"
+  if [ -z "${alertmanager_pagerduty_service_key+x}" ] && [ "${MAKEFILE_ENV_TARGET}" != "dev" ]; then
+    echo "Could not retrieve PagerDuty service key for Alertmanager. Did you run \`make ${MAKEFILE_ENV_TARGET} upload-pagerduty-secrets\`?"
     exit 1
   fi
 
@@ -129,7 +131,6 @@ disable_cf_acceptance_tests: ${DISABLE_CF_ACCEPTANCE_TESTS:-}
 disable_custom_acceptance_tests: ${DISABLE_CUSTOM_ACCEPTANCE_TESTS:-}
 disable_pipeline_locking: ${DISABLE_PIPELINE_LOCKING:-}
 aiven_api_token: ${aiven_api_token:-}
-pagerduty_integration_key: "${pagerduty_integration_key:-this-is-not-a-pagerduty-key}"
 concourse_atc_password: ${CONCOURSE_ATC_PASSWORD}
 oauth_client_id: "${oauth_client_id:-}"
 oauth_client_secret: "${oauth_client_secret:-}"

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -120,7 +120,7 @@ system_dns_zone_name: ${SYSTEM_DNS_ZONE_NAME}
 apps_dns_zone_name: ${APPS_DNS_ZONE_NAME}
 git_concourse_pool_clone_full_url_ssh: ${git_concourse_pool_clone_full_url_ssh}
 ALERT_EMAIL_ADDRESS: ${ALERT_EMAIL_ADDRESS:-}
-ENABLE_ALERT_EMAILS: ${ENABLE_ALERT_EMAILS:-true}
+ENABLE_ALERT_NOTIFICATIONS: ${ENABLE_ALERT_NOTIFICATIONS:-true}
 NEW_ACCOUNT_EMAIL_ADDRESS: "${NEW_ACCOUNT_EMAIL_ADDRESS:-}"
 disable_healthcheck_db: ${DISABLE_HEALTHCHECK_DB:-}
 test_heavy_load: ${TEST_HEAVY_LOAD:-false}

--- a/manifests/prometheus/alerts.d/concourse-smoketests-errors.yml
+++ b/manifests/prometheus/alerts.d/concourse-smoketests-errors.yml
@@ -13,7 +13,6 @@
         expr: increase(concourse_continuous_smoke_tests_errors[1h]) >= 3
         labels:
           severity: critical
-          notify: pagerduty
         annotations:
           summary: Concourse continuous-smoke-tests errors
           description: The continuous-smoke-tests Concourse job has been erroring for a while now.

--- a/manifests/prometheus/alerts.d/concourse-smoketests-errors.yml
+++ b/manifests/prometheus/alerts.d/concourse-smoketests-errors.yml
@@ -6,13 +6,10 @@
   value:
     name: ConcourseSmoketestsErrors
     rules:
-      - record: "concourse_continuous_smoke_tests_errors"
-        expr: sum(concourse_builds_finished{exported_job="continuous-smoke-tests",pipeline="create-cloudfoundry",status="errored"} or (absent(concourse_builds_finished{exported_job="continuous-smoke-tests",pipeline="create-cloudfoundry",status="errored"})-1))
-
       - alert: ConcourseSmoketestsErrors
-        expr: increase(concourse_continuous_smoke_tests_errors[1h]) >= 3
+        expr: increase(concourse_builds_finished{exported_job="continuous-smoke-tests",pipeline="create-cloudfoundry",status="errored"}[30m]) >= 3
         labels:
-          severity: critical
+          severity: warning
         annotations:
           summary: Concourse continuous-smoke-tests errors
-          description: The continuous-smoke-tests Concourse job has been erroring for a while now.
+          description: The continuous-smoke-tests Concourse job has an increased error rate

--- a/manifests/prometheus/alerts.d/concourse-smoketests-errors.yml
+++ b/manifests/prometheus/alerts.d/concourse-smoketests-errors.yml
@@ -13,6 +13,7 @@
         expr: increase(concourse_continuous_smoke_tests_errors[1h]) >= 3
         labels:
           severity: critical
+          notify: pagerduty
         annotations:
           summary: Concourse continuous-smoke-tests errors
           description: The continuous-smoke-tests Concourse job has been erroring for a while now.

--- a/manifests/prometheus/alerts.d/concourse-smoketests-failures.yml
+++ b/manifests/prometheus/alerts.d/concourse-smoketests-failures.yml
@@ -6,13 +6,19 @@
   value:
     name: ConcourseSmoketestsFailures
     rules:
-      - record: "concourse_continuous_smoke_tests_failures"
-        expr: sum(concourse_builds_finished{exported_job="continuous-smoke-tests",pipeline="create-cloudfoundry",status="failed"} or (absent(concourse_builds_finished{exported_job="continuous-smoke-tests",pipeline="create-cloudfoundry",status="failed"})-1))
-
-      - alert: ConcourseSmoketestsFailures
-        expr: increase(concourse_continuous_smoke_tests_failures[1h]) >= 3
+      - alert: ConcourseSmoketestsFailuresWarning
+        expr: increase(concourse_builds_finished{exported_job="continuous-smoke-tests",pipeline="create-cloudfoundry",status="failed"}[1h]) >= 2
         labels:
-          severity: critical
+          severity: warning
         annotations:
           summary: Concourse continuous-smoke-tests failures
-          description: The continuous-smoke-tests Concourse job has been failing for a while now.
+          description: The continuous-smoke-tests Concourse job has failed at least twice in the last hour.
+
+      - alert: ConcourseSmoketestsFailuresCritical
+        expr: increase(concourse_builds_finished{exported_job="continuous-smoke-tests",pipeline="create-cloudfoundry",status="failed"}[30m]) >= 3
+        labels:
+          severity: critical
+          notify: pagerduty
+        annotations:
+          summary: Concourse continuous-smoke-tests failures
+          description: The continuous-smoke-tests Concourse job has failed at least three times in the last 30 minutes.

--- a/manifests/prometheus/alerts.d/concourse-smoketests-no-data.yml
+++ b/manifests/prometheus/alerts.d/concourse-smoketests-no-data.yml
@@ -8,7 +8,7 @@
     rules:
       - alert: ConcourseSmoketestsNoData
         expr: absent(concourse_builds_finished{pipeline="create-cloudfoundry",exported_job="continuous-smoke-tests"})
-        for: 30m
+        for: 15m
         labels:
           severity: critical
         annotations:

--- a/manifests/prometheus/alerts.d/concourse-smoketests-no-data.yml
+++ b/manifests/prometheus/alerts.d/concourse-smoketests-no-data.yml
@@ -10,7 +10,15 @@
         expr: absent(concourse_builds_finished{pipeline="create-cloudfoundry",exported_job="continuous-smoke-tests"})
         for: 15m
         labels:
-          severity: critical
+          severity: warning
         annotations:
           summary: Concourse continuous-smoke-tests no data
           description: The continuous-smoke-tests Concourse job has not been reporting data for a while now.
+
+      - alert: ConcourseSmoketestsNotRunning
+        expr: sum(increase(concourse_builds_finished{exported_job="continuous-smoke-tests",pipeline="create-cloudfoundry"}[15m])) == 0
+        labels:
+          severity: warning
+        annotations:
+          summary: Concourse continuous-smoke-tests job is not running
+          description: The continuous-smoke-tests Concourse job has not been running for a while now.

--- a/manifests/prometheus/operations.d/310-alertmanager-routes.yml
+++ b/manifests/prometheus/operations.d/310-alertmanager-routes.yml
@@ -13,9 +13,15 @@
       - receiver: warning-receiver
         match:
           severity: "warning"
+        continue: true
       - receiver: critical-receiver
         match:
           severity: "critical"
+        continue: true
+      - receiver: pagerduty-receiver
+        match:
+          notify: "pagerduty"
+        repeat_interval: 4h
 
 - type: replace
   path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers?/-
@@ -36,3 +42,11 @@
         to: govpaas-alerting-((aws_account))+critical@digital.cabinet-office.gov.uk
         headers:
           Subject: "[((metrics_environment))] [critical] {{ .GroupLabels.SortedPairs.Values | join \" \" }}"
+
+- type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers?/-
+  value:
+    name: pagerduty-receiver
+    pagerduty_configs:
+      - service_key: ((alertmanager_pagerduty_service_key))
+        description: "[((metrics_environment))] {{ .GroupLabels.SortedPairs.Values | join \" \" }}"

--- a/manifests/prometheus/operations/disable-alert-notifications.yml
+++ b/manifests/prometheus/operations/disable-alert-notifications.yml
@@ -4,3 +4,6 @@
 
 - type: remove
   path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers/name=critical-receiver/email_configs
+
+- type: remove
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers/name=pagerduty-receiver/pagerduty_configs

--- a/manifests/prometheus/scripts/generate-manifest.sh
+++ b/manifests/prometheus/scripts/generate-manifest.sh
@@ -26,8 +26,8 @@ if [ -n "${VARS_STORE:-}" ]; then
   vars_store_args=" --var-errs --vars-store ${VARS_STORE}"
 fi
 
-if [ "${ENABLE_ALERT_EMAILS:-}" == "false" ]; then
-  opsfile_args+="-o ${PAAS_CF_DIR}/manifests/prometheus/operations/disable-email.yml"
+if [ "${ENABLE_ALERT_NOTIFICATIONS:-}" == "false" ]; then
+  opsfile_args+="-o ${PAAS_CF_DIR}/manifests/prometheus/operations/disable-alert-notifications.yml"
 fi
 
 variables_file="$(mktemp)"

--- a/manifests/prometheus/scripts/generate-manifest.sh
+++ b/manifests/prometheus/scripts/generate-manifest.sh
@@ -58,6 +58,7 @@ bosh interpolate \
   --vars-file="${variables_file}" \
   --vars-file="${WORKDIR}/terraform-outputs/cf.yml" \
   --vars-file="${WORKDIR}/bosh-secrets/bosh-secrets.yml" \
+  --vars-file="${WORKDIR}/pagerduty-secrets/pagerduty-secrets.yml" \
   --vars-file="${PAAS_CF_DIR}/manifests/prometheus/env-specific/${ENV_SPECIFIC_BOSH_VARS_FILE}" \
   --var-file bosh_ca_cert="${WORKDIR}/bosh-CA-crt/bosh-CA.crt" \
   ${opsfile_args} \

--- a/manifests/prometheus/spec/alerts/concourse-smoketests-errors.test.yml
+++ b/manifests/prometheus/spec/alerts/concourse-smoketests-errors.test.yml
@@ -6,19 +6,22 @@ rule_files:
 evaluation_interval: 1m
 
 tests:
-  - interval: 15m
+  - interval: 5m
     input_series:
       - series: 'concourse_builds_finished{exported_job="continuous-smoke-tests",pipeline="create-cloudfoundry",status="errored"}'
-        values: 10 11 12 13 14
+        values: 10 10 11 11 12 12 13
 
     alert_rule_test:
       - alertname: ConcourseSmoketestsErrors
-        eval_time: 10m
+        eval_time: 25m
       - alertname: ConcourseSmoketestsErrors
-        eval_time: 1h
+        eval_time: 30m
         exp_alerts:
           - exp_labels:
-              severity: critical
+              severity: warning
+              exported_job: continuous-smoke-tests
+              pipeline: create-cloudfoundry
+              status: errored
             exp_annotations:
               summary: Concourse continuous-smoke-tests errors
-              description: The continuous-smoke-tests Concourse job has been erroring for a while now.
+              description: The continuous-smoke-tests Concourse job has an increased error rate

--- a/manifests/prometheus/spec/alerts/concourse-smoketests-failures.test.yml
+++ b/manifests/prometheus/spec/alerts/concourse-smoketests-failures.test.yml
@@ -1,0 +1,56 @@
+---
+rule_files:
+  # See alerts_validation_spec.rb for details of how stdin gets set:
+  - /dev/stdin
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 5m
+    input_series:
+      - series: 'concourse_builds_finished{exported_job="continuous-smoke-tests",pipeline="create-cloudfoundry",status="failed"}'
+        values: 10 10 10 11 11 11 12 12 13
+
+    alert_rule_test:
+      - alertname: ConcourseSmoketestsFailuresWarning
+        eval_time: 25m
+
+      - alertname: ConcourseSmoketestsFailuresWarning
+        eval_time: 30m
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              exported_job: continuous-smoke-tests
+              pipeline: create-cloudfoundry
+              status: failed
+            exp_annotations:
+              summary: Concourse continuous-smoke-tests failures
+              description: The continuous-smoke-tests Concourse job has failed at least twice in the last hour.
+
+      - alertname: ConcourseSmoketestsFailuresWarning
+        eval_time: 60m
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              exported_job: continuous-smoke-tests
+              pipeline: create-cloudfoundry
+              status: failed
+            exp_annotations:
+              summary: Concourse continuous-smoke-tests failures
+              description: The continuous-smoke-tests Concourse job has failed at least twice in the last hour.
+
+      - alertname: ConcourseSmoketestsFailuresCritical
+        eval_time: 35m
+
+      - alertname: ConcourseSmoketestsFailuresCritical
+        eval_time: 40m
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              notify: pagerduty
+              exported_job: continuous-smoke-tests
+              pipeline: create-cloudfoundry
+              status: failed
+            exp_annotations:
+              summary: Concourse continuous-smoke-tests failures
+              description: The continuous-smoke-tests Concourse job has failed at least three times in the last 30 minutes.

--- a/manifests/prometheus/spec/operations/alertmanager_routes_spec.rb
+++ b/manifests/prometheus/spec/operations/alertmanager_routes_spec.rb
@@ -1,0 +1,6 @@
+RSpec.describe "alertmanager" do
+  it "should have a pagerduty receiver with a correct service key" do
+    pagerduty_configs = manifest_with_defaults.get("instance_groups.alertmanager.jobs.alertmanager.properties.alertmanager.receivers.pagerduty-receiver.pagerduty_configs")
+    expect(pagerduty_configs[0]['service_key']).to eq("test_alertmanager_pagerduty_service_key")
+  end
+end

--- a/manifests/prometheus/spec/support/manifest_helpers.rb
+++ b/manifests/prometheus/spec/support/manifest_helpers.rb
@@ -39,6 +39,7 @@ private
     copy_fixture_file('cf-vars-store.yml', "#{workdir}/cf-vars-store")
     copy_fixture_file('bosh-CA.crt', "#{workdir}/bosh-CA-crt")
     copy_fixture_file('bosh-secrets.yml', "#{workdir}/bosh-secrets")
+    copy_fixture_file('pagerduty-secrets.yml', "#{workdir}/pagerduty-secrets")
 
     env = fake_env_vars
     env['PAAS_CF_DIR'] = root.to_s

--- a/manifests/shared/spec/fixtures/pagerduty-secrets.yml
+++ b/manifests/shared/spec/fixtures/pagerduty-secrets.yml
@@ -1,0 +1,2 @@
+---
+alertmanager_pagerduty_service_key: test_alertmanager_pagerduty_service_key

--- a/scripts/upload-pagerduty-secrets.sh
+++ b/scripts/upload-pagerduty-secrets.sh
@@ -4,14 +4,14 @@ set -eu
 
 export PASSWORD_STORE_DIR=${PAGERDUTY_PASSWORD_STORE_DIR}
 
-KEY=$(pass "pagerduty/${MAKEFILE_ENV_TARGET}/pagerduty_integration_key")
+ALERTMANAGER_PAGERDUTY_SERVICE_KEY=$(pass "pagerduty/${MAKEFILE_ENV_TARGET}/alertmanager_pagerduty_service_key")
 
 SECRETS=$(mktemp secrets.yml.XXXXXX)
 trap 'rm  "${SECRETS}"' EXIT
 
 cat > "${SECRETS}" << EOF
 ---
-pagerduty_integration_key: ${KEY}
+alertmanager_pagerduty_service_key: ${ALERTMANAGER_PAGERDUTY_SERVICE_KEY}
 EOF
 
 aws s3 cp "${SECRETS}" "s3://gds-paas-${DEPLOY_ENV}-state/pagerduty-secrets.yml"


### PR DESCRIPTION
## What

Refactor the continuous-smoke-tests alerts.

 * The retry logic was removed from the continuous-smoke-tests job on Concourse, as it was hiding intermittent errors
 * The PagerDuty alert will be created from alertmanager instead of Concourse
 * The smoke tests failure/increase alerts won't default to 0 value if the data is missing (this would cause big increases when it comes back and most alerts would fire)
 * I created a new alert which will be triggered if the continuous-smoke-tests are paused (so we have data but no runs)
 * The ENABLE_ALERT_EMAILS environment variable was renamed to ENABLE_ALERT_NOTIFICATIONS
 * In the dev environments we won't create PagerDuty alerts (but it can be enabled with the ENABLE_ALERT_NOTIFICATIONS env var)
* The `pagerduty_integration_key` was removed from `pagerduty_secrets.yml`

## How to review

1. Deploy your CF from this branch: `ENABLE_ALERT_NOTIFICATIONS=true BRANCH=162014355-monitor-smoke-test-fails make dev pipelines`
1. Run `make upload-pagerduty-secrets`
1. Test all alert changes (to make the `continuous-smoke-tests` error change e.g. the image_resource to a non-existing Docker image in `assert-should-run`, to make it fail add `exit 1` to the end of `assert-should-run`)

## How to release

❗️ Requirement: admin access to PagerDuty.

1. In PagerDuty we need to move the existing integrations or set up new ones for Prometheus. Currently there is a new `GOV.UK PaaS Prometheus Alerts` service with integrations, but I suspect that won't be correct as we need to separate prod from the other envs.
1. All the integration keys need to be added/updated in paas-credentials under `pagerduty/[ENV]/alertmanager_pagerduty_service_key`. The `pagerduty/[ENV]/pagerduty_integration_key` keys can be removed. (We don't have a service key for stg-lon currently, so that needs to be created - or copied from staging)
1. Upload the pagerduty secrets to all environments
1. Merge this PR.

It's the easiest if there are no other deployments running while this is being released as removing the `pagerduty_integration_key` from the pagerduty secrets file might cause other deploys to fail. 

## Who can review

Not me.