### PR TITLE
[SUPPORT] Update capi-release to mitigate CVE-2019-3785

### DIFF
--- a/manifests/cf-manifest/operations.d/329-capi-release.yml
+++ b/manifests/cf-manifest/operations.d/329-capi-release.yml
@@ -1,0 +1,7 @@
+- type: replace
+  path: /releases/name=capi
+  value:
+    name: "capi"
+    version: "1.78.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.78.0"
+    sha1: "10a7ec24faeef95a49cb8ebe7845ecbf16fab761"


### PR DESCRIPTION
What
----

This was actioned because of https://www.cloudfoundry.org/blog/cve-2019-3785/

How to review
-------------

* Code review
* Check it has run down a pipeline

Who can review
--------------

Not @tnwhitwell 
