### PR TITLE
[#165633078] Mitigate USN-3947-1, USN-3885-2, USN-3943-1, CVE-2019-3801

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ compile_platform_tests:
 		platform/availability/monitor
 
 lint_yaml:
-	find . -name '*.yml' -not -path '*/vendor/*' -not -path './manifests/prometheus/upstream/*' | xargs yamllint -c yamllint.yml
+	find . -name '*.yml' -not -path '*/vendor/*' -not -path './manifests/prometheus/upstream/*' -not -path './manifests/cf-deployment/ci/template/*' | xargs yamllint -c yamllint.yml
 
 .PHONY: lint_terraform
 lint_terraform: dev ## Lint the terraform files.

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -299,7 +299,7 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-smoke-tests-release
-      tag_filter: "40.0.47"
+      tag_filter: "40.0.50"
       submodules:
       - "src/smoke_tests"
 

--- a/concourse/pipelines/monitor-remote.yml
+++ b/concourse/pipelines/monitor-remote.yml
@@ -19,7 +19,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloudfoundry/cf-smoke-tests-release
-    tag_filter: "40.0.47"
+    tag_filter: "40.0.50"
     submodules:
       - "src/smoke_tests"
 

--- a/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
+++ b/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
@@ -4,9 +4,9 @@
   path: /releases/name=cflinuxfs2
   value:
     name: "cflinuxfs2"
-    version: "1.275.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.275.0"
-    sha1: "64027babfdaac464242162c57b80465b973c5b40"
+    version: "1.281.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.281.0"
+    sha1: "1bdcf24c1fb9baf324aebab8ba28f8e64b846305"
 
 - type: replace
   path: /releases/name=cflinuxfs3

--- a/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
+++ b/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
@@ -12,6 +12,6 @@
   path: /releases/name=cflinuxfs3
   value:
     name: "cflinuxfs3"
-    version: "0.80.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.80.0"
-    sha1: "ac61fc9469bd8dcecfaccb450d6b137a66881aa0"
+    version: "0.81.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.81.0"
+    sha1: "47f4eb966f21881bdb0a7db879fec47dc04b8b9a"

--- a/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
+++ b/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
@@ -3,6 +3,6 @@
   path: /releases/name=uaa
   value:
     name: "uaa"
-    version: "71.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=71.0"
-    sha1: "5c41116e2a57a7d78a9ae4ceeb100415f949d8e3"
+    version: "72.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=72.0"
+    sha1: "7130e5ac640ed1e1f52c09e76995e4d0680f3b45"


### PR DESCRIPTION
What
----

This mitigates USN-3947-1, USN-3885-2, USN-3943-1 and CVE-2019-3801 by upgrading versions in line with triaging done in this comment: https://www.pivotaltracker.com/story/show/165633078/comments/202039197.

How to review
-------------

* 🐝 **Wait for Miki to try this in their dev environment;** 🐝
* Review alongside https://github.com/alphagov/paas-bootstrap/pull/270;
* [Review the choice of versions](https://www.pivotaltracker.com/story/show/165633078/comments/202039197);
* See if the tests pass;
* Code review.

Who can review
--------------

Not @46bit