### PR TITLE
Charge all apps by the second

### DIFF
--- a/config/billing/config.json.erb
+++ b/config/billing/config.json.erb
@@ -97,18 +97,18 @@
 		},
 		{
 			"name": "app",
-			"valid_from": "2017-01-01",
+			"valid_from": "2019-03-01",
 			"plan_guid": "f4d4b95a-f55e-4593-8d54-3364c25798c4",
 			"components": [
 				{
 					"name": "instance",
-					"formula": "$number_of_nodes * ceil($time_in_seconds / 3600) * ($memory_in_mb/1024.0) * <%= price("app_cost_per_gb_hour") %>",
+					"formula": "$number_of_nodes * $time_in_seconds * ($memory_in_mb/1024.0) * (<%= price("app_cost_per_gb_hour") %> / 3600)",
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "platform",
-					"formula": "($number_of_nodes * ceil($time_in_seconds / 3600) * ($memory_in_mb/1024.0) * <%= price("app_cost_per_gb_hour") %>) * <%= price("platform_fee") %>",
+					"formula": "($number_of_nodes * $time_in_seconds * ($memory_in_mb/1024.0) * (<%= price("app_cost_per_gb_hour") %> / 3600)) * <%= price("platform_fee") %>",
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -116,18 +116,18 @@
 		},
 		{
 			"name": "staging",
-			"valid_from": "2017-01-01",
+			"valid_from": "2019-03-01",
 			"plan_guid": "9d071c77-7a68-4346-9981-e8dafac95b6f",
 			"components": [
 				{
 					"name": "instance",
-					"formula": "$number_of_nodes * ceil($time_in_seconds / 3600) * ($memory_in_mb/1024.0) * <%= price("app_cost_per_gb_hour") %>",
+					"formula": "$number_of_nodes * $time_in_seconds * ($memory_in_mb/1024.0) * (<%= price("app_cost_per_gb_hour") %> / 3600)",
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "platform",
-					"formula": "($number_of_nodes * ceil($time_in_seconds / 3600) * ($memory_in_mb/1024.0) * <%= price("app_cost_per_gb_hour") %>) * <%= price("platform_fee") %>",
+					"formula": "($number_of_nodes * $time_in_seconds * ($memory_in_mb/1024.0) * (<%= price("app_cost_per_gb_hour") %> / 3600)) * <%= price("platform_fee") %>",
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -135,18 +135,18 @@
 		},
 		{
 			"name": "task",
-			"valid_from": "2017-01-01",
+			"valid_from": "2019-03-01",
 			"plan_guid": "ebfa9453-ef66-450c-8c37-d53dfd931038",
 			"components": [
 				{
 					"name": "instance",
-					"formula": "$number_of_nodes * ceil($time_in_seconds / 3600) * ($memory_in_mb/1024.0) * <%= price("app_cost_per_gb_hour") %>",
+					"formula": "$number_of_nodes * $time_in_seconds * ($memory_in_mb/1024.0) * (<%= price("app_cost_per_gb_hour") %> / 3600)",
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "platform",
-					"formula": "($number_of_nodes * ceil($time_in_seconds / 3600) * ($memory_in_mb/1024.0) * <%= price("app_cost_per_gb_hour") %>) * <%= price("platform_fee") %>",
+					"formula": "($number_of_nodes * $time_in_seconds * ($memory_in_mb/1024.0) * (<%= price("app_cost_per_gb_hour") %> / 3600)) * <%= price("platform_fee") %>",
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}

--- a/config/billing/output/eu-west-1.json
+++ b/config/billing/output/eu-west-1.json
@@ -97,18 +97,18 @@
 		},
 		{
 			"name": "app",
-			"valid_from": "2017-01-01",
+			"valid_from": "2019-03-01",
 			"plan_guid": "f4d4b95a-f55e-4593-8d54-3364c25798c4",
 			"components": [
 				{
 					"name": "instance",
-					"formula": "$number_of_nodes * ceil($time_in_seconds / 3600) * ($memory_in_mb/1024.0) * 0.01",
+					"formula": "$number_of_nodes * $time_in_seconds * ($memory_in_mb/1024.0) * (0.01 / 3600)",
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "platform",
-					"formula": "($number_of_nodes * ceil($time_in_seconds / 3600) * ($memory_in_mb/1024.0) * 0.01) * 0.40",
+					"formula": "($number_of_nodes * $time_in_seconds * ($memory_in_mb/1024.0) * (0.01 / 3600)) * 0.40",
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -116,18 +116,18 @@
 		},
 		{
 			"name": "staging",
-			"valid_from": "2017-01-01",
+			"valid_from": "2019-03-01",
 			"plan_guid": "9d071c77-7a68-4346-9981-e8dafac95b6f",
 			"components": [
 				{
 					"name": "instance",
-					"formula": "$number_of_nodes * ceil($time_in_seconds / 3600) * ($memory_in_mb/1024.0) * 0.01",
+					"formula": "$number_of_nodes * $time_in_seconds * ($memory_in_mb/1024.0) * (0.01 / 3600)",
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "platform",
-					"formula": "($number_of_nodes * ceil($time_in_seconds / 3600) * ($memory_in_mb/1024.0) * 0.01) * 0.40",
+					"formula": "($number_of_nodes * $time_in_seconds * ($memory_in_mb/1024.0) * (0.01 / 3600)) * 0.40",
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -135,18 +135,18 @@
 		},
 		{
 			"name": "task",
-			"valid_from": "2017-01-01",
+			"valid_from": "2019-03-01",
 			"plan_guid": "ebfa9453-ef66-450c-8c37-d53dfd931038",
 			"components": [
 				{
 					"name": "instance",
-					"formula": "$number_of_nodes * ceil($time_in_seconds / 3600) * ($memory_in_mb/1024.0) * 0.01",
+					"formula": "$number_of_nodes * $time_in_seconds * ($memory_in_mb/1024.0) * (0.01 / 3600)",
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "platform",
-					"formula": "($number_of_nodes * ceil($time_in_seconds / 3600) * ($memory_in_mb/1024.0) * 0.01) * 0.40",
+					"formula": "($number_of_nodes * $time_in_seconds * ($memory_in_mb/1024.0) * (0.01 / 3600)) * 0.40",
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}

--- a/config/billing/output/eu-west-2.json
+++ b/config/billing/output/eu-west-2.json
@@ -97,18 +97,18 @@
 		},
 		{
 			"name": "app",
-			"valid_from": "2017-01-01",
+			"valid_from": "2019-03-01",
 			"plan_guid": "f4d4b95a-f55e-4593-8d54-3364c25798c4",
 			"components": [
 				{
 					"name": "instance",
-					"formula": "$number_of_nodes * ceil($time_in_seconds / 3600) * ($memory_in_mb/1024.0) * 0.01",
+					"formula": "$number_of_nodes * $time_in_seconds * ($memory_in_mb/1024.0) * (0.01 / 3600)",
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "platform",
-					"formula": "($number_of_nodes * ceil($time_in_seconds / 3600) * ($memory_in_mb/1024.0) * 0.01) * 0.40",
+					"formula": "($number_of_nodes * $time_in_seconds * ($memory_in_mb/1024.0) * (0.01 / 3600)) * 0.40",
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -116,18 +116,18 @@
 		},
 		{
 			"name": "staging",
-			"valid_from": "2017-01-01",
+			"valid_from": "2019-03-01",
 			"plan_guid": "9d071c77-7a68-4346-9981-e8dafac95b6f",
 			"components": [
 				{
 					"name": "instance",
-					"formula": "$number_of_nodes * ceil($time_in_seconds / 3600) * ($memory_in_mb/1024.0) * 0.01",
+					"formula": "$number_of_nodes * $time_in_seconds * ($memory_in_mb/1024.0) * (0.01 / 3600)",
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "platform",
-					"formula": "($number_of_nodes * ceil($time_in_seconds / 3600) * ($memory_in_mb/1024.0) * 0.01) * 0.40",
+					"formula": "($number_of_nodes * $time_in_seconds * ($memory_in_mb/1024.0) * (0.01 / 3600)) * 0.40",
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -135,18 +135,18 @@
 		},
 		{
 			"name": "task",
-			"valid_from": "2017-01-01",
+			"valid_from": "2019-03-01",
 			"plan_guid": "ebfa9453-ef66-450c-8c37-d53dfd931038",
 			"components": [
 				{
 					"name": "instance",
-					"formula": "$number_of_nodes * ceil($time_in_seconds / 3600) * ($memory_in_mb/1024.0) * 0.01",
+					"formula": "$number_of_nodes * $time_in_seconds * ($memory_in_mb/1024.0) * (0.01 / 3600)",
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "platform",
-					"formula": "($number_of_nodes * ceil($time_in_seconds / 3600) * ($memory_in_mb/1024.0) * 0.01) * 0.40",
+					"formula": "($number_of_nodes * $time_in_seconds * ($memory_in_mb/1024.0) * (0.01 / 3600)) * 0.40",
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}


### PR DESCRIPTION
What
----

The `ceil()` in the formula meant that every app was being charged for
one hour at a minimum, meaning that if an app was autoscaled for 30
seconds, they would still be charged for an hour.

This change ensures that the apps are now just charged for the seconds
they are active for.

How to review
-------------

* Code Review
* Ensure that a short-lived app is not billed for an hour:
  1. Start an app for 30 seconds
  1. Restart billing collector
  1. Check that the app has not been billed for an hour
* Ensure that a longer-lived app is billed correctly
  1. Start an app for an hour
  1. Restart billing collector
  1. Check the app has been billed correctly

(The second of these may be a bit too long in the tooth - if a sanity check of the formula seems correct, this may be skipped)

Who can review
--------------

Not @tnwhitwell 