### PR TITLE
Use /healthcheck for paasmin pingdom healthchecks

### DIFF
--- a/terraform/pingdom/pingdom.tf
+++ b/terraform/pingdom/pingdom.tf
@@ -71,7 +71,7 @@ resource "pingdom_check" "paas_admin_healthcheck" {
   type                     = "http"
   name                     = "PaaS Admin - ${var.env}"
   host                     = "admin.${var.system_dns_zone_name}"
-  url                      = "/calculator"
+  url                      = "/healthcheck"
   shouldcontain            = "costs"
   encryption               = true
   resolution               = 1


### PR DESCRIPTION
What
----
`/calculator` requires billing to be up, which should be healthchecked separately.

We should just check whether paasmin's `/healthcheck` is healthy or not.

If we need a better check for health of paasmin, it should be
implemented in code in paasmin, and be used to compute the statuscode of
`/healthcheck`

Currently this is noisy because of problems with billing of which we are aware

How to review
-------------

Code review