### PR TITLE
Introduce deploy_env specific user accounts, and always create users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ dev: globals ## Set Environment to DEV
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
 	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipelineapps.digital)
 	$(eval export ALERT_EMAIL_ADDRESS?=govpaas-alerting-dev@digital.cabinet-office.gov.uk)
-	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS=${ALERT_EMAIL_ADDRESS})
+	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS?=the-multi-cloud-paas-team+dev@digital.cabinet-office.gov.uk)
 	$(eval export ENABLE_ALERT_NOTIFICATIONS ?= false)
 	$(eval export SKIP_COMMIT_VERIFICATION=true)
 	$(eval export ENV_SPECIFIC_BOSH_VARS_FILE=default.yml)

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ dev: globals ## Set Environment to DEV
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
 	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipelineapps.digital)
 	$(eval export ALERT_EMAIL_ADDRESS?=govpaas-alerting-dev@digital.cabinet-office.gov.uk)
+	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS=${ALERT_EMAIL_ADDRESS})
 	$(eval export ENABLE_ALERT_NOTIFICATIONS ?= false)
 	$(eval export SKIP_COMMIT_VERIFICATION=true)
 	$(eval export ENV_SPECIFIC_BOSH_VARS_FILE=default.yml)

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1085,7 +1085,6 @@ jobs:
               - name: cf-vars-store-updated
             params:
               ENV_SPECIFIC_BOSH_VARS_FILE: paas-cf/manifests/cf-manifest/env-specific/((env_specific_bosh_vars_file))
-              DISABLE_USER_CREATION: ((disable_user_creation))
               SLIM_DEV_DEPLOYMENT: ((slim_dev_deployment))
             run:
               path: sh
@@ -1995,7 +1994,6 @@ jobs:
             - name: cf-vars-store
             - name: cf-manifest
           params:
-            DISABLE_USER_CREATION: ((disable_user_creation))
             DEPLOY_ENV: ((deploy_env))
           run:
             path: sh
@@ -2003,8 +2001,6 @@ jobs:
               - -e
               - -c
               - |
-                ${DISABLE_USER_CREATION} && echo "WARNING: Admin user creation disabled in this environment!" && exit 0
-
                 . ./config/config.sh
 
                 VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1996,6 +1996,7 @@ jobs:
             - name: cf-manifest
           params:
             DISABLE_USER_CREATION: ((disable_user_creation))
+            DEPLOY_ENV: ((deploy_env))
           run:
             path: sh
             args:
@@ -2011,7 +2012,7 @@ jobs:
                 CF_ADMIN_PASSWORD=$($VAL_FROM_YAML cf_admin_password cf-vars-store/cf-vars-store.yml)
                 cd paas-cf/scripts
                 bundle
-                bundle exec sync-admin-users.rb "${API_ENDPOINT}" ../config/admin_users.yml "((NEW_ACCOUNT_EMAIL_ADDRESS))"
+                bundle exec sync-admin-users.rb "${API_ENDPOINT}" ../config/admin_users.yml "((NEW_ACCOUNT_EMAIL_ADDRESS))" "${DEPLOY_ENV}"
 
       - task: deploy-healthcheck
         tags: [colocated-with-web]

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -137,7 +137,6 @@ oauth_client_secret: "${oauth_client_secret:-}"
 notify_api_key: ${notify_api_key:-}
 auto_deploy: $([ "${ENABLE_AUTO_DEPLOY:-}" ] && echo "true" || echo "false")
 persistent_environment: ${PERSISTENT_ENVIRONMENT}
-disable_user_creation: $([ "${NEW_ACCOUNT_EMAIL_ADDRESS:-}" ] && echo "false" || echo "true")
 slim_dev_deployment: ${SLIM_DEV_DEPLOYMENT:-}
 monitored_state_bucket: ${MONITORED_STATE_BUCKET:-}
 monitored_aws_region: ${MONITORED_AWS_REGION:-}

--- a/config/admin_users.yml
+++ b/config/admin_users.yml
@@ -1,4 +1,8 @@
 ---
+- email: "andy.hunt@digital.cabinet-office.gov.uk"
+  origin: "google"
+  deploy_envs: ['andyhunt']
+
 - email: "chris.farmiloe@digital.cabinet-office.gov.uk"
   origin: "google"
   deploy_envs: ['prod', 'prod-lon', 'stg-lon']
@@ -10,6 +14,10 @@
 - email: "michael.mokrysz@digital.cabinet-office.gov.uk"
   origin: "google"
   deploy_envs: ['prod', 'prod-lon', 'stg-lon', 'miki']
+
+- email: "mohamed.deerow@digital.cabinet-office.gov.uk"
+  origin: "google"
+  deploy_envs: ['modeerow']
 
 - email: "rafal.proszowski@digital.cabinet-office.gov.uk"
   origin: "google"

--- a/config/admin_users.yml
+++ b/config/admin_users.yml
@@ -1,19 +1,36 @@
 ---
 - email: "chris.farmiloe@digital.cabinet-office.gov.uk"
   origin: "google"
+  deploy_envs: ['prod', 'prod-lon', 'stg-lon']
+
 - email: "lee.porte@digital.cabinet-office.gov.uk"
   origin: "google"
+  deploy_envs: ['prod', 'prod-lon', 'stg-lon', 'leeporte']
+
 - email: "michael.mokrysz@digital.cabinet-office.gov.uk"
   origin: "google"
+  deploy_envs: ['prod', 'prod-lon', 'stg-lon', 'miki']
+
 - email: "rafal.proszowski@digital.cabinet-office.gov.uk"
   origin: "google"
+  deploy_envs: ['prod', 'prod-lon', 'stg-lon']
+
 - email: "richard.towers@digital.cabinet-office.gov.uk"
   origin: "google"
+  deploy_envs: ['prod', 'prod-lon', 'stg-lon', 'towers']
+
 - email: "russell.howe@digital.cabinet-office.gov.uk"
   origin: "google"
+  deploy_envs: ['prod', 'prod-lon', 'stg-lon']
+
 - email: "sam.crang@digital.cabinet-office.gov.uk"
   origin: "google"
+  deploy_envs: ['prod', 'prod-lon', 'stg-lon']
+
 - email: "tom.whitwell@digital.cabinet-office.gov.uk"
   origin: "google"
+  deploy_envs: ['prod', 'prod-lon', 'stg-lon', 'tnw']
+
 - email: "toby.lornewelch-richards@digital.cabinet-office.gov.uk"
   origin: "google"
+  deploy_envs: ['prod', 'prod-lon', 'stg-lon', 'tlwr']

--- a/manifests/cf-manifest/scripts/generate-manifest.sh
+++ b/manifests/cf-manifest/scripts/generate-manifest.sh
@@ -16,10 +16,6 @@ for i in "${PAAS_CF_DIR}"/manifests/cf-manifest/operations.d/*.yml; do
   opsfile_args="$opsfile_args -o $i"
 done
 
-if [ "${DISABLE_USER_CREATION}" = "false" ] ; then
-  opsfile_args="$opsfile_args -o ${PAAS_CF_DIR}/manifests/cf-manifest/operations/uaa-add-google-oauth.yml"
-fi
-
 if [ "${SLIM_DEV_DEPLOYMENT-}" = "true" ]; then
   opsfile_args="$opsfile_args -o ${PAAS_CF_DIR}/manifests/cf-manifest/operations/scale-down-dev.yml"
 fi
@@ -44,6 +40,7 @@ bosh interpolate \
   --vars-file="${ENV_SPECIFIC_BOSH_VARS_FILE}" \
   --vars-file="${WORKDIR}/environment-variables.yml" \
   ${opsfile_args} \
+  --ops-file="${PAAS_CF_DIR}/manifests/cf-manifest/operations/uaa-add-google-oauth.yml" \
   --ops-file="${WORKDIR}/vpc-peering-opsfile/vpc-peers.yml" \
   ${vars_store_args} \
   "${CF_DEPLOYMENT_DIR}/cf-deployment.yml"

--- a/manifests/cf-manifest/spec/manifest/oauth_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/oauth_spec.rb
@@ -1,15 +1,8 @@
 RSpec.describe "Google OAuth" do
   let(:properties) { manifest.fetch("instance_groups.uaa.jobs.uaa.properties") }
 
-  describe "when user creation is not enabled" do
+  describe "by default" do
     let(:manifest) { manifest_with_defaults }
-    it "enables the Google OAuth provider in UAA" do
-      expect(properties.fetch('login')).to_not have_key 'oauth'
-    end
-  end
-
-  describe "when user creation is enabled" do
-    let(:manifest) { manifest_with_enable_user_creation }
     it "enables the Google OAuth provider in UAA" do
       providers = properties.fetch("login").fetch("oauth").fetch("providers")
       expect(providers).to have_key 'google'

--- a/manifests/cf-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/cf-manifest/spec/support/manifest_helpers.rb
@@ -29,12 +29,6 @@ module ManifestHelpers
     )
   end
 
-  def manifest_with_enable_user_creation
-    render_manifest_with_vars_store(
-      environment: "default",
-    )
-  end
-
   def manifest_for_env(deploy_env)
     Cache.instance["manifest_for_env_#{deploy_env}"] ||= render_manifest(
       environment: deploy_env,

--- a/manifests/cf-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/cf-manifest/spec/support/manifest_helpers.rb
@@ -12,7 +12,6 @@ module ManifestHelpers
     Cache.instance[:manifest_without_vars_store] ||= \
       render_manifest(
         environment: "default",
-        disable_user_creation: "true",
       )
   end
 
@@ -20,14 +19,12 @@ module ManifestHelpers
     Cache.instance[:manifest_with_defaults] ||= \
       render_manifest_with_vars_store(
         environment: "default",
-        disable_user_creation: "true",
       )
   end
 
   def manifest_with_custom_vars_store(vars_store_content)
     render_manifest_with_vars_store(
       environment: "default",
-      disable_user_creation: "true",
       custom_vars_store_content: vars_store_content,
     )
   end
@@ -35,14 +32,12 @@ module ManifestHelpers
   def manifest_with_enable_user_creation
     render_manifest_with_vars_store(
       environment: "default",
-      disable_user_creation: "false",
     )
   end
 
   def manifest_for_env(deploy_env)
     Cache.instance["manifest_for_env_#{deploy_env}"] ||= render_manifest(
       environment: deploy_env,
-      disable_user_creation: "true",
       vars_store_file: nil,
       env_specific_bosh_vars_file: "#{deploy_env}.yml",
     )
@@ -51,7 +46,6 @@ module ManifestHelpers
   def manifest_for_dev
     render_manifest(
       environment: "dev",
-      disable_user_creation: "true",
     )
   end
 
@@ -94,7 +88,6 @@ private
 
   def render_manifest(
     environment:,
-    disable_user_creation:,
     vars_store_file: nil,
     env_specific_bosh_vars_file: "default.yml"
   )
@@ -111,8 +104,7 @@ private
     env = {
       'PAAS_CF_DIR' => root.to_s,
       'WORKDIR' => workdir,
-      'ENV_SPECIFIC_BOSH_VARS_FILE' => root.join("manifests/cf-manifest/env-specific/#{env_specific_bosh_vars_file}").to_s,
-      'DISABLE_USER_CREATION' => disable_user_creation
+      'ENV_SPECIFIC_BOSH_VARS_FILE' => root.join("manifests/cf-manifest/env-specific/#{env_specific_bosh_vars_file}").to_s
     }
 
     if vars_store_file
@@ -130,7 +122,6 @@ private
 
   def render_manifest_with_vars_store(
     environment:,
-    disable_user_creation:,
     custom_vars_store_content: nil,
     env_specific_bosh_vars_file: "default.yml"
   )
@@ -140,7 +131,6 @@ private
 
       output = render_manifest(
         environment: environment,
-        disable_user_creation: disable_user_creation,
         vars_store_file: vars_store_tempfile.path,
         env_specific_bosh_vars_file: env_specific_bosh_vars_file,
       )


### PR DESCRIPTION
What
----

We are using single sign on everywhere, so we should use it

This PR allows us to only create user accounts for individual users, depending on environment, and enables user account creation everywhere, as we want it enabled always.

How to review
-------------

Run this branch down your pipeline, and google oauth yourself into admin

Who can review
--------------

Not @tlwr
