### PR TITLE
Bump paas-admin to v0.96.0

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -373,7 +373,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-admin
-      tag_filter: v0.94.0
+      tag_filter: v0.96.0
 
   - name: prometheus-vars-store
     type: s3-iam

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -373,7 +373,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-admin
-      tag_filter: v0.82.0
+      tag_filter: v0.94.0
 
   - name: prometheus-vars-store
     type: s3-iam


### PR DESCRIPTION
What
----

Full diff: https://github.com/alphagov/paas-admin/compare/v0.82.0...v0.94.0

Contains the following PRs by human beings:

- alphagov/paas-admin#146 Stub APIs needed for the calculator
- alphagov/paas-admin#148 Request logging
- alphagov/paas-admin#160 Use javascript naming for request log interceptor
- alphagov/paas-admin#173 Support: Fix bug showing allocations
- alphagov/paas-admin#180 Skip calculator getQuote if there are no items
- alphagov/paas-admin#181 Remove low-value, flakey test

And the following dependabot specials:

- alphagov/paas-admin#161 Bump nunjucks from 3.1.3 to 3.2.0
- alphagov/paas-admin#165 Bump glob from 7.1.2 to 7.1.3
- alphagov/paas-admin#164 Bump @types/source-map-support from 0.4.1 to 0.5.0
- alphagov/paas-admin#162 Bump webpack-cli from 3.1.0 to 3.3.1
- alphagov/paas-admin#170 Bump pino from 5.1.0 to 5.12.3
- alphagov/paas-admin#169 Bump @types/jest from 23.3.1 to 24.0.11
- alphagov/paas-admin#168 Bump nodemon-webpack-plugin from 4.0.3 to 4.0.8
- alphagov/paas-admin#167 Bump express-static-gzip from 1.1.1 to 1.1.3
- alphagov/paas-admin#166 Bump @types/uuid from 3.4.3 to 3.4.4
- alphagov/paas-admin#163 Bump @types/helmet from 0.0.38 to 0.0.43
- alphagov/paas-admin#174 Bump tslint-microsoft-contrib from 5.2.0 to 6.1.1
- alphagov/paas-admin#175 Bump qs from 6.5.2 to 6.7.0
- alphagov/paas-admin#176 Bump moment from 2.22.2 to 2.24.0
- alphagov/paas-admin#177 Bump jest from 23.5.0 to 23.6.0
- alphagov/paas-admin#178 Bump @types/passport from 0.4.6 to 1.0.0
- alphagov/paas-admin#179 Bump jest and ts-jest



How to review
-------------

* Quick glance over the PRs
* (Given there's a lot of changes) ensure this has run in a dev env

Who can review
--------------

Not @richardtowers