### PR TITLE
Reduce cells in ireland from 27 to 24

### DIFF
--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -1,5 +1,5 @@
 ---
-cell_instances: 27
+cell_instances: 24
 router_instances: 3
 api_instances: 4
 doppler_instances: 12


### PR DESCRIPTION
What
----

[The dashboard](https://grafana-1.cloud.service.gov.uk/d/paas-user-impact/user-impact-prod)
has been showing <= 22 cells required in Ireland for the last week. This
is probably due to people stopping applications that are no longer
required instead of migrating them to cflinuxfs3.

We should be able to scale down to 24 instances and still have plenty
capacity.

How to review
-------------

* Code review is fine

Who can review
--------------

Not @richardtowers