### PR TITLE
Collect paas_uaa_active_users_count metric

### DIFF
--- a/tools/metrics/acceptance/uaa_test.go
+++ b/tools/metrics/acceptance/uaa_test.go
@@ -9,6 +9,7 @@ var _ = Describe("UAA", func() {
 	It("should return UAA user metrics", func() {
 		Expect(metricFamilies).To(SatisfyAll(
 			HaveKey("paas_uaa_users_count"),
+			HaveKey("paas_uaa_active_users_count"),
 		))
 	})
 })

--- a/tools/metrics/gauges_uaa.go
+++ b/tools/metrics/gauges_uaa.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"time"
 
 	"code.cloudfoundry.org/lager"
@@ -58,6 +59,8 @@ func UAAMetrics(logger lager.Logger, cfg *UAAClientConfig) ([]Metric, error) {
 
 	lsession.Info("Computing UAA users by origin")
 	metrics = append(metrics, UAAUsersByOriginGauges(users)...)
+
+	lsession.Info(fmt.Sprintf("Found %d metrics", len(metrics)))
 
 	lsession.Info("Finished UAA metrics")
 	return metrics, nil

--- a/tools/metrics/gauges_uaa.go
+++ b/tools/metrics/gauges_uaa.go
@@ -47,7 +47,7 @@ func UAAMetrics(logger lager.Logger, cfg *UAAClientConfig) ([]Metric, error) {
 	}
 	lsession.Info("Validated UAA client")
 
-	users, err := uaa.ListAllUsers("", "", "origin", "")
+	users, err := uaa.ListAllUsers("", "", "origin,lastLogonTime", "")
 	if err != nil {
 		lsession.Error("Failed to list all UAA users", err)
 		return []Metric{}, err

--- a/tools/metrics/gauges_uaa_test.go
+++ b/tools/metrics/gauges_uaa_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -9,7 +11,7 @@ import (
 )
 
 var _ = Describe("UAA", func() {
-	Context("Aggregation", func() {
+	Context("Users Aggregation", func() {
 		It("Should aggregate users correctly for no users", func() {
 			gauges := UAAUsersByOriginGauges([]uaaclient.User{})
 
@@ -77,6 +79,163 @@ var _ = Describe("UAA", func() {
 					"Value": BeNumerically("==", 1),
 					"Tags": ContainElement(MatchFields(IgnoreExtras, Fields{
 						"Label": Equal("origin"), "Value": Equal("microsoft"),
+					})),
+				}),
+			))
+		})
+	})
+
+	Context("Active Users", func() {
+		It("Should select active users", func() {
+			activeUsers := []uaaclient.User{{
+				Origin:        "uaa",
+				LastLogonTime: int(time.Now().Add(-1*24*time.Hour).Unix() * 1000),
+			}}
+
+			Expect(UAAActiveUsers(activeUsers)).To(HaveLen(1))
+		})
+
+		It("Should reject inactive users", func() {
+			inactiveUsers := []uaaclient.User{{
+				Origin:        "uaa",
+				LastLogonTime: int(time.Now().Add(-1*24*time.Hour*31).Unix() * 1000),
+			}}
+
+			Expect(UAAActiveUsers(inactiveUsers)).To(HaveLen(0))
+		})
+
+		It("Should select active and reject inactive users", func() {
+			users := []uaaclient.User{{
+				Origin:        "google",
+				LastLogonTime: int(time.Now().Add(-1*24*time.Hour).Unix() * 1000),
+			}, {
+				Origin:        "uaa",
+				LastLogonTime: int(time.Now().Add(-1*24*time.Hour*31).Unix() * 1000),
+			}}
+
+			activeUsers := UAAActiveUsers(users)
+
+			Expect(activeUsers).To(HaveLen(1))
+			Expect(activeUsers[0].Origin).To(Equal("google"))
+		})
+	})
+
+	Context("Active Users Aggregation", func() {
+		It("Should select active users as gauges", func() {
+			users := []uaaclient.User{{
+				Origin:        "uaa",
+				LastLogonTime: int(time.Now().Add(-1*24*time.Hour).Unix() * 1000),
+			}}
+
+			gauges := UAAActiveUsersByOriginGauges(users)
+
+			Expect(gauges).To(HaveLen(1))
+			Expect(gauges).To(ContainElement(
+				MatchFields(IgnoreExtras, Fields{
+					"Name":  Equal("uaa.active.users"),
+					"Unit":  Equal("count"),
+					"Kind":  Equal(Gauge),
+					"Value": BeNumerically("==", 1),
+					"Tags": ContainElement(MatchFields(IgnoreExtras, Fields{
+						"Label": Equal("origin"), "Value": Equal("uaa"),
+					})),
+				}),
+			))
+		})
+
+		It("Should reject inactive users as gauges", func() {
+			users := []uaaclient.User{{
+				Origin:        "uaa",
+				LastLogonTime: int(time.Now().Add(-1*24*time.Hour*31).Unix() * 1000),
+			}}
+
+			gauges := UAAActiveUsersByOriginGauges(users)
+
+			Expect(gauges).To(HaveLen(0))
+		})
+
+		It("Should select active and reject inactive users as gauges", func() {
+			users := []uaaclient.User{{
+				Origin:        "google",
+				LastLogonTime: int(time.Now().Add(-1*24*time.Hour).Unix() * 1000),
+			}, {
+				Origin:        "uaa",
+				LastLogonTime: int(time.Now().Add(-1*24*time.Hour*31).Unix() * 1000),
+			}}
+
+			gauges := UAAActiveUsersByOriginGauges(users)
+
+			Expect(gauges).To(HaveLen(1))
+			Expect(gauges).To(ContainElement(
+				MatchFields(IgnoreExtras, Fields{
+					"Name":  Equal("uaa.active.users"),
+					"Unit":  Equal("count"),
+					"Kind":  Equal(Gauge),
+					"Value": BeNumerically("==", 1),
+					"Tags": ContainElement(MatchFields(IgnoreExtras, Fields{
+						"Label": Equal("origin"), "Value": Equal("google"),
+					})),
+				}),
+			))
+		})
+
+		It("Should select active and reject inactive users as gauges for many users", func() {
+			users := []uaaclient.User{{
+				Origin:        "google",
+				LastLogonTime: int(time.Now().Add(-1*24*time.Hour).Unix() * 1000),
+			}, {
+				Origin:        "google",
+				LastLogonTime: int(time.Now().Add(-1*24*time.Hour*60).Unix() * 1000),
+			}, {
+				Origin:        "microsoft",
+				LastLogonTime: int(time.Now().Add(-1*24*time.Hour*2).Unix() * 1000),
+			}, {
+				Origin:        "microsoft",
+				LastLogonTime: int(time.Now().Add(-1*24*time.Hour*91).Unix() * 1000),
+			}, {
+				Origin:        "uaa",
+				LastLogonTime: int(time.Now().Add(-1*24*time.Hour*2).Unix() * 1000),
+			}, {
+				Origin:        "uaa",
+				LastLogonTime: int(time.Now().Add(-1*24*time.Hour*31).Unix() * 1000),
+			}}
+
+			gauges := UAAActiveUsersByOriginGauges(users)
+
+			Expect(gauges).To(HaveLen(3))
+
+			Expect(gauges).To(ContainElement(
+				MatchFields(IgnoreExtras, Fields{
+					"Name":  Equal("uaa.active.users"),
+					"Unit":  Equal("count"),
+					"Kind":  Equal(Gauge),
+					"Value": BeNumerically("==", 1),
+					"Tags": ContainElement(MatchFields(IgnoreExtras, Fields{
+						"Label": Equal("origin"), "Value": Equal("google"),
+					})),
+				}),
+			))
+
+			Expect(gauges).To(ContainElement(
+				MatchFields(IgnoreExtras, Fields{
+					"Name":  Equal("uaa.active.users"),
+					"Unit":  Equal("count"),
+					"Kind":  Equal(Gauge),
+					"Value": BeNumerically("==", 1),
+					"Tags": ContainElement(MatchFields(IgnoreExtras, Fields{
+						"Label": Equal("origin"), "Value": Equal("microsoft"),
+					})),
+				}),
+			))
+
+			Expect(gauges).To(ContainElement(
+				MatchFields(IgnoreExtras, Fields{
+					"Name":  Equal("uaa.active.users"),
+					"Unit":  Equal("count"),
+					"Kind":  Equal(Gauge),
+					"Value": BeNumerically("==", 1),
+					"Tags": ContainElement(MatchFields(IgnoreExtras, Fields{
+						"Label": Equal("origin"), "Value": Equal("uaa"),
 					})),
 				}),
 			))

--- a/tools/metrics/gauges_uaa_test.go
+++ b/tools/metrics/gauges_uaa_test.go
@@ -11,6 +11,11 @@ import (
 )
 
 var _ = Describe("UAA", func() {
+
+	MinusOneDay := -1 * 24 * time.Hour
+	OneDayAgo := time.Now().Add(MinusOneDay)
+	ThirtyOneDaysAgo := time.Now().Add(MinusOneDay * 31)
+
 	Context("Users Aggregation", func() {
 		It("Should aggregate users correctly for no users", func() {
 			gauges := UAAUsersByOriginGauges([]uaaclient.User{})
@@ -85,11 +90,11 @@ var _ = Describe("UAA", func() {
 		})
 	})
 
-	Context("Active Users", func() {
+	Context("Active Users (logged in within 30 days)", func() {
 		It("Should select active users", func() {
 			activeUsers := []uaaclient.User{{
 				Origin:        "uaa",
-				LastLogonTime: int(time.Now().Add(-1*24*time.Hour).Unix() * 1000),
+				LastLogonTime: int(OneDayAgo.Unix() * 1000),
 			}}
 
 			Expect(UAAActiveUsers(activeUsers)).To(HaveLen(1))
@@ -98,7 +103,7 @@ var _ = Describe("UAA", func() {
 		It("Should reject inactive users", func() {
 			inactiveUsers := []uaaclient.User{{
 				Origin:        "uaa",
-				LastLogonTime: int(time.Now().Add(-1*24*time.Hour*31).Unix() * 1000),
+				LastLogonTime: int(ThirtyOneDaysAgo.Unix() * 1000),
 			}}
 
 			Expect(UAAActiveUsers(inactiveUsers)).To(HaveLen(0))
@@ -107,10 +112,10 @@ var _ = Describe("UAA", func() {
 		It("Should select active and reject inactive users", func() {
 			users := []uaaclient.User{{
 				Origin:        "google",
-				LastLogonTime: int(time.Now().Add(-1*24*time.Hour).Unix() * 1000),
+				LastLogonTime: int(OneDayAgo.Unix() * 1000),
 			}, {
 				Origin:        "uaa",
-				LastLogonTime: int(time.Now().Add(-1*24*time.Hour*31).Unix() * 1000),
+				LastLogonTime: int(ThirtyOneDaysAgo.Unix() * 1000),
 			}}
 
 			activeUsers := UAAActiveUsers(users)
@@ -120,11 +125,11 @@ var _ = Describe("UAA", func() {
 		})
 	})
 
-	Context("Active Users Aggregation", func() {
+	Context("Active Users Aggregation (logged in within 30 days)", func() {
 		It("Should select active users as gauges", func() {
 			users := []uaaclient.User{{
 				Origin:        "uaa",
-				LastLogonTime: int(time.Now().Add(-1*24*time.Hour).Unix() * 1000),
+				LastLogonTime: int(OneDayAgo.Unix() * 1000),
 			}}
 
 			gauges := UAAActiveUsersByOriginGauges(users)
@@ -146,7 +151,7 @@ var _ = Describe("UAA", func() {
 		It("Should reject inactive users as gauges", func() {
 			users := []uaaclient.User{{
 				Origin:        "uaa",
-				LastLogonTime: int(time.Now().Add(-1*24*time.Hour*31).Unix() * 1000),
+				LastLogonTime: int(ThirtyOneDaysAgo.Unix() * 1000),
 			}}
 
 			gauges := UAAActiveUsersByOriginGauges(users)
@@ -157,10 +162,10 @@ var _ = Describe("UAA", func() {
 		It("Should select active and reject inactive users as gauges", func() {
 			users := []uaaclient.User{{
 				Origin:        "google",
-				LastLogonTime: int(time.Now().Add(-1*24*time.Hour).Unix() * 1000),
+				LastLogonTime: int(OneDayAgo.Unix() * 1000),
 			}, {
 				Origin:        "uaa",
-				LastLogonTime: int(time.Now().Add(-1*24*time.Hour*31).Unix() * 1000),
+				LastLogonTime: int(ThirtyOneDaysAgo.Unix() * 1000),
 			}}
 
 			gauges := UAAActiveUsersByOriginGauges(users)
@@ -182,22 +187,22 @@ var _ = Describe("UAA", func() {
 		It("Should select active and reject inactive users as gauges for many users", func() {
 			users := []uaaclient.User{{
 				Origin:        "google",
-				LastLogonTime: int(time.Now().Add(-1*24*time.Hour).Unix() * 1000),
+				LastLogonTime: int(OneDayAgo.Unix() * 1000),
 			}, {
 				Origin:        "google",
-				LastLogonTime: int(time.Now().Add(-1*24*time.Hour*60).Unix() * 1000),
+				LastLogonTime: int(time.Now().Add(MinusOneDay * 60).Unix() * 1000),
 			}, {
 				Origin:        "microsoft",
-				LastLogonTime: int(time.Now().Add(-1*24*time.Hour*2).Unix() * 1000),
+				LastLogonTime: int(time.Now().Add(MinusOneDay * 2).Unix() * 1000),
 			}, {
 				Origin:        "microsoft",
-				LastLogonTime: int(time.Now().Add(-1*24*time.Hour*91).Unix() * 1000),
+				LastLogonTime: int(time.Now().Add(MinusOneDay * 91).Unix() * 1000),
 			}, {
 				Origin:        "uaa",
-				LastLogonTime: int(time.Now().Add(-1*24*time.Hour*2).Unix() * 1000),
+				LastLogonTime: int(time.Now().Add(MinusOneDay * 2).Unix() * 1000),
 			}, {
 				Origin:        "uaa",
-				LastLogonTime: int(time.Now().Add(-1*24*time.Hour*31).Unix() * 1000),
+				LastLogonTime: int(time.Now().Add(MinusOneDay * 31).Unix() * 1000),
 			}}
 
 			gauges := UAAActiveUsersByOriginGauges(users)


### PR DESCRIPTION
What
----

We have a key performance indicator (KPI) for single sign-on (SSO) which is:

> % of active users who are eligible to use SSO who are using it

A "starter-for-ten" is exposing the number of users who have logged in in the last 30 days as a metric, broken down by origin.

![image](https://user-images.githubusercontent.com/1482692/62123105-186ff980-b2bf-11e9-9e06-c8e525f24254.png)
_Bamber Gascoigne_

How to review
-------------

Code review, commit by commit

Because there are no pipeline changes, it is fine to

- `cd paas-cf/tools/metrics && cf push` ___to your dev environment please___
- then `curl https://paas-metrics.devenv.dev.cloudpipeline.digital/metrics`
- and look for `paas_uaa_active_users_count` metric

This can be demonstrated [here](https://paas-metrics.tlwr.dev.cloudpipelineapps.digital/metrics)

Also run the acceptance tests:
```
PAAS_METRICS_URL='https://paas-metrics.tlwr.dev.cloudpipelineapps.digital/metrics' ginkgo acceptance
```

Who can review
--------------

Not @tlwr
