### PR TITLE
Set s3 bucket to "free"

### DIFF
--- a/manifests/cf-manifest/operations.d/750-s3-broker.yml
+++ b/manifests/cf-manifest/operations.d/750-s3-broker.yml
@@ -59,7 +59,7 @@
                     - id: 24efab31-8cbd-47c0-8513-a9345f3c512b
                       name: default
                       description: A single S3 bucket
-                      free: false
+                      free: true
                       metadata:
                         displayName: A single S3 bucket
 


### PR DESCRIPTION

Signed-off-by: Toby Lorne <toby.lornewelch-richards@digital.cabinet-office.gov.uk>

What
----

https://www.pivotaltracker.com/story/show/165677471 indicates that the AWS s3 broker should be available to trial accounts, this is achieved by setting `free` to `true` (we will still generate chargeable events for it)

How to review
-------------

Code review

Who can review
--------------

Not @tlwr
