### PR TITLE
Revert "Scale up gorouters in `prod` (IE) from 3 to 6"

### DIFF
--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -1,6 +1,6 @@
 ---
 cell_instances: 24
-router_instances: 6
+router_instances: 3
 api_instances: 4
 doppler_instances: 12
 log_api_instances: 6

--- a/tools/metrics/tlscheck/tls_test.go
+++ b/tools/metrics/tlscheck/tls_test.go
@@ -41,7 +41,10 @@ var _ = Describe("TLSCheck", func() {
 		})
 
 		It("returns error for certificate with self-signed CA", func() {
-			_, err := checker.DaysUntilExpiry("self-signed.badssl.com:443", &tls.Config{})
+			_, err := checker.DaysUntilExpiry(
+				"self-signed.badssl.com:443",
+				&tls.Config{InsecureSkipVerify: true}, // we don't care if expired
+			)
 			Expect(err).To(HaveOccurred())
 		})
 


### PR DESCRIPTION
What
----

This reverts commit f8315caf4c2241503f358ecf85c82608d2fac0b8.

Notify can reproduce their load issues without scaling requests, so
there's no need for us to be running scaled up routers now.

How to review
-------------

* Code review is enough

Who can review
--------------

Not Rich