### PR TITLE
Add 3 cells to prod-lon

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -1,5 +1,5 @@
 ---
-cell_instances: 18
+cell_instances: 21
 router_instances: 3
 api_instances: 4
 doppler_instances: 12


### PR DESCRIPTION
What
----

The memory usage in prod-lon has been climbing, and we're now below our
threshold again.

Judging from this graph:

https://prometheus-1.london.cloud.service.gov.uk/graph?g0.range_input=2w&g0.expr=rep_memory_capacity_pct%3Aavg5m&g0.tab=0

Last time we increased our scale by 3 instances we got an extra 23%
rep_memory_capacity_pct. We're now running at 23%, which is below our
threshold of 33%. Increasing the cell instances by 3 should give us
another 20% or so, which should take us above the threshold again.

I'll raise a separate PR to scale back Ireland, which seems to be
swimming in free memory now.

How to review
-------------

* Code review should be fine

Who can review
--------------

Not @richardtowers