### PR TITLE
Correct the memory allocation for 8xlarge plans

### DIFF
--- a/manifests/cf-manifest/operations.d/320-cc-add-quotas.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-add-quotas.yml
@@ -3,7 +3,7 @@
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/quota_definitions?
   value:
     8xlarge:
-      memory_limit: 138400
+      memory_limit: 1638400
       non_basic_services_allowed: true
       total_routes: 4000
       total_services: 720


### PR DESCRIPTION
What
----

We were missing a digit - 8xlarge should have 1.6TB of memory, not
135GB.

How to review
-------------

* Check the numbers

Who can review
--------------

* Not @richardTowers (probably @tlwr)