### PR TITLE
[#165965445] Ensure billing-db created as "medium" in prod-lon

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2907,10 +2907,7 @@ jobs:
               - -c
               - |
                 BILLING_DB_PLAN="tiny-unencrypted-9.5"
-                if [ "${DEPLOY_ENV}" = "prod" ]; then
-                  BILLING_DB_PLAN="medium-9.5"
-                fi
-                if [ "${DEPLOY_ENV}" = "stg-lon" ]; then
+                if [ "${DEPLOY_ENV}" = "prod" ] || [ "${DEPLOY_ENV}" = "prod-lon" ] || [ "${DEPLOY_ENV}" = "stg-lon" ]; then
                   BILLING_DB_PLAN="medium-9.5"
                 fi
 


### PR DESCRIPTION
What
----

This won't actually have any effect, because the BILLING_DB_PLAN
variable is only used when creating new databases - we don't try and
update the plans once the DBs are there.

In actual fact the prod and prod-lon databases are on
medium-unencrypted-9.5, not medium-9.5, so ¯\_(ツ)_/¯

How to review
-------------

* Code review is enough

Who can review
--------------

Not Rich