### PR TITLE
Show DNS Resolution times on User Impact dashboard

### DIFF
--- a/manifests/prometheus/dashboards.d/user-impact.json
+++ b/manifests/prometheus/dashboards.d/user-impact.json
@@ -16,7 +16,8 @@
         "graphTooltip": 0,
         "id": null,
         "links": [],
-        "panels": [{
+        "panels": [
+            {
                 "aliasColors": {},
                 "bars": false,
                 "dashLength": 10,

--- a/manifests/prometheus/dashboards.d/user-impact.json
+++ b/manifests/prometheus/dashboards.d/user-impact.json
@@ -412,7 +412,7 @@
                 "fill": 0,
                 "gridPos": {
                     "h": 8,
-                    "w": 12,
+                    "w": 6,
                     "x": 0,
                     "y": 16
                 },
@@ -499,6 +499,97 @@
                     "alignLevel": null
                 },
                 "timeRegions": []
+            },
+            {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "description": "",
+                "fill": 1,
+                "gridPos": {
+                    "h": 8,
+                    "w": 6,
+                    "x": 6,
+                    "y": 16
+                },
+                "id": 16,
+                "legend": {
+                    "alignAsTable": false,
+                    "avg": false,
+                    "current": false,
+                    "hideEmpty": false,
+                    "hideZero": false,
+                    "max": false,
+                    "min": false,
+                    "rightSide": false,
+                    "show": false,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 2,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                    {
+                        "expr": "avg_over_time(dns_resolution_probe_duration_seconds[10m])",
+                        "format": "time_series",
+                        "instant": false,
+                        "interval": "",
+                        "intervalFactor": 1,
+                        "legendFormat": "{{address}}",
+                        "refId": "A"
+                    }
+                ],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeRegions": [],
+                "timeShift": null,
+                "title": "DNS Resolution performance (seconds)",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 2,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                },
+                "yaxes": [
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ],
+                "yaxis": {
+                    "align": false,
+                    "alignLevel": null
+                }
             },
             {
                 "aliasColors": {},
@@ -735,7 +826,7 @@
             }
         ],
         "refresh": "5s",
-        "schemaVersion": 16,
+        "schemaVersion": 18,
         "style": "dark",
         "tags": [],
         "templating": {


### PR DESCRIPTION
What
----

In an incident on 2019-05-20, we took awhile to realise that network problems on one of the VMs running Cloud Controller was the cause of elevated API error rates. We have seen this problem before. As this is a repeated and open issue it is definitely worth trying to improve our response next time.

This commit adds DNS Resolution times to the User Impact dashboard. It is highly visible in the team area and commonly looked at out-of-hours to know if there is a problem. Despite the name, the User Impact dashboard is not directly about user-facing problems.

The JSON is copied from manually editing this dashboard in `prod-lon`.

How to review
-------------

Here's what I'd have seen during Monday night's incident with this change applied. I think the DNS Resolution graph strongly attracts attention here:

<img width="1687" alt="Screen Shot 2019-05-22 at 14 59 49" src="https://user-images.githubusercontent.com/163111/58182562-bb940980-7ca5-11e9-9e25-bae606374f1b.png">

The new graph is inherently spiky. Here's `prod-lon` right now:

<img width="430" alt="Screen Shot 2019-05-22 at 15 25 17" src="https://user-images.githubusercontent.com/163111/58182594-cd75ac80-7ca5-11e9-8806-4fc8b3f4389e.png">

Real problems do stand out, though:

<img width="432" alt="Screen Shot 2019-05-22 at 14 59 56" src="https://user-images.githubusercontent.com/163111/58182611-d6ff1480-7ca5-11e9-9ac0-fbcb8dd03c4d.png">

Ideas very welcome on improvements.

Who can review
--------------

Not @46bit.