### PR TITLE
[SUPPORT] Upgrade UAA to 71.0 to mitigate CVE-2019-3788

### DIFF
--- a/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
+++ b/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
@@ -3,6 +3,6 @@
   path: /releases/name=uaa
   value:
     name: "uaa"
-    version: "70.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=70.0"
-    sha1: "c23b71fb2a3d01a1f494753b7f00ae40c549838f"
+    version: "71.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=71.0"
+    sha1: "5c41116e2a57a7d78a9ae4ceeb100415f949d8e3"


### PR DESCRIPTION
What
----

Upgraded the boshrelease for UAA to 71.0 in order to mitigate [CVE-2019-3788](https://www.cloudfoundry.org/blog/cve-2019-3788/)

How to review
-------------

I have run this down my pipeline without any issues, but it could be worth running that again.
Code review to ensure i can use a keyboard

Who can review
--------------

Not me!
