### PR TITLE
Remove apply immediately after database upgrade

### DIFF
--- a/terraform/cloudfoundry/cf_rds.tf
+++ b/terraform/cloudfoundry/cf_rds.tf
@@ -45,7 +45,6 @@ resource "aws_db_instance" "cf" {
   password             = "${var.secrets_cf_db_master_password}"
   db_subnet_group_name = "${aws_db_subnet_group.cf_rds.name}"
   parameter_group_name = "${aws_db_parameter_group.cf_pg_9_5.id}"
-  apply_immediately    = true
 
   storage_type               = "gp2"
   backup_window              = "02:00-03:00"


### PR DESCRIPTION
What
----

The following commits

* bc29e018 Switch m5 to m4 instance types for CF's RDS
* faf363b4 Apply DB instance upgrade immediately
* 5906f424 Upgrade CF RDS instance class and storage

changed the databases within business hours, rather than the maintenance
window, because database performance was degraded.

We usually want do do database updates during our maintenance window
unless explicitly set.

How to review
-------------

Code review

Who can review
--------------

Not @tlwr