### PR TITLE
[SUPPORT] Bump stemcells and stacks to address USNs

### DIFF
--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-xenial
-      version: "170.45"
+      version: "170.48"

--- a/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
+++ b/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
@@ -12,6 +12,6 @@
   path: /releases/name=cflinuxfs3
   value:
     name: "cflinuxfs3"
-    version: "0.72.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.72.0"
-    sha1: "b1b2acccb718440fb5f969a1a48c1f8cfec59a62"
+    version: "0.80.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.80.0"
+    sha1: "ac61fc9469bd8dcecfaccb450d6b137a66881aa0"


### PR DESCRIPTION
What
----

The following Ubuntu Security Notifications recommend bumping our
stemcells (the base OS for our virtual machines) and our stacks (the
base OS for cloud foundry applications):

- https://www.cloudfoundry.org/blog/usn-3931-2/
- https://www.cloudfoundry.org/blog/usn-3935-1/
- https://www.cloudfoundry.org/blog/usn-3945-1/

How to review
-------------

* Code review
* MAYBE wait for it to run down a pipeline, MAYBE just trust staging
  (it's currently running down https://deployer.towers.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry)

Who can review
--------------

Not @richardtowers