### PR TITLE
[#166927205] Add PaaS-Admin Google OIDC Client ID/Secret

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2882,6 +2882,8 @@ jobs:
                     MS_CLIENT_ID: ((microsoft_adminoidc_client_id))
                     MS_CLIENT_SECRET: ((microsoft_adminoidc_client_secret))
                     MS_TENANT_ID: ((microsoft_adminoidc_tenant_id))
+                    GOOGLE_CLIENT_ID: ((google_paas_admin_client_id))
+                    GOOGLE_CLIENT_SECRET: ((google_paas_admin_client_secret))
                     DOMAIN_NAME: "https://admin.${SYSTEM_DNS_ZONE_NAME}"
                 EOF
 

--- a/concourse/scripts/lib/google-oauth.sh
+++ b/concourse/scripts/lib/google-oauth.sh
@@ -9,6 +9,8 @@ get_google_oauth_secrets() {
   export google_oauth_client_secret
   export grafana_auth_google_client_id
   export grafana_auth_google_client_secret
+  export google_paas_admin_client_id
+  export google_paas_admin_client_secret
   secrets_size=$(aws s3 ls "${secrets_uri}" | awk '{print $3}')
   if [ "${secrets_size}" != 0 ] && [ -n "${secrets_size}" ]  ; then
     secrets_file=$(mktemp -t google-oauth-secrets.XXXXXX)
@@ -19,6 +21,9 @@ get_google_oauth_secrets() {
 
     grafana_auth_google_client_id=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.grafana_auth_google_client_id "${secrets_file}")
     grafana_auth_google_client_secret=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.grafana_auth_google_client_secret "${secrets_file}")
+
+    google_paas_admin_client_id=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.google_paas_admin_client_id "${secrets_file}")
+    google_paas_admin_client_secret=$("${SCRIPT_DIR}"/val_from_yaml.rb secrets.google_paas_admin_client_secret "${secrets_file}")
 
     rm -f "${secrets_file}"
   fi

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -145,6 +145,8 @@ aiven_api_token: ${aiven_api_token:-}
 concourse_web_password: ${CONCOURSE_WEB_PASSWORD}
 google_oauth_client_id: "${google_oauth_client_id:-}"
 google_oauth_client_secret: "${google_oauth_client_secret:-}"
+google_paas_admin_client_id: "${google_paas_admin_client_id:-}"
+google_paas_admin_client_secret: "${google_paas_admin_client_secret:-}"
 microsoft_oauth_tenant_id: "${microsoft_oauth_tenant_id:-}"
 microsoft_oauth_client_id: "${microsoft_oauth_client_id:-}"
 microsoft_oauth_client_secret: "${microsoft_oauth_client_secret:-}"

--- a/config/users.yml
+++ b/config/users.yml
@@ -1,56 +1,68 @@
 ---
 - email: "andy.hunt@digital.cabinet-office.gov.uk"
+  google_id: 105669475429351042864
   origin: "google"
   deploy_envs: ['prod', 'prod-lon', 'stg-lon', 'andyhunt']
   cf_admin: true
 
 - email: "lee.porte@digital.cabinet-office.gov.uk"
+  google_id: 117637881083888816781
   origin: "google"
   deploy_envs: ['prod', 'prod-lon', 'stg-lon', 'leeporte']
   cf_admin: true
 
 - email: "michael.mokrysz@digital.cabinet-office.gov.uk"
+  google_id: 107383114280997116147
   origin: "google"
   deploy_envs: ['prod', 'prod-lon', 'stg-lon', 'miki']
   cf_admin: true
 
 - email: "mohamed.deerow@digital.cabinet-office.gov.uk"
+  google_id: 113581158670217946218
   origin: "google"
   deploy_envs: ['prod', 'prod-lon', 'stg-lon', 'momo']
   cf_admin: true
 
 - email: "richard.towers@digital.cabinet-office.gov.uk"
+  google_id: 110880982070595988507
   origin: "google"
   deploy_envs: ['prod', 'prod-lon', 'stg-lon', 'towers']
   cf_admin: true
 
 - email: "russell.howe@digital.cabinet-office.gov.uk"
+  google_id: 109846986393208462188
   origin: "google"
   deploy_envs: ['prod', 'prod-lon', 'stg-lon']
   cf_admin: true
 
 - email: "tom.whitwell@digital.cabinet-office.gov.uk"
+  google_id: 106988454860052458239
   origin: "google"
   deploy_envs: ['prod', 'prod-lon', 'stg-lon', 'tnw']
   cf_admin: true
 
 - email: "toby.lornewelch-richards@digital.cabinet-office.gov.uk"
+  google_id: 115270948065632839284
   origin: "google"
   deploy_envs: ['prod', 'prod-lon', 'stg-lon', 'tlwr']
   cf_admin: true
 
 - email: "venus.bailey@digital.cabinet-office.gov.uk"
+  google_id: 1080011890811609622192
   origin: "google"
   deploy_envs: ['prod', 'prod-lon', 'stg-lon']
 
 - email: "luke.malcher@digital.cabinet-office.gov.uk"
+  google_id: 110778878978931011243
   origin: "google"
   deploy_envs: ['prod', 'prod-lon', 'stg-lon']
 
 - email: "paul.dougan@digital.cabinet-office.gov.uk"
+  google_id: 1042068992463395715702
   origin: "google"
   deploy_envs: ['prod', 'prod-lon', 'stg-lon']
 
 - email: "emma.pearce@digital.cabinet-office.gov.uk"
+  google_id: 116361542740992904571
   origin: "google"
   deploy_envs: ['prod', 'prod-lon', 'stg-lon']

--- a/manifests/cf-manifest/operations.d/330-uaa.yml
+++ b/manifests/cf-manifest/operations.d/330-uaa.yml
@@ -300,10 +300,9 @@
   path: /releases/-
   value:
     name: uaa-customized
-    version: 0.1.10
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-customized-0.1.10.tgz
-    sha1: a134a33a49ebd254c6531bec6ae530203c46307f
-
+    version: 0.1.12
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-customized-0.1.12.tgz
+    sha1: 3effea944ef1aa37c04c45188dab9baf8cb5700f
 
 - type: replace
   path: /instance_groups/name=uaa/jobs/-

--- a/manifests/cf-manifest/operations/uaa-add-google-oauth.yml
+++ b/manifests/cf-manifest/operations/uaa-add-google-oauth.yml
@@ -11,6 +11,7 @@
     redirectUrl: https://login.((system_domain))/uaa
     scopes:
       - openid
+      - profile
       - email
     linkText: Google
     showLinkText: true

--- a/manifests/cf-manifest/operations/uaa-add-google-oauth.yml
+++ b/manifests/cf-manifest/operations/uaa-add-google-oauth.yml
@@ -19,4 +19,4 @@
     relyingPartySecret: ((google_oauth_client_secret))
     skipSslValidation: false
     attributeMappings:
-      user_name: email
+      user_name: sub

--- a/manifests/cf-manifest/operations/uaa-add-google-oauth.yml
+++ b/manifests/cf-manifest/operations/uaa-add-google-oauth.yml
@@ -20,4 +20,11 @@
     relyingPartySecret: ((google_oauth_client_secret))
     skipSslValidation: false
     attributeMappings:
+      # UAA will attempt to find an existing user with a username matching the
+      # attribute from Google named below (e.g., `sub`.) If that fails it will
+      # attempt to find an existing UAA user whose email matches the email
+      # attribute from Google.
+      #
+      # This is secure because Google verifies email addresses and appears to
+      # forbid multiple accounts from having the same email address.
       user_name: sub

--- a/manifests/cf-manifest/operations/uaa-add-microsoft-oauth.yml
+++ b/manifests/cf-manifest/operations/uaa-add-microsoft-oauth.yml
@@ -22,4 +22,13 @@
     skipSslValidation: false
     storeCustomAttributes: false
     attributeMappings:
+      # UAA will attempt to find an existing user with a username matching the
+      # attribute from Google named below (e.g., `oid`.) If that fails it will
+      # attempt to find an existing UAA user whose email matches the email
+      # attribute from Google.
+      #
+      # We believe this is secure for Microsoft, but the reasoning is complex.
+      # Microsoft's `email` claim does not necessarily return a verified
+      # email address. But the domain in it must have been verified, which
+      # still proves some ownership/administration ability.
       user_name: oid

--- a/scripts/lib/uaa_sync_admin_users.rb
+++ b/scripts/lib/uaa_sync_admin_users.rb
@@ -158,6 +158,18 @@ class UaaSyncAdminUsers
     [created_users, deleted_users]
   end
 
+  def get_user_by_username(username)
+    query(:user, %(username eq "#{username}"))
+  end
+
+  def update_user(user)
+    cf_api_update_user(user)
+  end
+
+  def get_all_users
+    uaa.all_pages(:user)
+  end
+
 private
 
   attr_accessor :uaa
@@ -193,6 +205,10 @@ private
     nil
   end
 
+  def cf_api_update_user(user)
+    uaa.put(:user, user)
+  end
+
   def cf_api_request(method, path, headers = {})
     uri = URI.parse(@cf_api_url) + path
     http = Net::HTTP.new(uri.host, uri.port)
@@ -212,10 +228,6 @@ private
 
   def auth_header
     "#{token.fetch('token_type')} #{token.fetch('access_token')}"
-  end
-
-  def get_user_by_username(username)
-    query(:user, %(username eq "#{username}"))
   end
 
   def get_user_by_id(id)

--- a/scripts/migrate-google-sso-users.rb
+++ b/scripts/migrate-google-sso-users.rb
@@ -78,22 +78,18 @@ email_to_id_map.each { |email, id|
 
 puts ""
 puts "==> Verifying all Google SSO users have been migrated"
-all_users = uaa_sync_admin_users.get_all_users
-usernames = all_users.map { |u| u["username"] }
-pad = usernames.max_by(&:length).length
-all_users.each { |user|
-  if user["origin"] != "google"
-    next
-  elsif user["origin"] == "google"
-    if user["username"].match("\d{20,}") != nil
-      puts user["username"].rjust(pad) + ": FAILURE. SHOULD HAVE BEEN SOMETHING LIKE A GOOGLE ID"
-      next
-    end
-  end
 
-  if user["username"].match(URI::MailTo::EMAIL_REGEXP) != nil
-    puts user["username"].rjust(pad) + ": FAILURE"
-  else
-    puts user["username"].rjust(pad) + ": PASS (username: " + id_to_email_map[user["username"]] + ")"
+all_users = uaa_sync_admin_users.get_all_users
+google_users = all_users.select { |u| u["origin"] == "google" }
+google_usernames = google_users.map { |u| u["username"] }
+non_numeric_google_usernames = google_usernames.reject {|username| username.match("[^0-9]").nil? }
+
+if non_numeric_google_usernames.length > 0
+  puts "FAILURE: This does not seem to have transitioned all Google users to using numeric usernames."
+  puts "The following usernames are not entirely numeric:"
+  non_numeric_google_usernames.each do |username|
+    puts "  #{username}"
   end
-}
+else
+  puts "SUCCESS: All Google users have numeric usernames"
+end

--- a/scripts/migrate-google-sso-users.rb
+++ b/scripts/migrate-google-sso-users.rb
@@ -1,0 +1,99 @@
+require 'csv'
+require 'uri'
+require File.expand_path("../lib/uaa_sync_admin_users", __FILE__)
+
+# rubocop:disable Lint/RequireParentheses, Style/MultilineTernaryOperator
+module CF
+  module UAA
+    module Http
+      def json_parse_reply(style, status, body, headers)
+        raise ArgumentError unless style.nil? || style.is_a?(Symbol)
+        unless [200, 201, 204, 400, 401, 403, 409, 422].include? status
+          raise (status == 404 ? NotFound : BadResponse), "invalid status response: #{status}"
+        end
+        if body && !body.empty? && (status == 204 || headers.nil? ||
+              headers['content-type'] !~ /application\/json/i)
+          raise BadResponse, 'received invalid response content or type'
+        end
+        parsed_reply = Util.json_parse(body, style)
+        if status >= 400
+          puts parsed_reply.inspect
+          raise parsed_reply && parsed_reply['error'] == 'invalid_token' ?
+              InvalidToken.new(parsed_reply) : TargetError.new(parsed_reply), 'error response'
+        end
+        parsed_reply
+      rescue DecodeError
+        raise BadResponse, 'invalid JSON response'
+      end
+    end
+  end
+end
+# rubocop:enable Lint/RequireParentheses, Style/MultilineTernaryOperator
+
+file_path = ARGV[0] || raise("You must pass the path to the user ids CSV as first argument")
+cf_api_url = ARGV[1] || raise("You must pass API endpoint as second argument")
+cf_admin_username = 'admin'
+cf_admin_password = ENV['CF_ADMIN_PASSWORD'] || raise("Must set $CF_ADMIN_PASSWORD env var")
+
+options = {}
+options[:skip_ssl_validation] = true if ENV['SKIP_SSL_VERIFICATION'].to_s.casecmp("true").zero?
+
+uaa_sync_admin_users = UaaSyncAdminUsers.new(cf_api_url, cf_admin_username, cf_admin_password, options)
+uaa_sync_admin_users.request_token
+
+
+csv_lines = CSV.read(file_path)
+
+email_to_id_map = {}
+
+csv_lines.each { |line|
+  email_to_id_map[line[0]] = line[1]
+}
+id_to_email_map = email_to_id_map.invert
+
+puts "===> Considering the following email addresses"
+puts email_to_id_map.keys
+
+
+puts ""
+puts "===> Fetching & updating users"
+pad = email_to_id_map.keys.max_by(&:length).length
+email_to_id_map.each { |email, id|
+  user = uaa_sync_admin_users.get_user_by_username(email)
+
+  if user == nil
+    puts email.rjust(pad) + ": NOT FOUND"
+  else
+    if user["origin"] != "google"
+      puts email.rjust(pad) + ": NOT A GOOGLE USER"
+      next
+    end
+
+    puts email.rjust(pad) + ": WILL UPDATE TO ID " + id
+    user["username"] = id
+    uaa_sync_admin_users.update_user(user)
+    puts email.rjust(pad) + ": Updated UAA user " + user["id"]
+  end
+}
+
+puts ""
+puts "==> Verifying all Google SSO users have been migrated"
+all_users = uaa_sync_admin_users.get_all_users
+usernames = all_users.map { |u| u["username"] }
+pad = usernames.max_by(&:length).length
+all_users.each { |user|
+  if user["origin"] != "google"
+    next
+  elsif user["origin"] == "google"
+    if user["username"].match("\d{20,}") != nil
+      puts user["username"].rjust(pad) + ": FAILURE. SHOULD HAVE BEEN SOMETHING LIKE A GOOGLE ID"
+      next
+    end
+  end
+
+  if user["username"].match(URI::MailTo::EMAIL_REGEXP) != nil
+    puts user["username"].rjust(pad) + ": FAILURE"
+  else
+    puts user["username"].rjust(pad) + ": PASS (username: " + id_to_email_map[user["username"]] + ")"
+  end
+}

--- a/scripts/migrate-google-sso-users.rb
+++ b/scripts/migrate-google-sso-users.rb
@@ -49,7 +49,6 @@ email_to_id_map = {}
 csv_lines.each { |line|
   email_to_id_map[line[0]] = line[1]
 }
-id_to_email_map = email_to_id_map.invert
 
 puts "===> Considering the following email addresses"
 puts email_to_id_map.keys
@@ -82,14 +81,14 @@ puts "==> Verifying all Google SSO users have been migrated"
 all_users = uaa_sync_admin_users.get_all_users
 google_users = all_users.select { |u| u["origin"] == "google" }
 google_usernames = google_users.map { |u| u["username"] }
-non_numeric_google_usernames = google_usernames.reject {|username| username.match("[^0-9]").nil? }
+non_numeric_google_usernames = google_usernames.reject { |username| username.match("[^0-9]").nil? }
 
-if non_numeric_google_usernames.length > 0
+if non_numeric_google_usernames.length.empty?
+  puts "SUCCESS: All Google users have numeric usernames"
+else
   puts "FAILURE: This does not seem to have transitioned all Google users to using numeric usernames."
   puts "The following usernames are not entirely numeric:"
   non_numeric_google_usernames.each do |username|
     puts "  #{username}"
   end
-else
-  puts "SUCCESS: All Google users have numeric usernames"
 end

--- a/scripts/sync-admin-users.rb
+++ b/scripts/sync-admin-users.rb
@@ -11,7 +11,7 @@ def load_admin_user_list(filename, deploy_env)
     .select { |u| u.fetch('cf_admin', false) }
     .each_with_index.map { |u, i|
     {
-      username: u.fetch("username", u.fetch("email")),
+      username: u.fetch("google_id") || raise("User #{i} defined in file #{filename} is missing google_id"),
       email: u["email"] || raise("User #{i} defined in file #{filename} is missing email"),
       origin: u.fetch("origin", "uaa"),
     }

--- a/scripts/upload-google-oauth-secrets.sh
+++ b/scripts/upload-google-oauth-secrets.sh
@@ -10,6 +10,9 @@ GOOGLE_OAUTH_CLIENT_SECRET=$(pass "google/${MAKEFILE_ENV_TARGET}/oauth/client_se
 GRAFANA_AUTH_GOOGLE_CLIENT_ID=$(pass "google/${MAKEFILE_ENV_TARGET}/oauth/grafana_client_id")
 GRAFANA_AUTH_GOOGLE_CLIENT_SECRET=$(pass "google/${MAKEFILE_ENV_TARGET}/oauth/grafana_client_secret")
 
+GOOGLE_PAAS_ADMIN_CLIENT_ID=$(pass "google/${MAKEFILE_ENV_TARGET}/oauth/paas_admin_client_id")
+GOOGLE_PAAS_ADMIN_CLIENT_SECRET=$(pass "google/${MAKEFILE_ENV_TARGET}/oauth/paas_admin_client_secret")
+
 SECRETS=$(mktemp secrets.yml.XXXXXX)
 trap 'rm  "${SECRETS}"' EXIT
 
@@ -20,6 +23,8 @@ secrets:
   google_oauth_client_secret: ${GOOGLE_OAUTH_CLIENT_SECRET}
   grafana_auth_google_client_id: ${GRAFANA_AUTH_GOOGLE_CLIENT_ID}
   grafana_auth_google_client_secret: ${GRAFANA_AUTH_GOOGLE_CLIENT_SECRET}
+  google_paas_admin_client_id: ${GOOGLE_PAAS_ADMIN_CLIENT_ID}
+  google_paas_admin_client_secret: ${GOOGLE_PAAS_ADMIN_CLIENT_SECRET}
 EOF
 
 aws s3 cp "${SECRETS}" "s3://gds-paas-${DEPLOY_ENV}-state/google-oauth-secrets.yml"


### PR DESCRIPTION
What
----

- Script to migrate Google SSO users to have Google id's as usernames, given a CSV of email addresses and corresponding id's. This is a one-off script that needs to be run against each environment
- Adds the paas-admin Google client ID and secret so non-GDS users to enable Google SSO
- Maps the UAA username to the Google token sub

**Please hold off merging until the migration work has been completed**

How to review
-------------

- Run the upload-google-oauth-secrets make task
- ~Review https://github.com/alphagov/paas-admin/pull/343~ done
- ~Review https://github.com/alphagov/paas-uaa-customized-boshrelease/pull/10~ done
- ~Deploy to your dev env~ done
- ~⚠️ **Update the paas-uaa-customized-boshrelease version**~ done

Who can review
--------------

Not me
