### PR TITLE
Scale up Ireland to 6 Cloud Controller instances

### DIFF
--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -1,7 +1,7 @@
 ---
 cell_instances: 30
 router_instances: 3
-api_instances: 4
+api_instances: 6
 doppler_instances: 16
 log_api_instances: 6
 cc_hourly_rate_limit: 55000


### PR DESCRIPTION
What
----

A tenant reported some erratic API errors in Ireland. After some digging we suspect Cloud Controller can get a bit overloaded. This commit scales Ireland up from 4 to 6 Cloud Controller instances to better meet demand.

At present our `api` VMs use EC2 `m5.large` instances. An on-demand `m5.large` in Ireland (`eu-west-1`) costs ~$77/month. If reserved this goes down to ~$54/month. (Prices from https://www.ec2instances.info/?region=eu-west-1&selected=m5.large.) Therefore these 2 extra instances will cost $108–$154 depending upon how many are already reserved.

London has 12 `api` instances, whereas this PR only takes Ireland up to 6. Money doesn't grow on trees and we haven't seen big enough problems to scale Ireland up all the way yet.

How to review
-------------

* Code review;
* Talk to Miki about whether this change is justified. It feels like guesswork.

Who can review
--------------

Not @46bit.