### PR TITLE
Increase gorouters in `prod` from 3 to 6

### DIFF
--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -1,6 +1,6 @@
 ---
 cell_instances: 27
-router_instances: 3
+router_instances: 6
 api_instances: 4
 doppler_instances: 12
 log_api_instances: 6


### PR DESCRIPTION
What
----

During a tenant's performance testing, we expect `prod` to increase from 300 to 900 RPS. This PR doubles the number of gorouters we run in `prod` so that the load per gorouter will only increase 50%.

How to review
-------------

Code review.

Who can review
--------------

Not @46bit