### PR TITLE
[167571906] Migrate cf-vars-store and prometheus-vars-store to Credhub

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -21,14 +21,6 @@ resources:
       tag_filter: ((paas_cf_tag_filter))
       commit_verification_keys: ((gpg_public_keys))
 
-  - name: cf-vars-store
-    type: s3-iam
-    source:
-      bucket: ((state_bucket))
-      region_name: ((aws_region))
-      versioned_file: cf-vars-store.yml
-      initial_version: "-"
-
   - name: cf-manifest
     type: s3-iam
     source:
@@ -72,7 +64,6 @@ jobs:
         trigger: true
       - get: bosh-vars-store
       - get: paas-cf
-      - get: cf-vars-store
       - get: cf-manifest
       - get: bosh-CA-crt
 

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1120,13 +1120,34 @@ jobs:
             params:
               file: cloud-config/cloud-config.yml
 
+        - task: modify-cf-vars-store-for-credhub-migration
+          tags: [colocated-with-web]
+          config:
+            platform: linux
+            image_resource: *ruby-slim-image-resource
+            inputs:
+              - name: paas-cf
+              - name: cf-vars-store
+            outputs:
+              - name: vars_to_migrate
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  ruby paas-cf/concourse/scripts/modify_vars_store_for_credhub_migration.rb \
+                    cf-vars-store/cf-vars-store.yml
+
+                  mv cf_vars_to_migrate.yml vars_to_migrate
+
         - task: migrate-secrets-to-credhub
           tags: [colocated-with-web]
           config:
             platform: linux
             image_resource: *golang-image-resource
             inputs:
-              - name: cf-vars-store
+              - name: vars_to_migrate
               - name: migrator
             params:
               SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
@@ -1149,7 +1170,7 @@ jobs:
                   mkdir -p /go/src/github.com/alphagov/ && cp -R migrator /go/src/github.com/alphagov/
                   cd /go/src/github.com/alphagov/migrator && go install && cd
 
-                  migrator migrate -v cf-vars-store/cf-vars-store.yml -e "${DEPLOY_ENV}" -d "${DEPLOY_ENV}"
+                  migrator migrate -v vars_to_migrate/cf_vars_to_migrate.yml -e "${DEPLOY_ENV}" -d "${DEPLOY_ENV}"
 
         - task: generate-cf-manifest
           tags: [colocated-with-web]

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -428,6 +428,11 @@ resources:
       uri: https://github.com/alphagov/paas-yet-another-cloudwatch-exporter.git
       branch: gds_master
 
+  - name: migrator
+    type: git
+    source:
+      uri: https://github.com/alphagov/paas-migrator.git
+
   - name: pagerduty-secrets
     type: s3-iam
     source:
@@ -1014,6 +1019,7 @@ jobs:
           - get: cf-tfstate
             passed: ['cf-terraform']
           - get: logit-secrets
+          - get: migrator
 
       - aggregate:
         - task: extract-terraform-outputs
@@ -1114,13 +1120,43 @@ jobs:
             params:
               file: cloud-config/cloud-config.yml
 
+        - task: migrate-secrets-to-credhub
+          tags: [colocated-with-web]
+          config:
+            platform: linux
+            image_resource: *golang-image-resource
+            inputs:
+              - name: cf-vars-store
+              - name: migrator
+            params:
+              SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+              CREDHUB_CLIENT: credhub-admin
+              CREDHUB_SECRET: ((bosh-credhub-admin))
+              CREDHUB_CA_CERT: ((bosh-credhub-ca-cert))
+              DEPLOY_ENV: ((deploy_env))
+            run:
+              path: sh
+              args:
+                - -u
+                - -e
+                - -c
+                - |
+                  export CREDHUB_SERVER="https://bosh.${SYSTEM_DNS_ZONE_NAME}:8844/api"
+                  export GOBIN=/go/bin
+                  HOME="$(pwd)"
+                  export
+
+                  mkdir -p /go/src/github.com/alphagov/ && cp -R migrator /go/src/github.com/alphagov/
+                  cd /go/src/github.com/alphagov/migrator && go install && cd
+
+                  migrator migrate -v cf-vars-store/cf-vars-store.yml -e "${DEPLOY_ENV}" -d "${DEPLOY_ENV}"
+
         - task: generate-cf-manifest
           tags: [colocated-with-web]
           config:
             platform: linux
             image_resource: *gov-paas-bosh-cli-v2-image-resource
             inputs:
-              - name: cf-vars-store
               - name: paas-cf
               - name: ipsec-CA
               - name: terraform-outputs
@@ -1132,7 +1168,6 @@ jobs:
             outputs:
               - name: cf-manifest
               - name: cf-manifest-pre-vars
-              - name: cf-vars-store-updated
             params:
               ENV_SPECIFIC_BOSH_VARS_FILE: paas-cf/manifests/cf-manifest/env-specific/((env_specific_bosh_vars_file))
               SLIM_DEV_DEPLOYMENT: ((slim_dev_deployment))
@@ -1162,11 +1197,9 @@ jobs:
                   EOF
 
                   tar -xzf ./ipsec-CA/ipsec-CA.tar.gz -C ./ipsec-CA
-                  cp cf-vars-store/cf-vars-store.yml cf-vars-store-updated/
 
-                  VARS_STORE=cf-vars-store-updated/cf-vars-store.yml \
-                    ./paas-cf/manifests/cf-manifest/scripts/generate-manifest.sh \
-                      > cf-manifest/cf-manifest.yml
+                  ./paas-cf/manifests/cf-manifest/scripts/generate-manifest.sh \
+                    > cf-manifest/cf-manifest.yml
 
                   ./paas-cf/manifests/cf-manifest/scripts/generate-manifest.sh \
                     > cf-manifest-pre-vars/cf-manifest-pre-vars.yml
@@ -1179,9 +1212,6 @@ jobs:
             - put: cf-manifest-pre-vars
               params:
                 file: cf-manifest-pre-vars/cf-manifest-pre-vars.yml
-            - put: cf-vars-store
-              params:
-                file: cf-vars-store-updated/cf-vars-store.yml
 
   - name: cf-deploy
     serial_groups: [cf-deploy]
@@ -1200,8 +1230,6 @@ jobs:
           - get: bosh-vars-store
           - get: bosh-CA-crt
           - get: logit-secrets
-          - get: cf-vars-store
-            passed: ['generate-cf-config']
           - get: cf-tfstate
             passed: ['generate-cf-config']
 
@@ -1313,7 +1341,6 @@ jobs:
           inputs:
             - name: paas-cf
             - name: cf-manifest
-            - name: cf-vars-store
             - name: logit-secrets
             - name: cf-tfstate
           params:
@@ -1322,6 +1349,7 @@ jobs:
             CREDHUB_CLIENT_ID: credhub-admin
             CREDHUB_CLIENT_SECRET: ((bosh-credhub-admin))
             CREDHUB_CA_CERT: ((bosh-credhub-ca-cert))
+            DEPLOY_ENV: ((deploy_env))
           run:
             path: sh
             args:
@@ -1334,43 +1362,67 @@ jobs:
                 < cf-tfstate/cf.tfstate \
                 > cf-terraform-outputs.yml
 
+                echo 'Logging into Credhub'
+                credhub api -s "$BOSH_ENVIRONMENT:8844/api"
+                credhub login --client-name="${CREDHUB_CLIENT_ID}" --client-secret="${CREDHUB_CLIENT_SECRET}"
+
                 echo 'Getting variables'
+                BOSH_NS="/${DEPLOY_ENV}/${DEPLOY_ENV}"
                 CF_ADMIN=admin
-                CF_PASS=$($VAL_FROM_YAML cf_admin_password cf-vars-store/cf-vars-store.yml)
-                CF_CLIENT_SECRET=$($VAL_FROM_YAML secrets_uaa_clients_paas_billing_secret cf-vars-store/cf-vars-store.yml)
+                CF_PASS=$(credhub get -q -n "${BOSH_NS}/cf_admin_password")
+                CF_CLIENT_SECRET=$(credhub get -q -n "${BOSH_NS}/secrets_uaa_clients_paas_billing_secret")
                 API_ENDPOINT="https://api.${SYSTEM_DNS_ZONE_NAME}"
                 UAA_ENDPOINT=$($VAL_FROM_YAML instance_groups.api.jobs.cloud_controller_ng.properties.uaa.url cf-manifest/cf-manifest.yml)
-                PAAS_ACCOUNTS_PASSWORD=$($VAL_FROM_YAML secrets_paas_accounts_admin_password cf-vars-store/cf-vars-store.yml)
-                METRICS_SECRET=$($VAL_FROM_YAML secrets_uaa_clients_paas_metrics_secret cf-vars-store/cf-vars-store.yml)
+                PAAS_ACCOUNTS_PASSWORD=$(credhub get -q -n "${BOSH_NS}/secrets_paas_accounts_admin_password")
+                METRICS_SECRET=$(credhub get -q -n "${BOSH_NS}/secrets_uaa_clients_paas_metrics_secret")
                 METRICS_AWS_ACCESS_KEY_ID=$($VAL_FROM_YAML terraform_outputs_metrics_exporter_aws_access_key_id cf-terraform-outputs.yml)
                 METRICS_AWS_SECRET_ACCESS_KEY=$($VAL_FROM_YAML terraform_outputs_metrics_exporter_aws_secret_access_key cf-terraform-outputs.yml)
                 LOGIT_ADDRESS=syslog-tls://$($VAL_FROM_YAML meta.logit.syslog_address logit-secrets/logit-secrets.yml):$($VAL_FROM_YAML meta.logit.syslog_port logit-secrets/logit-secrets.yml)
                 LOGIT_ELASTICSEARCH_URL=$($VAL_FROM_YAML meta.logit.elasticsearch_url logit-secrets/logit-secrets.yml)
                 LOGIT_ELASTICSEARCH_API_KEY=$($VAL_FROM_YAML meta.logit.elasticsearch_api_key logit-secrets/logit-secrets.yml)
+                UAA_CLIENTS_CF_EXPORTER_SECRET=$(credhub get -q -n "${BOSH_NS}/uaa_clients_cf_exporter_secret")
+                UAA_CLIENTS_FIREHOSE_EXPORTER_SECRET=$(credhub get -q -n "${BOSH_NS}/uaa_clients_firehose_exporter_secret")
+                RDS_BROKER_PASS=$(credhub get -q -n "${BOSH_NS}/secrets_rds_broker_admin_password")
+                CDN_BROKER_PASS=$(credhub get -q -n "${BOSH_NS}/secrets_cdn_broker_admin_password")
+                AIVEN_BROKER_PASS=$(credhub get -q -n "${BOSH_NS}/secrets_aiven_broker_admin_password")
+                ELASTICACHE_BROKER_PASS=$(credhub get -q -n "${BOSH_NS}/secrets_elasticache_broker_admin_password")
+                S3_BROKER_PASS=$(credhub get -q -n "${BOSH_NS}/secrets_s3_broker_admin_password")
+                UAA_ADMIN_CLIENT_SECRET=$(credhub get -q -n "${BOSH_NS}/uaa_admin_client_secret")
+                UAA_CLIENTS_PAAS_ADMIN_SECRET=$(credhub get -q -n "${BOSH_NS}/uaa_clients_paas_admin_secret")
+                SECRETS_TEST_USER_PASSWORD=$(credhub get -q -n "${BOSH_NS}/secrets_test_user_password")
 
-                echo 'Logging into Credhub'
-                credhub api -s "$BOSH_ENVIRONMENT:8844/api"
-                credhub login --client-name="${CREDHUB_CLIENT_ID}" --client-secret="${CREDHUB_CLIENT_SECRET}"
 
                 echo 'Setting secrets'
-                credhub set --name=/concourse/main/create-cloudfoundry/cf-admin --type value --value "${CF_ADMIN}"
-                credhub set --name=/concourse/main/create-cloudfoundry/cf-pass --type password --password "${CF_PASS}"
-                credhub set --name=/concourse/main/create-cloudfoundry/cf-client-secret --type password --password "${CF_CLIENT_SECRET}"
+                TEAM_NS="/concourse/main"
+                PIPELINE_NS="${TEAM_NS}/create-cloudfoundry"
+                credhub set --name="${TEAM_NS}/cf_admin" --type value --value "${CF_ADMIN}"
+                credhub set --name="${TEAM_NS}/cf_pass" --type password --password "${CF_PASS}"
+                credhub set --name="${PIPELINE_NS}/cf_client_secret" --type password --password "${CF_CLIENT_SECRET}"
 
-                credhub set --name=/concourse/main/create-cloudfoundry/paas-accounts-password --type password --password "${PAAS_ACCOUNTS_PASSWORD}"
-                credhub set --name=/concourse/main/create-cloudfoundry/api-endpoint --type value --value "${API_ENDPOINT}"
-                credhub set --name=/concourse/main/create-cloudfoundry/uaa-endpoint --type value --value "${UAA_ENDPOINT}"
+                credhub set --name="${PIPELINE_NS}/paas_accounts_password" --type password --password "${PAAS_ACCOUNTS_PASSWORD}"
+                credhub set --name="${TEAM_NS}/api_endpoint" --type value --value "${API_ENDPOINT}"
+                credhub set --name="${PIPELINE_NS}/uaa_endpoint" --type value --value "${UAA_ENDPOINT}"
 
-                credhub set --name=/concourse/main/create-cloudfoundry/metrics-secret --type password --password "${METRICS_SECRET}"
-                credhub set --name=/concourse/main/create-cloudfoundry/metrics-aws-access-key-id --type password --password "${METRICS_AWS_ACCESS_KEY_ID}"
-                credhub set --name=/concourse/main/create-cloudfoundry/metrics-aws-secret-access-key --type password --password "${METRICS_AWS_SECRET_ACCESS_KEY}"
+                credhub set --name="${PIPELINE_NS}/metrics_secret" --type password --password "${METRICS_SECRET}"
+                credhub set --name="${PIPELINE_NS}/metrics_aws_access_key_id" --type password --password "${METRICS_AWS_ACCESS_KEY_ID}"
+                credhub set --name="${PIPELINE_NS}/metrics_aws_secret_access_key" --type password --password "${METRICS_AWS_SECRET_ACCESS_KEY}"
 
-                credhub set --name=/concourse/main/create-cloudfoundry/logit-address --type value --value "${LOGIT_ADDRESS}"
-                credhub set --name=/concourse/main/create-cloudfoundry/logit-elasticsearch-url --type value --value "${LOGIT_ELASTICSEARCH_URL}"
-                credhub set --name=/concourse/main/create-cloudfoundry/logit-elasticsearch-api-key --type password --password "${LOGIT_ELASTICSEARCH_API_KEY}"
+                credhub set --name="${PIPELINE_NS}/logit_address" --type value --value "${LOGIT_ADDRESS}"
+                credhub set --name="${PIPELINE_NS}/logit_elasticsearch_url" --type value --value "${LOGIT_ELASTICSEARCH_URL}"
+                credhub set --name="${PIPELINE_NS}/logit_elasticsearch_api_key" --type password --password "${LOGIT_ELASTICSEARCH_API_KEY}"
+                credhub set --name="${PIPELINE_NS}/uaa_clients_cf_exporter_secret" --type password --password "${UAA_CLIENTS_CF_EXPORTER_SECRET}"
+                credhub set --name="${PIPELINE_NS}/uaa_clients_firehose_exporter_secret" --type password --password "${UAA_CLIENTS_FIREHOSE_EXPORTER_SECRET}"
+                credhub set --name="${PIPELINE_NS}/secrets_rds_broker_admin_password" --type password --password "${RDS_BROKER_PASS}"
+                credhub set --name="${PIPELINE_NS}/secrets_cdn_broker_admin_password" --type password --password "${CDN_BROKER_PASS}"
+                credhub set --name="${PIPELINE_NS}/secrets_aiven_broker_admin_password" --type password --password "${AIVEN_BROKER_PASS}"
+                credhub set --name="${PIPELINE_NS}/secrets_elasticache_broker_admin_password" --type password --password "${ELASTICACHE_BROKER_PASS}"
+                credhub set --name="${PIPELINE_NS}/secrets_s3_broker_admin_password" --type password --password "${S3_BROKER_PASS}"
+                credhub set --name="${PIPELINE_NS}/uaa_admin_client_secret" --type password --password "${UAA_ADMIN_CLIENT_SECRET}"
+                credhub set --name="${PIPELINE_NS}/uaa_clients_paas_admin_secret" --type password --password "${UAA_CLIENTS_PAAS_ADMIN_SECRET}"
+                credhub set --name="${PIPELINE_NS}/secrets_test_user_password" --type password --password "${SECRETS_TEST_USER_PASSWORD}"
 
                 echo 'Accessible secrets'
-                credhub find --path /concourse/main/create-cloudfoundry
+                credhub find --path "${TEAM_NS}"
 
   - name: prometheus-deploy
     serial: true
@@ -1385,10 +1437,42 @@ jobs:
           - get: bosh-vars-store
           - get: bosh-CA-crt
           - get: bosh-secrets
-          - get: cf-vars-store
           - get: cf-tfstate
           - get: paas-yet-another-cloudwatch-exporter
           - get: pagerduty-secrets
+          - get: migrator
+
+      - task: migrate-prometheus-secrets-to-credhub
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *golang-image-resource
+          inputs:
+            - name: prometheus-vars-store
+            - name: migrator
+          params:
+            SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+            CREDHUB_CLIENT: credhub-admin
+            CREDHUB_SECRET: ((bosh-credhub-admin))
+            CREDHUB_CA_CERT: ((bosh-credhub-ca-cert))
+            DEPLOY_ENV: ((deploy_env))
+          run:
+            path: sh
+            args:
+              - -u
+              - -e
+              - -c
+              - |
+                export CREDHUB_SERVER="https://bosh.${SYSTEM_DNS_ZONE_NAME}:8844/api"
+                export GOBIN=/go/bin
+                HOME="$(pwd)"
+                export HOME
+
+
+                mkdir -p /go/src/github.com/alphagov/ && cp -R migrator /go/src/github.com/alphagov/
+                cd /go/src/github.com/alphagov/migrator && go install && cd
+
+                migrator migrate -v prometheus-vars-store/prometheus-vars-store.yml -e "${DEPLOY_ENV}" -d prometheus
 
       - task: extract-terraform-outputs
         tags: [colocated-with-web]
@@ -1417,17 +1501,14 @@ jobs:
           image_resource: *gov-paas-bosh-cli-v2-image-resource
           inputs:
             - name: paas-cf
-            - name: prometheus-vars-store
             - name: bosh-vars-store
             - name: bosh-CA-crt
-            - name: cf-vars-store
             - name: terraform-outputs
             - name: bosh-secrets
             - name: pagerduty-secrets
           outputs:
             - name: prometheus-manifest
             - name: prometheus-manifest-pre-vars
-            - name: prometheus-vars-store-updated
           params:
             AWS_ACCOUNT: ((aws_account))
             SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
@@ -1439,6 +1520,8 @@ jobs:
             ENV_SPECIFIC_BOSH_VARS_FILE: ((env_specific_bosh_vars_file))
             GRAFANA_AUTH_GOOGLE_CLIENT_ID: ((grafana_auth_google_client_id))
             GRAFANA_AUTH_GOOGLE_CLIENT_SECRET: ((grafana_auth_google_client_secret))
+            UAA_CLIENTS_CF_EXPORTER_SECRET: ((uaa_clients_cf_exporter_secret))
+            UAA_CLIENTS_FIREHOSE_EXPORTER_SECRET: ((uaa_clients_firehose_exporter_secret))
           run:
             path: sh
             args:
@@ -1446,23 +1529,16 @@ jobs:
               - -u
               - -c
               - |
-                cp prometheus-vars-store/prometheus-vars-store.yml prometheus-vars-store-updated/
-
-                VARS_STORE=prometheus-vars-store-updated/prometheus-vars-store.yml \
-                  ./paas-cf/manifests/prometheus/scripts/generate-manifest.sh \
-                    > prometheus-manifest/prometheus-manifest.yml
+                ./paas-cf/manifests/prometheus/scripts/generate-manifest.sh \
+                  > prometheus-manifest/prometheus-manifest.yml
 
                 ./paas-cf/manifests/prometheus/scripts/generate-manifest.sh \
                   > prometheus-manifest-pre-vars/prometheus-manifest-pre-vars.yml
 
         on_success:
-          aggregate:
-          - put: prometheus-vars-store
-            params:
-              file: prometheus-vars-store-updated/prometheus-vars-store.yml
-          - put: prometheus-manifest-pre-vars
-            params:
-              file: prometheus-manifest-pre-vars/prometheus-manifest-pre-vars.yml
+          put: prometheus-manifest-pre-vars
+          params:
+            file: prometheus-manifest-pre-vars/prometheus-manifest-pre-vars.yml
 
       - task: retrieve-config
         tags: [colocated-with-web]
@@ -1470,9 +1546,7 @@ jobs:
           platform: linux
           inputs:
             - name: paas-cf
-            - name: cf-vars-store
             - name: terraform-outputs
-            - name: prometheus-vars-store
           outputs:
             - name: config
           params:
@@ -1487,12 +1561,8 @@ jobs:
                 VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
 
                 cat << EOT > config/config.sh
-                export CF_ADMIN=admin
-                export CF_PASS=$($VAL_FROM_YAML cf_admin_password cf-vars-store/cf-vars-store.yml)
-                export API_ENDPOINT="https://api.${SYSTEM_DNS_ZONE_NAME}"
                 export YACE_AWS_ACCESS_KEY_ID=$($VAL_FROM_YAML terraform_outputs_yace_aws_access_key_id terraform-outputs/cf.yml)
                 export YACE_AWS_SECRET_ACCESS_KEY=$($VAL_FROM_YAML terraform_outputs_yace_aws_secret_access_key terraform-outputs/cf.yml)
-                export GRAFANA_PASS=$($VAL_FROM_YAML grafana_password prometheus-vars-store/prometheus-vars-store.yml)
                 EOT
 
       - task: prometheus-deploy
@@ -1523,6 +1593,39 @@ jobs:
 
                 bosh -n deploy prometheus-manifest/prometheus-manifest.yml
 
+      - task: copy-prometheus-secrets-to-concourse-credhub-ns
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *gov-paas-bosh-cli-v2-image-resource
+          inputs:
+            - name: paas-cf
+          params:
+            SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+            BOSH_ENVIRONMENT: ((bosh_fqdn))
+            CREDHUB_CLIENT_ID: credhub-admin
+            CREDHUB_CLIENT_SECRET: ((bosh-credhub-admin))
+            CREDHUB_CA_CERT: ((bosh-credhub-ca-cert))
+            DEPLOY_ENV: ((deploy_env))
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                echo 'Logging into Credhub'
+                credhub api -s "$BOSH_ENVIRONMENT:8844/api"
+                credhub login --client-name="${CREDHUB_CLIENT_ID}" --client-secret="${CREDHUB_CLIENT_SECRET}"
+
+                echo 'Getting variables'
+                GRAFANA_PASS=$(credhub get -q -n "/${DEPLOY_ENV}/prometheus/grafana_password")
+
+                echo 'Setting secrets'
+                credhub set --name=/concourse/main/create-cloudfoundry/grafana_password --type password --password "${GRAFANA_PASS}"
+
+                echo 'Accessible secrets'
+                credhub find --path /concourse/main/create-cloudfoundry
+
       - aggregate:
         - task: deploy-cloudwatch-exporter
           tags: [colocated-with-web]
@@ -1532,6 +1635,9 @@ jobs:
             params:
               DEPLOY_ENV: ((deploy_env))
               AWS_REGION: ((aws_region))
+              API_ENDPOINT: ((api_endpoint))
+              CF_ADMIN: ((cf_admin))
+              CF_PASS: ((cf_pass))
             inputs:
               - name: paas-cf
               - name: config
@@ -1577,9 +1683,9 @@ jobs:
               SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
               DEPLOY_ENV: ((deploy_env))
               SLIM_DEV_DEPLOYMENT: ((slim_dev_deployment))
+              GRAFANA_PASS: ((grafana_password))
             inputs:
               - name: paas-cf
-              - name: config
             run:
               path: sh
               args:
@@ -1587,7 +1693,6 @@ jobs:
                 - -u
                 - -c
                 - |
-                  . ./config/config.sh
                   AZ_COUNT=2
                   if [ "${SLIM_DEV_DEPLOYMENT}" = "true" ]; then
                     AZ_COUNT=1
@@ -1613,6 +1718,7 @@ jobs:
             SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
             DEPLOY_ENV: ((deploy_env))
             SLIM_DEV_DEPLOYMENT: ((slim_dev_deployment))
+            GRAFANA_PASS: ((grafana_password))
 
   - name: post-deploy
     serial: true
@@ -1629,8 +1735,6 @@ jobs:
         passed: ['generate-cf-config']
       - get: bosh-vars-store
         passed: ['cf-deploy']
-      - get: cf-vars-store
-        passed: ['generate-cf-config']
       - get: bosh-CA-crt
       - get: paas-aiven-broker
       - get: logit-secrets
@@ -1641,7 +1745,6 @@ jobs:
         platform: linux
         inputs:
           - name: paas-cf
-          - name: cf-vars-store
           - name: cf-manifest
           - name: cf-tfstate
           - name: logit-secrets
@@ -1663,20 +1766,12 @@ jobs:
                 > cf-terraform-outputs.yml
 
               cat << EOT > config/config.sh
-              export CF_ADMIN=admin
-              export CF_PASS=$($VAL_FROM_YAML cf_admin_password cf-vars-store/cf-vars-store.yml)
-              export API_ENDPOINT="https://api.${SYSTEM_DNS_ZONE_NAME}"
               export UAA_ENDPOINT=$($VAL_FROM_YAML instance_groups.api.jobs.cloud_controller_ng.properties.uaa.url cf-manifest/cf-manifest.yml)
               export DOPPLER_ENDPOINT=$($VAL_FROM_YAML instance_groups.scheduler.jobs.tps.properties.capi.tps.traffic_controller_url cf-manifest/cf-manifest.yml)
               export RDS_BROKER_SERVER=$($VAL_FROM_YAML terraform_outputs_rds_broker_elb_dns_name cf-terraform-outputs.yml)
-              export RDS_BROKER_PASS=$($VAL_FROM_YAML secrets_rds_broker_admin_password cf-vars-store/cf-vars-store.yml)
               export CDN_BROKER_SERVER=$($VAL_FROM_YAML terraform_outputs_cdn_broker_elb_dns_name cf-terraform-outputs.yml)
-              export CDN_BROKER_PASS=$($VAL_FROM_YAML secrets_cdn_broker_admin_password cf-vars-store/cf-vars-store.yml)
-              export AIVEN_BROKER_PASS=$($VAL_FROM_YAML secrets_aiven_broker_admin_password cf-vars-store/cf-vars-store.yml)
               export BROKER_IP_WHITELIST=$($VAL_FROM_YAML terraform_outputs_nat_public_ips_csv cf-terraform-outputs.yml)
-              export ELASTICACHE_BROKER_PASS=$($VAL_FROM_YAML secrets_elasticache_broker_admin_password cf-vars-store/cf-vars-store.yml)
               export ELASTICACHE_BROKER_SERVER=$($VAL_FROM_YAML terraform_outputs_elasticache_broker_elb_dns_name cf-terraform-outputs.yml)
-              export S3_BROKER_PASS=$($VAL_FROM_YAML secrets_s3_broker_admin_password cf-vars-store/cf-vars-store.yml)
               export S3_BROKER_SERVER=$($VAL_FROM_YAML terraform_outputs_s3_broker_elb_dns_name cf-terraform-outputs.yml)
               export METRICS_AWS_ACCESS_KEY_ID=$($VAL_FROM_YAML terraform_outputs_metrics_exporter_aws_access_key_id cf-terraform-outputs.yml)
               export METRICS_AWS_SECRET_ACCESS_KEY=$($VAL_FROM_YAML terraform_outputs_metrics_exporter_aws_secret_access_key cf-terraform-outputs.yml)
@@ -1693,14 +1788,16 @@ jobs:
           image_resource: *cf-cli-image-resource
           inputs:
             - name: paas-cf
-            - name: config
+          params:
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
           run:
             path: sh
             args:
               - -e
               - -c
               - |
-                . ./config/config.sh
                 echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}"
                 ./paas-cf/concourse/scripts/parse_buildpacks_and_run_uploader.rb paas-cf/config/buildpacks.yml
       - task: create-orgs
@@ -1713,6 +1810,9 @@ jobs:
             - name: config
           params:
             APPS_DNS_ZONE_NAME: ((apps_dns_zone_name))
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
           run:
             path: sh
             args:
@@ -1766,6 +1866,11 @@ jobs:
           inputs:
             - name: paas-cf
             - name: config
+          params:
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
+            RDS_BROKER_PASS: ((secrets_rds_broker_admin_password))
           run:
             path: sh
             args:
@@ -1851,6 +1956,11 @@ jobs:
           inputs:
             - name: paas-cf
             - name: config
+          params:
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
+            CDN_BROKER_PASS: ((secrets_cdn_broker_admin_password))
           run:
             path: sh
             args:
@@ -1877,6 +1987,11 @@ jobs:
           inputs:
             - name: paas-cf
             - name: config
+          params:
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
+            S3_BROKER_PASS: ((secrets_s3_broker_admin_password))
           run:
             path: sh
             args:
@@ -1902,9 +2017,11 @@ jobs:
           platform: linux
           inputs:
             - name: paas-cf
-            - name: config
             - name: cf-manifest
           params:
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
           image_resource: *cf-cli-image-resource
           run:
             path: sh
@@ -1913,7 +2030,6 @@ jobs:
               - -u
               - -c
               - |
-                . ./config/config.sh
                 echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}"
 
                 ./paas-cf/concourse/scripts/set_security_groups_from_manifest.rb cf-manifest/cf-manifest.yml
@@ -1924,9 +2040,11 @@ jobs:
           platform: linux
           inputs:
             - name: paas-cf
-            - name: config
             - name: cf-manifest
           params:
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
           image_resource: *cf-cli-image-resource
           run:
             path: sh
@@ -1935,8 +2053,6 @@ jobs:
               - -u
               - -c
               - |
-                . ./config/config.sh
-
                 echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}"
 
                 ./paas-cf/concourse/scripts/set_quotas_from_manifest.rb cf-manifest/cf-manifest.yml
@@ -1947,8 +2063,10 @@ jobs:
           platform: linux
           inputs:
             - name: paas-cf
-            - name: config
           params:
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
           image_resource: *cf-cli-image-resource
           run:
             path: sh
@@ -1957,8 +2075,6 @@ jobs:
               - -u
               - -c
               - |
-                . ./config/config.sh
-
                 echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}"
 
                 cf enable-feature-flag diego_docker
@@ -1969,8 +2085,10 @@ jobs:
           platform: linux
           inputs:
             - name: paas-cf
-            - name: config
           params:
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
           image_resource: *cf-cli-image-resource
           run:
             path: sh
@@ -1979,8 +2097,6 @@ jobs:
               - -u
               - -c
               - |
-                . ./config/config.sh
-
                 echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}"
 
                 if cf domains | awk '$1=="apps.internal" && $2=="shared" { r=1 } END { exit r }'; then
@@ -1994,10 +2110,10 @@ jobs:
           image_resource: *cf-cli-image-resource
           inputs:
             - name: paas-cf
-            - name: cf-vars-store
           params:
             LOGIN_URL: https://login.((system_dns_zone_name))
             UAA_URL: https://uaa.((system_dns_zone_name))
+            UAA_ADMIN_CLIENT_SECRET: ((uaa_admin_client_secret))
           run:
             path: sh
             args:
@@ -2005,9 +2121,6 @@ jobs:
               - -u
               - -c
               - |
-                export UAA_ADMIN_CLIENT_SECRET
-                UAA_ADMIN_CLIENT_SECRET=$(./paas-cf/concourse/scripts/val_from_yaml.rb uaa_admin_client_secret cf-vars-store/cf-vars-store.yml)
-
                 ./paas-cf/concourse/scripts/uaa_set_email_domains.sh '["*.*", "*.*.*", "*.*.*.*", "*.*.*.*.*", "*.*.*.*.*.*"]'
 
     - aggregate:
@@ -2018,7 +2131,10 @@ jobs:
           image_resource: *cf-cli-image-resource
           inputs:
             - name: paas-cf
-            - name: config
+          params:
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
           run:
             path: sh
             args:
@@ -2026,7 +2142,6 @@ jobs:
               - -u
               - -c
               - |
-                . ./config/config.sh
                 cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}" \
                   -o admin -s assets
 
@@ -2067,9 +2182,11 @@ jobs:
           image_resource: *cf-cli-image-resource
           params:
             TEST_HEAVY_LOAD: ((test_heavy_load))
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
           inputs:
             - name: paas-cf
-            - name: config
           run:
             path: sh
             args:
@@ -2082,7 +2199,6 @@ jobs:
                   exit 0
                 fi
 
-                . ./config/config.sh
                 echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}"
 
                 cf target -o admin -s healthchecks
@@ -2130,22 +2246,17 @@ jobs:
               tag: "2.5"
           inputs:
             - name: paas-cf
-            - name: config
-            - name: cf-vars-store
             - name: cf-manifest
           params:
             DEPLOY_ENV: ((deploy_env))
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN_PASSWORD: ((cf_pass))
           run:
             path: sh
             args:
               - -e
               - -c
               - |
-                . ./config/config.sh
-
-                VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
-                export CF_ADMIN_PASSWORD
-                CF_ADMIN_PASSWORD=$($VAL_FROM_YAML cf_admin_password cf-vars-store/cf-vars-store.yml)
                 cd paas-cf/scripts
                 bundle
                 bundle exec sync-admin-users.rb "${API_ENDPOINT}" ../config/users.yml "((NEW_ACCOUNT_EMAIL_ADDRESS))" "${DEPLOY_ENV}"
@@ -2158,9 +2269,11 @@ jobs:
           params:
             DISABLE_HEALTHCHECK_DB: ((disable_healthcheck_db))
             APPS_DNS_ZONE_NAME: ((apps_dns_zone_name))
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
           inputs:
             - name: paas-cf
-            - name: config
           outputs:
             - name: deployed-healthcheck
           run:
@@ -2170,7 +2283,6 @@ jobs:
               - -u
               - -c
               - |
-                . ./config/config.sh
                 echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}"
 
                 cf target -o admin -s healthchecks
@@ -2221,9 +2333,11 @@ jobs:
             image_resource: *cf-cli-image-resource
             inputs:
               - name: paas-cf
-              - name: config
             params:
               SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+              API_ENDPOINT: ((api_endpoint))
+              CF_ADMIN: ((cf_admin))
+              CF_PASS: ((cf_pass))
             run:
               path: sh
               args:
@@ -2231,7 +2345,6 @@ jobs:
                 - -u
                 - -c
                 - |
-                  . ./config/config.sh
                   cf api "${API_ENDPOINT}"
                   cf auth "${CF_ADMIN}" "${CF_PASS}"
                   cf target -o admin -s monitoring
@@ -2282,6 +2395,10 @@ jobs:
             AIVEN_PROJECT: paas-cf-((aws_account))
             AIVEN_CLOUD: aws-((aws_region))
             APPS_DNS_ZONE_NAME: ((apps_dns_zone_name))
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
+            AIVEN_BROKER_PASS: ((secrets_aiven_broker_admin_password))
           run:
             path: sh
             args:
@@ -2333,6 +2450,11 @@ jobs:
           inputs:
             - name: paas-cf
             - name: config
+          params:
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
+            ELASTICACHE_BROKER_PASS: ((secrets_elasticache_broker_admin_password))
           run:
             path: sh
             args:
@@ -2408,8 +2530,6 @@ jobs:
             passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
           - get: cf-manifest
             passed: ['post-deploy']
-          - get: cf-vars-store
-            passed: ['post-deploy']
 
       - do:
         - task: create-temp-user
@@ -2417,6 +2537,7 @@ jobs:
           file: paas-cf/concourse/tasks/create_admin.yml
           params:
             PREFIX: smoketest-user
+            UAA_ADMIN_CLIENT_PASS: ((uaa_admin_client_secret))
 
         - task: smoke-tests-config
           tags: [colocated-with-web]
@@ -2425,6 +2546,7 @@ jobs:
             TEST_PROPERTIES: smoke_tests
             APP_DOMAIN: ((apps_dns_zone_name))
             SYSTEM_DOMAIN: ((system_dns_zone_name))
+            TEST_USER_PASSWORD: ((secrets_test_user_password))
 
         - task: smoke-tests-run
           tags: [colocated-with-web]
@@ -2440,6 +2562,10 @@ jobs:
           task: remove-temp-user
           tags: [colocated-with-web]
           file: paas-cf/concourse/tasks/delete_admin.yml
+          params:
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
 
   - name: acceptance-tests
     plan:
@@ -2452,8 +2578,6 @@ jobs:
             passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
           - get: cf-manifest
             passed: ['post-deploy']
-          - get: cf-vars-store
-            passed: ['post-deploy']
 
       - do:
         - task: create-temp-user
@@ -2462,6 +2586,7 @@ jobs:
           params:
             PREFIX: acceptance-test-user
             DISABLE_ADMIN_USER_CREATION: ((disable_cf_acceptance_tests))
+            UAA_ADMIN_CLIENT_PASS: ((uaa_admin_client_secret))
 
         - do:
           - task: generate-test-config
@@ -2471,6 +2596,7 @@ jobs:
               TEST_PROPERTIES: acceptance_tests
               APP_DOMAIN: ((apps_dns_zone_name))
               SYSTEM_DOMAIN: ((system_dns_zone_name))
+              TEST_USER_PASSWORD: ((secrets_test_user_password))
           - task: run-tests
             tags: [colocated-with-web]
             config:
@@ -2500,6 +2626,9 @@ jobs:
             file: paas-cf/concourse/tasks/delete_admin.yml
             params:
               DISABLE_ADMIN_USER_CREATION: ((disable_cf_acceptance_tests))
+              API_ENDPOINT: ((api_endpoint))
+              CF_ADMIN: ((cf_admin))
+              CF_PASS: ((cf_pass))
 
   - name: custom-acceptance-tests
     plan:
@@ -2511,8 +2640,6 @@ jobs:
             passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
           - get: cf-manifest
             passed: ['post-deploy']
-          - get: cf-vars-store
-            passed: ['post-deploy']
           - get: cf-acceptance-tests
 
       - do:
@@ -2522,6 +2649,7 @@ jobs:
           params:
             PREFIX: custom-acceptance-test-user
             DISABLE_ADMIN_USER_CREATION: ((disable_custom_acceptance_tests))
+            UAA_ADMIN_CLIENT_PASS: ((uaa_admin_client_secret))
 
         - task: generate-test-config
           tags: [colocated-with-web]
@@ -2531,6 +2659,7 @@ jobs:
             APP_DOMAIN: ((apps_dns_zone_name))
             SYSTEM_DOMAIN: ((system_dns_zone_name))
             NAME_PREFIX: ACC
+            TEST_USER_PASSWORD: ((secrets_test_user_password))
 
         - aggregate:
           - task: "Run custom acceptance tests"
@@ -2556,11 +2685,11 @@ jobs:
               image_resource: *cf-cli-image-resource
               inputs:
                 - name: paas-cf
-                - name: cf-vars-store
                 - name: cf-manifest
               params:
                 CF_ADMIN: admin
                 SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+                CF_PASS: ((cf_pass))
               run:
                 path: bash
                 args:
@@ -2568,7 +2697,6 @@ jobs:
                   - |
                     set -ueo pipefail
 
-                    CF_PASS=$(awk '/cf_admin_password/ {print $2}' cf-vars-store/cf-vars-store.yml | tr -d '"')
                     API_ENDPOINT="https://api.${SYSTEM_DNS_ZONE_NAME}"
                     echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}" > /dev/null
 
@@ -2621,6 +2749,9 @@ jobs:
           file: paas-cf/concourse/tasks/delete_admin.yml
           params:
             DISABLE_ADMIN_USER_CREATION: ((disable_custom_acceptance_tests))
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
 
   - name: custom-broker-acceptance-tests
     plan:
@@ -2632,8 +2763,6 @@ jobs:
             passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
           - get: cf-manifest
             passed: ['post-deploy']
-          - get: cf-vars-store
-            passed: ['post-deploy']
           - get: cf-acceptance-tests
 
       - do:
@@ -2643,6 +2772,7 @@ jobs:
           params:
             PREFIX: custom-broker-acceptance-test-user
             DISABLE_ADMIN_USER_CREATION: ((disable_custom_acceptance_tests))
+            UAA_ADMIN_CLIENT_PASS: ((uaa_admin_client_secret))
 
         - task: generate-test-config
           tags: [colocated-with-web]
@@ -2652,6 +2782,7 @@ jobs:
             APP_DOMAIN: ((apps_dns_zone_name))
             SYSTEM_DOMAIN: ((system_dns_zone_name))
             NAME_PREFIX: BACC
+            TEST_USER_PASSWORD: ((secrets_test_user_password))
 
         - aggregate:
           - task: "Run broker custom acceptance tests"
@@ -2676,6 +2807,9 @@ jobs:
           file: paas-cf/concourse/tasks/delete_admin.yml
           params:
             DISABLE_ADMIN_USER_CREATION: ((disable_custom_acceptance_tests))
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
 
   - name: bosh-tests
     plan:
@@ -2743,10 +2877,10 @@ jobs:
           params:
             SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
             DEPLOY_ENV: ((deploy_env))
-            BASIC_AUTH_PASSWORD: ((paas-accounts-password))
-            API_ENDPOINT: ((api-endpoint))
-            CF_ADMIN: ((cf-admin))
-            CF_PASS: ((cf-pass))
+            BASIC_AUTH_PASSWORD: ((paas_accounts_password))
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
           inputs:
             - name: paas-cf
             - name: paas-accounts
@@ -2853,9 +2987,6 @@ jobs:
         - get: cf-manifest
           passed: ['post-deploy']
 
-        - get: cf-vars-store
-          passed: ['post-deploy']
-
       - task: build
         tags: [colocated-with-web]
         config:
@@ -2894,7 +3025,6 @@ jobs:
           inputs:
             - name: paas-cf
             - name: paas-admin-dist
-            - name: cf-vars-store
           outputs:
             - name: paas-admin-manifest
           params:
@@ -2902,6 +3032,7 @@ jobs:
             NOTIFY_API_KEY: ((notify_api_key))
             NOTIFY_WELCOME_TEMPLATE_ID: 1859ce68-f133-4218-ac6e-a8ef32a41292
             AWS_REGION: ((aws_region))
+            UAA_CLIENTS_PAAS_ADMIN_SECERT: uaa_clients_paas_admin_secret
           run:
             path: sh
             args:
@@ -2918,14 +3049,14 @@ jobs:
                    - logit-syslog-drain
                   env:
                     OAUTH_CLIENT_ID: "paas-admin"
-                    OAUTH_CLIENT_SECRET: "(( grab uaa_clients_paas_admin_secret ))"
+                    OAUTH_CLIENT_SECRET: ((uaa_clients_paas_admin_secret))
                     API_URL: "https://api.${SYSTEM_DNS_ZONE_NAME}"
                     BILLING_URL: "https://billing.${SYSTEM_DNS_ZONE_NAME}"
                     ACCOUNTS_URL: "https://accounts.${SYSTEM_DNS_ZONE_NAME}"
-                    ACCOUNTS_SECRET: "(( grab secrets_paas_accounts_admin_password ))"
+                    ACCOUNTS_SECRET: ((paas_accounts_password))
                     NOTIFY_API_KEY: "${NOTIFY_API_KEY}"
                     NOTIFY_WELCOME_TEMPLATE_ID: "${NOTIFY_WELCOME_TEMPLATE_ID}"
-                    SESSION_SECRET: (( concat "session-" uaa_clients_paas_admin_secret ))
+                    SESSION_SECRET: (( concat "session-" "${UAA_CLIENTS_PAAS_ADMIN_SECERT}" ))
                     AWS_REGION: "$AWS_REGION"
                     MS_CLIENT_ID: ((microsoft_adminoidc_client_id))
                     MS_CLIENT_SECRET: ((microsoft_adminoidc_client_secret))
@@ -2938,7 +3069,6 @@ jobs:
                 spruce merge \
                   paas-admin-dist/manifest.yml \
                   paas-admin-env-and-routes.yml \
-                  cf-vars-store/cf-vars-store.yml \
                   | spruce merge --cherry-pick applications \
                     > paas-admin-manifest/manifest.yml
 
@@ -2953,10 +3083,10 @@ jobs:
             - name: paas-admin-manifest
           params:
             SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
-            API_ENDPOINT: ((api-endpoint))
-            CF_ADMIN: ((cf-admin))
-            CF_PASS: ((cf-pass))
-            CF_CLIENT_SECRET: ((cf-client-secret))
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
+            CF_CLIENT_SECRET: ((cf_client_secret))
           run:
             path: sh
             args:
@@ -2979,6 +3109,7 @@ jobs:
           params:
             PREFIX: paas-admin-test-user
             DISABLE_ADMIN_USER_CREATION: false
+            UAA_ADMIN_CLIENT_PASS: ((uaa_admin_client_secret))
 
         - task: acceptance-tests
           tags: [colocated-with-web]
@@ -2993,7 +3124,7 @@ jobs:
               DISABLE_CUSTOM_ACCEPTANCE_TESTS: ((disable_custom_acceptance_tests))
               DEPLOY_ENV: ((deploy_env))
               SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
-              ACCOUNTS_PASSWORD: ((paas-accounts-password))
+              ACCOUNTS_PASSWORD: ((paas_accounts_password))
             inputs:
               - name: paas-cf
               - name: paas-admin
@@ -3024,6 +3155,10 @@ jobs:
           task: remove-temp-user
           tags: [colocated-with-web]
           file: paas-cf/concourse/tasks/delete_admin.yml
+          params:
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
 
       - get: paas-admin-git-keys
 
@@ -3107,11 +3242,11 @@ jobs:
             AWS_REGION: ((aws_region))
             SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
             DEPLOY_ENV: ((deploy_env))
-            CF_CLIENT_SECRET: ((cf-client-secret))
-            LOGIT_ADDRESS: ((logit-address))
-            API_ENDPOINT: ((api-endpoint))
-            CF_ADMIN: ((cf-admin))
-            CF_PASS: ((cf-pass))
+            CF_CLIENT_SECRET: ((cf_client_secret))
+            LOGIT_ADDRESS: ((logit_address))
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
           inputs:
             - name: paas-cf
             - name: paas-billing
@@ -3204,9 +3339,9 @@ jobs:
             AWS_REGION: ((aws_region))
             SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
             DEPLOY_ENV: ((deploy_env))
-            API_ENDPOINT: ((api-endpoint))
-            CF_ADMIN: ((cf-admin))
-            CF_PASS: ((cf-pass))
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
           inputs:
             - name: paas-cf
             - name: paas-billing
@@ -3246,18 +3381,18 @@ jobs:
             AIVEN_API_TOKEN: ((aiven_api_token))
             AIVEN_PROJECT: paas-cf-((aws_account))
 
-            UAA_ENDPOINT: ((uaa-endpoint))
-            API_ENDPOINT: ((api-endpoint))
+            UAA_ENDPOINT: ((uaa_endpoint))
+            API_ENDPOINT: ((api_endpoint))
 
-            CF_ADMIN: ((cf-admin))
-            CF_PASS: ((cf-pass))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
 
-            METRICS_SECRET: ((metrics-secret))
-            METRICS_AWS_ACCESS_KEY_ID: ((metrics-aws-access-key-id))
-            METRICS_AWS_SECRET_ACCESS_KEY: ((metrics-aws-secret-access-key))
+            METRICS_SECRET: ((metrics_secret))
+            METRICS_AWS_ACCESS_KEY_ID: ((metrics_aws_access_key_id))
+            METRICS_AWS_SECRET_ACCESS_KEY: ((metrics_aws_secret_access_key))
 
-            LOGIT_ELASTICSEARCH_URL: ((logit-elasticsearch-url))
-            LOGIT_ELASTICSEARCH_API_KEY: ((logit-elasticsearch-api-key))
+            LOGIT_ELASTICSEARCH_URL: ((logit_elasticsearch_url))
+            LOGIT_ELASTICSEARCH_API_KEY: ((logit_elasticsearch_api_key))
           inputs:
             - name: paas-cf
           run:
@@ -3912,7 +4047,6 @@ jobs:
           passed: ['pipeline-lock']
         - get: cf-manifest
           passed: ['post-deploy']
-        - get: cf-vars-store
 
       - task: assert-should-run
         tags: [colocated-with-web]
@@ -3945,6 +4079,7 @@ jobs:
           file: paas-cf/concourse/tasks/create_admin.yml
           params:
             PREFIX: cont-smoketest-user
+            UAA_ADMIN_CLIENT_PASS: ((uaa_admin_client_secret))
 
         - task: smoke-tests-config
           tags: [colocated-with-web]
@@ -3953,6 +4088,7 @@ jobs:
             TEST_PROPERTIES: smoke_tests
             APP_DOMAIN: ((apps_dns_zone_name))
             SYSTEM_DOMAIN: ((system_dns_zone_name))
+            TEST_USER_PASSWORD: ((secrets_test_user_password))
 
         - task: smoke-tests-run
           tags: [colocated-with-web]
@@ -3974,6 +4110,10 @@ jobs:
           task: remove-temp-user
           tags: [colocated-with-web]
           file: paas-cf/concourse/tasks/delete_admin.yml
+          params:
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
 
   - name: continuous-billing-smoke-tests
     serial_groups: [smoke-tests]
@@ -3988,7 +4128,6 @@ jobs:
           passed: ['pipeline-lock']
         - get: cf-manifest
           passed: ['post-deploy']
-        - get: cf-vars-store
 
       - do:
         - task: create-temp-user
@@ -3996,6 +4135,7 @@ jobs:
           file: paas-cf/concourse/tasks/create_admin.yml
           params:
             PREFIX: cont-billing-smoketest-user
+            UAA_ADMIN_CLIENT_PASS: ((uaa_admin_client_secret))
 
         - task: run-billing-smoke-tests
           tags: [colocated-with-web]
@@ -4029,6 +4169,10 @@ jobs:
           task: remove-temp-user
           tags: [colocated-with-web]
           file: paas-cf/concourse/tasks/delete_admin.yml
+          params:
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
 
   - name: check-certificates
     build_logs_to_retain: 50
@@ -4074,7 +4218,6 @@ jobs:
     plan:
       - aggregate:
         - get: paas-cf
-        - get: cf-vars-store
 
       - task: cleanup-deleted-cf-users
         tags: [colocated-with-web]
@@ -4083,21 +4226,17 @@ jobs:
           image_resource: *cf-cli-image-resource
           inputs:
             - name: paas-cf
-            - name: cf-vars-store
           params:
             SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
           run:
             path: sh
             args:
             - -e
             - -c
             - |
-              VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
-
-              CF_USER=admin
-              CF_PASS=$($VAL_FROM_YAML cf_admin_password cf-vars-store/cf-vars-store.yml)
-              API_ENDPOINT="https://api.${SYSTEM_DNS_ZONE_NAME}"
-
               echo | cf login -a "${API_ENDPOINT}" -u "${CF_USER}" -p "${CF_PASS}"
 
               ./paas-cf/scripts/cleanup-deleted-cf-users.sh --delete

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -70,14 +70,6 @@ resources:
       region_name: ((aws_region))
       versioned_file: cf-secrets.yml
 
-  - name: cf-vars-store
-    type: s3-iam
-    source:
-      bucket: ((state_bucket))
-      region_name: ((aws_region))
-      versioned_file: cf-vars-store.yml
-      initial_version: "-"
-
   - name: cf-manifest
     type: s3-iam
     source:
@@ -133,7 +125,6 @@ jobs:
             trigger: true
           - get: bosh-vars-store
           - get: paas-cf
-          - get: cf-vars-store
           - get: cf-manifest
           - get: bosh-CA-crt
 

--- a/concourse/scripts/modify_vars_store_for_credhub_migration.rb
+++ b/concourse/scripts/modify_vars_store_for_credhub_migration.rb
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+
+require 'yaml'
+
+unless ARGV[0]
+  puts "USAGE: #{$PROGRAM_NAME} /path/to/vars-store.yml"
+  exit 1
+end
+
+def should_migrate?(_, val)
+  return true if val['ca'] != ''
+end
+
+
+File.open(ARGV[0].to_s, 'r') do |f|
+  vars = YAML.safe_load(f)
+  vars_to_migrate = vars.select do |key, val|
+    should_migrate?(key, val)
+  end
+
+  File.write('cf_vars_to_migrate.yml', vars_to_migrate.to_yaml)
+end

--- a/concourse/tasks/configure-grafana.yml
+++ b/concourse/tasks/configure-grafana.yml
@@ -7,7 +7,6 @@ image_resource:
     tag: 2.5-slim
 inputs:
   - name: paas-cf
-  - name: config
 run:
   path: ruby
   args:
@@ -43,12 +42,11 @@ run:
         JSON.parse(resp.body)
       end
 
-      conf          = File.read("#{Dir.pwd}/config/config.sh")
       system_domain = ENV.fetch('SYSTEM_DNS_ZONE_NAME')
       deploy_env    = ENV.fetch('DEPLOY_ENV')
       slim          = ENV.fetch('SLIM_DEV_DEPLOYMENT')
       azs           = (slim == 'true') ? 1 : 2
-      grafana_pass  = conf[/GRAFANA_PASS=(.*)$/, 1]
+      grafana_pass  = ENV.fetch('GRAFANA_PASS')
 
       users_that_should_exist = YAML.load_file(
         "#{Dir.pwd}/paas-cf/config/users.yml"

--- a/concourse/tasks/create_admin.yml
+++ b/concourse/tasks/create_admin.yml
@@ -7,7 +7,6 @@ image_resource:
     tag: 4467c23cef4a5d87d531b88700300b222fbf2916
 inputs:
   - name: paas-cf
-  - name: cf-vars-store
   - name: cf-manifest
 outputs:
   - name: admin-creds
@@ -30,7 +29,6 @@ run:
       NAME=${PREFIX}-${SUFFIX}
 
       VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
-      UAA_ADMIN_CLIENT_PASS=$($VAL_FROM_YAML uaa_admin_client_secret cf-vars-store/cf-vars-store.yml)
       UAA_ENDPOINT=$($VAL_FROM_YAML instance_groups.api.jobs.cloud_controller_ng.properties.uaa.url cf-manifest/cf-manifest.yml)
 
       echo "Creating user ${NAME}"

--- a/concourse/tasks/delete_admin.yml
+++ b/concourse/tasks/delete_admin.yml
@@ -9,7 +9,6 @@ inputs:
   - name: paas-cf
   - name: cf-manifest
   - name: admin-creds
-  - name: cf-vars-store
 run:
   path: sh
   args:
@@ -22,11 +21,6 @@ run:
         exit 0
       fi
 
-      VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
-      SYSTEM_DNS_ZONE_NAME=$($VAL_FROM_YAML instance_groups.api.jobs.cloud_controller_ng.properties.system_domain cf-manifest/cf-manifest.yml)
-      API_ENDPOINT="https://api.${SYSTEM_DNS_ZONE_NAME}"
-      CF_ADMIN=admin
-      CF_PASS=$($VAL_FROM_YAML cf_admin_password cf-vars-store/cf-vars-store.yml)
       USERNAME=$(cat admin-creds/username)
 
       echo "Removing user ${USERNAME}"

--- a/concourse/tasks/generate-test-config.yml
+++ b/concourse/tasks/generate-test-config.yml
@@ -8,7 +8,6 @@ image_resource:
 inputs:
   - name: paas-cf
   - name: admin-creds
-  - name: cf-vars-store
 outputs:
   - name: test-config
 run:
@@ -18,11 +17,11 @@ run:
     - -c
     - |
       bosh interpolate --var-errs \
-        --vars-file=cf-vars-store/cf-vars-store.yml \
         --var=admin_user="$(cat admin-creds/username)" \
         --var=admin_password="$(cat admin-creds/password)" \
         --var=system_domain="${SYSTEM_DOMAIN}" \
         --var=app_domain="${APP_DOMAIN}" \
         --var=name_prefix="${NAME_PREFIX:-CATS}" \
+        --var=secrets_test_user_password="${TEST_USER_PASSWORD}" \
         "paas-cf/manifests/cf-manifest/test-config/${TEST_PROPERTIES}.yml" | \
           ruby -ryaml -rjson -e 'puts JSON.pretty_generate(YAML.load(STDIN))' > test-config/config.json

--- a/concourse/tasks/get-cf-cli-config.yml
+++ b/concourse/tasks/get-cf-cli-config.yml
@@ -7,7 +7,6 @@ image_resource:
     tag: 2.5-slim
 inputs:
   - name: paas-cf
-  - name: cf-vars-store
   - name: cf-manifest
 outputs:
   - name: config
@@ -18,14 +17,10 @@ run:
     - -u
     - -c
     - |
-      VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
-
       cat << EOT > config/config.sh
       export CF_ADMIN=admin
-      export CF_PASS=$($VAL_FROM_YAML cf_admin_password cf-vars-store/cf-vars-store.yml)
-
-      SYSTEM_DNS_ZONE_NAME=$($VAL_FROM_YAML instance_groups.api.jobs.cloud_controller_ng.properties.system_domain cf-manifest/cf-manifest.yml)
-      export API_ENDPOINT="https://api.\${SYSTEM_DNS_ZONE_NAME}"
+      export CF_PASS=((cf_pass))
+      export API_ENDPOINT=((api_endpoint))
 
       EOT
 

--- a/manifests/cf-manifest/scripts/generate-manifest.sh
+++ b/manifests/cf-manifest/scripts/generate-manifest.sh
@@ -16,11 +16,6 @@ if [ "${SLIM_DEV_DEPLOYMENT-}" = "true" ]; then
   opsfile_args="$opsfile_args -o ${PAAS_CF_DIR}/manifests/cf-manifest/operations/scale-down-dev.yml"
 fi
 
-vars_store_args=""
-if [ -n "${VARS_STORE:-}" ]; then
-  vars_store_args=" --var-errs --vars-store ${VARS_STORE}"
-fi
-
 # shellcheck disable=SC2086
 bosh interpolate \
   --var-file ipsec_ca.private_key="${WORKDIR}/ipsec-CA/ipsec-CA.key" \
@@ -40,5 +35,4 @@ bosh interpolate \
   --ops-file="${PAAS_CF_DIR}/manifests/cf-manifest/operations/uaa-add-google-oauth.yml" \
   --ops-file="${PAAS_CF_DIR}/manifests/cf-manifest/operations/uaa-add-microsoft-oauth.yml" \
   --ops-file="${WORKDIR}/vpc-peering-opsfile/vpc-peers.yml" \
-  ${vars_store_args} \
   "${CF_DEPLOYMENT_DIR}/cf-deployment.yml"

--- a/manifests/cf-manifest/spec/manifest/uaa_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/uaa_spec.rb
@@ -11,33 +11,6 @@ RSpec.describe "uaa properties" do
       expect(default_key.fetch("signingKey")).not_to be_empty
     end
   end
-  context "with and old certificate for jwt signing" do
-    let(:manifest) {
-      manifest_with_custom_vars_store %{---
-uaa_jwt_signing_key_id_old: 0b3b65a62f37f9deb947f01602ae0a122bf91d7a
-uaa_jwt_signing_key_old:
-  private_key: |
-    -----BEGIN RSA PRIVATE KEY-----
-    STUB_UAA_JWT_SIGNING_KEY_111111111111111111111111111111111111111
-    1111111111111111111111111111111111111111111111111111111111111111
-    1111111111111111111111111111111111111111111111111111111111111111
-    1111111111111111111111111111111111111111111111111111111111111111
-    1111111111111111111111111111111111111111111111111111111111111111
-    -----END RSA PRIVATE KEY-----
-}
-    }
-    let(:properties) { manifest.fetch("instance_groups.uaa.jobs.uaa.properties") }
-
-    it "has a different certificate for jwt policy signing keys" do
-      jwt_keys = properties.fetch("uaa").fetch("jwt").fetch("policy").fetch("keys")
-      expect(jwt_keys.keys.count).to eq(2)
-      jwt_active_key_id = properties.fetch("uaa").fetch("jwt").fetch("policy").fetch("active_key_id")
-      default_key = jwt_keys.fetch(jwt_active_key_id)
-      previous_key = jwt_keys.fetch("0b3b65a62f37f9deb947f01602ae0a122bf91d7a")
-      expect(default_key.fetch("signingKey")).not_to be_empty
-      expect(default_key).not_to eq(previous_key)
-    end
-  end
 
   context "when setting the cf cli token validity" do
     let(:manifest) { manifest_with_defaults }

--- a/manifests/prometheus/scripts/generate-manifest.sh
+++ b/manifests/prometheus/scripts/generate-manifest.sh
@@ -21,11 +21,6 @@ for i in "${PAAS_CF_DIR}"/manifests/prometheus/alerts.d/*.yml; do
   alerts_opsfile_args+="-o $i "
 done
 
-vars_store_args=""
-if [ -n "${VARS_STORE:-}" ]; then
-  vars_store_args=" --var-errs --vars-store ${VARS_STORE}"
-fi
-
 if [ "${ENABLE_ALERT_NOTIFICATIONS:-}" == "false" ]; then
   opsfile_args+="-o ${PAAS_CF_DIR}/manifests/prometheus/operations/disable-alert-notifications.yml"
 fi
@@ -36,7 +31,6 @@ trap 'rm -f "${variables_file}"' EXIT
 bosh interpolate - \
   --var-errs \
   --vars-file "${WORKDIR}/bosh-vars-store/bosh-vars-store.yml" \
-  --vars-file "${WORKDIR}/cf-vars-store/cf-vars-store.yml" \
 > "${variables_file}" \
 <<EOF
 ---
@@ -48,8 +42,8 @@ app_domain: $APPS_DNS_ZONE_NAME
 metron_deployment_name: $DEPLOY_ENV
 skip_ssl_verify: false
 traffic_controller_external_port: 443
-uaa_clients_cf_exporter_secret: ((uaa_clients_cf_exporter_secret))
-uaa_clients_firehose_exporter_secret: ((uaa_clients_firehose_exporter_secret))
+uaa_clients_cf_exporter_secret: $UAA_CLIENTS_CF_EXPORTER_SECRET
+uaa_clients_firehose_exporter_secret: $UAA_CLIENTS_FIREHOSE_EXPORTER_SECRET
 aws_account: $AWS_ACCOUNT
 grafana_auth_google_client_id: $GRAFANA_AUTH_GOOGLE_CLIENT_ID
 grafana_auth_google_client_secret: $GRAFANA_AUTH_GOOGLE_CLIENT_SECRET
@@ -65,5 +59,4 @@ bosh interpolate \
   --var-file bosh_ca_cert="${WORKDIR}/bosh-CA-crt/bosh-CA.crt" \
   ${opsfile_args} \
   ${alerts_opsfile_args} \
-  ${vars_store_args} \
   "${PROM_BOSHRELEASE_DIR}/manifests/prometheus.yml"

--- a/manifests/prometheus/spec/support/manifest_helpers.rb
+++ b/manifests/prometheus/spec/support/manifest_helpers.rb
@@ -28,6 +28,8 @@ private
     env['ENV_SPECIFIC_BOSH_VARS_FILE'] = 'default.yml'
     env['GRAFANA_AUTH_GOOGLE_CLIENT_ID'] = 'google-client-id'
     env['GRAFANA_AUTH_GOOGLE_CLIENT_SECRET'] = 'google-client-secret'
+    env['UAA_CLIENTS_CF_EXPORTER_SECRET'] = 'uaa_clients_cf_exporter_secret'
+    env['UAA_CLIENTS_FIREHOSE_EXPORTER_SECRET'] = 'uaa_clients_firehose_exporter_secret'
     env
   end
 


### PR DESCRIPTION
What
----

Following on from the reverted https://github.com/alphagov/paas-cf/pull/2039. This adds an additional task to remove any deleted certs with blank values from cf-vars-store. 

The PR above failed during `migrate-secrets-to-credhub` with the following
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x7ab049]
```

How to review
-------------

- Code review
- Deploy to your dev env

Who can review
--------------

Not me
