### PR TITLE
cf-deployment v🔟 Episode II - The Attack of the Envoys

### DIFF
--- a/manifests/cf-manifest/operations.d/350-diego-cell.yml
+++ b/manifests/cf-manifest/operations.d/350-diego-cell.yml
@@ -27,9 +27,6 @@
 - type: remove
   path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/destroy_containers_on_start
 
-- type: remove
-  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/containers
-
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=rep/properties/diego?/executor/memory_capacity_mb
   value: ((cell_memory_capacity_mb))

--- a/manifests/cf-manifest/operations.d/900-cf-cert-rotation.yml
+++ b/manifests/cf-manifest/operations.d/900-cf-cert-rotation.yml
@@ -189,6 +189,21 @@
   path: /instance_groups/name=diego-cell/jobs/name=rep/properties/diego/executor/instance_identity_ca_cert
   value: ((diego_instance_identity_ca.certificate))((diego_instance_identity_ca_old.certificate))
 
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/containers/proxy/trusted_ca_certificates
+  value:
+    # this should be the ca which gorouter_backend_tls uses
+    - ((service_cf_internal_ca.certificate))((service_cf_internal_ca_old.certificate))
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/containers/trusted_ca_certificates
+  value:
+    # this should include the diego_instance_identity_ca pair
+    - ((diego_instance_identity_ca.certificate))((diego_instance_identity_ca_old.certificate))
+    # and this should include the ca pair used by diego_instance_identity_ca
+    - ((application_ca.certificate))((application_ca_old.certificate))
+    # and this should include the uaa ca pair
+    - ((uaa_ca.certificate))((uaa_ca_old.certificate))
 
 # INSTANCE GROUPS / DOPPLER
 

--- a/manifests/cf-manifest/spec/manifest/diego_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/diego_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe "diego" do
+  context "with the default certificates" do
+    let(:manifest) { manifest_with_defaults }
+    let(:properties) { manifest.fetch("instance_groups.diego-cell.jobs.rep.properties") }
+
+    it "has containers configured" do
+      expect(properties.dig('containers')).not_to be_nil
+    end
+
+    it "has containers/proxy enabled" do
+      expect(properties.dig('containers', 'proxy', 'enabled')).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/167008683)
[Release notes](https://github.com/cloudfoundry/cf-deployment/releases/tag/v10.0.0)
***[Prerequisite PR](https://github.com/alphagov/paas-cf/pull/1995) must be merged first***

What
----

This is a follow up PR to #1995, which adds 3 commits, one of which is empty.

Previously, in #1333, we moved to cf-deployment with a no-op manifest. I.e. we replicated our own version of deployment of CF, using cf-deployment, rather than having a deployment that looked like cf-deployment.

One of [the commits](https://github.com/alphagov/paas-cf/pull/1333/commits/01730f50f4c9c216b4678a997329b6c2026d1205#diff-28c13109122f766fc787ca1c0aa21126R34) removed the `containers` configuration block of `rep` which, as of cf-deployment v🔟, is now `enabled: true`.

This pull request removes that operation, and adds a test that it is enabled.

Additionally, in order to conform with how we do certificate rotation, this PR adds an operation which adds the `_old` CAs to `rep`'s `trusted_ca_certificates` and `rep`'s `proxy`'s `trusted_ca_certificates`.

***This PR introduces downtime, so we should communicate with our tenants once it has been approved, and deploy it out of hours***

The [downtime](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/app-availability-tests/builds/172) it introduced in my developer environment was limited to applications, and was: `99.43019943019942%` uptime, however I'm wary that this may be higher in an environment with more diego cells.

How to review
-------------

Code review, commit by commit; review #1995 first and then the last 3 (2) commits of this PR.

Travis

Run this down your pipeline

Observe tlwr environment:
- [api-availability-tests](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/api-availability-tests/builds/175) `100.0%`
- [app-availability-tests](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/app-availability-tests/builds/172) `Success Rate: 99.43019943019942%`
- [acceptance-tests](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/acceptance-tests/builds/68)
- [custom-acceptance-tests](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/custom-acceptance-tests/builds/65)
- [custom-broker-acceptance-tests](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/custom-broker-acceptance-tests/builds/43)

Who can review
--------------

Not @tlwr