### PR TITLE
Support: Scale down gorouters in `prod` (IE) from 6 to 3

### DIFF
--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -1,6 +1,6 @@
 ---
 cell_instances: 27
-router_instances: 6
+router_instances: 3
 api_instances: 4
 doppler_instances: 12
 log_api_instances: 6


### PR DESCRIPTION
What
----

The tenants in question have finished performance testing

How to review
-------------

Code review

Look [here](https://prometheus-1.cloud.service.gov.uk/graph?g0.range_input=1w&g0.expr=sum(rate(firehose_counter_event_gorouter_total_requests_total%5B1h%5D))&g0.tab=0) and see that yesterday usage was comfortably < 300rps

Who can review
--------------

Not @tlwr