### PR TITLE
[#164143495] RDS broker enable/disable extensions

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 0.1.54 
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.54.tgz
-    sha1: 620bc4d4de371ff60b5432f9b762d42145069b00
+    version: 0.1.55
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.55.tgz
+    sha1: f1316c2633de273114794d2a1098e60f17d9c36e
 
 - type: replace
   path: /instance_groups/-


### PR DESCRIPTION
What
----

This updates the rds broker bosh release based on [this PR](https://github.com/alphagov/paas-rds-broker/pull/100) that adds the option to enable/disable extensions via an update call.

How to review
-------------

Deploy to your dev env and run the following.
- Create a postgres RDS instance via `cf create-service`
- Run `cf update-service svname -c '{"enable_extensions": ["pg_stat_statements"], "reboot": true}'`
- Confirm the right param group is in sync, extension is enabled via psql and tags are correct
- Run `cf update-service svname -c '{"disable_extensions": ["pg_stat_statements"], "reboot": true}'`
- Confirm the right param group is in sync, extension is disabled via psql and tags are correct

Merge Steps
------------

- Review and merge https://github.com/alphagov/paas-rds-broker/pull/100 when approved 
- Update the submodule for https://github.com/alphagov/paas-rds-broker-boshrelease/pull/82 and merge
- Amend [this commit](https://github.com/alphagov/paas-cf/pull/1817/commits/9e1277bc3369b383cad55843944150d326831155) with the updated bosh release and merge.

Who can review
--------------

Not me
