### PR TITLE
[#163861624] Add `google-site-verification` TXT record to apex of apps domain

### DIFF
--- a/terraform/cloudfoundry/dns-records.tf
+++ b/terraform/cloudfoundry/dns-records.tf
@@ -42,6 +42,14 @@ resource "aws_route53_record" "system_apex" {
   }
 }
 
+resource "aws_route53_record" "google_site_verification" {
+  zone_id = "${var.apps_dns_zone_id}"
+  name    = "${var.apps_dns_zone_name}."
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=N2Pyk2D-qppi7bFBYUrdq3E3gNXOcwOacJMkIV_12Ec"]
+}
+
 resource "aws_route53_record" "apps_apex" {
   zone_id = "${var.apps_dns_zone_id}"
   name    = "${var.apps_dns_zone_name}."


### PR DESCRIPTION
What
----

Added terraform to add a TXT record to the apps domain so it can be verified on my Google Search Console account.

How to review
-------------

Deploy in a dev environment, and ensure the record is created with:

`dig +short TXT ${env}.dev.cloudpipelineapps.digital`

Example of this working:

```
➜ dig +short TXT tnw.dev.cloudpipelineapps.digital
"google-site-verification=N2Pyk2D-qppi7bFBYUrdq3E3gNXOcwOacJMkIV_12Ec"
```


Who can review
--------------

Not me
