### PR TITLE
Estimate Aiven cost at the end of the month

### DIFF
--- a/manifests/prometheus/alerts.d/aiven-cost.yml
+++ b/manifests/prometheus/alerts.d/aiven-cost.yml
@@ -7,8 +7,7 @@
     name: AivenEstimatedCostHigh
     rules:
       - alert: AivenEstimatedCostHigh
-        expr: paas_aiven_estimated_cost_pounds > 6500
-        for: 1h
+        expr: delta(paas_aiven_estimated_cost_pounds[24h]) * 30 > 20000
         labels:
           severity: critical
         annotations:

--- a/manifests/prometheus/spec/alerts/aiven-cost.test.yml
+++ b/manifests/prometheus/spec/alerts/aiven-cost.test.yml
@@ -9,12 +9,16 @@ tests:
   - interval: 1h
     input_series:
       - series: "paas_aiven_estimated_cost_pounds"
-        values: 0+100x48
+        values: 0+100x24 2500+10x24
 
     alert_rule_test:
+
+      # Alert should not be firing initially
       - eval_time: 1h
         alertname: AivenEstimatedCostHigh
-      - eval_time: 25h
+
+      # Alert should be firing after we've been spending £100 / hour for the last 24 hours
+      - eval_time: 24h
         alertname: AivenEstimatedCostHigh
         exp_alerts:
           - exp_labels:
@@ -22,3 +26,7 @@ tests:
             exp_annotations:
               summary: "Aiven estimated cost is high, possibly need to alert finance."
               description: "The estimated monthly cost of Aiven is currently £72000.00, possibly need to alert finance."
+
+      # Alert should not be firing after we've been spending £10 / hour for the last 24 hours
+      - eval_time: 48h
+        alertname: AivenEstimatedCostHigh

--- a/manifests/prometheus/spec/alerts/aiven-cost.test.yml
+++ b/manifests/prometheus/spec/alerts/aiven-cost.test.yml
@@ -1,0 +1,24 @@
+---
+rule_files:
+  # See alerts_validation_spec.rb for details of how this gets set:
+  - spec/alerts/fixtures/rules.yml
+
+evaluation_interval: 1h
+
+tests:
+  - interval: 1h
+    input_series:
+      - series: "paas_aiven_estimated_cost_pounds"
+        values: 0+100x48
+
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: AivenEstimatedCostHigh
+      - eval_time: 25h
+        alertname: AivenEstimatedCostHigh
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+            exp_annotations:
+              summary: "Aiven estimated cost is high, possibly need to alert finance."
+              description: "The estimated monthly cost of Aiven is currently £72000.00, possibly need to alert finance."


### PR DESCRIPTION
What
----

The value of `paas_aiven_estimated_cost_pounds` is the current spend for
the month according to Aiven, so it goes up in a saw tooth from the
beginning of the month.

This uses a linear approximation that the cost for the month will be the
cost for the last 24 hours multiplied by 30 (for the days in the month).

The delta function just naively subtracts the value at the beginning of
the time period from the value at the end. You might think that the
`increase()` function would be a better fit, but sadly that only works
for counters that always strictly increase over time or reset to zero -
this one occasionally drops by a few pounds, which confuses prometheus.

For the first day of each month the value of
`delta(paas_aiven_estimated_cost_pounds[24h])` will be massively
negative as the counter resets to zero.

Previously we were just alerting when our spend for a month crossed a
particular threshold, which tended to happen towards the end of every
month.

This also changes the threshold significantly so the alert will stop firing - we'll have the conversation about whether we need to talk to finance again separately, we don't need a permanent red alert reminding us.

How to review
-------------

* Code review
* Look at these screenshots and check they look sensible:

Before:

![image](https://user-images.githubusercontent.com/1696784/54607042-4279fb00-4a45-11e9-9cb3-9ef0fcba7bcd.png)

After:

![image](https://user-images.githubusercontent.com/1696784/54607071-5b82ac00-4a45-11e9-8dc4-89f9810bf9fb.png)



Who can review
--------------

* Not @richardTowers 