### PR TITLE
cf-deployment v🔟 Episode I - The Phantom Istio

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -301,7 +301,7 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-acceptance-tests
-      branch: cf9.2
+      branch: cf10.0
 
   - name: cf-smoke-tests-release
     type: git

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -307,7 +307,7 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-smoke-tests-release
-      tag_filter: "40.0.107"
+      tag_filter: "40.0.113"
       submodules:
       - "src/smoke_tests"
 

--- a/concourse/pipelines/monitor-remote.yml
+++ b/concourse/pipelines/monitor-remote.yml
@@ -19,7 +19,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloudfoundry/cf-smoke-tests-release
-    tag_filter: "40.0.107"
+    tag_filter: "40.0.113"
     submodules:
       - "src/smoke_tests"
 

--- a/manifests/cf-manifest/operations.d/040-log-cache.yml
+++ b/manifests/cf-manifest/operations.d/040-log-cache.yml
@@ -1,8 +1,0 @@
----
-- type: replace
-  path: /releases/name=log-cache
-  value:
-    name: log-cache
-    version: 2.2.2
-    url: "https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.2.2"
-    sha1: 634dd3e134d0dac00f3f86beb00c06653579af4b

--- a/manifests/cf-manifest/operations.d/210-cf-disable-routing-api.yml
+++ b/manifests/cf-manifest/operations.d/210-cf-disable-routing-api.yml
@@ -10,3 +10,9 @@
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/routing_api
 - type: remove
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/routing_api
+- type: remove
+  path: /variables/name=routing_api_ca
+- type: remove
+  path: /variables/name=routing_api_tls
+- type: remove
+  path: /variables/name=routing_api_tls_client

--- a/manifests/cf-manifest/operations.d/329-capi-release.yml
+++ b/manifests/cf-manifest/operations.d/329-capi-release.yml
@@ -1,7 +1,0 @@
-- type: replace
-  path: /releases/name=capi
-  value:
-    name: "capi"
-    version: "1.81.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.81.0"
-    sha1: "8116229c5789dc47cc6ff35d59c8a5c7e363c174"

--- a/manifests/cf-manifest/operations.d/330-uaa.yml
+++ b/manifests/cf-manifest/operations.d/330-uaa.yml
@@ -25,10 +25,6 @@
   value: /var/vcap/jobs/uaa-customized/bin/health_check
 
 - type: replace
-  path: /instance_groups/name=uaa/jobs/name=route_registrar/properties/route_registrar/routes/name=uaa/port
-  value: 8081
-
-- type: replace
   path: /instance_groups/name=uaa/jobs/name=route_registrar/properties/route_registrar/routes/name=uaa/uris
   value:
     - "uaa.((system_domain))"

--- a/manifests/cf-manifest/operations.d/900-cf-cert-rotation.yml
+++ b/manifests/cf-manifest/operations.d/900-cf-cert-rotation.yml
@@ -212,6 +212,10 @@
   path: /instance_groups/name=doppler/jobs/name=log-cache-cf-auth-proxy/properties/uaa/ca_cert
   value: ((uaa_ca.certificate))((uaa_ca_old.certificate))
 
+- type: replace
+  path: /instance_groups/name=doppler/jobs/name=log-cache-cf-auth-proxy/properties/proxy_ca_cert
+  value: ((log_cache_ca.certificate))((log_cache_ca_old.certificate))
+
 
 # INSTANCE GROUPS / LOG API
 

--- a/manifests/cf-manifest/operations.d/900-cf-cert-rotation.yml
+++ b/manifests/cf-manifest/operations.d/900-cf-cert-rotation.yml
@@ -212,10 +212,6 @@
   path: /instance_groups/name=doppler/jobs/name=log-cache-cf-auth-proxy/properties/uaa/ca_cert
   value: ((uaa_ca.certificate))((uaa_ca_old.certificate))
 
-- type: replace
-  path: /instance_groups/name=doppler/jobs/name=log-cache-expvar-forwarder/properties/loggregator_agent/tls/ca_cert
-  value: ((loggregator_ca.certificate))((loggregator_ca_old.certificate))
-
 
 # INSTANCE GROUPS / LOG API
 
@@ -336,10 +332,6 @@
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=ssh_proxy/properties/backends/tls/ca_certificates/0
   value: ((application_ca.certificate))((application_ca_old.certificate))
-
-- type: replace
-  path: /instance_groups/name=scheduler/jobs/name=log-cache-expvar-forwarder/properties/loggregator_agent/tls/ca_cert
-  value: ((loggregator_ca.certificate))((loggregator_ca_old.certificate))
 
 
 # INSTANCE GROUPS / UAA

--- a/manifests/cf-manifest/operations.d/900-cf-cert-rotation.yml
+++ b/manifests/cf-manifest/operations.d/900-cf-cert-rotation.yml
@@ -24,7 +24,7 @@
   value: ((loggregator_ca.certificate))((loggregator_ca_old.certificate))
 
 - type: replace
-  path: /addons/name=loggregator_agent/jobs/name=loggr-expvar-forwarder/properties/log_agent/ca_cert
+  path: /addons/name=prom_scraper/jobs/name=prom_scraper/properties/loggregator_agent?/ca_cert
   value: ((loggregator_ca.certificate))((loggregator_ca_old.certificate))
 
 - type: replace

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "release versions" do
     pinned_releases = {
       'uaa' => {
         local: '0.1.9',
-        upstream: '72.0',
+        upstream: '73.4.0',
       }
     }
 


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/167008683)
[Release notes](https://github.com/cloudfoundry/cf-deployment/releases/tag/v10.0.0)

What
----

This pull request updates cf-deployment to v🔟, but does not include the Envoy changes.

This pull request is zero-downtime for the API, applications, and metrics; but it significantly changes how metrics are collected.

Each change is made in a separate commit

- The version of CAPI we are using is latest; so remove the upgrade ops file

- Our fork of UAA is 73.4, but cf-deployment is also v73.4 (previously v72); so update the pin

- Our update of log-cache-release is now behind latest; so remove it to get the latest

- Update smoke test version and acceptance test versions in pipeline

- UAA without TLS is now deprecated, we were using TLS; so remove the old, unnecessary port override operation

- A new cert required for doppler (cf-auth-proxy); so update the cert rotation ops file to rotate it

- Routing API is now mTLS only, however we don't use the routing API; so remove the new mTLS variables

- The concept of an expvar forwarder is deprecated: expvar forwarders were part of loggregator-agent and log-cache, and they were used to push metrics into loggregator. In the latest versions of these releases, they have prometheus compatible `/metrics` endpoints, and a new addon component in loggregator-agent is introduced: `prom_scraper`. `prom_scraper` scrapes Prometheus compatible `/metrics` endpoints and forwards them to loggregator. We need to make it know about cert rotation.

We, when were moving to use `cf-deployment`, in order to achieve a no-op manifest, removed the `containers` definition in the `rep` job of `diego-release`, which in cf-deployment v🔟 introduces the Istio/Envoy changes. This pull request does not remove the operation which does this, as this introduces a small amount of application downtime. So this pull request is safe and "fast" to deploy.

Additionally, later last week, we were seeing weird things with the `firehose-exporter` and phantom spikes in our metrics: `gorouter` was reporting 10000s of rps. Since the deprecation of the expvar forwarders, this has been fixed in my environment. This is either due to `prom_scraper` being better than the expvar forwarders, or because replacing the boxes fixed some bad thing. A chart is ⬇️ 

![Screen Shot 2019-07-21 at 18 46 36](https://user-images.githubusercontent.com/1482692/61594819-efc57100-abe7-11e9-873e-d2f22aebb2e7.png)
***A chart showing weird things happening, then not-happening to my environment***

How to review
-------------

Code review, commit by commit

Travis

Observe tlwr environment:
- [api-availability-tests](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/api-availability-tests/builds/174) `99.969902%`
- [app-availability-tests](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/app-availability-tests/builds/171) `Success Rate: 100.00%`
- [acceptance-tests](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/acceptance-tests/builds/67)
- [custom-acceptance-tests](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/custom-acceptance-tests/builds/64)
- [custom-broker-acceptance-tests](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/custom-broker-acceptance-tests/builds/42)

Push it to your development environment

Who can review
--------------

Not @tlwr