### PR TITLE
Support: Scale up log-api instances

### DIFF
--- a/manifests/cf-manifest/env-specific/default.yml
+++ b/manifests/cf-manifest/env-specific/default.yml
@@ -3,3 +3,4 @@ cell_instances: 3
 router_instances: 2
 api_instances: 2
 doppler_instances: 6
+log_api_instances: 2

--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -3,3 +3,4 @@ cell_instances: 30
 router_instances: 3
 api_instances: 4
 doppler_instances: 12
+log_api_instances: 6

--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -3,3 +3,4 @@ cell_instances: 27
 router_instances: 3
 api_instances: 4
 doppler_instances: 12
+log_api_instances: 6

--- a/manifests/cf-manifest/env-specific/stg-lon.yml
+++ b/manifests/cf-manifest/env-specific/stg-lon.yml
@@ -3,3 +3,4 @@ cell_instances: 6
 router_instances: 3
 api_instances: 2
 doppler_instances: 3
+log_api_instances: 3

--- a/manifests/cf-manifest/operations.d/360-log-api.yml
+++ b/manifests/cf-manifest/operations.d/360-log-api.yml
@@ -10,3 +10,11 @@
 - type: replace
   path: /instance_groups/name=log-api/jobs/name=loggregator_trafficcontroller/properties/system_domain
   value: ((terraform_outputs_cf_root_domain))
+
+- type: replace
+  path: /instance_groups/name=log-api/azs/-
+  value: z3
+
+- type: replace
+  path: /instance_groups/name=log-api/instances
+  value: ((log_api_instances))


### PR DESCRIPTION
What
----

We are currently at risk of dropping tenant logs, which we experience
occasionally when log volume gets too high:

---

Environment: Prod Ireland
Date: 02 April 2019 to 04 April 2019
Query:
```
sum by(environment) (rate(firehose_counter_event_loggregator_rlp_dropped_total[1h]))
```

---

This commit follows an existing pattern for env-specific values
saturating ops files.

The default value for `log-api` instances is the same as
`cf-deployment`.

I chose 6 instances in prod-london and prod-ireland arbitrarily. However
I feel that we should get to a position where we are dropping hardly any
logs, draft a SLO for log deliverability, and then do cost optimisation
when we have deliverability budget to spend according to the SLO.

Caveats
---

I didn't have a pipeline to test this against, the values in the ops files were found by

a) looking at existing opsfiles
b) using [boshfind](https://github.com/tlwr/boshfind)

How to review
-------------

- Code review
- Run it through your pipeline (this won't scale anything up, just ensure the ops files work)

Who can review
--------------

Not @tlwr
