### PR TITLE
Update the pausing and unpausing of kickoff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,11 +224,11 @@ trigger-deploy: check-env ## Trigger a run of the create-cloudfoundry pipeline.
 
 .PHONY: pause-kick-off
 pause-kick-off: check-env ## Pause the morning kick-off of deployment.
-	concourse/scripts/pause-kick-off.sh pause
+	concourse/scripts/pause-kick-off.sh pin
 
 .PHONY: unpause-kick-off
 unpause-kick-off: check-env ## Unpause the morning kick-off of deployment.
-	concourse/scripts/pause-kick-off.sh unpause
+	concourse/scripts/pause-kick-off.sh unpin
 
 .PHONY: showenv
 showenv: check-env ## Display environment information

--- a/concourse/scripts/pause-kick-off.sh
+++ b/concourse/scripts/pause-kick-off.sh
@@ -10,16 +10,16 @@ set -e
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
 case "${1:-}" in
-  pause)
+  pin)
     echo "Pausing pipeline kick-off."
-    action=pause
+    action=pin
     ;;
-  unpause)
+  unpin)
     echo "Unpausing pipeline kick-off."
-    action=unpause
+    action=unpin
     ;;
   *)
-    echo "Usage $0 <pause|unpause>"
+    echo "Usage $0 <pin|unpin>"
     exit 1
     ;;
 esac


### PR DESCRIPTION
What
----

With Concourse 5.x series pausing and unpausing of resources has been replaced by pinning and unpinning of resources. This PR reinstates the behaviour we had previously.

How to review
-------------

Code review
Deploy in your env and let it pin

unpin later in the day and see you have an env ready in the morning

Who can review
--------------

Anyone