### PR TITLE
Upgrade prod billing DBs from medium to large

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -3145,8 +3145,10 @@ jobs:
               - -c
               - |
                 BILLING_DB_PLAN="tiny-unencrypted-9.5"
-                if [ "${DEPLOY_ENV}" = "prod" ] || [ "${DEPLOY_ENV}" = "prod-lon" ] || [ "${DEPLOY_ENV}" = "stg-lon" ]; then
+                if [ "${DEPLOY_ENV}" = "stg-lon" ]; then
                   BILLING_DB_PLAN="medium-9.5"
+                elif [ "${DEPLOY_ENV}" = "prod" ] || [ "${DEPLOY_ENV}" = "prod-lon" ]; then
+                  BILLING_DB_PLAN="large-9.5"
                 fi
 
                 echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}" -o admin -s billing


### PR DESCRIPTION
What
----

The `BILLING_DB_PLAN` environment variable is only used when creating
new databases, so this will not actually have any effect.

Still worth correcting it so the pipeline matches what we currently
have, and so it's not misleading if we need to spin up a new production
environment.

How to review
-------------

* Code review should be enough (confirm that the BILLING_DB_PLAN
  variable is only used to create new DBs)

Who can review
--------------

Not Rich