### PR TITLE
[Support] Upgrade CF to 11.2, increase test parallelism, respond to CVEs

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -272,7 +272,7 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-acceptance-tests
-      branch: cf11.0
+      branch: cf11.2
 
   - name: cf-smoke-tests-release
     type: git

--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-xenial
-      version: "456.14"
+      version: "456.27"

--- a/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
+++ b/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
@@ -1,8 +1,0 @@
----
-- type: replace
-  path:  /releases/name=cflinuxfs3
-  value:
-    name: "cflinuxfs3"
-    version: "0.119.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.119.0"
-    sha1: "6ac411704ad441daca2bf6f0caef1d097263bff7"

--- a/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
+++ b/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
@@ -1,0 +1,8 @@
+---
+- type: replace
+  path:  /releases/name=cflinuxfs3
+  value:
+    name: "cflinuxfs3"
+    version: "0.129.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.129.0"
+    sha1: "ed8cb0044302aa38913566306b45deb2852d0dfd"

--- a/platform-tests/upstream/run_acceptance_tests.sh
+++ b/platform-tests/upstream/run_acceptance_tests.sh
@@ -8,7 +8,7 @@ if  [ "${DISABLE_CF_ACCEPTANCE_TESTS:-}" = "true" ]; then
 fi
 
 SLEEPTIME=90
-NODES=5
+NODES=12
 SLOW_SPEC_THRESHOLD=120
 
 # Build Skip regex to ignore tests
@@ -30,7 +30,7 @@ echo "Starting acceptace tests"
 cd src/github.com/cloudfoundry/cf-acceptance-tests
 ./bin/test \
   -keepGoing \
-  -timeout=1h15m \
+  -timeout=1h \
   -flakeAttempts=3 \
   -randomizeAllSpecs \
   -skipPackage=helpers \


### PR DESCRIPTION
What
----

### Upgrade CF deployment to 11.2

Whilst on support we received a user query about a docker application not health-checking properly, this is a bug in CAPI which was fixed in https://github.com/cloudfoundry/capi-release/releases/tag/1.85.0 which is present in CF deployment >= 11.1 (we are on 11.0)

I didn't go straight to 12 because this is a support task and CF deployment 12 allegedly needs a change to BOSH DNS service aliases, which we can look into in the actual story. Also it is firebreak so I want to fix the tenant's issue with a small review.

### Increase test parallelism

Read the commit message, but this drops my CF acceptance test time in my pipeline to 25 minutes from 40 (previously 1 hour).

### Respond to CVEs

See the last two commits for details.

- Bump stemcells to `456.27` (alphagov/paas-bootstrap PR todo)
- Bump cflinuxfs3 to `0.129.0`

How to review
-------------

Code review

Travis

[Look at my dev environment](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/tag-release/builds/42)

Who can review
--------------

Not @tlwr