### PR TITLE
Add PaaS-admin to Pingdom

### DIFF
--- a/terraform/pingdom/pingdom.tf
+++ b/terraform/pingdom/pingdom.tf
@@ -66,3 +66,18 @@ resource "pingdom_check" "cf_api_healthcheck" {
   notifywhenbackup         = true
   contactids               = ["${var.pingdom_contact_ids}"]
 }
+
+resource "pingdom_check" "paas_admin_healthcheck" {
+  type                     = "http"
+  name                     = "PaaS CF API - ${var.env}"
+  host                     = "admin.${var.system_dns_zone_name}"
+  url                      = "/calculator"
+  shouldcontain            = "costs"
+  encryption               = true
+  resolution               = 1
+  uselegacynotifications   = true
+  sendtoemail              = true
+  sendnotificationwhendown = 2
+  notifywhenbackup         = true
+  contactids               = ["${var.pingdom_contact_ids}"]
+}


### PR DESCRIPTION
What
----

I accidentally deleted the route in CF for PaaS-admin, because I am a fool and because `cf d -r -f app` which shares a route with another app deletes routes for both apps.

I would like to avoid this happening again, by making Pingdom tell us when PaaSmin goes down.

How to review
-------------

Code review

Who can review
--------------

Not @tlwr
