### PR TITLE
Update to 170.69 Stemcell

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1181,7 +1181,7 @@ jobs:
                     STEMCELL_VERSION=$($VAL_FROM_YAML "stemcells.${stemcell_index}.version" cf-manifest/cf-manifest.yml)
                     STEMCELL_OS=$($VAL_FROM_YAML "stemcells.${stemcell_index}.os" cf-manifest/cf-manifest.yml)
 
-                    wget "https://s3.amazonaws.com/bosh-core-stemcells-candidate/aws/bosh-stemcell-${STEMCELL_VERSION}-aws-xen-hvm-${STEMCELL_OS}-go_agent.tgz" -O stemcell.tgz
+                    wget "https://bosh.io/d/stemcells/bosh-aws-xen-hvm-${STEMCELL_OS}-go_agent?v=${STEMCELL_VERSION}" -O stemcell.tgz
 
                     bosh -n upload-stemcell stemcell.tgz
 

--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-xenial
-      version: "170.68"
+      version: "170.69"


### PR DESCRIPTION
What
----

The candidate stemcell we were using was 170.68, but 170.69 is the
"officially supported" version, so lets use that instead

How to review
-------------

Code review

Look at [tlwr](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/resources/paas-cf) at resource version `5bff0df5584c5a3999778bea9aff95a4ed459bf9 ` and see it has passed the tests.

Who can review
--------------

Not @tlwr
