### PR TITLE
[#163592114] Deprecate Elasticsearch 5.x

### DIFF
--- a/config/service-brokers/aiven/config.json
+++ b/config/service-brokers/aiven/config.json
@@ -6,7 +6,7 @@
       {
         "id": "1b45c99b-c90d-45b8-918d-9fb7dcb4beec",
         "name": "elasticsearch",
-        "description": "Elasticsearch instances provisioned via Aiven",
+        "description": "Elasticsearch instances provisioned via Aiven. (Elasticsearch 5.x plans are deprecated and will be removed on 2019/04/16.)",
         "bindable": true,
         "plan_updateable": true,
         "metadata": {
@@ -20,10 +20,10 @@
             "name": "tiny-5.x",
             "aiven_plan": "startup-4",
             "elasticsearch_version": "5",
-            "description": "NOT Highly Available, 1 dedicated VM, 1 CPU per VM, 4GB RAM per VM, 80GB disk space.",
+            "description": "[DEPRECATED] NOT Highly Available, 1 dedicated VM, 1 CPU per VM, 4GB RAM per VM, 80GB disk space.",
             "free": true,
             "metadata": {
-              "displayName": "Tiny, NOT Highly Available single-node Elasticsearch 5 cluster"
+              "displayName": "[DEPRECATED] Tiny, NOT Highly Available single-node Elasticsearch 5 cluster"
             }
           },
           {
@@ -42,10 +42,10 @@
             "name": "small-ha-5.x",
             "aiven_plan": "business-4",
             "elasticsearch_version": "5",
-            "description": "3 dedicated VMs, 1 CPU per VM, 4GB RAM per VM, 240GB disk space.",
+            "description": "[DEPRECATED] 3 dedicated VMs, 1 CPU per VM, 4GB RAM per VM, 240GB disk space.",
             "free": false,
             "metadata": {
-              "displayName": "Small, highly available Elasticsearch 5 cluster"
+              "displayName": "[DEPRECATED] Small, highly available Elasticsearch 5 cluster"
             }
           },
           {
@@ -64,10 +64,10 @@
             "name": "medium-ha-5.x",
             "aiven_plan": "business-8",
             "elasticsearch_version": "5",
-            "description": "3 dedicated VMs, 2 CPU per VM, 8GB RAM per VM, 525GB disk space.",
+            "description": "[DEPRECATED] 3 dedicated VMs, 2 CPU per VM, 8GB RAM per VM, 525GB disk space.",
             "free": false,
             "metadata": {
-              "displayName": "Medium, highly available Elasticsearch 5 cluster"
+              "displayName": "[DEPRECATED] Medium, highly available Elasticsearch 5 cluster"
             }
           },
           {


### PR DESCRIPTION
What
----
Update the descriptions and displayNames for all Elasticsearch 5 plans to indicate that they are deprecated.

The amended blocks are removed in another PR, which will be merged after the tenants notice period.

How to review
-------------
Code review should be enough. The changes made only affect the marketplace output.

Who can review
--------------
Not @tnwhitwell or @AP-Hunt 