### PR TITLE
Scale up London Dopplers

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -2,7 +2,7 @@
 cell_instances: 33
 router_instances: 3
 api_instances: 8
-doppler_instances: 21
+doppler_instances: 27
 log_api_instances: 6
 cc_hourly_rate_limit: 15000
 paas_region_name: london


### PR DESCRIPTION
What
----

Our dopplers are once again at capacity, scale them up +6 to deal with
new log volumes.

Who can review / How to review
-------------

Config change done as pair, manually applied to production