### PR TITLE
Add `cf-shell` script to scripts

### DIFF
--- a/scripts/cf-shell.sh
+++ b/scripts/cf-shell.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+PAAS_CF_DIR=${PAAS_CF_DIR:-"$GOPATH/src/github.com/alphagov/paas-cf"}
+
+ARGS=""
+SCRIPT="$0"
+usage() {
+  cat <<EOF
+Usage: $SCRIPT [-f] DEPLOY_ENV
+
+Log in to any GOV.UK PaaS environemnt, optionally forcing the login to happen
+inside a subshell.
+
+Supported DEPLOY_ENV values:
+  prod      Production Cloud Foundry deployment in Ireland (subshell forced)
+  prod-lon  Production Cloud Foundry deployment in London (subshell forced)
+  stg-lon   Staging Cloud Foundry deployment in London (subshell forced)
+  *         Assumed as a development Cloud Foundry deployment
+
+Options:
+  -f  Force the use of a subshell
+EOF
+  exit 1;
+}
+
+while getopts "f" o; do
+	case "${o}" in
+		f)
+			ARGS+=" -s"
+			;;
+
+		*)
+			usage
+			;;
+	esac
+done
+
+if [ -z "$1" ]; then
+  usage;
+fi
+
+shift $((OPTIND - 1))
+
+if [ "${1}" == "prod" ] ||  [ "${1}" == "prod-lon" ] ||  [ "${1}" == "stg-lon" ] ; then
+  "${PAAS_CF_DIR}/scripts/cf_subshell_scoped_login.sh" "${1}"
+else
+  eval "DEPLOY_ENV=${1} gds aws paas-dev -- $PAAS_CF_DIR/scripts/cf_admin_login_dev.sh ${ARGS}"
+fi


### PR DESCRIPTION
What
----

`cf-shell` logs in to a CF deployment using the `cf_subshell_scoped_login` and
`cf_admin_login_dev` scripts as appropriate (based on environment name).
Optionally allows the user to force the login to happen inside a subshell for
all environments.

This is useful for preventing us from being accidentally still logged in to an
environment when issuing `cf` commands.

The scripts expose a `$CF_SUBSHELL_TARGET` env var which holds the name of the
environment being targeted. This can be used in developers terminals to show
them which environment they're in.

Eg in my `.bashrc` I have the following

```
if [ "$SHLVL" -gt 1 ]; then
    export PS1+="\[${COLOUR_RESET}\]:\[${COLOUR_RED}\]SUBSHELL=${CF_SUBSHELL_TARGET:-unk}\[${COLOUR_RESET}\]"
fi
```

How to review
-------------

1. Code review
2. Test it

Who can review
--------------
Anyone