### PR TITLE
[#167483203] Add billing costs by plan metric

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -390,7 +390,7 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-billing.git
       branch: master
-      tag_filter: v0.64.0 
+      tag_filter: v0.65.0
 
   - name: paas-accounts
     type: git

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -3265,6 +3265,7 @@ jobs:
                     'UAA_ENDPOINT' => '${UAA_ENDPOINT}',
                     'DEPLOY_ENV' => '${DEPLOY_ENV}',
                     'ELB_ADDRESS' => 'https://healthcheck.${APPS_DNS_ZONE_NAME}/',
+                    'COSTS_ENDPOINT' => 'https://billing.${SYSTEM_DNS_ZONE_NAME}/totals',
                     'TLS_DOMAINS' => [
                       'healthcheck.${APPS_DNS_ZONE_NAME}',
                       'api.${SYSTEM_DNS_ZONE_NAME}',

--- a/tools/metrics/gauges_billing.go
+++ b/tools/metrics/gauges_billing.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"code.cloudfoundry.org/lager"
+)
+
+type CostByPlan struct {
+	PlanGUID string  `json:"plan_guid"`
+	Cost     float64 `json:"cost"`
+}
+
+func BillingCostsGauge(
+	logger lager.Logger,
+	endpoint string,
+	interval time.Duration,
+) MetricReadCloser {
+	return NewMetricPoller(interval, func(w MetricWriter) error {
+		lsession := logger.Session("billing-gauges")
+		costs, err := GetCostsByPlan(lsession, endpoint)
+		if err != nil {
+			lsession.Error("Failed to get billing costs metrics", err)
+			return err
+		}
+
+		metrics := CostsByPlanGauges(costs)
+
+		lsession.Info("Writing billing metrics")
+		return w.WriteMetrics(metrics)
+	})
+}
+
+func GetCostsByPlan(logger lager.Logger, endpoint string) ([]CostByPlan, error) {
+	lsession := logger.Session("billing-metrics")
+	lsession.Info("Started Billing metrics")
+	req, err := http.NewRequest("GET", endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	httpClient := http.DefaultClient
+
+	resp, err := httpClient.Do(req)
+
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Returned statuscode from costs endpoint %d", resp.StatusCode)
+	}
+	bodyBuffer, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	totalCosts := make([]CostByPlan, 0)
+	err = json.Unmarshal(bodyBuffer, &totalCosts)
+	if err != nil {
+		return nil, err
+	}
+
+	lsession.Info("Finished Billing metrics")
+	return totalCosts, nil
+}
+
+func CostsByPlanGauges(totalCosts []CostByPlan) []Metric {
+	metrics := make([]Metric, 0)
+
+	for _, plan := range totalCosts {
+		metrics = append(metrics, Metric{
+			Kind:  Gauge,
+			Time:  time.Now(),
+			Name:  "billing.total.costs",
+			Value: plan.Cost,
+			Tags:  MetricTags{MetricTag{Label: "plan_guid", Value: plan.PlanGUID}},
+			Unit:  "pounds",
+		})
+	}
+
+	return metrics
+}

--- a/tools/metrics/gauges_billing_test.go
+++ b/tools/metrics/gauges_billing_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+var _ = Describe("Billing Gauges", func() {
+	It("should return zero for no costs", func() {
+		totalCosts := []CostByPlan{}
+		gauges := CostsByPlanGauges(totalCosts)
+
+		Expect(gauges).To(HaveLen(0))
+	})
+
+	It("Should return the correct costs for a plan", func() {
+		totalCosts := []CostByPlan{
+			{
+				PlanGUID: "11f779fa-425c-4c86-9530-d0aebcb3c3e6",
+				Cost:     2.1,
+			},
+			{
+				PlanGUID: "24efab31-8cbd-47c0-8513-a9345f3c512b",
+				Cost:     0.02,
+			},
+			{
+				PlanGUID: "3a51701c-eef3-447c-882b-907ad2bcb7ab",
+				Cost:     0.06,
+			},
+			{
+				PlanGUID: "5f2eec8a-0cad-4ab9-b81e-d6adade2fd42",
+				Cost:     6.43,
+			},
+			{
+				PlanGUID: "69977068-8ef5-4172-bfdb-e8cea3c14d01",
+				Cost:     2.09,
+			},
+		}
+		gauges := CostsByPlanGauges(totalCosts)
+
+		Expect(gauges).To(HaveLen(5))
+
+		Expect(gauges).To(ContainElement(
+			MatchFields(IgnoreExtras, Fields{
+				"Name":  Equal("billing.total.costs"),
+				"Unit":  Equal("pounds"),
+				"Kind":  Equal(Gauge),
+				"Value": Equal(2.09),
+				"Tags": ContainElement(MatchFields(IgnoreExtras, Fields{
+					"Label": Equal("plan_guid"), "Value": Equal("69977068-8ef5-4172-bfdb-e8cea3c14d01"),
+				})),
+			}),
+		))
+	})
+})

--- a/tools/metrics/main.go
+++ b/tools/metrics/main.go
@@ -3,13 +3,14 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
 	"log"
 	"net/http"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -134,6 +135,7 @@ func Main() error {
 		S3BucketsGauge(logger, s3, 1*time.Hour),
 		CustomDomainCDNMetricsCollector(logger, cfs, cloudWatch, 10*time.Minute),
 		UAAGauges(logger, &uaaCfg, 5*time.Minute),
+		BillingCostsGauge(logger, os.Getenv("COSTS_ENDPOINT"), 15*time.Minute),
 	}
 	for _, addr := range strings.Split(os.Getenv("TLS_DOMAINS"), ",") {
 		gauges = append(gauges, TLSValidityGauge(logger, tlsChecker, strings.TrimSpace(addr), 15*time.Minute))


### PR DESCRIPTION
What
----

This adds a total costs by plan metric to that's collected via billing's /costs endpoint.

```
paas_billing_total_costs_count{plan_guid="9e29a085-95cc-4f48-9fa1-cd5e5cb61c67"} 3.14
paas_billing_total_costs_count{plan_guid="1e61512c-39c1-4426-aa0e-d4cb8b2d8c17"} 1.03
paas_billing_total_costs_count{plan_guid="54b75748-e8d1-4a01-9db0-e0d119823d2f"} 1.09
```

How to review
-------------

- Review and merge https://github.com/alphagov/paas-billing/pull/83
- Code review
- Deploy to your dev env and confirm the metric is in prometheus
- Update the paas-billing resource tag

Who can review
--------------

Not me or Lee
