### PR TITLE
[#163592114] Remove Elasticsearch 5.x from billing

### DIFF
--- a/config/billing/config.json.erb
+++ b/config/billing/config.json.erb
@@ -1153,19 +1153,6 @@
 			]
 		},
 		{
-			"name": "elasticsearch tiny-5.x",
-			"valid_from": "2018-09-01",
-			"plan_guid": "07264114-c666-440b-934a-015508be4475",
-			"components": [
-				{
-					"name": "instance",
-					"formula": "ceil($time_in_seconds/3600) * <%= price("aiven_elasticsearch_startup_4") %>",
-					"currency_code": "USD",
-					"vat_code": "Standard"
-				}
-			]
-		},
-		{
 			"name": "elasticsearch tiny-6.x",
 			"valid_from": "2018-09-01",
 			"plan_guid": "7c0e6f6a-e443-41a0-83df-981bd35923a9",
@@ -1179,19 +1166,6 @@
 			]
 		},
 		{
-			"name": "elasticsearch small-ha-5.x",
-			"valid_from": "2017-01-01",
-			"plan_guid": "0eee9e10-db37-4cc3-bc9b-39e378ff3a5f",
-			"components": [
-				{
-					"name": "instance",
-					"formula": "ceil($time_in_seconds/3600) * <%= price("aiven_elasticsearch_business_4") %>",
-					"currency_code": "USD",
-					"vat_code": "Standard"
-				}
-			]
-		},
-		{
 			"name": "elasticsearch small-ha-6.x",
 			"valid_from": "2017-01-01",
 			"plan_guid": "225e97cc-f786-408c-8b59-d2118248a53d",
@@ -1199,19 +1173,6 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * <%= price("aiven_elasticsearch_business_4") %>",
-					"currency_code": "USD",
-					"vat_code": "Standard"
-				}
-			]
-		},
-		{
-			"name": "elasticsearch medium-ha-5.x",
-			"valid_from": "2018-10-01",
-			"plan_guid": "242a4782-7454-4ff4-93b2-dd88b333cb46",
-			"components": [
-				{
-					"name": "instance",
-					"formula": "ceil($time_in_seconds/3600) * <%= price("aiven_elasticsearch_business_8") %>",
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}

--- a/config/billing/output/eu-west-1.json
+++ b/config/billing/output/eu-west-1.json
@@ -1153,19 +1153,6 @@
 			]
 		},
 		{
-			"name": "elasticsearch tiny-5.x",
-			"valid_from": "2018-09-01",
-			"plan_guid": "07264114-c666-440b-934a-015508be4475",
-			"components": [
-				{
-					"name": "instance",
-					"formula": "ceil($time_in_seconds/3600) * 0.178",
-					"currency_code": "USD",
-					"vat_code": "Standard"
-				}
-			]
-		},
-		{
 			"name": "elasticsearch tiny-6.x",
 			"valid_from": "2018-09-01",
 			"plan_guid": "7c0e6f6a-e443-41a0-83df-981bd35923a9",
@@ -1179,19 +1166,6 @@
 			]
 		},
 		{
-			"name": "elasticsearch small-ha-5.x",
-			"valid_from": "2017-01-01",
-			"plan_guid": "0eee9e10-db37-4cc3-bc9b-39e378ff3a5f",
-			"components": [
-				{
-					"name": "instance",
-					"formula": "ceil($time_in_seconds/3600) * 0.548",
-					"currency_code": "USD",
-					"vat_code": "Standard"
-				}
-			]
-		},
-		{
 			"name": "elasticsearch small-ha-6.x",
 			"valid_from": "2017-01-01",
 			"plan_guid": "225e97cc-f786-408c-8b59-d2118248a53d",
@@ -1199,19 +1173,6 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 0.548",
-					"currency_code": "USD",
-					"vat_code": "Standard"
-				}
-			]
-		},
-		{
-			"name": "elasticsearch medium-ha-5.x",
-			"valid_from": "2018-10-01",
-			"plan_guid": "242a4782-7454-4ff4-93b2-dd88b333cb46",
-			"components": [
-				{
-					"name": "instance",
-					"formula": "ceil($time_in_seconds/3600) * 1.096",
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}

--- a/config/billing/output/eu-west-2.json
+++ b/config/billing/output/eu-west-2.json
@@ -1153,19 +1153,6 @@
 			]
 		},
 		{
-			"name": "elasticsearch tiny-5.x",
-			"valid_from": "2018-09-01",
-			"plan_guid": "07264114-c666-440b-934a-015508be4475",
-			"components": [
-				{
-					"name": "instance",
-					"formula": "ceil($time_in_seconds/3600) * 0.178",
-					"currency_code": "USD",
-					"vat_code": "Standard"
-				}
-			]
-		},
-		{
 			"name": "elasticsearch tiny-6.x",
 			"valid_from": "2018-09-01",
 			"plan_guid": "7c0e6f6a-e443-41a0-83df-981bd35923a9",
@@ -1179,19 +1166,6 @@
 			]
 		},
 		{
-			"name": "elasticsearch small-ha-5.x",
-			"valid_from": "2017-01-01",
-			"plan_guid": "0eee9e10-db37-4cc3-bc9b-39e378ff3a5f",
-			"components": [
-				{
-					"name": "instance",
-					"formula": "ceil($time_in_seconds/3600) * 0.548",
-					"currency_code": "USD",
-					"vat_code": "Standard"
-				}
-			]
-		},
-		{
 			"name": "elasticsearch small-ha-6.x",
 			"valid_from": "2017-01-01",
 			"plan_guid": "225e97cc-f786-408c-8b59-d2118248a53d",
@@ -1199,19 +1173,6 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 0.548",
-					"currency_code": "USD",
-					"vat_code": "Standard"
-				}
-			]
-		},
-		{
-			"name": "elasticsearch medium-ha-5.x",
-			"valid_from": "2018-10-01",
-			"plan_guid": "242a4782-7454-4ff4-93b2-dd88b333cb46",
-			"components": [
-				{
-					"name": "instance",
-					"formula": "ceil($time_in_seconds/3600) * 1.096",
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}


### PR DESCRIPTION
What
----

As Elasticsearch 5.x is now EOL and no tenants are using it, it can be removed from the billing, so it is no longer visible in the calculator.

How to review
-------------

* Code review
* Ensure no tenants are running ES5 instances (instructions are available on https://github.com/alphagov/paas-cf/pull/1779)
Who can review
--------------

Not @tnwhitwell or @AP-Hunt 