### PR TITLE
Bump paas-billing to v0.66.0 (timing for /totals)

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -390,7 +390,7 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-billing.git
       branch: master
-      tag_filter: v0.65.0
+      tag_filter: v0.66.0
 
   - name: paas-accounts
     type: git


### PR DESCRIPTION
What
----

See https://github.com/alphagov/paas-billing/compare/v0.65.0...v0.66.0

How to review
-------------

* Code review is enough

Who can review
--------------

Not @richardtowers