### PR TITLE
[SUPPORT] Update the logit filter script file paths

### DIFF
--- a/scripts/generate_logit_filters.sh
+++ b/scripts/generate_logit_filters.sh
@@ -46,7 +46,7 @@ echo "filter {" > /output/generated_logit_filters.conf
     sed 's/^/  /' < /tmp/syslog_standard.conf
     sed 's/^/  /' < /mnt/config/logit/11_app_syslog_drain.conf
     sed 's/^/  /' < /tmp/logsearch-for-cloudfoundry/src/logsearch-config/target/logstash-filters-default.conf
-    sed 's/^/  /' < /mnt/config/logit/20_custom_filters.conf
+    sed 's/^/  /' < /mnt/config/logit/20_custom_cf_filters.conf
     echo "}"
 } >> /output/generated_logit_filters.conf
 


### PR DESCRIPTION
What
----

In [3cd9ca36fb5b60bb0f79a405027114b9ac78549e](https://github.com/alphagov/paas-cf/commit/3cd9ca36fb5b60bb0f79a405027114b9ac78549e) one of the files was renamed but updating the path in the generate logit filters script was missed.

How to review
-------------

Code review and run `make logit-filters`

Who can review
--------------

Anyone
