### PR TITLE
Bump cdn-broker (better logs, go 1.12)

### DIFF
--- a/manifests/cf-manifest/operations.d/720-cdn-broker.yml
+++ b/manifests/cf-manifest/operations.d/720-cdn-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: cdn-broker
-    version: 0.1.12
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.12.tgz
-    sha1: 44f6c6e3c741cad3c4d3f814be9b7e3e9eb6817e
+    version: 0.1.14
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.14.tgz
+    sha1: 17b4b782b1eaed2ed3aa38cebb2fffe2999aa7b8
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-


### PR DESCRIPTION
[Relevant PR](https://github.com/alphagov/paas-cdn-broker-boshrelease/pull/16)
[Story](https://www.pivotaltracker.com/n/projects/1275640/stories/164986888)

What
----

Bumps the CDN broker to the version which uses go 1.12 and which has better logging.

How to review
-------------

Read the [story](https://www.pivotaltracker.com/n/projects/1275640/stories/164986888) comments

Who can review
--------------

Not @tlwr