### PR TITLE
Scale up cells and dopplers in London

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -1,8 +1,8 @@
 ---
-cell_instances: 30
+cell_instances: 33
 router_instances: 3
 api_instances: 8
-doppler_instances: 12
+doppler_instances: 15
 log_api_instances: 6
 cc_hourly_rate_limit: 15000
 paas_region_name: london


### PR DESCRIPTION
What
----

We are going to deploy the envoy changes soon, which will require a
scale up (just to be safe) to 33.8 instances (30% extra than our current
capacity). Given that we under estimate capacity (AZ failure) 33 should
be enough.

We are seeing dropped doppler envelope alerts consistently in London
too. We should scale up our dopplers (by 3, 1 for each AZ)

How to review
-------------

Code review

Who can review
--------------

Not @tlwr
