### PR TITLE
Upgrade stemcells to 315.41

### DIFF
--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-xenial
-      version: "170.69"
+      version: "315.41"


### PR DESCRIPTION
What
----

Upgrade stemcells to `315.41` from `170.69`; so we are running the latest and greatest versions/patches.

**Contingent on https://github.com/alphagov/paas-bootstrap/pull/291 having been merged and deployed beforehand**

How to review
-------------

Run this down your pipeline

Who can review
--------------

Not @tlwr
