### PR TITLE
Support: Add 4xlarge and 8xlarge quotas

### DIFF
--- a/manifests/cf-manifest/operations.d/320-cc-add-quotas.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-add-quotas.yml
@@ -2,6 +2,16 @@
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/quota_definitions?
   value:
+    8xlarge:
+      memory_limit: 138400
+      non_basic_services_allowed: true
+      total_routes: 4000
+      total_services: 720
+    4xlarge:
+      memory_limit: 819200
+      non_basic_services_allowed: true
+      total_routes: 2000
+      total_services: 320
     2xlarge:
       memory_limit: 409600
       non_basic_services_allowed: true


### PR DESCRIPTION
What
----

We have some tenants who are running many things, and thus they require
a larger quota.

We will one of our tenants to the 4xlarge and have the 8xlarge on
standby in case they need to scale at short notice

How to review
-------------

- YAML review
- Check the quotas make sense

Who can review
--------------

Not @tlwr
