### PR TITLE
Revert "Bump UAA to 73.4.0 to fix CVE-2019-3794"

### DIFF
--- a/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
+++ b/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
@@ -3,6 +3,6 @@
   path: /releases/name=uaa
   value:
     name: "uaa"
-    version: "73.4.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=73.4.0"
-    sha1: "02a68b974150394d733015fba0a2be0ab2cd84c4"
+    version: "73.3.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=73.3.0"
+    sha1: "b6e8a9cbc8724edcecb8658fa9459ee6c8fc259e"


### PR DESCRIPTION
What
----

This reverts commit 3f98975b524eafd3ef262effde953bdc0e10a2ba.

We experienced elevated 401s during the deployment to staging which were
not experienced in development.

Reverting to unblock staging pipeline

How to review
-------------

Code review
