### PR TITLE
[#167571906] Update cf-vars-store.yml for credhub migration

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1124,7 +1124,7 @@ jobs:
           tags: [colocated-with-web]
           config:
             platform: linux
-            image_resource: *ruby-slim-image-resource
+            image_resource: *gov-paas-bosh-cli-v2-image-resource
             inputs:
               - name: paas-cf
               - name: cf-vars-store

--- a/concourse/scripts/modify_vars_store_for_credhub_migration.rb
+++ b/concourse/scripts/modify_vars_store_for_credhub_migration.rb
@@ -11,10 +11,22 @@ def should_migrate?(_, val)
   return true if val['ca'] != ''
 end
 
+def gen_public_key?(key, val)
+  if key == 'diego_ssh_proxy_host_key'
+    File.write('id_rsa', val['private_key'])
+    system("chmod 0600 id_rsa & ssh-keygen -y -f id_rsa > id_rsa.pub")
+    f = File.read('id_rsa.pub')
+    val['public_key'] = f.strip
+    system("rm id_rsa")
+  end
+end
+
 
 File.open(ARGV[0].to_s, 'r') do |f|
   vars = YAML.safe_load(f)
+
   vars_to_migrate = vars.select do |key, val|
+    gen_public_key?(key, val)
     should_migrate?(key, val)
   end
 


### PR DESCRIPTION
What
----

The credhub migration deployment errors because the public key fingerprint is missing from `cloud_controller_ng.yml`.

Updates `modify-cf-vars-store-for-credhub-migration` task to insert missing public key for `diego_ssh_proxy_host_key`. cf-vars-store has the private_key and public_key_fingerprint but doesn't include the public_key which is required to import/generate the public_key_fingerprint during migration.

How to review
-------------

Code review

Who can review
--------------

Not me
