### PR TITLE
[#163795598] Delete the db parameter group used for manually enabling the pg_stat_statements extension

### DIFF
--- a/terraform/cloudfoundry/rds_broker.tf
+++ b/terraform/cloudfoundry/rds_broker.tf
@@ -107,29 +107,6 @@ resource "aws_db_parameter_group" "rds_broker_postgres95" {
   }
 }
 
-resource "aws_db_parameter_group" "rds_broker_postgres95_shared_preload_libraries" {
-  name        = "rdsbroker-postgres95-${var.env}-shared-preload-libraries"
-  family      = "postgres9.5"
-  description = "RDS Broker Postgres 9.5 parameter group with some shared_preload_libraries enabled"
-
-  parameter {
-    apply_method = "pending-reboot"
-    name         = "rds.force_ssl"
-    value        = "1"
-  }
-
-  parameter {
-    apply_method = "pending-reboot"
-    name         = "shared_preload_libraries"
-    value        = "pg_stat_statements"
-  }
-
-  parameter {
-    name  = "rds.log_retention_period"
-    value = "10080"                    // 7 days in minutes
-  }
-}
-
 resource "aws_db_parameter_group" "rds_broker_postgres10" {
   name        = "rdsbroker-postgres10-${var.env}"
   family      = "postgres10"


### PR DESCRIPTION
What
----

The extension can now be enabled when creating/updating the database through the rds broker. The broker manages its own custom parameter groups.

All databases have been migrated to the new parameter groups so this one can be removed.

❗️ The PR can not be merged until all databases have been migrated to the new parameter group. Check https://www.pivotaltracker.com/n/projects/1275640/stories/163795598 for the list of databases to check.

How to review
-------------

Code review is enough

Who can review
--------------

Not me.