### PR TITLE
Add initial SLI dashboard

### DIFF
--- a/manifests/prometheus/dashboards.d/sli.json
+++ b/manifests/prometheus/dashboards.d/sli.json
@@ -1,0 +1,253 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorPostfix": false,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "#ff780a",
+        "#299c46"
+      ],
+      "decimals": 3,
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "pluginVersion": "6.1.4",
+      "postfix": " over the last 24 hours",
+      "postfixFontSize": "50%",
+      "prefix": "Uptime was",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "100 - avg_over_time(avg(paas_aws_cloudfront_5xxerrorrate_ratio unless topk(5, paas_aws_cloudfront_5xxerrorrate_ratio))[1d:])",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "99.8,99.99",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Average application uptime",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "content": "## About this dashboard\n\nWe've decided to measure \"uptime\" based on metrics from the CloudFront CDN. CloudFront sits on the outside the platform, so any errors due to the platform will be seen in the cloud front metrics.\n\nAt the time of writing there are about 40 CloudFront CDNs on the platform (across London and Ireland). They cover both production and non-production services.\n\nOur SLI should not be affected if a few services have high error rates - this probably indicates an issue with the individual applications.\nIf a large number of services have high error rates at the same time we should assume there's a problem with the platform.\n\nInitially our application uptime SLI is:\n\n```\nThe average (mean) percentage of 5XX responses from CloudFront, ignoring the 5 distributions with the highest percentage of errors\n```\n\n### Known issues\n\n* If more than 5 services have high error rates due to non-platform issues (e.g. bad application code), this will unfairly affect our SLI\n* If a platform issue causes high error rates for fewer than 5 services our SLI will not be affected\n* The `5xx_errorrate` metric is a percentage, so low-traffic services with a few requests per minute are weighted equally with high-traffic services which have many requests per second\n\n### References\n\nSee [the pivotal tracker story to implement this dashboard](https://www.pivotaltracker.com/story/show/165379426)",
+      "gridPos": {
+        "h": 16,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 12,
+      "links": [],
+      "mode": "markdown",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Description",
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "id": 10,
+      "interval": "",
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "100 - avg_over_time(avg(paas_aws_cloudfront_5xxerrorrate_ratio unless topk(5, paas_aws_cloudfront_5xxerrorrate_ratio))[1d:])",
+          "format": "time_series",
+          "interval": "1d",
+          "intervalFactor": 1,
+          "legendFormat": "1 day average of percentage non-5xx requests, excluding the 5 worst services",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Daily application uptime",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 3,
+          "format": "percent",
+          "label": "",
+          "logBase": 1,
+          "max": "100",
+          "min": "99.5",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 18,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Service Level Indicators",
+  "uid": "service-level-indicators",
+  "version": 22
+}


### PR DESCRIPTION
What
----

We've decided to measure "uptime" based on metrics from the CloudFront CDN. CloudFront sits on the outside the platform, so any errors due to the platform will be seen in the cloud front metrics.

At the time of writing there are about 40 CloudFront CDNs on the platform (across London and Ireland). They cover both production and non-production services.

Our SLI should not be affected if a few services have high error rates - this probably indicates an issue with the individual applications.
If a large number of services have high error rates at the same time we should assume there's a problem with the platform.

Initially our application uptime SLI is:

```
The average (mean) percentage of 5XX responses from CloudFront, ignoring the 5 distributions with the highest percentage of errors
```

**Known issues**

* If more than 5 services have high error rates due to non-platform issues (e.g. bad application code), this will unfairly affect our SLI
* If a platform issue causes high error rates for fewer than 5 services our SLI will not be affected
* The `5xx_errorrate` metric is a percentage, so low-traffic services with a few requests per minute are weighted equally with high-traffic services which have many requests per second


How to review
-------------

* View existing dashboard in Ireland: https://grafana-1.cloud.service.gov.uk/d/zIQ-cPMZk/service-level-indicators?orgId=1
* Sanity check the JSON

Who can review
--------------

Not @richardtowers or @tnwhitwell