### PR TITLE
Increase memory allocation to Envoy proxy

### DIFF
--- a/manifests/cf-manifest/operations.d/350-diego-cell.yml
+++ b/manifests/cf-manifest/operations.d/350-diego-cell.yml
@@ -11,6 +11,10 @@
   value: ((cell_instances))
 
 - type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/containers/proxy/additional_memory_allocation_mb?
+  value: 48
+
+- type: replace
   path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs3-rootfs-setup/properties/cflinuxfs3-rootfs/trusted_certs
   value:
     - ((aws_rds_combined_ca_bundle))


### PR DESCRIPTION
No story

What
----

We have seen some weird timeouts with some of our tenants, during all
parts of HTTP requests.

Hypothesis is that Envoy is running out of memory which causes the
timeouts

Increase memory 32mb to 48mb

How to review
-------------

Run it down your pipeline in an environment where `SLIM_DEV_DEPLOYMENT` is `false`

Who can review
--------------

Not @tlwr 
