### PR TITLE
[Support] Make paas-metrics deploy zero-downtime.

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2487,11 +2487,14 @@ jobs:
                   manifest['applications'].each { |app|
                     app['env'] = {} unless app['env']
                     app['env'].merge!(env)
+                    app['routes'] = [
+                      { 'route' => 'paas-metrics.${APPS_DNS_ZONE_NAME}' },
+                    ]
                   }
                   File.write('manifest.yml', manifest.to_yaml)
                 "
 
-                cf push paas-metrics
+                cf zero-downtime-push paas-metrics -f ./manifest.yml
 
       - task: deploy-paas-uaa-assets
         config:


### PR DESCRIPTION
What
----

At the moment we get a gap in the metrics this produces each time it
gets deployed. Making it zero-downtime to avoid this.

How to review
-------------

Code review - I've already tested this in my dev env.

Who can review
--------------

Not me.