### PR TITLE
[#164372981] Add our SPF record to the TXT record tf resource

### DIFF
--- a/terraform/cloudfoundry/dns-records.tf
+++ b/terraform/cloudfoundry/dns-records.tf
@@ -42,9 +42,17 @@ resource "aws_route53_record" "system_apex" {
   }
 }
 
-resource "aws_route53_record" "spf_and_google_site_verification" {
+resource "aws_route53_record" "spf_and_google_site_verification_apps" {
   zone_id = "${var.apps_dns_zone_id}"
   name    = "${var.apps_dns_zone_name}."
+  type    = "TXT"
+  ttl     = "300"
+  records = ["v=spf1 -all", "google-site-verification=N2Pyk2D-qppi7bFBYUrdq3E3gNXOcwOacJMkIV_12Ec"]
+}
+
+resource "aws_route53_record" "spf_and_google_site_verification_system" {
+  zone_id = "${var.system_dns_zone_id}"
+  name    = "${var.system_dns_zone_name}."
   type    = "TXT"
   ttl     = "300"
   records = ["v=spf1 -all", "google-site-verification=N2Pyk2D-qppi7bFBYUrdq3E3gNXOcwOacJMkIV_12Ec"]

--- a/terraform/cloudfoundry/dns-records.tf
+++ b/terraform/cloudfoundry/dns-records.tf
@@ -42,12 +42,12 @@ resource "aws_route53_record" "system_apex" {
   }
 }
 
-resource "aws_route53_record" "google_site_verification" {
+resource "aws_route53_record" "spf_and_google_site_verification" {
   zone_id = "${var.apps_dns_zone_id}"
   name    = "${var.apps_dns_zone_name}."
   type    = "TXT"
   ttl     = "300"
-  records = ["google-site-verification=N2Pyk2D-qppi7bFBYUrdq3E3gNXOcwOacJMkIV_12Ec"]
+  records = ["v=spf1 -all", "google-site-verification=N2Pyk2D-qppi7bFBYUrdq3E3gNXOcwOacJMkIV_12Ec"]
 }
 
 resource "aws_route53_record" "apps_apex" {


### PR DESCRIPTION
What
----

This needs to be added here, as the root domain's TXT record is also applied in account-wide terraform.
    
The AWS api doesn't have a PATCH method for route53, so the google_site_verification record was being overwritten each time the pipeline ran.

With both records in both places, we will no longer have the TXT record flip-flopping between `spf` and `google-site-verification`

How to review
-------------

Ensure that both records are created when the pipeline runs terraform with dig:

```
➜ dig +short TXT cloudapps.digital
"google-site-verification=N2Pyk2D-qppi7bFBYUrdq3E3gNXOcwOacJMkIV_12Ec"
"v=spf1 -all"

➜ dig +short TXT london.cloudapps.digital                  
"google-site-verification=N2Pyk2D-qppi7bFBYUrdq3E3gNXOcwOacJMkIV_12Ec"
"v=spf1 -all"
```

Who can review
--------------

Not me