### PR TITLE
Fix VPC peering for traderemedies-services

### DIFF
--- a/terraform/prod-lon.vpc_peering.json
+++ b/terraform/prod-lon.vpc_peering.json
@@ -6,7 +6,7 @@
         "subnet_cidr": "172.16.0.0/22"
     },
     {
-        "peer_name": "dit-services_datasci",
+        "peer_name": "traderemedies-services_datasci",
         "account_id": "604925858717",
         "vpc_id": "vpc-0338ce744086cd767",
         "subnet_cidr": "172.16.4.0/22"


### PR DESCRIPTION
What
----

There are two rules called dit-services_datasci, the later of which is
actually the VPC peering config for dit-services/datasci

The former rule is actually intended for traderemedies-services/datasci

See https://govuk.zendesk.com/agent/tickets/3823235 for context

For vpc peering configurations, the last entry with the correct name
wins

How to review
-------------

See this zendesk ticket: https://govuk.zendesk.com/agent/tickets/3823235

Who can review
--------------

Not @tlwr