### PR TITLE
Make billing alerts less noisy

### DIFF
--- a/manifests/prometheus/alerts.d/paas-billing-costs.yml
+++ b/manifests/prometheus/alerts.d/paas-billing-costs.yml
@@ -35,13 +35,13 @@
     name: PaaSBillingAppCostsExceedEC2Costs
     rules:
       - alert: PaaSBillingAppCostsExceedEC2Costs
-        expr: sum(increase(paas_billing_total_costs_pounds{name="app"}[24h])) / sum(paas_aws_cost_explorer_by_service_pounds{service=~"Amazon Elastic Compute Cloud - Compute"}) > 1.1
+        expr: sum(increase(paas_billing_total_costs_pounds{name="app"}[24h])) / sum(paas_aws_cost_explorer_by_service_pounds{service=~"Amazon Elastic Compute Cloud - Compute"}) > 1.4
         labels:
           severity: warning
           layer: billing
         annotations:
-          summary: "PaaS Billing App costs exceed AWS EC2 costs by > 10%"
-          description: "PaaS Billing App costs exceed AWS EC2 costs by > 10%. The difference is currently: £{{ $value | printf \"%.2f\" }}, which indicates there may be an issue with paas-billing's costs"
+          summary: "PaaS Billing App costs exceed AWS EC2 costs by > 40%"
+          description: "PaaS Billing App costs exceed AWS EC2 costs by > 40%. The difference is currently: £{{ $value | printf \"%.2f\" }}, which indicates there may be an issue with paas-billing's costs"
 
 - type: replace
   path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
@@ -49,10 +49,10 @@
     name: PaaSBillingAppCostsFallsShortOfEC2Costs
     rules:
       - alert: PaaSBillingAppCostsFallsShortOfEC2Costs
-        expr: sum(increase(paas_billing_total_costs_pounds{name="app"}[24h])) / sum(paas_aws_cost_explorer_by_service_pounds{service=~"Amazon Elastic Compute Cloud - Compute"}) < .9
+        expr: sum(increase(paas_billing_total_costs_pounds{name="app"}[24h])) / sum(paas_aws_cost_explorer_by_service_pounds{service=~"Amazon Elastic Compute Cloud - Compute"}) < .6
         labels:
           severity: warning
           layer: billing
         annotations:
-          summary: "PaaS Billing App costs fall short of AWS EC2 costs by > 10%"
-          description: "PaaS Billing App costs fall short of AWS EC2 costs by > 10%. The difference is currently: £{{ $value | printf \"%.2f\" }}, which indicates there may be an issue with paas-billing's costs"
+          summary: "PaaS Billing App costs fall short of AWS EC2 costs by > 40%"
+          description: "PaaS Billing App costs fall short of AWS EC2 costs by > 40%. The difference is currently: £{{ $value | printf \"%.2f\" }}, which indicates there may be an issue with paas-billing's costs"

--- a/manifests/prometheus/dashboards.d/user-impact.json
+++ b/manifests/prometheus/dashboards.d/user-impact.json
@@ -671,7 +671,7 @@
                 },
                 "tableColumn": "",
                 "targets": [{
-                    "expr": "count(ALERTS{alertstate=\"firing\",layer!=\"tenant\"}) or vector(0)",
+                    "expr": "count(ALERTS{alertstate=\"firing\",layer=\"\"}) or vector(0)",
                     "format": "time_series",
                     "instant": true,
                     "intervalFactor": 1,
@@ -694,8 +694,8 @@
                 "colorValue": false,
                 "colors": [
                     "#299c46",
-                    "rgba(237, 129, 40, 0.89)",
-                    "#d44a3a"
+                    "#fa6400",
+                    "#fa6400"
                 ],
                 "datasource": "prometheus",
                 "format": "none",
@@ -746,14 +746,14 @@
                 },
                 "tableColumn": "",
                 "targets": [{
-                    "expr": "count(ALERTS{alertstate=\"firing\",layer=\"tenant\"}) or vector(0)",
+                    "expr": "count(ALERTS{alertstate=\"firing\",layer=~\"^.+$\"}) or vector(0)",
                     "format": "time_series",
                     "instant": true,
                     "intervalFactor": 1,
                     "refId": "A"
                 }],
                 "thresholds": "1,1",
-                "title": "Tenant Alerts",
+                "title": "Other Alerts",
                 "type": "singlestat",
                 "valueFontSize": "200%",
                 "valueMaps": [{


### PR DESCRIPTION
What
----

Move billing alerts out of "Platform Alerts" and relax billing alerts so
they don't constantly fire.

How to review
-------------

* Code review
* Compare [the snowflaked ireland
  region](https://grafana-1.cloud.service.gov.uk/d/paas-user-impact/user-impact-prod)
  with [the standard London
  region](https://grafana-1.london.cloud.service.gov.uk/d/paas-user-impact/user-impact-prod)

Who can review
--------------

Not @richardtowers