### PR TITLE
[#166381355] Store auditing logs for UAA

### DIFF
--- a/manifests/cf-manifest/operations.d/330-uaa-ship-logs-for-auditing.yml
+++ b/manifests/cf-manifest/operations.d/330-uaa-ship-logs-for-auditing.yml
@@ -1,0 +1,16 @@
+---
+- type: replace
+  path: /instance_groups/name=uaa/jobs?/-
+  value:
+    name: awslogs-xenial
+    release: awslogs
+    properties:
+      awslogs-xenial:
+        region: ((terraform_outputs_region))
+        awslogs_files_config:
+          - name: /var/vcap/sys/log/uaa/uaa_events.log
+            file: /var/vcap/sys/log/uaa/uaa_events.log
+            log_group_name: uaa_audit_events_((deployment_name))
+            log_stream_name: "{{instance_id}}"
+            initial_position: start_of_file
+            datetime_format: "%Y-%m-%d %H:%M:%S"

--- a/terraform/cloudfoundry/audit_log_retention.tf
+++ b/terraform/cloudfoundry/audit_log_retention.tf
@@ -7,3 +7,8 @@ resource "aws_cloudwatch_log_group" "cc_security_events" {
   name              = "cc_security_events_${var.env}"
   retention_in_days = "${var.cloudwatch_log_retention_period}"
 }
+
+resource "aws_cloudwatch_log_group" "uaa_audit_events" {
+  name              = "uaa_audit_events_${var.env}"
+  retention_in_days = "${var.cloudwatch_log_retention_period}"
+}


### PR DESCRIPTION
What
----

Ships the UAA Audit Events from https://docs.cloudfoundry.org/loggregator/cc-uaa-logging.html#uaa into CloudWatch Logs. See commit messages for more details.

This is very similar to #1960 which did this for Cloud Controller.

How to review
-------------

* Code review;
* Look at the logs in CloudWatch Logs coming from `miki` dev env.

Who can review
--------------

Not @46bit