### PR TITLE
[#166154766] Continuously deploy PaaS-admin

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -379,7 +379,8 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-admin.git
       branch: master
-      tag_filter: v0.158.0
+      tag_filter: ((deploy_env_tag_prefix))
+      commit_verification_keys: ((gpg_public_keys))
 
   - name: prometheus-vars-store
     type: s3-iam
@@ -2930,6 +2931,67 @@ jobs:
           task: remove-temp-user
           tags: [colocated-with-web]
           file: paas-cf/concourse/tasks/delete_admin.yml
+
+      - get: git-keys
+
+      - task: tag-app-repo
+        tags: [colocated-with-web]
+        config: &tag-app-repo-config
+          platform: linux
+          image_resource: *git-ssh-image-resource
+          inputs:
+            - name: git-keys
+
+            - name: paas-admin
+              path: repo
+          params:
+            DEPLOY_ENV: ((deploy_env))
+            REPO: paas-admin
+            GIT_REPO_SSH: git@github.com:alphagov/paas-admin.git
+            GIT_EMAIL: the-multi-cloud-paas-team+deployer-ci@digital.cabinet-office.gov.uk
+            GIT_USER: gov-paas-((deploy_env))
+          run:
+            path: sh
+            args:
+              - -e
+              - -u
+              - -c
+              - |
+                new_tag="${DEPLOY_ENV}-$(date +%Y-%m-%d-%H-%M-%S)"
+
+                num_git_keys="$(tar -tzf git-keys/git-keys.tar.gz | wc -l)"
+                echo "Found ${num_git_keys} files in git-keys"
+
+                echo "Extracting ${num_git_keys} into .ssh"
+                tar xzf git-keys/git-keys.tar.gz
+                mkdir -p ~/.ssh
+
+                echo 'Configuring .ssh/config'
+                cat <<EOF > ~/.ssh/config
+                Host github.com
+                  StrictHostKeyChecking no
+                  IdentityFile $(pwd)/git-key
+                EOF
+
+                cd repo
+
+                if [ "$DEPLOY_ENV" = "stg-lon" ]; then
+                  echo 'Going to tag repo'
+                else
+                  echo 'Skipping: create-cloudfoundry only tags in staging'
+                  exit 0
+                fi
+
+                echo 'Configuring git'
+                git config --global user.email "${GIT_EMAIL}"
+                git config --global user.name "${GIT_USER}"
+                git remote add tag_origin "${GIT_REPO_SSH}"
+
+                echo "New tag for ${REPO} is ${new_tag}"
+                git tag "${new_tag}"
+
+                echo "Pushing tag refs/tags/${new_tag} to ${REPO}"
+                git push tag_origin "refs/tags/${new_tag}"
 
   - name: deploy-paas-billing
     serial: true

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -357,19 +357,19 @@ resources:
   - name: paas-aiven-broker
     type: git
     source:
-      uri: https://github.com/alphagov/paas-aiven-broker
+      uri: https://github.com/alphagov/paas-aiven-broker.git
       tag_filter: v0.15.0
 
   - name: paas-billing
     type: git
     source:
-      uri: https://github.com/alphagov/paas-billing
+      uri: https://github.com/alphagov/paas-billing.git
       tag_filter: v0.61.0
 
   - name: paas-accounts
     type: git
     source:
-      uri: https://github.com/alphagov/paas-accounts
+      uri: https://github.com/alphagov/paas-accounts.git
       tag_filter: v0.10.0
 
   - name: paas-admin
@@ -396,7 +396,7 @@ resources:
   - name: paas-yet-another-cloudwatch-exporter
     type: git
     source:
-      uri: https://github.com/alphagov/paas-yet-another-cloudwatch-exporter
+      uri: https://github.com/alphagov/paas-yet-another-cloudwatch-exporter.git
       branch: gds_master
 
   - name: pagerduty-secrets

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -364,18 +364,21 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-billing.git
+      branch: master
       tag_filter: v0.61.0
 
   - name: paas-accounts
     type: git
     source:
       uri: https://github.com/alphagov/paas-accounts.git
+      branch: master
       tag_filter: v0.10.0
 
   - name: paas-admin
     type: git
     source:
-      uri: https://github.com/alphagov/paas-admin
+      uri: https://github.com/alphagov/paas-admin.git
+      branch: master
       tag_filter: v0.158.0
 
   - name: prometheus-vars-store

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -323,6 +323,16 @@ resources:
       # This is an empty tar.gz file base64 encoded
       initial_content_binary: "H4sICMtSp1YAA2NvbmNvdXJzZS1jZXJ0cy50YXIA7cEBDQAAAMKg909tDjegAAAAAAAAAAAAgDcDmt4dJwAoAAA="
 
+  - name: paas-admin-git-keys
+    type: s3-iam
+    source:
+      bucket: ((state_bucket))
+      region_name: ((aws_region))
+      versioned_file: paas-admin-git-keys.tar.gz
+      initial_version: "-"
+      # This is an empty tar.gz file base64 encoded
+      initial_content_binary: "H4sICMtSp1YAA2NvbmNvdXJzZS1jZXJ0cy50YXIA7cEBDQAAAMKg909tDjegAAAAAAAAAAAAgDcDmt4dJwAoAAA="
+
   - name: release-version
     type: semver-iam
     source:
@@ -2932,7 +2942,7 @@ jobs:
           tags: [colocated-with-web]
           file: paas-cf/concourse/tasks/delete_admin.yml
 
-      - get: git-keys
+      - get: paas-admin-git-keys
 
       - task: tag-app-repo
         tags: [colocated-with-web]
@@ -2940,7 +2950,7 @@ jobs:
           platform: linux
           image_resource: *git-ssh-image-resource
           inputs:
-            - name: git-keys
+            - name: paas-admin-git-keys
 
             - name: paas-admin
               path: repo
@@ -2950,6 +2960,7 @@ jobs:
             GIT_REPO_SSH: git@github.com:alphagov/paas-admin.git
             GIT_EMAIL: the-multi-cloud-paas-team+deployer-ci@digital.cabinet-office.gov.uk
             GIT_USER: gov-paas-((deploy_env))
+            GIT_KEYS: paas-admin-git-keys
           run:
             path: sh
             args:
@@ -2959,18 +2970,18 @@ jobs:
               - |
                 new_tag="${DEPLOY_ENV}-$(date +%Y-%m-%d-%H-%M-%S)"
 
-                num_git_keys="$(tar -tzf git-keys/git-keys.tar.gz | wc -l)"
+                num_git_keys="$(tar -tzf "${GIT_KEYS}/${GIT_KEYS}.tar.gz" | wc -l)"
                 echo "Found ${num_git_keys} files in git-keys"
 
                 echo "Extracting ${num_git_keys} into .ssh"
-                tar xzf git-keys/git-keys.tar.gz
+                tar xzf "${GIT_KEYS}/${GIT_KEYS}.tar.gz"
                 mkdir -p ~/.ssh
 
                 echo 'Configuring .ssh/config'
                 cat <<EOF > ~/.ssh/config
                 Host github.com
                   StrictHostKeyChecking no
-                  IdentityFile $(pwd)/git-key
+                  IdentityFile $(pwd)/private-key
                 EOF
 
                 cd repo

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -101,6 +101,13 @@ prepare_environment() {
   export EXPOSE_PIPELINE=1
 }
 
+deploy_env_tag_prefix="*" # this matches all tags and is the default
+if [ "${DEPLOY_ENV}" = "prod" ] || [ "${DEPLOY_ENV}" = "prod-lon" ] ; then
+  deploy_env_tag_prefix="stg-lon-*" # this matches all tags created by stg-lon
+elif [ "${DEPLOY_ENV}" = "stg-lon" ]; then
+  deploy_env_tag_prefix="v[0-9]*" # this matches all tags created by release ci
+fi
+
 generate_vars_file() {
   cat <<EOF
 ---
@@ -150,6 +157,7 @@ monitored_aws_region: ${MONITORED_AWS_REGION:-}
 monitored_deploy_env: ${MONITORED_DEPLOY_ENV:-}
 grafana_auth_google_client_id: "${grafana_auth_google_client_id:-}"
 grafana_auth_google_client_secret: "${grafana_auth_google_client_secret:-}"
+deploy_env_tag_prefix: "${deploy_env_tag_prefix}"
 EOF
   echo -e "pipeline_lock_git_private_key: |\\n  ${git_id_rsa//$'\n'/$'\n'  }"
 }


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/166154766)

What
----

We currently have three problems which this PR attempts to address:

- We have to manually bump the `tag_filter` for the `paas-admin` git resource. 
- A staging pipeline run where the paas-admin acceptance tests fail can proceed to production and break production paas-admin.
- The entire staging pipeline must run even if the only thing which has changed is paas-admin.

It does this by cribbing off the existing tagging script, but puts it inside the pipeline and simplifies it somewhat. This is done with a view to doing it for paas-billing, paas-accounts, paas-auditor, etc in the future.

How to review
-------------

- Code review commit by commit
- Ensure that this does nothing in your dev pipeline
- Ensure that the deployer key present in this github repository is also present in paas-admin
- Ensure that this works in staging once you're happy with the code and the keys

- [This](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/deploy-paas-admin/builds/92) is an example of where it runs (snowflaked tlwr as one of the deploy envs for which it should push)
- [This](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/deploy-paas-admin/builds/93) is a normal dev env run.


Who can review
--------------

Not @tlwr
