### PR TITLE
Add second VPC peer for dit-services / datasci

### DIFF
--- a/terraform/prod-lon.vpc_peering.json
+++ b/terraform/prod-lon.vpc_peering.json
@@ -22,5 +22,11 @@
         "account_id": "165562107270",
         "vpc_id": "vpc-074a7e7c7b4eccc8c",
         "subnet_cidr": "172.18.0.0/22"
+    },
+    {
+        "peer_name": "dit-services_datasci",
+        "account_id": "165562107270",
+        "vpc_id": "vpc-0911316657ad779ee",
+        "subnet_cidr": "172.18.4.0/22"
     }
 ]


### PR DESCRIPTION
Adding a second VPC peer for dit-services / datasci. Note that the same peer_name, `dit-services_datasci`, is used as the original peer. I'm not sure if this is desired or if it would cause problems.