### PR TITLE
[skip-ci] Logstash filters index app source, and gorouter numbers

### DIFF
--- a/config/logit/11_app_syslog_drain.conf
+++ b/config/logit/11_app_syslog_drain.conf
@@ -15,4 +15,41 @@ if [syslog_program] =~ /^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9
     # This is an ugly hack to set the correct @source.component if the @type is "LogMessage"
     rename => { "app_log_type" => "[parsed_json_field][source_type]" }
   }
+
+  # When a CF app is syslog drained the @source.host is org.space.app
+  # e.g. admin.public.paas-admin
+  # e.g. admin.monitoring.paas-metrics
+  #
+  # We want to index these as
+  # @source.org_name
+  # @source.space_name
+  # @source.app_name
+  #
+  # to match @source.app_id above
+  #
+  # We want to split out the values in @source.host without modifying it
+  mutate {
+    copy => {
+      "[@source][host]" => "splithost"
+    }
+  }
+
+  # We split values and then index them
+  mutate {
+    split => {
+      "splithost" => "."
+    }
+
+    add_field => {
+      "[@source][org_name]" => "%{splithost[0]}"
+      "[@source][space_name]" => "%{splithost[1]}"
+      "[@source][app_name]" => "%{splithost[2]}"
+    }
+  }
+
+  # Now we have indexed the split values we should remove the temporary field
+  # so that it is not indexed as an array
+  mutate {
+    remove_field => ["splithost"]
+  }
 }

--- a/config/logit/20_custom_cf_filters.conf
+++ b/config/logit/20_custom_cf_filters.conf
@@ -73,7 +73,7 @@ mutate {
 # Some gorouter fields are numbers
 mutate {
   convert => {
-    "[gorouter][time_duration]" => "float"
+    "[gorouter][header][response_time]" => "float"
     "[gorouter][bytessent]" => "integer"
     "[gorouter][bytesreceived]" => "integer"
   }

--- a/config/logit/20_custom_cf_filters.conf
+++ b/config/logit/20_custom_cf_filters.conf
@@ -69,3 +69,12 @@ mutate {
     "[@source][director]"
   ]
 }
+
+# Some gorouter fields are numbers
+mutate {
+  convert => {
+    "[gorouter][time_duration]" => "float"
+    "[gorouter][bytessent]" => "integer"
+    "[gorouter][bytesreceived]" => "integer"
+  }
+}

--- a/config/logit/output/generated_logit_filters.conf
+++ b/config/logit/output/generated_logit_filters.conf
@@ -1063,7 +1063,7 @@ filter {
   # Some gorouter fields are numbers
   mutate {
     convert => {
-      "[gorouter][time_duration]" => "float"
+      "[gorouter][header][response_time]" => "float"
       "[gorouter][bytessent]" => "integer"
       "[gorouter][bytesreceived]" => "integer"
     }

--- a/config/logit/output/generated_logit_filters.conf
+++ b/config/logit/output/generated_logit_filters.conf
@@ -1059,4 +1059,13 @@ filter {
       "[@source][director]"
     ]
   }
+
+  # Some gorouter fields are numbers
+  mutate {
+    convert => {
+      "[gorouter][time_duration]" => "float"
+      "[gorouter][bytessent]" => "integer"
+      "[gorouter][bytesreceived]" => "integer"
+    }
+  }
 }

--- a/config/logit/output/generated_logit_filters.conf
+++ b/config/logit/output/generated_logit_filters.conf
@@ -1068,4 +1068,12 @@ filter {
       "[gorouter][bytesreceived]" => "integer"
     }
   }
+  # `paas-billing` provides the value of DEPLOY_ENV through an
+  # `app.data.deployment` field. We want to set `@source.deployment` so
+  # that it can be queried like the rest of the platform.
+  if [app][source] == "paas-billing" {
+    mutate {
+      add_field => { "[@source][deployment]" => "%{[app][data][deployment]}" }
+    }
+  }
 }

--- a/config/logit/output/generated_logit_filters.conf
+++ b/config/logit/output/generated_logit_filters.conf
@@ -180,6 +180,43 @@ filter {
       # This is an ugly hack to set the correct @source.component if the @type is "LogMessage"
       rename => { "app_log_type" => "[parsed_json_field][source_type]" }
     }
+
+    # When a CF app is syslog drained the @source.host is org.space.app
+    # e.g. admin.public.paas-admin
+    # e.g. admin.monitoring.paas-metrics
+    #
+    # We want to index these as
+    # @source.org_name
+    # @source.space_name
+    # @source.app_name
+    #
+    # to match @source.app_id above
+    #
+    # We want to split out the values in @source.host without modifying it
+    mutate {
+      copy => {
+        "[@source][host]" => "splithost"
+      }
+    }
+
+    # We split values and then index them
+    mutate {
+      split => {
+        "splithost" => "."
+      }
+
+      add_field => {
+        "[@source][org_name]" => "%{splithost[0]}"
+        "[@source][space_name]" => "%{splithost[1]}"
+        "[@source][app_name]" => "%{splithost[2]}"
+      }
+    }
+
+    # Now we have indexed the split values we should remove the temporary field
+    # so that it is not indexed as an array
+    mutate {
+      remove_field => ["splithost"]
+    }
   }
   # NOTE: All parsed data should include @message, @level and @source.component.
   # Otherwise these fields are set from syslog_ fields in teardown script afterwards.

--- a/scripts/generate_logit_filters.sh
+++ b/scripts/generate_logit_filters.sh
@@ -47,6 +47,7 @@ echo "filter {" > /output/generated_logit_filters.conf
     sed 's/^/  /' < /mnt/config/logit/11_app_syslog_drain.conf
     sed 's/^/  /' < /tmp/logsearch-for-cloudfoundry/src/logsearch-config/target/logstash-filters-default.conf
     sed 's/^/  /' < /mnt/config/logit/20_custom_cf_filters.conf
+    sed 's/^/  /' < /mnt/config/logit/21_paas_billing_filters.conf
     echo "}"
 } >> /output/generated_logit_filters.conf
 


### PR DESCRIPTION
What
----

A paas-billing improvement was not added to the generate script, so I added it.

Gorouter reports a few numbers which we should index as numbers:
- `gorouter.header.response_time` the duration in seconds, should be indexed as float - this is required for HAProxy deprecation
- `gorouter.bytes{sent,received}`

CF Syslog drain sets the destination as `$orgname.$spacename.$appname` which we can re-index so that we can do queries like:

```
@source.app_name:paas-admin
```

or

```
@source.org_name:admin
```

I chose `app_name`, `org_name`, and `space_name` because they are consistent with `app_id`, although arguable `app_org_name` `app_space_name` `app_name` are better

How to review
-------------

Look at the following links:

- [gorouter example, click JSON on a log and ensure that `gorouter.header.response_time` and `bytes{sent,received}` are numbers](https://kibana.logit.io/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),exists:(field:gorouter.header.response_time),meta:(alias:!n,disabled:!f,index:'logstash-*',key:gorouter.header.response_time,negate:!f,type:exists,value:exists))),index:'logstash-*',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'@source.component:gorouter')),sort:!('@timestamp',desc)))
- [paas-admin query](https://kibana.logit.io/app/kibana#/discover?_g=()&_a=(columns:!(_source),index:'logstash-*',interval:auto,query:(query_string:(query:'@source.app_name:paas-admin')),sort:!('@timestamp',desc)))

Code review

Tell @tlwr to put the updated filters in Logit

Who can review
--------------

Not @tlwr