### PR TITLE
165633059 + 165633078 CVEs

### DIFF
--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-xenial
-      version: "170.48"
+      version: "170.51"

--- a/manifests/prometheus/alerts.d/bosh-stemcells-not-in-sync.yml
+++ b/manifests/prometheus/alerts.d/bosh-stemcells-not-in-sync.yml
@@ -1,0 +1,16 @@
+# Source: bosh-exporter
+---
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: BoshStemcellsNotInSync
+    rules:
+      - alert: BoshStemcellsNotInSync
+        expr: "sum by (bosh_stemcell_version) (bosh_deployment_stemcell_info) != 3"
+        for: 12h
+        labels:
+          severity: warning
+        annotations:
+          summary: "Bosh deployment stemcell versions are not in sync"
+          description: "The three bosh deployments should have the same stemcell version, if this alert fires either deploys are taking a long time or paas-bootstrap and paas-cf are not in sync"


### PR DESCRIPTION
What
----

USN-3947-1
CVE-2019-11068
USN-3943-1
CVE-2018-20483
CVE-2019-5953

For https://www.pivotaltracker.com/n/projects/1275640/stories/165633059 and https://www.pivotaltracker.com/n/projects/1275640/stories/165633078

This also adds a `warning` alert which fires if our bosh stemcells are out of sync. We have 3 bosh deployments (concourse, prometheus, cf (eg prod or prod-lon)), therefore summing by the version should be 3. This alert would fire during deploys, therefore it should only fire if it is red for > 12h.

How to review
-------------

Code review

```
export DEPLOY_ENV=tlwr
# Assume a role in dev account
cd paas-bootstrap
make dev bosh-cli
bosh stemcells
# Check that only one stemcell is in use and that it is 170.51
```

[Look at this chart of the new alert in tlwr](https://prometheus-1.tlwr.dev.cloudpipeline.digital/graph?g0.range_input=2h&g0.expr=sum%20by%20(bosh_stemcell_version)%20(bosh_deployment_stemcell_info)&g0.tab=0)

[Look at this chart of the new alert in prod](https://prometheus-1.cloud.service.gov.uk/graph?g0.range_input=12h&g0.expr=sum%20by%20(bosh_stemcell_version)%20(bosh_deployment_stemcell_info)&g0.tab=0)

Who can review
--------------

Not @tlwr
