### PR TITLE
[#166056703] Remove certs that are no longer required

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1108,6 +1108,30 @@ jobs:
                   tar -xzf ./ipsec-CA/ipsec-CA.tar.gz -C ./ipsec-CA
                   cp cf-vars-store/cf-vars-store.yml cf-vars-store-updated/
 
+                  # FIXME: This remove the old certs that are no longer in use.
+                  # These were overlooked in previous commits.
+                  # These keys should be removed after the first deployment
+                  # of this code.
+                  ruby -ryaml -e '
+
+                  list_secrets_to_remove = %w{
+                   consul_agent
+                   consul_agent_ca
+                   consul_agent_ca_old
+                   consul_server
+                   consul_encrypt_key
+                   log_cache_tls_cc_auth_proxy
+                   loggregator_tls_metron
+                  }
+
+                  existing_vars = YAML.load_file("cf-vars-store/cf-vars-store.yml")
+
+                  existing_vars = existing_vars.delete_if { |k, | list_secrets_to_remove.include? k } if existing_vars
+                  puts existing_vars.to_yaml
+                  File.write("cf-vars-store-updated/cf-vars-store.yml", existing_vars.to_yaml)
+                  '
+                  sed -i '/---/d' cf-vars-store-updated/cf-vars-store.yml
+
                   VARS_STORE=cf-vars-store-updated/cf-vars-store.yml \
                     ./paas-cf/manifests/cf-manifest/scripts/generate-manifest.sh \
                       > cf-manifest/cf-manifest.yml


### PR DESCRIPTION
What
----

We have several certs in the pipeline that are no longer required, these include the Consul certs, which were left unused after https://github.com/alphagov/paas-cf/commit/7fbe371cfe4fe04fc54213b320d95d7fb27e6809 was merged. And, metron related certs that are no longer required due to changes in the loggregator sub-system.

This commit will remove these certs from the vars store and enable our cert checking tests to pass again. The test has been failing as these carts are no longer part of the cert rotation job and have been left in the vars store.

How to review
-------------

code review

download one of the prod cf-vars-store-yaml and modify the paths in the script and run it locally. then verify that the certs have gone in the cf-vars-store-updated.yml

Who can review
--------------

Anyone with prod access.
