### PR TITLE
Relax the Aiven cost alert slightly

### DIFF
--- a/manifests/prometheus/alerts.d/aiven-cost.yml
+++ b/manifests/prometheus/alerts.d/aiven-cost.yml
@@ -7,7 +7,7 @@
     name: AivenEstimatedCostHigh
     rules:
       - alert: AivenEstimatedCostHigh
-        expr: delta(paas_aiven_estimated_cost_pounds[24h]) * 30 > 20000
+        expr: delta(paas_aiven_estimated_cost_pounds[24h]) * 30 > 25000
         labels:
           severity: critical
         annotations:


### PR DESCRIPTION
What
----

We have enough budget to cover this without talking to finance now, and
it's annoying having the alert firing all the time.

By loosening the alert a bit we'll stop ourselves from learning to
ignore it, and we'll actually react when it fires next time.

Currently the metric looks like this:

![image](https://user-images.githubusercontent.com/1696784/64448312-54c02200-d0d5-11e9-99fc-3fbed65395cb.png)

With lines added for 20k (the current threshold) and 25k (the proposed threshold).

How to review
-------------

* Code review is enough

Who can review
--------------

Not richardtowers