### PR TITLE
[#167862846] [CVE-2019-9893] Upgrade to cf deployment v11.0.0

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -302,13 +302,14 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-acceptance-tests
-      branch: cf10.0
+      branch: master
+      tag_filter: v3.5.0
 
   - name: cf-smoke-tests-release
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-smoke-tests-release
-      tag_filter: "40.0.113"
+      tag_filter: "40.0.116"
       submodules:
       - "src/smoke_tests"
 

--- a/concourse/pipelines/monitor-remote.yml
+++ b/concourse/pipelines/monitor-remote.yml
@@ -19,7 +19,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloudfoundry/cf-smoke-tests-release
-    tag_filter: "40.0.113"
+    tag_filter: "40.0.116"
     submodules:
       - "src/smoke_tests"
 

--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-xenial
-      version: "315.64"
+      version: "456.3"

--- a/manifests/cf-manifest/operations.d/040-cf-routing.yml
+++ b/manifests/cf-manifest/operations.d/040-cf-routing.yml
@@ -1,8 +1,0 @@
----
-- type: replace
-  path: /releases/name=routing
-  value:
-    name: routing
-    version: 0.188.0
-    url: "https://bosh.io/d/github.com/cloudfoundry-incubator/cf-routing-release?v=0.188.0"
-    sha1: d3420851c470790e8980ff0c506f75e3e52c15d9

--- a/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
+++ b/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
@@ -1,8 +1,0 @@
----
-- type: replace
-  path: /releases/name=cflinuxfs3
-  value:
-    name: "cflinuxfs3"
-    version: "0.115.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.115.0"
-    sha1: "0dd761305b31f50715edda690b7feca1322f9d7f"

--- a/manifests/cf-manifest/operations.d/230-loggregator-deployment.yml
+++ b/manifests/cf-manifest/operations.d/230-loggregator-deployment.yml
@@ -12,11 +12,3 @@
 - type: replace
   path: /addons/name=forwarder_agent/jobs/name=loggr-forwarder-agent/properties/tags?/deployment
   value: ((environment))
-
-- type: replace
-  path: /releases/name=loggregator-agent
-  value:
-    name: "loggregator-agent"
-    version: "3.19"
-    url: "https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=3.19"
-    sha1: "cecab8716a456387e979b8cefdf74c1a9a9f2a51"

--- a/manifests/cf-manifest/operations.d/360-log-api.yml
+++ b/manifests/cf-manifest/operations.d/360-log-api.yml
@@ -22,3 +22,14 @@
 - type: replace
   path: /instance_groups/name=log-api/instances
   value: ((log_api_instances))
+
+- type: replace
+  path: /releases/name=loggregator
+  # We cannot use a version of loggregator past 105.5 until we get rid of ELBs
+  # This is because of TLS cipher suite mismatch
+  value:
+    name: "loggregator"
+    version: "105.5"
+    url: "https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=105.5"
+    sha1: "62b9210def7c5179f6088b9449f551f57f1a1ee8"
+

--- a/manifests/cf-manifest/operations.d/900-cf-cert-rotation.yml
+++ b/manifests/cf-manifest/operations.d/900-cf-cert-rotation.yml
@@ -24,7 +24,7 @@
   value: ((loggregator_ca.certificate))((loggregator_ca_old.certificate))
 
 - type: replace
-  path: /addons/name=prom_scraper/jobs/name=prom_scraper/properties/loggregator_agent?/ca_cert
+  path: /addons/name=prom_scraper/jobs/name=prom_scraper/properties?/loggregator_agent?/tls?/ca_cert
   value: ((loggregator_ca.certificate))((loggregator_ca_old.certificate))
 
 - type: replace

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -29,11 +29,11 @@ RSpec.describe "release versions" do
     pinned_releases = {
       'uaa' => {
         local: '0.1.11',
-        upstream: '73.4.0',
+        upstream: '74.0.0',
       },
-      'loggregator-agent' => {
-        local: '3.19',
-        upstream: '3.18',
+      'loggregator' => {
+        local: '105.5',
+        upstream: '105.6',
       }
     }
 
@@ -112,9 +112,13 @@ RSpec.describe "release versions" do
       .fetch(0)
 
     upstream_version = Gem::Version.new(cf_manifest_version.gsub(/^v/, '').gsub(/\.0$/, ''))
-    paas_version = Gem::Version.new(cf_acceptance_tests_resource['source']['branch'].gsub(/^cf/, ''))
 
-    expect(paas_version).to be >= upstream_version, "we should upgrade the cf-acceptance-tests' branch in the create-cloundfoundry pipeline to 'cf#{upstream_version}'"
+    if cf_acceptance_tests_resource['source']['branch'] == 'master'
+      expect(upstream_version).to be == Gem::Version.new('11.0'), 'there was no release of github.com/cloudfoundry/cf-acceptance-tests for cf-deployment v11.0. remove this erroring line and uncomment the below if they fix this for v12'
+    else
+      paas_version = Gem::Version.new(cf_acceptance_tests_resource['source']['branch'].gsub(/^cf/, ''))
+      expect(paas_version).to be >= upstream_version, "we should upgrade the cf-acceptance-tests' branch in the create-cloundfoundry pipeline to 'cf#{upstream_version}'"
+    end
   end
 
   specify "releases do not include buildpacks" do


### PR DESCRIPTION
What
----

Upgrades our `cf-deployment` from `v10.0.0` to [`v11.0.0`](https://github.com/cloudfoundry/cf-deployment/releases/tag/v11.0.0).

ℹ️ This would include UAA `74.0.0` except for our fork. In https://github.com/alphagov/paas-cf/pull/2021 we have already upgraded our fork to be based on that version.

ℹ️ This would upgrade our buildpacks except I've been told we pin them.

How to review
-------------

* Code review;
* See if the tests pass;
* Try deploying to your dev env and check everything passes;
* Check that the buildpacks were not upgraded (as we'd need to do tenant comms.)

So long as support stays quiet, Miki is going to deploy it and test it to speed things up.

Who can review
--------------

Not @46bit