### PR TITLE
Add a script to list the developer environments

### DIFF
--- a/scripts/list-dev-envs.sh
+++ b/scripts/list-dev-envs.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ -z "${AWS_ACCESS_KEY_ID:-}" ]; then
+  >&2 echo "Must be run with AWS dev account creds"
+  exit 1
+fi
+
+aws s3 ls | grep 'gds-paas.*-state' | grep -v 'account-wide' | cut -d '-' -f 5
+


### PR DESCRIPTION
What
----

Sometimes I find myself wondering what people have called their
developer environments. Am I `richt`? Or `towers`? You just have to
know.

It's possible to find out by looking at the names of the state buckets
in S3. This script does that, so people don't have to faff around in the
AWS web console.

[ci skip] - https://github.com/concourse/git-resource#check-check-for-new-commits

How to review
-------------

* Code review is enough

Who can review
--------------

Not @richardtowers