### PR TITLE
Switch user origin script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ unpause-kick-off: check-env ## Unpause the morning kick-off of deployment.
 showenv: check-env ## Display environment information
 	$(eval export TARGET_CONCOURSE=deployer)
 	@concourse/scripts/environment.sh
-	@scripts/show-vars-store-secrets.sh cf-vars-store cf_admin_password
+	@scripts/show-vars-store-secrets.sh cf-vars-store cf_admin_password uaa_admin_client_secret
 	@echo export CONCOURSE_IP=$$(aws ec2 describe-instances \
 		--filters "Name=tag:deploy_env,Values=${DEPLOY_ENV}" 'Name=tag:instance_group,Values=concourse' \
 		--query 'Reservations[].Instances[].PublicIpAddress' --output text)

--- a/scripts/update-user-origin.rb
+++ b/scripts/update-user-origin.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+require 'json'
+
+def usage
+  <<~USAGE
+    Usage: #{$0} user-guid desired-origin
+
+    e.g. #{$0} 00000000-0000-0000-0000-000000000000 google
+
+    This script requires:
+    - uaac to be installed
+    - a valid uaac token
+    - the uaac target is set up correctly
+
+    Set the UAA target with uaac target:
+
+    > uaac target https://uaa.cloud.service.gov.uk
+
+    You can get a token with the following command
+
+    > uaac token client get admin -s <uaa-admin-token>
+
+    Where <uaa-admin-token> can be retrieved with make prod showenv
+  USAGE
+end
+
+user_guid, desired_origin = ARGV[0, 2]
+
+abort usage if desired_origin.nil? || user_guid.nil?
+abort usage unless user_guid.match?(/^\h{8}-\h{4}-\h{4}-\h{4}-\h{12}$/)
+
+resp = `uaac curl '/Users/#{user_guid}' | awk '/RESPONSE BODY/,0'`
+user = JSON.parse(resp.lines.map(&:chomp).drop(1).join(' '))
+
+puts 'Current user:'
+pp user
+
+user = user.keep_if { |k, _| %w[userName name emails].include?(k) }
+user = user.update('origin': desired_origin)
+
+
+command = <<~COMMAND.lines.map(&:chomp).join(' ')
+  uaac curl '/Users/#{user_guid}'
+  -X PUT
+  -H 'If-Match: *'
+  -H 'Content-Type: application/json'
+  -H 'Accept: application/json'
+  -d '#{user.to_json}'
+COMMAND
+
+puts "Updating user: #{user_guid} with origin #{desired_origin}"
+puts `#{command}`
+abort unless $?.success?
+
+resp = `uaac curl '/Users/#{user_guid}' | awk '/RESPONSE BODY/,0'`
+user = JSON.parse(resp.lines.map(&:chomp).drop(1).join(' '))
+
+puts 'Updated user:'
+pp user


### PR DESCRIPTION
What
----

- Shows UAA admin token in `showenv` `make` task
- Adds a script to change the origin of a user (this will be documented in the team manual)

How to review
-------------

Code review

Attempt to change the origin of a user (in a dev env)

Who can review
--------------

Not @tlwr
