### PR TITLE
[#167986184] Attach logapi instances to Doppler ALB target group

### DIFF
--- a/manifests/cf-manifest/operations.d/360-log-api.yml
+++ b/manifests/cf-manifest/operations.d/360-log-api.yml
@@ -1,5 +1,4 @@
 ---
-
 - type: replace
   path: /instance_groups/name=log-api/vm_extensions?/-
   value: cf_doppler_elbs
@@ -7,7 +6,7 @@
 - type: replace
   path: /instance_groups/name=log-api/vm_extensions?/-
   value: cf_loggregator_rlp_target_groups
-
+  
 - type: remove
   path: /instance_groups/name=log-api/jobs/name=route_registrar
 

--- a/manifests/cloud-config/cloud-config.yml
+++ b/manifests/cloud-config/cloud-config.yml
@@ -242,14 +242,17 @@ vm_extensions:
 - name: cf_doppler_elbs
   cloud_properties:
     elbs:
-    - ((terraform_outputs_cf_doppler_elb_name))
+      - ((terraform_outputs_cf_doppler_elb_name))
     lb_target_groups:
-    - ((terraform_outputs_cf_doppler_target_group_name))
+      - ((terraform_outputs_cf_doppler_target_group_name))
 
 - name: cf_loggregator_rlp_target_groups
   cloud_properties:
     lb_target_groups:
-    - ((terraform_outputs_cf_loggregator_rlp_target_group_name))
+      - ((terraform_outputs_cf_loggregator_rlp_target_group_name))
+      # The doppler target group is duplicated here
+      # because vm extensions are shallow merged.
+      - ((terraform_outputs_cf_doppler_target_group_name))
 
 - name: ssh_proxy_elb
   cloud_properties:

--- a/terraform/cloudfoundry/lbs.tf
+++ b/terraform/cloudfoundry/lbs.tf
@@ -79,21 +79,6 @@ resource "aws_lb_listener_rule" "cf_loggregator_rlp_log_stream" {
   }
 }
 
-resource "aws_lb_target_group" "cf_doppler" {
-  name     = "${var.env}-cf-doppler"
-  port     = 8081
-  protocol = "HTTPS"
-  vpc_id   = "${var.vpc_id}"
-
-  health_check {
-    matcher = "200-499"
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
 resource "aws_lb_listener_rule" "cf_doppler" {
   listener_arn = "${aws_lb_listener.cf_loggregator.arn}"
   priority     = "113"
@@ -106,6 +91,21 @@ resource "aws_lb_listener_rule" "cf_doppler" {
   condition {
     field  = "host-header"
     values = ["doppler.*"]
+  }
+}
+
+resource "aws_lb_target_group" "cf_doppler" {
+  name     = "${var.env}-cf-doppler"
+  port     = 8081
+  protocol = "HTTPS"
+  vpc_id   = "${var.vpc_id}"
+
+  health_check {
+    matcher = "200-499"
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 


### PR DESCRIPTION
What
----
This commit is the first step in moving doppler.((system_domain)) to live
behind the existing Loggregator ALB.

Future commits will upgrade doppler, point the DNS entry at the ALB, and retire
the classic load balancer currently serving traffic on that domain.

🚨 **There are more PRs in this chain** 🚨 
Also see #2053 and #2050

N.B.
---
This PR must me merged and fully deployed before the others

How to review
-------------

1. Code review
2. Run it down your pipeline, then run #2053 and #2050 in order

Who can review
--------------
Not I