### PR TITLE
[SUPPORT] Reduce the number of cells to 30 in Ireland, add 3 in London

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -1,5 +1,5 @@
 ---
-cell_instances: 27
+cell_instances: 30
 router_instances: 3
 api_instances: 4
 doppler_instances: 12

--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -1,5 +1,5 @@
 ---
-cell_instances: 33
+cell_instances: 30
 router_instances: 3
 api_instances: 4
 doppler_instances: 12


### PR DESCRIPTION
What
--------------

As more tenants have migrated over to London we have a surplus of cells in Ireland, this commit removes another 3. Further reductions will take place over successive PRs.

Also we add 3 more in London as the memory capacity is below 35% again.

How to review
-------------

Code review alongside [User impact dashboard](https://grafana-1.cloud.service.gov.uk/d/paas-user-impact/user-impact-prod?refresh=5s&orgId=1)

Who can review
--------------

anyone
