### PR TITLE
Fix Grafana idempotency and add spec tests

### DIFF
--- a/manifests/prometheus/dashboards.d/sli.json
+++ b/manifests/prometheus/dashboards.d/sli.json
@@ -249,7 +249,8 @@
     },
     "timezone": "",
     "title": "Service Level Indicators",
-    "uid": "service-level-indicators",
-    "version": 22
-  }
+    "uid": "service-level-indicators"
+  },
+  "overwrite": true,
+  "folderId": 0
 }

--- a/manifests/prometheus/spec/dashboard_validation_spec.rb
+++ b/manifests/prometheus/spec/dashboard_validation_spec.rb
@@ -1,0 +1,42 @@
+require 'json'
+
+RSpec.describe 'grafana dashboards' do
+  grafana_dashboards.each do |dashboard_name, dashboard_contents|
+    it 'should end in .json' do
+      expect(dashboard_name).to match(/[.]json$/)
+    end
+
+    it 'should be valid json' do
+      expect { JSON.parse dashboard_contents }.to_not raise_error
+    end
+
+    it 'should be overwritable' do
+      dashboard = JSON.parse(dashboard_contents)
+
+      overwrite = dashboard.dig('overwrite')
+
+      expect(overwrite).to eq(true)
+    end
+
+    it 'should have folderId 0' do
+      dashboard = JSON.parse(dashboard_contents)
+
+      folder_id = dashboard.dig('folderId')
+
+      expect(folder_id).to eq(0)
+    end
+
+    it 'should have a title and uid' do
+      dashboard = JSON.parse(dashboard_contents)
+
+      title = dashboard.dig('dashboard', 'title')
+      uid = dashboard.dig('dashboard', 'uid')
+
+      expect(title).to be_kind_of(String)
+      expect(uid).to be_kind_of(String)
+
+      expect(title).to match(/[-A-Za-z0-9]+/)
+      expect(uid).to match(/^[-a-z0-9]+$/)
+    end
+  end
+end

--- a/manifests/prometheus/spec/spec_helper.rb
+++ b/manifests/prometheus/spec/spec_helper.rb
@@ -98,3 +98,11 @@ end
 Dir[File.expand_path("../../shared/spec/support/**/*.rb", __dir__)].each { |f| require f }
 Dir[File.expand_path("../../cloud-config/spec/support/**/*.rb", __dir__)].each { |f| require f }
 Dir[File.expand_path("support/**/*.rb", __dir__)].each { |f| require f }
+
+def grafana_dashboards
+  Dir.glob(
+    File.expand_path(
+      File.join(__dir__, '..', 'dashboards.d', '*.json')
+    )
+  ).map { |filepath| [File.basename(filepath), File.read(filepath)] }
+end


### PR DESCRIPTION
What
----

Every Grafana dashboard needs to have `{"overwrite": true}` otherwise we get `HTTP 412` when we attempt to create/update

This PR adds `overwrite` to the offending dashboard and adds some spec tests to prevent non-idempotent dashboard configurations.

How to review
-------------

Code review

Run the tests

Who can review
--------------

Not @tlwr
