### PR TITLE
[#164278101] Parse application JSON logs correctly

### DIFF
--- a/config/logit/11_app_syslog_drain.conf
+++ b/config/logit/11_app_syslog_drain.conf
@@ -6,8 +6,13 @@ if [syslog_program] =~ /^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9
   }
 
   mutate {
+    add_field => { "[@source][app_id]" => "%{[syslog_program]}" }
+  }
+
+  mutate {
+    update => { "syslog_program" => "app" }
+    update => { "@type" => "LogMessage" }
     # This is an ugly hack to set the correct @source.component if the @type is "LogMessage"
     rename => { "app_log_type" => "[parsed_json_field][source_type]" }
-    update => { "@type" => "LogMessage" }
   }
 }

--- a/config/logit/20_custom_filters.conf
+++ b/config/logit/20_custom_filters.conf
@@ -42,10 +42,18 @@ mutate {
   remove_field => [ "[nginx][timestamp]" ]
 }
 
+# If the JSON message was succesfully parsed and @message is still in JSON, then we can remove it
+if [@source][component] == "app" and !("unknown_msg_format" in [tags]) and [@message] =~ /^\s*{".*}\s*$/ {
+  mutate {
+    remove_field => "@message"
+  }
+}
+
 # Remove unnecessary or empty fields
 mutate {
   remove_field => [
     "syslog5424_ver",
+    "syslog6587_msglen",
     "syslog_msgid",
     "syslog_procid",
     "syslog_sd_id",

--- a/config/logit/output/generated_logit_filters.conf
+++ b/config/logit/output/generated_logit_filters.conf
@@ -171,9 +171,14 @@ filter {
     }
 
     mutate {
+      add_field => { "[@source][app_id]" => "%{[syslog_program]}" }
+    }
+
+    mutate {
+      update => { "syslog_program" => "app" }
+      update => { "@type" => "LogMessage" }
       # This is an ugly hack to set the correct @source.component if the @type is "LogMessage"
       rename => { "app_log_type" => "[parsed_json_field][source_type]" }
-      update => { "@type" => "LogMessage" }
     }
   }
   # NOTE: All parsed data should include @message, @level and @source.component.
@@ -649,7 +654,7 @@ filter {
   ##------------------------------
   # Platform conf. Parses CF logs.|
   ##------------------------------
-  if [@index_type] == "platform" {
+  if [@index_type] == "platform" and [@source][component] != "app" {
 
       mutate {
           replace => { "[@source][type]" => "system" } # default for platform logs
@@ -816,7 +821,7 @@ filter {
   ##-----------------------------
   # Vcap conf. Parses vcap* logs.|
   ##-----------------------------
-  if [@source][component] != "uaa" {
+  if [@source][component] != "uaa" and [@source][component] != "app" {
 
       # minus vcap. prefix
       mutate {
@@ -990,10 +995,18 @@ filter {
     remove_field => [ "[nginx][timestamp]" ]
   }
 
+  # If the JSON message was succesfully parsed and @message is still in JSON, then we can remove it
+  if [@source][component] == "app" and !("unknown_msg_format" in [tags]) and [@message] =~ /^\s*{".*}\s*$/ {
+    mutate {
+      remove_field => "@message"
+    }
+  }
+
   # Remove unnecessary or empty fields
   mutate {
     remove_field => [
       "syslog5424_ver",
+      "syslog6587_msglen",
       "syslog_msgid",
       "syslog_procid",
       "syslog_sd_id",

--- a/scripts/generate_logit_filters.sh
+++ b/scripts/generate_logit_filters.sh
@@ -53,9 +53,13 @@ echo "filter {" > /output/generated_logit_filters.conf
 sed -i 's/^ *$//g' /output/generated_logit_filters.conf
 
 sed -i \
-    "s/if \[@source\]\[component\] != \"vcap.uaa\".*/if [@source][component] != \"uaa\" {/" \
+    "s/if \[@source\]\[component\] != \"vcap.uaa\".*/if [@source][component] != \"uaa\" and [@source][component] != \"app\" {/" \
+    /output/generated_logit_filters.conf
+
+sed -i \
+    "s/if \[@index_type\] == \"platform\" {/if [@index_type] == \"platform\" and [@source][component] != \"app\" {/" \
     /output/generated_logit_filters.conf
 
 sed -i \
     "s/vcap\.uaa/uaa/" \
-    /output/generated_logit_filters.conf	
+    /output/generated_logit_filters.conf


### PR DESCRIPTION
What
----

Currently we send the PaaS admin logs to Logit - using a log service. The
current Logstash filters are parsing the JSON message twice, once by adding it
with "app." prefix and once more by adding the "[app guid]." prefix.

This commit:
 - creates a new field @source.app_id which will contain the app guid (not using @cf.app_id here as that would have additional side effects)
 - updates the syslog_program to "app", which will be the new value of @source.component
 - adds a condition that we don't try to parse the JSON message if @source.component is "app"
 - adds a condition that we don't try to parse app logs as platform logs
 - removes the @message field for apps if it still contains the full JSON message
 - removes the unnecessary syslog6587_msglen field

How to review
-------------

1. I deployed the changes to Kibana in dev. Search for "email_address" and check whether the app messages was parsed as intended.
1. Check that platform messages were not affected (e.g. those still have the @message field)

Who can review
--------------

Not me.
