### PR TITLE
Update exchange rate to match current average

### DIFF
--- a/config/billing/config.json.erb
+++ b/config/billing/config.json.erb
@@ -8,6 +8,11 @@
 		{
 			"code": "USD",
 			"valid_from": "epoch",
+			"rate": 0.8
+		},
+		{
+			"code": "USD",
+			"valid_from": "2019-08-01",
 			"rate": 0.82
 		}
 	],

--- a/config/billing/config.json.erb
+++ b/config/billing/config.json.erb
@@ -8,7 +8,7 @@
 		{
 			"code": "USD",
 			"valid_from": "epoch",
-			"rate": 0.8
+			"rate": 0.82
 		}
 	],
 	"vat_rates": [


### PR DESCRIPTION
What
----

It's been 0.8 since at least March 2018
(alphagov/paas-billing@838212be12318a4c03598666e525fb5b9ea899b1). For
most of that time the actual rate has been quite a bit lower than that,
but now it's more like 0.82.

Updating it to match so we don't undercharge people for the AWS
resources we're using.

This will affect all non-consolidated bills (so everything from the
month this is merged onwards).

How to review
-------------

* Check 'em

Who can review
--------------

Not richard, probably should run it past Luke