### PR TITLE
[#166351405] Audit CloudController events

### DIFF
--- a/manifests/cf-manifest/operations.d/200-awslogs.yml
+++ b/manifests/cf-manifest/operations.d/200-awslogs.yml
@@ -1,0 +1,8 @@
+---
+- type: replace
+  path: /releases/-
+  value:
+    name: awslogs
+    version: 0.1.1
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/awslogs-0.1.1.tgz
+    sha1: dd307700e55c6c45376a5d76583243601e7559e6

--- a/manifests/cf-manifest/operations.d/320-cc-enable-security-event-logging.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-enable-security-event-logging.yml
@@ -1,0 +1,4 @@
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/security_event_logging?
+  value:
+    enabled: true

--- a/manifests/cf-manifest/operations.d/320-cc-ship-logs-for-auditing.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-ship-logs-for-auditing.yml
@@ -1,0 +1,16 @@
+---
+- type: replace
+  path: /instance_groups/name=api/jobs?/-
+  value:
+    name: awslogs-xenial
+    release: awslogs
+    properties:
+      awslogs-xenial:
+        region: ((terraform_outputs_region))
+        awslogs_files_config:
+          - name: /var/vcap/sys/log/cloud_controller_ng/security_events.log
+            file: /var/vcap/sys/log/cloud_controller_ng/security_events.log
+            log_group_name: cc_security_events_((deployment_name))
+            log_stream_name: "{{instance_id}}"
+            initial_position: start_of_file
+            datetime_format: "%Y-%m-%dT%H:%M:%S"

--- a/terraform/cloudfoundry/cc_security_events_log_retention.tf
+++ b/terraform/cloudfoundry/cc_security_events_log_retention.tf
@@ -1,0 +1,9 @@
+variable cloudwatch_log_retention_period {
+  description = "how long cloudwatch logs should be retained for (in days). Default 18 months"
+  default     = 545
+}
+
+resource "aws_cloudwatch_log_group" "cc_security_events" {
+  name              = "cc_security_events_${var.env}"
+  retention_in_days = "${var.cloudwatch_log_retention_period}"
+}


### PR DESCRIPTION
What
----

As part of increasing the security on the PaaS we want to collect all of the [Security Events from Cloud Controller](https://docs.cloudfoundry.org/loggregator/cc-uaa-logging.html#cc). 

We have forked a boshrelease from 18F and modified it for this usecase. Those changes were already merged in [awslogs-boshrelease](https://github.com/alphagov/paas-awslogs-boshrelease).

We are retaining the logs for 18 months as that gives plenty of scope for moving backwards in time with auditing actions on the platform. 

How to review
-------------

* Code review;
* This is deployed in the `miki` dev env and is deploying (as of 10:21am on the 26th) in the `towers` dev env. Feel free to deploy yourself but those will save you time. These logs should then be visible in CloudWatch Logs in the AWS Console.

Who can review
--------------

Anyone
