### PR TITLE
Fixes for billing alerts

### DIFF
--- a/manifests/prometheus/alerts.d/paas-billing-costs.yml
+++ b/manifests/prometheus/alerts.d/paas-billing-costs.yml
@@ -7,12 +7,12 @@
     name: PaaSBillingDBCostsExceedRDSCosts
     rules:
       - alert: PaaSBillingDBCostsExceedRDSCosts
-        expr: sum(increase(paas_billing_total_costs_pounds{name=~"mysql.+|postgres.+"}[24h])) / sum(paas_aws_cost_explorer_by_service_pounds{service="Amazon Relational Database Service"}) > 1.1
+        expr: sum(increase(paas_billing_total_costs_pounds{name=~"mysql.+|postgres.+"}[24h])) / sum(paas_aws_cost_explorer_by_service_pounds{service="Amazon Relational Database Service"}) > 1
         labels:
           severity: warning
         annotations:
-          summary: "PaaS Billing DB costs exceed AWS RDS costs by > 10%"
-          description: "PaaS Billing DB costs exceed AWS RDS costs by > 10%. The difference is currently: £{{ $value | printf \"%.2f\" }}, which indicates there may be an issue with paas-billing's costs"
+          summary: "PaaS Billing DB costs exceed AWS RDS costs"
+          description: "PaaS Billing DB costs exceed AWS RDS costs. The difference is currently: £{{ $value | printf \"%.2f\" }}, which indicates there may be an issue with paas-billing's costs"
 
 - type: replace
   path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
@@ -20,12 +20,12 @@
     name: PaaSBillingDBCostsFallsShortOfRDSCosts
     rules:
       - alert: PaaSBillingDBCostsFallsShortOfRDSCosts
-        expr: sum(increase(paas_billing_total_costs_pounds{name=~"mysql.+|postgres.+"}[24h])) / sum(paas_aws_cost_explorer_by_service_pounds{service="Amazon Relational Database Service"}) < .9
+        expr: sum(increase(paas_billing_total_costs_pounds{name=~"mysql.+|postgres.+"}[24h])) / sum(paas_aws_cost_explorer_by_service_pounds{service="Amazon Relational Database Service"}) < .6
         labels:
           severity: warning
         annotations:
-          summary: "PaaS Billing DB costs fall short of AWS RDS costs by > 10%"
-          description: "PaaS Billing DB costs fall short of AWS RDS costs by > 10%. The difference is currently: £{{ $value | printf \"%.2f\" }}, which indicates there may be an issue with paas-billing's costs"
+          summary: "PaaS Billing DB costs fall short of AWS RDS costs by > 40%"
+          description: "PaaS Billing DB costs fall short of AWS RDS costs by > 40%. The difference is currently: £{{ $value | printf \"%.2f\" }}, which indicates there may be an issue with paas-billing's costs"
 
 - type: replace
   path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-

--- a/manifests/prometheus/alerts.d/paas-billing-costs.yml
+++ b/manifests/prometheus/alerts.d/paas-billing-costs.yml
@@ -35,7 +35,7 @@
     name: PaaSBillingAppCostsExceedEC2Costs
     rules:
       - alert: PaaSBillingAppCostsExceedEC2Costs
-        expr: sum(increase(paas_billing_total_costs_pounds{name="app"}[24h])) / sum(paas_aws_cost_explorer_by_service_pounds{service=~"^EC2.+"}) > 1.1
+        expr: sum(increase(paas_billing_total_costs_pounds{name="app"}[24h])) / sum(paas_aws_cost_explorer_by_service_pounds{service=~"Amazon Elastic Compute Cloud - Compute"}) > 1.1
         labels:
           severity: warning
           layer: billing
@@ -49,7 +49,7 @@
     name: PaaSBillingAppCostsFallsShortOfEC2Costs
     rules:
       - alert: PaaSBillingAppCostsFallsShortOfEC2Costs
-        expr: sum(increase(paas_billing_total_costs_pounds{name="app"}[24h])) / sum(paas_aws_cost_explorer_by_service_pounds{service=~"^EC2.+"}) < .9
+        expr: sum(increase(paas_billing_total_costs_pounds{name="app"}[24h])) / sum(paas_aws_cost_explorer_by_service_pounds{service=~"Amazon Elastic Compute Cloud - Compute"}) < .9
         labels:
           severity: warning
           layer: billing

--- a/manifests/prometheus/alerts.d/paas-billing-costs.yml
+++ b/manifests/prometheus/alerts.d/paas-billing-costs.yml
@@ -10,6 +10,7 @@
         expr: sum(increase(paas_billing_total_costs_pounds{name=~"mysql.+|postgres.+"}[24h])) / sum(paas_aws_cost_explorer_by_service_pounds{service="Amazon Relational Database Service"}) > 1
         labels:
           severity: warning
+          layer: billing
         annotations:
           summary: "PaaS Billing DB costs exceed AWS RDS costs"
           description: "PaaS Billing DB costs exceed AWS RDS costs. The difference is currently: £{{ $value | printf \"%.2f\" }}, which indicates there may be an issue with paas-billing's costs"
@@ -23,6 +24,7 @@
         expr: sum(increase(paas_billing_total_costs_pounds{name=~"mysql.+|postgres.+"}[24h])) / sum(paas_aws_cost_explorer_by_service_pounds{service="Amazon Relational Database Service"}) < .6
         labels:
           severity: warning
+          layer: billing
         annotations:
           summary: "PaaS Billing DB costs fall short of AWS RDS costs by > 40%"
           description: "PaaS Billing DB costs fall short of AWS RDS costs by > 40%. The difference is currently: £{{ $value | printf \"%.2f\" }}, which indicates there may be an issue with paas-billing's costs"
@@ -36,6 +38,7 @@
         expr: sum(increase(paas_billing_total_costs_pounds{name="app"}[24h])) / sum(paas_aws_cost_explorer_by_service_pounds{service=~"^EC2.+"}) > 1.1
         labels:
           severity: warning
+          layer: billing
         annotations:
           summary: "PaaS Billing App costs exceed AWS EC2 costs by > 10%"
           description: "PaaS Billing App costs exceed AWS EC2 costs by > 10%. The difference is currently: £{{ $value | printf \"%.2f\" }}, which indicates there may be an issue with paas-billing's costs"
@@ -49,6 +52,7 @@
         expr: sum(increase(paas_billing_total_costs_pounds{name="app"}[24h])) / sum(paas_aws_cost_explorer_by_service_pounds{service=~"^EC2.+"}) < .9
         labels:
           severity: warning
+          layer: billing
         annotations:
           summary: "PaaS Billing App costs fall short of AWS EC2 costs by > 10%"
           description: "PaaS Billing App costs fall short of AWS EC2 costs by > 10%. The difference is currently: £{{ $value | printf \"%.2f\" }}, which indicates there may be an issue with paas-billing's costs"


### PR DESCRIPTION
What
----

These are currently alerting because we're only billing for ~70% of our
RDS usage, but this may actually be reasonable because we run some RDS
instances ourselves.

The EC2 alerts were pointing at the wrong metrics, which themselves were not being calculated correctly given our reserved instances (fixed in #2031).

I've also added a "layer: billing" label to them so we can hide them from Grafana.

How to review
-------------

* Code review should be enough

Who can review
--------------

Not Richard