### PR TITLE
Revert changes affecting UAA

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1053,33 +1053,6 @@ jobs:
 
                   cat vpc-peering-opsfile/vpc-peers.yml
 
-        - task: generate-microsoft-oauth-endpoints
-          tags: [colocated-with-web]
-          config:
-            platform: linux
-            image_resource: *cf-cli-image-resource
-            outputs:
-              - name: ms-oauth-endpoints
-            run:
-              path: sh
-              args:
-                - -e
-                - -c
-                - |
-                  DISCOVERY_DOC=$(curl https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration)
-
-                  echo "$DISCOVERY_DOC" | jq '.authorization_endpoint' --raw-output \
-                    > ms-oauth-endpoints/authorization_endpoint
-
-                  echo "$DISCOVERY_DOC" | jq '.token_endpoint' --raw-output \
-                    > ms-oauth-endpoints/token_endpoint
-
-                  echo "$DISCOVERY_DOC" | jq '.jwks_uri' --raw-output \
-                    > ms-oauth-endpoints/token_key_endpoint
-
-                  echo "$DISCOVERY_DOC" | jq '.issuer' --raw-output \
-                    > ms-oauth-endpoints/issuer
-
       - do:
         - task: generate-cloud-config
           tags: [colocated-with-web]
@@ -1118,7 +1091,6 @@ jobs:
               - name: cf-secrets
               - name: vpc-peering-opsfile
               - name: logit-secrets
-              - name: ms-oauth-endpoints
             outputs:
               - name: cf-manifest
               - name: cf-manifest-pre-vars
@@ -1145,10 +1117,6 @@ jobs:
                   microsoft_oauth_tenant_id: ((microsoft_oauth_tenant_id))
                   microsoft_oauth_client_id: ((microsoft_oauth_client_id))
                   microsoft_oauth_client_secret: ((microsoft_oauth_client_secret))
-                  microsoft_oauth_auth_url: $(cat ms-oauth-endpoints/authorization_endpoint)
-                  microsoft_oauth_token_url: $(cat ms-oauth-endpoints/token_endpoint)
-                  microsoft_oauth_token_key_url: $(cat ms-oauth-endpoints/token_key_endpoint)
-                  microsoft_oauth_issuer: $(cat ms-oauth-endpoints/issuer)
                   EOF
 
                   tar -xzf ./ipsec-CA/ipsec-CA.tar.gz -C ./ipsec-CA
@@ -2869,10 +2837,6 @@ jobs:
                     NOTIFY_WELCOME_TEMPLATE_ID: "${NOTIFY_WELCOME_TEMPLATE_ID}"
                     SESSION_SECRET: (( concat "session-" uaa_clients_paas_admin_secret ))
                     AWS_REGION: "$AWS_REGION"
-                    MS_CLIENT_ID: ((microsoft_adminoidc_client_id))
-                    MS_CLIENT_SECRET: ((microsoft_adminoidc_client_secret))
-                    MS_TENANT_ID: ((microsoft_adminoidc_tenant_id))
-                    DOMAIN_NAME: "https://admin.${SYSTEM_DNS_ZONE_NAME}"
                 EOF
 
                 spruce merge \

--- a/concourse/scripts/lib/microsoft-oauth.sh
+++ b/concourse/scripts/lib/microsoft-oauth.sh
@@ -8,9 +8,6 @@ get_microsoft_oauth_secrets() {
   export microsoft_oauth_tenant_id
   export microsoft_oauth_client_id
   export microsoft_oauth_client_secret
-  export microsoft_adminoidc_tenant_id
-  export microsoft_adminoidc_client_id
-  export microsoft_adminoidc_client_secret
   secrets_size=$(aws s3 ls "${secrets_uri}" | awk '{print $3}')
   if [ "${secrets_size}" != 0 ] && [ -n "${secrets_size}" ]  ; then
     secrets_file=$(mktemp -t microsoft-oauth-secrets.XXXXXX)
@@ -19,10 +16,6 @@ get_microsoft_oauth_secrets() {
     microsoft_oauth_tenant_id=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.microsoft_oauth_tenant_id "${secrets_file}")
     microsoft_oauth_client_id=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.microsoft_oauth_client_id "${secrets_file}")
     microsoft_oauth_client_secret=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.microsoft_oauth_client_secret "${secrets_file}")
-
-		microsoft_adminoidc_tenant_id=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.microsoft_adminoidc_tenant_id "${secrets_file}")
-		microsoft_adminoidc_client_id=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.microsoft_adminoidc_client_id "${secrets_file}")
-		microsoft_adminoidc_client_secret=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.microsoft_adminoidc_client_secret "${secrets_file}")
 
     rm -f "${secrets_file}"
   fi

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -148,9 +148,6 @@ google_oauth_client_secret: "${google_oauth_client_secret:-}"
 microsoft_oauth_tenant_id: "${microsoft_oauth_tenant_id:-}"
 microsoft_oauth_client_id: "${microsoft_oauth_client_id:-}"
 microsoft_oauth_client_secret: "${microsoft_oauth_client_secret:-}"
-microsoft_adminoidc_tenant_id: "${microsoft_adminoidc_tenant_id:-}"
-microsoft_adminoidc_client_id: "${microsoft_adminoidc_client_id:-}"
-microsoft_adminoidc_client_secret: "${microsoft_adminoidc_client_secret:-}"
 notify_api_key: ${notify_api_key:-}
 auto_deploy: $([ "${ENABLE_AUTO_DEPLOY:-}" ] && echo "true" || echo "false")
 persistent_environment: ${PERSISTENT_ENVIRONMENT}

--- a/manifests/cf-manifest/operations.d/330-uaa.yml
+++ b/manifests/cf-manifest/operations.d/330-uaa.yml
@@ -304,10 +304,9 @@
   path: /releases/-
   value:
     name: uaa-customized
-    version: 0.1.10
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-customized-0.1.10.tgz
-    sha1: a134a33a49ebd254c6531bec6ae530203c46307f
-
+    version: 0.1.9
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-customized-0.1.9.tgz
+    sha1: c47b9c55e9be2aee77034e0f41556651a6cd3b04
 
 - type: replace
   path: /instance_groups/name=uaa/jobs/-

--- a/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
+++ b/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
@@ -4,5 +4,5 @@
   value:
     name: uaa
     version: 0.1.3
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/paas-uaa-0.1.3.tgz
-    sha1: 83054dfa84e5ad1ed42684ec7be5d36e3f6ea842
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-0.1.3.tgz
+    sha1: 19c75b5e1d0b5eaeaaa0ed937bee5f6bcf156e48

--- a/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
+++ b/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
@@ -2,7 +2,7 @@
 - type: replace
   path: /releases/name=uaa
   value:
-    name: uaa
-    version: 0.1.3
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-0.1.3.tgz
-    sha1: 19c75b5e1d0b5eaeaaa0ed937bee5f6bcf156e48
+    name: "uaa"
+    version: "73.3.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=73.3.0"
+    sha1: "b6e8a9cbc8724edcecb8658fa9459ee6c8fc259e"

--- a/manifests/cf-manifest/operations/uaa-add-microsoft-oauth.yml
+++ b/manifests/cf-manifest/operations/uaa-add-microsoft-oauth.yml
@@ -4,11 +4,10 @@
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/login/oauth?/providers/microsoft
   value:
     type: oidc1.0
-    authUrl: ((microsoft_oauth_auth_url))
-    tokenUrl: ((microsoft_oauth_token_url))
-    tokenKeyUrl: ((microsoft_oauth_token_key_url))
-    issuer: ((microsoft_oauth_issuer))
-    issuerValidationMode: domain_only
+    authUrl: https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize
+    tokenUrl: https://login.microsoftonline.com/organizations/oauth2/v2.0/token
+    tokenKeyUrl: https://login.microsoftonline.com/organizations/discovery/v2.0/keys
+    issuer: https://login.microsoftonline.com/((microsoft_oauth_tenant_id))/v2.0
     redirectUrl: https://login.((system_domain))/uaa
     scopes:
       - openid

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -26,12 +26,7 @@ RSpec.describe "release versions" do
       Gem::Version.new(v.gsub(/^v/, '').gsub(/^([0-9]+)$/, '0.0.\1'))
     end
 
-    pinned_releases = {
-      'uaa' => {
-        local: '0.1.3',
-        upstream: '72.0',
-      }
-    }
+    pinned_releases = {}
 
     manifest_releases = manifest_without_vars_store.fetch("releases").map { |release|
       [release['name'], release['version']]

--- a/manifests/shared/spec/fixtures/environment-variables.yml
+++ b/manifests/shared/spec/fixtures/environment-variables.yml
@@ -9,7 +9,3 @@ google_oauth_client_secret: abcd1234
 microsoft_oauth_tenant_id: abcd1234
 microsoft_oauth_client_id: abcd1234
 microsoft_oauth_client_secret: abcd1234
-microsoft_oauth_auth_url: abcd1234
-microsoft_oauth_token_key_url: abcd1234
-microsoft_oauth_token_url: abcd1234
-microsoft_oauth_issuer: https://login.microsoft.com

--- a/scripts/upload-microsoft-oauth-secrets.sh
+++ b/scripts/upload-microsoft-oauth-secrets.sh
@@ -8,12 +8,6 @@ MICROSOFT_OAUTH_TENANT_ID=$(pass "microsoft/${MAKEFILE_ENV_TARGET}/oauth/tenant_
 MICROSOFT_OAUTH_CLIENT_ID=$(pass "microsoft/${MAKEFILE_ENV_TARGET}/oauth/client_id")
 MICROSOFT_OAUTH_CLIENT_SECRET=$(pass "microsoft/${MAKEFILE_ENV_TARGET}/oauth/client_secret")
 
-MICROSOFT_ADMINOIDC_TENANT_ID=$(pass "microsoft/${MAKEFILE_ENV_TARGET}/paas-admin-oidc/tenant_id")
-MICROSOFT_ADMINOIDC_CLIENT_ID=$(pass "microsoft/${MAKEFILE_ENV_TARGET}/paas-admin-oidc/client_id")
-MICROSOFT_ADMINOIDC_CLIENT_SECRET=$(pass "microsoft/${MAKEFILE_ENV_TARGET}/paas-admin-oidc/client_secret")
-
-
-
 SECRETS=$(mktemp secrets.yml.XXXXXX)
 trap 'rm  "${SECRETS}"' EXIT
 
@@ -23,9 +17,6 @@ secrets:
   microsoft_oauth_tenant_id: ${MICROSOFT_OAUTH_TENANT_ID}
   microsoft_oauth_client_id: ${MICROSOFT_OAUTH_CLIENT_ID}
   microsoft_oauth_client_secret: ${MICROSOFT_OAUTH_CLIENT_SECRET}
-  microsoft_adminoidc_tenant_id: ${MICROSOFT_ADMINOIDC_TENANT_ID}
-  microsoft_adminoidc_client_id: ${MICROSOFT_ADMINOIDC_CLIENT_ID}
-  microsoft_adminoidc_client_secret: ${MICROSOFT_ADMINOIDC_CLIENT_SECRET}
 EOF
 
 aws s3 cp "${SECRETS}" "s3://gds-paas-${DEPLOY_ENV}-state/microsoft-oauth-secrets.yml"


### PR DESCRIPTION
What
----

We've established that the new version of UAA makes some changes to the
database which aren't zero-downtime.

Specifically, it runs a migration that changes passwords and oauth
secrets to begin with `{bcrypt}`, and then updates the code to only work
with passwords prefixed with `{bcrypt}`.

This caused downtime during our initial staging release (as soon as the
migrations ran, the currently deployed code broke). We rolled staging
back to the previous release, but we didn't unpick the migration. That
caused a bunch of users to get passwords without the `{bcrypt}` prefix.

We were unsuccessful in reproducing the release downtime in our
developer environments, so we decided to attempt the release to staging
again.

This time it failed entirely, because the migrations had already been
run, but non-migrated code had but unprefixed entries into the DB.

We plan to:

* Roll back all the UAA related changes so they match current production
* Unpick the migrations from staging by hand
* Release this to production to get the pipelines green
* Update UAA to handle both prefixed and unprefixed passwords (so it's
  backwards compatible)
* Remove the migrations from UAA
* Release the backwards compatible UAA to production
* Revert the removal of the migrations
* Release UAA with the migrations to production

How to review
-------------

* Confirm that this removes everything except #1974 (`git diff prod-0.2.355`)
* Check that the plan above makes sense to you

Who can review
--------------

Suggest @tlwr since we've been pairing on the investigation