### PR TITLE
Update pausing of dev deployments

### DIFF
--- a/concourse/scripts/pause-kick-off.sh
+++ b/concourse/scripts/pause-kick-off.sh
@@ -30,4 +30,7 @@ $("${SCRIPT_DIR}/environment.sh")
 "${SCRIPT_DIR}/fly_sync_and_login.sh"
 FLY="$FLY_CMD -t ${FLY_TARGET}"
 
-${FLY} "${action}-resource" -r "deployment-kick-off/deployment-timer"
+VERSION="$(${FLY} resource-versions -r deployment-kick-off/deployment-timer | grep time | cut -d ' ' -f3 | head -n 1)"
+
+${FLY} "${action}-resource" -r "deployment-kick-off/deployment-timer" -v "${VERSION}"
+


### PR DESCRIPTION
What
----

Now that pinning and unpinning of dev resources is present in Concourse we can resurrect this behaviour to save money from unused dev instances.

How to review
-------------

Code review and test with
```
export VERSION="bin/fly -t $DEPLOY_ENV resource-versions -r deployment-kick-off/deployment-timer | grep time | cut -d ' ' -f3"

bin/fly -t $DEPLOY_ENV "pin-resource" -r "deployment-kick-off/deployment-timer" -v $VERSION

```
Who can review
--------------

Anyone
