### PR TITLE
[#168881844] transition cloud-config to paas-cf cloud-config

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -244,12 +244,12 @@ resources:
       region_name: ((aws_region))
       versioned_file: cf-manifest-pre-vars.yml
 
-  - name: cloud-config
+  - name: paas-cf-cloud-config
     type: s3-iam
     source:
       bucket: ((state_bucket))
       region_name: ((aws_region))
-      versioned_file: cloud-config.yml
+      versioned_file: paas-cf-cloud-config.yml
 
   - name: deployed-healthcheck
     type: s3-iam
@@ -1068,7 +1068,7 @@ jobs:
                     > ms-oauth-endpoints/issuer
 
       - do:
-        - task: generate-cloud-config
+        - task: generate-paas-cf-cloud-config
           tags: [colocated-with-web]
           config:
             platform: linux
@@ -1077,19 +1077,19 @@ jobs:
               - name: paas-cf
               - name: terraform-outputs
             outputs:
-              - name: cloud-config
+              - name: paas-cf-cloud-config
             run:
               path: sh
               args:
                 - -e
                 - -c
                 - |
-                  paas-cf/manifests/cloud-config/scripts/generate-cloud-config.sh > cloud-config/cloud-config.yml
+                  paas-cf/manifests/cloud-config/scripts/generate-cloud-config.sh > paas-cf-cloud-config/paas-cf-cloud-config.yml
 
           on_success:
-            put: cloud-config
+            put: paas-cf-cloud-config
             params:
-              file: cloud-config/cloud-config.yml
+              file: paas-cf-cloud-config/paas-cf-cloud-config.yml
 
         - task: generate-cf-manifest
           tags: [colocated-with-web]
@@ -1157,7 +1157,7 @@ jobs:
             trigger: true
           - get: paas-cf
             passed: ['generate-cf-config']
-          - get: cloud-config
+          - get: paas-cf-cloud-config
             passed: ['generate-cf-config']
           - get: cf-manifest
             passed: ['generate-cf-config']
@@ -1205,13 +1205,13 @@ jobs:
                     stemcell_index=$((stemcell_index + 1))
                   done
 
-        - task: update-cloud-config
+        - task: update-paas-cf-cloud-config
           tags: [colocated-with-web]
           config:
             platform: linux
             image_resource: *gov-paas-bosh-cli-v2-image-resource
             inputs:
-              - name: cloud-config
+              - name: paas-cf-cloud-config
               - name: paas-cf
             params:
               BOSH_ENVIRONMENT: ((bosh_fqdn))
@@ -1227,7 +1227,10 @@ jobs:
                   BOSH_CLIENT=admin
                   export BOSH_CLIENT
 
-                  bosh -n update-cloud-config cloud-config/cloud-config.yml
+                  bosh -n update-config \
+                    --type=cloud \
+                    --name=paas-cf \
+                    paas-cf-cloud-config/paas-cf-cloud-config.yml
 
       - task: cf-deploy
         tags: [colocated-with-web]

--- a/manifests/cloud-config/paas-cf-cloud-config.yml
+++ b/manifests/cloud-config/paas-cf-cloud-config.yml
@@ -1,18 +1,14 @@
 ---
 azs:
 - name: z1
+  cpi: aws
   cloud_properties: {availability_zone: ((terraform_outputs_zone0)) }
 - name: z2
+  cpi: aws
   cloud_properties: {availability_zone: ((terraform_outputs_zone1)) }
 - name: z3
+  cpi: aws
   cloud_properties: {availability_zone: ((terraform_outputs_zone2)) }
-
-compilation:
-  vm_type: compilation
-  az: z1
-  network: cf
-  reuse_compilation_vms: true
-  workers: 6
 
 disk_types:
 - name: 5GB
@@ -136,14 +132,6 @@ networks:
     az: z3
 
 vm_types:
-- name: compilation
-  cloud_properties:
-    iam_instance_profile: compilation-vm
-    instance_type: ((compilation_vm_instance_type))
-    ephemeral_disk:
-      size: 20480
-      type: gp2
-
 - name: nano
   cloud_properties:
     instance_type: ((nano_vm_instance_type))

--- a/manifests/cloud-config/scripts/generate-cloud-config.sh
+++ b/manifests/cloud-config/scripts/generate-cloud-config.sh
@@ -18,4 +18,4 @@ bosh interpolate \
   --vars-file="${WORKDIR}/terraform-outputs/cf.yml" \
   --vars-file="${PAAS_CF_DIR}/manifests/variables.yml" \
   ${opsfile_args} \
-  "${PAAS_CF_DIR}/manifests/cloud-config/cloud-config.yml"
+  "${PAAS_CF_DIR}/manifests/cloud-config/paas-cf-cloud-config.yml"

--- a/manifests/cloud-config/spec/compilation_spec.rb
+++ b/manifests/cloud-config/spec/compilation_spec.rb
@@ -1,16 +1,6 @@
 
 RSpec.describe "compilation" do
-  it "is defined" do
-    expect(cloud_config_with_defaults["compilation"]).not_to be_empty
-  end
-
-  it "references an existing AZ" do
-    az_list = cloud_config_with_defaults["azs"].map { |az| az["name"] }
-    expect(az_list).to include(cloud_config_with_defaults["compilation"]["az"])
-  end
-
-  it "references an existing vm_type" do
-    vm_type_list = cloud_config_with_defaults["vm_types"].map { |az| az["name"] }
-    expect(vm_type_list).to include(cloud_config_with_defaults["compilation"]["vm_type"])
+  it "is not defined" do
+    expect(cloud_config_with_defaults["compilation"]).to be_nil
   end
 end

--- a/manifests/cloud-config/spec/vm_types_spec.rb
+++ b/manifests/cloud-config/spec/vm_types_spec.rb
@@ -2,6 +2,14 @@
 RSpec.describe "vm_types" do
   let(:vm_types) { cloud_config_with_defaults.fetch("vm_types") }
 
+  describe "compilation" do
+    let(:pool) { vm_types.find { |p| p["name"] == "router" } }
+
+    it "should not exist" do
+      expect(vm_types.find { |p| p["name"] == "compilation" }).to be_nil
+    end
+  end
+
   describe "the router pool" do
     let(:pool) { vm_types.find { |p| p["name"] == "router" } }
 

--- a/manifests/prometheus/operations.d/201-monitor-bosh-internally.yml
+++ b/manifests/prometheus/operations.d/201-monitor-bosh-internally.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=bosh_exporter/properties/bosh_exporter/filter?/cidrs?
+  value: 10.0.0.0/8,127.0.0.0/8


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/168881844)

What
----

We need some cloud config to live in paas-bootstrap, so that we can move the concourse manifest to be a v2 bosh manifest.

Cloud config cannot overlap, so we have to delete some things from the cloud config in paas-cf:

- the vm definitions for compilation
- the compilation section definition

Additionally we have to specify the cpi defined in paas-bootstrap

We should name the cloud config defined in paas-cf "paas-cf" instead of "default" otherwise it is confusing.

How to review
-------------

Code review

Run this down your pipeline after https://github.com/alphagov/paas-bootstrap/pull/311

Who can review
--------------

Not @tlwr
