### PR TITLE
[#167986184] Point doppler domain at ALB

### DIFF
--- a/manifests/cf-manifest/operations.d/360-log-api.yml
+++ b/manifests/cf-manifest/operations.d/360-log-api.yml
@@ -1,11 +1,7 @@
 ---
 - type: replace
   path: /instance_groups/name=log-api/vm_extensions?/-
-  value: cf_doppler_elbs
-
-- type: replace
-  path: /instance_groups/name=log-api/vm_extensions?/-
-  value: cf_loggregator_rlp_target_groups
+  value: cf_loggregator_doppler_target_groups
   
 - type: remove
   path: /instance_groups/name=log-api/jobs/name=route_registrar

--- a/manifests/cf-manifest/operations.d/360-log-api.yml
+++ b/manifests/cf-manifest/operations.d/360-log-api.yml
@@ -20,11 +20,9 @@
 
 - type: replace
   path: /releases/name=loggregator
-  # We cannot use a version of loggregator past 105.5 until we get rid of ELBs
-  # This is because of TLS cipher suite mismatch
   value:
     name: "loggregator"
-    version: "105.5"
-    url: "https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=105.5"
-    sha1: "62b9210def7c5179f6088b9449f551f57f1a1ee8"
+    version: "105.6"
+    url: "https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=105.6"
+    sha1: "eccfbd65e1d217a2b46afd414163e82553fb3084"
 

--- a/manifests/cf-manifest/operations.d/360-log-api.yml
+++ b/manifests/cf-manifest/operations.d/360-log-api.yml
@@ -1,5 +1,4 @@
 ---
-
 - type: replace
   path: /instance_groups/name=log-api/vm_extensions?/-
   value: cf_doppler_elbs
@@ -7,7 +6,7 @@
 - type: replace
   path: /instance_groups/name=log-api/vm_extensions?/-
   value: cf_loggregator_rlp_target_groups
-
+  
 - type: remove
   path: /instance_groups/name=log-api/jobs/name=route_registrar
 

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -30,10 +30,6 @@ RSpec.describe "release versions" do
       'uaa' => {
         local: '0.1.11',
         upstream: '74.0.0',
-      },
-      'loggregator' => {
-        local: '105.5',
-        upstream: '105.6',
       }
     }
 

--- a/manifests/cloud-config/cloud-config.yml
+++ b/manifests/cloud-config/cloud-config.yml
@@ -242,14 +242,17 @@ vm_extensions:
 - name: cf_doppler_elbs
   cloud_properties:
     elbs:
-    - ((terraform_outputs_cf_doppler_elb_name))
+      - ((terraform_outputs_cf_doppler_elb_name))
     lb_target_groups:
-    - ((terraform_outputs_cf_doppler_target_group_name))
+      - ((terraform_outputs_cf_doppler_target_group_name))
 
 - name: cf_loggregator_rlp_target_groups
   cloud_properties:
     lb_target_groups:
-    - ((terraform_outputs_cf_loggregator_rlp_target_group_name))
+      - ((terraform_outputs_cf_loggregator_rlp_target_group_name))
+      # The doppler target group is duplicated here
+      # because vm extensions are shallow merged.
+      - ((terraform_outputs_cf_doppler_target_group_name))
 
 - name: ssh_proxy_elb
   cloud_properties:

--- a/manifests/cloud-config/cloud-config.yml
+++ b/manifests/cloud-config/cloud-config.yml
@@ -239,19 +239,10 @@ vm_extensions:
     - ((terraform_outputs_cf_rds_client_security_group))
     - ((terraform_outputs_cloud_controller_security_group))
 
-- name: cf_doppler_elbs
-  cloud_properties:
-    elbs:
-      - ((terraform_outputs_cf_doppler_elb_name))
-    lb_target_groups:
-      - ((terraform_outputs_cf_doppler_target_group_name))
-
-- name: cf_loggregator_rlp_target_groups
+- name: cf_loggregator_doppler_target_groups
   cloud_properties:
     lb_target_groups:
       - ((terraform_outputs_cf_loggregator_rlp_target_group_name))
-      # The doppler target group is duplicated here
-      # because vm extensions are shallow merged.
       - ((terraform_outputs_cf_doppler_target_group_name))
 
 - name: ssh_proxy_elb

--- a/platform-tests/src/platform/acceptance/tls_version_test.go
+++ b/platform-tests/src/platform/acceptance/tls_version_test.go
@@ -2,32 +2,77 @@ package acceptance_test
 
 import (
 	"crypto/tls"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
+const (
+	LB_TYPE_CLASSIC = "classic"
+	LB_TYPE_ALB     = "ALB"
+)
+
+type tlsTestConfig struct {
+	HostPortGetter   func() string
+	LoadBalancerType string
+}
+
+func AssertTLSErrorOnClassicLB(err error) {
+	Expect(err).To(HaveOccurred())
+	Expect(err).To(SatisfyAny(
+		MatchError("tls: no supported versions satisfy MinVersion and MaxVersion"),
+		MatchError("EOF"),
+	))
+}
+
+func AssertTLSErrorOnALB(err error) {
+	Expect(err).To(HaveOccurred())
+	Expect(err.Error()).To(SatisfyAny(
+		// An ALB will close the connection when trying to
+		// connect with an unsupported version of TLS,
+		ContainSubstring("read: connection reset by peer"),
+		// but will return an error, which crypto/tls can
+		// translate in to the below, when connecting with SSL.
+		ContainSubstring("tls: no supported versions satisfy MinVersion and MaxVersion"),
+	))
+}
+
 var _ = Describe("Checking the TLS version", func() {
-	testHostPortGetters := map[string]func() string{
-		"apps_apex": func() string {
-			return testConfig.GetAppsDomain() + ":443"
+	testHostPortGetters := map[string]tlsTestConfig{
+		"apps_apex": {
+			func() string {
+				return testConfig.GetAppsDomain() + ":443"
+			},
+			LB_TYPE_CLASSIC,
 		},
-		"apps": func() string {
-			return "healthcheck." + testConfig.GetAppsDomain() + ":443"
+		"apps": {
+			func() string {
+				return "healthcheck." + testConfig.GetAppsDomain() + ":443"
+			},
+			LB_TYPE_CLASSIC,
 		},
-		"system": func() string {
-			return testConfig.GetApiEndpoint() + ":443"
+		"system": {
+			func() string {
+				return testConfig.GetApiEndpoint() + ":443"
+			},
+			LB_TYPE_CLASSIC,
 		},
-		"doppler": func() string {
-			return "doppler." + GetConfigFromEnvironment("SYSTEM_DNS_ZONE_NAME") + ":443"
+		"doppler": {
+			func() string {
+				return "doppler." + GetConfigFromEnvironment("SYSTEM_DNS_ZONE_NAME") + ":443"
+			},
+			LB_TYPE_ALB,
 		},
-		"concourse": func() string {
-			return "deployer." + GetConfigFromEnvironment("SYSTEM_DNS_ZONE_NAME") + ":443"
+		"concourse": {
+			func() string {
+				return "deployer." + GetConfigFromEnvironment("SYSTEM_DNS_ZONE_NAME") + ":443"
+			},
+			LB_TYPE_CLASSIC,
 		},
 	}
 
-	for domainClass, hostPortGetter := range testHostPortGetters {
-		domainClass, hostPortGetter := domainClass, hostPortGetter
+	for domainClass, testConfig := range testHostPortGetters {
+		hostPortGetter := testConfig.HostPortGetter
+		loadBalancerType := testConfig.LoadBalancerType
 
 		Context(domainClass+" domain", func() {
 			It("should not allow SSL 3.0", func() {
@@ -40,11 +85,17 @@ var _ = Describe("Checking the TLS version", func() {
 				if err == nil {
 					defer conn.Close()
 				}
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(SatisfyAny(
-					MatchError("tls: no supported versions satisfy MinVersion and MaxVersion"),
-					MatchError("EOF"),
-				))
+
+				switch loadBalancerType {
+				case LB_TYPE_CLASSIC:
+				default:
+					AssertTLSErrorOnClassicLB(err)
+					break
+
+				case LB_TYPE_ALB:
+					AssertTLSErrorOnALB(err)
+					break
+				}
 			})
 			It("should not allow TLS 1.0", func() {
 				tlsConfig := &tls.Config{
@@ -56,11 +107,17 @@ var _ = Describe("Checking the TLS version", func() {
 				if err == nil {
 					defer conn.Close()
 				}
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(SatisfyAny(
-					MatchError("tls: no supported versions satisfy MinVersion and MaxVersion"),
-					MatchError("EOF"),
-				))
+
+				switch loadBalancerType {
+				case LB_TYPE_CLASSIC:
+				default:
+					AssertTLSErrorOnClassicLB(err)
+					break
+
+				case LB_TYPE_ALB:
+					AssertTLSErrorOnALB(err)
+					break
+				}
 			})
 			It("should not allow TLS 1.1", func() {
 				tlsConfig := &tls.Config{
@@ -72,11 +129,17 @@ var _ = Describe("Checking the TLS version", func() {
 				if err == nil {
 					defer conn.Close()
 				}
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(SatisfyAny(
-					MatchError("tls: no supported versions satisfy MinVersion and MaxVersion"),
-					MatchError("EOF"),
-				))
+
+				switch loadBalancerType {
+				case LB_TYPE_CLASSIC:
+				default:
+					AssertTLSErrorOnClassicLB(err)
+					break
+
+				case LB_TYPE_ALB:
+					AssertTLSErrorOnALB(err)
+					break
+				}
 			})
 
 			It("should allow TLS 1.2", func() {

--- a/terraform/cloudfoundry/dns-records.tf
+++ b/terraform/cloudfoundry/dns-records.tf
@@ -19,7 +19,7 @@ resource "aws_route53_record" "cf_doppler" {
   name    = "doppler.${var.system_dns_zone_name}."
   type    = "CNAME"
   ttl     = "60"
-  records = ["${aws_elb.cf_doppler.dns_name}"]
+  records = ["${aws_lb.cf_loggregator.dns_name}"]
 }
 
 resource "aws_route53_record" "cf_ssh_proxy" {

--- a/terraform/cloudfoundry/lbs.tf
+++ b/terraform/cloudfoundry/lbs.tf
@@ -79,21 +79,6 @@ resource "aws_lb_listener_rule" "cf_loggregator_rlp_log_stream" {
   }
 }
 
-resource "aws_lb_target_group" "cf_doppler" {
-  name     = "${var.env}-cf-doppler"
-  port     = 8081
-  protocol = "HTTPS"
-  vpc_id   = "${var.vpc_id}"
-
-  health_check {
-    matcher = "200-499"
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
 resource "aws_lb_listener_rule" "cf_doppler" {
   listener_arn = "${aws_lb_listener.cf_loggregator.arn}"
   priority     = "113"
@@ -106,6 +91,21 @@ resource "aws_lb_listener_rule" "cf_doppler" {
   condition {
     field  = "host-header"
     values = ["doppler.*"]
+  }
+}
+
+resource "aws_lb_target_group" "cf_doppler" {
+  name     = "${var.env}-cf-doppler"
+  port     = 8081
+  protocol = "HTTPS"
+  vpc_id   = "${var.vpc_id}"
+
+  health_check {
+    matcher = "200-499"
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 


### PR DESCRIPTION
What
----
Point `doppler.((system_domain))` at ALB, and upgrade the version of doppler in use.

This commit is the second step in serving traffic for `doppler.((system_domain))` from the existing Loggregator ALB. Future PRs will retire the classic load balancer currently serving traffic on the domain.

N.B.
---
This PR should not be merged before #2052 has been merged and fully released.

This branch is branched from `add_logapi_instances_to_doppler_alb_target_group_167986184` and the first commit does not matter.

How to review
-------------
1. Code review
2. Deploy in sequence with #2052 and #2050

Who can review
--------------
Not I
