### PR TITLE
[#163359677] Grafana OAuth

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1483,6 +1483,164 @@ jobs:
                     done;
                   done
 
+        - task: create-grafana-users
+          tags: [colocated-with-web]
+          config:
+            platform: linux
+            image_resource: *ruby-slim-image-resource
+            params:
+              SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+              DEPLOY_ENV: ((deploy_env))
+              SLIM_DEV_DEPLOYMENT: ((slim_dev_deployment))
+            inputs:
+              - name: paas-cf
+              - name: config
+            run:
+              path: ruby
+              args:
+                - -e
+                - |
+                  require 'json'
+                  require 'net/http'
+                  require 'openssl'
+                  require 'securerandom'
+                  require 'uri'
+                  require 'yaml'
+
+                  conf          = File.read("#{Dir.pwd}/config/config.sh")
+                  system_domain = ENV.fetch('SYSTEM_DNS_ZONE_NAME')
+                  deploy_env    = ENV.fetch('DEPLOY_ENV')
+                  slim          = ENV.fetch('SLIM_DEV_DEPLOYMENT')
+                  azs           = (slim == 'true') ? 1 : 2
+                  grafana_pass  = conf[/GRAFANA_PASS=(.*)$/, 1]
+
+                  users_that_should_exist = YAML.load_file(
+                    "#{Dir.pwd}/paas-cf/config/users.yml"
+                  ).select do |u|
+                    u.dig('deploy_envs').include? deploy_env
+                  end.reject do |u|
+                    u.dig('email').nil?
+                  end.map do |u|
+                    u.fetch('email')
+                  end
+
+                  puts 'Users that should exist:'
+                  pp users_that_should_exist
+
+                  azs.times do |az|
+                    base_url  = "https://grafana-#{az + 1}.#{system_domain}/"
+                    puts "Configuring #{base_url}"
+
+                    uri = URI("#{base_url}/api/users")
+                    grafana_users  = JSON
+                      .parse(
+                        Net::HTTP.start(
+                          uri.host, uri.port, use_ssl: true
+                        ) do |http|
+                          req = Net::HTTP::Get.new(uri)
+                          req.basic_auth 'admin', grafana_pass
+                          http.request(req).body
+                        end
+                      )
+                      .reject { |u| %w[admin mon].include? u.dig('login') }
+
+                    puts 'Existing grafana_users:'
+                    pp grafana_users
+
+                    users_to_create = users_that_should_exist.reject do |email|
+                      grafana_users.any? { |u| u.dig('email') == email }
+                    end
+
+                    users_to_delete = grafana_users.reject do |user|
+                      users_that_should_exist.include? user.dig('email')
+                    end
+
+                    puts 'Users to create:'
+                    pp users_to_create
+
+                    puts 'Users to delete:'
+                    pp users_to_delete
+
+                    users_to_create.each do |email|
+                      puts "Creating user #{email}"
+
+                      uri = URI("#{base_url}/api/admin/users")
+                      resp = Net::HTTP.start(
+                        uri.host, uri.port, use_ssl: true
+                      ) do |http|
+                        req = Net::HTTP::Post.new(uri)
+                        req.basic_auth 'admin', grafana_pass
+                        req['Content-Type'] = 'application/json'
+                        req.body = {
+                          name:     email.split('@').first,
+                          login:    email,
+                          email:    email,
+                          password: SecureRandom.hex(32)
+                        }.to_json
+                        http.request(req)
+                      end
+                      abort "Error #{resp.body}" unless resp.code == '200'
+                      puts resp.body
+
+                      puts "Created user #{email}"
+                    end
+
+                    users_to_delete.each do |user|
+                      user_id = user.fetch('id')
+
+                      puts "Deleting user #{user_id} / #{user.dig('email')}"
+
+                      uri = URI("#{base_url}/api/admin/users/#{user_id}")
+                      resp = Net::HTTP.start(
+                        uri.host, uri.port, use_ssl: true
+                      ) do |http|
+                        req = Net::HTTP::Delete.new(uri)
+                        req.basic_auth 'admin', grafana_pass
+                        http.request(req)
+                      end
+                      abort "Error #{resp.body}" unless resp.code == '200'
+                      puts resp.body
+
+                      puts "Deleted user #{user_id} / #{user.dig('email')}"
+                    end
+
+                    uri = URI("#{base_url}/api/users")
+                    grafana_users = Net::HTTP.start(
+                        uri.host, uri.port, use_ssl: true
+                      ) do |http|
+                        req = Net::HTTP::Get.new(uri)
+                        req.basic_auth 'admin', grafana_pass
+                        http.request(req)
+                      end
+                    unless grafana_users.code == '200'
+                      abort "Error #{grafana_users}"
+                    end
+
+                    JSON
+                      .parse(grafana_users.body)
+                      .reject { |u| %w[admin mon].include? u.dig('login') }
+                      .each do |user|
+
+                      user_id = user.fetch('id')
+                      puts "Elevating #{user_id} / #{user.dig('email')}"
+
+                      uri = URI("#{base_url}/api/admin/users/#{user_id}/permissions")
+                      resp = Net::HTTP.start(
+                        uri.host, uri.port, use_ssl: true
+                      ) do |http|
+                        req = Net::HTTP::Put.new(uri)
+                        req.basic_auth 'admin', grafana_pass
+                        req['Content-Type'] = 'application/json'
+                        req.body = { 'isGrafanaAdmin' => true }.to_json
+                        http.request(req)
+                      end
+                      abort "Error #{resp.body}" unless resp.code == '200'
+                      puts resp.body
+
+                      puts "Elevated user #{user_id} / #{user.dig('email')}"
+                    end
+                  end
+
   - name: post-deploy
     serial: true
     plan:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2015,7 +2015,7 @@ jobs:
                 CF_ADMIN_PASSWORD=$($VAL_FROM_YAML cf_admin_password cf-vars-store/cf-vars-store.yml)
                 cd paas-cf/scripts
                 bundle
-                bundle exec sync-admin-users.rb "${API_ENDPOINT}" ../config/admin_users.yml "((NEW_ACCOUNT_EMAIL_ADDRESS))" "${DEPLOY_ENV}"
+                bundle exec sync-admin-users.rb "${API_ENDPOINT}" ../config/users.yml "((NEW_ACCOUNT_EMAIL_ADDRESS))" "${DEPLOY_ENV}"
 
       - task: deploy-healthcheck
         tags: [colocated-with-web]

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1398,87 +1398,88 @@ jobs:
 
                 bosh -n deploy prometheus-manifest/prometheus-manifest.yml
 
-      - task: deploy-cloudwatch-exporter
-        tags: [colocated-with-web]
-        config:
-          platform: linux
-          image_resource: *cf-cli-image-resource
-          params:
-            DEPLOY_ENV: ((deploy_env))
-            AWS_REGION: ((aws_region))
-          inputs:
-            - name: paas-cf
-            - name: config
-            - name: paas-yet-another-cloudwatch-exporter
-          run:
-            path: sh
-            args:
-              - -e
-              - -c
-              - |
-                . ./config/config.sh
-                echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}" -o admin -s monitoring
+      - aggregate:
+        - task: deploy-cloudwatch-exporter
+          tags: [colocated-with-web]
+          config:
+            platform: linux
+            image_resource: *cf-cli-image-resource
+            params:
+              DEPLOY_ENV: ((deploy_env))
+              AWS_REGION: ((aws_region))
+            inputs:
+              - name: paas-cf
+              - name: config
+              - name: paas-yet-another-cloudwatch-exporter
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  . ./config/config.sh
+                  echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}" -o admin -s monitoring
 
-                spruce merge paas-cf/config/cloudwatch-exporter/config.yml > paas-yet-another-cloudwatch-exporter/src/config.yml
+                  spruce merge paas-cf/config/cloudwatch-exporter/config.yml > paas-yet-another-cloudwatch-exporter/src/config.yml
 
-                cd paas-yet-another-cloudwatch-exporter/src
+                  cd paas-yet-another-cloudwatch-exporter/src
 
-                cat << EOF > manifest.yml
-                ---
-                applications:
-                  - name: cloudwatch-exporter
-                    memory: 128M
-                    disk_quota: 100M
-                    instances: 1
-                    buildpack: go_buildpack
-                    health-check-type: http
-                    stack: cflinuxfs3
-                    env:
-                      GOPACKAGENAME: github.com/alphagov/paas-yet-another-cloudwatch-exporter/src
-                      AWS_ACCESS_KEY_ID: "${YACE_AWS_ACCESS_KEY_ID}"
-                      AWS_SECRET_ACCESS_KEY: "${YACE_AWS_SECRET_ACCESS_KEY}"
-                    command: "src -listen-address=0.0.0.0:\$PORT"
-                EOF
+                  cat << EOF > manifest.yml
+                  ---
+                  applications:
+                    - name: cloudwatch-exporter
+                      memory: 128M
+                      disk_quota: 100M
+                      instances: 1
+                      buildpack: go_buildpack
+                      health-check-type: http
+                      stack: cflinuxfs3
+                      env:
+                        GOPACKAGENAME: github.com/alphagov/paas-yet-another-cloudwatch-exporter/src
+                        AWS_ACCESS_KEY_ID: "${YACE_AWS_ACCESS_KEY_ID}"
+                        AWS_SECRET_ACCESS_KEY: "${YACE_AWS_SECRET_ACCESS_KEY}"
+                      command: "src -listen-address=0.0.0.0:\$PORT"
+                  EOF
 
-                cf zero-downtime-push cloudwatch-exporter -f manifest.yml
+                  cf zero-downtime-push cloudwatch-exporter -f manifest.yml
 
-      - task: upload-grafana-dashboards
-        tags: [colocated-with-web]
-        config:
-          platform: linux
-          image_resource: *curl-ssl-image-resource
-          params:
-            SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
-            DEPLOY_ENV: ((deploy_env))
-            SLIM_DEV_DEPLOYMENT: ((slim_dev_deployment))
-          inputs:
-            - name: paas-cf
-            - name: config
-          run:
-            path: sh
-            args:
-              - -e
-              - -u
-              - -c
-              - |
-                . ./config/config.sh
-                AZ_COUNT=2
-                if [ "${SLIM_DEV_DEPLOYMENT}" = "true" ]; then
-                  AZ_COUNT=1
-                fi
+        - task: upload-grafana-dashboards
+          tags: [colocated-with-web]
+          config:
+            platform: linux
+            image_resource: *curl-ssl-image-resource
+            params:
+              SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+              DEPLOY_ENV: ((deploy_env))
+              SLIM_DEV_DEPLOYMENT: ((slim_dev_deployment))
+            inputs:
+              - name: paas-cf
+              - name: config
+            run:
+              path: sh
+              args:
+                - -e
+                - -u
+                - -c
+                - |
+                  . ./config/config.sh
+                  AZ_COUNT=2
+                  if [ "${SLIM_DEV_DEPLOYMENT}" = "true" ]; then
+                    AZ_COUNT=1
+                  fi
 
-                for f in "$(pwd)/paas-cf/manifests/prometheus/dashboards.d/"*.json; do
-                  for az in $(seq 1 $AZ_COUNT); do
-                    sed "s/__SYSTEM_DNS_ZONE_NAME__/${SYSTEM_DNS_ZONE_NAME}/g" "${f}" \
-                    | sed "s/__DEPLOY_ENV__/${DEPLOY_ENV}/g" \
-                    | curl "https://grafana-${az}.${SYSTEM_DNS_ZONE_NAME}/api/dashboards/db" \
-                      --user "admin:$GRAFANA_PASS" \
-                      --header 'Content-Type: application/json' \
-                      --data "@-" \
-                      --fail \
-                      --include
-                  done;
-                done
+                  for f in "$(pwd)/paas-cf/manifests/prometheus/dashboards.d/"*.json; do
+                    for az in $(seq 1 $AZ_COUNT); do
+                      sed "s/__SYSTEM_DNS_ZONE_NAME__/${SYSTEM_DNS_ZONE_NAME}/g" "${f}" \
+                      | sed "s/__DEPLOY_ENV__/${DEPLOY_ENV}/g" \
+                      | curl "https://grafana-${az}.${SYSTEM_DNS_ZONE_NAME}/api/dashboards/db" \
+                        --user "admin:$GRAFANA_PASS" \
+                        --header 'Content-Type: application/json' \
+                        --data "@-" \
+                        --fail \
+                        --include
+                    done;
+                  done
 
   - name: post-deploy
     serial: true

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1314,6 +1314,8 @@ jobs:
             ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
             SLIM_DEV_DEPLOYMENT: ((slim_dev_deployment))
             ENV_SPECIFIC_BOSH_VARS_FILE: ((env_specific_bosh_vars_file))
+            GRAFANA_AUTH_GOOGLE_CLIENT_ID: ((grafana_auth_google_client_id))
+            GRAFANA_AUTH_GOOGLE_CLIENT_SECRET: ((grafana_auth_google_client_secret))
           run:
             path: sh
             args:

--- a/concourse/scripts/lib/google-oauth.sh
+++ b/concourse/scripts/lib/google-oauth.sh
@@ -7,6 +7,8 @@ get_google_oauth_secrets() {
   secrets_uri="s3://${state_bucket}/google-oauth-secrets.yml"
   export google_oauth_client_id
   export google_oauth_client_secret
+  export grafana_auth_google_client_id
+  export grafana_auth_google_client_secret
   secrets_size=$(aws s3 ls "${secrets_uri}" | awk '{print $3}')
   if [ "${secrets_size}" != 0 ] && [ -n "${secrets_size}" ]  ; then
     secrets_file=$(mktemp -t google-oauth-secrets.XXXXXX)
@@ -14,6 +16,9 @@ get_google_oauth_secrets() {
     aws s3 cp "${secrets_uri}" "${secrets_file}"
     google_oauth_client_id=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.google_oauth_client_id "${secrets_file}")
     google_oauth_client_secret=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.google_oauth_client_secret "${secrets_file}")
+
+    grafana_auth_google_client_id=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.grafana_auth_google_client_id "${secrets_file}")
+    grafana_auth_google_client_secret=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.grafana_auth_google_client_secret "${secrets_file}")
 
     rm -f "${secrets_file}"
   fi

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -148,6 +148,8 @@ slim_dev_deployment: ${SLIM_DEV_DEPLOYMENT:-}
 monitored_state_bucket: ${MONITORED_STATE_BUCKET:-}
 monitored_aws_region: ${MONITORED_AWS_REGION:-}
 monitored_deploy_env: ${MONITORED_DEPLOY_ENV:-}
+grafana_auth_google_client_id: "${grafana_auth_google_client_id:-}"
+grafana_auth_google_client_secret: "${grafana_auth_google_client_secret:-}"
 EOF
   echo -e "pipeline_lock_git_private_key: |\\n  ${git_id_rsa//$'\n'/$'\n'  }"
 }

--- a/config/users.yml
+++ b/config/users.yml
@@ -2,39 +2,61 @@
 - email: "andy.hunt@digital.cabinet-office.gov.uk"
   origin: "google"
   deploy_envs: ['prod', 'prod-lon', 'stg-lon', 'andyhunt']
+  cf_admin: true
 
 - email: "chris.farmiloe@digital.cabinet-office.gov.uk"
   origin: "google"
   deploy_envs: ['prod', 'prod-lon', 'stg-lon']
+  cf_admin: true
 
 - email: "lee.porte@digital.cabinet-office.gov.uk"
   origin: "google"
   deploy_envs: ['prod', 'prod-lon', 'stg-lon', 'leeporte']
+  cf_admin: true
 
 - email: "michael.mokrysz@digital.cabinet-office.gov.uk"
   origin: "google"
   deploy_envs: ['prod', 'prod-lon', 'stg-lon', 'miki']
+  cf_admin: true
 
 - email: "mohamed.deerow@digital.cabinet-office.gov.uk"
   origin: "google"
   deploy_envs: ['modeerow']
+  cf_admin: true
 
 - email: "rafal.proszowski@digital.cabinet-office.gov.uk"
   origin: "google"
   deploy_envs: ['prod', 'prod-lon', 'stg-lon']
+  cf_admin: true
 
 - email: "richard.towers@digital.cabinet-office.gov.uk"
   origin: "google"
   deploy_envs: ['prod', 'prod-lon', 'stg-lon', 'towers']
+  cf_admin: true
 
 - email: "russell.howe@digital.cabinet-office.gov.uk"
   origin: "google"
   deploy_envs: ['prod', 'prod-lon', 'stg-lon']
+  cf_admin: true
 
 - email: "tom.whitwell@digital.cabinet-office.gov.uk"
   origin: "google"
   deploy_envs: ['prod', 'prod-lon', 'stg-lon', 'tnw']
+  cf_admin: true
 
 - email: "toby.lornewelch-richards@digital.cabinet-office.gov.uk"
   origin: "google"
   deploy_envs: ['prod', 'prod-lon', 'stg-lon', 'tlwr']
+  cf_admin: true
+
+- email: "venus.bailey@digital.cabinet-office.gov.uk"
+  origin: "google"
+  deploy_envs: ['prod', 'prod-lon', 'stg-lon']
+
+- email: "luke.malcher@digital.cabinet-office.gov.uk"
+  origin: "google"
+  deploy_envs: ['prod', 'prod-lon', 'stg-lon']
+
+- email: "paul.dougan@digital.cabinet-office.gov.uk"
+  origin: "google"
+  deploy_envs: ['prod', 'prod-lon', 'stg-lon']

--- a/manifests/prometheus/operations.d/250-grafana-oauth.yml
+++ b/manifests/prometheus/operations.d/250-grafana-oauth.yml
@@ -1,0 +1,24 @@
+- type: replace
+  path: /instance_groups/name=grafana/jobs/name=grafana/properties/grafana/server?/root_url?
+  value: https://grafana-1.((system_domain))
+
+- type: replace
+  path: /instance_groups/name=grafana/jobs/name=grafana/properties/grafana/auth?/google/allow_sign_up
+  value: false
+
+- type: replace
+  path: /instance_groups/name=grafana/jobs/name=grafana/properties/grafana/auth?/google/enabled
+  value: true
+
+- type: replace
+  path: /instance_groups/name=grafana/jobs/name=grafana/properties/grafana/auth?/google/client_id
+  value: ((grafana_auth_google_client_id))
+
+- type: replace
+  path: /instance_groups/name=grafana/jobs/name=grafana/properties/grafana/auth?/google/client_secret
+  value: ((grafana_auth_google_client_secret))
+
+- type: replace
+  path: /instance_groups/name=grafana/jobs/name=grafana/properties/grafana/auth?/google/allowed_domains
+  value:
+    - digital.cabinet-office.gov.uk

--- a/manifests/prometheus/scripts/generate-manifest.sh
+++ b/manifests/prometheus/scripts/generate-manifest.sh
@@ -51,6 +51,8 @@ traffic_controller_external_port: 443
 uaa_clients_cf_exporter_secret: ((uaa_clients_cf_exporter_secret))
 uaa_clients_firehose_exporter_secret: ((uaa_clients_firehose_exporter_secret))
 aws_account: $AWS_ACCOUNT
+grafana_auth_google_client_id: $GRAFANA_AUTH_GOOGLE_CLIENT_ID
+grafana_auth_google_client_secret: $GRAFANA_AUTH_GOOGLE_CLIENT_SECRET
 EOF
 
 # shellcheck disable=SC2086

--- a/manifests/prometheus/spec/support/manifest_helpers.rb
+++ b/manifests/prometheus/spec/support/manifest_helpers.rb
@@ -26,6 +26,8 @@ private
     env['DEPLOY_ENV'] = 'test'
     env['BOSH_URL'] = 'https://bosh.example.com:25555'
     env['ENV_SPECIFIC_BOSH_VARS_FILE'] = 'default.yml'
+    env['GRAFANA_AUTH_GOOGLE_CLIENT_ID'] = 'google-client-id'
+    env['GRAFANA_AUTH_GOOGLE_CLIENT_SECRET'] = 'google-client-secret'
     env
   end
 

--- a/scripts/sync-admin-users.rb
+++ b/scripts/sync-admin-users.rb
@@ -8,6 +8,7 @@ def load_admin_user_list(filename, deploy_env)
   users = YAML.load_file(filename)
   users
     .select { |u| u.fetch('deploy_envs', []).include? deploy_env }
+    .select { |u| u.fetch('cf_admin', false) }
     .each_with_index.map { |u, i|
     {
       username: u.fetch("username", u.fetch("email")),

--- a/scripts/upload-google-oauth-secrets.sh
+++ b/scripts/upload-google-oauth-secrets.sh
@@ -7,6 +7,9 @@ export PASSWORD_STORE_DIR=${OAUTH_PASSWORD_STORE_DIR}
 GOOGLE_OAUTH_CLIENT_ID=$(pass "google/${MAKEFILE_ENV_TARGET}/oauth/client_id")
 GOOGLE_OAUTH_CLIENT_SECRET=$(pass "google/${MAKEFILE_ENV_TARGET}/oauth/client_secret")
 
+GRAFANA_AUTH_GOOGLE_CLIENT_ID=$(pass "google/${MAKEFILE_ENV_TARGET}/oauth/grafana_client_id")
+GRAFANA_AUTH_GOOGLE_CLIENT_SECRET=$(pass "google/${MAKEFILE_ENV_TARGET}/oauth/grafana_client_secret")
+
 SECRETS=$(mktemp secrets.yml.XXXXXX)
 trap 'rm  "${SECRETS}"' EXIT
 
@@ -15,6 +18,8 @@ cat > "${SECRETS}" << EOF
 secrets:
   google_oauth_client_id: ${GOOGLE_OAUTH_CLIENT_ID}
   google_oauth_client_secret: ${GOOGLE_OAUTH_CLIENT_SECRET}
+  grafana_auth_google_client_id: ${GRAFANA_AUTH_GOOGLE_CLIENT_ID}
+  grafana_auth_google_client_secret: ${GRAFANA_AUTH_GOOGLE_CLIENT_SECRET}
 EOF
 
 aws s3 cp "${SECRETS}" "s3://gds-paas-${DEPLOY_ENV}-state/google-oauth-secrets.yml"


### PR DESCRIPTION
What
----

As a GOV.UK PaaS operator, I want to be able to use Google OAuth to sign in to Grafana, so I can look at the health of the platform.

This PR does the following:

- Optimise the pipeline such that `prometheus-deploy` is faster (using `aggregate`)
- Refactor `admin_users.yml` into `users.yml` with a flag for whether they need a CF admin account
- Adds Prometheus deploy ops file to enable Grafana OAuth
- Adds Concourse task to manage Grafana users

Other PRs
---

- https://github.com/alphagov/paas-credentials/pull/152

How to review
-------------

- Code review
- Run this down your pipeline
- Log in to Grafana using OAuth
- Ensure SSO still works

Who can review
--------------

Not @tlwr 
