### PR TITLE
[#165534387] Run paas-billing acceptance tests after deployment

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2890,6 +2890,35 @@ jobs:
                   paas-billing-collector \
                   -f manifest-collector.yml
 
+      - task: paas-billing-acceptance-tests
+        config:
+          platform: linux
+          image_resource: *cf-acceptance-tests-image-resource
+          params:
+            AWS_REGION: ((aws_region))
+            SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+            DEPLOY_ENV: ((deploy_env))
+          inputs:
+            - name: paas-cf
+            - name: paas-billing
+              path: src/github.com/alphagov/paas-billing
+            - name: config
+            - name: cf-vars-store
+          run:
+            path: sh
+            args:
+              - -e
+              - -u
+              - -c
+              - |
+                . ./config/config.sh
+                echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}" -o admin -s billing
+
+                export GOPATH="${PWD}"
+                export BILLING_API_URL="https://billing.${SYSTEM_DNS_ZONE_NAME}"
+                cd src/github.com/alphagov/paas-billing
+                make acceptance
+
   - name: deploy-paas-metrics
     serial: true
     plan:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -361,7 +361,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-billing
-      tag_filter: v0.59.0
+      tag_filter: v0.60.0
 
   - name: paas-accounts
     type: git


### PR DESCRIPTION
What
----
Runs paas-billing acceptance tests once paas-billing has been deployed

Review first
---

https://github.com/alphagov/paas-billing/pull/77

How to review
-------------

1. Code review;
2. Run it down your pipeline and test;
3. Review/merge https://github.com/alphagov/paas-billing/pull/77;
4. Replace the `[TMP]` commit with one that imports the resulting new version of `paas-billing`;
5. Done 🎉 

Who can review
--------------

Not @AP-Hunt @46bit
