### PR TITLE
Explicitly enable route_services_internal_lookup

### DIFF
--- a/manifests/cf-manifest/operations.d/310-router.yml
+++ b/manifests/cf-manifest/operations.d/310-router.yml
@@ -47,6 +47,12 @@
   path: /instance_groups/name=router/jobs/name=gorouter/properties/router/enable_ssl
   value: false
 
+  # As of routing release 0.188.0 this causes hairpinning for router services
+  # unless this is set to true, the default is false
+- type: replace
+  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/route_services_internal_lookup?
+  value: true
+
 - type: replace
   path: /instance_groups/name=router/jobs/name=gorouter/properties/router/status/user
   value: router_user


### PR DESCRIPTION
What
----

Make gorouter not hairpin: Gorouter as of routing release 0.188.0 forces all route services to
hairpin unless this configuration is set to true

new: https://bosh.io/jobs/gorouter?source=github.com/cloudfoundry-incubator/cf-routing-release&version=0.188.0
vs
old: https://bosh.io/jobs/gorouter?source=github.com/cloudfoundry-incubator/cf-routing-release&version=0.184.0

gorouter changes: https://github.com/cloudfoundry/gorouter/compare/a2e8fcfec056587806ca192fced3eb272b9770aa...e4915481282eddbd22f38f6965e0c5a3b2be8783

individual commit: https://github.com/cloudfoundry/gorouter/commit/e4915481282eddbd22f38f6965e0c5a3b2be8783

How to review
-------------

Code review

I have a [safelist route service](https://github.com/alphagov/re-paas-ip-safelist-service) working which I have demoed to @46bit 

Who can review
--------------

Not @tlwr
