### PR TITLE
[SUPPORT] Add some more cells in London

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -1,5 +1,5 @@
 ---
-cell_instances: 15
+cell_instances: 18
 router_instances: 3
 api_instances: 4
 doppler_instances: 12


### PR DESCRIPTION
What
----

We are currently triggering / hovering close to triggering the alarm in London for the available memory on cells. This means we need to add more cells.

`rep_memory_capacity_pct:avg5m` is sitting around 32.8%, which is less than the threshold of 33.

As we require the number of instances to be divisible by #AZs, we scale to 18 cells.

How to review
-------------

Code review

Who can review
--------------

Anyone but me