### PR TITLE
Use Concourse web password from credhub not s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,10 +186,9 @@ need to run the pipeline from start in order to bring the changes forward.
 
 ## Concourse credentials
 
-By default, the environment setup script retrieves the admin user password set
-in paas-bootstrap and stored in S3 in the `concourse-secrets.yml` file. If the
-`CONCOURSE_WEB_PASSWORD` environment variable is set, this will be used instead.
-These credentials are output by all of the pipeline deployment tasks.
+When run from your laptop, the environment setup script does not interact with
+Concourse using long lived credentials. If you need to get persistent Concourse
+credentials please use `make <env> credhub`.
 
 ## Overnight deletion of environments
 

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -511,6 +511,7 @@ jobs:
             SKIP_AWS_CREDENTIAL_VALIDATION: true
             NEW_ACCOUNT_EMAIL_ADDRESS: ((NEW_ACCOUNT_EMAIL_ADDRESS))
             SLIM_DEV_DEPLOYMENT: ((slim_dev_deployment))
+            CONCOURSE_WEB_PASSWORD: ((concourse_web_password))
           run:
             path: ./paas-cf/concourse/scripts/self-update-pipeline.sh
       - put: pipeline-trigger

--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -80,6 +80,7 @@ jobs:
             - name: paas-cf
           params:
             AWS_DEFAULT_REGION: ((aws_region))
+            CONCOURSE_WEB_PASSWORD: ((concourse_web_password))
             DEPLOY_ENV: ((deploy_env))
             SKIP_AWS_CREDENTIAL_VALIDATION: true
           run:
@@ -111,6 +112,7 @@ jobs:
             - name: paas-cf
           params:
             AWS_DEFAULT_REGION: ((aws_region))
+            CONCOURSE_WEB_PASSWORD: ((concourse_web_password))
             DEPLOY_ENV: ((deploy_env))
             SKIP_AWS_CREDENTIAL_VALIDATION: true
           run:

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -110,6 +110,7 @@ jobs:
             ENABLE_DESTROY: ((enable_destroy))
             SKIP_AWS_CREDENTIAL_VALIDATION: true
             NEW_ACCOUNT_EMAIL_ADDRESS: ((NEW_ACCOUNT_EMAIL_ADDRESS))
+            CONCOURSE_WEB_PASSWORD: ((concourse_web_password))
           run:
             path: ./paas-cf/concourse/scripts/self-update-pipeline.sh
       - put: pipeline-trigger

--- a/concourse/pipelines/monitor-remote.yml
+++ b/concourse/pipelines/monitor-remote.yml
@@ -66,6 +66,7 @@ jobs:
         MONITORED_DEPLOY_ENV: ((monitored_deploy_env))
         MONITORED_STATE_BUCKET: ((monitored_state_bucket))
         MONITORED_AWS_REGION: ((monitored_aws_region))
+        CONCOURSE_WEB_PASSWORD: ((concourse_web_password))
       run:
         path: ./paas-cf/concourse/scripts/self-update-pipeline.sh
 

--- a/concourse/scripts/environment.sh
+++ b/concourse/scripts/environment.sh
@@ -28,16 +28,18 @@ case $TARGET_CONCOURSE in
     ;;
 esac
 
-CONCOURSE_WEB_USER=${CONCOURSE_WEB_USER:-admin}
-if [ -z "${CONCOURSE_WEB_PASSWORD:-}" ]; then
-  CONCOURSE_WEB_PASSWORD=$(concourse/scripts/val_from_yaml.rb secrets.concourse_web_password <(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/concourse-secrets.yml" -))
+if [ "$USER" == "root" ] ; then
+  # We are running in Concourse
+  : "${CONCOURSE_WEB_PASSWORD:?CONCOURSE_WEB_PASSWORD must be set}"
+  cat <<EOF
+export CONCOURSE_WEB_USER=${CONCOURSE_WEB_USER:-admin}
+export CONCOURSE_WEB_PASSWORD=${CONCOURSE_WEB_PASSWORD}
+EOF
 fi
 
 cat <<EOF
 export AWS_ACCOUNT=${AWS_ACCOUNT}
 export DEPLOY_ENV=${DEPLOY_ENV}
-export CONCOURSE_WEB_USER=${CONCOURSE_WEB_USER}
-export CONCOURSE_WEB_PASSWORD=${CONCOURSE_WEB_PASSWORD}
 export CONCOURSE_URL=${CONCOURSE_URL}
 export FLY_CMD=${FLY_CMD}
 export FLY_TARGET=${FLY_TARGET}

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -89,7 +89,6 @@ bosh_fqdn: bosh.${SYSTEM_DNS_ZONE_NAME}
 disable_cf_acceptance_tests: ${DISABLE_CF_ACCEPTANCE_TESTS:-}
 disable_custom_acceptance_tests: ${DISABLE_CUSTOM_ACCEPTANCE_TESTS:-}
 disable_pipeline_locking: ${DISABLE_PIPELINE_LOCKING:-}
-concourse_web_password: ${CONCOURSE_WEB_PASSWORD}
 auto_deploy: $([ "${ENABLE_AUTO_DEPLOY:-}" ] && echo "true" || echo "false")
 persistent_environment: ${PERSISTENT_ENVIRONMENT}
 slim_dev_deployment: ${SLIM_DEV_DEPLOYMENT:-}

--- a/scripts/templates/credhub_bashrc.sh
+++ b/scripts/templates/credhub_bashrc.sh
@@ -20,6 +20,7 @@ GRAFANA MONITOR PASSWORD|/$DEPLOY_ENV/prometheus/grafana_mon_password
 ALERTMANAGER PASSWORD|/$DEPLOY_ENV/prometheus/alertmanager_password
 CF ADMIN PASSWORD|/$DEPLOY_ENV/$DEPLOY_ENV/cf_admin_password
 UAA ADMIN CLIENT SECRET|/concourse/main/create-cloudfoundry/uaa_admin_client_secret
+CONCOURSE ADMIN USER PASSWORD|/concourse/main/concourse_web_password
 PATHS
 )
 -------


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/168427704)

🐝 This is contingent on https://github.com/alphagov/paas-bootstrap/pull/307 🐝 

What
----

We now have credhub and can avoid using the concourse admin password in
stored in s3.

We don't need to use the concourse admin username/password in paas-cf
because we are using github everywhere now. As a result we can use our
own identities when doing operations locally.

How to review
-------------

Code review

Run `make dev pipelines` locally (Did I break your workflow)

Run `create-cloudfoundry` and ensure it can set its own pipeline

Who can review
--------------

Not @tlwr