### PR TITLE
[#164397255] Bump paas-cdn-broker to 0.1.11

### DIFF
--- a/manifests/cf-manifest/operations.d/720-cdn-broker.yml
+++ b/manifests/cf-manifest/operations.d/720-cdn-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: cdn-broker
-    version: 0.1.10
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.10.tgz
-    sha1: f87500708e59bbdcf9da43b34025310f245d8477
+    version: 0.1.11
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.11.tgz
+    sha1: fd788ca994f617aa00fa855d40cf269b32171530
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-


### PR DESCRIPTION
What
----
Bumps CDN broker to 0.11.1 to deploy changes made in https://github.com/alphagov/paas-cdn-broker/pull/11

How to review
-------------
Check the release version matches the one built [here](https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/cdn-broker-release/jobs/build-final-release/builds/13)

Who can review
--------------
Not I
