### PR TITLE
Ignore instance ID in logs for custom acceptance

### DIFF
--- a/platform-tests/src/platform/acceptance/logging_pipeline_test.go
+++ b/platform-tests/src/platform/acceptance/logging_pipeline_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Logging pipeline", func() {
 				appLogs := cf.Cf("logs", "--recent", appName)
 				Expect(appLogs.Wait("30s")).To(Exit(0))
 				return appLogs
-			}, "2m", "10s").Should(gbytes.Say("APP[/]PROC[/]WEB[/]0"))
+			}, "2m", "10s").Should(gbytes.Say("APP[/]PROC[/]WEB[/]"))
 		})
 	})
 
@@ -55,7 +55,7 @@ var _ = Describe("Logging pipeline", func() {
 				appLogs := cf.Cf("logs", "--recent", appName)
 				Expect(appLogs.Wait("30s")).To(Exit(0))
 				return appLogs
-			}, "2m", "10s").Should(gbytes.Say("RTR[/]0"))
+			}, "2m", "10s").Should(gbytes.Say("RTR[/]"))
 		})
 	})
 })


### PR DESCRIPTION
What
----

The custom acceptance test which checks logging is flakey because the logs are not guaranteed to be RTR/0 or APP/PROC/WEB/0 just APP/PROC/WEB/x or RTR/x

This PR removes the instance index from the test


How to review
-------------

Code review + YOLO merge

Who can review
--------------

Not @tlwr
