### PR TITLE
Bump UAA Customized release and alter UAA Route Registrar health checks

### DIFF
--- a/manifests/cf-manifest/operations.d/330-uaa.yml
+++ b/manifests/cf-manifest/operations.d/330-uaa.yml
@@ -21,6 +21,10 @@
   value: cf_uaa_health_check
 
 - type: replace
+  path: /instance_groups/name=uaa/jobs/name=route_registrar/properties/route_registrar/routes/name=uaa/health_check/script_path
+  value: /var/vcap/jobs/uaa-customized/bin/health_check
+
+- type: replace
   path: /instance_groups/name=uaa/jobs/name=route_registrar/properties/route_registrar/routes/name=uaa/port
   value: 8081
 
@@ -277,9 +281,9 @@
   path: /releases/-
   value:
     name: uaa-customized
-    version: 0.1.1
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-customized-0.1.1.tgz
-    sha1: 103fca0cdeae86b82ca8aa6700d8bc9faba46987
+    version: 0.1.3
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-customized-0.1.3.tgz
+    sha1: 54e4103f9682c2bdd67a0becff4eddf8841d17e1
 
 - type: replace
   path: /instance_groups/name=uaa/jobs/-

--- a/platform-tests/src/platform/availability/monitor/monitor.go
+++ b/platform-tests/src/platform/availability/monitor/monitor.go
@@ -24,12 +24,12 @@ func (r *Report) String() string {
 	s := "\nReport:\n"
 	s += "==============\n"
 	s += fmt.Sprintf("Total task executions: %d\n", total)
-	s += fmt.Sprintf("Total successes: %d\n", r.SuccessCount)
-	s += fmt.Sprintf("Total failures: %d\n", r.FailureCount)
-	s += fmt.Sprintf("Total warnings: %d\n", r.WarningCount)
-	s += fmt.Sprintf("Total errors: %d\n", r.ErrorCount)
-	s += fmt.Sprintf("Elapsed time: %s\n", r.Elapsed.String())
-	s += fmt.Sprintf("Average rate: %.2f tasks/sec\n", float64(total)/r.Elapsed.Seconds())
+	s += fmt.Sprintf("Total successes:       %d\n", r.SuccessCount)
+	s += fmt.Sprintf("Total failures:        %d\n", r.FailureCount)
+	s += fmt.Sprintf("Total warnings:        %d\n", r.WarningCount)
+	s += fmt.Sprintf("Total errors:          %d\n", r.ErrorCount)
+	s += fmt.Sprintf("Elapsed time:          %s\n", r.Elapsed.String())
+	s += fmt.Sprintf("Average rate:          %.2f tasks/sec\n", float64(total)/r.Elapsed.Seconds())
 
 	if len(r.Errors) > 0 {
 		s += fmt.Sprintf("\nErrors:\n")

--- a/platform-tests/src/platform/availability/monitor/monitor.go
+++ b/platform-tests/src/platform/availability/monitor/monitor.go
@@ -13,6 +13,7 @@ type Report struct {
 	SuccessCount int64
 	FailureCount int64
 	WarningCount int64
+	ErrorCount   int64
 	Errors       map[*Task]map[string]int // number of errors by error message by task
 	Warnings     map[*Task]map[string]int // number of warnings by error message by task
 	Elapsed      time.Duration
@@ -26,6 +27,7 @@ func (r *Report) String() string {
 	s += fmt.Sprintf("Total successes: %d\n", r.SuccessCount)
 	s += fmt.Sprintf("Total failures: %d\n", r.FailureCount)
 	s += fmt.Sprintf("Total warnings: %d\n", r.WarningCount)
+	s += fmt.Sprintf("Total errors: %d\n", r.ErrorCount)
 	s += fmt.Sprintf("Elapsed time: %s\n", r.Elapsed.String())
 	s += fmt.Sprintf("Average rate: %.2f tasks/sec\n", float64(total)/r.Elapsed.Seconds())
 
@@ -113,6 +115,7 @@ func (m *Monitor) statsCollector() {
 						report.Errors[result.task] = map[string]int{}
 					}
 					report.Errors[result.task][msg]++
+					report.ErrorCount++
 					report.FailureCount++
 				} else {
 					if report.Warnings[result.task] == nil {


### PR DESCRIPTION
What
----

Reformats the API availability summary message to include the number of errors.

Bumps the version of uaa-customized and uses the uaa-customized health check script for UAA's route registrar.

[See this PR for more info](https://github.com/alphagov/paas-uaa-customized-boshrelease/pull/2)

How to review
-------------

Code review

Run it down your pipeline

Who can review
--------------

Not @tlwr

Notes
---

There is a WIP commit until https://github.com/alphagov/paas-uaa-customized-boshrelease/pull/2 is merged
