### PR TITLE
Support: Add layer label to tenant alerts

### DIFF
--- a/manifests/prometheus/alerts.d/cloudfront_tls_certificates_expiry.yml
+++ b/manifests/prometheus/alerts.d/cloudfront_tls_certificates_expiry.yml
@@ -17,3 +17,4 @@
         labels:
           severity: warning
           service: cloudfront
+          layer: tenant

--- a/manifests/prometheus/alerts.d/cloudfront_tls_certificates_validity.yml
+++ b/manifests/prometheus/alerts.d/cloudfront_tls_certificates_validity.yml
@@ -17,3 +17,4 @@
         labels:
           severity: warning
           service: cloudfront
+          layer: tenant


### PR DESCRIPTION
What
----

We have some alerts which require tenant action or communication to resolve.

These alerts should be segregated from platform level alerts to reduce alert blindness.

Cloud Foundry provides some alerts out of the box which will not be labelled, so lazily we can assume that any alert without a layer label is a platform level alert.

Tenant alerts will be available with the query:

```
ALERTS{layer="tenant"}
```

Non-tenant alerts will be available with the query:

```
ALERTS{layer!="tenant"}
```

Any alert without a layer (i.e. platform level alerts) will be available
with the query:

```
ALERTS{layer!~"^.+$"}
```

Thinking
---

- Alert blindness is bad
- If we separate out the platform into more layers (e.g. core, services, tenants) then these layers will scale
- The `layer` label is used elsewhere at GDS (e.g. Verify, Observe)
- A separate PR will be raised to change the dashboard

How to review
-------------

- Have a noodle in prometheus with the queries
- If you are extremely diligent, run it through your pipeline

Who can review
--------------

Not @tlwr
