### PR TITLE
Bump paas-billing from v0.58.0 to v0.59.0

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -361,7 +361,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-billing
-      tag_filter: v0.58.0
+      tag_filter: v0.59.0
 
   - name: paas-accounts
     type: git


### PR DESCRIPTION
What
----

Full diff: https://github.com/alphagov/paas-billing/compare/v0.58.0...v0.59.0

Just the one PR - alphagov/paas-billing#66 ([#164493738] Billable events are already in GBP)

How to review
-------------

* Code review
* Probably not necessary to test this in a dev env, because it's very small

Who can review
--------------

Not @richardtowers