### PR TITLE
[#163651298] Deploy paas-billing-collector that doesn't block other queries while the init/refresh runs

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -327,7 +327,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-billing
-      tag_filter: v0.50.0
+      tag_filter: v0.51.0
 
   - name: paas-accounts
     type: git


### PR DESCRIPTION
What
----

This PR deployed the updated paas-billing app that is not blocking access to the database during initialisation and refreshes of the data.

How to review
-------------

Deploy from this branch and view the recent logs from paas-billing to see a much faster init. Leave this running for an hour to verify that the refresh function has run correctly.

How to merge
--------------

Update the commit with the tagged release once https://github.com/alphagov/paas-billing/pull/62 has been merged.

Who can review
--------------

Not @LeePorte or @mogds 
