### PR TITLE
[SUPPORT] Scale up doppler in production

### DIFF
--- a/manifests/cf-manifest/env-specific/default.yml
+++ b/manifests/cf-manifest/env-specific/default.yml
@@ -2,3 +2,4 @@
 cell_instances: 3
 router_instances: 2
 api_instances: 2
+doppler_instances: 6

--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -2,3 +2,4 @@
 cell_instances: 15
 router_instances: 3
 api_instances: 4
+doppler_instances: 12

--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -2,3 +2,4 @@
 cell_instances: 42
 router_instances: 3
 api_instances: 4
+doppler_instances: 12

--- a/manifests/cf-manifest/env-specific/stg-lon.yml
+++ b/manifests/cf-manifest/env-specific/stg-lon.yml
@@ -2,3 +2,4 @@
 cell_instances: 6
 router_instances: 3
 api_instances: 2
+doppler_instances: 3

--- a/manifests/cf-manifest/operations.d/360-doppler.yml
+++ b/manifests/cf-manifest/operations.d/360-doppler.yml
@@ -6,4 +6,4 @@
 
 - type: replace
   path: /instance_groups/name=doppler/instances
-  value: 6
+  value: ((doppler_instances))

--- a/manifests/cf-manifest/spec/manifest/env_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/env_spec.rb
@@ -21,6 +21,13 @@ RSpec.describe "Environment specific configuration" do
     expect(default_api_instances).to be < prod_api_instances
   end
 
+  it "should allow a higher number of instances of Doppler instances in production" do
+    default_doppler_instances = get_instance_group_instances(default_manifest, "doppler")
+    prod_doppler_instances = get_instance_group_instances(prod_manifest, "doppler")
+
+    expect(default_doppler_instances).to be < prod_doppler_instances
+  end
+
   %w(prod prod-lon stg-lon).each do |env|
     context "for the #{env} environment" do
       let(:env_manifest) { manifest_for_env(env) }


### PR DESCRIPTION
What
----

* Number of doppler instances in production have been scaled to 12 in prod, and 6 in all other instances.
* Test has been added to ensure this is the case

How to review
-------------

* Code Review
* Check unit tests pass
* Check the number of doppler instances do not change when run down Dev pipeline.

Who can review
--------------

Not @tnwhitwell 
