### PR TITLE
[#164493738 ] Upgrade to paas-billing v0.57.0

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -361,7 +361,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-billing
-      tag_filter: v0.54.0
+      tag_filter: v0.57.0
 
   - name: paas-accounts
     type: git


### PR DESCRIPTION
What
----

This PR exists to release https://github.com/alphagov/paas-billing/pull/70, but also releases two refactoring PRs. See commit message for details.

Who can review
--------------

Not @46bit