### PR TITLE
[#164104586] Rename Postgres 10 plans to reflect reality

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1609,15 +1609,15 @@ jobs:
                 EOF
 
                 cat <<EOF | xargs -n1 cf enable-service-access postgres -p
-                tiny-unencrypted-10.5
-                small-10.5
-                small-ha-10.5
-                medium-10.5
-                medium-ha-10.5
-                large-10.5
-                large-ha-10.5
-                xlarge-10.5
-                xlarge-ha-10.5
+                tiny-unencrypted-10
+                small-10
+                small-ha-10
+                medium-10
+                medium-ha-10
+                large-10
+                large-ha-10
+                xlarge-10
+                xlarge-ha-10
                 EOF
 
                 # Disable deprecated plans

--- a/manifests/cf-manifest/operations.d/713-rds-broker-postgres10-plans.yml
+++ b/manifests/cf-manifest/operations.d/713-rds-broker-postgres10-plans.yml
@@ -42,12 +42,12 @@
   path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog/services/name=postgres/plans?/-
   value:
     id: "11f779fa-425c-4c86-9530-d0aebcb3c3e6"
-    name: "tiny-unencrypted-10.5"
-    description: "5GB Storage, NOT BACKED UP, Dedicated Instance, Max 50 Concurrent Connections. Postgres Version 10.5. DB Instance Class: db.t2.micro."
+    name: "tiny-unencrypted-10"
+    description: "5GB Storage, NOT BACKED UP, Dedicated Instance, Max 50 Concurrent Connections. Postgres Version 10. DB Instance Class: db.t2.micro."
     free: true
     metadata:
       bullets:
-        - "Dedicated Postgres 10.5 server"
+        - "Dedicated Postgres 10 server"
         - "AWS RDS"
     rds_properties:
       <<: *default_postgres_rds_properties # yamllint disable-line
@@ -57,8 +57,8 @@
   path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog/services/name=postgres/plans?/-
   value:
     id: "a68e4934-6c37-4f10-89b2-6388df093221"
-    name: "small-10.5"
-    description: "20GB Storage, Dedicated Instance, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 10.5. DB Instance Class: db.t2.small."
+    name: "small-10"
+    description: "20GB Storage, Dedicated Instance, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 10. DB Instance Class: db.t2.small."
     free: false
     metadata:
       costs:
@@ -66,7 +66,7 @@
             usd: 0.039
           unit: "HOUR"
       bullets:
-        - "Dedicated Postgres 10.5 server"
+        - "Dedicated Postgres 10 server"
         - "Storage Encrypted"
         - "AWS RDS"
     rds_properties:
@@ -78,8 +78,8 @@
   path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog/services/name=postgres/plans?/-
   value:
     id: "b2ef068e-5937-4522-ab97-758f6e9ce0ff"
-    name: "small-ha-10.5"
-    description: "20GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 10.5. DB Instance Class: db.t2.small."
+    name: "small-ha-10"
+    description: "20GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 10. DB Instance Class: db.t2.small."
     free: false
     metadata:
       costs:
@@ -87,7 +87,7 @@
             usd: 0.078
           unit: "HOUR"
       bullets:
-        - "Dedicated Postgres 10.5 server"
+        - "Dedicated Postgres 10 server"
         - "AWS RDS"
     rds_properties:
       <<: *default_postgres_rds_properties # yamllint disable-line
@@ -99,8 +99,8 @@
   path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog/services/name=postgres/plans?/-
   value:
     id: "d9e7b133-e584-4a9b-bef9-c53c2f2142f6"
-    name: "medium-10.5"
-    description: "100GB Storage, Dedicated Instance, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 10.5. DB Instance Class: db.m4.large."
+    name: "medium-10"
+    description: "100GB Storage, Dedicated Instance, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m4.large."
     free: false
     metadata:
       costs:
@@ -108,7 +108,7 @@
             usd: 0.201
           unit: "HOUR"
       bullets:
-        - "Dedicated Postgres 10.5 server"
+        - "Dedicated Postgres 10 server"
         - "Storage Encrypted"
         - "AWS RDS"
     rds_properties:
@@ -120,8 +120,8 @@
   path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog/services/name=postgres/plans?/-
   value:
     id: "0c89ea29-e6b3-44be-9b39-85cd42c3911e"
-    name: "medium-ha-10.5"
-    description: "100GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 10.5. DB Instance Class: db.m4.large."
+    name: "medium-ha-10"
+    description: "100GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m4.large."
     free: false
     metadata:
       costs:
@@ -129,7 +129,7 @@
             usd: 0.402
           unit: "HOUR"
       bullets:
-        - "Dedicated Postgres 10.5 server"
+        - "Dedicated Postgres 10 server"
         - "Storage Encrypted"
         - "AWS RDS"
     rds_properties:
@@ -142,8 +142,8 @@
   path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog/services/name=postgres/plans?/-
   value:
     id: "da44b024-52bd-459f-8078-38591d574c90"
-    name: "large-10.5"
-    description: "512GB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10.5. DB Instance Class: db.m4.2xlarge."
+    name: "large-10"
+    description: "512GB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m4.2xlarge."
     free: false
     metadata:
       costs:
@@ -151,7 +151,7 @@
             usd: 0.806
           unit: "HOUR"
       bullets:
-        - "Dedicated Postgres 10.5 server"
+        - "Dedicated Postgres 10 server"
         - "Storage Encrypted"
         - "AWS RDS"
     rds_properties:
@@ -163,8 +163,8 @@
   path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog/services/name=postgres/plans?/-
   value:
     id: "4140d479-601a-4585-ae1e-df67a9fa6b36"
-    name: "large-ha-10.5"
-    description: "512GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10.5. DB Instance Class: db.m4.2xlarge."
+    name: "large-ha-10"
+    description: "512GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m4.2xlarge."
     free: false
     metadata:
       costs:
@@ -172,7 +172,7 @@
             usd: 1.612
           unit: "HOUR"
       bullets:
-        - "Dedicated Postgres 10.5 server"
+        - "Dedicated Postgres 10 server"
         - "Storage Encrypted"
         - "AWS RDS"
     rds_properties:
@@ -185,8 +185,8 @@
   path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog/services/name=postgres/plans?/-
   value:
     id: "43b01f78-0c9f-482e-b77f-e28189ccd870"
-    name: "xlarge-10.5"
-    description: "2TB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10.5. DB Instance Class: db.m4.4xlarge."
+    name: "xlarge-10"
+    description: "2TB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m4.4xlarge."
     free: false
     metadata:
       costs:
@@ -194,7 +194,7 @@
             usd: 1.612
           unit: "HOUR"
       bullets:
-        - "Dedicated Postgres 10.5 server"
+        - "Dedicated Postgres 10 server"
         - "Storage Encrypted"
         - "AWS RDS"
     rds_properties:
@@ -206,8 +206,8 @@
   path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog/services/name=postgres/plans?/-
   value:
     id: "2f6df103-8216-4bc4-bb38-a6422e03c981"
-    name: "xlarge-ha-10.5"
-    description: "2TB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10.5. DB Instance Class: db.m4.4xlarge."
+    name: "xlarge-ha-10"
+    description: "2TB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m4.4xlarge."
     free: false
     metadata:
       costs:
@@ -215,7 +215,7 @@
             usd: 3.224
           unit: "HOUR"
       bullets:
-        - "Dedicated Postgres 10.5 server"
+        - "Dedicated Postgres 10 server"
         - "Storage Encrypted"
         - "AWS RDS"
     rds_properties:

--- a/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
@@ -177,15 +177,15 @@ RSpec.describe "RDS broker properties" do
           "xlarge-9.5",
           "xlarge-ha-unencrypted-9.5",
           "xlarge-ha-9.5",
-          "tiny-unencrypted-10.5",
-          "small-10.5",
-          "small-ha-10.5",
-          "medium-10.5",
-          "medium-ha-10.5",
-          "large-10.5",
-          "large-ha-10.5",
-          "xlarge-10.5",
-          "xlarge-ha-10.5",
+          "tiny-unencrypted-10",
+          "small-10",
+          "small-ha-10",
+          "medium-10",
+          "medium-ha-10",
+          "large-10",
+          "large-ha-10",
+          "xlarge-10",
+          "xlarge-ha-10",
         )
       end
 
@@ -212,7 +212,7 @@ RSpec.describe "RDS broker properties" do
           end
         end
 
-        shared_examples "postgres 10.5 plans" do
+        shared_examples "postgres 10 plans" do
           let(:rds_properties) { subject.fetch("rds_properties") }
 
           it "uses postgres 10" do
@@ -411,104 +411,104 @@ RSpec.describe "RDS broker properties" do
           it_behaves_like "Encryption enabled plans"
         end
 
-        # Postgres 10.5
-        describe "tiny-unencrypted-10.5" do
-          subject { pg_plans.find { |p| p["name"] == "tiny-unencrypted-10.5" } }
+        # Postgres 10
+        describe "tiny-unencrypted-10" do
+          subject { pg_plans.find { |p| p["name"] == "tiny-unencrypted-10" } }
 
           it "is marked as free" do
             expect(subject.fetch("free")).to eq(true)
           end
 
           it_behaves_like "all postgres plans"
-          it_behaves_like "postgres 10.5 plans"
+          it_behaves_like "postgres 10 plans"
           it_behaves_like "tiny sized plans"
           it_behaves_like "backup disabled plans"
           it_behaves_like "non-HA plans"
           it_behaves_like "Encryption disabled plans"
         end
 
-        describe "small-10.5" do
-          subject { pg_plans.find { |p| p["name"] == "small-10.5" } }
+        describe "small-10" do
+          subject { pg_plans.find { |p| p["name"] == "small-10" } }
 
           it_behaves_like "all postgres plans"
-          it_behaves_like "postgres 10.5 plans"
+          it_behaves_like "postgres 10 plans"
           it_behaves_like "small sized plans"
           it_behaves_like "backup enabled plans"
           it_behaves_like "non-HA plans"
           it_behaves_like "Encryption enabled plans"
         end
 
-        describe "small-ha-10.5" do
-          subject { pg_plans.find { |p| p["name"] == "small-ha-10.5" } }
+        describe "small-ha-10" do
+          subject { pg_plans.find { |p| p["name"] == "small-ha-10" } }
 
           it_behaves_like "all postgres plans"
-          it_behaves_like "postgres 10.5 plans"
+          it_behaves_like "postgres 10 plans"
           it_behaves_like "small sized plans"
           it_behaves_like "backup enabled plans"
           it_behaves_like "HA plans"
           it_behaves_like "Encryption enabled plans"
         end
 
-        describe "medium-10.5" do
-          subject { pg_plans.find { |p| p["name"] == "medium-10.5" } }
+        describe "medium-10" do
+          subject { pg_plans.find { |p| p["name"] == "medium-10" } }
 
           it_behaves_like "all postgres plans"
-          it_behaves_like "postgres 10.5 plans"
+          it_behaves_like "postgres 10 plans"
           it_behaves_like "medium sized plans"
           it_behaves_like "backup enabled plans"
           it_behaves_like "non-HA plans"
           it_behaves_like "Encryption enabled plans"
         end
 
-        describe "medium-ha-10.5" do
-          subject { pg_plans.find { |p| p["name"] == "medium-ha-10.5" } }
+        describe "medium-ha-10" do
+          subject { pg_plans.find { |p| p["name"] == "medium-ha-10" } }
 
           it_behaves_like "all postgres plans"
-          it_behaves_like "postgres 10.5 plans"
+          it_behaves_like "postgres 10 plans"
           it_behaves_like "medium sized plans"
           it_behaves_like "backup enabled plans"
           it_behaves_like "HA plans"
           it_behaves_like "Encryption enabled plans"
         end
 
-        describe "large-10.5" do
-          subject { pg_plans.find { |p| p["name"] == "large-10.5" } }
+        describe "large-10" do
+          subject { pg_plans.find { |p| p["name"] == "large-10" } }
 
           it_behaves_like "all postgres plans"
-          it_behaves_like "postgres 10.5 plans"
+          it_behaves_like "postgres 10 plans"
           it_behaves_like "large sized plans"
           it_behaves_like "backup enabled plans"
           it_behaves_like "non-HA plans"
           it_behaves_like "Encryption enabled plans"
         end
 
-        describe "large-ha-10.5" do
-          subject { pg_plans.find { |p| p["name"] == "large-ha-10.5" } }
+        describe "large-ha-10" do
+          subject { pg_plans.find { |p| p["name"] == "large-ha-10" } }
 
           it_behaves_like "all postgres plans"
-          it_behaves_like "postgres 10.5 plans"
+          it_behaves_like "postgres 10 plans"
           it_behaves_like "large sized plans"
           it_behaves_like "backup enabled plans"
           it_behaves_like "HA plans"
           it_behaves_like "Encryption enabled plans"
         end
 
-        describe "xlarge-10.5" do
-          subject { pg_plans.find { |p| p["name"] == "xlarge-10.5" } }
+        describe "xlarge-10" do
+          subject { pg_plans.find { |p| p["name"] == "xlarge-10" } }
 
           it_behaves_like "all postgres plans"
-          it_behaves_like "postgres 10.5 plans"
+          it_behaves_like "postgres 10 plans"
           it_behaves_like "xlarge sized plans"
           it_behaves_like "backup enabled plans"
           it_behaves_like "non-HA plans"
           it_behaves_like "Encryption enabled plans"
         end
 
-        describe "xlarge-ha-10.5" do
-          subject { pg_plans.find { |p| p["name"] == "xlarge-ha-10.5" } }
+        describe "xlarge-ha-10" do
+          subject { pg_plans.find { |p| p["name"] == "xlarge-ha-10" } }
 
           it_behaves_like "all postgres plans"
-          it_behaves_like "postgres 10.5 plans"
+          it_behaves_like "postgres 10 plans"
           it_behaves_like "xlarge sized plans"
           it_behaves_like "backup enabled plans"
           it_behaves_like "HA plans"

--- a/platform-tests/src/platform/acceptance/postgres_service_test.go
+++ b/platform-tests/src/platform/acceptance/postgres_service_test.go
@@ -17,7 +17,7 @@ import (
 var _ = Describe("Postgres backing service", func() {
 	const (
 		serviceName  = "postgres"
-		testPlanName = "tiny-unencrypted-10.5"
+		testPlanName = "tiny-unencrypted-10"
 	)
 
 	It("should have registered the postgres service", func() {
@@ -40,15 +40,15 @@ var _ = Describe("Postgres backing service", func() {
 			Expect(cfMarketplaceOutput).To(ContainSubstring("large-ha-9.5"))
 			Expect(cfMarketplaceOutput).To(ContainSubstring("xlarge-9.5"))
 			Expect(cfMarketplaceOutput).To(ContainSubstring("xlarge-ha-9.5"))
-			Expect(cfMarketplaceOutput).To(ContainSubstring("tiny-unencrypted-10.5"))
-			Expect(cfMarketplaceOutput).To(ContainSubstring("small-10.5"))
-			Expect(cfMarketplaceOutput).To(ContainSubstring("small-ha-10.5"))
-			Expect(cfMarketplaceOutput).To(ContainSubstring("medium-10.5"))
-			Expect(cfMarketplaceOutput).To(ContainSubstring("medium-ha-10.5"))
-			Expect(cfMarketplaceOutput).To(ContainSubstring("large-10.5"))
-			Expect(cfMarketplaceOutput).To(ContainSubstring("large-ha-10.5"))
-			Expect(cfMarketplaceOutput).To(ContainSubstring("xlarge-10.5"))
-			Expect(cfMarketplaceOutput).To(ContainSubstring("xlarge-ha-10.5"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("tiny-unencrypted-10"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("small-10"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("small-ha-10"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("medium-10"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("medium-ha-10"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("large-10"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("large-ha-10"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("xlarge-10"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("xlarge-ha-10"))
 			Expect(cfMarketplaceOutput).ToNot(ContainSubstring("small-unencrypted-9.5"))
 			Expect(cfMarketplaceOutput).ToNot(ContainSubstring("small-ha-unencrypted-9.5"))
 			Expect(cfMarketplaceOutput).ToNot(ContainSubstring("medium-unencrypted-9.5"))


### PR DESCRIPTION
## What

With the change in Postgres versioning[1], these plan names no longer
reflect reality as it won't necessarily be postgres 10.5 that tenants
end up with, it'll be the latest 10.x that RDS has available.

This therefore updates the plan names and descriptions to reflect this.

[1]https://www.postgresql.org/support/versioning/

How to review
-------------

Code review - run it down a pipeline and verify existing instances still work, and get the new plan names.

## 🚨 Do not merge before 27th Feb 🚨 

Who can review
--------------

Not me.