### PR TITLE
Update uaa release to be zdd with v73.4.0

### DIFF
--- a/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
+++ b/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
@@ -3,6 +3,6 @@
   path: /releases/name=uaa
   value:
     name: "uaa"
-    version: "73.3.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=73.3.0"
-    sha1: "b6e8a9cbc8724edcecb8658fa9459ee6c8fc259e"
+    version: "0.1.6"
+    url: "https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-0.1.6.tgz"
+    sha1: "709987b24596bc157481ab3434e083b8bde0c845"

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -26,7 +26,12 @@ RSpec.describe "release versions" do
       Gem::Version.new(v.gsub(/^v/, '').gsub(/^([0-9]+)$/, '0.0.\1'))
     end
 
-    pinned_releases = {}
+    pinned_releases = {
+      'uaa' => {
+        local: '0.1.6',
+        upstream: '72.0',
+      }
+    }
 
     manifest_releases = manifest_without_vars_store.fetch("releases").map { |release|
       [release['name'], release['version']]


### PR DESCRIPTION
***do not merge***

What
----

We want to release a version of UAA which uses the
DelegatingPasswordEncoder which is zero downtime, once UAA understands
BOTH password hashes with the "{bcrypt}" prefix and without, then we can
release a version which runs migrations to ensure that all password
hashes start with '{bcrypt}'

How to review
-------------

Be @richardTowers 
