### PR TITLE
Upgrade control plane

### DIFF
--- a/manifests/cloud-config/cloud-config.yml
+++ b/manifests/cloud-config/cloud-config.yml
@@ -139,28 +139,28 @@ vm_types:
 - name: compilation
   cloud_properties:
     iam_instance_profile: compilation-vm
-    instance_type: c4.large
+    instance_type: ((compilation_vm_instance_type))
     ephemeral_disk:
       size: 20480
       type: gp2
 
 - name: nano
   cloud_properties:
-    instance_type: t2.nano
+    instance_type: ((nano_vm_instance_type))
     ephemeral_disk:
       size: 10240
       type: gp2
 
 - name: small
   cloud_properties:
-    instance_type: t2.small
+    instance_type: ((small_vm_instance_type))
     ephemeral_disk:
       size: 10240
       type: gp2
 
 - name: errand
   cloud_properties:
-    instance_type: t2.small
+    instance_type: ((small_vm_instance_type))
     ephemeral_disk:
       size: 10240
       type: gp2
@@ -168,21 +168,21 @@ vm_types:
 
 - name: medium
   cloud_properties:
-    instance_type: t2.medium
+    instance_type: ((medium_vm_instance_type))
     ephemeral_disk:
       size: 10240
       type: gp2
 
 - name: large
   cloud_properties:
-    instance_type: m4.large
+    instance_type: ((large_vm_instance_type))
     ephemeral_disk:
       size: 10240
       type: gp2
 
 - name: router
   cloud_properties:
-    instance_type: c4.large
+    instance_type: ((router_instance_type))
     ephemeral_disk:
       size: 10240
       type: gp2

--- a/manifests/cloud-config/cloud-config.yml
+++ b/manifests/cloud-config/cloud-config.yml
@@ -151,6 +151,13 @@ vm_types:
       size: 10240
       type: gp2
 
+- name: nano_previous_generation
+  cloud_properties:
+    instance_type: ((nano_vm_previous_generation_instance_type))
+    ephemeral_disk:
+      size: 10240
+      type: gp2
+
 - name: small
   cloud_properties:
     instance_type: ((small_vm_instance_type))
@@ -169,6 +176,13 @@ vm_types:
 - name: medium
   cloud_properties:
     instance_type: ((medium_vm_instance_type))
+    ephemeral_disk:
+      size: 10240
+      type: gp2
+
+- name: medium_previous_generation
+  cloud_properties:
+    instance_type: ((medium_vm_previous_generation_instance_type))
     ephemeral_disk:
       size: 10240
       type: gp2

--- a/manifests/prometheus/operations.d/100-update-vm-types.yml
+++ b/manifests/prometheus/operations.d/100-update-vm-types.yml
@@ -1,9 +1,9 @@
 - type: replace
   path: /instance_groups/name=alertmanager/vm_type
-  value: nano
+  value: nano_previous_generation
 - type: replace
   path: /instance_groups/name=grafana/vm_type
-  value: nano
+  value: nano_previous_generation
 - type: replace
   path: /instance_groups/name=prometheus2/vm_type
-  value: medium
+  value: medium_previous_generation

--- a/manifests/prometheus/spec/operations/monitor_cf_spec.rb
+++ b/manifests/prometheus/spec/operations/monitor_cf_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "Monitor CF" do
   it "adds the firehose instance_group" do
     firehose = manifest_with_defaults.get("instance_groups.prometheus2")
     expect(firehose).not_to be_nil
-    expect(firehose["vm_type"]).to eq("medium")
+    expect(firehose["vm_type"]).to eq("medium_previous_generation")
     expect(firehose["networks"]).to eq([{ "name" => "cf" }])
   end
 

--- a/manifests/prometheus/spec/operations/update_vm_types_spec.rb
+++ b/manifests/prometheus/spec/operations/update_vm_types_spec.rb
@@ -1,9 +1,9 @@
 
 RSpec.describe "update-vm-types.yml" do
   {
-    "alertmanager" => "nano",
-    "grafana" => "nano",
-    "prometheus2" => "medium",
+    "alertmanager" => "nano_previous_generation",
+    "grafana" => "nano_previous_generation",
+    "prometheus2" => "medium_previous_generation",
   }.each do |name, type|
     it "sets the vm_type for #{name} to #{type}" do
       expect(manifest_with_defaults.get("instance_groups.#{name}.vm_type")).to eq(type)

--- a/manifests/variables.yml
+++ b/manifests/variables.yml
@@ -1,4 +1,10 @@
 ---
+compilation_vm_instance_type: c4.large
+nano_vm_instance_type: t2.nano
+small_vm_instance_type: t2.small
+medium_vm_instance_type: t2.medium
+large_vm_instance_type: m4.large
+router_instance_type: c4.large
 cell_instance_type: r5.xlarge
 
 # Advertised memory capacity of the cells.

--- a/manifests/variables.yml
+++ b/manifests/variables.yml
@@ -1,10 +1,12 @@
 ---
-compilation_vm_instance_type: c4.large
-nano_vm_instance_type: t2.nano
-small_vm_instance_type: t2.small
-medium_vm_instance_type: t2.medium
-large_vm_instance_type: m4.large
-router_instance_type: c4.large
+compilation_vm_instance_type: c5.large
+nano_vm_instance_type: t3.nano
+nano_vm_previous_generation_instance_type: t2.nano
+small_vm_instance_type: t3.small
+medium_vm_instance_type: t3.medium
+medium_vm_previous_generation_instance_type: t2.medium
+large_vm_instance_type: m5.large
+router_instance_type: c5.large
 cell_instance_type: r5.xlarge
 
 # Advertised memory capacity of the cells.


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/166728064)

What
----

- Introduce variables for our instance types
- Upgrade instance types to latest generation of AWS
  > note that the upgrade excludes the `prometheus` deployment as our version of the AWS CPI does not work well with NVMe instance types (c5, t3, m5, r5)
- ~Upgrades stemcells to `315x` series~
- Deletes the alert which warns us of our bosh stemcells being out sync (we will reinstate it when paas-bootstrap is up to date)

Why
---

New instance types are:
- Cheaper
- Faster
- More reliable network performance

Making instance types all the latest generation across GDS's entire estate would let us reserve instances and save money.

How to review
-------------

- Code review
- See [this PR](https://github.com/alphagov/paas-cf/pull/1941), which was the same thing but for Diego cells
- See [this commit](https://github.com/cloudfoundry/bosh-aws-cpi-release/commit/9f2a9cc58dafc547e1f77cbb68b1f0a5ac207208) in Bosh, which shows support for these instance types
- Observe the tests passing:
  - [Acceptance](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/acceptance-tests/builds/41)
  - [Custom acceptance](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/custom-acceptance-tests/builds/39)
  - [Broker custom acceptance](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/custom-broker-acceptance-tests/builds/16)

Who can review
--------------

Not @tlwr
