### PR TITLE
[#167835423] Monitor paas-billing costs

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -3255,6 +3255,8 @@ jobs:
                 . ./config/config.sh
                 echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}" -o admin -s monitoring
 
+                jq '.pricing_plans | map({(.plan_guid): (.name)}) | add' "paas-cf/config/billing/output/${AWS_REGION}.json" > paas-cf/tools/metrics/plan_guids.json
+
                 cd paas-cf/tools/metrics
 
                 ruby -ryaml -e "

--- a/manifests/prometheus/alerts.d/paas-billing-costs.yml
+++ b/manifests/prometheus/alerts.d/paas-billing-costs.yml
@@ -1,0 +1,54 @@
+# Source: paas-metrics
+---
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: PaaSBillingDBCostsExceedRDSCosts
+    rules:
+      - alert: PaaSBillingDBCostsExceedRDSCosts
+        expr: sum(increase(paas_billing_total_costs_pounds{name=~"mysql.+|postgres.+"}[24h])) / sum(paas_aws_cost_explorer_by_service_pounds{service="Amazon Relational Database Service"}) > 1.1
+        labels:
+          severity: warning
+        annotations:
+          summary: "PaaS Billing DB costs exceed AWS RDS costs by > 10%"
+          description: "PaaS Billing DB costs exceed AWS RDS costs by > 10%. The difference is currently: £{{ $value | printf \"%.2f\" }}, which indicates there may be an issue with paas-billing's costs"
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: PaaSBillingDBCostsFallsShortOfRDSCosts
+    rules:
+      - alert: PaaSBillingDBCostsFallsShortOfRDSCosts
+        expr: sum(increase(paas_billing_total_costs_pounds{name=~"mysql.+|postgres.+"}[24h])) / sum(paas_aws_cost_explorer_by_service_pounds{service="Amazon Relational Database Service"}) < .9
+        labels:
+          severity: warning
+        annotations:
+          summary: "PaaS Billing DB costs fall short of AWS RDS costs by > 10%"
+          description: "PaaS Billing DB costs fall short of AWS RDS costs by > 10%. The difference is currently: £{{ $value | printf \"%.2f\" }}, which indicates there may be an issue with paas-billing's costs"
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: PaaSBillingAppCostsExceedEC2Costs
+    rules:
+      - alert: PaaSBillingAppCostsExceedEC2Costs
+        expr: sum(increase(paas_billing_total_costs_pounds{name="app"}[24h])) / sum(paas_aws_cost_explorer_by_service_pounds{service=~"^EC2.+"}) > 1.1
+        labels:
+          severity: warning
+        annotations:
+          summary: "PaaS Billing App costs exceed AWS EC2 costs by > 10%"
+          description: "PaaS Billing App costs exceed AWS EC2 costs by > 10%. The difference is currently: £{{ $value | printf \"%.2f\" }}, which indicates there may be an issue with paas-billing's costs"
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: PaaSBillingAppCostsFallsShortOfEC2Costs
+    rules:
+      - alert: PaaSBillingAppCostsFallsShortOfEC2Costs
+        expr: sum(increase(paas_billing_total_costs_pounds{name="app"}[24h])) / sum(paas_aws_cost_explorer_by_service_pounds{service=~"^EC2.+"}) < .9
+        labels:
+          severity: warning
+        annotations:
+          summary: "PaaS Billing App costs fall short of AWS EC2 costs by > 10%"
+          description: "PaaS Billing App costs fall short of AWS EC2 costs by > 10%. The difference is currently: £{{ $value | printf \"%.2f\" }}, which indicates there may be an issue with paas-billing's costs"

--- a/tools/metrics/billing.go
+++ b/tools/metrics/billing.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+)
+
+func GetPlanGUIDS(filename string) (map[string]string, error) {
+	var plans map[string]string
+	b, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return plans, err
+	}
+
+	err = json.Unmarshal(b, &plans)
+	if err != nil {
+		return plans, err
+	}
+
+	return plans, nil
+}

--- a/tools/metrics/gauges_billing_test.go
+++ b/tools/metrics/gauges_billing_test.go
@@ -8,13 +8,21 @@ import (
 
 var _ = Describe("Billing Gauges", func() {
 	It("should return zero for no costs", func() {
+		plans := map[string]string{}
 		totalCosts := []CostByPlan{}
-		gauges := CostsByPlanGauges(totalCosts)
+		gauges := CostsByPlanGauges(totalCosts, plans)
 
 		Expect(gauges).To(HaveLen(0))
 	})
 
 	It("Should return the correct costs for a plan", func() {
+		plans := map[string]string{
+			"11f779fa-425c-4c86-9530-d0aebcb3c3e6": "app",
+			"24efab31-8cbd-47c0-8513-a9345f3c512b": "postgres tiny",
+			"3a51701c-eef3-447c-882b-907ad2bcb7ab": "unknown-plan",
+			"5f2eec8a-0cad-4ab9-b81e-d6adade2fd42": "task",
+			"69977068-8ef5-4172-bfdb-e8cea3c14d01": "postgres small",
+		}
 		totalCosts := []CostByPlan{
 			{
 				PlanGUID: "11f779fa-425c-4c86-9530-d0aebcb3c3e6",
@@ -37,7 +45,7 @@ var _ = Describe("Billing Gauges", func() {
 				Cost:     2.09,
 			},
 		}
-		gauges := CostsByPlanGauges(totalCosts)
+		gauges := CostsByPlanGauges(totalCosts, plans)
 
 		Expect(gauges).To(HaveLen(5))
 
@@ -49,6 +57,14 @@ var _ = Describe("Billing Gauges", func() {
 				"Value": Equal(2.09),
 				"Tags": ContainElement(MatchFields(IgnoreExtras, Fields{
 					"Label": Equal("plan_guid"), "Value": Equal("69977068-8ef5-4172-bfdb-e8cea3c14d01"),
+				})),
+			}),
+		))
+
+		Expect(gauges).To(ContainElement(
+			MatchFields(IgnoreExtras, Fields{
+				"Tags": ContainElement(MatchFields(IgnoreExtras, Fields{
+					"Label": Equal("name"), "Value": Equal("postgres small"),
 				})),
 			}),
 		))

--- a/tools/metrics/main.go
+++ b/tools/metrics/main.go
@@ -123,6 +123,11 @@ func Main() error {
 
 	costExplorer := costexplorer.New(sess)
 
+	plans, err := GetPlanGUIDS("plan_guids.json")
+	if err != nil {
+		return errors.Wrap(err, "failed to load plan_guids.json")
+	}
+
 	// Combine all metrics into single stream
 	gauges := []MetricReader{
 		AppCountGauge(c, 5*time.Minute),                 // poll number of apps
@@ -143,7 +148,7 @@ func Main() error {
 		CustomDomainCDNMetricsCollector(logger, cfs, cloudWatch, 10*time.Minute),
 		AWSCostExplorerGauge(logger, awsRegion, costExplorer, 6*time.Hour),
 		UAAGauges(logger, &uaaCfg, 5*time.Minute),
-		BillingCostsGauge(logger, os.Getenv("COSTS_ENDPOINT"), 15*time.Minute),
+		BillingCostsGauge(logger, os.Getenv("COSTS_ENDPOINT"), 15*time.Minute, plans),
 	}
 	for _, addr := range strings.Split(os.Getenv("TLS_DOMAINS"), ",") {
 		gauges = append(gauges, TLSValidityGauge(logger, tlsChecker, strings.TrimSpace(addr), 15*time.Minute))


### PR DESCRIPTION
What
----

- Updates the paas-metrics deployment to include a file with a map of plan_guid to name that's used to add a name label to the paas_billing_total_costs metric
- Adds an alert to monitor the paas-billing costs against AWS EC2/RDS costs

How to review
-------------

- Code review
- Deploy to your dev env


Who can review
--------------

Not me
