### PR TITLE
[#166056703] Remove the cert cleanup code

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1108,29 +1108,6 @@ jobs:
                   tar -xzf ./ipsec-CA/ipsec-CA.tar.gz -C ./ipsec-CA
                   cp cf-vars-store/cf-vars-store.yml cf-vars-store-updated/
 
-                  # FIXME: This remove the old certs that are no longer in use.
-                  # These were overlooked in previous commits.
-                  # These keys should be removed after the first deployment
-                  # of this code.
-                  ruby -ryaml -e '
-
-                  list_secrets_to_remove = %w{
-                   consul_agent
-                   consul_agent_ca
-                   consul_agent_ca_old
-                   consul_server
-                   consul_encrypt_key
-                   loggregator_tls_metron
-                   log_cache_tls_cc_auth_proxy
-                  }
-
-                  existing_vars = YAML.load_file("cf-vars-store/cf-vars-store.yml")
-
-                  existing_vars = existing_vars.delete_if { |k, | list_secrets_to_remove.include? k } if existing_vars
-                  puts existing_vars.to_yaml
-                  File.write("cf-vars-store-updated/cf-vars-store.yml", existing_vars.to_yaml)
-                  '
-
                   VARS_STORE=cf-vars-store-updated/cf-vars-store.yml \
                     ./paas-cf/manifests/cf-manifest/scripts/generate-manifest.sh \
                       > cf-manifest/cf-manifest.yml


### PR DESCRIPTION
What
----

These certs have been removed from `cf-vars-store.yml` and as a result this code is no longer required.

Once this has been merged and deployed we can forget about it as it is removing the code to remove the obsolete certificates from the vars store.

How to review
-------------

Code review

Who can review
--------------

Anyone
