### PR TITLE
Separate tenant and platform alerts

### DIFF
--- a/manifests/prometheus/dashboards.d/user-impact.json
+++ b/manifests/prometheus/dashboards.d/user-impact.json
@@ -601,7 +601,7 @@
                     "thresholdMarkers": true
                 },
                 "gridPos": {
-                    "h": 8,
+                    "h": 4,
                     "w": 4,
                     "x": 20,
                     "y": 16
@@ -640,14 +640,14 @@
                 },
                 "tableColumn": "",
                 "targets": [{
-                    "expr": "count(ALERTS{alertstate=\"firing\"}) or vector(0)",
+                    "expr": "count(ALERTS{alertstate=\"firing\",layer!=\"tenant\"}) or vector(0)",
                     "format": "time_series",
                     "instant": true,
                     "intervalFactor": 1,
                     "refId": "A"
                 }],
                 "thresholds": "1,1",
-                "title": "Firing Alerts",
+                "title": "Platform Alerts",
                 "type": "singlestat",
                 "valueFontSize": "200%",
                 "valueMaps": [{
@@ -676,12 +676,12 @@
                     "thresholdMarkers": true
                 },
                 "gridPos": {
-                    "h": 8,
+                    "h": 4,
                     "w": 4,
                     "x": 20,
-                    "y": 16
+                    "y": 20
                 },
-                "id": 5,
+                "id": 14,
                 "interval": null,
                 "links": [{
                     "targetBlank": true,
@@ -715,14 +715,14 @@
                 },
                 "tableColumn": "",
                 "targets": [{
-                    "expr": "count(ALERTS{alertstate=\"firing\"}) or vector(0)",
+                    "expr": "count(ALERTS{alertstate=\"firing\",layer=\"tenant\"}) or vector(0)",
                     "format": "time_series",
                     "instant": true,
                     "intervalFactor": 1,
                     "refId": "A"
                 }],
                 "thresholds": "1,1",
-                "title": "Firing Alerts",
+                "title": "Tenant Alerts",
                 "type": "singlestat",
                 "valueFontSize": "200%",
                 "valueMaps": [{

--- a/manifests/prometheus/dashboards.d/user-impact.json
+++ b/manifests/prometheus/dashboards.d/user-impact.json
@@ -656,6 +656,81 @@
                     "value": "null"
                 }],
                 "valueName": "current"
+            },
+            {
+                "cacheTimeout": null,
+                "colorBackground": true,
+                "colorValue": false,
+                "colors": [
+                    "#299c46",
+                    "rgba(237, 129, 40, 0.89)",
+                    "#d44a3a"
+                ],
+                "datasource": "prometheus",
+                "format": "none",
+                "gauge": {
+                    "maxValue": 100,
+                    "minValue": 0,
+                    "show": false,
+                    "thresholdLabels": false,
+                    "thresholdMarkers": true
+                },
+                "gridPos": {
+                    "h": 8,
+                    "w": 4,
+                    "x": 20,
+                    "y": 16
+                },
+                "id": 5,
+                "interval": null,
+                "links": [{
+                    "targetBlank": true,
+                    "title": "https://prometheus-1.__SYSTEM_DNS_ZONE_NAME__/alerts",
+                    "type": "absolute",
+                    "url": "https://prometheus-1.__SYSTEM_DNS_ZONE_NAME__/alerts"
+                }],
+                "mappingType": 1,
+                "mappingTypes": [{
+                        "name": "value to text",
+                        "value": 1
+                    },
+                    {
+                        "name": "range to text",
+                        "value": 2
+                    }
+                ],
+                "maxDataPoints": 100,
+                "nullPointMode": "connected",
+                "nullText": null,
+                "postfix": "",
+                "postfixFontSize": "50%",
+                "prefix": "",
+                "prefixFontSize": "50%",
+                "rangeMaps": [],
+                "sparkline": {
+                    "fillColor": "rgba(31, 118, 189, 0.18)",
+                    "full": false,
+                    "lineColor": "rgb(31, 120, 193)",
+                    "show": false
+                },
+                "tableColumn": "",
+                "targets": [{
+                    "expr": "count(ALERTS{alertstate=\"firing\"}) or vector(0)",
+                    "format": "time_series",
+                    "instant": true,
+                    "intervalFactor": 1,
+                    "refId": "A"
+                }],
+                "thresholds": "1,1",
+                "title": "Firing Alerts",
+                "type": "singlestat",
+                "valueFontSize": "200%",
+                "valueMaps": [{
+                    "op": "=",
+                    "text": "N/A",
+                    "value": "null"
+                }],
+                "valueName": "current"
             }
         ],
         "refresh": "5s",


### PR DESCRIPTION
What
----

Let's have separate boxes for platform alerts and tenant alerts so it doesn't look like the platform is in trouble when there's a tenant cert due to expire:

![image](https://user-images.githubusercontent.com/1696784/55975940-fd7f6800-5c82-11e9-97cf-77233be626f2.png)

We already have a `layer` label which is set to `tenant` for expiring certificate notifications.

How to review
-------------

* This has run down `towers` - see https://grafana-1.towers.dev.cloudpipeline.digital/d/paas-user-impact/user-impact-towers?refresh=5s&orgId=1
* The commits are broken down so you can see the changes - see b3f590d

Who can review
--------------

Not @richardTowers 