### PR TITLE
Bump UAA to paas-uaa/0.1.9

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2837,6 +2837,10 @@ jobs:
                     NOTIFY_WELCOME_TEMPLATE_ID: "${NOTIFY_WELCOME_TEMPLATE_ID}"
                     SESSION_SECRET: (( concat "session-" uaa_clients_paas_admin_secret ))
                     AWS_REGION: "$AWS_REGION"
+                    MS_CLIENT_ID: ((microsoft_adminoidc_client_id))
+                    MS_CLIENT_SECRET: ((microsoft_adminoidc_client_secret))
+                    MS_TENANT_ID: ((microsoft_adminoidc_tenant_id))
+                    DOMAIN_NAME: "https://admin.${SYSTEM_DNS_ZONE_NAME}"
                 EOF
 
                 spruce merge \

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1053,6 +1053,34 @@ jobs:
 
                   cat vpc-peering-opsfile/vpc-peers.yml
 
+        - task: generate-microsoft-oauth-endpoints
+          tags: [colocated-with-web]
+          config:
+            platform: linux
+            image_resource: *cf-cli-image-resource
+            outputs:
+              - name: ms-oauth-endpoints
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  DISCOVERY_DOC=$(curl https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration)
+                  export DISCOVERY_DOC
+
+                  echo "$DISCOVERY_DOC" | jq '.authorization_endpoint' --raw-output \
+                    > ms-oauth-endpoints/authorization_endpoint
+
+                  echo "$DISCOVERY_DOC" | jq '.token_endpoint' --raw-output \
+                    > ms-oauth-endpoints/token_endpoint
+
+                  echo "$DISCOVERY_DOC" | jq '.jwks_uri' --raw-output \
+                    > ms-oauth-endpoints/token_key_endpoint
+
+                  echo "$DISCOVERY_DOC" | jq '.issuer' --raw-output \
+                    > ms-oauth-endpoints/issuer
+
       - do:
         - task: generate-cloud-config
           tags: [colocated-with-web]
@@ -1091,6 +1119,7 @@ jobs:
               - name: cf-secrets
               - name: vpc-peering-opsfile
               - name: logit-secrets
+              - name: ms-oauth-endpoints
             outputs:
               - name: cf-manifest
               - name: cf-manifest-pre-vars
@@ -1117,6 +1146,10 @@ jobs:
                   microsoft_oauth_tenant_id: ((microsoft_oauth_tenant_id))
                   microsoft_oauth_client_id: ((microsoft_oauth_client_id))
                   microsoft_oauth_client_secret: ((microsoft_oauth_client_secret))
+                  microsoft_oauth_auth_url: $(cat ms-oauth-endpoints/authorization_endpoint)
+                  microsoft_oauth_token_url: $(cat ms-oauth-endpoints/token_endpoint)
+                  microsoft_oauth_token_key_url: $(cat ms-oauth-endpoints/token_key_endpoint)
+                  microsoft_oauth_issuer: $(cat ms-oauth-endpoints/issuer)
                   EOF
 
                   tar -xzf ./ipsec-CA/ipsec-CA.tar.gz -C ./ipsec-CA

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1067,7 +1067,6 @@ jobs:
                 - -c
                 - |
                   DISCOVERY_DOC=$(curl https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration)
-                  export DISCOVERY_DOC
 
                   echo "$DISCOVERY_DOC" | jq '.authorization_endpoint' --raw-output \
                     > ms-oauth-endpoints/authorization_endpoint

--- a/concourse/scripts/lib/microsoft-oauth.sh
+++ b/concourse/scripts/lib/microsoft-oauth.sh
@@ -8,6 +8,9 @@ get_microsoft_oauth_secrets() {
   export microsoft_oauth_tenant_id
   export microsoft_oauth_client_id
   export microsoft_oauth_client_secret
+  export microsoft_adminoidc_tenant_id
+  export microsoft_adminoidc_client_id
+  export microsoft_adminoidc_client_secret
   secrets_size=$(aws s3 ls "${secrets_uri}" | awk '{print $3}')
   if [ "${secrets_size}" != 0 ] && [ -n "${secrets_size}" ]  ; then
     secrets_file=$(mktemp -t microsoft-oauth-secrets.XXXXXX)
@@ -16,6 +19,10 @@ get_microsoft_oauth_secrets() {
     microsoft_oauth_tenant_id=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.microsoft_oauth_tenant_id "${secrets_file}")
     microsoft_oauth_client_id=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.microsoft_oauth_client_id "${secrets_file}")
     microsoft_oauth_client_secret=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.microsoft_oauth_client_secret "${secrets_file}")
+
+		microsoft_adminoidc_tenant_id=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.microsoft_adminoidc_tenant_id "${secrets_file}")
+		microsoft_adminoidc_client_id=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.microsoft_adminoidc_client_id "${secrets_file}")
+		microsoft_adminoidc_client_secret=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.microsoft_adminoidc_client_secret "${secrets_file}")
 
     rm -f "${secrets_file}"
   fi

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -148,6 +148,9 @@ google_oauth_client_secret: "${google_oauth_client_secret:-}"
 microsoft_oauth_tenant_id: "${microsoft_oauth_tenant_id:-}"
 microsoft_oauth_client_id: "${microsoft_oauth_client_id:-}"
 microsoft_oauth_client_secret: "${microsoft_oauth_client_secret:-}"
+microsoft_adminoidc_tenant_id: "${microsoft_adminoidc_tenant_id:-}"
+microsoft_adminoidc_client_id: "${microsoft_adminoidc_client_id:-}"
+microsoft_adminoidc_client_secret: "${microsoft_adminoidc_client_secret:-}"
 notify_api_key: ${notify_api_key:-}
 auto_deploy: $([ "${ENABLE_AUTO_DEPLOY:-}" ] && echo "true" || echo "false")
 persistent_environment: ${PERSISTENT_ENVIRONMENT}

--- a/manifests/cf-manifest/operations.d/330-uaa.yml
+++ b/manifests/cf-manifest/operations.d/330-uaa.yml
@@ -304,9 +304,10 @@
   path: /releases/-
   value:
     name: uaa-customized
-    version: 0.1.9
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-customized-0.1.9.tgz
-    sha1: c47b9c55e9be2aee77034e0f41556651a6cd3b04
+    version: 0.1.10
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-customized-0.1.10.tgz
+    sha1: a134a33a49ebd254c6531bec6ae530203c46307f
+
 
 - type: replace
   path: /instance_groups/name=uaa/jobs/-

--- a/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
+++ b/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
@@ -3,6 +3,6 @@
   path: /releases/name=uaa
   value:
     name: "uaa"
-    version: "0.1.8"
-    url: "https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-0.1.8.tgz"
-    sha1: "036f11ace6fa89d65c6a51dd39141c7ce0d261ad"
+    version: "0.1.9"
+    url: "https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-0.1.9.tgz"
+    sha1: "c103d7266639c4be65fef5352130a3ab013ed2a3"

--- a/manifests/cf-manifest/operations/uaa-add-microsoft-oauth.yml
+++ b/manifests/cf-manifest/operations/uaa-add-microsoft-oauth.yml
@@ -4,10 +4,11 @@
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/login/oauth?/providers/microsoft
   value:
     type: oidc1.0
-    authUrl: https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize
-    tokenUrl: https://login.microsoftonline.com/organizations/oauth2/v2.0/token
-    tokenKeyUrl: https://login.microsoftonline.com/organizations/discovery/v2.0/keys
-    issuer: https://login.microsoftonline.com/((microsoft_oauth_tenant_id))/v2.0
+    authUrl: ((microsoft_oauth_auth_url))
+    tokenUrl: ((microsoft_oauth_token_url))
+    tokenKeyUrl: ((microsoft_oauth_token_key_url))
+    issuer: ((microsoft_oauth_issuer))
+    issuerValidationMode: domain_only
     redirectUrl: https://login.((system_domain))/uaa
     scopes:
       - openid

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "release versions" do
 
     pinned_releases = {
       'uaa' => {
-        local: '0.1.8',
+        local: '0.1.9',
         upstream: '72.0',
       }
     }

--- a/manifests/shared/spec/fixtures/environment-variables.yml
+++ b/manifests/shared/spec/fixtures/environment-variables.yml
@@ -9,3 +9,7 @@ google_oauth_client_secret: abcd1234
 microsoft_oauth_tenant_id: abcd1234
 microsoft_oauth_client_id: abcd1234
 microsoft_oauth_client_secret: abcd1234
+microsoft_oauth_auth_url: abcd1234
+microsoft_oauth_token_key_url: abcd1234
+microsoft_oauth_token_url: abcd1234
+microsoft_oauth_issuer: https://login.microsoft.com

--- a/scripts/upload-microsoft-oauth-secrets.sh
+++ b/scripts/upload-microsoft-oauth-secrets.sh
@@ -8,6 +8,12 @@ MICROSOFT_OAUTH_TENANT_ID=$(pass "microsoft/${MAKEFILE_ENV_TARGET}/oauth/tenant_
 MICROSOFT_OAUTH_CLIENT_ID=$(pass "microsoft/${MAKEFILE_ENV_TARGET}/oauth/client_id")
 MICROSOFT_OAUTH_CLIENT_SECRET=$(pass "microsoft/${MAKEFILE_ENV_TARGET}/oauth/client_secret")
 
+MICROSOFT_ADMINOIDC_TENANT_ID=$(pass "microsoft/${MAKEFILE_ENV_TARGET}/paas-admin-oidc/tenant_id")
+MICROSOFT_ADMINOIDC_CLIENT_ID=$(pass "microsoft/${MAKEFILE_ENV_TARGET}/paas-admin-oidc/client_id")
+MICROSOFT_ADMINOIDC_CLIENT_SECRET=$(pass "microsoft/${MAKEFILE_ENV_TARGET}/paas-admin-oidc/client_secret")
+
+
+
 SECRETS=$(mktemp secrets.yml.XXXXXX)
 trap 'rm  "${SECRETS}"' EXIT
 
@@ -17,6 +23,9 @@ secrets:
   microsoft_oauth_tenant_id: ${MICROSOFT_OAUTH_TENANT_ID}
   microsoft_oauth_client_id: ${MICROSOFT_OAUTH_CLIENT_ID}
   microsoft_oauth_client_secret: ${MICROSOFT_OAUTH_CLIENT_SECRET}
+  microsoft_adminoidc_tenant_id: ${MICROSOFT_ADMINOIDC_TENANT_ID}
+  microsoft_adminoidc_client_id: ${MICROSOFT_ADMINOIDC_CLIENT_ID}
+  microsoft_adminoidc_client_secret: ${MICROSOFT_ADMINOIDC_CLIENT_SECRET}
 EOF
 
 aws s3 cp "${SECRETS}" "s3://gds-paas-${DEPLOY_ENV}-state/microsoft-oauth-secrets.yml"


### PR DESCRIPTION
What
----

This replays the reverted PR #1961 with a later version.

We had some trouble with UAA version 73.4.0 due to bad ZDD changes and database migrations which we had to workaround with some semi-manual work and a lot of revert/revert changes.

This pull request reverts the revert of #1961 with an updated version of alphagov/paas-uaa

How to review
-------------

Code review

pending see [tlwr pipeline()

Who can review
--------------

Done as pair with @AP-Hunt - will merge when TLWR pipeline is green