### PR TITLE
Bump s3 broker and configure locket for it

### DIFF
--- a/manifests/cf-manifest/operations.d/750-s3-broker.yml
+++ b/manifests/cf-manifest/operations.d/750-s3-broker.yml
@@ -40,6 +40,11 @@
             iam_user_path: "/paas-s3-broker/"
             iam_ip_restriction_policy_arn: "((terraform_outputs_s3_broker_ip_restriction_policy_arn))"
             deploy_environment: "((environment))"
+            locket:
+              api_location: "locket.service.cf.internal:8891"
+              ca_cert: "((service_cf_internal_ca.certificate))((service_cf_internal_ca_old.certificate))"
+              client_cert: "((diego_locket_client.certificate))"
+              client_key: "((diego_locket_client.private_key))"
             catalog:
               services:
                 - id: 36880794-1682-4a4b-8771-be655904237d

--- a/manifests/cf-manifest/operations.d/750-s3-broker.yml
+++ b/manifests/cf-manifest/operations.d/750-s3-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: s3-broker
-    version: 0.1.5
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/s3-broker-0.1.5.tgz
-    sha1: 2435604b0d06bd5abad9c11cb3bd0b7a128134a6
+    version: 0.1.6
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/s3-broker-0.1.6.tgz
+    sha1: 852233b4a97a03738e84338fae8e0a5a6dca2705
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-

--- a/platform-tests/src/platform/acceptance/run_tests.sh
+++ b/platform-tests/src/platform/acceptance/run_tests.sh
@@ -2,18 +2,15 @@
 
 set -eu
 
-nodes=4
-if [ "${SLIM_DEV_DEPLOYMENT:-}" = "true" ]; then
-  nodes=2
-fi
+nodes=5
 
 if [ -n "${GINKGO_FOCUS:-}" ]; then
   ginkgo -p \
     -nodes="${nodes}" \
-    -timeout=1h30m \
+    -timeout=20m \
     -focus="${GINKGO_FOCUS}"
 else
   ginkgo -p \
     -nodes="${nodes}" \
-    -timeout=1h30m
+    -timeout=20m
 fi

--- a/platform-tests/src/platform/broker-acceptance/run_tests.sh
+++ b/platform-tests/src/platform/broker-acceptance/run_tests.sh
@@ -2,18 +2,15 @@
 
 set -eu
 
-nodes=4
-if [ "${SLIM_DEV_DEPLOYMENT:-}" = "true" ]; then
-  nodes=2
-fi
+nodes=5
 
 if [ -n "${GINKGO_FOCUS:-}" ]; then
   ginkgo -p \
     -nodes="${nodes}" \
-    -timeout=1h30m \
+    -timeout=40m \
     -focus="${GINKGO_FOCUS}"
 else
   ginkgo -p \
     -nodes="${nodes}" \
-    -timeout=1h30m
+    -timeout=40m
 fi

--- a/platform-tests/src/platform/broker-acceptance/s3_broker_test.go
+++ b/platform-tests/src/platform/broker-acceptance/s3_broker_test.go
@@ -85,4 +85,113 @@ var _ = Describe("S3 broker", func() {
 
 		})
 	})
+
+	Context("multiple operations against a single bucket", func(){
+		var (
+			appOneName          string
+			appTwoName          string
+			serviceInstanceName string
+		)
+
+		It("do not run in to race conditions", func(){
+			appOneName = generator.PrefixedRandomName(testConfig.GetNamePrefix(), "APP")
+			appTwoName = generator.PrefixedRandomName(testConfig.GetNamePrefix(), "APP")
+			serviceInstanceName = generator.PrefixedRandomName(testConfig.GetNamePrefix(), "test-s3-bucket")
+
+			By("creating the service: " + serviceInstanceName, func() {
+				Expect(
+					cf.
+						Cf("create-service", serviceName, testPlanName, serviceInstanceName).
+						Wait(testConfig.DefaultTimeoutDuration()),
+				).
+				To(Exit(0))
+				pollForServiceCreationCompletion(serviceInstanceName)
+			})
+
+			defer By("deleting the service", func() {
+				Expect(
+					cf.Cf("delete-service", serviceInstanceName, "-f").
+						Wait(testConfig.DefaultTimeoutDuration()),
+				).To(Exit(0))
+				pollForServiceDeletionCompletion(serviceInstanceName)
+			})
+
+			By("deploying a first app", func() {
+				Expect(cf.Cf(
+					"push", appOneName,
+					"--no-start",
+					"-b", testConfig.GetGoBuildpackName(),
+					"-p", "../../../example-apps/healthcheck",
+					"-f", "../../../example-apps/healthcheck/manifest.yml",
+					"-d", testConfig.GetAppsDomain(),
+				).Wait(testConfig.CfPushTimeoutDuration())).To(Exit(0))
+			})
+			defer By("deleting the first app", func() {
+				cf.Cf("delete", appOneName, "-f").Wait(testConfig.DefaultTimeoutDuration())
+			})
+
+			By("deploying a second app", func() {
+				Expect(cf.Cf(
+					"push", appOneName,
+					"--no-start",
+					"-b", testConfig.GetGoBuildpackName(),
+					"-p", "../../../example-apps/healthcheck",
+					"-f", "../../../example-apps/healthcheck/manifest.yml",
+					"-d", testConfig.GetAppsDomain(),
+				).Wait(testConfig.CfPushTimeoutDuration())).To(Exit(0))
+			})
+			defer By("deleting the second app", func() {
+				cf.Cf("delete", appTwoName, "-f").Wait(testConfig.DefaultTimeoutDuration())
+			})
+
+			By("binding and unbinding the two apps simultaneously, we should see no errors", func(){
+				// Prepare four channels
+				bindAppOneChan := make(chan int)
+				bindAppTwoChan := make(chan int)
+				unbindAppOneChan := make(chan int)
+				unbindAppTwoChan := make(chan int)
+
+				// Concurrently (as possible) bind and unbind the services
+				bindServiceToAppAsync(appOneName, serviceInstanceName, bindAppOneChan)
+				bindServiceToAppAsync(appTwoName, serviceInstanceName, bindAppTwoChan)
+				unbindServiceFromAppAsync(appOneName, serviceInstanceName, unbindAppOneChan)
+				unbindServiceFromAppAsync(appTwoName, serviceInstanceName, unbindAppTwoChan)
+
+				// Check that every channel exited 0 (ie didn't error)
+				Eventually(func() int {
+					return <-bindAppOneChan
+				}).Should(Equal(0))
+
+				Eventually(func() int {
+					return <-bindAppTwoChan
+				}).Should(Equal(0))
+
+				Eventually(func() int {
+					return <-unbindAppOneChan
+				}).Should(Equal(0))
+
+				Eventually(func() int {
+					return <-unbindAppTwoChan
+				}).Should(Equal(0))
+			})
+		})
+	})
 })
+
+func bindServiceToAppAsync(appName string, serviceInstanceName string, outChan chan<- int) {
+	go (func() {
+		session := cf.Cf("bind-service", appName, serviceInstanceName).Wait(testConfig.DefaultTimeoutDuration())
+		exitCode := session.ExitCode()
+
+		outChan <- exitCode
+	})()
+}
+
+func unbindServiceFromAppAsync(appName string, serviceInstanceName string, outChan chan<- int) {
+	go (func() {
+		session := cf.Cf("unbind-service", appName, serviceInstanceName).Wait(testConfig.DefaultTimeoutDuration())
+		exitCode := session.ExitCode()
+
+		outChan <- exitCode
+	})()
+}

--- a/platform-tests/src/platform/broker-acceptance/s3_broker_test.go
+++ b/platform-tests/src/platform/broker-acceptance/s3_broker_test.go
@@ -86,25 +86,25 @@ var _ = Describe("S3 broker", func() {
 		})
 	})
 
-	Context("multiple operations against a single bucket", func(){
+	Context("multiple operations against a single bucket", func() {
 		var (
 			appOneName          string
 			appTwoName          string
 			serviceInstanceName string
 		)
 
-		It("do not run in to race conditions", func(){
+		It("do not run in to race conditions", func() {
 			appOneName = generator.PrefixedRandomName(testConfig.GetNamePrefix(), "APP")
 			appTwoName = generator.PrefixedRandomName(testConfig.GetNamePrefix(), "APP")
 			serviceInstanceName = generator.PrefixedRandomName(testConfig.GetNamePrefix(), "test-s3-bucket")
 
-			By("creating the service: " + serviceInstanceName, func() {
+			By("creating the service: "+serviceInstanceName, func() {
 				Expect(
 					cf.
 						Cf("create-service", serviceName, testPlanName, serviceInstanceName).
 						Wait(testConfig.DefaultTimeoutDuration()),
 				).
-				To(Exit(0))
+					To(Exit(0))
 				pollForServiceCreationCompletion(serviceInstanceName)
 			})
 
@@ -144,7 +144,7 @@ var _ = Describe("S3 broker", func() {
 				cf.Cf("delete", appTwoName, "-f").Wait(testConfig.DefaultTimeoutDuration())
 			})
 
-			By("binding and unbinding the two apps simultaneously, we should see no errors", func(){
+			By("binding and unbinding the two apps simultaneously, we should see no errors", func() {
 				// Prepare four channels
 				bindAppOneChan := make(chan int)
 				bindAppTwoChan := make(chan int)

--- a/platform-tests/src/platform/broker-acceptance/s3_broker_test.go
+++ b/platform-tests/src/platform/broker-acceptance/s3_broker_test.go
@@ -107,7 +107,6 @@ var _ = Describe("S3 broker", func() {
 					To(Exit(0))
 				pollForServiceCreationCompletion(serviceInstanceName)
 			})
-
 			defer By("deleting the service", func() {
 				Expect(
 					cf.Cf("delete-service", serviceInstanceName, "-f").
@@ -144,20 +143,13 @@ var _ = Describe("S3 broker", func() {
 				cf.Cf("delete", appTwoName, "-f").Wait(testConfig.DefaultTimeoutDuration())
 			})
 
-			By("binding and unbinding the two apps simultaneously, we should see no errors", func() {
-				// Prepare four channels
+			By("binding the two apps simultaneously, we should see no errors", func() {
 				bindAppOneChan := make(chan int)
 				bindAppTwoChan := make(chan int)
-				unbindAppOneChan := make(chan int)
-				unbindAppTwoChan := make(chan int)
 
-				// Concurrently (as possible) bind and unbind the services
 				bindServiceToAppAsync(appOneName, serviceInstanceName, bindAppOneChan)
 				bindServiceToAppAsync(appTwoName, serviceInstanceName, bindAppTwoChan)
-				unbindServiceFromAppAsync(appOneName, serviceInstanceName, unbindAppOneChan)
-				unbindServiceFromAppAsync(appTwoName, serviceInstanceName, unbindAppTwoChan)
 
-				// Check that every channel exited 0 (ie didn't error)
 				Eventually(func() int {
 					return <-bindAppOneChan
 				}).Should(Equal(0))
@@ -165,6 +157,14 @@ var _ = Describe("S3 broker", func() {
 				Eventually(func() int {
 					return <-bindAppTwoChan
 				}).Should(Equal(0))
+			})
+
+			By("unbinding the two apps simultaneously, we should see no errors", func() {
+				unbindAppOneChan := make(chan int)
+				unbindAppTwoChan := make(chan int)
+
+				unbindServiceFromAppAsync(appOneName, serviceInstanceName, unbindAppOneChan)
+				unbindServiceFromAppAsync(appTwoName, serviceInstanceName, unbindAppTwoChan)
 
 				Eventually(func() int {
 					return <-unbindAppOneChan

--- a/platform-tests/src/platform/broker-acceptance/s3_broker_test.go
+++ b/platform-tests/src/platform/broker-acceptance/s3_broker_test.go
@@ -132,7 +132,7 @@ var _ = Describe("S3 broker", func() {
 
 			By("deploying a second app", func() {
 				Expect(cf.Cf(
-					"push", appOneName,
+					"push", appTwoName,
 					"--no-start",
 					"-b", testConfig.GetGoBuildpackName(),
 					"-p", "../../../example-apps/healthcheck",

--- a/platform-tests/upstream/run_acceptance_tests.sh
+++ b/platform-tests/upstream/run_acceptance_tests.sh
@@ -8,7 +8,7 @@ if  [ "${DISABLE_CF_ACCEPTANCE_TESTS:-}" = "true" ]; then
 fi
 
 SLEEPTIME=90
-NODES=3
+NODES=5
 SLOW_SPEC_THRESHOLD=120
 
 # Build Skip regex to ignore tests


### PR DESCRIPTION
What
----
Bumps the version of the S3 broker to a version that supports locking on bucket operations, and configures the release appropriately

Also adds an acceptance test to cover the race condition.

See [the S3 broker PR](https://github.com/alphagov/paas-s3-broker/pull/16) for most of the details

How to review
-------------

1. Code review
2. Run this branch down your pipeline
3. Test

Who can review
--------------
Anyone