### PR TITLE
Set the cf-acceptance-tests branch to cf7.9

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -267,7 +267,7 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-acceptance-tests
-      branch: master
+      branch: cf7.9
 
   - name: cf-smoke-tests-release
     type: git
@@ -2747,7 +2747,6 @@ jobs:
             passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
             trigger: true
           - get: cf-acceptance-tests
-            version: {ref: 5550ae6462f849142a341f7f8e2bd2ba6571943f}
           - get: paas-cf
             passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
           - get: cf-manifest
@@ -2809,7 +2808,6 @@ jobs:
           - get: cf-vars-store
             passed: ['post-deploy']
           - get: cf-acceptance-tests
-            version: {ref: 5550ae6462f849142a341f7f8e2bd2ba6571943f}
           - get: paas-admin
             passed: ['post-deploy']
 

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -102,11 +102,6 @@ RSpec.describe "release versions" do
       .select { |v| v['name'] == 'cf-acceptance-tests' }
       .fetch(0)
 
-    if cf_manifest_version == 'v7.7.0'
-      expect(cf_acceptance_tests_resource['source']['branch']).to be == 'master', "There's no cf7.7 branch, so we're using the master acceptance tests branch (specifying commit c2159c0) for cf-deployment 7.7. Next time we update cf-deployment we should check if there's a branch in cf-acceptance-tests for it and remove this conditional if so. See https://github.com/cloudfoundry/cf-acceptance-tests/branches/all?utf8=%E2%9C%93&query=cf"
-      next
-    end
-
     upstream_version = Gem::Version.new(cf_manifest_version.gsub(/^v/, '').gsub(/\.0$/, ''))
     paas_version = Gem::Version.new(cf_acceptance_tests_resource['source']['branch'].gsub(/^cf/, ''))
 


### PR DESCRIPTION
What
----

As part of the [buildpack upgrade](https://github.com/alphagov/paas-cf/pull/1832), we switched to specifying a tag for the cf-acceptance-tests as there wasn't a branch that supported the go buildpack update.

A cf7.9 branch has been added so this PR reverts the change described above. 

How to review
-------------

- Code review
- Deploy to your env (already tested in mine)

Who can review
--------------

Not me
