### PR TITLE
Bump paas-admin to v0.132.0

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -373,7 +373,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-admin
-      tag_filter: v0.131.0
+      tag_filter: v0.132.0
 
   - name: prometheus-vars-store
     type: s3-iam


### PR DESCRIPTION
What
----

Full diff:
https://github.com/alphagov/paas-admin/compare/v0.131.0...v0.132.0

Just https://github.com/alphagov/paas-admin/pull/237

How to review
-------------

* Code review is enough

Who can review
--------------

Not Richard