### PR TITLE
Increase the node alert limit for elasticache

### DIFF
--- a/manifests/prometheus/env-specific/prod-lon.yml
+++ b/manifests/prometheus/env-specific/prod-lon.yml
@@ -1,6 +1,6 @@
 ---
 
 # AWS Limits not accesible via API
-aws_limits_elasticache_cache_parameter_groups: 200
-aws_limits_elasticache_nodes: 200
+aws_limits_elasticache_cache_parameter_groups: 300
+aws_limits_elasticache_nodes: 300
 aws_limits_s3_buckets: 100


### PR DESCRIPTION
What
----

In support case
https://console.aws.amazon.com/support/cases#/6436861931/en we increased
our limit for aws_limits_elasticache_cache_parameter_groups and
aws_limits_elasticache_nodes to 300

This makes the alert match our limit, so the alert stops being red unnecessarily.

How to review
-------------

Read the support ticket: https://console.aws.amazon.com/support/cases#/6436861931/en 

Code review

Who can review
--------------

Not @tlwr