### PR TITLE
Refactor metric tags to a slice of structs

### DIFF
--- a/tools/metrics/gauges_cf.go
+++ b/tools/metrics/gauges_cf.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
-	cfclient "github.com/cloudfoundry-community/go-cfclient"
+	"github.com/cloudfoundry-community/go-cfclient"
 )
 
 func QuotaGauge(c *Client, interval time.Duration) MetricReadCloser {
@@ -178,9 +178,9 @@ func AppCountGauge(c *Client, interval time.Duration) MetricReadCloser {
 					Time:  time.Now(),
 					Name:  "op.apps.count",
 					Value: float64(count),
-					Tags: []string{
-						"state:" + state,
-						fmt.Sprintf("trial_org:%t", orgIsTrial),
+					Tags: MetricTags{
+						{Label: "state", Value: state},
+						{Label: "trial_org", Value: strconv.FormatBool(orgIsTrial)},
 					},
 					Unit: "count",
 				})
@@ -276,10 +276,10 @@ func ServiceCountGauge(c *Client, interval time.Duration) MetricReadCloser {
 						Time:  time.Now(),
 						Name:  "op.services.provisioned",
 						Value: float64(count),
-						Tags: []string{
-							"type:" + serviceLabel,
-							fmt.Sprintf("trial_org:%t", orgIsTrial),
-							fmt.Sprintf("free_service:%t", servicePlanIsFree),
+						Tags: MetricTags{
+							{Label: "type", Value: serviceLabel},
+							{Label: "trial_org", Value: strconv.FormatBool(orgIsTrial)},
+							{Label: "free_service", Value: strconv.FormatBool(servicePlanIsFree)},
 						},
 						Unit: "count",
 					})
@@ -315,7 +315,7 @@ func OrgCountGauge(c *Client, interval time.Duration) MetricReadCloser {
 				Time:  time.Now(),
 				Name:  "op.orgs.count",
 				Value: float64(count),
-				Tags:  []string{"quota:" + name},
+				Tags:  MetricTags{{Label: "quota", Value: name}},
 				Unit:  "count",
 			})
 		}

--- a/tools/metrics/gauges_custom_domain_cdn_metrics.go
+++ b/tools/metrics/gauges_custom_domain_cdn_metrics.go
@@ -125,9 +125,9 @@ func getMetricsForDistribution(id string, cloudWatch CloudWatchService, logger l
 	return metrics, nil
 }
 
-func metricLabels(id string) []string {
-	return []string{
-		fmt.Sprintf("distribution_id:%s", id),
+func metricLabels(id string) MetricTags {
+	return MetricTags{
+		{ Label: "distribution_id", Value: id },
 	}
 }
 

--- a/tools/metrics/gauges_custom_domain_cdn_metrics_test.go
+++ b/tools/metrics/gauges_custom_domain_cdn_metrics_test.go
@@ -2,7 +2,6 @@ package main_test
 
 import (
 	"code.cloudfoundry.org/lager"
-	"fmt"
 	"github.com/alphagov/paas-cf/tools/metrics/fakes"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
@@ -198,7 +197,7 @@ var _ = Describe("GaugesCustomDomainCDNMetrics", func() {
 				return len(metrics)
 			}, 3*time.Second).Should(BeNumerically(">=", 6))
 
-			expected := fmt.Sprintf("distribution_id:%s", "dist-1")
+			expected := MetricTag{ Label: "distribution_id", Value: "dist-1"}
 			Expect(metrics[0].Tags).To(ContainElement(expected))
 			Expect(metrics[1].Tags).To(ContainElement(expected))
 			Expect(metrics[2].Tags).To(ContainElement(expected))

--- a/tools/metrics/gauges_tls.go
+++ b/tools/metrics/gauges_tls.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"crypto/tls"
-	"fmt"
 	"net"
 	"strings"
 	"time"
@@ -35,8 +34,8 @@ func TLSValidityGauge(logger lager.Logger, certChecker tlscheck.CertChecker, add
 			Time:  time.Now(),
 			Name:  "tls.certificates.validity",
 			Value: daysUntilExpiry,
-			Tags: []string{
-				fmt.Sprintf("hostname:%s", host),
+			Tags: MetricTags{
+				{ Label: "hostname", Value: host },
 			},
 			Unit: "days",
 		}
@@ -73,8 +72,8 @@ func CDNTLSValidityGauge(logger lager.Logger, certChecker tlscheck.CertChecker, 
 					Time:  time.Now(),
 					Name:  "cdn.tls.certificates.expiry",
 					Value: daysUntilExpiry,
-					Tags: []string{
-						fmt.Sprintf("hostname:%s", customDomain.AliasDomain),
+					Tags: MetricTags{
+						{ Label:"hostname", Value: customDomain.AliasDomain },
 					},
 					Unit: "days",
 				})
@@ -85,8 +84,8 @@ func CDNTLSValidityGauge(logger lager.Logger, certChecker tlscheck.CertChecker, 
 				Time:  time.Now(),
 				Name:  "cdn.tls.certificates.validity",
 				Value: float64(validity),
-				Tags: []string{
-					fmt.Sprintf("hostname:%s", customDomain.AliasDomain),
+				Tags: MetricTags{
+					{ Label: "hostname", Value: customDomain.AliasDomain },
 				},
 				Unit: "",
 			})

--- a/tools/metrics/gauges_tls_test.go
+++ b/tools/metrics/gauges_tls_test.go
@@ -22,9 +22,10 @@ func ExpectMetric(metric Metric, name string, value int, host string) {
 	Expect(metric.Name).To(Equal(name))
 	Expect(metric.Value).To(Equal(float64(value)))
 	Expect(metric.Kind).To(Equal(Gauge))
-	Expect(metric.Tags).To(Equal([]string{
-		fmt.Sprintf("hostname:" + host),
-	}))
+
+
+	expectedTag := MetricTag { Label: "hostname", Value: host }
+	Expect(metric.Tags).To(ContainElement(expectedTag))
 }
 
 var _ = Describe("TLS gauges", func() {
@@ -161,9 +162,9 @@ var _ = Describe("TLS gauges", func() {
 					return err
 				}, 3*time.Second).ShouldNot(HaveOccurred())
 				Expect(metric.Value).To(Equal(float64(123)))
-				Expect(metric.Tags).To(Equal([]string{
-					fmt.Sprintf("hostname:somedomain.com"),
-				}))
+
+				expectedTag := MetricTag{ Label: "hostname", Value: "somedomain.com"}
+				Expect(metric.Tags).To(ContainElement(expectedTag))
 			})
 		})
 

--- a/tools/metrics/metrics.go
+++ b/tools/metrics/metrics.go
@@ -37,13 +37,32 @@ type MetricReadCloser interface {
 	MetricCloser
 }
 
+type MetricTags []MetricTag
+type MetricTag struct {
+	Label string
+	Value string
+}
+
+func (t MetricTag) String() string {
+	return fmt.Sprintf("%s:%s", t.Label, t.Value)
+}
+
+func (ts MetricTags) String() string {
+	var strs []string
+	for _, t := range ts {
+		strs = append(strs, t.String())
+	}
+
+	return strings.Join(strs, ",")
+}
+
 type Metric struct {
 	ID    string
 	Kind  eventKind
 	Name  string
 	Time  time.Time
 	Value float64
-	Tags  []string
+	Tags  MetricTags
 	Unit  string
 }
 
@@ -56,7 +75,7 @@ func (m Metric) String() string {
 		m.Name,
 		m.Value,
 		m.Unit,
-		strings.Join(m.Tags, ","),
+		m.Tags.String(),
 	)
 }
 

--- a/tools/metrics/prometheus_reporter.go
+++ b/tools/metrics/prometheus_reporter.go
@@ -30,10 +30,10 @@ func (p *PrometheusReporter) WriteMetrics(events []Metric) error {
 		labels := prometheus.Labels{}
 		labelNames := make([]string, len(event.Tags))
 		for i, tag := range event.Tags {
-			tagParts := strings.SplitN(tag, ":", 2)
-			labelNames[i] = tagParts[0]
-			labels[tagParts[0]] = tagParts[1]
+			labelNames[i] = tag.Label
+			labels[tag.Label] = tag.Value
 		}
+
 
 		metricName := strings.Replace(event.Name, ".", "_", -1)
 

--- a/tools/metrics/prometheus_reporter_test.go
+++ b/tools/metrics/prometheus_reporter_test.go
@@ -72,7 +72,10 @@ var _ = Describe("PrometheusReporter", func() {
 					Value: 12.34,
 					Time:  time.Now(),
 					Unit:  "count",
-					Tags:  []string{"foo:bar", "bar:baz"},
+					Tags: MetricTags{
+						{Label: "foo", Value: "bar"},
+						{Label: "bar", Value: "baz"},
+					},
 				},
 			}
 		})
@@ -104,7 +107,10 @@ var _ = Describe("PrometheusReporter", func() {
 					Value: 12.34,
 					Time:  time.Now(),
 					Unit:  "count",
-					Tags:  []string{"foo:bar", "bar:baz"},
+					Tags: MetricTags{
+						{Label: "foo", Value: "bar"},
+						{Label: "bar", Value: "baz"},
+					},
 				},
 			}
 		})


### PR DESCRIPTION
What
----
Applying the boy scout rule. This was a problem hit during an earlier story, with an easy fix.

Previously, metric tags were a slice of strings, which were required to be "key:value" pairs. This wasn't clear from the interface alone, and was only obvious on seeing the error message in the prometheus reporter (which made the assumption about string format). In this commit, I refactored the tags to be a slice of the `MetricTag` struct, and added some stringer methods. This should make the interface clearer, and this particular error avoidable in future.

How to review
-------------
Code review
`cf push` to a dev env and check the metrics are the same as before.

Who can review
--------------
Anyone