### PR TITLE
[FIX] Pin Travis to Ruby 2.5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: trusty
 sudo: false
 rvm:
-  - 2.5
+  - 2.5.3
 env:
   global:
     - TF_VERSION="0.11.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,13 @@ dist: trusty
 sudo: false
 rvm:
   - 2.5.3
+# Travis currently translates "2.5" into "2.5.4", which has bundler problems.
+# This build is here to discover when "2.5" stops breaking. It's allowed to fail by
+# the "matrix" key, below
+  - 2.5
+matrix:
+  allow_failures:
+    - rvm: 2.5
 env:
   global:
     - TF_VERSION="0.11.1"


### PR DESCRIPTION
What
----

This PR pins Ruby version to 2.5.3 in Travis.

Ruby 2.5.4 was recently released, and appears to have problems with bundler. We
previously pinned Ruby at 2.5 in Travis, and Travis is now resolving this to
the "broken" 2.5.4. We pin to 2.5.3 to maintain passing builds.

We also add a Ruby 2.5 matrix build to Travis

When Travis began resolving 2.5 to 2.5.4 in [1], the build began failing for
reasons other than a test failure. This 2nd commit adds a second build to the
matrix, pinned to 2.5, which is allowed to fail. This should allow us to see
when the latest 2.5.x build is safe to use, without failing the build in the
meantime.

Matrix builds aren't carried out consecutively, so we don't believe it doubles
the build time.

How to review
-------------

Check the ruby 2.5.3 build is green, and the 2nd build (on 2.5.4 or later) is red.

Who can review
--------------

Anyone.