### PR TITLE
Increase maximum app disk to 4gb

### DIFF
--- a/manifests/cf-manifest/operations.d/320-cc-increase-max-app-disk.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-increase-max-app-disk.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/maximum_app_disk_in_mb?
+  value: 4096


### PR DESCRIPTION
What
----

One of our tenants wants to push a Docker image that is 2.2GB in size. Cloud Foundry limits the disk usage of apps to 2GB by default, and so they have not been able to release their app on the PaaS.

This PR increases that limit to 4GB. This is meant as an idea for discussion rather than a PR to definitely be merged.

How to review
-------------

Understand the change:

* https://github.com/cloudfoundry/cloud_controller_ng/blob/master/config/cloud_controller.yml#L51 https://bosh.io/jobs/cloud_controller_ng?source=github.com/cloudfoundry/cf-release&version=203#p%3dcc.maximum_app_disk_in_mb
* https://pvtl.force.com/s/question/0D50P00003wKIRMSA4/we-are-new-to-pivotal-our-docker-image-is-approximately-7-gb-as-per-the-document-we-can-only-deploy-2gb-of-docket-image-please-let-us-know-if-we-can-deploy-the-docker-image-exceeding-2-gb


Who can review
--------------

Not @46bit 