### PR TITLE
CVE-2019-3789

### DIFF
--- a/manifests/cf-manifest/operations.d/040-cf-routing.yml
+++ b/manifests/cf-manifest/operations.d/040-cf-routing.yml
@@ -1,0 +1,8 @@
+---
+- type: replace
+  path: /releases/name=routing
+  value:
+    name: routing
+    version: 0.188.0
+    url: "https://bosh.io/d/github.com/cloudfoundry-incubator/cf-routing-release?v=0.188.0"
+    sha1: d3420851c470790e8980ff0c506f75e3e52c15d9


### PR DESCRIPTION
What
----

Adds a new ops file to bump cf-routing release to 0.188.0 which contains
the CVE fix for [CVE-2019-3789](https://www.cloudfoundry.org/blog/cve-2019-3789/)

How to review
-------------

- 🔍 [Release notes](https://github.com/cloudfoundry/routing-release/releases)

- Code review

- `cd paas-bootstrap ; DEPLOY_ENV=tlwr make dev bosh-cli ; bosh releases | grep routing`

- 🔍 [ATS & CATS in dev/tlwr](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry)

Who can review
--------------

Not @tlwr
