### PR TITLE
[Support] Increase Elasticache limits in London

### DIFF
--- a/manifests/prometheus/env-specific/prod-lon.yml
+++ b/manifests/prometheus/env-specific/prod-lon.yml
@@ -1,5 +1,5 @@
 ---
 
 # AWS Limits not accesible via API
-aws_limits_elasticache_cache_parameter_groups: 100
-aws_limits_elasticache_nodes: 100
+aws_limits_elasticache_cache_parameter_groups: 200
+aws_limits_elasticache_nodes: 200


### PR DESCRIPTION
What
----

We've had our limit raised by AWS, so this updates the thresholds used
by our alerts to match.

How to review
-------------

Verify the new limits match those in the AWS support ticket.

Who can review
--------------

Not me.