### PR TITLE
Revert "Update exchange rate to match current average"

### DIFF
--- a/config/billing/config.json.erb
+++ b/config/billing/config.json.erb
@@ -9,11 +9,6 @@
 			"code": "USD",
 			"valid_from": "epoch",
 			"rate": 0.8
-		},
-		{
-			"code": "USD",
-			"valid_from": "2019-08-01",
-			"rate": 0.82
 		}
 	],
 	"vat_rates": [


### PR DESCRIPTION
What
----

This reverts commit f0ad7e6670ac066be39020b5543d7d6d07599d22.

It turns out that the extra complexity that this adds to billing's
queries causes it to fall over.

We could consider changing the `epoch` exchange rate and relying on the
consolidation to keep the past consistent, but for now let's just try
and fix the thing.

![GIF of a cat entering a bathtub](https://media.giphy.com/media/Mdct4RNEkGIrm/giphy.gif)

How to review
-------------

* Code review should be enough

Who can review
--------------

Not @richardTowers