### PR TITLE
Use zero-downtime-push for Aiven broker.

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2403,11 +2403,13 @@ jobs:
                   manifest['applications'].each { |app|
                     app['env'] ||= {}
                     app['env'].merge!(env)
+                    app['routes'] = [
+                      { 'route' => 'aiven-broker.${APPS_DNS_ZONE_NAME}' },
+                    ]
                   }
                   File.write('manifest.yml', manifest.to_yaml)
                 "
-                cf blue-green-deploy aiven-broker
-                cf delete -f aiven-broker-old
+                cf zero-downtime-push aiven-broker -f ./manifest.yml
 
                 if cf service-brokers | grep 'aiven-broker\s'; then
                   cf update-service-broker aiven-broker aiven-broker "$AIVEN_BROKER_PASS" "https://aiven-broker.${APPS_DNS_ZONE_NAME}"


### PR DESCRIPTION
## What

...instead of blue-green-deploy. This makes it consistent with all the
other apps we push from this pipeline. It also means that we don't need
to manually cleanup the old app.

It has another advantage in that it renames the existing app before
pushing the new app, meaning the new app is initially pushed with the
correct name. This means that it will show up in billing with this name
instead of the -new variant.

How to review
-------------

Code review. I've already run this down my dev environment.

Who can review
--------------

Not me.