### PR TITLE
[#164363210] Extract extra fields from cloud_controllger_ng logs

### DIFF
--- a/config/logit/20_custom_filters.conf
+++ b/config/logit/20_custom_filters.conf
@@ -34,6 +34,14 @@ if [@source][component] == "vcap_nginx_access" {
       }
   }
 }
+if [@source][component] == "cloud_controller_ng" {
+  grok {
+    match => {
+      "@message" =>
+      'Started %{WORD:[cloud_controller_ng][method]} "%{URIPATHPARAM:[cloud_controller_ng][uri]}" for user: (%{UUID:[cloud_controller_ng][user]})?, ip: %{IP:[cloud_controller_ng][source_ip]}'
+      }
+  }
+}
 date {
   match => [ "[nginx][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601" ]
   target => "@timestamp"

--- a/config/logit/output/generated_logit_filters.conf
+++ b/config/logit/output/generated_logit_filters.conf
@@ -987,6 +987,14 @@ filter {
         }
     }
   }
+  if [@source][component] == "cloud_controller_ng" {
+    grok {
+      match => {
+        "@message" =>
+        'Started %{WORD:[cloud_controller_ng][method]} "%{URIPATHPARAM:[cloud_controller_ng][uri]}" for user: (%{UUID:[cloud_controller_ng][user]})?, ip: %{IP:[cloud_controller_ng][source_ip]}'
+        }
+    }
+  }
   date {
     match => [ "[nginx][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601" ]
     target => "@timestamp"


### PR DESCRIPTION
What
----
Cloud Controller outputs log lines like "Started VERB /api/uri for user: name, ip". We add an extra logstash filter to extract the verb, uri, username and source ip fields from those messages. This will allow us to get a more accurate picture of how many requests each user in the system is making in a timeframe, for the purposes of working out a reasonable request rate limit.

How to review
-------------

1. Code review
2. Check the dev Logit stack where this has already been applied, and ensure that log lines matching the above format have had the relevant fields extracted

Who can review
--------------
Not @tnwhitwell or @AP-Hunt.
