### PR TITLE
[#166027792] Grant the `scim.write` authority to paas-admin UAA client

### DIFF
--- a/manifests/cf-manifest/operations.d/200-paas-admin-uaa-client.yml
+++ b/manifests/cf-manifest/operations.d/200-paas-admin-uaa-client.yml
@@ -6,7 +6,7 @@
     autoapprove: true
     secret: "((uaa_clients_paas_admin_secret))"
     scope: cloud_controller.read,cloud_controller.admin_read_only,cloud_controller.global_auditor,cloud_controller.write,scim.me,openid,profile,uaa.user,cloud_controller.admincloud_controller.read,cloud_controller.admin_read_only,cloud_controller.global_auditor,cloud_controller.write,scim.me,openid,profile,uaa.user,cloud_controller.admin
-    authorities: scim.userids,scim.invite,scim.read
+    authorities: scim.userids,scim.invite,scim.read,scim.write
     redirect-uri: "https://admin.((system_domain))/auth/login/callback"
 
 - type: replace


### PR DESCRIPTION
What
----
As per the UAA API documentation [1], the `scim.write` authority is required
for clients to update or patch users. This commit grants that authority to the
paas-admin UAA client.

[1] https://docs.cloudfoundry.org/api/uaa/version/4.31.0/index.html#patch

How to review
-------------

Code review
See the docs and double check paas-admin has all the authorities granted that it needs to be able to modify a user's origin

Who can review
--------------
Anyone
