### PR TITLE
[#166440328] Change cells to `r5.xlarge` EC2 instance type

### DIFF
--- a/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
@@ -178,10 +178,10 @@ RSpec.describe "base properties" do
     describe "executor" do
       subject(:executor) { manifest["instance_groups.diego-cell.jobs.rep.properties.diego.executor"] }
 
-      it "should have a memory_capacity_mb of at least 30G" do
+      it "should have a memory_capacity_mb of at least 32G" do
         memory_capacity_mb = executor['memory_capacity_mb']
         expect(memory_capacity_mb).to be_a_kind_of(Integer)
-        expect(memory_capacity_mb).to be >= (30 * 1024)
+        expect(memory_capacity_mb).to be >= (32 * 1024)
       end
     end
   end

--- a/manifests/variables.yml
+++ b/manifests/variables.yml
@@ -1,5 +1,5 @@
 ---
-cell_instance_type: r4.xlarge
+cell_instance_type: r5.xlarge
 
 # Advertised memory capacity of the cells.
 #
@@ -13,9 +13,9 @@ cell_instance_type: r4.xlarge
 #
 # For instance:
 #
-# ruby -e 'puts "cell_memory_capacity_mb: #{ (30662 * 1.66).floor }";'
+# ruby -e 'puts "cell_memory_capacity_mb: #{ (32 * 1024 * 1.66).floor }";'
 #
-cell_memory_capacity_mb: 50898
+cell_memory_capacity_mb: 54394
 
 # Used by cf-deployment/operations/rename-network-and-deployment.yml
 network_name: cf


### PR DESCRIPTION
What
----

We want to utilise Reserved Instances to reduce our EC2 costs. We want to reserve the newest type of instances so that we are investing effectively.

Until now our cells have used the `r4.xlarge` EC2 instance type. This commit changes us to use the `r5.xlarge` EC2 instance type. These new instances have more memory (32GiB rather than 30.5GiB [1]) and so this commit updates where that number is used.

[1] https://www.ec2instances.info/?min_memory=20&min_vcpus=4&region=eu-west-2&selected=r4.xlarge,r5.xlarge

How to review
-------------

Code review. This is deployed to the `miki` dev environment and everything went green [2].

[2] `custom-acceptance-tests` failed, but the only failing test is because I still haven't deleted the `cflinuxfs2` buildpacks from the `miki` dev environment.

Who can review
--------------

Not @46bit.