### PR TITLE
[#167194597] Monitor UAA Errors

### DIFF
--- a/manifests/prometheus/alerts.d/uaa-5xx-errors.yml
+++ b/manifests/prometheus/alerts.d/uaa-5xx-errors.yml
@@ -1,0 +1,15 @@
+# Source: firehose-exporter
+---
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: UAA5xxErrorCount
+    rules:
+      - alert: UAA5xxErrorCount
+        expr: sum(increase(firehose_value_metric_uaa_requests_global_status_5_xx_count[6h])) > 10
+        labels:
+          severity: warning
+        annotations:
+          summary: "UAA - 5xx error count"
+          description: "Amount of 5xx errors in UAA has increased considerably over the last six hours: {{ $value | printf \"%.0f\" }}"

--- a/manifests/prometheus/spec/alerts/uaa-5xx-errors.test.yml
+++ b/manifests/prometheus/spec/alerts/uaa-5xx-errors.test.yml
@@ -1,0 +1,33 @@
+---
+rule_files:
+  # See alerts_validation_spec.rb for details of how stdin gets set:
+  - spec/alerts/fixtures/rules.yml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1h
+    input_series:
+      - series: 'firehose_value_metric_uaa_requests_global_status_5_xx_count{bosh_job_ip="0.0.0.1"}'
+        values: 0 2 0 1 0 0 0 2
+      - series: 'firehose_value_metric_uaa_requests_global_status_5_xx_count{bosh_job_ip="0.0.0.2"}'
+        values: 0 0 0 1 0 0 0 2
+      - series: 'firehose_value_metric_uaa_requests_global_status_5_xx_count{bosh_job_ip="0.0.0.3"}'
+        values: 0 0 0 1 2 0 0 1
+
+    alert_rule_test:
+      # Does not fire without enough data
+      - eval_time: 3h
+        alertname: UAA5xxErrorCount
+      # Does not fire when not reaching the threshold
+      - eval_time: 6h
+        alertname: UAA5xxErrorCount
+      # Fires when there has been an increase of 10 errors over 6h
+      - eval_time: 8h
+        alertname: UAA5xxErrorCount
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: "UAA - 5xx error count"
+              description: "Amount of 5xx errors in UAA has increased considerably over the last six hours: 11"


### PR DESCRIPTION
What
----

Adds an alert to monitor UAA. The alert will be triggered if there's an increase in UAA 5xx errors over a 6 hour period.

How to review
-------------

Code review

Who can review
--------------

Not me
