### PR TITLE
Allow subshell scope logins for dev envs [skip ci]

### DIFF
--- a/scripts/cf_admin_login_dev.sh
+++ b/scripts/cf_admin_login_dev.sh
@@ -2,7 +2,22 @@
 
 set -euo pipefail
 
+usage() { echo "Usage: $0 [-s]" 1>&2; exit 1; }
+
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+SUBSHELL=false
+while getopts "s,subshell" o; do
+	case "${o}" in
+		s)
+			SUBSHELL=true
+			;;
+
+		*)
+			usage
+			;;
+	esac
+done
 
 # shellcheck disable=SC1090
 source "${SCRIPT_DIR}/common.sh"
@@ -13,5 +28,31 @@ API_URL="https://api.${DEPLOY_ENV}.dev.cloudpipeline.digital"
 # shellcheck disable=SC2091
 $("${SCRIPT_DIR}/show-vars-store-secrets.sh" cf-vars-store cf_admin_password)
 
+if [ $SUBSHELL == true ]; then
+	TMPDIR=${TMPDIR:-/tmp}
+	CF_HOME=$(mktemp -d "${TMPDIR}/cf_home.XXXXXX")
+	cleanup() {
+	  echo "Cleaning up temporary CF_HOME..."
+	  cf logout || true
+	  rm -r "${CF_HOME}"
+	}
+	trap 'cleanup' EXIT
+
+	mkdir -p "${HOME}/.cf/plugins" "${CF_HOME}/.cf"
+	ln -s "${HOME}/.cf/plugins" "${CF_HOME}/.cf/plugins"
+
+	export CF_HOME
+	export CF_SUBSHELL_TARGET=$DEPLOY_ENV
+fi
+
 cf api "$API_URL"
 cf login -u admin -p "${CF_ADMIN_PASSWORD}"
+
+
+if [ $SUBSHELL == true ]; then
+	echo
+	echo "You are now in a subshell with CF_HOME set to ${CF_HOME}"
+	echo "This will be cleaned up when this shell is closed."
+	echo
+	${SHELL:-bash} -il
+fi


### PR DESCRIPTION

What
----

In the same spirit as `scripts/cf_subshell_scoped_login.sh`, this commit adds
an option to `scripts/cf_admin_login_dev` to allow users to scope the login to
a subshell. It uses the same method to do that as the former.

This is intended as a quality of life improvement, for those times when devs
are working across multiple spaces and the global nature of the `cf` tool is a
hindrance.

How to review
-------------

1. Code review
2. Try it out

Who can review
--------------
Not @AP-Hunt 