### PR TITLE
Fix link to prometheus from grafana

### DIFF
--- a/manifests/prometheus/dashboards.d/user-impact.json
+++ b/manifests/prometheus/dashboards.d/user-impact.json
@@ -598,9 +598,9 @@
                 "interval": null,
                 "links": [{
                     "targetBlank": true,
-                    "title": "https://prometheus.__SYSTEM_DNS_ZONE_NAME__/alerts",
+                    "title": "https://prometheus-1.__SYSTEM_DNS_ZONE_NAME__/alerts",
                     "type": "absolute",
-                    "url": "https://prometheus.__SYSTEM_DNS_ZONE_NAME__/alerts"
+                    "url": "https://prometheus-1.__SYSTEM_DNS_ZONE_NAME__/alerts"
                 }],
                 "mappingType": 1,
                 "mappingTypes": [{


### PR DESCRIPTION
What
----

Since we've switched to "highly available" prometheus the url is
prometheus-1... not prometheus...

The "Alerts" box in grafana should link to the right URL.

I'm just using -1 (rather than working out which instance we're actually
on) because it's easier.

How to review
-------------

* Code review

Who can review
--------------

Not @richardtowers