### PR TITLE
Fix healthcheck to expect "OK" instead of costs

### DIFF
--- a/terraform/pingdom/pingdom.tf
+++ b/terraform/pingdom/pingdom.tf
@@ -72,7 +72,7 @@ resource "pingdom_check" "paas_admin_healthcheck" {
   name                     = "PaaS Admin - ${var.env}"
   host                     = "admin.${var.system_dns_zone_name}"
   url                      = "/healthcheck"
-  shouldcontain            = "costs"
+  shouldcontain            = "\"OK\""
   encryption               = true
   resolution               = 1
   uselegacynotifications   = true


### PR DESCRIPTION
What
----

Now it's pointing at /healthcheck "costs" is the wrong thing to look
for.

How to review
-------------

* Code review should be enough (prefereably from someone who knows
  enough HCL to confirm that `\"` is the right escape sequence)

Who can review
--------------

Not richard