### PR TITLE
[#167062292] Add liveness monitoring for billing

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -118,6 +118,7 @@ groups:
   - name: health
     jobs:
       - continuous-smoke-tests
+      - continuous-billing-smoke-tests
       - check-certificates
   - name: credentials
     jobs:
@@ -297,6 +298,15 @@ resources:
       initial_version: "-"
       initial_content_text: "no"
 
+  - name: deployed-billing
+    type: s3-iam
+    source:
+      bucket: ((state_bucket))
+      region_name: ((aws_region))
+      versioned_file: billing-deployed
+      initial_version: "-"
+      initial_content_text: "no"
+
   - name: cf-acceptance-tests
     type: git
     source:
@@ -358,6 +368,15 @@ resources:
     type: time
     source:
       interval: 5m
+
+  - name: billing-smoke-tests-timer
+    type: time
+    source:
+      interval: 5m
+      location: Europe/London
+      start: 9:00 AM
+      stop: 5:00 PM
+      days: [Monday, Tuesday, Wednesday, Thursday, Friday]
 
   - name: check-certificates-timer
     type: time
@@ -3157,6 +3176,8 @@ jobs:
               path: src/github.com/alphagov/paas-billing
             - name: config
             - name: cf-vars-store
+          outputs:
+            - name: deployed-billing
           run:
             path: sh
             args:
@@ -3167,10 +3188,27 @@ jobs:
                 . ./config/config.sh
                 echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}" -o admin -s billing
 
+                BUILD_ROOT=$(pwd)
                 export GOPATH="${PWD}"
                 export BILLING_API_URL="https://billing.${SYSTEM_DNS_ZONE_NAME}"
                 cd src/github.com/alphagov/paas-billing
                 make acceptance
+                PASSED=$?
+                cd "${BUILD_ROOT}"
+                if [ "$PASSED" -ne 0 ]; then
+                  echo "no" > deployed-billing/billing-deployed
+                  exit 1
+                else
+                  echo "yes" > deployed-billing/billing-deployed
+                fi
+        on_success:
+          put: deployed-billing
+          params:
+            file: deployed-billing/billing-deployed
+        on_failure:
+          put: deployed-billing
+          params:
+            file: deployed-billing/billing-deployed
 
   - name: deploy-paas-metrics
     serial: true
@@ -3919,6 +3957,85 @@ jobs:
             file: paas-cf/concourse/tasks/upload-test-artifacts.yml
             params:
               TEST_ARTIFACTS_BUCKET: ((test_artifacts_bucket))
+
+        ensure:
+          task: remove-temp-user
+          tags: [colocated-with-web]
+          file: paas-cf/concourse/tasks/delete_admin.yml
+
+  - name: continuous-billing-smoke-tests
+    serial_groups: [smoke-tests]
+    build_logs_to_retain: 10000
+    plan:
+      - aggregate:
+        - get: billing-smoke-tests-timer
+          trigger: true
+        - get: paas-billing
+          passed: ['deploy-paas-billing']
+        - get: deployed-billing
+        - get: paas-cf
+          passed: ['pipeline-lock']
+        - get: cf-manifest
+          passed: ['post-deploy']
+        - get: cf-vars-store
+
+      - task: assert-should-run
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: alpine
+              tag: 3.9
+          inputs:
+            - name: deployed-billing
+          run:
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              BILLING_DEPLOYED=$(cat deployed-billing/billing-deployed)
+              if [ "$BILLING_DEPLOYED" = "no" ]; then
+                echo "Billing is not deployed"
+                echo "Skipping smoke tests"
+                exit 1
+              fi
+      - do:
+        - task: create-temp-user
+          tags: [colocated-with-web]
+          file: paas-cf/concourse/tasks/create_admin.yml
+          params:
+            PREFIX: cont-billing-smoketest-user
+
+        - task: run-billing-smoke-tests
+          tags: [colocated-with-web]
+          config:
+            platform: linux
+            image_resource: *cf-acceptance-tests-image-resource
+            params:
+              AWS_REGION: ((aws_region))
+              SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+              DEPLOY_ENV: ((deploy_env))
+            inputs:
+              - name: paas-cf
+              - name: paas-billing
+                path: src/github.com/alphagov/paas-billing
+              - name: admin-creds
+            run:
+              path: sh
+              args:
+                - -e
+                - -u
+                - -c
+                - |
+                  echo | cf login -a "https://api.${SYSTEM_DNS_ZONE_NAME}" -u "$(cat admin-creds/username)" -p "$(cat admin-creds/password)" -o admin -s billing
+
+                  export GOPATH="${PWD}"
+                  export BILLING_API_URL="https://billing.${SYSTEM_DNS_ZONE_NAME}"
+                  cd src/github.com/alphagov/paas-billing
+                  make acceptance
 
         ensure:
           task: remove-temp-user

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -298,15 +298,6 @@ resources:
       initial_version: "-"
       initial_content_text: "no"
 
-  - name: deployed-billing
-    type: s3-iam
-    source:
-      bucket: ((state_bucket))
-      region_name: ((aws_region))
-      versioned_file: billing-deployed
-      initial_version: "-"
-      initial_content_text: "no"
-
   - name: cf-acceptance-tests
     type: git
     source:
@@ -3176,8 +3167,6 @@ jobs:
               path: src/github.com/alphagov/paas-billing
             - name: config
             - name: cf-vars-store
-          outputs:
-            - name: deployed-billing
           run:
             path: sh
             args:
@@ -3188,27 +3177,10 @@ jobs:
                 . ./config/config.sh
                 echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}" -o admin -s billing
 
-                BUILD_ROOT=$(pwd)
                 export GOPATH="${PWD}"
                 export BILLING_API_URL="https://billing.${SYSTEM_DNS_ZONE_NAME}"
                 cd src/github.com/alphagov/paas-billing
                 make acceptance
-                PASSED=$?
-                cd "${BUILD_ROOT}"
-                if [ "$PASSED" -ne 0 ]; then
-                  echo "no" > deployed-billing/billing-deployed
-                  exit 1
-                else
-                  echo "yes" > deployed-billing/billing-deployed
-                fi
-        on_success:
-          put: deployed-billing
-          params:
-            file: deployed-billing/billing-deployed
-        on_failure:
-          put: deployed-billing
-          params:
-            file: deployed-billing/billing-deployed
 
   - name: deploy-paas-metrics
     serial: true
@@ -3972,36 +3944,12 @@ jobs:
           trigger: true
         - get: paas-billing
           passed: ['deploy-paas-billing']
-        - get: deployed-billing
         - get: paas-cf
           passed: ['pipeline-lock']
         - get: cf-manifest
           passed: ['post-deploy']
         - get: cf-vars-store
 
-      - task: assert-should-run
-        tags: [colocated-with-web]
-        config:
-          platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: alpine
-              tag: 3.9
-          inputs:
-            - name: deployed-billing
-          run:
-            path: sh
-            args:
-            - -e
-            - -c
-            - |
-              BILLING_DEPLOYED=$(cat deployed-billing/billing-deployed)
-              if [ "$BILLING_DEPLOYED" = "no" ]; then
-                echo "Billing is not deployed"
-                echo "Skipping smoke tests"
-                exit 1
-              fi
       - do:
         - task: create-temp-user
           tags: [colocated-with-web]

--- a/manifests/prometheus/alerts.d/concourse-billingsmoketests-errors.yml
+++ b/manifests/prometheus/alerts.d/concourse-billingsmoketests-errors.yml
@@ -1,0 +1,15 @@
+# Source: concourse
+---
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: ConcourseBillingSmoketestsErrors
+    rules:
+      - alert: ConcourseSmoketestsErrors
+        expr: increase(concourse_builds_finished{exported_job="continuous-billing-smoke-tests",pipeline="create-cloudfoundry",status="errored"}[30m]) >= 3
+        labels:
+          severity: warning
+        annotations:
+          summary: Concourse continuous-billing-smoke-tests errors
+          description: The continuous-billing-smoke-tests Concourse job has an increased error rate

--- a/manifests/prometheus/alerts.d/concourse-billingsmoketests-failures.yml
+++ b/manifests/prometheus/alerts.d/concourse-billingsmoketests-failures.yml
@@ -1,0 +1,24 @@
+# Source: concourse
+---
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: ConcourseBillingSmoketestsFailures
+    rules:
+      - alert: ConcourseBillingSmoketestsFailuresWarning
+        expr: increase(concourse_builds_finished{exported_job="continuous-billing-smoke-tests",pipeline="create-cloudfoundry",status="failed"}[1h]) >= 2
+        labels:
+          severity: warning
+        annotations:
+          summary: Concourse continuous-billing-smoke-tests failures
+          description: The continuous-billing-smoke-tests Concourse job has failed at least twice in the last hour.
+
+      - alert: ConcourseBillingSmoketestsFailuresCritical
+        expr: increase(concourse_builds_finished{exported_job="continuous-billing-smoke-tests",pipeline="create-cloudfoundry",status="failed"}[30m]) >= 3
+        labels:
+          severity: critical
+          notify: pagerduty
+        annotations:
+          summary: Concourse continuous-billing-smoke-tests failures
+          description: The continuous-billing-smoke-tests Concourse job has failed at least three times in the last 30 minutes.


### PR DESCRIPTION
What
----

We currently run the acceptance tests after deploying paas-billing but we have no monitoring and alerting. This adds a `continuous-billing-smoke-tests` job that runs the acceptance tests on a 5 min interval between 9-5 Mon-Fri and alerts based on job errors/failures.

How to review
-------------

- Deploy to your dev env
- Confirm the `continuous-billing-smoke-tests` run and alert as expected

Who can review
--------------

Not me
