### PR TITLE
Wait a bit before running paas-metrics acceptance

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -3287,6 +3287,8 @@ jobs:
               - |
                 cd paas-cf/tools/metrics/acceptance
                 go install github.com/onsi/ginkgo/ginkgo
+                echo 'Waiting 2 minutes before running the acceptance tests'
+                sleep 120
                 ginkgo
 
   - name: tag-release


### PR DESCRIPTION
What
----

Sometimes the paas-metrics acceptance test goes red in the pipeline. This is because it has not yet had enough time to collect metrics.

Sleep a few minutes before acceptance testing so we can ensure that paas-metrics has had enough time to collect the metrics that we test.

How to review
-------------

Code review