### PR TITLE
[#163951798] Run smoke tests continuously from other regions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ dev: globals ## Set Environment to DEV
 	$(eval export ENABLE_AUTODELETE=true)
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
 	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipelineapps.digital)
-	$(eval export ALERT_EMAIL_ADDRESS=govpaas-alerting-dev@digital.cabinet-office.gov.uk)
+	$(eval export ALERT_EMAIL_ADDRESS?=govpaas-alerting-dev@digital.cabinet-office.gov.uk)
 	$(eval export ENABLE_ALERT_NOTIFICATIONS ?= false)
 	$(eval export SKIP_COMMIT_VERIFICATION=true)
 	$(eval export ENV_SPECIFIC_BOSH_VARS_FILE=default.yml)

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -95,6 +95,7 @@ groups:
       - rotate-cf-certs-cas
       - rotate-cf-certs-leafs
       - delete-old-cf-certs
+      - set-smoke-test-creds
 resource_types:
 - name: s3-iam
   type: docker-image
@@ -275,6 +276,13 @@ resources:
       tag_filter: "40.0.44"
       submodules:
       - "src/smoke_tests"
+
+  - name: smoke-test-config
+    type: s3-iam
+    source:
+      bucket: ((state_bucket))
+      region_name: ((aws_region))
+      versioned_file: smoke-test-config.json
 
   - name: git-keys
     type: s3-iam
@@ -3347,6 +3355,48 @@ jobs:
         put: cf-vars-store
         params:
           file: updated-cf-certs/cf-vars-store.yml
+
+  - name: set-smoke-test-creds
+    serial: true
+    plan:
+    - aggregate:
+      - get: paas-cf
+      - get: cf-vars-store
+    - task: retrieve-config
+      config:
+        image_resource: *ruby-slim-image-resource
+        platform: linux
+        inputs:
+          - name: paas-cf
+          - name: cf-vars-store
+        outputs:
+          - name: config
+        params:
+          SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+        run:
+          path: sh
+          args:
+            - -e
+            - -c
+            - |
+              VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
+
+              cat << EOT > config/config.sh
+              export CF_ADMIN=admin
+              export CF_PASS=$($VAL_FROM_YAML cf_admin_password cf-vars-store/cf-vars-store.yml)
+              export API_ENDPOINT="https://api.${SYSTEM_DNS_ZONE_NAME}"
+              EOT
+
+              ls -l config/*
+
+    - task: set-smoke-test-creds
+      file: paas-cf/concourse/tasks/set-smoke-test-creds.yml
+      params:
+        APP_DOMAIN: ((apps_dns_zone_name))
+        SYSTEM_DOMAIN: ((system_dns_zone_name))
+        STATE_BUCKET: ((state_bucket))
+    - put: smoke-test-config
+      params: { file: new-smoke-test-config/smoke-test-config.json }
 
   - name: delete-old-cf-certs
     serial: true

--- a/concourse/pipelines/monitor-prod-lon.yml
+++ b/concourse/pipelines/monitor-prod-lon.yml
@@ -1,0 +1,1 @@
+monitor-remote.yml

--- a/concourse/pipelines/monitor-prod.yml
+++ b/concourse/pipelines/monitor-prod.yml
@@ -1,0 +1,1 @@
+monitor-remote.yml

--- a/concourse/pipelines/monitor-remote.yml
+++ b/concourse/pipelines/monitor-remote.yml
@@ -1,0 +1,94 @@
+---
+resource_types:
+- name: s3-iam
+  type: docker-image
+  source:
+    repository: governmentpaas/s3-resource
+    tag: fda60bf4c5f85e96c16f704e128e5ead9e84d30d
+
+resources:
+- name: paas-cf
+  type: git
+  source:
+    uri: https://github.com/alphagov/paas-cf.git
+    branch: ((branch_name))
+    tag_filter: ((paas_cf_tag_filter))
+    commit_verification_keys: ((gpg_public_keys))
+
+- name: cf-smoke-tests-release
+  type: git
+  source:
+    uri: https://github.com/cloudfoundry/cf-smoke-tests-release
+    tag_filter: "40.0.44"
+    submodules:
+      - "src/smoke_tests"
+
+- name: test-config
+  type: s3-iam
+  source:
+    bucket: ((monitored_state_bucket))
+    region_name: ((monitored_aws_region))
+    versioned_file: smoke-test-config.json
+
+- name: every-5m
+  type: time
+  source: {interval: 5m}
+
+jobs:
+- name: self-update-pipeline
+  serial: true
+  plan:
+  - get: paas-cf
+    trigger: true
+  - task: self-update-pipeline
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: governmentpaas/self-update-pipelines
+          tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+      inputs:
+      - name: paas-cf
+      params:
+        DEPLOY_ENV: ((deploy_env))
+        BRANCH: ((branch_name))
+        MAKEFILE_ENV_TARGET: ((makefile_env_target))
+        AWS_DEFAULT_REGION: ((aws_region))
+        SELF_UPDATE_PIPELINE: ((self_update_pipeline))
+        PIPELINES_TO_UPDATE: ((pipeline_name))
+        ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
+        BOSH_AZ: ((bosh_az))
+        SKIP_AWS_CREDENTIAL_VALIDATION: true
+        NEW_ACCOUNT_EMAIL_ADDRESS: ((NEW_ACCOUNT_EMAIL_ADDRESS))
+        SLIM_DEV_DEPLOYMENT: ((slim_dev_deployment))
+        MONITORED_DEPLOY_ENV: ((monitored_deploy_env))
+        MONITORED_STATE_BUCKET: ((monitored_state_bucket))
+        MONITORED_AWS_REGION: ((monitored_aws_region))
+      run:
+        path: ./paas-cf/concourse/scripts/self-update-pipeline.sh
+
+- name: smoke-tests
+  serial: true
+  plan:
+  - aggregate:
+    - get: test-config
+    - get: paas-cf
+    - get: cf-smoke-tests-release
+    - get: every-5m
+      trigger: true
+  - task: smoke-tests-run
+    file: paas-cf/concourse/tasks/smoke-tests-run.yml
+    params:
+      AWS_DEFAULT_REGION: ((aws_region))
+      DEPLOY_ENV: ((deploy_env))
+      SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+      ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
+      EMAIL_ON_SMOKE_TEST_FAILURE: ((ENABLE_ALERT_NOTIFICATIONS))
+      SMOKE_TEST_CONFIG: ./test-config/smoke-test-config.json
+      MONITORED_DEPLOY_ENV: ((monitored_deploy_env))
+    ensure:
+      task: upload-test-artifacts
+      file: paas-cf/concourse/tasks/upload-test-artifacts.yml
+      params:
+        TEST_ARTIFACTS_BUCKET: ((test_artifacts_bucket))

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -139,6 +139,9 @@ auto_deploy: $([ "${ENABLE_AUTO_DEPLOY:-}" ] && echo "true" || echo "false")
 persistent_environment: ${PERSISTENT_ENVIRONMENT}
 disable_user_creation: $([ "${NEW_ACCOUNT_EMAIL_ADDRESS:-}" ] && echo "false" || echo "true")
 slim_dev_deployment: ${SLIM_DEV_DEPLOYMENT:-}
+monitored_state_bucket: ${MONITORED_STATE_BUCKET:-}
+monitored_aws_region: ${MONITORED_AWS_REGION:-}
+monitored_deploy_env: ${MONITORED_DEPLOY_ENV:-}
 EOF
   echo -e "pipeline_lock_git_private_key: |\\n  ${git_id_rsa//$'\n'/$'\n'  }"
 }
@@ -191,6 +194,9 @@ update_pipeline() {
         echo "WARNING: Pipeline to autodelete Cloud Foundry has NOT been setup"
         echo "         To enable it, set ENABLE_AUTODELETE=true"
       fi
+    ;;
+    monitor-*)
+      upload_pipeline
     ;;
     *)
       echo "ERROR: Unknown pipeline definition: $pipeline_name"

--- a/concourse/scripts/smoke_tests_email.sh
+++ b/concourse/scripts/smoke_tests_email.sh
@@ -6,14 +6,23 @@ DEPLOY_ENV=$1
 SYSTEM_DNS_ZONE_NAME=$2
 ALERT_EMAIL_ADDRESS=$3
 
+set +u
+if [ "$4" = "" ]; then
+  message_file=message-local.json
+  MONITORED_DEPLOY_ENV=""
+else
+  message_file=message-remote.json
+  MONITORED_DEPLOY_ENV=$4
+fi
+set -u
+
 TO="${ALERT_EMAIL_ADDRESS}"
 FROM="${ALERT_EMAIL_ADDRESS}"
 # SMOKE_TEST_LOG=./smoke-tests-log/smoke-tests.log
 # LAST_COMMIT_LOG=./smoke-tests-log/last-commit.log
 
 write_message_json() {
-
-  cat <<EOF > message.json
+  cat <<EOF > message-local.json
 {
   "Subject": {
     "Data": "Smoke tests failed in ${DEPLOY_ENV}"
@@ -27,8 +36,22 @@ write_message_json() {
   }
 }
 EOF
+  cat <<EOF > message-remote.json
+{
+  "Subject": {
+    "Data": "Smoke tests failed in ${MONITORED_DEPLOY_ENV}, says ${DEPLOY_ENV}"
+  },
+  "Body": {
+    "Html": {
+      "Data": "The smoke tests monitoring <b>${MONITORED_DEPLOY_ENV}</b> have failed in ${DEPLOY_ENV}'s Concourse. See \
+      <a href='https://deployer.${SYSTEM_DNS_ZONE_NAME}/teams/main/pipelines/monitor-${MONITORED_DEPLOY_ENV}'>Concourse</a> \
+      for details<br/>"
+    }
+  }
+}
+EOF
 }
 
 write_message_json
 
-aws ses send-email --region eu-west-1 --to "${TO}" --message file://message.json --from "${FROM}"
+aws ses send-email --region eu-west-1 --to "${TO}" --message file://${message_file} --from "${FROM}"

--- a/concourse/tasks/set-smoke-test-creds.yml
+++ b/concourse/tasks/set-smoke-test-creds.yml
@@ -1,0 +1,56 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/cf-cli
+    tag: b77e27029dfcb85f6c58f0a59298d05cc5eeb903
+inputs:
+  - name: config
+outputs:
+  - name: new-smoke-test-config
+run:
+  path: sh
+  args:
+    - -e
+    - -c
+    - |
+      . ./config/config.sh
+
+      NEW_SMOKE_TEST_PASSWORD=$(tr -cd '[:alpha:]0-9' < /dev/urandom | head -c32)
+      TEST_CONFIG=new-smoke-test-config/smoke-test-config.json
+
+      cat <<EOF > "${TEST_CONFIG}"
+      {
+        "api": "api.${SYSTEM_DOMAIN}",
+        "apps_domain": "${APP_DOMAIN}",
+        "user": "smoke-test",
+        "password": "${NEW_SMOKE_TEST_PASSWORD}",
+        "org": "continuous-smoke-test",
+        "space": "continuous-smoke-test",
+        "use_existing_org": true,
+        "use_existing_space": true,
+        "skip_ssl_validation": false,
+        "artifacts_directory": "/tmp/artifacts",
+        "suite_name": "CF_SMOKE_TESTS",
+        "logging_app": "",
+        "runtime_app": "",
+        "ginkgo_opts": "",
+        "backend": ""
+      }
+      EOF
+
+      echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}"
+
+      cf create-org continuous-smoke-test
+      cf create-space continuous-smoke-test -o continuous-smoke-test
+
+      TEST_PASSWORD="$(jq -r .password $TEST_CONFIG)"
+      TEST_ORG="$(jq -r .org $TEST_CONFIG)"
+      TEST_SPACE="$(jq -r .space $TEST_CONFIG)"
+      TEST_USER="$(jq -r .user $TEST_CONFIG)"
+
+      cf t -o "${TEST_ORG}" -s "${TEST_SPACE}"
+      cf delete-user "${TEST_USER}" -f # create-user isn't idempotent :-(
+      cf create-user "${TEST_USER}" "${TEST_PASSWORD}"
+      cf set-space-role "${TEST_USER}" "${TEST_ORG}" "${TEST_SPACE}" SpaceManager

--- a/concourse/tasks/smoke-tests-run.yml
+++ b/concourse/tasks/smoke-tests-run.yml
@@ -21,7 +21,7 @@ run:
     if [ "$EMAIL_ON_SMOKE_TEST_FAILURE" = "true" ]; then
       if [ "$TEST_EXIT_CODE" -gt 0 ]; then
         paas-cf/concourse/scripts/smoke_tests_email.sh \
-          "${DEPLOY_ENV}" "${SYSTEM_DNS_ZONE_NAME}" "${ALERT_EMAIL_ADDRESS}"
+          "${DEPLOY_ENV}" "${SYSTEM_DNS_ZONE_NAME}" "${ALERT_EMAIL_ADDRESS}" "${MONITORED_DEPLOY_ENV}"
       fi
     fi
     exit $TEST_EXIT_CODE

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -84,6 +84,24 @@ RSpec.describe "release versions" do
     expect(paas_version).to be >= upstream_version, "we should upgrade the cf-smoke-tests-release's tag_filter in the create-cloundfoundry pipeline to #{upstream_version} or greater"
   end
 
+  specify "create-cloudfoundry cf-smoke-tests-release version to match monitor-remote" do
+    cf_smoke_tests_resource_version = cf_pipeline
+      .fetch('resources')
+      .select { |v| v['name'] == 'cf-smoke-tests-release' }
+      .fetch(0)
+      .fetch('source')
+      .fetch('tag_filter')
+
+    monitor_remote_smoke_tests_resource_version = monitor_remote_pipeline
+      .fetch('resources')
+      .select { |v| v['name'] == 'cf-smoke-tests-release' }
+      .fetch(0)
+      .fetch('source')
+      .fetch('tag_filter')
+
+    expect(monitor_remote_smoke_tests_resource_version).to eq(cf_smoke_tests_resource_version)
+  end
+
   specify "cf-acceptance-tests version should be the same as the CF manifest version" do
     cf_manifest_version = cf_deployment_manifest
       .fetch('manifest_version')

--- a/manifests/cf-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/cf-manifest/spec/support/manifest_helpers.rb
@@ -63,6 +63,10 @@ module ManifestHelpers
     Cache.instance[:cf_pipeline] ||= YAML.load_file(root.join('concourse/pipelines/create-cloudfoundry.yml'))
   end
 
+  def monitor_remote_pipeline
+    Cache.instance[:monitor_remote_pipeline] ||= YAML.load_file(root.join('concourse/pipelines/monitor-remote.yml'))
+  end
+
   def property_tree(tree)
     PropertyTree.new(tree)
   end

--- a/manifests/prometheus/alerts.d/concourse-smoketests-errors.yml
+++ b/manifests/prometheus/alerts.d/concourse-smoketests-errors.yml
@@ -13,3 +13,16 @@
         annotations:
           summary: Concourse continuous-smoke-tests errors
           description: The continuous-smoke-tests Concourse job has an increased error rate
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: ConcourseSmoketestsRemoteErrors
+    rules:
+      - alert: ConcourseSmoketestsRemoteErrors
+        expr: increase(concourse_builds_finished{exported_job="smoke-tests",pipeline=~"monitor-.+",status="errored"}[30m]) >= 3
+        labels:
+          severity: warning
+        annotations:
+          summary: "Concourse remote smoke-tests errors on {{ $labels.pipeline }} pipeline"
+          description: "The Concourse job running smoke-tests remotely (in the {{ $labels.pipeline }} pipeline) has an increased error rate"

--- a/manifests/prometheus/alerts.d/concourse-smoketests-failures.yml
+++ b/manifests/prometheus/alerts.d/concourse-smoketests-failures.yml
@@ -14,3 +14,25 @@
         annotations:
           summary: Concourse continuous-smoke-tests failures
           description: The continuous-smoke-tests Concourse job has failed at least twice in the last hour.
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: ConcourseSmoketestsRemoteFailures
+    rules:
+      - alert: ConcourseSmoketestsRemoteFailuresWarning
+        expr: increase(concourse_builds_finished{exported_job="smoke-tests",pipeline=~"monitor-.+",status="failed"}[1h]) >= 2
+        labels:
+          severity: warning
+        annotations:
+          summary: "Concourse remote smoke-tests failures on {{ $labels.pipeline }} pipeline"
+          description: "The Concourse job running smoke-tests remotely (in the {{ $labels.pipeline }} pipeline) has failed at least twice in the last hour."
+
+      - alert: ConcourseSmoketestsRemoteFailuresCritical
+        expr: increase(concourse_builds_finished{exported_job="smoke-tests",pipeline=~"monitor-.+",status="failed"}[30m]) >= 3
+        labels:
+          severity: critical
+          notify: pagerduty
+        annotations:
+          summary: "Concourse remote smoke-tests failures on {{ $labels.pipeline }} pipeline"
+          description: "The Concourse job running smoke-tests remotely (in the {{ $labels.pipeline }} pipeline) has failed at least three times in the last 30 minutes."

--- a/manifests/prometheus/alerts.d/concourse-smoketests-no-data.yml
+++ b/manifests/prometheus/alerts.d/concourse-smoketests-no-data.yml
@@ -22,3 +22,25 @@
         annotations:
           summary: Concourse continuous-smoke-tests job is not running
           description: The continuous-smoke-tests Concourse job has not been running for a while now.
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: ConcourseSmoketestsRemoteNoData
+    rules:
+      - alert: ConcourseSmoketestsRemoteNoData
+        expr: absent(concourse_builds_finished{pipeline=~"monitor-.+",exported_job="smoke-tests"})
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Concourse remote smoke-tests no data for {{ $labels.pipeline }} pipeline"
+          description: "The Concourse job running smoke-tests remotely (in the {{ $labels.pipeline }} pipeline) has not been reporting data for a while now."
+
+      - alert: ConcourseSmoketestsRemoteNotRunning
+        expr: sum(increase(concourse_builds_finished{exported_job="smoke-tests",pipeline=~"monitor-.+"}[15m])) == 0
+        labels:
+          severity: warning
+        annotations:
+          summary: "Concourse remote smoke-tests job is not running for {{ $labels.pipeline }} pipeline"
+          description: "The Concourse job running smoke-tests remotely (in the {{ $labels.pipeline }} pipeline) has not been running for a while now."

--- a/platform-tests/upstream/run_smoke_tests.sh
+++ b/platform-tests/upstream/run_smoke_tests.sh
@@ -2,8 +2,22 @@
 
 set -eu
 
+relative_to_absolute_path() {
+  echo "$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"
+}
+
+set +u
+CONFIG="${SMOKE_TEST_CONFIG:-./test-config/config.json}"
+set -u
+
+CONFIG="$(relative_to_absolute_path "${CONFIG}")"
+
+[ -f "$CONFIG" ] || {
+    echo "Config file \"${CONFIG}\" does not exist"
+    exit 1
+}
+
 export CONFIG
-CONFIG="$(pwd)/test-config/config.json"
 
 echo "Linking smoke-tests directory inside $GOPATH"
 CF_GOPATH=/go/src/github.com/cloudfoundry


### PR DESCRIPTION
What
----

This PR adds the ability for one DEPLOY_ENV's deployer Concourse to monitor
one or more other DEPLOY_ENV's Cloud Foundries, via the standard CF smoke tests.

In order for env1 to monitor env2, the following must be true:

- env1 must be able to access env2's state bucket.
- env1 must be able to access env2's CF API
  - this is more of a problem in dev than in prod; in dev you may wish to test this by having an env test itself - this works as expected.
- env2 must have had the `set-smoke-test-creds` job run at least once
  - it's in the `credentials` job group of the `create-cloudfoundry` pipeline
  - this job also rotates creds if they already exist.
- a symlink from `paas-cf::/concourse/pipelines/monitor-<env2>.yml` must point towards the target `paas-cf::/concourse/pipelines/monitor-remote.yml`.
  - `prod` and `prod-lon` have been set up as part of this commit.

Once this is in place, run the following in an AWS STS context:

```
$ DEPLOY_ENV=env1 make <AWS-account> monitor-<env2>
```

e.g.

```
$ DEPLOY_ENV=jonmtest make dev monitor-modeerow
```

This will upload a new pipeline to env1's deployer Concourse, named
`monitor-<env2>`.

Once set up, this pipeline will update itself automatically as the contents
of `monitor-remote.yml` changes.

How to review
-------------

- Use the above instructions to point a dev env at itself
- Once merged, use the above instructions to tell `prod-lon` to monitor `prod` and vice versa

Who can review
--------------

Someone with prod access, to do the prod/-lon modifications.