### PR TITLE
[Spike] Add Grafana and Metric Store

### DIFF
--- a/manifests/cf-manifest/operations.d/100-cf-update-vm-types.yml
+++ b/manifests/cf-manifest/operations.d/100-cf-update-vm-types.yml
@@ -29,6 +29,9 @@
 - type: replace
   path: /instance_groups/name=rotate-cc-database-key/vm_type
   value: errand
+- type: replace
+  path: /instance_groups/name=metric-store/vm_type
+  value: medium
 
 # TODO: Remove the router vm_type. Not needed with extensions
 - type: replace

--- a/manifests/cf-manifest/operations.d/380-metric-store.yml
+++ b/manifests/cf-manifest/operations.d/380-metric-store.yml
@@ -25,3 +25,99 @@
   value:
     instance_groups:
       - metric-store
+
+- type: replace
+  path: /releases/-
+  value:
+    name: "grafana"
+    version: "13.2.2"
+    url: "https://bosh.io/d/github.com/vito/grafana-boshrelease?v=13.2.2"
+    sha1: "685b38e91db9e66369183799eb74069604dbb4b2"
+
+- type: replace
+  path: /variables/-
+  value:
+    name: observe_grafana_password
+    type: password
+
+- type: replace
+  path: /variables/-
+  value:
+    name: observe_grafana_uaa_client_secret
+    type: password
+
+- type: replace
+  path: /variables/-
+  value:
+    name: observe_grafana_tls
+    type: certificate
+    options:
+      ca: service_cf_internal_ca
+      common_name: observe.service.cf.internal
+
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/observe-grafana?
+  value:
+    authorities: ''
+    scope: openid,uaa.resource,doppler.firehose,logs.admin,cloud_controller.read
+    authorized-grant-types: authorization_code,refresh_token
+    override: true
+    secret: ((observe_grafana_uaa_client_secret))
+    redirect-uri: https://observe.((system_domain))/login/generic_oauth
+
+- type: replace
+  path: /instance_groups/name=metric-store/jobs/-
+  value:
+    name: grafana
+    release: grafana
+    properties:
+      grafana:
+        root_url: https://observe.((system_domain))
+        admin_username: observe
+        admin_password: ((observe_grafana_password))
+        ssl:
+          cert: ((observe_grafana_tls.certificate))
+          key: ((observe_grafana_tls.private_key))
+        users:
+          auto_assign_organization_role: Editor
+        auth:
+          generic_oauth:
+            name: GOV.UK PaaS
+            enabled: true
+            allow_sign_up: true
+            client_id: observe-grafana
+            client_secret: ((observe_grafana_uaa_client_secret))
+
+            scopes:
+              - openid
+              - uaa.resource
+              - doppler.firehose
+              - logs.admin
+              - cloud_controller.read
+
+            auth_url: https://login.((system_domain))/oauth/authorize
+            token_url: https://login.((system_domain))/oauth/token
+            api_url: https://login.((system_domain))/userinfo
+        datasources:
+          - name: Prometheus
+            url: https://metric-store.((app_domain))
+            type: prometheus
+            editable: false
+            orgId: 1
+            jsonData: '{"httpMethod":"GET","keepCookies":[],"oauthPassThru":true}'
+
+- type: replace
+  path: /instance_groups/name=metric-store/jobs/name=route_registrar/properties/route_registrar/routes/-
+  value:
+    name: observe-grafana
+    port: 3000
+    registration_interval: 20s
+    server_cert_domain_san: observe.service.cf.internal
+    tls_port: 3000
+    uris:
+      - observe.((system_domain))
+      - observe.((app_domain))
+
+- type: replace
+  path: /instance_groups/name=metric-store/jobs/name=route_registrar/properties/route_registrar/routes/name=metric-store-reverse-proxy/uris/-
+  value: metric-store.((app_domain))

--- a/manifests/cf-manifest/operations.d/380-metric-store.yml
+++ b/manifests/cf-manifest/operations.d/380-metric-store.yml
@@ -1,0 +1,27 @@
+- type: replace
+  path: /instance_groups/name=api/azs
+  value: [z1, z2, z3]
+
+- type: replace
+  path: /instance_groups/name=metric-store/networks/0/name
+  value: cf
+
+  # As this is experimental for now, only 2 instances is fine
+- type: replace
+  path: /instance_groups/name=metric-store/instances
+  value: 2
+
+- type: replace
+  path: /instance_groups/name=metric-store/persistent_disk_type
+  value: 100GB
+
+  # The default exclude for prom_scraper is job=smoke_tests
+  # We do not run smoke tests on bosh vms, so it is okay to override this
+  # We must override this fully, rather than add a criterion to it because
+  # criteria within an exclude/include statement are treated as AND rather than
+  # OR (except for values within lists)
+- type: replace
+  path: /addons/name=prom_scraper/exclude
+  value:
+    instance_groups:
+      - metric-store

--- a/manifests/cf-manifest/operations.d/800-set-vcap-password.yml
+++ b/manifests/cf-manifest/operations.d/800-set-vcap-password.yml
@@ -47,3 +47,6 @@
 - type: replace
   path: /instance_groups/name=s3_broker/env?/bosh/password
   value: ((secrets.vcap_password))
+- type: replace
+  path: /instance_groups/name=metric-store/env?/bosh/password
+  value: ((secrets.vcap_password))

--- a/manifests/cf-manifest/operations.d/900-cf-cert-rotation.yml
+++ b/manifests/cf-manifest/operations.d/900-cf-cert-rotation.yml
@@ -259,6 +259,32 @@
   value: ((loggregator_ca.certificate))((loggregator_ca_old.certificate))
 
 
+# INSTANCE GROUPS / METRIC STORE
+
+- type: replace
+  path: /instance_groups/name=metric-store/jobs/name=prom_scraper/properties/loggregator_agent?/ca_cert
+  value: ((loggregator_ca.certificate))((loggregator_ca_old.certificate))
+
+- type: replace
+  path: /instance_groups/name=metric-store/jobs/name=metric-store/properties/tls/ca_cert
+  value: ((metric_store_ca.certificate))((metric_store_ca_old.certificate))
+
+- type: replace
+  path: /instance_groups/name=metric-store/jobs/name=metric-store-nozzle/properties/logs_provider/tls/ca_cert
+  value: ((loggregator_ca.certificate))((loggregator_ca_old.certificate))
+
+- type: replace
+  path: /instance_groups/name=metric-store/jobs/name=metric-store-cf-auth-proxy/properties/cc/ca_cert
+  value: ((service_cf_internal_ca.certificate))((service_cf_internal_ca_old.certificate))
+
+- type: replace
+  path: /instance_groups/name=metric-store/jobs/name=metric-store-cf-auth-proxy/properties/proxy_ca_cert
+  value: ((metric_store_ca.certificate))((metric_store_ca_old.certificate))
+
+- type: replace
+  path: /instance_groups/name=metric-store/jobs/name=metric-store-cf-auth-proxy/properties/uaa/ca_cert
+  value: ((uaa_ca.certificate))((uaa_ca_old.certificate))
+
 # INSTANCE GROUPS / SCHEDULER
 
 - type: replace
@@ -453,5 +479,14 @@
     options:
       ca: application_ca
       common_name: instanceIdentityCA
+      is_ca: true
+    type: certificate
+
+- type: replace
+  path: /variables/-
+  value:
+    name: metric_store_ca_old
+    options:
+      common_name: metric-store
       is_ca: true
     type: certificate

--- a/manifests/cf-manifest/operations/scale-down-dev.yml
+++ b/manifests/cf-manifest/operations/scale-down-dev.yml
@@ -66,6 +66,10 @@
 # Ensure there is 1 of everything that is not availability tested
 
 - type: replace
+  path: /instance_groups/name=metric-store/instances
+  value: 1
+
+- type: replace
   path: /instance_groups/name=rds_broker/instances
   value: 1
 
@@ -126,3 +130,7 @@
 - type: replace
   path: /instance_groups/name=router/vm_type
   value: slim_router
+
+- type: replace
+  path: /instance_groups/name=metric-store/vm_type
+  value: small

--- a/manifests/cf-manifest/scripts/generate-manifest.sh
+++ b/manifests/cf-manifest/scripts/generate-manifest.sh
@@ -36,6 +36,7 @@ bosh interpolate \
   --vars-file="${ENV_SPECIFIC_BOSH_VARS_FILE}" \
   --vars-file="${WORKDIR}/environment-variables.yml" \
   --ops-file="${CF_DEPLOYMENT_DIR}/operations/use-internal-lookup-for-route-services.yml" \
+  --ops-file="${CF_DEPLOYMENT_DIR}/operations/experimental/add-metric-store.yml" \
   ${opsfile_args} \
   --ops-file="${PAAS_CF_DIR}/manifests/cf-manifest/operations/uaa-add-google-oauth.yml" \
   --ops-file="${PAAS_CF_DIR}/manifests/cf-manifest/operations/uaa-add-microsoft-oauth.yml" \


### PR DESCRIPTION
This is a spike for people to deploy to their development environments, so that they can test [metric-store](https://github.com/cloudfoundry/metric-store-release).

What
----

Metric Store is an experimental Loggregator component which provides a Prometheus API compatible Cloud Foundry auth aware interface for your CF platform metrics.

Currently it only works for admins, but it is [theoretically possible](https://github.com/cloudfoundry/metric-store-release/issues/39) for it to be exposable to tenants.

This pull request does two things:

1. Includes `metric-store-release` using the upstream experimental ops file, with some custom config (multi-AZ in non-dev, configure machine type)

2. Adds a Grafana, which uses CF UAA for auth, which can connect to Metric Store (masquerading as Prometheus)

_Please note that metric-store is deployed to metric-store on the `((app_domain))` as well as the `((system domain))`, because in our developer environments we lock down ingress to GDS IP space, which prevents Grafana from talking to metric-store._

How to get started
-------------

1. Deploy this to your development environment

2. Navigate to `https://observe.env.dev.cloudpipeline.digital`

3. Sign in using `GOV.UK PaaS`

4. Explore, example query for a tenant app would be `http_count{source_id="56da9ba4-dd0a-44df-bbf5-c3c3ec862424"}` where `source_id` is an app GUID.
