### PR TITLE
[#163364479] Bumping prometheus-boshrelease version to v24.1.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "manifests/cf-deployment"]
 	path = manifests/cf-deployment
 	url = https://github.com/cloudfoundry/cf-deployment
-[submodule "manifests/prometheus/upstream"]
+[submodule "prometheus"]
 	path = manifests/prometheus/upstream
-	url = https://github.com/alphagov/paas-prometheus-boshrelease
+	url = https://github.com/bosh-prometheus/prometheus-boshrelease

--- a/manifests/prometheus/operations.d/000-custom-prometheus-bosh-release.yml
+++ b/manifests/prometheus/operations.d/000-custom-prometheus-bosh-release.yml
@@ -1,9 +1,0 @@
----
-
-- type: replace
-  path: /releases/name=prometheus
-  value:
-    name: prometheus
-    version: 0.1.3
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/prometheus-0.1.3.tgz
-    sha1: a19681ffac93bc36fc274fc3daead794f965f7b5


### PR DESCRIPTION
What
----
Bumps prometheus-boshrelease version to v24.1.0 on the upstream repository. Previously, we deployed a version from our [fork](https://github.com/alphagov/paas-prometheus-boshrelease) because it contained a number of commits we needed and weren't yet available in the upstream. v24.1.0 contains those commits. 

How to review
-------------
Reviewed during dev by running down the pipeline to a full-fat dev environment with this as the only change.

Who can review
--------------
Paired on throughout by @jpluscplusm and @AP-Hunt 