### PR TITLE
[#166116997] API availability tests

### DIFF
--- a/platform-tests/src/platform/availability/monitor/monitor.go
+++ b/platform-tests/src/platform/availability/monitor/monitor.go
@@ -13,7 +13,6 @@ type Report struct {
 	SuccessCount int64
 	FailureCount int64
 	WarningCount int64
-	ErrorCount   int64
 	Errors       map[*Task]map[string]int // number of errors by error message by task
 	Warnings     map[*Task]map[string]int // number of warnings by error message by task
 	Elapsed      time.Duration
@@ -27,7 +26,6 @@ func (r *Report) String() string {
 	s += fmt.Sprintf("Total successes:       %d\n", r.SuccessCount)
 	s += fmt.Sprintf("Total failures:        %d\n", r.FailureCount)
 	s += fmt.Sprintf("Total warnings:        %d\n", r.WarningCount)
-	s += fmt.Sprintf("Total errors:          %d\n", r.ErrorCount)
 	s += fmt.Sprintf("Elapsed time:          %s\n", r.Elapsed.String())
 	s += fmt.Sprintf("Average rate:          %.2f tasks/sec\n", float64(total)/r.Elapsed.Seconds())
 
@@ -115,7 +113,6 @@ func (m *Monitor) statsCollector() {
 						report.Errors[result.task] = map[string]int{}
 					}
 					report.Errors[result.task][msg]++
-					report.ErrorCount++
 					report.FailureCount++
 				} else {
 					if report.Warnings[result.task] == nil {

--- a/platform-tests/src/platform/availability/monitor/monitor_suite_test.go
+++ b/platform-tests/src/platform/availability/monitor/monitor_suite_test.go
@@ -1,4 +1,4 @@
-package monitor_test
+package monitor
 
 import (
 	. "github.com/onsi/ginkgo"

--- a/platform-tests/src/platform/availability/monitor/monitor_test.go
+++ b/platform-tests/src/platform/availability/monitor/monitor_test.go
@@ -1,8 +1,7 @@
-package monitor_test
+package monitor
 
 import (
 	"errors"
-	. "platform/availability/monitor"
 	"regexp"
 	"time"
 

--- a/platform-tests/src/platform/availability/monitor/monitor_test.go
+++ b/platform-tests/src/platform/availability/monitor/monitor_test.go
@@ -11,15 +11,22 @@ import (
 )
 
 var _ = Describe("Monitor", func() {
-	var taskRatePerSecond int64
+	var (
+		taskRatePerSecond int64
+		targetReliability float64
+	)
 
 	BeforeEach(func() {
 		taskRatePerSecond = 20
+		targetReliability = 99.95
 	})
 
 	Context("When a task is registered", func() {
 		It("should handle successful runs", func() {
-			monitor := NewMonitor(&cfclient.Config{}, GinkgoWriter, 2, []*regexp.Regexp{}, taskRatePerSecond)
+			monitor := NewMonitor(
+				&cfclient.Config{}, GinkgoWriter, 2, []*regexp.Regexp{},
+				taskRatePerSecond, targetReliability,
+			)
 			monitor.Add("test", func(cfg *cfclient.Config) error {
 				<-time.After(1 * time.Second)
 				return nil
@@ -35,7 +42,10 @@ var _ = Describe("Monitor", func() {
 		}, 4)
 
 		It("should handle errors", func() {
-			monitor := NewMonitor(&cfclient.Config{}, GinkgoWriter, 2, []*regexp.Regexp{}, taskRatePerSecond)
+			monitor := NewMonitor(
+				&cfclient.Config{}, GinkgoWriter, 2, []*regexp.Regexp{},
+				taskRatePerSecond, targetReliability,
+			)
 			monitor.Add("test", func(cfg *cfclient.Config) error {
 				<-time.After(1 * time.Second)
 				return errors.New("some error")
@@ -51,9 +61,11 @@ var _ = Describe("Monitor", func() {
 		}, 4)
 
 		It("should handle specific errors as warning", func() {
-			monitor := NewMonitor(&cfclient.Config{}, GinkgoWriter, 2, []*regexp.Regexp{
-				regexp.MustCompile("this is a warning"),
-			}, taskRatePerSecond)
+			monitor := NewMonitor(
+				&cfclient.Config{}, GinkgoWriter, 2,
+				[]*regexp.Regexp{regexp.MustCompile("this is a warning")},
+				taskRatePerSecond, targetReliability,
+			)
 			monitor.Add("test", func(cfg *cfclient.Config) error {
 				<-time.After(1 * time.Second)
 				return errors.New("foo, this is a warning, bar")
@@ -70,9 +82,12 @@ var _ = Describe("Monitor", func() {
 
 	})
 
-	Describe("rate limiting", func() {
+	Context("Rate limiting", func() {
 		It("should limit the rate by which tasks are added to the queue", func() {
-			monitor := NewMonitor(&cfclient.Config{}, GinkgoWriter, 2, []*regexp.Regexp{}, taskRatePerSecond)
+			monitor := NewMonitor(
+				&cfclient.Config{}, GinkgoWriter, 2, []*regexp.Regexp{},
+				taskRatePerSecond, targetReliability,
+			)
 			monitor.Add("consume as fast as possible", func(cfg *cfclient.Config) error {
 				return nil
 			})
@@ -84,6 +99,95 @@ var _ = Describe("Monitor", func() {
 			expectedTaskLimit := taskRatePerSecond * 3
 
 			Expect(report.SuccessCount).To(BeNumerically("<", expectedTaskLimit))
+		})
+	})
+
+	Context("Acceptance or failure", func() {
+		It("should fail if the targetReliability is not set", func() {
+			monitor := NewMonitor(
+				&cfclient.Config{}, GinkgoWriter, 2, []*regexp.Regexp{},
+				taskRatePerSecond, 0.0,
+			)
+
+			Expect(monitor.HaveTestsPassed(Report{})).To(Equal(false))
+		})
+
+		It("should fail if the tests have not run", func() {
+			monitor := NewMonitor(
+				&cfclient.Config{}, GinkgoWriter, 2, []*regexp.Regexp{},
+				taskRatePerSecond, targetReliability,
+			)
+
+			report := Report{
+				SuccessCount: 0, WarningCount: 0, FailureCount: 0,
+			}
+
+			Expect(monitor.HaveTestsPassed(report)).To(Equal(false))
+		})
+
+		It("should fail if there are no successes", func() {
+			monitor := NewMonitor(
+				&cfclient.Config{}, GinkgoWriter, 2, []*regexp.Regexp{},
+				taskRatePerSecond, targetReliability,
+			)
+
+			report := Report{
+				SuccessCount: 0, WarningCount: 7, FailureCount: 9,
+			}
+
+			Expect(monitor.HaveTestsPassed(report)).To(Equal(false))
+		})
+
+		It("should pass if there are no failures", func() {
+			monitor := NewMonitor(
+				&cfclient.Config{}, GinkgoWriter, 2, []*regexp.Regexp{},
+				taskRatePerSecond, targetReliability,
+			)
+
+			report := Report{
+				SuccessCount: 1, WarningCount: 0, FailureCount: 0,
+			}
+
+			Expect(monitor.HaveTestsPassed(report)).To(Equal(true))
+		})
+
+		It("should pass if there are some warnings", func() {
+			monitor := NewMonitor(
+				&cfclient.Config{}, GinkgoWriter, 2, []*regexp.Regexp{},
+				taskRatePerSecond, targetReliability,
+			)
+
+			report := Report{
+				SuccessCount: 5000, WarningCount: 2, FailureCount: 0,
+			}
+
+			Expect(monitor.HaveTestsPassed(report)).To(Equal(true))
+		})
+
+		It("should pass if there are some failures", func() {
+			monitor := NewMonitor(
+				&cfclient.Config{}, GinkgoWriter, 2, []*regexp.Regexp{},
+				taskRatePerSecond, targetReliability,
+			)
+
+			report := Report{
+				SuccessCount: 5000, WarningCount: 0, FailureCount: 2,
+			}
+
+			Expect(monitor.HaveTestsPassed(report)).To(Equal(true))
+		})
+
+		It("should pass if there are bad executions", func() {
+			monitor := NewMonitor(
+				&cfclient.Config{}, GinkgoWriter, 2, []*regexp.Regexp{},
+				taskRatePerSecond, targetReliability,
+			)
+
+			report := Report{
+				SuccessCount: 5000, WarningCount: 1, FailureCount: 1,
+			}
+
+			Expect(monitor.HaveTestsPassed(report)).To(Equal(true))
 		})
 	})
 })

--- a/platform-tests/src/platform/availability/monitor/report.go
+++ b/platform-tests/src/platform/availability/monitor/report.go
@@ -1,0 +1,66 @@
+package monitor
+
+import (
+	"fmt"
+	"time"
+)
+
+type Report struct {
+	SuccessCount int64
+	FailureCount int64
+	WarningCount int64
+	Errors       map[*Task]map[string]int // number of errors by error message by task
+	Warnings     map[*Task]map[string]int // number of warnings by error message by task
+	Elapsed      time.Duration
+}
+
+func (r *Report) badExecutions() int64 {
+	return r.FailureCount + r.WarningCount
+}
+
+func (r *Report) TotalExecutions() int64 {
+	return r.SuccessCount + r.badExecutions()
+}
+
+func (r *Report) PercentageGoodExecutions() float64 {
+	return 100.0 * (float64(r.SuccessCount) / float64(r.TotalExecutions()))
+}
+
+func (r *Report) tasksPerSecond() float64 {
+	return float64(r.TotalExecutions()) / r.Elapsed.Seconds()
+}
+
+func (r *Report) String() string {
+	s := "\nReport:\n"
+	s += "==============\n"
+	s += fmt.Sprintf("Total task executions: %d\n", r.TotalExecutions())
+	s += fmt.Sprintf("Good executions %%:     %5f%%\n", r.PercentageGoodExecutions())
+	s += "--------------\n"
+	s += fmt.Sprintf("Total successes:       %d\n", r.SuccessCount)
+	s += fmt.Sprintf("Total bad executions:  %d\n", r.badExecutions())
+	s += fmt.Sprintf("  -> failures:         %d\n", r.FailureCount)
+	s += fmt.Sprintf("  -> warnings:         %d\n", r.WarningCount)
+	s += "--------------\n"
+	s += fmt.Sprintf("Elapsed time:          %s\n", r.Elapsed.String())
+	s += fmt.Sprintf("Average rate:          %.2f tasks/sec\n", r.tasksPerSecond())
+
+	if len(r.Errors) > 0 {
+		s += fmt.Sprintf("\nErrors:\n")
+		for task, errCounts := range r.Errors {
+			s += fmt.Sprintf("\n    %s:\n", task.name)
+			for err, count := range errCounts {
+				s += fmt.Sprintf("        %s (%d failures)\n", err, count)
+			}
+		}
+	}
+	if len(r.Warnings) > 0 {
+		s += fmt.Sprintf("\nWarnings:\n")
+		for task, warningCounts := range r.Warnings {
+			s += fmt.Sprintf("\n    %s:\n", task.name)
+			for warning, count := range warningCounts {
+				s += fmt.Sprintf("        %s (%d warnings)\n", warning, count)
+			}
+		}
+	}
+	return s
+}

--- a/platform-tests/src/platform/availability/monitor/report_test.go
+++ b/platform-tests/src/platform/availability/monitor/report_test.go
@@ -1,0 +1,106 @@
+package monitor
+
+import (
+	"math"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Report", func() {
+	Context("Bad executions", func() {
+		It("should calculate zero bad executions", func() {
+			report := Report{FailureCount: 0, WarningCount: 0}
+			Expect(report.badExecutions()).To(BeNumerically("==", 0))
+		})
+
+		It("should calculate bad executions only failures", func() {
+			report := Report{FailureCount: 7, WarningCount: 0}
+			Expect(report.badExecutions()).To(BeNumerically("==", 7))
+		})
+
+		It("should calculate bad executions only errors", func() {
+			report := Report{FailureCount: 0, WarningCount: 9}
+			Expect(report.badExecutions()).To(BeNumerically("==", 9))
+		})
+
+		It("should calculate bad executions", func() {
+			report := Report{FailureCount: 7, WarningCount: 9}
+			Expect(report.badExecutions()).To(BeNumerically("==", 16))
+		})
+	})
+
+	Context("Total executions", func() {
+		It("should calculate zero executions", func() {
+			report := Report{SuccessCount: 0, FailureCount: 0, WarningCount: 0}
+			Expect(report.TotalExecutions()).To(BeNumerically("==", 0))
+		})
+
+		It("should calculate only bad executions", func() {
+			report := Report{SuccessCount: 0, FailureCount: 7, WarningCount: 9}
+			Expect(report.TotalExecutions()).To(BeNumerically("==", 16))
+		})
+
+		It("should calculate only good executions", func() {
+			report := Report{SuccessCount: 11, FailureCount: 0, WarningCount: 0}
+			Expect(report.TotalExecutions()).To(BeNumerically("==", 11))
+		})
+
+		It("should calculate total executions", func() {
+			report := Report{SuccessCount: 11, FailureCount: 7, WarningCount: 9}
+			Expect(report.TotalExecutions()).To(BeNumerically("==", 27))
+		})
+	})
+
+	Context("Percentage good executions", func() {
+		It("should return NaN for zero executions", func() {
+			report := Report{SuccessCount: 0, FailureCount: 0, WarningCount: 0}
+
+			Expect(
+				math.IsNaN(report.PercentageGoodExecutions()),
+			).To(
+				Equal(true),
+			)
+		})
+
+		It("should calculate only bad executions", func() {
+			report := Report{SuccessCount: 0, FailureCount: 7, WarningCount: 9}
+
+			Expect(
+				report.PercentageGoodExecutions(),
+			).To(
+				BeNumerically("==", 0.0),
+			)
+		})
+
+		It("should calculate only good executions", func() {
+			report := Report{SuccessCount: 11, FailureCount: 0, WarningCount: 0}
+
+			Expect(
+				report.PercentageGoodExecutions(),
+			).To(
+				BeNumerically("==", 100.0),
+			)
+		})
+
+		It("should calculate total executions", func() {
+			report := Report{SuccessCount: 11, FailureCount: 7, WarningCount: 9}
+
+			Expect(
+				report.PercentageGoodExecutions(),
+			).To(
+				BeNumerically("~", 40.75, 0.01),
+			)
+		})
+
+		It("should calculate large total executions", func() {
+			report := Report{SuccessCount: 13000, FailureCount: 3, WarningCount: 2}
+
+			Expect(
+				report.PercentageGoodExecutions(),
+			).To(
+				BeNumerically("~", 99.96, 0.01),
+			)
+		})
+	})
+})


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/166116997)

What
----

Changes:

- Cleanup availability test code and remove duplication
- Cleanup old Golang package syntax
- Refactor the tests to use a % rule instead of constant

Ramifications:

- Tests will no longer fail for a single failure
- The test report output has changed
- For tests with a low number of executions, this will fail more often
  > (4 failures out of 100 executions, which was previously okay, will fail)

How to review
-------------

- Code review
- Travis
- Run down pipeline -> green
- Run down pipeline, simulate a failure while the tests are running (e.g. `pkill -9 java` on a UAA instance)

Who can review
--------------

Not @tlwr
