### PR TITLE
Switch back to normal cf-acceptance-tests pinning

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -302,8 +302,7 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-acceptance-tests
-      branch: master
-      tag_filter: v3.5.0
+      branch: cf11.0
 
   - name: cf-smoke-tests-release
     type: git


### PR DESCRIPTION
What
----

In #2024 we pinned https://github.com/cloudfoundry/cf-acceptance-tests in an unusual way because their build pipeline was broken and so the normal way wasn't available. This PR moves us back to the normal way now things are fixed. See commit message for more details.

How to review
-------------

* Code review;
* See if the tests go green;
* I think we're fine to deploy this straightforwardly.

Who can review
--------------

Not @46bit