### PR TITLE
BAU: API availability tests should not be rate limited

### DIFF
--- a/manifests/cf-manifest/env-specific/stg-lon.yml
+++ b/manifests/cf-manifest/env-specific/stg-lon.yml
@@ -4,4 +4,4 @@ router_instances: 3
 api_instances: 2
 doppler_instances: 3
 log_api_instances: 3
-cc_hourly_rate_limit: 10000
+cc_hourly_rate_limit: 100000


### PR DESCRIPTION
What
----

The API availability tests in `stg-lon` (our staging environment) were rate limited today. It appears that each run of them generally causes about 20,000 requests but this could be much higher in a long running deploy (e.g., BOSH recreating all VMs due to a new stemcell.)

This commit increases the per-user API rate limit in `stg-lon` to 100,000 requests/hour. This is roughly 30/second and should be enough to avoid any recurrence.

Alternative implementation choices:

* Disable rate limiting in staging. `bosh interpolate` does not appear to support ternary operators and I didn't want to have an extra variable to control whether rate limiting is on or off.

* Try to specifically avoid rate limiting the availability test users. This would take more research but seems a better fix.

How to review
-------------

Code review.

Who can review
--------------

Not @46bit. I suggest either @richardTowers (he saw the rate limit earlier today) or @tlwr (he worked on this feature.)