### PR TITLE
UAA migrations not double

### DIFF
--- a/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
+++ b/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
@@ -3,6 +3,6 @@
   path: /releases/name=uaa
   value:
     name: "uaa"
-    version: "0.1.6"
-    url: "https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-0.1.6.tgz"
-    sha1: "709987b24596bc157481ab3434e083b8bde0c845"
+    version: "0.1.7"
+    url: "https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-0.1.7.tgz"
+    sha1: "4c332a57026c48736410a8da4caa394ff7878a29"

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "release versions" do
 
     pinned_releases = {
       'uaa' => {
-        local: '0.1.6',
+        local: '0.1.7',
         upstream: '72.0',
       }
     }


### PR DESCRIPTION
What
----

We are using our own custom version of UAA which doesnt do silly things
with migrations which will break everything:

- password hashes with {bcrypt} prepended would get {bcrypt} prepended
again
- but we have our own custom migrations which fix this

How to review
-------------

Code review

See [tlwr pipeline](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/acceptance-tests/builds/56) (red but only with flakey test)

Who can review
--------------

Not @tlwr
