### PR TITLE
[#164728419]Bump Prometheus boshrelease to v25.0.0

### DIFF
--- a/manifests/cf-manifest/operations.d/510-add-prometheus-blackbox-exporter.yml
+++ b/manifests/cf-manifest/operations.d/510-add-prometheus-blackbox-exporter.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: "prometheus"
-    version: "23.1.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=23.1.0"
-    sha1: "d9ef31b8e57d8668de14cdf976cbaffa78a80897"
+    version: "25.0.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=25.0.0"
+    sha1: "f2a1de6d1b00c856402964347685274877b33910"
 
 - type: replace
   path: /addons?/-

--- a/manifests/prometheus/alerts.d/bosh-duplicate-releases.yml
+++ b/manifests/prometheus/alerts.d/bosh-duplicate-releases.yml
@@ -1,0 +1,19 @@
+# Source: bosh-exporter
+---
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: BoshDuplicateReleases
+    rules:
+      - alert: BoshDuplicateReleases_Warning
+        expr: |
+          count by (bosh_release_name) (
+            count by (bosh_release_name, bosh_release_version) (bosh_deployment_release_info{bosh_release_name!="bpm"})
+          ) > 1
+        labels:
+          severity: warning
+        for: 2h
+        annotations:
+          summary: "Duplicate bosh release of {{ $labels.bosh_release_name }}"
+          description: "There are {{ $value }} versions of {{ $labels.bosh_release_name }} and we should probably only have one"

--- a/manifests/prometheus/operations.d/001-set-retention.yml
+++ b/manifests/prometheus/operations.d/001-set-retention.yml
@@ -1,8 +1,9 @@
 ---
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties?/prometheus/storage/tsdb/retention
-  value: 450d
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties?/prometheus/storage/tsdb/retention?
+  value:
+    time: 450d
 
 - type: replace
   path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties?/prometheus/storage/tsdb/max_block_duration


### PR DESCRIPTION
What
----

The upgrade to Concourse 5 means that Prometheus cannot scrape concourse anymore, this is fixed in v25.

There were not many breaking changes other than prometheus retention time syntax.

Adds an alert to check for multiple bosh release versions (except for bpm as bpm is likely to have multiple versions)

How to review
-------------

Code review

```
cd paas-bootstrap
make dev bosh-cli
bosh releases # check prometheus with a * is only 25
```

Check that the alert works

Who can review
--------------

Not @tlwr
