### PR TITLE
[#163521334] Move CF manifest upstream opsfiles to ordered symlinks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
     - BOSH_CLI_VERSION="2.0.48"
     - PROMETHEUS_VERSION="2.6.1"
     - DEPLOY_ENV="travis"
+    - TMPDIR="/tmp"
 
 addons:
   apt:

--- a/manifests/cf-manifest/operations.d/001-rename-network-and-deployment-UPSTREAM.yml
+++ b/manifests/cf-manifest/operations.d/001-rename-network-and-deployment-UPSTREAM.yml
@@ -1,0 +1,1 @@
+../../cf-deployment/operations/rename-network-and-deployment.yml

--- a/manifests/cf-manifest/operations.d/002-aws-UPSTREAM.yml
+++ b/manifests/cf-manifest/operations.d/002-aws-UPSTREAM.yml
@@ -1,0 +1,1 @@
+../../cf-deployment/operations/aws.yml

--- a/manifests/cf-manifest/operations.d/003-use-external-blobstore-UPSTREAM.yml
+++ b/manifests/cf-manifest/operations.d/003-use-external-blobstore-UPSTREAM.yml
@@ -1,0 +1,1 @@
+../../cf-deployment/operations/use-external-blobstore.yml

--- a/manifests/cf-manifest/operations.d/004-use-s3-blobstore-UPSTREAM.yml
+++ b/manifests/cf-manifest/operations.d/004-use-s3-blobstore-UPSTREAM.yml
@@ -1,0 +1,1 @@
+../../cf-deployment/operations/use-s3-blobstore.yml

--- a/manifests/cf-manifest/operations.d/005-use-external-dbs-UPSTREAM.yml
+++ b/manifests/cf-manifest/operations.d/005-use-external-dbs-UPSTREAM.yml
@@ -1,0 +1,1 @@
+../../cf-deployment/operations/use-external-dbs.yml

--- a/manifests/cf-manifest/operations.d/006-stop-skipping-tls-validation-UPSTREAM.yml
+++ b/manifests/cf-manifest/operations.d/006-stop-skipping-tls-validation-UPSTREAM.yml
@@ -1,0 +1,1 @@
+../../cf-deployment/operations/stop-skipping-tls-validation.yml

--- a/manifests/cf-manifest/operations.d/007-enable-service-discovery-UPSTREAM.yml
+++ b/manifests/cf-manifest/operations.d/007-enable-service-discovery-UPSTREAM.yml
@@ -1,0 +1,1 @@
+../../cf-deployment/operations/enable-service-discovery.yml

--- a/manifests/cf-manifest/operations.d/008-add-prometheus-uaa-clients-UPSTREAM.yml
+++ b/manifests/cf-manifest/operations.d/008-add-prometheus-uaa-clients-UPSTREAM.yml
@@ -1,0 +1,1 @@
+../../prometheus/upstream/manifests/operators/cf/add-prometheus-uaa-clients.yml

--- a/manifests/cf-manifest/scripts/generate-manifest.sh
+++ b/manifests/cf-manifest/scripts/generate-manifest.sh
@@ -4,7 +4,6 @@ set -eu -o pipefail
 
 PAAS_CF_DIR=${PAAS_CF_DIR:-paas-cf}
 CF_DEPLOYMENT_DIR=${PAAS_CF_DIR}/manifests/cf-deployment
-PROMETHEUS_DEPLOYMENT_DIR=${PAAS_CF_DIR}/manifests/prometheus/upstream
 WORKDIR=${WORKDIR:-.}
 
 opsfile_args=""
@@ -44,14 +43,6 @@ bosh interpolate \
   --vars-file="${PAAS_CF_DIR}/manifests/variables.yml" \
   --vars-file="${ENV_SPECIFIC_BOSH_VARS_FILE}" \
   --vars-file="${WORKDIR}/environment-variables.yml" \
-  --ops-file="${CF_DEPLOYMENT_DIR}/operations/rename-network-and-deployment.yml" \
-  --ops-file="${CF_DEPLOYMENT_DIR}/operations/aws.yml" \
-  --ops-file="${CF_DEPLOYMENT_DIR}/operations/use-external-blobstore.yml" \
-  --ops-file="${CF_DEPLOYMENT_DIR}/operations/use-s3-blobstore.yml" \
-  --ops-file="${CF_DEPLOYMENT_DIR}/operations/use-external-dbs.yml" \
-  --ops-file="${CF_DEPLOYMENT_DIR}/operations/stop-skipping-tls-validation.yml" \
-  --ops-file="${CF_DEPLOYMENT_DIR}/operations/enable-service-discovery.yml" \
-  --ops-file="${PROMETHEUS_DEPLOYMENT_DIR}/manifests/operators/cf/add-prometheus-uaa-clients.yml" \
   ${opsfile_args} \
   --ops-file="${WORKDIR}/vpc-peering-opsfile/vpc-peers.yml" \
   ${vars_store_args} \

--- a/scripts/test_posix_newline.sh
+++ b/scripts/test_posix_newline.sh
@@ -2,6 +2,10 @@
 RET_CODE=0
 
 test_posix_newline() {
+  if [ -L "$1" ]; then
+    RET_CODE=0
+    return
+  fi
   if [ ! -f "$1" ]; then
     echo "$1 is not a regular file" 1>&2
     RET_CODE=1

--- a/scripts/test_symlinks.sh
+++ b/scripts/test_symlinks.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -ueo pipefail
+
+R=0
+while read -r LINK; do
+  if [ ! -r "$LINK" ]; then
+    echo "$LINK is a hanging symlink" >&2
+    R=1
+  fi
+done
+
+exit "$R"


### PR DESCRIPTION
What
----
Removes hard-coded upstream operations files references out of `scripts/generate-manifest.sh`, and replaces them with numerically-ordered symlinks in the `operations.d` directory.

How to review
-------------
1. Code review
2. Check tests pass
~3. Run this branch down the pipeline and check everything is OK. (Double check things affected by the newly-symlinked ops files?)~ This is "obviously" correct, and anything going wrong will be so catastrophic that it'll also be obvious in staging.

Who can review
--------------
Paired on by @jpluscplusm and @AP-Hunt. Reviewed in pair.
