### PR TITLE
[#164864261] Upgrade to cf-deployment v7.7.0

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -273,7 +273,7 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-smoke-tests-release
-      tag_filter: "40.0.45"
+      tag_filter: "40.0.47"
       submodules:
       - "src/smoke_tests"
 

--- a/concourse/pipelines/monitor-remote.yml
+++ b/concourse/pipelines/monitor-remote.yml
@@ -19,7 +19,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloudfoundry/cf-smoke-tests-release
-    tag_filter: "40.0.45"
+    tag_filter: "40.0.47"
     submodules:
       - "src/smoke_tests"
 

--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-xenial
-      version: "170.39"
+      version: "170.45"

--- a/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
+++ b/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
@@ -4,14 +4,14 @@
   path: /releases/name=cflinuxfs2
   value:
     name: "cflinuxfs2"
-    version: "1.274.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.274.0"
-    sha1: "c445d573ff1ec25046adb79f86511155670484b7"
+    version: "1.275.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.275.0"
+    sha1: "64027babfdaac464242162c57b80465b973c5b40"
 
 - type: replace
   path: /releases/name=cflinuxfs3
   value:
     name: "cflinuxfs3"
-    version: "0.71.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.71.0"
-    sha1: "33a22f6cf0829bcddf92bf0a829968373d965e47"
+    version: "0.72.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.72.0"
+    sha1: "b1b2acccb718440fb5f969a1a48c1f8cfec59a62"

--- a/manifests/cf-manifest/operations.d/320-cc-set-ccdb.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-set-ccdb.yml
@@ -20,3 +20,6 @@
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/ccdb
   value: *cloud_controller_ng_ccdb
 
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb
+  value: *cloud_controller_ng_ccdb

--- a/manifests/cf-manifest/operations.d/350-diego-cell.yml
+++ b/manifests/cf-manifest/operations.d/350-diego-cell.yml
@@ -12,17 +12,17 @@
 
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs2-rootfs-setup/properties/cflinuxfs2-rootfs/trusted_certs
-  value: |
-    ((aws_rds_combined_ca_bundle))
-    ((application_ca.certificate))((application_ca_old.certificate))
-    ((uaa_ca.certificate))((uaa_ca_old.certificate))
+  value:
+    - ((aws_rds_combined_ca_bundle))
+    - ((application_ca.certificate))((application_ca_old.certificate))
+    - ((uaa_ca.certificate))((uaa_ca_old.certificate))
 
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs3-rootfs-setup/properties/cflinuxfs3-rootfs/trusted_certs
-  value: |
-    ((aws_rds_combined_ca_bundle))
-    ((application_ca.certificate))((application_ca_old.certificate))
-    ((uaa_ca.certificate))((uaa_ca_old.certificate))
+  value:
+    - ((aws_rds_combined_ca_bundle))
+    - ((application_ca.certificate))((application_ca_old.certificate))
+    - ((uaa_ca.certificate))((uaa_ca_old.certificate))
 
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden?/log_level

--- a/manifests/cf-manifest/operations.d/400-upgrade-log-cache-version.yml
+++ b/manifests/cf-manifest/operations.d/400-upgrade-log-cache-version.yml
@@ -1,8 +1,0 @@
-- type: replace
-  path: /releases/name=log-cache
-  value:
-    name: log-cache
-    # This is v2.1.1 + a backported fix for a 2nd pagination issue - https://github.com/alphagov/paas-log-cache-release/pull/1 was merged upstream; pull/2 was not
-    version: 0.1.4
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/log-cache-0.1.4.tgz
-    sha1: 88e591efab85f338560a66af1e741dbde886272b

--- a/manifests/cf-manifest/operations.d/900-cf-cert-rotation.yml
+++ b/manifests/cf-manifest/operations.d/900-cf-cert-rotation.yml
@@ -132,6 +132,10 @@
   value: ((service_cf_internal_ca.certificate))((service_cf_internal_ca_old.certificate))
 
 - type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/cc/mutual_tls/ca_cert
+  value: ((service_cf_internal_ca.certificate))((service_cf_internal_ca_old.certificate))
+
+- type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/uaa/ca_cert
   value: ((uaa_ca.certificate))((uaa_ca_old.certificate))
 

--- a/manifests/cf-manifest/spec/manifest/database_encryption_keys_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/database_encryption_keys_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe "database encryption keys" do
         /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/db_encryption_key
         /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/database_encryption/keys/((cc_db_encryption_key_id))
         /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/db_encryption_key
+        /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/cc/db_encryption_key
       }
       expect(found_locations).to contain_exactly(*expected_locations)
     end

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -26,12 +26,7 @@ RSpec.describe "release versions" do
       Gem::Version.new(v.gsub(/^v/, '').gsub(/^([0-9]+)$/, '0.0.\1'))
     end
 
-    pinned_releases = {
-      "log-cache" => {
-        local: "0.1.4",
-        upstream: "2.1.1",
-      },
-    }
+    pinned_releases = {}
 
     manifest_releases = manifest_without_vars_store.fetch("releases").map { |release|
       [release['name'], release['version']]

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "release versions" do
     expect(monitor_remote_smoke_tests_resource_version).to eq(cf_smoke_tests_resource_version)
   end
 
-  specify "cf-acceptance-tests version should be the same as the CF manifest version" do
+  skip "cf-acceptance-tests version should be the same as the CF manifest version" do
     cf_manifest_version = cf_deployment_manifest
       .fetch('manifest_version')
 

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "release versions" do
     expect(monitor_remote_smoke_tests_resource_version).to eq(cf_smoke_tests_resource_version)
   end
 
-  skip "cf-acceptance-tests version should be the same as the CF manifest version" do
+  specify "cf-acceptance-tests version should be the same as the CF manifest version" do
     cf_manifest_version = cf_deployment_manifest
       .fetch('manifest_version')
 
@@ -101,6 +101,11 @@ RSpec.describe "release versions" do
       .fetch('resources')
       .select { |v| v['name'] == 'cf-acceptance-tests' }
       .fetch(0)
+
+    if cf_manifest_version == 'v7.7.0'
+      expect(cf_acceptance_tests_resource['source']['branch']).to be == 'cf7.6', "There's no cf7.7 branch, so we're using the cf7.6 acceptance tests branch for cf-deployment 7.7. Next time we update cf-deployment we should check if there's a branch in cf-acceptance-tests for it and remove this conditional if so. See https://github.com/cloudfoundry/cf-acceptance-tests/branches/all?utf8=%E2%9C%93&query=cf"
+      next
+    end
 
     upstream_version = Gem::Version.new(cf_manifest_version.gsub(/^v/, '').gsub(/\.0$/, ''))
     paas_version = Gem::Version.new(cf_acceptance_tests_resource['source']['branch'].gsub(/^cf/, ''))


### PR DESCRIPTION
What
----

CF upgrade from v7.5.0 to  v7.7.0 with the following changes
- Upgrade cf-smoke-tests-release from 40.0.45 to 40.0.47
- Updating the relevant ops files to take into account the `cc_deployment_updater` changes in v7.6.0
- Upgrading log-cache from 2.1.1 to 2.2.0 by removing our log-cache fork and using the upstream

Release Notes
-------

- https://github.com/cloudfoundry/cf-deployment/releases/tag/v7.6.0
- https://github.com/cloudfoundry/cf-deployment/releases/tag/v7.7.0

How to review
-------------

- Code Review 
- Deploy to your dev env 

Who can review
--------------

Not @mogds or @richardTowers 