### PR TITLE
[#168214024] Billing smoke tests should not page out of hours

### DIFF
--- a/concourse/scripts/lib/pagerduty.sh
+++ b/concourse/scripts/lib/pagerduty.sh
@@ -5,12 +5,14 @@ set -u
 get_pagerduty_secrets() {
   # shellcheck disable=SC2154
   secrets_uri="s3://${state_bucket}/pagerduty-secrets.yml"
-  export alertmanager_pagerduty_service_key
+  export alertmanager_pagerduty_24_7_service_key
+  export alertmanager_pagerduty_in_hours_service_key
   if aws s3 ls "$secrets_uri" > /dev/null ; then
     secrets_file=$(mktemp -t pagerduty-secrets.XXXXXX)
 
     aws s3 cp "$secrets_uri" "$secrets_file"
-    alertmanager_pagerduty_service_key=$("${SCRIPT_DIR}/val_from_yaml.rb" alertmanager_pagerduty_service_key "$secrets_file")
+    alertmanager_pagerduty_24_7_service_key=$("${SCRIPT_DIR}/val_from_yaml.rb" alertmanager_pagerduty_24_7_service_key "$secrets_file")
+    alertmanager_pagerduty_in_hours_service_key=$("${SCRIPT_DIR}/val_from_yaml.rb" alertmanager_pagerduty_in_hours_service_key "$secrets_file")
 
     rm -f "$secrets_file"
   fi

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -85,8 +85,13 @@ prepare_environment() {
   # Note: this credential is not interpolated into the pipeline. It is used as a guard against forgetting
   # to upload the credentials and has been placed here for consistency with the other credentials.
   # shellcheck disable=SC2154
-  if [ -z "${alertmanager_pagerduty_service_key+x}" ] && [ "${MAKEFILE_ENV_TARGET}" != "dev" ]; then
-    echo "Could not retrieve PagerDuty service key for Alertmanager. Did you run \`make ${MAKEFILE_ENV_TARGET} upload-pagerduty-secrets\`?"
+  if [ -z "${alertmanager_pagerduty_24_7_service_key+x}" ] && [ "${MAKEFILE_ENV_TARGET}" != "dev" ]; then
+    echo "Could not retrieve PagerDuty 24/7 service key for Alertmanager. Did you run \`make ${MAKEFILE_ENV_TARGET} upload-pagerduty-secrets\`?"
+    exit 1
+  fi
+  # shellcheck disable=SC2154
+  if [ -z "${alertmanager_pagerduty_in_hours_service_key+x}" ] && [ "${MAKEFILE_ENV_TARGET}" != "dev" ]; then
+    echo "Could not retrieve PagerDuty in-hours service key for Alertmanager. Did you run \`make ${MAKEFILE_ENV_TARGET} upload-pagerduty-secrets\`?"
     exit 1
   fi
 

--- a/manifests/prometheus/alerts.d/concourse-billingsmoketests-failures.yml
+++ b/manifests/prometheus/alerts.d/concourse-billingsmoketests-failures.yml
@@ -18,7 +18,7 @@
         expr: increase(concourse_builds_finished{exported_job="continuous-billing-smoke-tests",pipeline="create-cloudfoundry",status="failed"}[30m]) >= 3
         labels:
           severity: critical
-          notify: pagerduty
+          notify: pagerduty-in-hours
         annotations:
           summary: Concourse continuous-billing-smoke-tests failures
           description: The continuous-billing-smoke-tests Concourse job has failed at least three times in the last 30 minutes.

--- a/manifests/prometheus/alerts.d/concourse-smoketests-failures.yml
+++ b/manifests/prometheus/alerts.d/concourse-smoketests-failures.yml
@@ -18,7 +18,7 @@
         expr: increase(concourse_builds_finished{exported_job="continuous-smoke-tests",pipeline="create-cloudfoundry",status="failed"}[30m]) >= 3
         labels:
           severity: critical
-          notify: pagerduty
+          notify: pagerduty-24-7
         annotations:
           summary: Concourse continuous-smoke-tests failures
           description: The continuous-smoke-tests Concourse job has failed at least three times in the last 30 minutes.
@@ -40,7 +40,7 @@
         expr: increase(concourse_builds_finished{exported_job="smoke-tests",pipeline=~"monitor-.+",status="failed"}[30m]) >= 3
         labels:
           severity: critical
-          notify: pagerduty
+          notify: pagerduty-24-7
         annotations:
           summary: "Concourse remote smoke-tests failures on {{ $labels.pipeline }} pipeline"
           description: "The Concourse job running smoke-tests remotely (in the {{ $labels.pipeline }} pipeline) has failed at least three times in the last 30 minutes."

--- a/manifests/prometheus/operations.d/310-alertmanager-routes.yml
+++ b/manifests/prometheus/operations.d/310-alertmanager-routes.yml
@@ -18,9 +18,14 @@
         match:
           severity: "critical"
         continue: true
-      - receiver: pagerduty-receiver
+      - receiver: pagerduty-24-7-receiver
         match:
-          notify: "pagerduty"
+          notify: "pagerduty-24-7"
+        repeat_interval: 4h
+        continue: true
+      - receiver: pagerduty-in-hours-receiver
+        match:
+          notify: "pagerduty-in-hours"
         repeat_interval: 4h
 
 - type: replace
@@ -46,7 +51,15 @@
 - type: replace
   path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers?/-
   value:
-    name: pagerduty-receiver
+    name: pagerduty-24-7-receiver
     pagerduty_configs:
-      - service_key: ((alertmanager_pagerduty_service_key))
+      - service_key: ((alertmanager_pagerduty_24_7_service_key))
+        description: "[((metrics_environment))] {{ .GroupLabels.SortedPairs.Values | join \" \" }}"
+
+- type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers?/-
+  value:
+    name: pagerduty-in-hours-receiver
+    pagerduty_configs:
+      - service_key: ((alertmanager_pagerduty_in_hours_service_key))
         description: "[((metrics_environment))] {{ .GroupLabels.SortedPairs.Values | join \" \" }}"

--- a/manifests/prometheus/operations/disable-alert-notifications.yml
+++ b/manifests/prometheus/operations/disable-alert-notifications.yml
@@ -6,4 +6,7 @@
   path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers/name=critical-receiver/email_configs
 
 - type: remove
-  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers/name=pagerduty-receiver/pagerduty_configs
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers/name=pagerduty-24-7-receiver/pagerduty_configs
+
+- type: remove
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers/name=pagerduty-in-hours-receiver/pagerduty_configs

--- a/manifests/prometheus/spec/alerts/concourse-smoketests-failures.test.yml
+++ b/manifests/prometheus/spec/alerts/concourse-smoketests-failures.test.yml
@@ -47,7 +47,7 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: critical
-              notify: pagerduty
+              notify: pagerduty-24-7
               exported_job: continuous-smoke-tests
               pipeline: create-cloudfoundry
               status: failed

--- a/manifests/prometheus/spec/operations/alertmanager_routes_spec.rb
+++ b/manifests/prometheus/spec/operations/alertmanager_routes_spec.rb
@@ -1,6 +1,11 @@
 RSpec.describe "alertmanager" do
-  it "should have a pagerduty receiver with a correct service key" do
-    pagerduty_configs = manifest_with_defaults.get("instance_groups.alertmanager.jobs.alertmanager.properties.alertmanager.receivers.pagerduty-receiver.pagerduty_configs")
-    expect(pagerduty_configs[0]['service_key']).to eq("test_alertmanager_pagerduty_service_key")
+  it "should have a 24/7 pagerduty receiver with a correct service key" do
+    pagerduty_24_7_configs = manifest_with_defaults.get("instance_groups.alertmanager.jobs.alertmanager.properties.alertmanager.receivers.pagerduty-24-7-receiver.pagerduty_configs")
+    expect(pagerduty_24_7_configs[0]['service_key']).to eq("test_alertmanager_pagerduty_24_7_service_key")
+  end
+
+  it "should have an in-hours pagerduty receiver with a correct service key" do
+    pagerduty_in_hours_configs = manifest_with_defaults.get("instance_groups.alertmanager.jobs.alertmanager.properties.alertmanager.receivers.pagerduty-in-hours-receiver.pagerduty_configs")
+    expect(pagerduty_in_hours_configs[0]['service_key']).to eq("test_alertmanager_pagerduty_in_hours_service_key")
   end
 end

--- a/manifests/shared/spec/fixtures/pagerduty-secrets.yml
+++ b/manifests/shared/spec/fixtures/pagerduty-secrets.yml
@@ -1,2 +1,3 @@
 ---
-alertmanager_pagerduty_service_key: test_alertmanager_pagerduty_service_key
+alertmanager_pagerduty_24_7_service_key: test_alertmanager_pagerduty_24_7_service_key
+alertmanager_pagerduty_in_hours_service_key: test_alertmanager_pagerduty_in_hours_service_key

--- a/scripts/upload-pagerduty-secrets.sh
+++ b/scripts/upload-pagerduty-secrets.sh
@@ -4,14 +4,16 @@ set -eu
 
 export PASSWORD_STORE_DIR=${PAGERDUTY_PASSWORD_STORE_DIR}
 
-ALERTMANAGER_PAGERDUTY_SERVICE_KEY=$(pass "pagerduty/${MAKEFILE_ENV_TARGET}/alertmanager_pagerduty_service_key")
+ALERTMANAGER_PAGERDUTY_24_7_SERVICE_KEY=$(pass "pagerduty/${MAKEFILE_ENV_TARGET}/alertmanager_pagerduty_24_7_service_key")
+ALERTMANAGER_PAGERDUTY_IN_HOURS_SERVICE_KEY=$(pass "pagerduty/${MAKEFILE_ENV_TARGET}/alertmanager_pagerduty_in_hours_service_key")
 
 SECRETS=$(mktemp secrets.yml.XXXXXX)
 trap 'rm  "${SECRETS}"' EXIT
 
 cat > "${SECRETS}" << EOF
 ---
-alertmanager_pagerduty_service_key: ${ALERTMANAGER_PAGERDUTY_SERVICE_KEY}
+alertmanager_pagerduty_24_7_service_key: ${ALERTMANAGER_PAGERDUTY_24_7_SERVICE_KEY}
+alertmanager_pagerduty_in_hours_service_key: ${ALERTMANAGER_PAGERDUTY_IN_HOURS_SERVICE_KEY}
 EOF
 
 aws s3 cp "${SECRETS}" "s3://gds-paas-${DEPLOY_ENV}-state/pagerduty-secrets.yml"


### PR DESCRIPTION
What
----

This PR changes alerting behaviour for failed billing smoke tests. They will now only page us in-hours. To do that it does some tidyup and adds a second set of Pagerduty credentials. It goes alongside https://github.com/alphagov/paas-credentials/pull/158. See the commit messages for more context.

How to review
-------------

* 🐝 Code review alongside https://github.com/alphagov/paas-credentials/pull/158;
* ℹ️ Run the updated `upload-pagerduty-secrets` using the updated credentials (if you haven't done that the deploy will fail harmlessly);
* ⚠️ After merging and deploying to prod, trigger various alerts and check we get paged appropriately (or at least, be sure that smoke test failures will page us out-of-hours.)

I have already verified that this triggers Pagerduty and emails correctly for my `miki` dev environment. There's a `ENABLE_ALERT_NOTIFICATIONS=true` flag to enable alert emails and Pagerduty alerting in dev environments.

Who can review
--------------

Not @46bit