### PR TITLE
[#164363210] Set API limits per user for Cloud Controller

### DIFF
--- a/manifests/cf-manifest/env-specific/default.yml
+++ b/manifests/cf-manifest/env-specific/default.yml
@@ -4,3 +4,4 @@ router_instances: 2
 api_instances: 2
 doppler_instances: 6
 log_api_instances: 2
+cc_hourly_rate_limit: 10000

--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -4,3 +4,4 @@ router_instances: 3
 api_instances: 4
 doppler_instances: 12
 log_api_instances: 6
+cc_hourly_rate_limit: 15000

--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -4,3 +4,4 @@ router_instances: 3
 api_instances: 4
 doppler_instances: 12
 log_api_instances: 6
+cc_hourly_rate_limit: 55000

--- a/manifests/cf-manifest/operations.d/320-cc-set-api-limits.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-set-api-limits.yml
@@ -2,6 +2,6 @@
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/rate_limiter?
   value:
     enabled: true
-    general_limit: 4000
+    general_limit: 50000
     reset_interval_in_minutes: 60
     unauthenticated_limit: 100

--- a/manifests/cf-manifest/operations.d/320-cc-set-api-limits.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-set-api-limits.yml
@@ -2,6 +2,6 @@
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/rate_limiter?
   value:
     enabled: true
-    general_limit: 50000
+    general_limit: ((cc_hourly_rate_limit))
     reset_interval_in_minutes: 60
     unauthenticated_limit: 100

--- a/manifests/cf-manifest/operations.d/320-cc-set-api-limits.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-set-api-limits.yml
@@ -1,0 +1,7 @@
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/rate_limiter?
+  value:
+    enabled: true
+    general_limit: 4000
+    reset_interval_in_minutes: 60
+    unauthenticated_limit: 100


### PR DESCRIPTION
What
----

This PR sets API limits for Cloud Controller in order to prevent Denial of Service caused by one or two users.

Currently we have no API rate limiting in place. this sets global limits based upon https://bosh.io/jobs/cloud_controller_ng?source=github.com/cloudfoundry/capi-release&version=1.77.0#p%3dcc.rate_limiter

If we require further fine tuning we can use https://bosh.io/jobs/cloud_controller_ng?source=github.com/cloudfoundry/capi-release&version=1.77.0#p%3dcc.nginx_rate_limit_zones

I have arrived at these numbers by taking the defaults then reducing the reset time and then dividing the defaults by the time reduction factor and then applied a bit of rounding.

How to review
-------------

Describe the steps required to test the changes.

Who can review
--------------

Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.
