### PR TITLE
[SUPPORT] Upgrade CAPI to 1.79.0 to mitigate cve-2019-3798

### DIFF
--- a/manifests/cf-manifest/operations.d/329-capi-release.yml
+++ b/manifests/cf-manifest/operations.d/329-capi-release.yml
@@ -2,6 +2,6 @@
   path: /releases/name=capi
   value:
     name: "capi"
-    version: "1.78.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.78.0"
-    sha1: "10a7ec24faeef95a49cb8ebe7845ecbf16fab761"
+    version: "1.79.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.79.0"
+    sha1: "85d0765ad9815962e46fc99712294c21514e6f7f"


### PR DESCRIPTION
What
----

Upgrade CAPI to v1.79.0 as recommended in mitigations for [cve-2019-3798](https://www.cloudfoundry.org/blog/cve-2019-3798/).

How to review
-------------

* Code review
* Ensure it has successfully run down a pipeline (has already been run down mine - that may be enough)

Who can review
--------------

Not me
