### PR TITLE
[#166028209] Scaffolding for Microsoft IDP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,7 @@ showenv: check-env ## Display environment information
 	@scripts/show-vars-store-secrets.sh prometheus-vars-store alertmanager_password grafana_password grafana_mon_password prometheus_password
 
 .PHONY: upload-all-secrets
-upload-all-secrets: upload-google-oauth-secrets upload-notify-secrets upload-aiven-secrets upload-logit-secrets upload-pagerduty-secrets
+upload-all-secrets: upload-google-oauth-secrets upload-microsoft-oauth-secrets upload-notify-secrets upload-aiven-secrets upload-logit-secrets upload-pagerduty-secrets
 
 .PHONY: upload-google-oauth-secrets
 upload-google-oauth-secrets: check-env ## Decrypt and upload Google Admin Console credentials to S3
@@ -248,6 +248,14 @@ upload-google-oauth-secrets: check-env ## Decrypt and upload Google Admin Consol
 	$(if ${OAUTH_PASSWORD_STORE_DIR},,$(error Must pass OAUTH_PASSWORD_STORE_DIR=<path_to_password_store>))
 	$(if $(wildcard ${OAUTH_PASSWORD_STORE_DIR}),,$(error Password store ${OAUTH_PASSWORD_STORE_DIR} does not exist))
 	@scripts/upload-google-oauth-secrets.sh
+
+.PHONY: upload-microsoft-oauth-secrets
+upload-microsoft-oauth-secrets: check-env ## Decrypt and upload Microsoft Identity credentials to S3
+	$(eval export OAUTH_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
+	$(if ${MAKEFILE_ENV_TARGET},,$(error Must set MAKEFILE_ENV_TARGET))
+	$(if ${OAUTH_PASSWORD_STORE_DIR},,$(error Must pass OAUTH_PASSWORD_STORE_DIR=<path_to_password_store>))
+	$(if $(wildcard ${OAUTH_PASSWORD_STORE_DIR}),,$(error Password store ${OAUTH_PASSWORD_STORE_DIR} does not exist))
+	@scripts/upload-microsoft-oauth-secrets.sh
 
 .PHONY: upload-notify-secrets
 upload-notify-secrets: check-env ## Decrypt and upload Notify Credentials to S3

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1102,6 +1102,9 @@ jobs:
                   aws_account: ((aws_account))
                   google_oauth_client_id: ((google_oauth_client_id))
                   google_oauth_client_secret: ((google_oauth_client_secret))
+                  microsoft_oauth_tenant_id: ((microsoft_oauth_tenant_id))
+                  microsoft_oauth_client_id: ((microsoft_oauth_client_id))
+                  microsoft_oauth_client_secret: ((microsoft_oauth_client_secret))
                   EOF
 
                   tar -xzf ./ipsec-CA/ipsec-CA.tar.gz -C ./ipsec-CA

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1100,8 +1100,8 @@ jobs:
                   environment: ((deploy_env))
                   deployment_name: ((deploy_env))
                   aws_account: ((aws_account))
-                  oauth_client_id: ((oauth_client_id))
-                  oauth_client_secret: ((oauth_client_secret))
+                  google_oauth_client_id: ((google_oauth_client_id))
+                  google_oauth_client_secret: ((google_oauth_client_secret))
                   EOF
 
                   tar -xzf ./ipsec-CA/ipsec-CA.tar.gz -C ./ipsec-CA

--- a/concourse/scripts/lib/google-oauth.sh
+++ b/concourse/scripts/lib/google-oauth.sh
@@ -5,15 +5,15 @@ set -u
 get_google_oauth_secrets() {
   # shellcheck disable=SC2154
   secrets_uri="s3://${state_bucket}/google-oauth-secrets.yml"
-  export oauth_client_id
-  export oauth_client_secret
+  export google_oauth_client_id
+  export google_oauth_client_secret
   secrets_size=$(aws s3 ls "${secrets_uri}" | awk '{print $3}')
   if [ "${secrets_size}" != 0 ] && [ -n "${secrets_size}" ]  ; then
     secrets_file=$(mktemp -t google-oauth-secrets.XXXXXX)
 
     aws s3 cp "${secrets_uri}" "${secrets_file}"
-    oauth_client_id=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.google_oauth_client_id "${secrets_file}")
-    oauth_client_secret=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.google_oauth_client_secret "${secrets_file}")
+    google_oauth_client_id=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.google_oauth_client_id "${secrets_file}")
+    google_oauth_client_secret=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.google_oauth_client_secret "${secrets_file}")
 
     rm -f "${secrets_file}"
   fi

--- a/concourse/scripts/lib/microsoft-oauth.sh
+++ b/concourse/scripts/lib/microsoft-oauth.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+set -u
+
+get_microsoft_oauth_secrets() {
+  # shellcheck disable=SC2154
+  secrets_uri="s3://${state_bucket}/microsoft-oauth-secrets.yml"
+  export microsoft_oauth_tenant_id
+  export microsoft_oauth_client_id
+  export microsoft_oauth_client_secret
+  secrets_size=$(aws s3 ls "${secrets_uri}" | awk '{print $3}')
+  if [ "${secrets_size}" != 0 ] && [ -n "${secrets_size}" ]  ; then
+    secrets_file=$(mktemp -t microsoft-oauth-secrets.XXXXXX)
+
+    aws s3 cp "${secrets_uri}" "${secrets_file}"
+    microsoft_oauth_tenant_id=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.microsoft_oauth_tenant_id "${secrets_file}")
+    microsoft_oauth_client_id=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.microsoft_oauth_client_id "${secrets_file}")
+    microsoft_oauth_client_secret=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.microsoft_oauth_client_secret "${secrets_file}")
+
+    rm -f "${secrets_file}"
+  fi
+}

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -132,8 +132,8 @@ disable_custom_acceptance_tests: ${DISABLE_CUSTOM_ACCEPTANCE_TESTS:-}
 disable_pipeline_locking: ${DISABLE_PIPELINE_LOCKING:-}
 aiven_api_token: ${aiven_api_token:-}
 concourse_web_password: ${CONCOURSE_WEB_PASSWORD}
-oauth_client_id: "${oauth_client_id:-}"
-oauth_client_secret: "${oauth_client_secret:-}"
+google_oauth_client_id: "${google_oauth_client_id:-}"
+google_oauth_client_secret: "${google_oauth_client_secret:-}"
 notify_api_key: ${notify_api_key:-}
 auto_deploy: $([ "${ENABLE_AUTO_DEPLOY:-}" ] && echo "true" || echo "false")
 persistent_environment: ${PERSISTENT_ENVIRONMENT}

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -13,6 +13,9 @@ $("${SCRIPT_DIR}/environment.sh" "$@")
 . "${SCRIPT_DIR}/lib/google-oauth.sh"
 
 # shellcheck disable=SC1090
+. "${SCRIPT_DIR}/lib/microsoft-oauth.sh"
+
+# shellcheck disable=SC1090
 . "${SCRIPT_DIR}/lib/notify.sh"
 
 # shellcheck disable=SC1090
@@ -57,6 +60,7 @@ prepare_environment() {
   get_git_concourse_pool_clone_full_url_ssh
   get_aiven_secrets
   get_google_oauth_secrets
+  get_microsoft_oauth_secrets
   get_notify_secrets
   get_logit_ca_cert
   get_pagerduty_secrets
@@ -134,6 +138,9 @@ aiven_api_token: ${aiven_api_token:-}
 concourse_web_password: ${CONCOURSE_WEB_PASSWORD}
 google_oauth_client_id: "${google_oauth_client_id:-}"
 google_oauth_client_secret: "${google_oauth_client_secret:-}"
+microsoft_oauth_tenant_id: "${microsoft_oauth_tenant_id:-}"
+microsoft_oauth_client_id: "${microsoft_oauth_client_id:-}"
+microsoft_oauth_client_secret: "${microsoft_oauth_client_secret:-}"
 notify_api_key: ${notify_api_key:-}
 auto_deploy: $([ "${ENABLE_AUTO_DEPLOY:-}" ] && echo "true" || echo "false")
 persistent_environment: ${PERSISTENT_ENVIRONMENT}

--- a/manifests/cf-manifest/operations.d/330-uaa.yml
+++ b/manifests/cf-manifest/operations.d/330-uaa.yml
@@ -281,9 +281,9 @@
   path: /releases/-
   value:
     name: uaa-customized
-    version: 0.1.5
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-customized-0.1.5.tgz
-    sha1: a9c75f9f49d99ed2b9387cc4a4cd5c4cf1a12170
+    version: 0.1.6
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-customized-0.1.6.tgz
+    sha1: 7308e71b1746302faa5ed855866d4026e22ceb4b
 
 - type: replace
   path: /instance_groups/name=uaa/jobs/-

--- a/manifests/cf-manifest/operations/uaa-add-google-oauth.yml
+++ b/manifests/cf-manifest/operations/uaa-add-google-oauth.yml
@@ -12,7 +12,7 @@
     scopes:
       - openid
       - email
-    linkText: GOV.UK PaaS internal account login
+    linkText: Google
     showLinkText: true
     addShadowUserOnLogin: false
     relyingPartyId: ((google_oauth_client_id))

--- a/manifests/cf-manifest/operations/uaa-add-google-oauth.yml
+++ b/manifests/cf-manifest/operations/uaa-add-google-oauth.yml
@@ -15,8 +15,8 @@
     linkText: GOV.UK PaaS internal account login
     showLinkText: true
     addShadowUserOnLogin: false
-    relyingPartyId: ((oauth_client_id))
-    relyingPartySecret: ((oauth_client_secret))
+    relyingPartyId: ((google_oauth_client_id))
+    relyingPartySecret: ((google_oauth_client_secret))
     skipSslValidation: false
     attributeMappings:
       user_name: email

--- a/manifests/cf-manifest/operations/uaa-add-microsoft-oauth.yml
+++ b/manifests/cf-manifest/operations/uaa-add-microsoft-oauth.yml
@@ -1,0 +1,24 @@
+---
+
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/login/oauth?/providers/microsoft
+  value:
+    type: oidc1.0
+    authUrl: https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize
+    tokenUrl: https://login.microsoftonline.com/organizations/oauth2/v2.0/token
+    tokenKeyUrl: https://login.microsoftonline.com/organizations/discovery/v2.0/keys
+    issuer: https://login.microsoftonline.com/((microsoft_oauth_tenant_id))/v2.0
+    redirectUrl: https://login.((system_domain))/uaa
+    scopes:
+      - openid
+      - profile
+      - email
+    linkText: Microsoft
+    showLinkText: true
+    addShadowUserOnLogin: false
+    relyingPartyId: ((microsoft_oauth_client_id))
+    relyingPartySecret: ((microsoft_oauth_client_secret))
+    skipSslValidation: false
+    storeCustomAttributes: false
+    attributeMappings:
+      user_name: oid

--- a/manifests/cf-manifest/scripts/generate-manifest.sh
+++ b/manifests/cf-manifest/scripts/generate-manifest.sh
@@ -41,6 +41,7 @@ bosh interpolate \
   --vars-file="${WORKDIR}/environment-variables.yml" \
   ${opsfile_args} \
   --ops-file="${PAAS_CF_DIR}/manifests/cf-manifest/operations/uaa-add-google-oauth.yml" \
+  --ops-file="${PAAS_CF_DIR}/manifests/cf-manifest/operations/uaa-add-microsoft-oauth.yml" \
   --ops-file="${WORKDIR}/vpc-peering-opsfile/vpc-peers.yml" \
   ${vars_store_args} \
   "${CF_DEPLOYMENT_DIR}/cf-deployment.yml"

--- a/manifests/shared/spec/fixtures/environment-variables.yml
+++ b/manifests/shared/spec/fixtures/environment-variables.yml
@@ -6,3 +6,6 @@ deployment_name: unit-test
 aws_account: dev
 google_oauth_client_id: abcd1234
 google_oauth_client_secret: abcd1234
+microsoft_oauth_tenant_id: abcd1234
+microsoft_oauth_client_id: abcd1234
+microsoft_oauth_client_secret: abcd1234

--- a/manifests/shared/spec/fixtures/environment-variables.yml
+++ b/manifests/shared/spec/fixtures/environment-variables.yml
@@ -4,5 +4,5 @@ app_domain: unit-test.dev-apps.paas.example.com
 environment: unit-test
 deployment_name: unit-test
 aws_account: dev
-oauth_client_id: abcd1234
-oauth_client_secret: abcd1234
+google_oauth_client_id: abcd1234
+google_oauth_client_secret: abcd1234

--- a/scripts/upload-google-oauth-secrets.sh
+++ b/scripts/upload-google-oauth-secrets.sh
@@ -4,8 +4,8 @@ set -eu
 
 export PASSWORD_STORE_DIR=${OAUTH_PASSWORD_STORE_DIR}
 
-OAUTH_CLIENT_ID=$(pass "google/${MAKEFILE_ENV_TARGET}/oauth/client_id")
-OAUTH_CLIENT_SECRET=$(pass "google/${MAKEFILE_ENV_TARGET}/oauth/client_secret")
+GOOGLE_OAUTH_CLIENT_ID=$(pass "google/${MAKEFILE_ENV_TARGET}/oauth/client_id")
+GOOGLE_OAUTH_CLIENT_SECRET=$(pass "google/${MAKEFILE_ENV_TARGET}/oauth/client_secret")
 
 SECRETS=$(mktemp secrets.yml.XXXXXX)
 trap 'rm  "${SECRETS}"' EXIT
@@ -13,8 +13,8 @@ trap 'rm  "${SECRETS}"' EXIT
 cat > "${SECRETS}" << EOF
 ---
 secrets:
-  google_oauth_client_id: ${OAUTH_CLIENT_ID}
-  google_oauth_client_secret: ${OAUTH_CLIENT_SECRET}
+  google_oauth_client_id: ${GOOGLE_OAUTH_CLIENT_ID}
+  google_oauth_client_secret: ${GOOGLE_OAUTH_CLIENT_SECRET}
 EOF
 
 aws s3 cp "${SECRETS}" "s3://gds-paas-${DEPLOY_ENV}-state/google-oauth-secrets.yml"

--- a/scripts/upload-microsoft-oauth-secrets.sh
+++ b/scripts/upload-microsoft-oauth-secrets.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -eu
+
+export PASSWORD_STORE_DIR=${OAUTH_PASSWORD_STORE_DIR}
+
+MICROSOFT_OAUTH_TENANT_ID=$(pass "microsoft/${MAKEFILE_ENV_TARGET}/oauth/tenant_id")
+MICROSOFT_OAUTH_CLIENT_ID=$(pass "microsoft/${MAKEFILE_ENV_TARGET}/oauth/client_id")
+MICROSOFT_OAUTH_CLIENT_SECRET=$(pass "microsoft/${MAKEFILE_ENV_TARGET}/oauth/client_secret")
+
+SECRETS=$(mktemp secrets.yml.XXXXXX)
+trap 'rm  "${SECRETS}"' EXIT
+
+cat > "${SECRETS}" << EOF
+---
+secrets:
+  microsoft_oauth_tenant_id: ${MICROSOFT_OAUTH_TENANT_ID}
+  microsoft_oauth_client_id: ${MICROSOFT_OAUTH_CLIENT_ID}
+  microsoft_oauth_client_secret: ${MICROSOFT_OAUTH_CLIENT_SECRET}
+EOF
+
+aws s3 cp "${SECRETS}" "s3://gds-paas-${DEPLOY_ENV}-state/microsoft-oauth-secrets.yml"


### PR DESCRIPTION
What
----

This PR is mainly for this PR: https://github.com/alphagov/paas-uaa-customized-boshrelease/pull/5

- Renames `oauth_client_...` to `google_client_...` for clarity
- Adds a task to upload Microsoft Azure Active Directory secrets (named `microsoft_oauth_...` to be consistent with `google_oauth_...`)
- Adds Microsoft as an IDP
- Bumps the uaa-customized release (***FIXME once merged***) to update the sign in page, and ignore Microsoft as an IDP

Notes
---

Credentials are added in this PR https://github.com/alphagov/paas-credentials/pull/151

How to review
-------------

- Deploy to your dev env
- Code review

Who can review
--------------

Not @tlwr

This work was based heavily on a spike by @46bit and so perhaps Miki a good person to review

Further work in different stories
---

- Enable this for people
- Update uplift user journey to work for Microsoft AND Google