### PR TITLE
Switch to using "candidate" stemcell

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1181,7 +1181,7 @@ jobs:
                     STEMCELL_VERSION=$($VAL_FROM_YAML "stemcells.${stemcell_index}.version" cf-manifest/cf-manifest.yml)
                     STEMCELL_OS=$($VAL_FROM_YAML "stemcells.${stemcell_index}.os" cf-manifest/cf-manifest.yml)
 
-                    wget "https://bosh.io/d/stemcells/bosh-aws-xen-hvm-${STEMCELL_OS}-go_agent?v=${STEMCELL_VERSION}" -O stemcell.tgz
+                    wget "https://s3.amazonaws.com/bosh-core-stemcells-candidate/aws/bosh-stemcell-${STEMCELL_VERSION}-aws-xen-hvm-${STEMCELL_OS}-go_agent.tgz" -O stemcell.tgz
 
                     bosh -n upload-stemcell stemcell.tgz
 

--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-xenial
-      version: "170.51"
+      version: "170.68"


### PR DESCRIPTION
What
----

bosh haven't released an official stemcell that patches the recent Intel
CPU vulnerabilities yet.

This commit switches to using one of their "candidate" stemcell releases
(from [this commit](https://github.com/bosh-io/stemcells-core-index/commit/ef0d9d9c281cb072d238ad9fa5b6814ae631fd96) ).
This won't have had the benefit of whatever testing upstream usually do
before releasing stemcells, but it does have the linux kernel update we
need to mitigate the CVEs.

Also note this is a "heavy" stemcell, rather than the usual "light"
stemcell we use (this means it includes the machine image, rather than
using an AMI that's already been pushed to AWS).

How to review
-------------

* Code review
* Confirm it ran down a dev env successfully (see https://deployer.leeporte.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/resources/pipeline-trigger 0.0.4)

Who can review
--------------

Richard and Toby have paired on it, so probably Toby.