### PR TITLE
Convert billing API perf logs to metrics

### DIFF
--- a/tools/metrics/gauges_billing_api_performance.go
+++ b/tools/metrics/gauges_billing_api_performance.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"code.cloudfoundry.org/lager"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/alphagov/paas-cf/tools/metrics/pkg/logit"
+	m "github.com/alphagov/paas-cf/tools/metrics/pkg/metrics"
+)
+
+type BillingApiHitLabels struct {
+	Deployment             string
+	CommaSeparatedOrgGUIDs string
+	RangeStart             string
+	RangeStop              string
+}
+type BillingApiElasticsearchHit struct {
+	Source struct {
+		Timestamp string `json:"@timestamp"`
+		App       struct {
+			Data struct {
+				Elapsed    int64  `json:"elapsed"`
+				Deployment string `json:"deployment"`
+				Filter     struct {
+					OrgGUIDs   []string `json:"OrgGUIDs"`
+					RangeStart string   `json:"RangeStart"`
+					RangeStop  string   `json:"RangeStop"`
+				} `json:"filter"`
+			} `json:"data"`
+		} `json:"app"`
+	} `json:"_source"`
+}
+
+func BillingApiPerformanceGauge(
+	logger lager.Logger,
+	interval time.Duration,
+	client logit.LogitElasticsearchClient,
+) m.MetricReadCloser {
+	return m.NewMetricPoller(interval, func(w m.MetricWriter) error {
+		metrics, err := BillingApiPerformanceMetricGauges(logger, client)
+		if err != nil {
+			logger.Error("billing-api-performance-metric-gauges", err)
+			return err
+		}
+		err = w.WriteMetrics(metrics)
+		if err != nil {
+			logger.Error("billing-api-performance-gauge-write-metrics", err)
+			return err
+		}
+		return nil
+	})
+}
+
+type BillingApiElasticsearchQueryParams struct {
+	Message       string
+	QueryInterval string
+}
+
+func BillingApiPerformanceMetricGauges(logger lager.Logger, client logit.LogitElasticsearchClient) ([]m.Metric, error) {
+	queries := []BillingApiElasticsearchQueryParams{
+		{
+			Message:       "paas-billing.store.get-consolidated-billable-event-rows-query",
+			QueryInterval: "15m",
+		},
+		{
+			Message:       "paas-billing.store.get-billable-event-rows-query",
+			QueryInterval: "15m",
+		},
+	}
+	var metrics []m.Metric
+	for _, query := range queries {
+		hits, err := GetElapsedTimesByTags(logger, client, query)
+		if err != nil {
+			return metrics, err
+		}
+		for tags, hits := range hits {
+			var elapsedTimes []int64
+			for _, hit := range hits {
+				elapsedTimes = append(elapsedTimes, hit.Source.App.Data.Elapsed)
+			}
+			if average, ok := ArithmeticMean(elapsedTimes); ok {
+				metrics = append(metrics, m.Metric{
+					Kind: m.Gauge,
+					Name: "billing.api.performance.elapsed",
+					Time: time.Now(),
+					Tags: []m.MetricTag{
+						{Label: "deployment", Value: tags.Deployment},
+						{Label: "orgGUIDs", Value: tags.CommaSeparatedOrgGUIDs},
+						{Label: "rangeStart", Value: tags.RangeStart},
+						{Label: "rangeStop", Value: tags.RangeStop},
+						{Label: "message", Value: query.Message},
+					},
+					Unit:  "seconds",
+					Value: average / 1e9,
+				})
+			}
+		}
+	}
+	return metrics, nil
+}
+
+func GetElapsedTimesByTags(
+	logger lager.Logger,
+	client logit.LogitElasticsearchClient,
+	queryParams BillingApiElasticsearchQueryParams,
+) (map[BillingApiHitLabels][]BillingApiElasticsearchHit, error) {
+	query, err := BuildBillingApiElasticsearchQuery(queryParams)
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Hits struct {
+			Hits []BillingApiElasticsearchHit `json:"hits"`
+		} `json:"hits"`
+	}
+	err = client.Search(query, &response)
+	if err != nil {
+		logger.Error("get-billing-api-elapsed-times", err, lager.Data{
+			"message": queryParams.Message,
+		})
+		return nil, err
+	}
+	result := map[BillingApiHitLabels][]BillingApiElasticsearchHit{}
+	for _, hit := range response.Hits.Hits {
+		orgGUIDs := hit.Source.App.Data.Filter.OrgGUIDs
+		sort.Strings(orgGUIDs)
+		commaSeparatedOrgGUIDs := strings.Join(orgGUIDs, ",")
+		labels := BillingApiHitLabels{
+			Deployment:             hit.Source.App.Data.Deployment,
+			CommaSeparatedOrgGUIDs: commaSeparatedOrgGUIDs,
+			RangeStart:             hit.Source.App.Data.Filter.RangeStart,
+			RangeStop:              hit.Source.App.Data.Filter.RangeStop,
+		}
+		result[labels] = append(result[labels], hit)
+	}
+	return result, nil
+}
+
+func BuildBillingApiElasticsearchQuery(queryParams BillingApiElasticsearchQueryParams) (string, error) {
+	type M map[string]interface{}
+	criteria := []interface{}{
+		M{"match_phrase": M{"@message": queryParams.Message}},
+		M{"range": M{
+			"@timestamp": M{"time_zone": "UTC", "gt": fmt.Sprintf("now-%s", queryParams.QueryInterval)},
+		}},
+	}
+	bytes, err := json.Marshal(M{
+		"query": M{"bool": M{"must": criteria}},
+		"from":  0,
+		"size":  1000,
+		"_source": []string{
+			"app.data.elapsed",
+			"app.data.deployment",
+			"app.data.filter.OrgGUIDs",
+			"app.data.filter.RangeStart",
+			"app.data.filter.RangeStop",
+			"@timestamp",
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}

--- a/tools/metrics/gauges_billing_api_performance_test.go
+++ b/tools/metrics/gauges_billing_api_performance_test.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"code.cloudfoundry.org/lager"
+	"encoding/json"
+	"fmt"
+	"github.com/alphagov/paas-cf/tools/metrics/pkg/logit/logitfakes"
+	"github.com/onsi/gomega/gbytes"
+	"strings"
+
+	m "github.com/alphagov/paas-cf/tools/metrics/pkg/metrics"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Billing API Performance Gauges", func() {
+	var elasticsearchSingleResponse = []byte(`{
+		"hits": {
+			"hits": [{
+				"_source": {
+					"@timestamp": "2019-01-01T00:00:00.000Z",
+					"app": {
+						"data": {
+							"elapsed": 123456789,
+							"filter": {
+								"OrgGUIDs": ["some-org-guid"],
+								"RangeStart": "1970-01-01",
+								"RangeStop": "1970-02-01"
+							},
+							"deployment": "test"
+						}
+					}
+				}
+			}]
+		}
+	}`)
+
+	logger := lager.NewLogger("billing-performance")
+	logger.RegisterSink(lager.NewWriterSink(gbytes.NewBuffer(), lager.INFO))
+
+	It("should have no gauges when no results are found in elasticsearch", func() {
+		fakeLogitElasticsearchClient := logitfakes.FakeLogitElasticsearchClient{}
+		metrics, err := BillingApiPerformanceMetricGauges(logger, &fakeLogitElasticsearchClient)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(metrics).To(BeEmpty())
+	})
+
+	It("should have a billable event rows gauge when there are results from elasticsearch", func() {
+		fakeLogitElasticsearchClient := logitfakes.FakeLogitElasticsearchClient{}
+		fakeLogitElasticsearchClient.SearchStub = func(query string, response interface{}) error {
+			if strings.Contains(query, "paas-billing.store.get-billable-event-rows-query") {
+				return json.Unmarshal(elasticsearchSingleResponse, response)
+			}
+			return nil
+		}
+		metrics, err := BillingApiPerformanceMetricGauges(logger, &fakeLogitElasticsearchClient)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(metrics).To(HaveLen(1))
+		Expect(metrics[0].Kind).To(Equal(m.Gauge))
+		Expect(metrics[0].Name).To(Equal("billing.api.performance.elapsed"))
+		Expect(metrics[0].Value).To(Equal(0.123456789))
+		Expect(metrics[0].Tags).To(Equal(m.MetricTags{
+			{Label: "deployment", Value: "test"},
+			{Label: "orgGUIDs", Value: "some-org-guid"},
+			{Label: "rangeStart", Value: "1970-01-01"},
+			{Label: "rangeStop", Value: "1970-02-01"},
+			{Label: "message", Value: "paas-billing.store.get-billable-event-rows-query"},
+		}))
+	})
+
+	It("should have a consolidated billable event rows gauge when there are results from elasticsearch", func() {
+		fakeLogitElasticsearchClient := logitfakes.FakeLogitElasticsearchClient{}
+		fakeLogitElasticsearchClient.SearchStub = func(query string, response interface{}) error {
+			if strings.Contains(query, "paas-billing.store.get-consolidated-billable-event-rows-query") {
+				return json.Unmarshal(elasticsearchSingleResponse, response)
+			}
+			return nil
+		}
+		metrics, err := BillingApiPerformanceMetricGauges(logger, &fakeLogitElasticsearchClient)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(metrics).To(HaveLen(1))
+		Expect(metrics[0].Kind).To(Equal(m.Gauge))
+		Expect(metrics[0].Name).To(Equal("billing.api.performance.elapsed"))
+		Expect(metrics[0].Value).To(Equal(0.123456789))
+		Expect(metrics[0].Tags).To(Equal(m.MetricTags{
+			{Label: "deployment", Value: "test"},
+			{Label: "orgGUIDs", Value: "some-org-guid"},
+			{Label: "rangeStart", Value: "1970-01-01"},
+			{Label: "rangeStop", Value: "1970-02-01"},
+			{Label: "message", Value: "paas-billing.store.get-consolidated-billable-event-rows-query"},
+		}))
+	})
+
+	It("should calculate the average time elapsed grouped by tags", func() {
+		fakeLogitElasticsearchClient := logitfakes.FakeLogitElasticsearchClient{}
+		fakeLogitElasticsearchClient.SearchStub = func(query string, response interface{}) error {
+			if strings.Contains(query, "paas-billing.store.get-billable-event-rows-query") {
+				return json.Unmarshal([]byte(`{
+					"hits": {
+						"hits": [{
+							"_source": {
+								"@timestamp": "2019-01-01T00:00:00.000Z",
+								"app": {
+									"data": {
+										"elapsed": 1000000000,
+										"filter": {
+											"OrgGUIDs": ["org-guid-with-one-result"],
+											"RangeStart": "1970-01-01",
+											"RangeStop": "1970-02-01"
+										},
+										"deployment": "some-deployment"
+									}
+								}
+							}
+						}, {
+							"_source": {
+								"@timestamp": "2019-01-01T00:00:00.000Z",
+								"app": {
+									"data": {
+										"elapsed": 2000000000,
+										"filter": {
+											"OrgGUIDs": ["org-guid-with-two-results"],
+											"RangeStart": "1970-01-01",
+											"RangeStop": "1970-02-01"
+										},
+										"deployment": "some-deployment"
+									}
+								}
+							}
+						}, {
+							"_source": {
+								"@timestamp": "2019-01-01T00:00:00.000Z",
+								"app": {
+									"data": {
+										"elapsed": 4000000000,
+										"filter": {
+											"OrgGUIDs": ["org-guid-with-two-results"],
+											"RangeStart": "1970-01-01",
+											"RangeStop": "1970-02-01"
+										},
+										"deployment": "some-deployment"
+									}
+								}
+							}
+						}]
+					}
+				}`), response)
+			}
+			return nil
+		}
+		metrics, err := BillingApiPerformanceMetricGauges(logger, &fakeLogitElasticsearchClient)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(metrics).To(HaveLen(2))
+
+		var orgWithOneResultMetric m.Metric
+		var orgWithTwoResultsMetric m.Metric
+		for _, metric := range metrics {
+			for _, tag := range metric.Tags {
+				if tag.Label == "orgGUIDs" {
+					if tag.Value == "org-guid-with-one-result" {
+						orgWithOneResultMetric = metric
+					} else if tag.Value == "org-guid-with-two-results" {
+						orgWithTwoResultsMetric = metric
+					} else {
+						Fail(fmt.Sprintf("Unexpected metric with orgGUID %s", tag.Value))
+					}
+				}
+			}
+		}
+		Expect(orgWithOneResultMetric).NotTo(Equal(m.Metric{}))
+		Expect(orgWithTwoResultsMetric).NotTo(Equal(m.Metric{}))
+
+		Expect(orgWithOneResultMetric.Kind).To(Equal(m.Gauge))
+		Expect(orgWithOneResultMetric.Name).To(Equal("billing.api.performance.elapsed"))
+		Expect(orgWithOneResultMetric.Tags).To(Equal(m.MetricTags{
+			{Label: "deployment", Value: "some-deployment"},
+			{Label: "orgGUIDs", Value: "org-guid-with-one-result"},
+			{Label: "rangeStart", Value: "1970-01-01"},
+			{Label: "rangeStop", Value: "1970-02-01"},
+			{Label: "message", Value: "paas-billing.store.get-billable-event-rows-query"},
+		}))
+		Expect(orgWithOneResultMetric.Value).To(Equal(1.0))
+
+		Expect(orgWithTwoResultsMetric.Kind).To(Equal(m.Gauge))
+		Expect(orgWithTwoResultsMetric.Name).To(Equal("billing.api.performance.elapsed"))
+		Expect(orgWithTwoResultsMetric.Tags).To(Equal(m.MetricTags{
+			{Label: "deployment", Value: "some-deployment"},
+			{Label: "orgGUIDs", Value: "org-guid-with-two-results"},
+			{Label: "rangeStart", Value: "1970-01-01"},
+			{Label: "rangeStop", Value: "1970-02-01"},
+			{Label: "message", Value: "paas-billing.store.get-billable-event-rows-query"},
+		}))
+		Expect(orgWithTwoResultsMetric.Value).To(Equal((2.0 + 4.0) / 2))
+	})
+
+})

--- a/tools/metrics/main.go
+++ b/tools/metrics/main.go
@@ -163,7 +163,8 @@ func Main() error {
 		UAAGauges(logger, &uaaCfg, 5*time.Minute),
 		BillingCostsGauge(logger, os.Getenv("BILLING_ENDPOINT"), 15*time.Minute),
 		CurrencyGauges(logger, 5*time.Minute),
-		BillingPerformanceGauge(logger, 15*time.Minute, logitClient),
+		BillingCollectorPerformanceGauge(logger, 15*time.Minute, logitClient),
+		BillingApiPerformanceGauge(logger, 15*time.Minute, logitClient),
 	}
 	for _, addr := range strings.Split(os.Getenv("TLS_DOMAINS"), ",") {
 		gauges = append(gauges, TLSValidityGauge(logger, tlsChecker, strings.TrimSpace(addr), 15*time.Minute))

--- a/tools/metrics/maths.go
+++ b/tools/metrics/maths.go
@@ -1,0 +1,13 @@
+package main
+
+func ArithmeticMean(data []int64) (float64, bool) {
+	count := len(data)
+	if count <= 0 {
+		return 0, false
+	}
+	sum := int64(0)
+	for _, hit := range data {
+		sum += hit
+	}
+	return float64(sum) / float64(count), true
+}


### PR DESCRIPTION
What
----

In #2029 we made paas-metrics query elasticsearch to fetch the timings
of some of the SQL queries that paas-billing's collector makes, so we
could report them to prometheus and track their performance over a
longer time frame.

This commit does the same thing, but for the queries billing API makes.
This gives us more of an insight into the user-facing performance of
billing. As the pages in paas-admin generally only make one API call,
which only makes one slow SQL query these numbers are a good proxy for
how long the pages users see take to load.

As with the other PR, because this queries logit this spans multiple
deployments (so we'll see both `prod` and `prod-lon` in production).

In my dev environment this looks like:

```
 # HELP paas_billing_api_performance_elapsed_seconds
 # TYPE paas_billing_api_performance_elapsed_seconds gauge
 paas_billing_api_performance_elapsed_seconds{deployment="leeporte",message="paas-billing.store.get-billable-event-rows-query",orgGUIDs="",rangeStart="2019-09-16",rangeStop="2019-09-17"} 0.021888704
 paas_billing_api_performance_elapsed_seconds{deployment="miki",message="paas-billing.store.get-billable-event-rows-query",orgGUIDs="",rangeStart="2019-09-16",rangeStop="2019-09-17"} 0.0217637155
 paas_billing_api_performance_elapsed_seconds{deployment="momo",message="paas-billing.store.get-billable-event-rows-query",orgGUIDs="",rangeStart="2019-09-16",rangeStop="2019-09-17"} 0.020462683
 paas_billing_api_performance_elapsed_seconds{deployment="tlwr",message="paas-billing.store.get-billable-event-rows-query",orgGUIDs="",rangeStart="2019-09-16",rangeStop="2019-09-17"} 0.019776676666666666
 paas_billing_api_performance_elapsed_seconds{deployment="towers",message="paas-billing.store.get-billable-event-rows-query",orgGUIDs="fea642e0-a0a9-47c3-ac66-e36d8ea3e92b",rangeStart="2019-09-01",rangeStop="2019-10-01"} 0.032616076
```

How to review
-------------

* Code review
* `cf push` it into your dev environment and look at the metrics

Who can review
--------------

Not @richardtowers