### PR TITLE
Bump the Instance Types for the Databases

### DIFF
--- a/manifests/cf-manifest/operations.d/711-rds-broker-postgres95-plans.yml
+++ b/manifests/cf-manifest/operations.d/711-rds-broker-postgres95-plans.yml
@@ -21,21 +21,21 @@
       allowed_extensions: ["uuid-ossp", "postgis", "pg_stat_statements"]
 
     tiny_plan_rds_properties: &tiny_plan_rds_properties
-      db_instance_class: "db.t2.micro"
+      db_instance_class: "db.t3.micro"
       allocated_storage: 5
       backup_retention_period: 0
       skip_final_snapshot: true
     small_plan_rds_properties: &small_plan_rds_properties
-      db_instance_class: "db.t2.small"
+      db_instance_class: "db.t3.small"
       allocated_storage: 20
     medium_plan_rds_properties: &medium_plan_rds_properties
-      db_instance_class: "db.m4.large"
+      db_instance_class: "db.m5.large"
       allocated_storage: 100
     large_plan_rds_properties: &large_plan_rds_properties
-      db_instance_class: "db.m4.2xlarge"
+      db_instance_class: "db.m5.2xlarge"
       allocated_storage: 512
     xlarge_plan_rds_properties: &xlarge_plan_rds_properties
-      db_instance_class: "db.m4.4xlarge"
+      db_instance_class: "db.m5.4xlarge"
       allocated_storage: 2048
 
 - type: replace
@@ -62,7 +62,7 @@
   value:
     id: "5f2eec8a-0cad-4ab9-b81e-d6adade2fd42"
     name: "tiny-unencrypted-9.5"
-    description: "5GB Storage, NOT BACKED UP, Dedicated Instance, Max 50 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t2.micro."
+    description: "5GB Storage, NOT BACKED UP, Dedicated Instance, Max 50 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t3.micro."
     free: true
     metadata:
       bullets:
@@ -77,7 +77,7 @@
   value:
     id: "2611d776-9991-4940-a755-880eafbc33a0"
     name: "small-9.5"
-    description: "20GB Storage, Dedicated Instance, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t2.small."
+    description: "20GB Storage, Dedicated Instance, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t3.small."
     free: false
     metadata:
       costs:
@@ -98,7 +98,7 @@
   value:
     id: "d9f1d61d-0a65-45ad-8fc9-88c921d038d2"
     name: "small-ha-9.5"
-    description: "20GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t2.small."
+    description: "20GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t3.small."
     free: false
     metadata:
       costs:
@@ -119,7 +119,7 @@
   value:
     id: "17ef8670-5134-4ae6-b7fc-9ee8e52394c5"
     name: "medium-9.5"
-    description: "100GB Storage, Dedicated Instance, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.large."
+    description: "100GB Storage, Dedicated Instance, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m5.large."
     free: false
     metadata:
       costs:
@@ -140,7 +140,7 @@
   value:
     id: "8d50ccc5-707c-4306-be8f-f59a158eb736"
     name: "medium-ha-9.5"
-    description: "100GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.large."
+    description: "100GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m5.large."
     free: false
     metadata:
       costs:
@@ -162,7 +162,7 @@
   value:
     id: "8ea15f55-fbd2-41a3-a679-482d67a3d9ea"
     name: "large-9.5"
-    description: "512GB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.2xlarge."
+    description: "512GB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m5.2xlarge."
     free: false
     metadata:
       costs:
@@ -183,7 +183,7 @@
   value:
     id: "620055b3-fe7c-46fc-87ad-c7d8f4fe7f34"
     name: "large-ha-9.5"
-    description: "512GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.2xlarge."
+    description: "512GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m5.2xlarge."
     free: false
     metadata:
       costs:
@@ -205,7 +205,7 @@
   value:
     id: "3cb1947e-1df5-4483-8e9e-07c9294f9347"
     name: "xlarge-9.5"
-    description: "2TB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.4xlarge."
+    description: "2TB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m5.4xlarge."
     free: false
     metadata:
       costs:
@@ -226,7 +226,7 @@
   value:
     id: "a91c8e59-8869-42fd-8a99-8989151d7353"
     name: "xlarge-ha-9.5"
-    description: "2TB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.4xlarge."
+    description: "2TB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m5.4xlarge."
     free: false
     metadata:
       costs:
@@ -250,7 +250,7 @@
   value:
     id: "b7d0a368-ac92-4eff-9b8d-ab4ba45bed0e"
     name: "small-unencrypted-9.5"
-    description: "20GB Storage, Dedicated Instance, Max 200 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t2.small."
+    description: "20GB Storage, Dedicated Instance, Max 200 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t3.small."
     free: false
     metadata:
       costs:
@@ -269,7 +269,7 @@
   value:
     id: "359bcb39-0264-46bd-9120-0182c3829067"
     name: "small-ha-unencrypted-9.5"
-    description: "20GB Storage, Dedicated Instance, Highly Available, Max 200 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t2.small."
+    description: "20GB Storage, Dedicated Instance, Highly Available, Max 200 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t3.small."
     free: false
     metadata:
       costs:
@@ -289,7 +289,7 @@
   value:
     id: "9b882524-ab58-4c18-b501-d2a3f4619104"
     name: "medium-unencrypted-9.5"
-    description: "100GB Storage, Dedicated Instance, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.large."
+    description: "100GB Storage, Dedicated Instance, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m5.large."
     free: false
     metadata:
       costs:
@@ -308,7 +308,7 @@
   value:
     id: "bf5b99c2-7990-4b66-b341-1bb83566d76e"
     name: "medium-ha-unencrypted-9.5"
-    description: "100GB Storage, Dedicated Instance, Highly Available, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.large."
+    description: "100GB Storage, Dedicated Instance, Highly Available, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m5.large."
     free: false
     metadata:
       costs:
@@ -328,7 +328,7 @@
   value:
     id: "238a1328-4f77-4b70-9bd9-2cdbbfb999c8"
     name: "large-unencrypted-9.5"
-    description: "512GB Storage, Dedicated Instance, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.2xlarge."
+    description: "512GB Storage, Dedicated Instance, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m5.2xlarge."
     free: false
     metadata:
       costs:
@@ -347,7 +347,7 @@
   value:
     id: "dfe4ab2b-2069-41a5-ba08-2be21b0c76d3"
     name: "large-ha-unencrypted-9.5"
-    description: "512GB Storage, Dedicated Instance, Highly Available, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.2xlarge."
+    description: "512GB Storage, Dedicated Instance, Highly Available, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m5.2xlarge."
     free: false
     metadata:
       costs:
@@ -367,7 +367,7 @@
   value:
     id: "1065c353-54dd-4f6b-a5b4-a4b5aa4575c6"
     name: "xlarge-unencrypted-9.5"
-    description: "2TB Storage, Dedicated Instance, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.4xlarge."
+    description: "2TB Storage, Dedicated Instance, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m5.4xlarge."
     free: false
     metadata:
       costs:
@@ -386,7 +386,7 @@
   value:
     id: "7119925f-518d-4263-96ac-16990295aad6"
     name: "xlarge-ha-unencrypted-9.5"
-    description: "2TB Storage, Dedicated Instance, Highly Available, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.4xlarge."
+    description: "2TB Storage, Dedicated Instance, Highly Available, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m5.4xlarge."
     free: false
     metadata:
       costs:

--- a/manifests/cf-manifest/operations.d/712-rds-broker-mysql-plans.yml
+++ b/manifests/cf-manifest/operations.d/712-rds-broker-mysql-plans.yml
@@ -19,21 +19,21 @@
       engine_family: "mysql5.7"
 
     tiny_plan_rds_properties: &tiny_plan_rds_properties
-      db_instance_class: "db.t2.micro"
+      db_instance_class: "db.t3.micro"
       allocated_storage: 5
       backup_retention_period: 0
       skip_final_snapshot: true
     small_plan_rds_properties: &small_plan_rds_properties
-      db_instance_class: "db.t2.small"
+      db_instance_class: "db.t3.small"
       allocated_storage: 20
     medium_plan_rds_properties: &medium_plan_rds_properties
-      db_instance_class: "db.m4.large"
+      db_instance_class: "db.m5.large"
       allocated_storage: 100
     large_plan_rds_properties: &large_plan_rds_properties
-      db_instance_class: "db.m4.2xlarge"
+      db_instance_class: "db.m5.2xlarge"
       allocated_storage: 512
     xlarge_plan_rds_properties: &xlarge_plan_rds_properties
-      db_instance_class: "db.m4.4xlarge"
+      db_instance_class: "db.m5.4xlarge"
       allocated_storage: 2048
 
 - type: replace
@@ -60,7 +60,7 @@
   value:
     id: 69977068-8ef5-4172-bfdb-e8cea3c14d01
     name: "tiny-unencrypted-5.7"
-    description: "5GB Storage, NOT BACKED UP, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.t2.micro."
+    description: "5GB Storage, NOT BACKED UP, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.t3.micro."
     free: true
     metadata:
       bullets:
@@ -75,7 +75,7 @@
   value:
     id: "b0ccc8c9-09b0-4c3e-9880-091cc41c2ab5"
     name: "small-5.7"
-    description: "20GB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.t2.small."
+    description: "20GB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.t3.small."
     free: false
     metadata:
       costs:
@@ -96,7 +96,7 @@
   value:
     id: "6aa563c1-5aeb-46a1-9509-badcf5995c96"
     name: "small-ha-5.7"
-    description: "20GB Storage, Dedicated Instance, Highly Available. Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.t2.small."
+    description: "20GB Storage, Dedicated Instance, Highly Available. Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.t3.small."
     free: false
     metadata:
       costs:
@@ -117,7 +117,7 @@
   value:
     id: "29cdedeb-e910-4a7a-b606-2c4e42eea478"
     name: "medium-5.7"
-    description: "100GB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.large."
+    description: "100GB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m5.large."
     free: false
     metadata:
       costs:
@@ -138,7 +138,7 @@
   value:
     id: "8d139b9e-bc82-4749-8ad6-7733980292d6"
     name: "medium-ha-5.7"
-    description: "100GB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.large."
+    description: "100GB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m5.large."
     free: false
     metadata:
       costs:
@@ -160,7 +160,7 @@
   value:
     id: "98a9b7cf-e067-4915-8190-ce8224dd04dc"
     name: "large-5.7"
-    description: "512GB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.2xlarge."
+    description: "512GB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m5.2xlarge."
     free: false
     metadata:
       costs:
@@ -181,7 +181,7 @@
   value:
     id: "d5efbf83-5e00-47a5-a668-2ef1307d5a23"
     name: "large-ha-5.7"
-    description: "512GB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.2xlarge."
+    description: "512GB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m5.2xlarge."
     free: false
     metadata:
       costs:
@@ -203,7 +203,7 @@
   value:
     id: "e03020e8-eaed-49c2-bd58-23b7cb871c22"
     name: "xlarge-5.7"
-    description: "2TB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.4xlarge."
+    description: "2TB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m5.4xlarge."
     free: false
     metadata:
       costs:
@@ -224,7 +224,7 @@
   value:
     id: "4edc975c-3f07-46f1-bd87-ecb35b76298f"
     name: "xlarge-ha-5.7"
-    description: "2TB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.4xlarge."
+    description: "2TB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m5.4xlarge."
     free: false
     metadata:
       costs:
@@ -248,7 +248,7 @@
   value:
     id: "72279ebd-6001-4e38-aaef-72b68c4fa6fd"
     name: "small-ha-unencrypted-5.7"
-    description: "20GB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.t2.small."
+    description: "20GB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.t3.small."
     free: false
     metadata:
       costs:
@@ -269,7 +269,7 @@
   value:
     id: "4eb35ca9-a7ec-46c6-b137-d819848536cd"
     name: "medium-unencrypted-5.7"
-    description: "100GB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.m4.large."
+    description: "100GB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.m5.large."
     free: false
     metadata:
       costs:
@@ -289,7 +289,7 @@
   value:
     id: "e60edf62-b701-4e38-846f-b0b3db728349"
     name: "medium-ha-unencrypted-5.7"
-    description: "100GB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.m4.large."
+    description: "100GB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.m5.large."
     free: false
     metadata:
       costs:
@@ -310,7 +310,7 @@
   value:
     id: "6725bf1f-71e8-447a-b6a1-659247fcc03c"
     name: "large-unencrypted-5.7"
-    description: "512GB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.m4.2xlarge."
+    description: "512GB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.m5.2xlarge."
     free: false
     metadata:
       costs:
@@ -330,7 +330,7 @@
   value:
     id: "63cdac92-9e44-42a6-ba3f-7be3dccf5dc6"
     name: "large-ha-unencrypted-5.7"
-    description: "512GB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.m4.2xlarge."
+    description: "512GB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.m5.2xlarge."
     free: false
     metadata:
       costs:
@@ -351,7 +351,7 @@
   value:
     id: "a37144bf-4e05-451b-87ba-0a2c57a23a91"
     name: "xlarge-unencrypted-5.7"
-    description: "2TB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.m4.4xlarge."
+    description: "2TB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.m5.4xlarge."
     free: false
     metadata:
       costs:
@@ -371,7 +371,7 @@
   value:
     id: "065a7de5-28e8-4de1-8a39-4b4f752e2f2f"
     name: "xlarge-ha-unencrypted-5.7"
-    description: "2TB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.m4.4xlarge."
+    description: "2TB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.m5.4xlarge."
     free: false
     metadata:
       costs:
@@ -392,7 +392,7 @@
   value:
     id: "7fdde6ea-cc27-466c-86aa-46181fc20d25"
     name: "small-unencrypted-5.7"
-    description: "20GB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.t2.small."
+    description: "20GB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.t3.small."
     free: false
     metadata:
       costs:

--- a/manifests/cf-manifest/operations.d/713-rds-broker-postgres10-plans.yml
+++ b/manifests/cf-manifest/operations.d/713-rds-broker-postgres10-plans.yml
@@ -21,21 +21,21 @@
       allowed_extensions: ["uuid-ossp", "postgis", "citext", "pg_stat_statements"]
 
     tiny_plan_rds_properties: &tiny_plan_rds_properties
-      db_instance_class: "db.t2.micro"
+      db_instance_class: "db.t3.micro"
       allocated_storage: 5
       backup_retention_period: 0
       skip_final_snapshot: true
     small_plan_rds_properties: &small_plan_rds_properties
-      db_instance_class: "db.t2.small"
+      db_instance_class: "db.t3.small"
       allocated_storage: 20
     medium_plan_rds_properties: &medium_plan_rds_properties
-      db_instance_class: "db.m4.large"
+      db_instance_class: "db.m5.large"
       allocated_storage: 100
     large_plan_rds_properties: &large_plan_rds_properties
-      db_instance_class: "db.m4.2xlarge"
+      db_instance_class: "db.m5.2xlarge"
       allocated_storage: 512
     xlarge_plan_rds_properties: &xlarge_plan_rds_properties
-      db_instance_class: "db.m4.4xlarge"
+      db_instance_class: "db.m5.4xlarge"
       allocated_storage: 2048
 
 - type: replace


### PR DESCRIPTION
## What

M5 instances are the latest generation of General Purpose Instances and
provide improved performance over M4.

Also comes with a nice discount of ~2.600473% :D

This should not change the current instances automatically. It will only
be applied to new instances, unless the `cf update-service` command has
been executed, which would mark the database to be automatically
upgraded during the next maintenance window.

Partially tested on Pay - no CF interaction.

How to review
-------------

- Code review - I may be rusty on CF :trollface: 
- Spin up dev environment from `master`
- [Set up a PostgreSQL service](https://docs.cloud.service.gov.uk/deploying_services/postgresql/#set-up-a-postgresql-service)
- Spin up dev environment from `bump-rds-instance-type`
- Change [PostgreSQL maintenance times](https://docs.cloud.service.gov.uk/deploying_services/postgresql/#postgresql-maintenance-times) to something soon
- Wait and see successful upgraded service 🤔 