### PR TITLE
[#163521947] Tidy up Prometheus alerts

### DIFF
--- a/manifests/prometheus/alerts.d/bosh-high-cpu-utilisation.yml
+++ b/manifests/prometheus/alerts.d/bosh-high-cpu-utilisation.yml
@@ -9,7 +9,7 @@
       - record: "bosh_job:bosh_job_cpu:avg1h"
         expr: avg_over_time(bosh_job_cpu_sys{bosh_job_name!="diego-cell",bosh_job_name!="concourse"}[1h]) + avg_over_time(bosh_job_cpu_user{bosh_job_name!="diego-cell",bosh_job_name!="concourse"}[1h]) + avg_over_time(bosh_job_cpu_wait{bosh_job_name!="diego-cell",bosh_job_name!="concourse"}[1h])
 
-      - alert: BoshHighCPUUtilisation_Warning
+      - alert: BoshHighCPUUtilisation
         expr: "bosh_job:bosh_job_cpu:avg1h > 70"
         labels:
           severity: warning

--- a/manifests/prometheus/alerts.d/cc-api-job-queue-length.yml
+++ b/manifests/prometheus/alerts.d/cc-api-job-queue-length.yml
@@ -6,7 +6,7 @@
   value:
     name: CCJobQueueCount
     rules:
-      - alert: CCJobQueueCount_Warning
+      - alert: CCJobQueueCount
         expr: avg_over_time(firehose_value_metric_cc_job_queue_length_total[30m]) > 20
         labels:
           severity: warning

--- a/manifests/prometheus/alerts.d/cc-failed-job-count.yml
+++ b/manifests/prometheus/alerts.d/cc-failed-job-count.yml
@@ -9,7 +9,7 @@
       - record: firehose_value_metric_cc_failed_job_count_total:avg30m
         expr: avg_over_time(firehose_value_metric_cc_failed_job_count_total[30m])
 
-      - alert: CCFailedJobCount_Warning
+      - alert: CCFailedJobCount
         expr: max(delta(firehose_value_metric_cc_failed_job_count_total:avg30m[30m])) > 3
         labels:
           severity: warning

--- a/manifests/prometheus/alerts.d/cc-latency-by-gorouter.yml
+++ b/manifests/prometheus/alerts.d/cc-latency-by-gorouter.yml
@@ -6,7 +6,7 @@
   value:
     name: CloudControllerLatencyByGorouter
     rules:
-      - alert: CloudControllerLatencyByGorouter_Warning
+      - alert: CloudControllerLatencyByGorouter
         expr: avg(avg_over_time(firehose_value_metric_gorouter_latency_cloud_controller[30m])) > 500
         labels:
           severity: warning

--- a/manifests/prometheus/alerts.d/cc-log-error-count.yml
+++ b/manifests/prometheus/alerts.d/cc-log-error-count.yml
@@ -6,7 +6,7 @@
   value:
     name: CCLogErrorCount
     rules:
-      - alert: CCLogErrorCount_Warning
+      - alert: CCLogErrorCount
         expr: sum(increase(firehose_value_metric_cc_log_count_error[1h])) > 20
         labels:
           severity: warning

--- a/manifests/prometheus/alerts.d/cf-syslog-drains.yml
+++ b/manifests/prometheus/alerts.d/cf-syslog-drains.yml
@@ -6,7 +6,7 @@
   value:
     name: CFSyslogDrains
     rules:
-    - alert: CFSyslogDrains_Warning
+    - alert: CFSyslogDrains
       expr: firehose_value_metric_cf_syslog_drain_scheduler_drains > 250
       labels:
         severity: warning

--- a/manifests/prometheus/alerts.d/cloudfront_tls_certificates_expiry.yml
+++ b/manifests/prometheus/alerts.d/cloudfront_tls_certificates_expiry.yml
@@ -7,7 +7,7 @@
     name: CloudFrontTLSCertificateExpiresSoon
     rules:
 
-      - alert: CloudFrontTLSCertificateExpiresSoon_Warning
+      - alert: CloudFrontTLSCertificateExpiresSoon
         expr: "paas_cdn_tls_certificates_expiry_days <= 21"
         for: 5m
         annotations:

--- a/manifests/prometheus/alerts.d/cloudfront_tls_certificates_validity.yml
+++ b/manifests/prometheus/alerts.d/cloudfront_tls_certificates_validity.yml
@@ -7,7 +7,7 @@
     name: CloudFrontInvalidTLSCertificates
     rules:
 
-      - alert: CloudFrontInvalidTLSCertificates_Warning
+      - alert: CloudFrontInvalidTLSCertificates
         expr: "count(paas_cdn_tls_certificates_validity == 0) >= 3"
         for: 5m
         annotations:

--- a/manifests/prometheus/alerts.d/concourse-load.yml
+++ b/manifests/prometheus/alerts.d/concourse-load.yml
@@ -9,7 +9,7 @@
       - record: "bosh_job:bosh_job_cpu:avg1h"
         expr: avg_over_time(bosh_job_load_avg01{bosh_job_name="concourse"}[1h])
 
-      - alert: ConcourseHighCPUUtilisation_Warning
+      - alert: ConcourseHighCPUUtilisation
         expr: "bosh_job:bosh_job_cpu:avg1h > 150"
         labels:
           severity: warning

--- a/manifests/prometheus/alerts.d/concourse-smoketests-failures.yml
+++ b/manifests/prometheus/alerts.d/concourse-smoketests-failures.yml
@@ -15,6 +15,15 @@
           summary: Concourse continuous-smoke-tests failures
           description: The continuous-smoke-tests Concourse job has failed at least twice in the last hour.
 
+      - alert: ConcourseSmoketestsFailuresCritical
+        expr: increase(concourse_builds_finished{exported_job="continuous-smoke-tests",pipeline="create-cloudfoundry",status="failed"}[30m]) >= 3
+        labels:
+          severity: critical
+          notify: pagerduty
+        annotations:
+          summary: Concourse continuous-smoke-tests failures
+          description: The continuous-smoke-tests Concourse job has failed at least three times in the last 30 minutes.
+
 - type: replace
   path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
   value:

--- a/manifests/prometheus/alerts.d/diego_cell_available_cpu_idle.yml
+++ b/manifests/prometheus/alerts.d/diego_cell_available_cpu_idle.yml
@@ -5,7 +5,7 @@
   value:
     name: BoshDiegoCellIdleCPU
     rules:
-      - alert: BoshDiegoCellIdleCPU_Warning
+      - alert: BoshDiegoCellIdleCPU
         expr: avg(avg_over_time(bosh_job_cpu_idle{bosh_job_name="diego-cell"}[1d])) < 37
         labels:
           severity: warning

--- a/manifests/prometheus/alerts.d/diego_cell_available_memory.yml
+++ b/manifests/prometheus/alerts.d/diego_cell_available_memory.yml
@@ -5,7 +5,7 @@
   value:
     name: BoshDiegoCellAvailableMemory
     rules:
-      - alert: BoshDiegoCellAvailableMemory_Warning
+      - alert: BoshDiegoCellAvailableMemory
         expr: avg(avg_over_time(bosh_job_mem_percent{bosh_job_name="diego-cell"}[1d])) >= 45
         labels:
           severity: warning

--- a/manifests/prometheus/alerts.d/diego_cell_rep_container_capacity.yml
+++ b/manifests/prometheus/alerts.d/diego_cell_rep_container_capacity.yml
@@ -10,7 +10,7 @@
           100 *
           sum(avg_over_time(firehose_value_metric_rep_container_count{environment="((metrics_environment))"}[5m])) by (environment) /
           sum(avg_over_time(firehose_value_metric_rep_capacity_total_containers{environment="((metrics_environment))"}[5m])) by (environment)
-      - alert: DiegoCellRepContainerCapacity_Warning
+      - alert: DiegoCellRepContainerCapacity
         expr:  rep_container_capacity_pct:avg5m > 75
         for: 2h
         labels:

--- a/manifests/prometheus/alerts.d/diego_cell_rep_memory_capacity.yml
+++ b/manifests/prometheus/alerts.d/diego_cell_rep_memory_capacity.yml
@@ -10,7 +10,7 @@
           100 *
           sum(avg_over_time(firehose_value_metric_rep_capacity_remaining_memory{environment="((metrics_environment))"}[5m])) by (environment) /
           sum(avg_over_time(firehose_value_metric_rep_capacity_total_memory{environment="((metrics_environment))"}[5m])) by (environment)
-      - alert: DiegoCellRepMemoryCapacity_Warning
+      - alert: DiegoCellRepMemoryCapacity
         expr:  rep_memory_capacity_pct:avg5m < 35
         for: 2h
         labels:

--- a/manifests/prometheus/alerts.d/dns-resolution-time.yml
+++ b/manifests/prometheus/alerts.d/dns-resolution-time.yml
@@ -6,7 +6,7 @@
   value:
     name: DNSResolutionTime
     rules:
-    - alert: DNSResolutionTime_Warning
+    - alert: DNSResolutionTime
       expr: avg_over_time(dns_resolution_probe_duration_seconds[10m]) > 0.2
       labels:
         severity: warning

--- a/manifests/prometheus/alerts.d/doppler-dropped-envelopes.yml
+++ b/manifests/prometheus/alerts.d/doppler-dropped-envelopes.yml
@@ -6,7 +6,7 @@
   value:
     name: DopplerDroppedEnvelopes
     rules:
-      - alert: DopplerDroppedEnvelopes_Warning
+      - alert: DopplerDroppedEnvelopes
         expr: sum(increase(firehose_counter_event_loggregator_doppler_dropped_total[1h])) > 100
         labels:
           severity: warning

--- a/manifests/prometheus/alerts.d/ec2_cpu_credits.yml
+++ b/manifests/prometheus/alerts.d/ec2_cpu_credits.yml
@@ -6,7 +6,7 @@
   value:
     name: EC2CPUCreditsLow
     rules:
-      - alert: EC2CPUCreditsLow_Warning
+      - alert: EC2CPUCreditsLow
         expr: avg_over_time(aws_ec2_cpucredit_balance_minimum[30m]) <= 20
         labels:
           severity: warning

--- a/manifests/prometheus/alerts.d/elasticache-node-count.yml
+++ b/manifests/prometheus/alerts.d/elasticache-node-count.yml
@@ -6,7 +6,7 @@
   value:
     name: ElasticacheNodeCountCloseToLimit
     rules:
-      - alert: ElasticacheNodeCountCloseToLimit_Warning
+      - alert: ElasticacheNodeCountCloseToLimit
         expr: paas_aws_elasticache_node_count > ((aws_limits_elasticache_nodes)) / 100 * 80
         for: 1h
         labels:

--- a/manifests/prometheus/alerts.d/elasticache-parameter-group-count.yml
+++ b/manifests/prometheus/alerts.d/elasticache-parameter-group-count.yml
@@ -6,7 +6,7 @@
   value:
     name: ElasticacheParamGroupCountCloseToLimit
     rules:
-      - alert: ElasticacheParamGroupCountCloseToLimit_Warning
+      - alert: ElasticacheParamGroupCountCloseToLimit
         expr: paas_aws_elasticache_cache_parameter_group_count > ((aws_limits_elasticache_cache_parameter_groups)) / 100 * 80
         for: 1h
         labels:

--- a/manifests/prometheus/alerts.d/gorouter-latency.yml
+++ b/manifests/prometheus/alerts.d/gorouter-latency.yml
@@ -6,7 +6,7 @@
   value:
     name: GorouterLatency
     rules:
-      - alert: GorouterLatency_Warning
+      - alert: GorouterLatency
         expr: min(avg_over_time(firehose_value_metric_gorouter_latency[5m])) > 750
         for: 15m
         labels:

--- a/manifests/prometheus/alerts.d/platform_tls_certificates_expiry.yml
+++ b/manifests/prometheus/alerts.d/platform_tls_certificates_expiry.yml
@@ -7,7 +7,7 @@
     name: PlatformTLSCertificateExpiresSoon
     rules:
 
-      - alert: PlatformTLSCertificateExpiresSoon_Warning
+      - alert: PlatformTLSCertificateExpiresSoon
         expr: "paas_tls_certificates_validity_days <= 30"
         for: 5m
         annotations:

--- a/manifests/prometheus/alerts.d/rds_cpu_credits.yml
+++ b/manifests/prometheus/alerts.d/rds_cpu_credits.yml
@@ -6,7 +6,7 @@
   value:
     name: RDSCPUCreditsLow
     rules:
-      - alert: RDSCPUCreditsLow_Warning
+      - alert: RDSCPUCreditsLow
         expr: avg_over_time(aws_rds_cpucredit_balance_minimum[30m]) <= 20
         labels:
           severity: warning

--- a/manifests/prometheus/alerts.d/rds_disk_utilisation.yml
+++ b/manifests/prometheus/alerts.d/rds_disk_utilisation.yml
@@ -6,7 +6,7 @@
   value:
     name: RDSCPUDiskUtilisation
     rules:
-      - alert: RDSCPUDiskUtilisation_Warning
+      - alert: RDSCPUDiskUtilisation
         expr: aws_rds_free_storage_space_minimum <= 2 * 1024 ^ 3
         labels:
           severity: warning

--- a/manifests/prometheus/spec/alerts/bosh-high-cpu-utilisation.test.yml
+++ b/manifests/prometheus/spec/alerts/bosh-high-cpu-utilisation.test.yml
@@ -20,9 +20,9 @@ tests:
 
     alert_rule_test:
       - eval_time: 30m
-        alertname: BoshHighCPUUtilisation_Warning
+        alertname: BoshHighCPUUtilisation
       - eval_time: 61m
-        alertname: BoshHighCPUUtilisation_Warning
+        alertname: BoshHighCPUUtilisation
         exp_alerts:
           - exp_labels:
               severity: warning

--- a/manifests/prometheus/spec/alerts/cc-latency-by-gorouter.test.yml
+++ b/manifests/prometheus/spec/alerts/cc-latency-by-gorouter.test.yml
@@ -17,15 +17,15 @@ tests:
     alert_rule_test:
       # Does not fire before half an hour
       - eval_time: 20m
-        alertname: CloudControllerLatencyByGorouter_Warning
+        alertname: CloudControllerLatencyByGorouter
 
       # Does not fire when the value is not high enough
       - eval_time: 40m
-        alertname: CloudControllerLatencyByGorouter_Warning
+        alertname: CloudControllerLatencyByGorouter
 
       # Fires when the average of the last 30 minutes is above the threshold
       - eval_time: 70m
-        alertname: CloudControllerLatencyByGorouter_Warning
+        alertname: CloudControllerLatencyByGorouter
         exp_alerts:
           - exp_labels:
               severity: warning

--- a/manifests/prometheus/spec/alerts/concourse-smoketests-failures.test.yml
+++ b/manifests/prometheus/spec/alerts/concourse-smoketests-failures.test.yml
@@ -40,3 +40,19 @@ tests:
             exp_annotations:
               summary: Concourse continuous-smoke-tests failures
               description: The continuous-smoke-tests Concourse job has failed at least twice in the last hour.
+
+      - alertname: ConcourseSmoketestsFailuresCritical
+        eval_time: 35m
+
+      - alertname: ConcourseSmoketestsFailuresCritical
+        eval_time: 40m
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              notify: pagerduty
+              exported_job: continuous-smoke-tests
+              pipeline: create-cloudfoundry
+              status: failed
+            exp_annotations:
+              summary: Concourse continuous-smoke-tests failures
+              description: The continuous-smoke-tests Concourse job has failed at least three times in the last 30 minutes.

--- a/manifests/prometheus/spec/alerts/diego_cell_available_memory.test.yml
+++ b/manifests/prometheus/spec/alerts/diego_cell_available_memory.test.yml
@@ -15,16 +15,16 @@ tests:
     alert_rule_test:
       # Does not fire with insufficient data
       - eval_time: 12h
-        alertname: BoshDiegoCellAvailableMemory_Warning
+        alertname: BoshDiegoCellAvailableMemory
 
       # Does not fire when the average of the averages over
       # the last 24h window is less than the threshold
       - eval_time: 48h
-        alertname: BoshDiegoCellAvailableMemory_Warning
+        alertname: BoshDiegoCellAvailableMemory
 
 
       - eval_time: 72h
-        alertname: BoshDiegoCellAvailableMemory_Warning
+        alertname: BoshDiegoCellAvailableMemory
         exp_alerts:
           - exp_labels:
               severity: warning

--- a/manifests/prometheus/spec/alerts/diego_cell_rep_container_capacity.test.yml
+++ b/manifests/prometheus/spec/alerts/diego_cell_rep_container_capacity.test.yml
@@ -24,18 +24,18 @@ tests:
       # Does not fire when the percentage of container
       # capacity used is below the threshold
       - eval_time: 2h
-        alertname: DiegoCellRepContainerCapacity_Warning
+        alertname: DiegoCellRepContainerCapacity
 
       # Does not fire when the percentage of container
       # capacity used has not been above the threshold
       # for long enough
       - eval_time: 4h
-        alertname: DiegoCellRepContainerCapacity_Warning
+        alertname: DiegoCellRepContainerCapacity
 
       # Fires when the percentage of container capacity
       # used has been above the threshold for 2 hours
       - eval_time: 5h
-        alertname: DiegoCellRepContainerCapacity_Warning
+        alertname: DiegoCellRepContainerCapacity
         exp_alerts:
           - exp_labels:
               severity: warning

--- a/manifests/prometheus/spec/alerts/diego_cell_rep_memory_capacity.test..yml
+++ b/manifests/prometheus/spec/alerts/diego_cell_rep_memory_capacity.test..yml
@@ -24,17 +24,17 @@ tests:
       # Does not fire when the percentage of free memory
       # is above the threshold
       - eval_time: 2h
-        alertname: DiegoCellRepMemoryCapacity_Warning
+        alertname: DiegoCellRepMemoryCapacity
 
       # Does not fire when the percentage of free memory
       # has not been below the threshold for long enough
       - eval_time: 4h
-        alertname: DiegoCellRepMemoryCapacity_Warning
+        alertname: DiegoCellRepMemoryCapacity
 
       # Fires when the percentage of free memory
       # has been below the threshold for 2 hours
       - eval_time: 5h
-        alertname: DiegoCellRepMemoryCapacity_Warning
+        alertname: DiegoCellRepMemoryCapacity
         exp_alerts:
           - exp_labels:
               severity: warning

--- a/manifests/prometheus/spec/alerts/doppler-dropped-envelopes.test.yml
+++ b/manifests/prometheus/spec/alerts/doppler-dropped-envelopes.test.yml
@@ -23,16 +23,16 @@ tests:
     alert_rule_test:
       # Does not fire without an hour of data points
       - eval_time: 30m
-        alertname: DopplerDroppedEnvelopes_Warning
+        alertname: DopplerDroppedEnvelopes
 
       # Does not fire when the sum of the increases
       # of gorouter latencies is less than the threshold
       - eval_time: 90m
-        alertname: DopplerDroppedEnvelopes_Warning
+        alertname: DopplerDroppedEnvelopes
 
       # Fires when the average of the last 30 minutes is above the threshold
       - eval_time: 180m
-        alertname: DopplerDroppedEnvelopes_Warning
+        alertname: DopplerDroppedEnvelopes
         exp_alerts:
           - exp_labels:
               severity: warning

--- a/manifests/prometheus/spec/alerts/gorouter-latency.test.yml
+++ b/manifests/prometheus/spec/alerts/gorouter-latency.test.yml
@@ -17,9 +17,9 @@ tests:
 
     alert_rule_test:
       - eval_time: 15m
-        alertname: GorouterLatency_Warning
+        alertname: GorouterLatency
       - eval_time: 31m
-        alertname: GorouterLatency_Warning
+        alertname: GorouterLatency
         exp_alerts:
           - exp_labels:
               severity: warning


### PR DESCRIPTION
What
----

Follow up from [PR 1786](https://github.com/alphagov/paas-cf/pull/1786)
- The critical continuous smoke test alert was removed as part of the previous PR. This re-adds the alert so a pager duty notification is triggered on three failures.
- Removes "Warning" from the alert names that no longer have a critical alert.

How to review
-------------

Code review

Who can review
--------------

Not me
