### PR TITLE
[#167668232] Ship updated CDN Broker documentation URL

### DIFF
--- a/manifests/cf-manifest/operations.d/720-cdn-broker.yml
+++ b/manifests/cf-manifest/operations.d/720-cdn-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: cdn-broker
-    version: 0.1.16
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.16.tgz
-    sha1: aab2942b400a8a136257e636409a9987290eb5e9
+    version: 0.1.18
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.18.tgz
+    sha1: 14ca2ea82727849b4509564b4e7c4e0ffc187692
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-


### PR DESCRIPTION
What
----

Release https://github.com/alphagov/paas-cdn-broker/pull/25 and https://github.com/alphagov/paas-cdn-broker-boshrelease/pull/20.

How to review
-------------

🐝 *Merge https://github.com/alphagov/paas-cdn-broker/pull/25 first. Before merging this PR, update the `[WIP]` commit to point to the boshrelease built from its updated master.* 🐝 

Who can review
--------------

Not @46bit