### PR TITLE
[#163592114] Remove Elasticsearch 5.x

### DIFF
--- a/config/service-brokers/aiven/config.json
+++ b/config/service-brokers/aiven/config.json
@@ -6,7 +6,7 @@
       {
         "id": "1b45c99b-c90d-45b8-918d-9fb7dcb4beec",
         "name": "elasticsearch",
-        "description": "Elasticsearch instances provisioned via Aiven. (Elasticsearch 5.x plans are deprecated and will be removed on 2019/04/16.)",
+        "description": "Elasticsearch instances provisioned via Aiven",
         "bindable": true,
         "plan_updateable": true,
         "metadata": {
@@ -15,17 +15,6 @@
           "supportUrl": "https://www.cloud.service.gov.uk/support"
         },
         "plans": [
-          {
-            "id": "07264114-c666-440b-934a-015508be4475",
-            "name": "tiny-5.x",
-            "aiven_plan": "startup-4",
-            "elasticsearch_version": "5",
-            "description": "[DEPRECATED] NOT Highly Available, 1 dedicated VM, 1 CPU per VM, 4GB RAM per VM, 80GB disk space.",
-            "free": true,
-            "metadata": {
-              "displayName": "[DEPRECATED] Tiny, NOT Highly Available single-node Elasticsearch 5 cluster"
-            }
-          },
           {
             "id": "7c0e6f6a-e443-41a0-83df-981bd35923a9",
             "name": "tiny-6.x",
@@ -38,17 +27,6 @@
             }
           },
           {
-            "id": "0eee9e10-db37-4cc3-bc9b-39e378ff3a5f",
-            "name": "small-ha-5.x",
-            "aiven_plan": "business-4",
-            "elasticsearch_version": "5",
-            "description": "[DEPRECATED] 3 dedicated VMs, 1 CPU per VM, 4GB RAM per VM, 240GB disk space.",
-            "free": false,
-            "metadata": {
-              "displayName": "[DEPRECATED] Small, highly available Elasticsearch 5 cluster"
-            }
-          },
-          {
             "id": "225e97cc-f786-408c-8b59-d2118248a53d",
             "name": "small-ha-6.x",
             "aiven_plan": "business-4",
@@ -57,17 +35,6 @@
             "free": false,
             "metadata": {
               "displayName": "Small, highly available Elasticsearch 6 cluster"
-            }
-          },
-          {
-            "id": "242a4782-7454-4ff4-93b2-dd88b333cb46",
-            "name": "medium-ha-5.x",
-            "aiven_plan": "business-8",
-            "elasticsearch_version": "5",
-            "description": "[DEPRECATED] 3 dedicated VMs, 2 CPU per VM, 8GB RAM per VM, 525GB disk space.",
-            "free": false,
-            "metadata": {
-              "displayName": "[DEPRECATED] Medium, highly available Elasticsearch 5 cluster"
             }
           },
           {

--- a/platform-tests/src/platform/acceptance/elasticsearch_service_test.go
+++ b/platform-tests/src/platform/acceptance/elasticsearch_service_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Elasticsearch backing service", func() {
 	})
 
 	It("has the expected plans available", func() {
-		expectedPlans := []string{"tiny-5.x", "tiny-6.x", "small-ha-5.x", "small-ha-6.x"}
+		expectedPlans := []string{"tiny-6.x", "small-ha-6.x", "medium-ha-6.x", "large-ha-6.x"}
 
 		actualPlans := cf.Cf("marketplace", "-s", serviceName).Wait(testConfig.DefaultTimeoutDuration())
 		Expect(actualPlans).To(Exit(0))

--- a/scripts/audit-services.rb
+++ b/scripts/audit-services.rb
@@ -1,0 +1,145 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'httparty'
+require 'optparse'
+require 'json'
+require 'yaml'
+require 'pp'
+
+CF_OAUTH_TOKEN = `cf oauth-token`.freeze
+API_ENDPOINT = `cf api`[/https.*$/].freeze
+
+HEADERS = {
+  Authorization: CF_OAUTH_TOKEN
+}.freeze
+
+service_plan_guid = ARGV[0]
+
+Filter = Struct.new(
+  :org_regex,
+  :space_regex,
+  :plan_regex,
+  :org_guid,
+  :space_guid
+) do
+  def unmarshal(input)
+    data = JSON.parse(input)
+    data.each do |key, value|
+      self[key] = value
+    rescue NameError
+      $stderr.print("'#{key}' is not a valid filter term\n")
+      raise
+    end
+    self
+  end
+end
+
+filters = Filter.new
+
+def parse_filter_json(input)
+  filters = Filter.new
+  filters.unmarshal(input)
+end
+
+op = OptionParser.new
+op.accept(Filter) do |filter|
+  parse_filter_json(filter)
+end
+
+op.on('-f', '--filter [JSON]', Filter, 'JSON to Filter results') do |f|
+  filters = f
+end
+
+op.parse!
+
+if service_plan_guid.nil?
+  puts <<-USAGE
+  Usage:
+  #{$PROGRAM_NAME} service-plan-guid [--filter 'valid-filter-json']
+
+  Get service-plan-guid with:
+
+  ```
+  CF_TRACE=1 cf m | grep -A10 "elasticsearch"
+  "label": "elasticsearch",
+  ...
+  "service_plans_url": "/v2/services/0c248093-6025-4d07-b559-ef647c2f58d1/service_plans", <<<<< SERVICE_PLAN_GUID = "0c248093-6025-4d07-b559-ef647c2f58d1"
+  ```
+
+  Filter JSON accepts the following:
+  {
+    "org_regex": REGEX_MATCHER,
+    "space_regex": REGEX_MATCHER,
+    "plan_regex": REGEX_MATCHER,
+    "org_guid": GUID-OF-ORG,
+    "space_guid": GUID-OF-SPACE
+  }
+  USAGE
+  exit 1
+end
+
+def do_paginated_capi_request(uri) # rubocop:disable Metrics/MethodLength, Lint/UnneededDisable, Metrics/LineLength
+  resources = []
+  until uri.nil?
+    req = HTTParty.get(
+      "#{API_ENDPOINT}#{uri}",
+      headers: HEADERS
+    )
+    resp = req.parsed_response
+    uri = resp['next_url']
+    if resp['resources'].nil?
+      resources = resp['entity']
+    else
+      resources.concat resp['resources']
+    end
+  end
+  resources
+end
+es_plans_req = do_paginated_capi_request(
+  "/v2/service_plans?q=service_guid:#{service_plan_guid}"
+)
+
+plans = {}
+
+es_plans_req.each do |plan| # rubocop:disable Metrics/BlockLength
+  plan_name = plan['entity']['name']
+  next unless plan_name \
+      =~ Regexp.new(/#{filters.plan_regex}/)
+  plan_instances_req = do_paginated_capi_request(
+    plan['entity']['service_instances_url']
+  )
+  next if plan_instances_req.length.zero?
+
+  plan_instances_req.each do |instance|
+    name = instance['entity']['name']
+    next unless instance['entity']['space_guid'] \
+      =~ Regexp.new(/#{filters.space_guid}/)
+
+    owning_space_req = do_paginated_capi_request(
+      instance['entity']['space_url']
+    )
+    owning_space_name = owning_space_req['name']
+    next unless owning_space_name \
+      =~ Regexp.new(/#{filters.space_regex}/)
+
+    next unless owning_space_req['organization_guid'] \
+      =~ Regexp.new(/#{filters.org_guid}/)
+
+    owning_org_url = owning_space_req['organization_url']
+    owning_guid_req = do_paginated_capi_request(
+      owning_org_url
+    )
+    owning_org_name = owning_guid_req['name']
+    next unless owning_org_name =~ Regexp.new(/#{filters.org_regex}/)
+
+    plans[plan_name].nil? && plans[plan_name] = []
+    plans[plan_name] << {
+      'name' => name,
+      'org_name' => owning_org_name,
+      'space_name' => owning_space_name
+    }
+  end
+end
+
+puts plans.to_yaml


### PR DESCRIPTION
What
----

Remove Elasticsearch 5.x plans from the Aiven broker

How to review
-------------

* Code Review
* Deploy in a dev environment, ensure the whole pipeline runs as expected and `cf m` no longer shows 5.x versions
* Ensure that no tenants have ES 5.x instances in any region:
  * London: `scripts/audit_services.rb 8698b363-51a3-4734-bb31-11ecb4ade7f5 --filter '{"plan_regex": ".*5.x$"}'
  * Ireland: `scripts/audit_services.rb b98f53e7-85a7-4964-bace-9ce27fac142a --filter '{"plan_regex": ".*5.x$"}'

Who can review
--------------

Not @tnwhitwell or @AP-Hunt 
