### PR TITLE
[#166728064] Upgrade prometheus to latest generation

### DIFF
--- a/manifests/cloud-config/cloud-config.yml
+++ b/manifests/cloud-config/cloud-config.yml
@@ -151,13 +151,6 @@ vm_types:
       size: 10240
       type: gp2
 
-- name: nano_previous_generation
-  cloud_properties:
-    instance_type: ((nano_vm_previous_generation_instance_type))
-    ephemeral_disk:
-      size: 10240
-      type: gp2
-
 - name: small
   cloud_properties:
     instance_type: ((small_vm_instance_type))
@@ -176,13 +169,6 @@ vm_types:
 - name: medium
   cloud_properties:
     instance_type: ((medium_vm_instance_type))
-    ephemeral_disk:
-      size: 10240
-      type: gp2
-
-- name: medium_previous_generation
-  cloud_properties:
-    instance_type: ((medium_vm_previous_generation_instance_type))
     ephemeral_disk:
       size: 10240
       type: gp2

--- a/manifests/prometheus/operations.d/100-update-vm-types.yml
+++ b/manifests/prometheus/operations.d/100-update-vm-types.yml
@@ -1,9 +1,9 @@
 - type: replace
   path: /instance_groups/name=alertmanager/vm_type
-  value: nano_previous_generation
+  value: nano
 - type: replace
   path: /instance_groups/name=grafana/vm_type
-  value: nano_previous_generation
+  value: nano
 - type: replace
   path: /instance_groups/name=prometheus2/vm_type
-  value: medium_previous_generation
+  value: medium

--- a/manifests/prometheus/spec/operations/monitor_cf_spec.rb
+++ b/manifests/prometheus/spec/operations/monitor_cf_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "Monitor CF" do
   it "adds the firehose instance_group" do
     firehose = manifest_with_defaults.get("instance_groups.prometheus2")
     expect(firehose).not_to be_nil
-    expect(firehose["vm_type"]).to eq("medium_previous_generation")
+    expect(firehose["vm_type"]).to eq("medium")
     expect(firehose["networks"]).to eq([{ "name" => "cf" }])
   end
 

--- a/manifests/prometheus/spec/operations/update_vm_types_spec.rb
+++ b/manifests/prometheus/spec/operations/update_vm_types_spec.rb
@@ -1,9 +1,9 @@
 
 RSpec.describe "update-vm-types.yml" do
   {
-    "alertmanager" => "nano_previous_generation",
-    "grafana" => "nano_previous_generation",
-    "prometheus2" => "medium_previous_generation",
+    "alertmanager" => "nano",
+    "grafana" => "nano",
+    "prometheus2" => "medium",
   }.each do |name, type|
     it "sets the vm_type for #{name} to #{type}" do
       expect(manifest_with_defaults.get("instance_groups.#{name}.vm_type")).to eq(type)

--- a/manifests/variables.yml
+++ b/manifests/variables.yml
@@ -1,10 +1,8 @@
 ---
 compilation_vm_instance_type: c5.large
 nano_vm_instance_type: t3.nano
-nano_vm_previous_generation_instance_type: t2.nano
 small_vm_instance_type: t3.small
 medium_vm_instance_type: t3.medium
-medium_vm_previous_generation_instance_type: t2.medium
 large_vm_instance_type: m5.large
 router_instance_type: c5.large
 cell_instance_type: r5.xlarge


### PR DESCRIPTION
**Depends on  [this paas-bootstrap PR](https://github.com/alphagov/paas-bootstrap/pull/289) being merged and deployed**

[Story](https://www.pivotaltracker.com/story/show/166728064)

What
----

This PR removes the `{medium,nano}_previous_generation` instances which we added for grafana/prometheus/alertmanager (the things with disks in paas-cf). Since we have upgraded the bosh-aws-cpi-release to >=v74 ([this pr]()) we can now upgrade these instances to the latest generation also.

How to review
-------------

Code review

Look at Travis

Run it down your pipeline

Who can review
--------------

Not @tlwr
