### PR TITLE
Scale CAPI from 8 to 12 in London

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -1,7 +1,7 @@
 ---
 cell_instances: 33
 router_instances: 3
-api_instances: 8
+api_instances: 12
 doppler_instances: 27
 log_api_instances: 6
 cc_hourly_rate_limit: 15000


### PR DESCRIPTION
What
----

We had a latency spike around 11pm last night, which has been causing
the cross-region smoke tests to fail.

I've already done this scale up by hand using bosh, so this just updates
the infra-as-code to match.

How to review
-------------

* Code review is enough

Who can review
--------------

Not @richardtowers