### PR TITLE
Increase cells in London from 9 to 11

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -1,4 +1,4 @@
 ---
-cell_instances: 9
+cell_instances: 11
 router_instances: 3
 api_instances: 2


### PR DESCRIPTION
What
----

The "DiegoCellRepMemoryCapacity_Critical" is currently firing in
prod-lon, because `rep_memory_capacity_pct:avg5m` is sitting around
30.8%, which is less than the threshold of 33.

Increasing the number of instances to 10 would probably only increase
the free memory by 1/9, which would only just put us above the threshold
of 33:

30.8 + 30.8 * 1/9 = 34.2%

Scaling up to 11 should increase the free memory by 2/9, which gives us
a bit more margin:

30.8 + 30.8 * 2/9 = 37.6%

The numbers may not work out quite so neatly in reality, so we'll have
to keep an eye on the metrics.

How to review
-------------

* Code review only - no point in testing in a non-prod-lon environment.

Who can review
--------------

Not @richardtowers