### PR TITLE
Fork cflinuxfs3-release, bump to v0.88.0

### DIFF
--- a/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
+++ b/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
@@ -10,6 +10,6 @@
   path: /releases/name=cflinuxfs3
   value:
     name: "cflinuxfs3"
-    version: "0.81.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.81.0"
-    sha1: "47f4eb966f21881bdb0a7db879fec47dc04b8b9a"
+    version: "0.1.1"
+    url: "https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cflinuxfs3-0.1.1.tgz"
+    sha1: "ebe456be2f4d3eb2ec91fa05b48b6fbf53759ed1"

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -26,7 +26,12 @@ RSpec.describe "release versions" do
       Gem::Version.new(v.gsub(/^v/, '').gsub(/^([0-9]+)$/, '0.0.\1'))
     end
 
-    pinned_releases = {}
+    pinned_releases = {
+      'cflinuxfs3' => {
+        local: "0.1.1",
+        upstream: "0.73.0"
+      }
+    }
 
     manifest_releases = manifest_without_vars_store.fetch("releases").map { |release|
       [release['name'], release['version']]


### PR DESCRIPTION
What
----

This is based on cflinuxfs3-release [v0.88.0](https://github.com/cloudfoundry/cflinuxfs3-release/releases/tag/v0.88.0)
but has an additional change that makes the `pre-start` script
idempotent.

See https://github.com/cloudfoundry/cflinuxfs3-release/compare/cloudfoundry:da46147...alphagov:c49d64f for a full diff from upstream

How to review
-------------

* Code review
* Check it's run down a dev environment

Who can review
--------------

Not @richardtowers