### PR TITLE
[#164728558] Buildpack upgrade

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -341,7 +341,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-accounts
-      tag_filter: v0.4.0
+      tag_filter: v0.5.0
 
   - name: paas-admin
     type: git

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -267,7 +267,7 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-acceptance-tests
-      branch: cf7.6
+      branch: master
 
   - name: cf-smoke-tests-release
     type: git
@@ -2649,6 +2649,7 @@ jobs:
             passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
             trigger: true
           - get: cf-acceptance-tests
+            version: {ref: c2159c05d325b5d5546302c24ff8f723387418d9}
           - get: paas-cf
             passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
           - get: cf-manifest
@@ -2710,6 +2711,7 @@ jobs:
           - get: cf-vars-store
             passed: ['post-deploy']
           - get: cf-acceptance-tests
+            version: {ref: c2159c05d325b5d5546302c24ff8f723387418d9}
           - get: paas-admin
             passed: ['post-deploy']
 

--- a/config/buildpacks.yml
+++ b/config/buildpacks.yml
@@ -725,6 +725,56 @@ buildpacks:
     version: 1.15.9
     cf_stacks:
     - cflinuxfs3
+- name: nginx_buildpack
+  repo_name: nginx-buildpack
+  stack: cflinuxfs2
+  version: v1.0.8
+  sha: 34f2a634bfe3769fb6692d0c0ee4d0c42f51b1c5e3a5583d1b5ea3adfcdbc8f5
+  filename: nginx-buildpack-cflinuxfs2-v1.0.8.zip
+  url: https://github.com/cloudfoundry/nginx-buildpack/releases/download/v1.0.8/nginx-buildpack-cflinuxfs2-v1.0.8.zip
+  dependencies:
+  - name: nginx
+    version: 1.14.2
+    cf_stacks:
+    - cflinuxfs2
+    - cflinuxfs3
+  - name: nginx
+    version: 1.15.8
+    cf_stacks:
+    - cflinuxfs2
+    - cflinuxfs3
+  - name: openresty
+    version: 1.13.6.2
+    cf_stacks:
+    - cflinuxfs2
+    - cflinuxfs3
+- name: r_buildpack
+  repo_name: r-buildpack
+  stack: cflinuxfs2
+  version: v1.0.8
+  sha: 4e641141681c1f00b89cdb235f43ff9ae929e6bf9550a1f1b6eac0da7b328dcb
+  filename: r-buildpack-cflinuxfs2-v1.0.8.zip
+  url: https://github.com/cloudfoundry/r-buildpack/releases/download/v1.0.8/r-buildpack-cflinuxfs2-v1.0.8.zip
+  dependencies:
+  - name: r
+    version: 3.4.3
+    cf_stacks:
+    - cflinuxfs2
+  - name: r
+    version: 3.4.4
+    cf_stacks:
+    - cflinuxfs2
+    - cflinuxfs3
+  - name: r
+    version: 3.5.2
+    cf_stacks:
+    - cflinuxfs2
+    - cflinuxfs3
+  - name: r
+    version: 3.5.3
+    cf_stacks:
+    - cflinuxfs2
+    - cflinuxfs3
 - name: binary_buildpack
   repo_name: binary-buildpack
   stack: cflinuxfs3
@@ -1450,4 +1500,54 @@ buildpacks:
   - name: nginx
     version: 1.15.9
     cf_stacks:
+    - cflinuxfs3
+- name: nginx_buildpack
+  repo_name: nginx-buildpack
+  stack: cflinuxfs3
+  version: v1.0.8
+  sha: 18b5f7ee6b63b7c6463ef97b5706f4db0c260bc7efc7024f1508930b7be69bf9
+  filename: nginx-buildpack-cflinuxfs3-v1.0.8.zip
+  url: https://github.com/cloudfoundry/nginx-buildpack/releases/download/v1.0.8/nginx-buildpack-cflinuxfs3-v1.0.8.zip
+  dependencies:
+  - name: nginx
+    version: 1.14.2
+    cf_stacks:
+    - cflinuxfs2
+    - cflinuxfs3
+  - name: nginx
+    version: 1.15.8
+    cf_stacks:
+    - cflinuxfs2
+    - cflinuxfs3
+  - name: openresty
+    version: 1.13.6.2
+    cf_stacks:
+    - cflinuxfs2
+    - cflinuxfs3
+- name: r_buildpack
+  repo_name: r-buildpack
+  stack: cflinuxfs3
+  version: v1.0.8
+  sha: e1717a96610edec81e5d3fdddf08e1404697333cbc8e9aee439c6bb4a3b45403
+  filename: r-buildpack-cflinuxfs3-v1.0.8.zip
+  url: https://github.com/cloudfoundry/r-buildpack/releases/download/v1.0.8/r-buildpack-cflinuxfs3-v1.0.8.zip
+  dependencies:
+  - name: r
+    version: 3.4.3
+    cf_stacks:
+    - cflinuxfs2
+  - name: r
+    version: 3.4.4
+    cf_stacks:
+    - cflinuxfs2
+    - cflinuxfs3
+  - name: r
+    version: 3.5.2
+    cf_stacks:
+    - cflinuxfs2
+    - cflinuxfs3
+  - name: r
+    version: 3.5.3
+    cf_stacks:
+    - cflinuxfs2
     - cflinuxfs3

--- a/config/buildpacks.yml
+++ b/config/buildpacks.yml
@@ -2,39 +2,23 @@ buildpacks:
 - name: binary_buildpack
   repo_name: binary-buildpack
   stack: cflinuxfs2
-  version: v1.0.29
-  sha: c8e69c368677f893bea8ff4fb3673b07427e0f057843eed6a23aecc6f5b05b0e
-  filename: binary-buildpack-cflinuxfs2-v1.0.29.zip
-  url: https://github.com/cloudfoundry/binary-buildpack/releases/download/v1.0.29/binary-buildpack-cflinuxfs2-v1.0.29.zip
+  version: v1.0.31
+  sha: eb722d44702103083b6bfc9f58071a42aef36875ac2938ca359bc66b1f9cfee9
+  filename: binary-buildpack-cflinuxfs2-v1.0.31.zip
+  url: https://github.com/cloudfoundry/binary-buildpack/releases/download/v1.0.31/binary-buildpack-cflinuxfs2-v1.0.31.zip
   dependencies: []
 - name: dotnet_core_buildpack
   repo_name: dotnet-core-buildpack
   stack: cflinuxfs2
-  version: v2.2.4
-  sha: d1b2e46d2c4b67b717fe014898a5ae69cce80e127e4fc784d15bae834cf7a894
-  filename: dotnet-core-buildpack-cflinuxfs2-v2.2.4.zip
-  url: https://github.com/cloudfoundry/dotnet-core-buildpack/releases/download/v2.2.4/dotnet-core-buildpack-cflinuxfs2-v2.2.4.zip
+  version: v2.2.8
+  sha: c2e8f53cb12356b9179ea5f0044b64ef1483686f5124592df61469b528234546
+  filename: dotnet-core-buildpack-cflinuxfs2-v2.2.8.zip
+  url: https://github.com/cloudfoundry/dotnet-core-buildpack/releases/download/v2.2.8/dotnet-core-buildpack-cflinuxfs2-v2.2.8.zip
   dependencies:
   - name: bower
-    version: 1.8.4
+    version: 1.8.8
     cf_stacks:
     - cflinuxfs2
-    - cflinuxfs3
-  - name: dotnet-aspnetcore
-    version: 2.1.4
-    cf_stacks:
-    - cflinuxfs2
-  - name: dotnet-aspnetcore
-    version: 2.1.4
-    cf_stacks:
-    - cflinuxfs3
-  - name: dotnet-aspnetcore
-    version: 2.1.5
-    cf_stacks:
-    - cflinuxfs2
-  - name: dotnet-aspnetcore
-    version: 2.1.5
-    cf_stacks:
     - cflinuxfs3
   - name: dotnet-aspnetcore
     version: 2.1.7
@@ -45,19 +29,35 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: dotnet-aspnetcore
-    version: 2.2.0
+    version: 2.1.8
     cf_stacks:
     - cflinuxfs2
   - name: dotnet-aspnetcore
-    version: 2.2.0
+    version: 2.1.8
     cf_stacks:
     - cflinuxfs3
   - name: dotnet-aspnetcore
-    version: 2.2.1
+    version: 2.1.9
     cf_stacks:
     - cflinuxfs2
   - name: dotnet-aspnetcore
-    version: 2.2.1
+    version: 2.1.9
+    cf_stacks:
+    - cflinuxfs3
+  - name: dotnet-aspnetcore
+    version: 2.2.2
+    cf_stacks:
+    - cflinuxfs2
+  - name: dotnet-aspnetcore
+    version: 2.2.2
+    cf_stacks:
+    - cflinuxfs3
+  - name: dotnet-aspnetcore
+    version: 2.2.3
+    cf_stacks:
+    - cflinuxfs2
+  - name: dotnet-aspnetcore
+    version: 2.2.3
     cf_stacks:
     - cflinuxfs3
   - name: dotnet-runtime
@@ -69,33 +69,19 @@ buildpacks:
     cf_stacks:
     - cflinuxfs2
   - name: dotnet-runtime
-    version: 1.1.9
+    version: 1.1.11
     cf_stacks:
     - cflinuxfs2
   - name: dotnet-runtime
-    version: 1.1.10
-    cf_stacks:
-    - cflinuxfs2
-  - name: dotnet-runtime
-    version: 1.1.10
+    version: 1.1.11
     cf_stacks:
     - cflinuxfs3
   - name: dotnet-runtime
-    version: 2.0.7
-    cf_stacks:
-    - cflinuxfs2
-    - cflinuxfs3
-  - name: dotnet-runtime
-    version: 2.0.9
-    cf_stacks:
-    - cflinuxfs2
-    - cflinuxfs3
-  - name: dotnet-runtime
-    version: 2.1.5
+    version: 1.1.12
     cf_stacks:
     - cflinuxfs2
   - name: dotnet-runtime
-    version: 2.1.5
+    version: 1.1.12
     cf_stacks:
     - cflinuxfs3
   - name: dotnet-runtime
@@ -107,11 +93,19 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: dotnet-runtime
-    version: 2.2.0
+    version: 2.1.8
     cf_stacks:
     - cflinuxfs2
   - name: dotnet-runtime
-    version: 2.2.0
+    version: 2.1.8
+    cf_stacks:
+    - cflinuxfs3
+  - name: dotnet-runtime
+    version: 2.1.9
+    cf_stacks:
+    - cflinuxfs2
+  - name: dotnet-runtime
+    version: 2.1.9
     cf_stacks:
     - cflinuxfs3
   - name: dotnet-runtime
@@ -122,16 +116,20 @@ buildpacks:
     version: 2.2.1
     cf_stacks:
     - cflinuxfs3
-  - name: dotnet-sdk
-    version: 1.0.4
+  - name: dotnet-runtime
+    version: 2.2.2
     cf_stacks:
     - cflinuxfs2
-  - name: dotnet-sdk
-    version: 1.1.10
+  - name: dotnet-runtime
+    version: 2.2.2
+    cf_stacks:
+    - cflinuxfs3
+  - name: dotnet-runtime
+    version: 2.2.3
     cf_stacks:
     - cflinuxfs2
-  - name: dotnet-sdk
-    version: 1.1.10
+  - name: dotnet-runtime
+    version: 2.2.3
     cf_stacks:
     - cflinuxfs3
   - name: dotnet-sdk
@@ -143,9 +141,20 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: dotnet-sdk
-    version: 2.0.3
+    version: 1.1.12
     cf_stacks:
     - cflinuxfs2
+  - name: dotnet-sdk
+    version: 1.1.12
+    cf_stacks:
+    - cflinuxfs3
+  - name: dotnet-sdk
+    version: 1.1.13
+    cf_stacks:
+    - cflinuxfs2
+  - name: dotnet-sdk
+    version: 1.1.13
+    cf_stacks:
     - cflinuxfs3
   - name: dotnet-sdk
     version: 2.1.403
@@ -156,19 +165,27 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: dotnet-sdk
-    version: 2.1.503
+    version: 2.1.505
     cf_stacks:
     - cflinuxfs2
   - name: dotnet-sdk
-    version: 2.1.503
+    version: 2.1.505
     cf_stacks:
     - cflinuxfs3
   - name: dotnet-sdk
-    version: 2.2.102
+    version: 2.2.105
     cf_stacks:
     - cflinuxfs2
   - name: dotnet-sdk
-    version: 2.2.102
+    version: 2.2.105
+    cf_stacks:
+    - cflinuxfs3
+  - name: libgdiplus
+    version: "5.6"
+    cf_stacks:
+    - cflinuxfs2
+  - name: libgdiplus
+    version: "5.6"
     cf_stacks:
     - cflinuxfs3
   - name: libunwind
@@ -180,27 +197,27 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: node
-    version: 6.16.0
+    version: 6.17.0
     cf_stacks:
     - cflinuxfs2
   - name: node
-    version: 6.16.0
+    version: 6.17.0
     cf_stacks:
     - cflinuxfs3
 - name: go_buildpack
   repo_name: go-buildpack
   stack: cflinuxfs2
-  version: v1.8.31
-  sha: e513b429eb3b104e93e0005acb6b57df17ef04aecb323355d964bcd2e47dc0e6
-  filename: go-buildpack-cflinuxfs2-v1.8.31.zip
-  url: https://github.com/cloudfoundry/go-buildpack/releases/download/v1.8.31/go-buildpack-cflinuxfs2-v1.8.31.zip
+  version: v1.8.36
+  sha: b4169fb3ad55b50fefe8c4a73e0e27de6e05966507bd745ada6ad73ac10789a9
+  filename: go-buildpack-cflinuxfs2-v1.8.36.zip
+  url: https://github.com/cloudfoundry/go-buildpack/releases/download/v1.8.36/go-buildpack-cflinuxfs2-v1.8.36.zip
   dependencies:
   - name: dep
-    version: 0.5.0
+    version: 0.5.1
     cf_stacks:
     - cflinuxfs2
   - name: dep
-    version: 0.5.0
+    version: 0.5.1
     cf_stacks:
     - cflinuxfs3
   - name: glide
@@ -212,38 +229,6 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: go
-    version: 1.8.6
-    cf_stacks:
-    - cflinuxfs2
-  - name: go
-    version: 1.8.7
-    cf_stacks:
-    - cflinuxfs2
-  - name: go
-    version: 1.8.7
-    cf_stacks:
-    - cflinuxfs3
-  - name: go
-    version: 1.9.6
-    cf_stacks:
-    - cflinuxfs2
-  - name: go
-    version: 1.9.7
-    cf_stacks:
-    - cflinuxfs2
-  - name: go
-    version: 1.9.7
-    cf_stacks:
-    - cflinuxfs3
-  - name: go
-    version: 1.10.5
-    cf_stacks:
-    - cflinuxfs2
-  - name: go
-    version: 1.10.5
-    cf_stacks:
-    - cflinuxfs3
-  - name: go
     version: 1.10.7
     cf_stacks:
     - cflinuxfs2
@@ -252,19 +237,43 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: go
-    version: 1.11.2
+    version: 1.10.8
     cf_stacks:
     - cflinuxfs2
   - name: go
-    version: 1.11.2
+    version: 1.10.8
     cf_stacks:
     - cflinuxfs3
   - name: go
-    version: 1.11.4
+    version: 1.11.5
     cf_stacks:
     - cflinuxfs2
   - name: go
-    version: 1.11.4
+    version: 1.11.5
+    cf_stacks:
+    - cflinuxfs3
+  - name: go
+    version: 1.11.6
+    cf_stacks:
+    - cflinuxfs2
+  - name: go
+    version: 1.11.6
+    cf_stacks:
+    - cflinuxfs3
+  - name: go
+    version: "1.12"
+    cf_stacks:
+    - cflinuxfs2
+  - name: go
+    version: "1.12"
+    cf_stacks:
+    - cflinuxfs3
+  - name: go
+    version: 1.12.1
+    cf_stacks:
+    - cflinuxfs2
+  - name: go
+    version: 1.12.1
     cf_stacks:
     - cflinuxfs3
   - name: godep
@@ -278,28 +287,20 @@ buildpacks:
 - name: java_buildpack
   repo_name: java-buildpack
   stack: cflinuxfs2
-  version: v4.17.2
-  sha: aa05f046e47033e8b5ef5fd8a1673e54c692709dcec9a608748c51dd109db041
-  filename: java-buildpack-v4.17.2.zip
-  url: https://github.com/cloudfoundry/java-buildpack/releases/download/v4.17.2/java-buildpack-v4.17.2.zip
+  version: v4.18
+  sha: 61bbd5792d0629d604aeff4aa409c44b85716ac69fa8fc4263b934b75fdd249b
+  filename: java-buildpack-v4.18.zip
+  url: https://github.com/cloudfoundry/java-buildpack/releases/download/v4.18/java-buildpack-v4.18.zip
   dependencies: []
 - name: nodejs_buildpack
   repo_name: nodejs-buildpack
   stack: cflinuxfs2
-  version: v1.6.41
-  sha: e32c792d0828d4f403c56ee8a6780bbcdcec543a716b3a1835c0d2009ab6643a
-  filename: nodejs-buildpack-cflinuxfs2-v1.6.41.zip
-  url: https://github.com/cloudfoundry/nodejs-buildpack/releases/download/v1.6.41/nodejs-buildpack-cflinuxfs2-v1.6.41.zip
+  version: v1.6.46
+  sha: b6f4e343b5c6fde61d36ddfbdd4417aa202fa60ee3b144be04e27930a7e1f982
+  filename: nodejs-buildpack-cflinuxfs2-v1.6.46.zip
+  url: https://github.com/cloudfoundry/nodejs-buildpack/releases/download/v1.6.46/nodejs-buildpack-cflinuxfs2-v1.6.46.zip
   dependencies:
   - name: node
-    version: 6.15.1
-    cf_stacks:
-    - cflinuxfs2
-  - name: node
-    version: 6.15.1
-    cf_stacks:
-    - cflinuxfs3
-  - name: node
     version: 6.16.0
     cf_stacks:
     - cflinuxfs2
@@ -308,11 +309,11 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: node
-    version: 8.14.1
+    version: 6.17.0
     cf_stacks:
     - cflinuxfs2
   - name: node
-    version: 8.14.1
+    version: 6.17.0
     cf_stacks:
     - cflinuxfs3
   - name: node
@@ -324,15 +325,11 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: node
-    version: 9.11.1
+    version: 8.15.1
     cf_stacks:
     - cflinuxfs2
   - name: node
-    version: 9.11.2
-    cf_stacks:
-    - cflinuxfs2
-  - name: node
-    version: 9.11.2
+    version: 8.15.1
     cf_stacks:
     - cflinuxfs3
   - name: node
@@ -340,37 +337,37 @@ buildpacks:
     cf_stacks:
     - cflinuxfs2
   - name: node
-    version: 10.14.2
-    cf_stacks:
-    - cflinuxfs3
-  - name: node
     version: 10.15.0
     cf_stacks:
     - cflinuxfs2
   - name: node
-    version: 10.15.0
+    version: 10.15.2
     cf_stacks:
     - cflinuxfs3
   - name: node
-    version: 11.5.0
+    version: 10.15.3
     cf_stacks:
     - cflinuxfs3
   - name: node
-    version: 11.6.0
+    version: 11.10.1
+    cf_stacks:
+    - cflinuxfs3
+  - name: node
+    version: 11.12.0
     cf_stacks:
     - cflinuxfs3
   - name: yarn
-    version: 1.13.0
+    version: 1.15.2
     cf_stacks:
     - cflinuxfs2
     - cflinuxfs3
 - name: php_buildpack
   repo_name: php-buildpack
   stack: cflinuxfs2
-  version: v4.3.69
-  sha: 08bfd406da86c15af8c619f25bc748cae814ca864cbc16ac711f9ea72b8fe762
-  filename: php-buildpack-cflinuxfs2-v4.3.69.zip
-  url: https://github.com/cloudfoundry/php-buildpack/releases/download/v4.3.69/php-buildpack-cflinuxfs2-v4.3.69.zip
+  version: v4.3.72
+  sha: 2d6c78c3b5fb1746bd2afbd8991eff70a7513503897ed24d717ed46e547513ff
+  filename: php-buildpack-cflinuxfs2-v4.3.72.zip
+  url: https://github.com/cloudfoundry/php-buildpack/releases/download/v4.3.72/php-buildpack-cflinuxfs2-v4.3.72.zip
   dependencies:
   - name: CAAPM
     version: 10.7.0
@@ -378,21 +375,21 @@ buildpacks:
     - cflinuxfs2
     - cflinuxfs3
   - name: appdynamics
-    version: 4.5.6.2534
+    version: 4.5.7.2661
     cf_stacks:
     - cflinuxfs2
     - cflinuxfs3
   - name: composer
-    version: 1.8.0
+    version: 1.8.4
     cf_stacks:
     - cflinuxfs2
     - cflinuxfs3
   - name: httpd
-    version: 2.4.37
+    version: 2.4.38
     cf_stacks:
     - cflinuxfs2
   - name: httpd
-    version: 2.4.37
+    version: 2.4.38
     cf_stacks:
     - cflinuxfs3
   - name: newrelic
@@ -409,43 +406,11 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: nginx
-    version: 1.15.8
+    version: 1.15.9
     cf_stacks:
     - cflinuxfs2
   - name: nginx
-    version: 1.15.8
-    cf_stacks:
-    - cflinuxfs3
-  - name: php
-    version: 5.6.39
-    cf_stacks:
-    - cflinuxfs2
-  - name: php
-    version: 5.6.40
-    cf_stacks:
-    - cflinuxfs2
-  - name: php
-    version: 7.0.32
-    cf_stacks:
-    - cflinuxfs2
-  - name: php
-    version: 7.0.32
-    cf_stacks:
-    - cflinuxfs3
-  - name: php
-    version: 7.0.33
-    cf_stacks:
-    - cflinuxfs2
-  - name: php
-    version: 7.0.33
-    cf_stacks:
-    - cflinuxfs3
-  - name: php
-    version: 7.1.25
-    cf_stacks:
-    - cflinuxfs2
-  - name: php
-    version: 7.1.25
+    version: 1.15.9
     cf_stacks:
     - cflinuxfs3
   - name: php
@@ -457,28 +422,44 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: php
-    version: 7.2.13
+    version: 7.1.27
     cf_stacks:
     - cflinuxfs2
   - name: php
-    version: 7.2.13
+    version: 7.1.27
     cf_stacks:
     - cflinuxfs3
   - name: php
-    version: 7.2.14
+    version: 7.2.15
     cf_stacks:
     - cflinuxfs2
   - name: php
-    version: 7.2.14
+    version: 7.2.15
+    cf_stacks:
+    - cflinuxfs3
+  - name: php
+    version: 7.2.16
+    cf_stacks:
+    - cflinuxfs2
+  - name: php
+    version: 7.2.16
+    cf_stacks:
+    - cflinuxfs3
+  - name: php
+    version: 7.3.2
+    cf_stacks:
+    - cflinuxfs3
+  - name: php
+    version: 7.3.3
     cf_stacks:
     - cflinuxfs3
 - name: python_buildpack
   repo_name: python-buildpack
   stack: cflinuxfs2
-  version: v1.6.27
-  sha: 74ebb64890fd86af08118fa9da4e218d04d43be83456245ca055f5218217de54
-  filename: python-buildpack-cflinuxfs2-v1.6.27.zip
-  url: https://github.com/cloudfoundry/python-buildpack/releases/download/v1.6.27/python-buildpack-cflinuxfs2-v1.6.27.zip
+  version: v1.6.29
+  sha: d2cd58ed5d8034466e95d7bc8c37186a0c7d0efd165199af2802ba64135c7cdf
+  filename: python-buildpack-cflinuxfs2-v1.6.29.zip
+  url: https://github.com/cloudfoundry/python-buildpack/releases/download/v1.6.29/python-buildpack-cflinuxfs2-v1.6.29.zip
   dependencies:
   - name: libffi
     version: 3.2.1
@@ -506,7 +487,7 @@ buildpacks:
     - cflinuxfs2
     - cflinuxfs3
   - name: pip-pop
-    version: 0.1.1
+    version: 0.1.3
     cf_stacks:
     - cflinuxfs2
     - cflinuxfs3
@@ -519,19 +500,19 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: python
-    version: 2.7.14
+    version: 2.7.15
     cf_stacks:
     - cflinuxfs2
   - name: python
-    version: 2.7.14
+    version: 2.7.15
     cf_stacks:
     - cflinuxfs3
   - name: python
-    version: 2.7.15
+    version: 2.7.16
     cf_stacks:
     - cflinuxfs2
   - name: python
-    version: 2.7.15
+    version: 2.7.16
     cf_stacks:
     - cflinuxfs3
   - name: python
@@ -591,17 +572,17 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: setuptools
-    version: 40.6.3
+    version: 40.8.0
     cf_stacks:
     - cflinuxfs2
     - cflinuxfs3
 - name: ruby_buildpack
   repo_name: ruby-buildpack
   stack: cflinuxfs2
-  version: v1.7.30
-  sha: 05f8b237495a636172114a53c07d3d8b0e5ae8c1d2d033dbc4802e8b80e52e30
-  filename: ruby-buildpack-cflinuxfs2-v1.7.30.zip
-  url: https://github.com/cloudfoundry/ruby-buildpack/releases/download/v1.7.30/ruby-buildpack-cflinuxfs2-v1.7.30.zip
+  version: v1.7.35
+  sha: 898288746e06a4cb559b399b9a2243188c751f1167177ebb22e4fbbf4089b22c
+  filename: ruby-buildpack-cflinuxfs2-v1.7.35.zip
+  url: https://github.com/cloudfoundry/ruby-buildpack/releases/download/v1.7.35/ruby-buildpack-cflinuxfs2-v1.7.35.zip
   dependencies:
   - name: bundler
     version: 1.17.3
@@ -622,19 +603,19 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: jruby
-    version: 9.2.5.0
+    version: 9.2.6.0
     cf_stacks:
     - cflinuxfs2
   - name: jruby
-    version: 9.2.5.0
+    version: 9.2.6.0
     cf_stacks:
     - cflinuxfs3
   - name: node
-    version: 6.16.0
+    version: 6.17.0
     cf_stacks:
     - cflinuxfs2
   - name: node
-    version: 6.16.0
+    version: 6.17.0
     cf_stacks:
     - cflinuxfs3
   - name: openjdk1.8-latest
@@ -687,14 +668,6 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: ruby
-    version: 2.5.1
-    cf_stacks:
-    - cflinuxfs2
-  - name: ruby
-    version: 2.5.1
-    cf_stacks:
-    - cflinuxfs3
-  - name: ruby
     version: 2.5.3
     cf_stacks:
     - cflinuxfs2
@@ -703,75 +676,75 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: ruby
-    version: 2.6.0
+    version: 2.5.5
     cf_stacks:
     - cflinuxfs2
   - name: ruby
-    version: 2.6.0
+    version: 2.5.5
+    cf_stacks:
+    - cflinuxfs3
+  - name: ruby
+    version: 2.6.1
+    cf_stacks:
+    - cflinuxfs2
+  - name: ruby
+    version: 2.6.1
+    cf_stacks:
+    - cflinuxfs3
+  - name: ruby
+    version: 2.6.2
+    cf_stacks:
+    - cflinuxfs2
+  - name: ruby
+    version: 2.6.2
     cf_stacks:
     - cflinuxfs3
   - name: rubygems
-    version: 3.0.2
+    version: 3.0.3
     cf_stacks:
     - cflinuxfs2
     - cflinuxfs3
   - name: yarn
-    version: 1.13.0
+    version: 1.15.2
     cf_stacks:
     - cflinuxfs2
     - cflinuxfs3
 - name: staticfile_buildpack
   repo_name: staticfile-buildpack
   stack: cflinuxfs2
-  version: v1.4.38
-  sha: f55eb84ff8332dd6e0c692dd1b094a34ed094baa91d916d10ce6b67eeb09c847
-  filename: staticfile-buildpack-cflinuxfs2-v1.4.38.zip
-  url: https://github.com/cloudfoundry/staticfile-buildpack/releases/download/v1.4.38/staticfile-buildpack-cflinuxfs2-v1.4.38.zip
+  version: v1.4.40
+  sha: 836dc65b31fe82381a26aba9c55a178d4cea71fc271789c88d51a9401f20b2cc
+  filename: staticfile-buildpack-cflinuxfs2-v1.4.40.zip
+  url: https://github.com/cloudfoundry/staticfile-buildpack/releases/download/v1.4.40/staticfile-buildpack-cflinuxfs2-v1.4.40.zip
   dependencies:
   - name: nginx
-    version: 1.15.8
+    version: 1.15.9
     cf_stacks:
     - cflinuxfs2
   - name: nginx
-    version: 1.15.8
+    version: 1.15.9
     cf_stacks:
     - cflinuxfs3
 - name: binary_buildpack
   repo_name: binary-buildpack
   stack: cflinuxfs3
-  version: v1.0.29
-  sha: c6cbef62a13870f34491e2e32cbaa370c7402cb5f5387e4236b20c6f2b65005d
-  filename: binary-buildpack-cflinuxfs3-v1.0.29.zip
-  url: https://github.com/cloudfoundry/binary-buildpack/releases/download/v1.0.29/binary-buildpack-cflinuxfs3-v1.0.29.zip
+  version: v1.0.31
+  sha: 5a869d5c256932f5288c42755b8e65d7e9731f0ff2226c244cb3cd13bebd34a1
+  filename: binary-buildpack-cflinuxfs3-v1.0.31.zip
+  url: https://github.com/cloudfoundry/binary-buildpack/releases/download/v1.0.31/binary-buildpack-cflinuxfs3-v1.0.31.zip
   dependencies: []
 - name: dotnet_core_buildpack
   repo_name: dotnet-core-buildpack
   stack: cflinuxfs3
-  version: v2.2.4
-  sha: 44ab219714e680aacf00b0bf8040fc80295d8db1e14f66716e4fd4f0b9802d0b
-  filename: dotnet-core-buildpack-cflinuxfs3-v2.2.4.zip
-  url: https://github.com/cloudfoundry/dotnet-core-buildpack/releases/download/v2.2.4/dotnet-core-buildpack-cflinuxfs3-v2.2.4.zip
+  version: v2.2.8
+  sha: 9d4d330060ae1afb4c96ba0d1c567f5940f706854c7d22fe4a689f2a75859100
+  filename: dotnet-core-buildpack-cflinuxfs3-v2.2.8.zip
+  url: https://github.com/cloudfoundry/dotnet-core-buildpack/releases/download/v2.2.8/dotnet-core-buildpack-cflinuxfs3-v2.2.8.zip
   dependencies:
   - name: bower
-    version: 1.8.4
+    version: 1.8.8
     cf_stacks:
     - cflinuxfs2
-    - cflinuxfs3
-  - name: dotnet-aspnetcore
-    version: 2.1.4
-    cf_stacks:
-    - cflinuxfs2
-  - name: dotnet-aspnetcore
-    version: 2.1.4
-    cf_stacks:
-    - cflinuxfs3
-  - name: dotnet-aspnetcore
-    version: 2.1.5
-    cf_stacks:
-    - cflinuxfs2
-  - name: dotnet-aspnetcore
-    version: 2.1.5
-    cf_stacks:
     - cflinuxfs3
   - name: dotnet-aspnetcore
     version: 2.1.7
@@ -782,19 +755,35 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: dotnet-aspnetcore
-    version: 2.2.0
+    version: 2.1.8
     cf_stacks:
     - cflinuxfs2
   - name: dotnet-aspnetcore
-    version: 2.2.0
+    version: 2.1.8
     cf_stacks:
     - cflinuxfs3
   - name: dotnet-aspnetcore
-    version: 2.2.1
+    version: 2.1.9
     cf_stacks:
     - cflinuxfs2
   - name: dotnet-aspnetcore
-    version: 2.2.1
+    version: 2.1.9
+    cf_stacks:
+    - cflinuxfs3
+  - name: dotnet-aspnetcore
+    version: 2.2.2
+    cf_stacks:
+    - cflinuxfs2
+  - name: dotnet-aspnetcore
+    version: 2.2.2
+    cf_stacks:
+    - cflinuxfs3
+  - name: dotnet-aspnetcore
+    version: 2.2.3
+    cf_stacks:
+    - cflinuxfs2
+  - name: dotnet-aspnetcore
+    version: 2.2.3
     cf_stacks:
     - cflinuxfs3
   - name: dotnet-runtime
@@ -806,33 +795,19 @@ buildpacks:
     cf_stacks:
     - cflinuxfs2
   - name: dotnet-runtime
-    version: 1.1.9
+    version: 1.1.11
     cf_stacks:
     - cflinuxfs2
   - name: dotnet-runtime
-    version: 1.1.10
-    cf_stacks:
-    - cflinuxfs2
-  - name: dotnet-runtime
-    version: 1.1.10
+    version: 1.1.11
     cf_stacks:
     - cflinuxfs3
   - name: dotnet-runtime
-    version: 2.0.7
-    cf_stacks:
-    - cflinuxfs2
-    - cflinuxfs3
-  - name: dotnet-runtime
-    version: 2.0.9
-    cf_stacks:
-    - cflinuxfs2
-    - cflinuxfs3
-  - name: dotnet-runtime
-    version: 2.1.5
+    version: 1.1.12
     cf_stacks:
     - cflinuxfs2
   - name: dotnet-runtime
-    version: 2.1.5
+    version: 1.1.12
     cf_stacks:
     - cflinuxfs3
   - name: dotnet-runtime
@@ -844,11 +819,19 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: dotnet-runtime
-    version: 2.2.0
+    version: 2.1.8
     cf_stacks:
     - cflinuxfs2
   - name: dotnet-runtime
-    version: 2.2.0
+    version: 2.1.8
+    cf_stacks:
+    - cflinuxfs3
+  - name: dotnet-runtime
+    version: 2.1.9
+    cf_stacks:
+    - cflinuxfs2
+  - name: dotnet-runtime
+    version: 2.1.9
     cf_stacks:
     - cflinuxfs3
   - name: dotnet-runtime
@@ -859,16 +842,20 @@ buildpacks:
     version: 2.2.1
     cf_stacks:
     - cflinuxfs3
-  - name: dotnet-sdk
-    version: 1.0.4
+  - name: dotnet-runtime
+    version: 2.2.2
     cf_stacks:
     - cflinuxfs2
-  - name: dotnet-sdk
-    version: 1.1.10
+  - name: dotnet-runtime
+    version: 2.2.2
+    cf_stacks:
+    - cflinuxfs3
+  - name: dotnet-runtime
+    version: 2.2.3
     cf_stacks:
     - cflinuxfs2
-  - name: dotnet-sdk
-    version: 1.1.10
+  - name: dotnet-runtime
+    version: 2.2.3
     cf_stacks:
     - cflinuxfs3
   - name: dotnet-sdk
@@ -880,9 +867,20 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: dotnet-sdk
-    version: 2.0.3
+    version: 1.1.12
     cf_stacks:
     - cflinuxfs2
+  - name: dotnet-sdk
+    version: 1.1.12
+    cf_stacks:
+    - cflinuxfs3
+  - name: dotnet-sdk
+    version: 1.1.13
+    cf_stacks:
+    - cflinuxfs2
+  - name: dotnet-sdk
+    version: 1.1.13
+    cf_stacks:
     - cflinuxfs3
   - name: dotnet-sdk
     version: 2.1.403
@@ -893,19 +891,27 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: dotnet-sdk
-    version: 2.1.503
+    version: 2.1.505
     cf_stacks:
     - cflinuxfs2
   - name: dotnet-sdk
-    version: 2.1.503
+    version: 2.1.505
     cf_stacks:
     - cflinuxfs3
   - name: dotnet-sdk
-    version: 2.2.102
+    version: 2.2.105
     cf_stacks:
     - cflinuxfs2
   - name: dotnet-sdk
-    version: 2.2.102
+    version: 2.2.105
+    cf_stacks:
+    - cflinuxfs3
+  - name: libgdiplus
+    version: "5.6"
+    cf_stacks:
+    - cflinuxfs2
+  - name: libgdiplus
+    version: "5.6"
     cf_stacks:
     - cflinuxfs3
   - name: libunwind
@@ -917,27 +923,27 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: node
-    version: 6.16.0
+    version: 6.17.0
     cf_stacks:
     - cflinuxfs2
   - name: node
-    version: 6.16.0
+    version: 6.17.0
     cf_stacks:
     - cflinuxfs3
 - name: go_buildpack
   repo_name: go-buildpack
   stack: cflinuxfs3
-  version: v1.8.31
-  sha: 17b4ecef6c5d0f937747061acd8d0cbc640ec9415ff41206b1912a985e4b34d0
-  filename: go-buildpack-cflinuxfs3-v1.8.31.zip
-  url: https://github.com/cloudfoundry/go-buildpack/releases/download/v1.8.31/go-buildpack-cflinuxfs3-v1.8.31.zip
+  version: v1.8.36
+  sha: 3e22f3a3274c0dc1e8ecff4bb01922e370435214d1b04440efba720f5ae12576
+  filename: go-buildpack-cflinuxfs3-v1.8.36.zip
+  url: https://github.com/cloudfoundry/go-buildpack/releases/download/v1.8.36/go-buildpack-cflinuxfs3-v1.8.36.zip
   dependencies:
   - name: dep
-    version: 0.5.0
+    version: 0.5.1
     cf_stacks:
     - cflinuxfs2
   - name: dep
-    version: 0.5.0
+    version: 0.5.1
     cf_stacks:
     - cflinuxfs3
   - name: glide
@@ -949,38 +955,6 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: go
-    version: 1.8.6
-    cf_stacks:
-    - cflinuxfs2
-  - name: go
-    version: 1.8.7
-    cf_stacks:
-    - cflinuxfs2
-  - name: go
-    version: 1.8.7
-    cf_stacks:
-    - cflinuxfs3
-  - name: go
-    version: 1.9.6
-    cf_stacks:
-    - cflinuxfs2
-  - name: go
-    version: 1.9.7
-    cf_stacks:
-    - cflinuxfs2
-  - name: go
-    version: 1.9.7
-    cf_stacks:
-    - cflinuxfs3
-  - name: go
-    version: 1.10.5
-    cf_stacks:
-    - cflinuxfs2
-  - name: go
-    version: 1.10.5
-    cf_stacks:
-    - cflinuxfs3
-  - name: go
     version: 1.10.7
     cf_stacks:
     - cflinuxfs2
@@ -989,19 +963,43 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: go
-    version: 1.11.2
+    version: 1.10.8
     cf_stacks:
     - cflinuxfs2
   - name: go
-    version: 1.11.2
+    version: 1.10.8
     cf_stacks:
     - cflinuxfs3
   - name: go
-    version: 1.11.4
+    version: 1.11.5
     cf_stacks:
     - cflinuxfs2
   - name: go
-    version: 1.11.4
+    version: 1.11.5
+    cf_stacks:
+    - cflinuxfs3
+  - name: go
+    version: 1.11.6
+    cf_stacks:
+    - cflinuxfs2
+  - name: go
+    version: 1.11.6
+    cf_stacks:
+    - cflinuxfs3
+  - name: go
+    version: "1.12"
+    cf_stacks:
+    - cflinuxfs2
+  - name: go
+    version: "1.12"
+    cf_stacks:
+    - cflinuxfs3
+  - name: go
+    version: 1.12.1
+    cf_stacks:
+    - cflinuxfs2
+  - name: go
+    version: 1.12.1
     cf_stacks:
     - cflinuxfs3
   - name: godep
@@ -1015,28 +1013,20 @@ buildpacks:
 - name: java_buildpack
   repo_name: java-buildpack
   stack: cflinuxfs3
-  version: v4.17.2
-  sha: aa05f046e47033e8b5ef5fd8a1673e54c692709dcec9a608748c51dd109db041
-  filename: java-buildpack-v4.17.2.zip
-  url: https://github.com/cloudfoundry/java-buildpack/releases/download/v4.17.2/java-buildpack-v4.17.2.zip
+  version: v4.18
+  sha: 61bbd5792d0629d604aeff4aa409c44b85716ac69fa8fc4263b934b75fdd249b
+  filename: java-buildpack-v4.18.zip
+  url: https://github.com/cloudfoundry/java-buildpack/releases/download/v4.18/java-buildpack-v4.18.zip
   dependencies: []
 - name: nodejs_buildpack
   repo_name: nodejs-buildpack
   stack: cflinuxfs3
-  version: v1.6.41
-  sha: 2701a27ce62e106381bb8b5db58b0a00570017707b8988afc3353a255b22b278
-  filename: nodejs-buildpack-cflinuxfs3-v1.6.41.zip
-  url: https://github.com/cloudfoundry/nodejs-buildpack/releases/download/v1.6.41/nodejs-buildpack-cflinuxfs3-v1.6.41.zip
+  version: v1.6.46
+  sha: 7d7826abc5a52c16a3f85aa1e789d2b2a5dfb1fa26b3a95ebfba9c5f6e7a3362
+  filename: nodejs-buildpack-cflinuxfs3-v1.6.46.zip
+  url: https://github.com/cloudfoundry/nodejs-buildpack/releases/download/v1.6.46/nodejs-buildpack-cflinuxfs3-v1.6.46.zip
   dependencies:
   - name: node
-    version: 6.15.1
-    cf_stacks:
-    - cflinuxfs2
-  - name: node
-    version: 6.15.1
-    cf_stacks:
-    - cflinuxfs3
-  - name: node
     version: 6.16.0
     cf_stacks:
     - cflinuxfs2
@@ -1045,11 +1035,11 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: node
-    version: 8.14.1
+    version: 6.17.0
     cf_stacks:
     - cflinuxfs2
   - name: node
-    version: 8.14.1
+    version: 6.17.0
     cf_stacks:
     - cflinuxfs3
   - name: node
@@ -1061,15 +1051,11 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: node
-    version: 9.11.1
+    version: 8.15.1
     cf_stacks:
     - cflinuxfs2
   - name: node
-    version: 9.11.2
-    cf_stacks:
-    - cflinuxfs2
-  - name: node
-    version: 9.11.2
+    version: 8.15.1
     cf_stacks:
     - cflinuxfs3
   - name: node
@@ -1077,37 +1063,37 @@ buildpacks:
     cf_stacks:
     - cflinuxfs2
   - name: node
-    version: 10.14.2
-    cf_stacks:
-    - cflinuxfs3
-  - name: node
     version: 10.15.0
     cf_stacks:
     - cflinuxfs2
   - name: node
-    version: 10.15.0
+    version: 10.15.2
     cf_stacks:
     - cflinuxfs3
   - name: node
-    version: 11.5.0
+    version: 10.15.3
     cf_stacks:
     - cflinuxfs3
   - name: node
-    version: 11.6.0
+    version: 11.10.1
+    cf_stacks:
+    - cflinuxfs3
+  - name: node
+    version: 11.12.0
     cf_stacks:
     - cflinuxfs3
   - name: yarn
-    version: 1.13.0
+    version: 1.15.2
     cf_stacks:
     - cflinuxfs2
     - cflinuxfs3
 - name: php_buildpack
   repo_name: php-buildpack
   stack: cflinuxfs3
-  version: v4.3.69
-  sha: 477b88c2f8e7023ad8143cc87434ae256859bf2cf3599656c6bebb4838c43510
-  filename: php-buildpack-cflinuxfs3-v4.3.69.zip
-  url: https://github.com/cloudfoundry/php-buildpack/releases/download/v4.3.69/php-buildpack-cflinuxfs3-v4.3.69.zip
+  version: v4.3.72
+  sha: d21bfbdbcd992c7a19270ca4ea559db4491bc7f6db7b8efa21c1c9583cc36e11
+  filename: php-buildpack-cflinuxfs3-v4.3.72.zip
+  url: https://github.com/cloudfoundry/php-buildpack/releases/download/v4.3.72/php-buildpack-cflinuxfs3-v4.3.72.zip
   dependencies:
   - name: CAAPM
     version: 10.7.0
@@ -1115,21 +1101,21 @@ buildpacks:
     - cflinuxfs2
     - cflinuxfs3
   - name: appdynamics
-    version: 4.5.6.2534
+    version: 4.5.7.2661
     cf_stacks:
     - cflinuxfs2
     - cflinuxfs3
   - name: composer
-    version: 1.8.0
+    version: 1.8.4
     cf_stacks:
     - cflinuxfs2
     - cflinuxfs3
   - name: httpd
-    version: 2.4.37
+    version: 2.4.38
     cf_stacks:
     - cflinuxfs2
   - name: httpd
-    version: 2.4.37
+    version: 2.4.38
     cf_stacks:
     - cflinuxfs3
   - name: newrelic
@@ -1146,43 +1132,11 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: nginx
-    version: 1.15.8
+    version: 1.15.9
     cf_stacks:
     - cflinuxfs2
   - name: nginx
-    version: 1.15.8
-    cf_stacks:
-    - cflinuxfs3
-  - name: php
-    version: 5.6.39
-    cf_stacks:
-    - cflinuxfs2
-  - name: php
-    version: 5.6.40
-    cf_stacks:
-    - cflinuxfs2
-  - name: php
-    version: 7.0.32
-    cf_stacks:
-    - cflinuxfs2
-  - name: php
-    version: 7.0.32
-    cf_stacks:
-    - cflinuxfs3
-  - name: php
-    version: 7.0.33
-    cf_stacks:
-    - cflinuxfs2
-  - name: php
-    version: 7.0.33
-    cf_stacks:
-    - cflinuxfs3
-  - name: php
-    version: 7.1.25
-    cf_stacks:
-    - cflinuxfs2
-  - name: php
-    version: 7.1.25
+    version: 1.15.9
     cf_stacks:
     - cflinuxfs3
   - name: php
@@ -1194,28 +1148,44 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: php
-    version: 7.2.13
+    version: 7.1.27
     cf_stacks:
     - cflinuxfs2
   - name: php
-    version: 7.2.13
+    version: 7.1.27
     cf_stacks:
     - cflinuxfs3
   - name: php
-    version: 7.2.14
+    version: 7.2.15
     cf_stacks:
     - cflinuxfs2
   - name: php
-    version: 7.2.14
+    version: 7.2.15
+    cf_stacks:
+    - cflinuxfs3
+  - name: php
+    version: 7.2.16
+    cf_stacks:
+    - cflinuxfs2
+  - name: php
+    version: 7.2.16
+    cf_stacks:
+    - cflinuxfs3
+  - name: php
+    version: 7.3.2
+    cf_stacks:
+    - cflinuxfs3
+  - name: php
+    version: 7.3.3
     cf_stacks:
     - cflinuxfs3
 - name: python_buildpack
   repo_name: python-buildpack
   stack: cflinuxfs3
-  version: v1.6.27
-  sha: b88bc22f69ea630f062c29be4c6424710f47c4f1310a1ed3943981d3bb5201e5
-  filename: python-buildpack-cflinuxfs3-v1.6.27.zip
-  url: https://github.com/cloudfoundry/python-buildpack/releases/download/v1.6.27/python-buildpack-cflinuxfs3-v1.6.27.zip
+  version: v1.6.29
+  sha: 704a7e137bb66c45e50e74b0a39dd7ae92bb9cd813668d03d838f5c762919fc6
+  filename: python-buildpack-cflinuxfs3-v1.6.29.zip
+  url: https://github.com/cloudfoundry/python-buildpack/releases/download/v1.6.29/python-buildpack-cflinuxfs3-v1.6.29.zip
   dependencies:
   - name: libffi
     version: 3.2.1
@@ -1243,7 +1213,7 @@ buildpacks:
     - cflinuxfs2
     - cflinuxfs3
   - name: pip-pop
-    version: 0.1.1
+    version: 0.1.3
     cf_stacks:
     - cflinuxfs2
     - cflinuxfs3
@@ -1256,19 +1226,19 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: python
-    version: 2.7.14
+    version: 2.7.15
     cf_stacks:
     - cflinuxfs2
   - name: python
-    version: 2.7.14
+    version: 2.7.15
     cf_stacks:
     - cflinuxfs3
   - name: python
-    version: 2.7.15
+    version: 2.7.16
     cf_stacks:
     - cflinuxfs2
   - name: python
-    version: 2.7.15
+    version: 2.7.16
     cf_stacks:
     - cflinuxfs3
   - name: python
@@ -1328,17 +1298,17 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: setuptools
-    version: 40.6.3
+    version: 40.8.0
     cf_stacks:
     - cflinuxfs2
     - cflinuxfs3
 - name: ruby_buildpack
   repo_name: ruby-buildpack
   stack: cflinuxfs3
-  version: v1.7.30
-  sha: 05f5fcd8b1f63fee583a7ad2534c40c2ba9b3f990fcb07e41368212c6d57e7a3
-  filename: ruby-buildpack-cflinuxfs3-v1.7.30.zip
-  url: https://github.com/cloudfoundry/ruby-buildpack/releases/download/v1.7.30/ruby-buildpack-cflinuxfs3-v1.7.30.zip
+  version: v1.7.35
+  sha: aa82ee8192989150ec2a85482f649b9ae34361d6e76e76c9000ed02a2f77a84f
+  filename: ruby-buildpack-cflinuxfs3-v1.7.35.zip
+  url: https://github.com/cloudfoundry/ruby-buildpack/releases/download/v1.7.35/ruby-buildpack-cflinuxfs3-v1.7.35.zip
   dependencies:
   - name: bundler
     version: 1.17.3
@@ -1359,19 +1329,19 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: jruby
-    version: 9.2.5.0
+    version: 9.2.6.0
     cf_stacks:
     - cflinuxfs2
   - name: jruby
-    version: 9.2.5.0
+    version: 9.2.6.0
     cf_stacks:
     - cflinuxfs3
   - name: node
-    version: 6.16.0
+    version: 6.17.0
     cf_stacks:
     - cflinuxfs2
   - name: node
-    version: 6.16.0
+    version: 6.17.0
     cf_stacks:
     - cflinuxfs3
   - name: openjdk1.8-latest
@@ -1424,14 +1394,6 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: ruby
-    version: 2.5.1
-    cf_stacks:
-    - cflinuxfs2
-  - name: ruby
-    version: 2.5.1
-    cf_stacks:
-    - cflinuxfs3
-  - name: ruby
     version: 2.5.3
     cf_stacks:
     - cflinuxfs2
@@ -1440,36 +1402,52 @@ buildpacks:
     cf_stacks:
     - cflinuxfs3
   - name: ruby
-    version: 2.6.0
+    version: 2.5.5
     cf_stacks:
     - cflinuxfs2
   - name: ruby
-    version: 2.6.0
+    version: 2.5.5
+    cf_stacks:
+    - cflinuxfs3
+  - name: ruby
+    version: 2.6.1
+    cf_stacks:
+    - cflinuxfs2
+  - name: ruby
+    version: 2.6.1
+    cf_stacks:
+    - cflinuxfs3
+  - name: ruby
+    version: 2.6.2
+    cf_stacks:
+    - cflinuxfs2
+  - name: ruby
+    version: 2.6.2
     cf_stacks:
     - cflinuxfs3
   - name: rubygems
-    version: 3.0.2
+    version: 3.0.3
     cf_stacks:
     - cflinuxfs2
     - cflinuxfs3
   - name: yarn
-    version: 1.13.0
+    version: 1.15.2
     cf_stacks:
     - cflinuxfs2
     - cflinuxfs3
 - name: staticfile_buildpack
   repo_name: staticfile-buildpack
   stack: cflinuxfs3
-  version: v1.4.38
-  sha: 869aa9cd863a3b219d9f3b9476956c5e08fd18f26390d5f1f0906b076791ec40
-  filename: staticfile-buildpack-cflinuxfs3-v1.4.38.zip
-  url: https://github.com/cloudfoundry/staticfile-buildpack/releases/download/v1.4.38/staticfile-buildpack-cflinuxfs3-v1.4.38.zip
+  version: v1.4.40
+  sha: 1a2e160fbb596be0b539c0c0eb92d0ed9ef6494c9875e45855f019c4c7d19270
+  filename: staticfile-buildpack-cflinuxfs3-v1.4.40.zip
+  url: https://github.com/cloudfoundry/staticfile-buildpack/releases/download/v1.4.40/staticfile-buildpack-cflinuxfs3-v1.4.40.zip
   dependencies:
   - name: nginx
-    version: 1.15.8
+    version: 1.15.9
     cf_stacks:
     - cflinuxfs2
   - name: nginx
-    version: 1.15.8
+    version: 1.15.9
     cf_stacks:
     - cflinuxfs3

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe "release versions" do
       .fetch(0)
 
     if cf_manifest_version == 'v7.7.0'
-      expect(cf_acceptance_tests_resource['source']['branch']).to be == 'cf7.6', "There's no cf7.7 branch, so we're using the cf7.6 acceptance tests branch for cf-deployment 7.7. Next time we update cf-deployment we should check if there's a branch in cf-acceptance-tests for it and remove this conditional if so. See https://github.com/cloudfoundry/cf-acceptance-tests/branches/all?utf8=%E2%9C%93&query=cf"
+      expect(cf_acceptance_tests_resource['source']['branch']).to be == 'master', "There's no cf7.7 branch, so we're using the master acceptance tests branch (specifying commit c2159c0) for cf-deployment 7.7. Next time we update cf-deployment we should check if there's a branch in cf-acceptance-tests for it and remove this conditional if so. See https://github.com/cloudfoundry/cf-acceptance-tests/branches/all?utf8=%E2%9C%93&query=cf"
       next
     end
 

--- a/platform-tests/example-apps/http_tester/Godeps/Godeps.json
+++ b/platform-tests/example-apps/http_tester/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/alphagov/paas-cf/platform-tests/example-apps/http_tester",
-	"GoVersion": "go1.8",
+	"GoVersion": "go1.11",
 	"GodepVersion": "v79",
 	"Packages": [
 		"./..."

--- a/tools/buildpacks/email.go
+++ b/tools/buildpacks/email.go
@@ -11,7 +11,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/google/go-github/v21/github"
+	"github.com/google/go-github/v24/github"
 	"golang.org/x/oauth2"
 	yaml "gopkg.in/yaml.v2"
 )

--- a/tools/buildpacks/go.mod
+++ b/tools/buildpacks/go.mod
@@ -1,11 +1,7 @@
 module github.com/alphagov/paas-cf/tools/buildpacks
 
 require (
-	github.com/golang/protobuf v1.2.0
-	github.com/google/go-github/v21 v21.0.0
-	github.com/google/go-querystring v1.0.0
-	golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e
+	github.com/google/go-github/v24 v24.0.0
 	golang.org/x/oauth2 v0.0.0-20190115181402-5dab4167f31c
-	google.golang.org/appengine v1.4.0
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/tools/buildpacks/go.sum
+++ b/tools/buildpacks/go.sum
@@ -3,8 +3,8 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
-github.com/google/go-github/v21 v21.0.0 h1:tn4/tmCgPAsezJFwZcMnE7U0R9/AtKRBGX4s4LFdDzI=
-github.com/google/go-github/v21 v21.0.0/go.mod h1:RNbKQQDOg+lBuuu5l/v0joCrygzKEexxDEwaleXEHxA=
+github.com/google/go-github/v24 v24.0.0 h1:11gKs9XbwcUO5yEgg+GAbtg6z6CH7tK77wDM3mnAnXc=
+github.com/google/go-github/v24 v24.0.0/go.mod h1:CRqaW1Uns1TCkP0wqTpxYyRxRjxwvKU/XSS44u6X74M=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 golang.org/x/crypto v0.0.0-20180820150726-614d502a4dac/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -15,12 +15,14 @@ golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190115181402-5dab4167f31c h1:pcBdqVcrlT+A3i+tWsOROFONQyey9tisIQHI4xqVGLg=
 golang.org/x/oauth2 v0.0.0-20190115181402-5dab4167f31c/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180824143301-4910a1d54f87/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/tools/buildpacks/main.go
+++ b/tools/buildpacks/main.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/google/go-github/v21/github"
+	"github.com/google/go-github/v24/github"
 	"golang.org/x/oauth2"
 	yaml "gopkg.in/yaml.v2"
 )


### PR DESCRIPTION
**Blocked: Can't be merged until after 05/04/2019**

What
----

- Upgrades buildpacks to the latest versions 
- Adds R buildpack
- Adds Nginx buildpack
- Updates go-github module as I have issues with v21
- Fixes cf-acceptance-tests to latest commit on master with test app that supports the latest go buildpack
- Updates paas-accounts version with go bump

How to review
-------------

- Deploy to dev env
- Generate notification email via `create_buildpacks_email.sh`

Who can review
--------------

Not me