### PR TITLE
Clarify alert when multiple Stemcells are in-use

### DIFF
--- a/manifests/prometheus/alerts.d/bosh-stemcells-not-in-sync.yml
+++ b/manifests/prometheus/alerts.d/bosh-stemcells-not-in-sync.yml
@@ -13,4 +13,4 @@
           severity: warning
         annotations:
           summary: "Bosh deployment stemcell versions are not in sync"
-          description: "The three bosh deployments should have the same stemcell version, if this alert fires either deploys are taking a long time or paas-bootstrap and paas-cf are not in sync"
+          description: "The three bosh deployments should have the same stemcell version. If this alert fires then either deploys are taking a long time or the most recent deploys of paas-bootstrap and paas-cf specified different stemcell versions"


### PR DESCRIPTION
What
----

We recently added an alert to warn us when more than one BOSH Stemcell version is in use. This alert is helpful because it is easy to forget that Stemcell upgrades must be performed in both https://github.com/alphagov/paas-bootstrap and https://github.com/alphagov/paas-cf.
 
The alert went off for the first time to warn of this problem, but the `paas-bootstrap and paas-cf are not in sync` description may not have been specific enough to explain the problem. This commit clarifies the message further to make the alert more effective.

How to review
-------------

Code review.

Who can review
--------------

Not @46bit 