### PR TITLE
[#164104586] Stop specifying Postgres10 minor version for broker

### DIFF
--- a/manifests/cf-manifest/operations.d/713-rds-broker-postgres10-plans.yml
+++ b/manifests/cf-manifest/operations.d/713-rds-broker-postgres10-plans.yml
@@ -15,7 +15,7 @@
       vpc_security_group_ids:
         - ((terraform_outputs_rds_broker_dbs_security_group_id))
       engine: "postgres"
-      engine_version: "10.5"
+      engine_version: "10"
       db_parameter_group_name: ((terraform_outputs_rds_broker_postgres10_db_parameter_group))
       postgres_extensions: ["uuid-ossp", "postgis", "citext"]
 

--- a/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
@@ -215,8 +215,8 @@ RSpec.describe "RDS broker properties" do
         shared_examples "postgres 10.5 plans" do
           let(:rds_properties) { subject.fetch("rds_properties") }
 
-          it "uses postgres 10.5" do
-            expect(rds_properties["engine_version"]).to eq("10.5")
+          it "uses postgres 10" do
+            expect(rds_properties["engine_version"]).to eq("10")
           end
         end
 


### PR DESCRIPTION
## What

The Postgres versioning scheme has changed starting with Postgres 10[1],
and it now only uses a 2 part version number instead of the 3 part
number that was used for 9.x and earlier.

For Postgres 9.x we're only specifying the first 2 parts so that we
don't have conflicts when RDS auto-upgrades the minor versions. We want
the same behaviour for Postgres 10.x, so we need this to only specify on
version part.

With this change, the plan names no longer reflect reality as RDS will
use postgres 10.6. We'l rename these in a separate PR becuase this
change will require notifying tenants.

[1]https://www.postgresql.org/support/versioning/

How to review
-------------

Code review may be enough. I've run this down my dev environment and verified that it works. I've also verified that doing an update-service on a 10.6 instance works correctly where previously it would attempt to downgrade it which would be rejected by RDS.

Who can review
--------------

Not me.