### PR TITLE
[support] Update UAA for CVE-2019-3775

### DIFF
--- a/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
+++ b/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
@@ -1,0 +1,8 @@
+---
+- type: replace
+  path: /releases/name=uaa
+  value:
+    name: "uaa"
+    version: "70.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=70.0"
+    sha1: "c23b71fb2a3d01a1f494753b7f00ae40c549838f"


### PR DESCRIPTION
What
----

This commit updates UAA to address the newly released [CVE-2019-3775](https://www.cloudfoundry.org/blog/cve-2019-3775/). It replaces the component at risk with the updated version.

How to review
-------------

Code review should be enough, I have run it down my dev pipeline.

[UAA latest release data for manifest](https://bosh.io/releases/github.com/cloudfoundry/uaa-release?all=1#latest)

Who can review
--------------

Not @LeePorte 
