### PR TITLE
Add a UAA client for paas-auditor

### DIFF
--- a/manifests/cf-manifest/operations.d/330-uaa.yml
+++ b/manifests/cf-manifest/operations.d/330-uaa.yml
@@ -122,6 +122,18 @@
     secret: ((secrets_uaa_clients_paas_billing_secret))
 
 - type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/paas-auditor?
+  value:
+    access-token-validity: 1209600
+    authorities: cloud_controller.admin_read_only,uaa.resource
+    authorized-grant-types: client_credentials,refresh_token,authorization_code
+    autoapprove: true
+    override: true
+    redirect-uri: https://auditor.((system_domain))/oauth/callback
+    scope: openid,oauth.approvals,cloud_controller.admin_read_only,cloud_controller.read,cloud_controller.global_auditor,cloud_controller.admin
+    secret: ((secrets_uaa_clients_paas_auditor_secret))
+
+- type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/paas-metrics?
   value:
     access-token-validity: 1209600
@@ -277,6 +289,11 @@
   path: /variables/-
   value:
     name: secrets_uaa_clients_paas_billing_secret
+    type: password
+- type: replace
+  path: /variables/-
+  value:
+    name: secrets_uaa_clients_paas_auditor_secret
     type: password
 
 - type: replace


### PR DESCRIPTION
What
----

My firebreak project is two apps:

* One named `paas-auditor` will regularly fetch CC Audit Events and save them into a Postgres database;

* The other named `paas-activity` will display a summary of tenant activity on the platform using that Postgres database.

I have failed to manually configure the UAA client that this commit configures, so I am putting it in the pipelines. This work is all a proof-of-concept and so the apps themselves are not included.

Depending on whether this firebreak project appeals this commit may be reverted next week.

How to review
-------------

Code review. Compare it to the `paas-billing` YAML which is immediately above both the changed lines.

Who can review
--------------

Not @46bit 