### PR TITLE
Support: Use logstash prune high cardinality fields

### DIFF
--- a/config/logit/output/generated_logit_filters.conf
+++ b/config/logit/output/generated_logit_filters.conf
@@ -1022,4 +1022,11 @@ filter {
       "[@source][director]"
     ]
   }
+
+  prune {
+    blacklist_names = [
+      "[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}"
+    ]
+  }
+
 }

--- a/scripts/generate_logit_filters.sh
+++ b/scripts/generate_logit_filters.sh
@@ -63,3 +63,21 @@ sed -i \
 sed -i \
     "s/vcap\.uaa/uaa/" \
     /output/generated_logit_filters.conf
+
+prune_guids='
+  prune {
+    blacklist_names = [
+      "[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}"
+    ]
+  }
+'
+
+# capture then re-output to prevent empty file
+final_output="$(
+  cat \
+    <(head -n -1 /output/generated_logit_filters.conf) \
+    <(echo "$prune_guids") \
+    <(echo "}")
+)"
+
+echo "$final_output" > /output/generated_logit_filters.conf


### PR DESCRIPTION
I haven't tested this at all, it is a PoC to start a discussion

What
----

We have guids in some of our field names

As of the time of writing we have over 4k fields in our index in
elasticsearch, which makes kibana hard to use

How to review
-------------

Code review

Test in the dev stack in logit

Who can review
--------------

Not @tlwr