### PR TITLE
Fix path of cf admin password in credhub preamble

### DIFF
--- a/scripts/templates/credhub_bashrc.sh
+++ b/scripts/templates/credhub_bashrc.sh
@@ -18,7 +18,7 @@ PROMETHEUS PASSWORD|/$DEPLOY_ENV/prometheus/prometheus_password
 GRAFANA PASSWORD|/$DEPLOY_ENV/prometheus/grafana_password
 GRAFANA MONITOR PASSWORD|/$DEPLOY_ENV/prometheus/grafana_mon_password
 ALERTMANAGER PASSWORD|/$DEPLOY_ENV/prometheus/alertmanager_password
-CF ADMIN PASSWORD|/$DEPLOY_ENV/prometheus/cf_admin_password
+CF ADMIN PASSWORD|/$DEPLOY_ENV/$DEPLOY_ENV/cf_admin_password
 UAA ADMIN CLIENT SECRET|/concourse/main/create-cloudfoundry/uaa_admin_client_secret
 PATHS
 )


### PR DESCRIPTION
What
----

Fix path of cf admin password in credhub preamble - it was using
prometheus, but it should be using the deploy env.

How to review
-------------

* Code review is enough

Who can review
--------------

Not @richardtowers