### PR TITLE
[#164467168] Change the billing-db's plan in staging to medium-9.5

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2041,6 +2041,9 @@ jobs:
                 if [ "${DEPLOY_ENV}" = "prod" ]; then
                   BILLING_DB_PLAN="medium-9.5"
                 fi
+                if [ "${DEPLOY_ENV}" = "stg-lon" ]; then
+                  BILLING_DB_PLAN="medium-9.5"
+                fi
 
                 VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
                 CF_CLIENT_SECRET=$($VAL_FROM_YAML secrets_uaa_clients_paas_billing_secret cf-vars-store/cf-vars-store.yml)


### PR DESCRIPTION
What
----

In staging I had to manually upgrade the billing-db from tiny-unencrypted-9.5 to medium-unencrypted-9.5 (upgrade is not supported between unecrypted <-> encrypted in the RDS broker).

If we ever recreate staging this change will make sure we use an encrypted one.

This change won't effect any existing databases.

How to review
-------------

Code review should be enough. It's unnecessary to run through the staging/prod pipelines, so a Github merge with `[skip ci]` should be enough IMO.

Who can review
--------------

Not me.
