### PR TITLE
[Firebreak] [#169004501] Concourse deploy markers in Prometheus

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -132,7 +132,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli-v2
-              tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+              tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
           run:
             path: sh
             args:
@@ -168,7 +168,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/awscli
-              tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+              tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
           run:
             path: ./paas-cf/concourse/scripts/rds_instances.sh
             args:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -378,6 +378,17 @@ resource_types:
     tag: f2a80c95481056aa57d837e3b14f0012b542fdb3
 
 resources:
+  - name: metadata
+    type: metadata
+
+  - name: overview-marker-id
+    type: s3-iam
+    source:
+      bucket: ((state_bucket))
+      region_name: ((aws_region))
+      versioned_file: overview_marker_id
+      initial_version: "-"
+
   - name: pipeline-trigger
     type: semver-iam
     source:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -4171,8 +4171,6 @@ jobs:
     serial_groups: [smoke-tests]
     build_logs_to_retain: 10000
     plan:
-      - *add-grafana-job-annotation
-
       - in_parallel:
         - get: smoke-tests-timer
           trigger: true
@@ -4251,14 +4249,10 @@ jobs:
                 CF_ADMIN: ((cf_admin))
                 CF_PASS: ((cf_pass))
 
-            - *end-grafana-job-annotation
-
   - name: continuous-billing-smoke-tests
     serial_groups: [smoke-tests]
     build_logs_to_retain: 10000
     plan:
-      - *add-grafana-job-annotation
-
       - in_parallel:
         - get: billing-smoke-tests-timer
           trigger: true
@@ -4314,8 +4308,6 @@ jobs:
                 API_ENDPOINT: ((api_endpoint))
                 CF_ADMIN: ((cf_admin))
                 CF_PASS: ((cf_pass))
-
-            - *end-grafana-job-annotation
 
   - name: check-certificates
     build_logs_to_retain: 50

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -165,7 +165,7 @@ meta:
                     --fail
                 done
     - &add-grafana-overview-annotation
-      get: overview-marker-id
+      put: metadata
       on_success:
         try:
           task: add-grafana-overview-annotation
@@ -221,8 +221,11 @@ meta:
             put: overview-marker-id
             params:
               file: marker_id/overview_marker_id
+
     - &end-grafana-overview-annotation
-      get: overview-marker-id
+      do:
+        - get: overview-marker-id
+        - put: metadata
       on_success:
         try:
           task: end-grafana-overview-annotation
@@ -3603,7 +3606,6 @@ jobs:
 
   - name: tag-release
     plan:
-      - *add-grafana-job-annotation
       - in_parallel:
           - get: pipeline-trigger
             passed: ['smoke-tests', 'acceptance-tests', 'custom-acceptance-tests', 'custom-broker-acceptance-tests', 'bosh-tests']
@@ -3641,7 +3643,7 @@ jobs:
               fi
               paas-cf/concourse/scripts/tag_release.sh \
                 "${OUTPUT_TAG_PREFIX}" "${aws_account}" "${deploy_env}" "${INPUT_TAG_PREFIX}"
-      - *end-grafana-job-annotation
+
       - *end-grafana-overview-annotation
 
   - name: pipeline-unlock

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -5,27 +5,27 @@ meta:
       type: docker-image
       source:
         repository: governmentpaas/awscli
-        tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+        tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: docker-image
       source:
         repository: governmentpaas/bosh-cli-v2
-        tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+        tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
     cf-acceptance-tests: &cf-acceptance-tests-image-resource
       type: docker-image
       source:
         repository: governmentpaas/cf-acceptance-tests
-        tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+        tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
     cf-cli: &cf-cli-image-resource
       type: docker-image
       source:
         repository: governmentpaas/cf-cli
-        tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+        tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
     git-ssh: &git-ssh-image-resource
       type: docker-image
       source:
         repository: governmentpaas/git-ssh
-        tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+        tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
     ruby-slim: &ruby-slim-image-resource
       type: docker-image
       source:
@@ -40,12 +40,12 @@ meta:
       type: docker-image
       source:
         repository: governmentpaas/terraform
-        tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+        tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
     curl-ssl: &curl-ssl-image-resource
       type: docker-image
       source:
         repository: governmentpaas/curl-ssl
-        tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+        tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
 
 groups:
   - name: deploy
@@ -467,7 +467,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/self-update-pipelines
-              tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+              tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
           inputs:
             - name: paas-cf
           params:
@@ -508,7 +508,7 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/certstrap
-                tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+                tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
             inputs:
               - name: paas-cf
               - name: ipsec-CA
@@ -960,7 +960,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/psql
-              tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+              tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
           inputs:
             - name: terraform-variables
             - name: paas-cf
@@ -2882,7 +2882,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/spruce
-              tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+              tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
           inputs:
             - name: paas-cf
             - name: paas-admin-dist
@@ -3484,7 +3484,7 @@ jobs:
           type: docker-image
           source:
             repository: governmentpaas/cf-uaac
-            tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+            tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
         inputs:
           - name: paas-cf
           - name: rotated-cf-vars-store

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -639,7 +639,7 @@ jobs:
     plan:
       - *add-grafana-job-annotation
       - *add-grafana-overview-annotation
-      - aggregate:
+      - in_parallel:
         - get: paas-cf
           trigger: ((auto_deploy))
         - get: git-ssh-private-key
@@ -738,14 +738,14 @@ jobs:
     serial_groups: [cf-deploy]
     serial: true
     plan:
-      - aggregate:
+      - in_parallel:
           - get: paas-cf
             passed: ['pipeline-lock']
           - get: pipeline-trigger
             passed: ['pipeline-lock']
             trigger: true
           - get: ipsec-CA
-      - aggregate:
+      - in_parallel:
         - task: generate-ipsec-CA
           tags: [colocated-with-web]
           config:
@@ -834,7 +834,7 @@ jobs:
 
   - name: pre-deploy
     plan:
-      - aggregate:
+      - in_parallel:
           - get: pipeline-trigger
             passed: ['generate-secrets']
             trigger: true
@@ -928,7 +928,7 @@ jobs:
   - name: app-availability-tests
     serial: true
     plan:
-      - aggregate:
+      - in_parallel:
           - get: pipeline-trigger
             passed: ['generate-secrets']
             trigger: true
@@ -976,7 +976,7 @@ jobs:
   - name: api-availability-tests
     serial: true
     plan:
-      - aggregate:
+      - in_parallel:
           - get: pipeline-trigger
             passed: ['generate-secrets']
             trigger: true
@@ -1074,7 +1074,7 @@ jobs:
     serial: true
     plan:
       - *add-grafana-job-annotation
-      - aggregate:
+      - in_parallel:
           - get: paas-cf
             passed: ['pre-deploy']
           - get: pipeline-trigger
@@ -1229,7 +1229,7 @@ jobs:
     serial: true
     plan:
       - *add-grafana-job-annotation
-      - aggregate:
+      - in_parallel:
           - get: pipeline-trigger
             passed: ['cf-terraform']
             trigger: true
@@ -1241,7 +1241,7 @@ jobs:
           - get: cf-tfstate
             passed: ['cf-terraform']
 
-      - aggregate:
+      - in_parallel:
         - task: extract-terraform-outputs
           tags: [colocated-with-web]
           config:
@@ -1388,7 +1388,7 @@ jobs:
                     > cf-manifest-pre-vars/cf-manifest-pre-vars.yml
 
           on_success:
-            aggregate:
+            in_parallel:
             - put: cf-manifest
               params:
                 file: cf-manifest/cf-manifest.yml
@@ -1402,7 +1402,7 @@ jobs:
     serial: true
     plan:
       - *add-grafana-job-annotation
-      - aggregate:
+      - in_parallel:
           - get: pipeline-trigger
             passed: ['generate-cf-config']
             trigger: true
@@ -1415,7 +1415,7 @@ jobs:
           - get: cf-tfstate
             passed: ['generate-cf-config']
 
-      - aggregate:
+      - in_parallel:
         - task: get-and-upload-stemcell
           tags: [colocated-with-web]
           config:
@@ -1596,7 +1596,7 @@ jobs:
     plan:
       - *add-grafana-job-annotation
 
-      - aggregate:
+      - in_parallel:
           - get: pipeline-trigger
             passed: ['cf-deploy']
             trigger: true
@@ -1756,7 +1756,7 @@ jobs:
                 echo 'Accessible secrets'
                 credhub find --path /concourse/main/create-cloudfoundry
 
-      - aggregate:
+      - in_parallel:
         - task: deploy-cloudwatch-exporter
           tags: [colocated-with-web]
           config:
@@ -1856,7 +1856,7 @@ jobs:
     serial: true
     plan:
     - *add-grafana-job-annotation
-    - aggregate:
+    - in_parallel:
       - get: pipeline-trigger
         passed: ['cf-deploy']
         trigger: true
@@ -1907,7 +1907,7 @@ jobs:
 
               ls -l config/*
 
-    - aggregate:
+    - in_parallel:
       - task: upload-buildpacks
         tags: [colocated-with-web]
         config:
@@ -2251,7 +2251,7 @@ jobs:
               - |
                 ./paas-cf/concourse/scripts/uaa_set_email_domains.sh '["*.*", "*.*.*", "*.*.*.*", "*.*.*.*.*", "*.*.*.*.*.*"]'
 
-    - aggregate:
+    - in_parallel:
       - task: block-create-account-endpoints
         tags: [colocated-with-web]
         config:
@@ -2503,7 +2503,7 @@ jobs:
 
                   bosh run-errand rotate-cc-database-key --when-changed
 
-    - aggregate:
+    - in_parallel:
       - task: deploy-aiven-service-broker
         tags: [colocated-with-web]
         config:
@@ -2647,7 +2647,7 @@ jobs:
     serial_groups: [smoke-tests]
     plan:
       - *add-grafana-job-annotation
-      - aggregate:
+      - in_parallel:
           - get: pipeline-trigger
             passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
             trigger: true
@@ -2697,7 +2697,7 @@ jobs:
   - name: acceptance-tests
     plan:
       - *add-grafana-job-annotation
-      - aggregate:
+      - in_parallel:
           - get: pipeline-trigger
             passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
             trigger: true
@@ -2762,7 +2762,7 @@ jobs:
   - name: custom-acceptance-tests
     plan:
       - *add-grafana-job-annotation
-      - aggregate:
+      - in_parallel:
           - get: pipeline-trigger
             passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
             trigger: true
@@ -2791,7 +2791,7 @@ jobs:
             NAME_PREFIX: ACC
             TEST_USER_PASSWORD: ((secrets_test_user_password))
 
-        - aggregate:
+        - in_parallel:
           - task: "Run custom acceptance tests"
             tags: [colocated-with-web]
             file: paas-cf/concourse/tasks/custom-acceptance-tests-run.yml
@@ -2887,7 +2887,7 @@ jobs:
   - name: custom-broker-acceptance-tests
     plan:
       - *add-grafana-job-annotation
-      - aggregate:
+      - in_parallel:
           - get: pipeline-trigger
             passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
             trigger: true
@@ -2916,7 +2916,7 @@ jobs:
             NAME_PREFIX: BACC
             TEST_USER_PASSWORD: ((secrets_test_user_password))
 
-        - aggregate:
+        - in_parallel:
           - task: "Run broker custom acceptance tests"
             tags: [colocated-with-web]
             file: paas-cf/concourse/tasks/custom-broker-acceptance-tests-run.yml
@@ -2946,7 +2946,7 @@ jobs:
 
   - name: bosh-tests
     plan:
-      - aggregate:
+      - in_parallel:
           - get: pipeline-trigger
             passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
             trigger: true
@@ -2992,7 +2992,7 @@ jobs:
       - get: paas-accounts
         trigger: true
 
-      - aggregate:
+      - in_parallel:
         - get: paas-cf
           trigger: true
           passed: ['post-deploy']
@@ -3109,7 +3109,7 @@ jobs:
       - get: paas-admin
         trigger: true
 
-      - aggregate:
+      - in_parallel:
         - get: paas-cf
           trigger: true
           passed: ['post-deploy']
@@ -3360,7 +3360,7 @@ jobs:
       - get: paas-billing
         trigger: true
 
-      - aggregate:
+      - in_parallel:
         - get: paas-cf
           trigger: true
           passed: ['post-deploy']
@@ -3604,7 +3604,7 @@ jobs:
   - name: tag-release
     plan:
       - *add-grafana-job-annotation
-      - aggregate:
+      - in_parallel:
           - get: pipeline-trigger
             passed: ['smoke-tests', 'acceptance-tests', 'custom-acceptance-tests', 'custom-broker-acceptance-tests', 'bosh-tests']
             trigger: true
@@ -3726,7 +3726,7 @@ jobs:
     serial: true
     serial_groups: [smoke-tests]
     plan:
-    - aggregate:
+    - in_parallel:
       - get: paas-cf
       - get: cf-vars-store
 
@@ -3792,7 +3792,7 @@ jobs:
     serial: true
     serial_groups: [smoke-tests]
     plan:
-    - aggregate:
+    - in_parallel:
       - get: paas-cf
         passed: ['rotate-cf-admin-password']
       - get: cf-vars-store
@@ -3879,7 +3879,7 @@ jobs:
   - name: rotate-database-encryption-keys
     serial: true
     plan:
-    - aggregate:
+    - in_parallel:
       - get: paas-cf
       - get: cf-vars-store
       - get: cf-manifest-pre-vars
@@ -3918,7 +3918,7 @@ jobs:
   - name: rotate-prometheus-credentials
     serial: true
     plan:
-    - aggregate:
+    - in_parallel:
       - get: paas-cf
       - get: prometheus-vars-store
       - get: prometheus-manifest-pre-vars
@@ -3956,7 +3956,7 @@ jobs:
   - name: expire-aws-keys
     serial: true
     plan:
-    - aggregate:
+    - in_parallel:
       - get: paas-cf
       - get: cf-tfstate
       - get: expire-aws-keys-timer
@@ -3974,7 +3974,7 @@ jobs:
   - name: rotate-cf-certs-cas
     serial: true
     plan:
-    - aggregate:
+    - in_parallel:
       - get: paas-cf
       - get: cf-manifest-pre-vars
       - get: cf-vars-store
@@ -4007,7 +4007,7 @@ jobs:
   - name: rotate-cf-certs-leafs
     serial: true
     plan:
-    - aggregate:
+    - in_parallel:
       - get: paas-cf
       - get: cf-manifest-pre-vars
       - get: cf-vars-store
@@ -4040,7 +4040,7 @@ jobs:
   - name: set-smoke-test-creds
     serial: true
     plan:
-    - aggregate:
+    - in_parallel:
       - get: paas-cf
       - get: cf-vars-store
     - task: retrieve-config
@@ -4084,7 +4084,7 @@ jobs:
   - name: delete-old-cf-certs
     serial: true
     plan:
-    - aggregate:
+    - in_parallel:
       - get: paas-cf
       - get: cf-manifest-pre-vars
       - get: cf-vars-store
@@ -4173,7 +4173,7 @@ jobs:
     plan:
       - *add-grafana-job-annotation
 
-      - aggregate:
+      - in_parallel:
         - get: smoke-tests-timer
           trigger: true
         - get: deployed-healthcheck
@@ -4242,7 +4242,7 @@ jobs:
               TEST_ARTIFACTS_BUCKET: ((test_artifacts_bucket))
 
         ensure:
-          aggregate:
+          in_parallel:
             - task: remove-temp-user
               tags: [colocated-with-web]
               file: paas-cf/concourse/tasks/delete_admin.yml
@@ -4259,7 +4259,7 @@ jobs:
     plan:
       - *add-grafana-job-annotation
 
-      - aggregate:
+      - in_parallel:
         - get: billing-smoke-tests-timer
           trigger: true
         - get: paas-billing
@@ -4306,7 +4306,7 @@ jobs:
                   make acceptance
 
         ensure:
-          aggregate:
+          in_parallel:
             - task: remove-temp-user
               tags: [colocated-with-web]
               file: paas-cf/concourse/tasks/delete_admin.yml
@@ -4320,7 +4320,7 @@ jobs:
   - name: check-certificates
     build_logs_to_retain: 50
     plan:
-      - aggregate:
+      - in_parallel:
         - get: check-certificates-timer
           trigger: true
         - get: paas-cf
@@ -4359,7 +4359,7 @@ jobs:
   - name: cleanup-deleted-cf-users
     serial: true
     plan:
-      - aggregate:
+      - in_parallel:
         - get: paas-cf
 
       - task: cleanup-deleted-cf-users

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -638,6 +638,8 @@ jobs:
   - name: pipeline-lock
     serial: true
     plan:
+      - *add-grafana-job-annotation
+      - *add-grafana-overview-annotation
       - aggregate:
         - get: paas-cf
           trigger: ((auto_deploy))
@@ -731,11 +733,13 @@ jobs:
             path: ./paas-cf/concourse/scripts/self-update-pipeline.sh
       - put: pipeline-trigger
         params: {bump: patch}
+      - *end-grafana-job-annotation
 
   - name: generate-secrets
     serial_groups: [cf-deploy]
     serial: true
     plan:
+      - *add-grafana-job-annotation
       - aggregate:
           - get: paas-cf
             passed: ['pipeline-lock']
@@ -829,9 +833,11 @@ jobs:
                     value=$(credhub get --name "/concourse/main/$secret_name" --quiet)
                     credhub set --type password --name "/$DEPLOY_ENV/$DEPLOY_ENV/$secret_name" --password "$value"
                   done
+      - *end-grafana-job-annotation
 
   - name: pre-deploy
     plan:
+      - *add-grafana-job-annotation
       - aggregate:
           - get: pipeline-trigger
             passed: ['generate-secrets']
@@ -922,10 +928,12 @@ jobs:
 
                 echo "timeout waiting for api-availability-tests job to start"
                 exit 1
+      - *end-grafana-job-annotation
 
   - name: app-availability-tests
     serial: true
     plan:
+      - *add-grafana-job-annotation
       - aggregate:
           - get: pipeline-trigger
             passed: ['generate-secrets']
@@ -970,10 +978,12 @@ jobs:
 
                 echo "Running app-availability-tests"
                 ./paas-cf/platform-tests/run_tests.sh ./paas-cf/platform-tests/src/platform/availability/app
+      - *end-grafana-job-annotation
 
   - name: api-availability-tests
     serial: true
     plan:
+      - *add-grafana-job-annotation
       - aggregate:
           - get: pipeline-trigger
             passed: ['generate-secrets']
@@ -1066,11 +1076,13 @@ jobs:
                   PIPELINE_TRIGGER_VERSION=$(cat pipeline-trigger/number)
                   JOB_FILE="jobs/${PIPELINE_TRIGGER_VERSION}/api-availability-tests"
                   aws s3 rm "s3://((state_bucket))/${JOB_FILE}"
+      - *end-grafana-job-annotation
 
   - name: cf-terraform
     serial_groups: [cf-deploy]
     serial: true
     plan:
+      - *add-grafana-job-annotation
       - aggregate:
           - get: paas-cf
             passed: ['pre-deploy']
@@ -1219,11 +1231,13 @@ jobs:
                 . cf-terraform-outputs/cf.tfstate.sh
 
                 paas-cf/manifests/cf-manifest/scripts/create-cf-dbs.sh
+      - *end-grafana-job-annotation
 
   - name: generate-cf-config
     serial_groups: [cf-deploy]
     serial: true
     plan:
+      - *add-grafana-job-annotation
       - aggregate:
           - get: pipeline-trigger
             passed: ['cf-terraform']
@@ -1390,11 +1404,12 @@ jobs:
             - put: cf-manifest-pre-vars
               params:
                 file: cf-manifest-pre-vars/cf-manifest-pre-vars.yml
-
+      - *end-grafana-job-annotation
   - name: cf-deploy
     serial_groups: [cf-deploy]
     serial: true
     plan:
+      - *add-grafana-job-annotation
       - aggregate:
           - get: pipeline-trigger
             passed: ['generate-cf-config']
@@ -1582,10 +1597,13 @@ jobs:
 
                 echo 'Accessible secrets'
                 credhub find --path "${TEAM_NS}"
+      - *end-grafana-job-annotation
 
   - name: prometheus-deploy
     serial: true
     plan:
+      - *add-grafana-job-annotation
+
       - aggregate:
           - get: pipeline-trigger
             passed: ['cf-deploy']
@@ -1840,9 +1858,12 @@ jobs:
             SLIM_DEV_DEPLOYMENT: ((slim_dev_deployment))
             GRAFANA_PASS: ((grafana_password))
 
+      - *end-grafana-job-annotation
+
   - name: post-deploy
     serial: true
     plan:
+    - *add-grafana-job-annotation
     - aggregate:
       - get: pipeline-trigger
         passed: ['cf-deploy']
@@ -2628,10 +2649,11 @@ jobs:
                 delete_unused_keys ses_smtp_aws_access_key_id "ses-smtp-${DEPLOY_ENV}"
                 delete_unused_keys metrics_exporter_aws_access_key_id "metrics-exporter-${DEPLOY_ENV}"
                 delete_unused_keys yace_aws_access_key_id "yace-${DEPLOY_ENV}"
-
+    - *end-grafana-job-annotation
   - name: smoke-tests
     serial_groups: [smoke-tests]
     plan:
+      - *add-grafana-job-annotation
       - aggregate:
           - get: pipeline-trigger
             passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
@@ -2677,9 +2699,11 @@ jobs:
             API_ENDPOINT: ((api_endpoint))
             CF_ADMIN: ((cf_admin))
             CF_PASS: ((cf_pass))
+      - *end-grafana-job-annotation
 
   - name: acceptance-tests
     plan:
+      - *add-grafana-job-annotation
       - aggregate:
           - get: pipeline-trigger
             passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
@@ -2740,9 +2764,11 @@ jobs:
               API_ENDPOINT: ((api_endpoint))
               CF_ADMIN: ((cf_admin))
               CF_PASS: ((cf_pass))
+      - *end-grafana-job-annotation
 
   - name: custom-acceptance-tests
     plan:
+      - *add-grafana-job-annotation
       - aggregate:
           - get: pipeline-trigger
             passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
@@ -2863,9 +2889,11 @@ jobs:
             API_ENDPOINT: ((api_endpoint))
             CF_ADMIN: ((cf_admin))
             CF_PASS: ((cf_pass))
+      - *end-grafana-job-annotation
 
   - name: custom-broker-acceptance-tests
     plan:
+      - *add-grafana-job-annotation
       - aggregate:
           - get: pipeline-trigger
             passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
@@ -2921,9 +2949,11 @@ jobs:
             API_ENDPOINT: ((api_endpoint))
             CF_ADMIN: ((cf_admin))
             CF_PASS: ((cf_pass))
+      - *end-grafana-job-annotation
 
   - name: bosh-tests
     plan:
+      - *add-grafana-job-annotation
       - aggregate:
           - get: pipeline-trigger
             passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
@@ -2962,10 +2992,12 @@ jobs:
                 else
                   echo "Success: All VMs are up and running."
                 fi
+      - *end-grafana-job-annotation
 
   - name: deploy-paas-accounts
     serial: true
     plan:
+      - *add-grafana-job-annotation
       - get: paas-accounts
         trigger: true
 
@@ -3077,10 +3109,12 @@ jobs:
 
                 done
                 )
+      - *end-grafana-job-annotation
 
   - name: deploy-paas-admin
     serial: true
     plan:
+      - *add-grafana-job-annotation
       - get: paas-admin
         trigger: true
 
@@ -3326,10 +3360,12 @@ jobs:
 
                 echo "Pushing tag refs/tags/${new_tag} to ${REPO}"
                 git push tag_origin "refs/tags/${new_tag}"
+      - *end-grafana-job-annotation
 
   - name: deploy-paas-billing
     serial: true
     plan:
+      - *add-grafana-job-annotation
       - get: paas-billing
         trigger: true
 
@@ -3466,10 +3502,12 @@ jobs:
                 export BILLING_API_URL="https://billing.${SYSTEM_DNS_ZONE_NAME}"
                 cd src/github.com/alphagov/paas-billing
                 make acceptance
+      - *end-grafana-job-annotation
 
   - name: deploy-paas-metrics
     serial: true
     plan:
+      - *add-grafana-job-annotation
       - get: paas-cf
         trigger: true
         passed: ['post-deploy']
@@ -3570,9 +3608,11 @@ jobs:
                 echo 'Waiting 2 minutes before running the acceptance tests'
                 sleep 120
                 ginkgo
+      - *end-grafana-job-annotation
 
   - name: tag-release
     plan:
+      - *add-grafana-job-annotation
       - aggregate:
           - get: pipeline-trigger
             passed: ['smoke-tests', 'acceptance-tests', 'custom-acceptance-tests', 'custom-broker-acceptance-tests', 'bosh-tests']
@@ -3610,10 +3650,13 @@ jobs:
               fi
               paas-cf/concourse/scripts/tag_release.sh \
                 "${OUTPUT_TAG_PREFIX}" "${aws_account}" "${deploy_env}" "${INPUT_TAG_PREFIX}"
+      - *end-grafana-job-annotation
+      - *end-grafana-overview-annotation
 
   - name: pipeline-unlock
     serial: true
     plan:
+      - *add-grafana-job-annotation
       - get: pipeline-trigger
         passed: ['tag-release']
         trigger: true
@@ -3644,9 +3687,11 @@ jobs:
             put: pipeline-pool
             params:
               release: pipeline-pool
+      - *end-grafana-job-annotation
 
   - name: pipeline-check-lock
     plan:
+      - *add-grafana-job-annotation
       - get: pipeline-pool
       - task: print-pipeline-lock-state
         tags: [colocated-with-web]
@@ -3679,13 +3724,16 @@ jobs:
                - %cr at %ci
                - %s
               "
+      - *end-grafana-job-annotation
 
   - name: pipeline-release-lock
     plan:
+      - *add-grafana-job-annotation
       - get: pipeline-pool
       - put: pipeline-pool
         params:
           release: pipeline-pool
+      - *end-grafana-job-annotation
 
   - name: rotate-cf-admin-password
     serial: true

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -932,7 +932,6 @@ jobs:
   - name: app-availability-tests
     serial: true
     plan:
-      - *add-grafana-job-annotation
       - aggregate:
           - get: pipeline-trigger
             passed: ['generate-secrets']
@@ -977,12 +976,10 @@ jobs:
 
                 echo "Running app-availability-tests"
                 ./paas-cf/platform-tests/run_tests.sh ./paas-cf/platform-tests/src/platform/availability/app
-      - *end-grafana-job-annotation
 
   - name: api-availability-tests
     serial: true
     plan:
-      - *add-grafana-job-annotation
       - aggregate:
           - get: pipeline-trigger
             passed: ['generate-secrets']
@@ -1075,7 +1072,6 @@ jobs:
                   PIPELINE_TRIGGER_VERSION=$(cat pipeline-trigger/number)
                   JOB_FILE="jobs/${PIPELINE_TRIGGER_VERSION}/api-availability-tests"
                   aws s3 rm "s3://((state_bucket))/${JOB_FILE}"
-      - *end-grafana-job-annotation
 
   - name: cf-terraform
     serial_groups: [cf-deploy]

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -106,9 +106,9 @@ meta:
                       --data "${post_data}" \
                       --silent \
                       --fail)"
-                    echo -ne "${response}" | jq '.id' > "annotation_details/${az}"
+                    echo "${response}" | jq '.id' > "annotation_details/${az}"
                   done
-                  echo -ne ${START_TIME} > "annotation_details/start_time"
+                  echo "${START_TIME}" > "annotation_details/start_time"
     - &end-grafana-job-annotation
       try:
         task: end-grafana-job-annotation
@@ -157,7 +157,7 @@ meta:
                 )"
                 for az in $(seq 1 ${AZ_COUNT}); do
                   curl --request PUT \
-                    --url "https://grafana-${az}.${SYSTEM_DNS_ZONE_NAME}/api/annotations/$(cat annotation_details/${az})" \
+                    --url "https://grafana-${az}.${SYSTEM_DNS_ZONE_NAME}/api/annotations/$(cat "annotation_details/${az}")" \
                     --user "admin:${GRAFANA_PASS}" \
                     --header 'content-type: application/json' \
                     --data "${patch_data}" \
@@ -207,7 +207,6 @@ meta:
                   }
                   DATA
                   )"
-                  echo -ne > marker_id/marker_id
                   for az in $(seq 1 ${AZ_COUNT}); do
                     response="$(curl --request POST \
                       --url "https://grafana-${az}.${SYSTEM_DNS_ZONE_NAME}/api/annotations" \
@@ -216,7 +215,7 @@ meta:
                       --data "${post_data}" \
                       --silent \
                       --fail)"
-                    echo -ne "${response}" | jq '.id' >> "marker_id/overview_marker_id"
+                    echo "${response}" | jq '.id' >> "marker_id/overview_marker_id"
                   done
           on_success:
             put: overview-marker-id

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -637,7 +637,6 @@ jobs:
   - name: pipeline-lock
     serial: true
     plan:
-      - *add-grafana-overview-annotation
       - in_parallel:
         - get: paas-cf
           trigger: ((auto_deploy))
@@ -729,6 +728,9 @@ jobs:
             CONCOURSE_WEB_PASSWORD: ((concourse_web_password))
           run:
             path: ./paas-cf/concourse/scripts/self-update-pipeline.sh
+
+      - *add-grafana-overview-annotation
+
       - put: pipeline-trigger
         params: {bump: patch}
 

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -738,7 +738,6 @@ jobs:
     serial_groups: [cf-deploy]
     serial: true
     plan:
-      - *add-grafana-job-annotation
       - aggregate:
           - get: paas-cf
             passed: ['pipeline-lock']
@@ -832,11 +831,9 @@ jobs:
                     value=$(credhub get --name "/concourse/main/$secret_name" --quiet)
                     credhub set --type password --name "/$DEPLOY_ENV/$DEPLOY_ENV/$secret_name" --password "$value"
                   done
-      - *end-grafana-job-annotation
 
   - name: pre-deploy
     plan:
-      - *add-grafana-job-annotation
       - aggregate:
           - get: pipeline-trigger
             passed: ['generate-secrets']
@@ -927,7 +924,6 @@ jobs:
 
                 echo "timeout waiting for api-availability-tests job to start"
                 exit 1
-      - *end-grafana-job-annotation
 
   - name: app-availability-tests
     serial: true
@@ -1400,6 +1396,7 @@ jobs:
               params:
                 file: cf-manifest-pre-vars/cf-manifest-pre-vars.yml
       - *end-grafana-job-annotation
+
   - name: cf-deploy
     serial_groups: [cf-deploy]
     serial: true
@@ -2645,6 +2642,7 @@ jobs:
                 delete_unused_keys metrics_exporter_aws_access_key_id "metrics-exporter-${DEPLOY_ENV}"
                 delete_unused_keys yace_aws_access_key_id "yace-${DEPLOY_ENV}"
     - *end-grafana-job-annotation
+
   - name: smoke-tests
     serial_groups: [smoke-tests]
     plan:
@@ -2948,7 +2946,6 @@ jobs:
 
   - name: bosh-tests
     plan:
-      - *add-grafana-job-annotation
       - aggregate:
           - get: pipeline-trigger
             passed: ['post-deploy','prometheus-deploy','app-availability-tests','api-availability-tests']
@@ -2987,7 +2984,6 @@ jobs:
                 else
                   echo "Success: All VMs are up and running."
                 fi
-      - *end-grafana-job-annotation
 
   - name: deploy-paas-accounts
     serial: true
@@ -3686,7 +3682,6 @@ jobs:
 
   - name: pipeline-check-lock
     plan:
-      - *add-grafana-job-annotation
       - get: pipeline-pool
       - task: print-pipeline-lock-state
         tags: [colocated-with-web]
@@ -3719,16 +3714,13 @@ jobs:
                - %cr at %ci
                - %s
               "
-      - *end-grafana-job-annotation
 
   - name: pipeline-release-lock
     plan:
-      - *add-grafana-job-annotation
       - get: pipeline-pool
       - put: pipeline-pool
         params:
           release: pipeline-pool
-      - *end-grafana-job-annotation
 
   - name: rotate-cf-admin-password
     serial: true

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -637,7 +637,6 @@ jobs:
   - name: pipeline-lock
     serial: true
     plan:
-      - *add-grafana-job-annotation
       - *add-grafana-overview-annotation
       - in_parallel:
         - get: paas-cf
@@ -732,7 +731,6 @@ jobs:
             path: ./paas-cf/concourse/scripts/self-update-pipeline.sh
       - put: pipeline-trigger
         params: {bump: patch}
-      - *end-grafana-job-annotation
 
   - name: generate-secrets
     serial_groups: [cf-deploy]
@@ -3647,7 +3645,6 @@ jobs:
   - name: pipeline-unlock
     serial: true
     plan:
-      - *add-grafana-job-annotation
       - get: pipeline-trigger
         passed: ['tag-release']
         trigger: true
@@ -3678,7 +3675,6 @@ jobs:
             put: pipeline-pool
             params:
               release: pipeline-pool
-      - *end-grafana-job-annotation
 
   - name: pipeline-check-lock
     plan:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -4171,6 +4171,8 @@ jobs:
     serial_groups: [smoke-tests]
     build_logs_to_retain: 10000
     plan:
+      - *add-grafana-job-annotation
+
       - aggregate:
         - get: smoke-tests-timer
           trigger: true
@@ -4240,18 +4242,23 @@ jobs:
               TEST_ARTIFACTS_BUCKET: ((test_artifacts_bucket))
 
         ensure:
-          task: remove-temp-user
-          tags: [colocated-with-web]
-          file: paas-cf/concourse/tasks/delete_admin.yml
-          params:
-            API_ENDPOINT: ((api_endpoint))
-            CF_ADMIN: ((cf_admin))
-            CF_PASS: ((cf_pass))
+          aggregate:
+            - task: remove-temp-user
+              tags: [colocated-with-web]
+              file: paas-cf/concourse/tasks/delete_admin.yml
+              params:
+                API_ENDPOINT: ((api_endpoint))
+                CF_ADMIN: ((cf_admin))
+                CF_PASS: ((cf_pass))
+
+            - *end-grafana-job-annotation
 
   - name: continuous-billing-smoke-tests
     serial_groups: [smoke-tests]
     build_logs_to_retain: 10000
     plan:
+      - *add-grafana-job-annotation
+
       - aggregate:
         - get: billing-smoke-tests-timer
           trigger: true
@@ -4299,13 +4306,16 @@ jobs:
                   make acceptance
 
         ensure:
-          task: remove-temp-user
-          tags: [colocated-with-web]
-          file: paas-cf/concourse/tasks/delete_admin.yml
-          params:
-            API_ENDPOINT: ((api_endpoint))
-            CF_ADMIN: ((cf_admin))
-            CF_PASS: ((cf_pass))
+          aggregate:
+            - task: remove-temp-user
+              tags: [colocated-with-web]
+              file: paas-cf/concourse/tasks/delete_admin.yml
+              params:
+                API_ENDPOINT: ((api_endpoint))
+                CF_ADMIN: ((cf_admin))
+                CF_PASS: ((cf_pass))
+
+            - *end-grafana-job-annotation
 
   - name: check-certificates
     build_logs_to_retain: 50

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -47,6 +47,233 @@ meta:
         repository: governmentpaas/curl-ssl
         tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
 
+  tasks:
+    - &add-grafana-job-annotation
+      put: metadata
+      on_success:
+        try:
+          task: add-grafana-job-annotation
+          tags: [colocated-with-web]
+          config:
+            platform: linux
+            image_resource: *curl-ssl-image-resource
+            inputs:
+              - name: metadata
+            outputs:
+              - name: annotation_details
+            params:
+                  SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+                  DEPLOY_ENV: ((deploy_env))
+                  SLIM_DEV_DEPLOYMENT: ((slim_dev_deployment))
+                  GRAFANA_PASS: ((grafana_password))
+            run:
+              path: sh
+              args:
+                - -e
+                - -u
+                - -c
+                - |
+                  AZ_COUNT=2
+                  if [ "${SLIM_DEV_DEPLOYMENT}" = "true" ]; then
+                    AZ_COUNT=1
+                  fi
+                  START_TIME=$(date +%s000)
+                  BUILD_PIPELINE_NAME=$(cat metadata/build_pipeline_name)
+                  BUILD_JOB_NAME=$(cat metadata/build_job_name)
+                  BUILD_NAME=$(cat metadata/build_name)
+                  post_data="$(cat <<DATA
+                  {
+                    "tags": [
+                      "deployment",
+                      "concourse",
+                      "incomplete",
+                      "${BUILD_PIPELINE_NAME}",
+                      "${BUILD_JOB_NAME}",
+                      "BUILD_ID=${BUILD_NAME}"
+                    ],
+                    "time": ${START_TIME},
+                    "isRegion": true,
+                    "timeEnd": ${START_TIME},
+                    "text": "Started ${BUILD_PIPELINE_NAME}/${BUILD_JOB_NAME} #${BUILD_NAME}"
+                  }
+                  DATA
+                  )"
+                  for az in $(seq 1 ${AZ_COUNT}); do
+                    response="$(curl --request POST \
+                      --url "https://grafana-${az}.${SYSTEM_DNS_ZONE_NAME}/api/annotations" \
+                      --user "admin:${GRAFANA_PASS}" \
+                      --header 'content-type: application/json' \
+                      --data "${post_data}" \
+                      --silent \
+                      --fail)"
+                    echo -ne "${response}" | jq '.id' > "annotation_details/${az}"
+                  done
+                  echo -ne ${START_TIME} > "annotation_details/start_time"
+    - &end-grafana-job-annotation
+      try:
+        task: end-grafana-job-annotation
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *curl-ssl-image-resource
+          inputs:
+            - name: metadata
+            - name: annotation_details
+          params:
+                SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+                DEPLOY_ENV: ((deploy_env))
+                SLIM_DEV_DEPLOYMENT: ((slim_dev_deployment))
+                GRAFANA_PASS: ((grafana_password))
+          run:
+            path: sh
+            args:
+              - -e
+              - -u
+              - -c
+              - |
+                AZ_COUNT=2
+                if [ "${SLIM_DEV_DEPLOYMENT}" = "true" ]; then
+                  AZ_COUNT=1
+                fi
+                BUILD_PIPELINE_NAME=$(cat metadata/build_pipeline_name)
+                BUILD_JOB_NAME=$(cat metadata/build_job_name)
+                BUILD_NAME=$(cat metadata/build_name)
+                patch_data="$(cat <<DATA
+                {
+                  "tags": [
+                    "deployment",
+                    "concourse",
+                    "completed",
+                    "${BUILD_PIPELINE_NAME}",
+                    "${BUILD_JOB_NAME}",
+                    "BUILD_ID=${BUILD_NAME}"
+                  ],
+                  "text": "${BUILD_PIPELINE_NAME}/${BUILD_JOB_NAME} #${BUILD_NAME}",
+                  "time": $(cat annotation_details/start_time),
+                  "isRegion": true,
+                  "timeEnd": $(date +%s000)
+                }
+                DATA
+                )"
+                for az in $(seq 1 ${AZ_COUNT}); do
+                  curl --request PUT \
+                    --url "https://grafana-${az}.${SYSTEM_DNS_ZONE_NAME}/api/annotations/$(cat annotation_details/${az})" \
+                    --user "admin:${GRAFANA_PASS}" \
+                    --header 'content-type: application/json' \
+                    --data "${patch_data}" \
+                    --silent \
+                    --fail
+                done
+    - &add-grafana-overview-annotation
+      get: overview-marker-id
+      on_success:
+        try:
+          task: add-grafana-overview-annotation
+          tags: [colocated-with-web]
+          config:
+            platform: linux
+            image_resource: *curl-ssl-image-resource
+            inputs:
+              - name: metadata
+            outputs:
+              - name: marker_id
+            params:
+                  SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+                  DEPLOY_ENV: ((deploy_env))
+                  SLIM_DEV_DEPLOYMENT: ((slim_dev_deployment))
+                  GRAFANA_PASS: ((grafana_password))
+            run:
+              path: sh
+              args:
+                - -e
+                - -u
+                - -c
+                - |
+                  AZ_COUNT=2
+                  if [ "${SLIM_DEV_DEPLOYMENT}" = "true" ]; then
+                    AZ_COUNT=1
+                  fi
+                  BUILD_PIPELINE_NAME=$(cat metadata/build_pipeline_name)
+                  post_data="$(cat <<DATA
+                  {
+                    "tags": [
+                      "deployment-overview",
+                      "concourse",
+                      "incomplete",
+                      "${BUILD_PIPELINE_NAME}"
+                    ],
+                    "isRegion": true,
+                    "text": "Deployment of ${BUILD_PIPELINE_NAME} started"
+                  }
+                  DATA
+                  )"
+                  echo -ne > marker_id/marker_id
+                  for az in $(seq 1 ${AZ_COUNT}); do
+                    response="$(curl --request POST \
+                      --url "https://grafana-${az}.${SYSTEM_DNS_ZONE_NAME}/api/annotations" \
+                      --user "admin:${GRAFANA_PASS}" \
+                      --header 'content-type: application/json' \
+                      --data "${post_data}" \
+                      --silent \
+                      --fail)"
+                    echo -ne "${response}" | jq '.id' >> "marker_id/overview_marker_id"
+                  done
+          on_success:
+            put: overview-marker-id
+            params:
+              file: marker_id/overview_marker_id
+    - &end-grafana-overview-annotation
+      get: overview-marker-id
+      on_success:
+        try:
+          task: end-grafana-overview-annotation
+          tags: [colocated-with-web]
+          config:
+            platform: linux
+            image_resource: *curl-ssl-image-resource
+            inputs:
+              - name: metadata
+              - name: overview-marker-id
+            params:
+                  SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+                  DEPLOY_ENV: ((deploy_env))
+                  SLIM_DEV_DEPLOYMENT: ((slim_dev_deployment))
+                  GRAFANA_PASS: ((grafana_password))
+            run:
+              path: sh
+              args:
+                - -e
+                - -u
+                - -c
+                - |
+                  AZ_COUNT=2
+                  if [ "${SLIM_DEV_DEPLOYMENT}" = "true" ]; then
+                    AZ_COUNT=1
+                  fi
+                  BUILD_PIPELINE_NAME=$(cat metadata/build_pipeline_name)
+                  patch_data="$(cat <<DATA
+                  {
+                    "tags": [
+                      "deployment-overview",
+                      "concourse",
+                      "completed",
+                      "${BUILD_PIPELINE_NAME}"
+                    ],
+                    "timeEnd": $(date +%s000),
+                    "text": "Deployment of ${BUILD_PIPELINE_NAME}"
+                  }
+                  DATA
+                  )"
+                  for az in $(seq 1 ${AZ_COUNT}); do
+                    this_grafana_annotation_id=$(sed -n "${az}p" overview-marker-id/overview_marker_id)
+                    curl --request PATCH \
+                      --url "https://grafana-${az}.${SYSTEM_DNS_ZONE_NAME}/api/annotations/${this_grafana_annotation_id}" \
+                      --user "admin:${GRAFANA_PASS}" \
+                      --header 'content-type: application/json' \
+                      --data "${patch_data}" \
+                      --silent \
+                      --fail
+                  done
 groups:
   - name: deploy
     jobs:
@@ -132,6 +359,12 @@ groups:
       - delete-old-cf-certs
       - set-smoke-test-creds
 resource_types:
+- name: metadata
+  type: docker-image
+  source:
+    repository: olhtbr/metadata-resource
+    tag: 2.0.1
+
 - name: s3-iam
   type: docker-image
   source:

--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -61,7 +61,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/awscli
-              tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+              tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
           run:
             path: ./paas-cf/concourse/scripts/rds_instances.sh
             args:
@@ -75,7 +75,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/self-update-pipelines
-              tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+              tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
           inputs:
             - name: paas-cf
           params:
@@ -107,7 +107,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/self-update-pipelines
-              tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+              tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
           inputs:
             - name: paas-cf
           params:

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -90,7 +90,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/self-update-pipelines
-              tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+              tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
           inputs:
             - name: paas-cf
           params:
@@ -161,7 +161,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli-v2
-              tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+              tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
           inputs:
             - name: bosh-vars-store
             - name: paas-cf
@@ -256,7 +256,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
-              tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+              tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
           inputs:
             - name: terraform-variables
             - name: paas-cf

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -113,7 +113,7 @@ jobs:
     serial_groups: [ destroy ]
     serial: true
     plan:
-      - aggregate:
+      - in_parallel:
           - get: pipeline-trigger
             passed: ['init']
             trigger: true
@@ -195,7 +195,7 @@ jobs:
     serial_groups: [ destroy ]
     serial: true
     plan:
-      - aggregate:
+      - in_parallel:
           - get: pipeline-trigger
             passed: ['delete-deployment']
             trigger: true

--- a/concourse/pipelines/monitor-remote.yml
+++ b/concourse/pipelines/monitor-remote.yml
@@ -73,7 +73,7 @@ jobs:
 - name: smoke-tests
   serial: true
   plan:
-  - aggregate:
+  - in_parallel:
     - get: test-config
     - get: paas-cf
     - get: cf-smoke-tests-release

--- a/concourse/pipelines/monitor-remote.yml
+++ b/concourse/pipelines/monitor-remote.yml
@@ -48,7 +48,7 @@ jobs:
         type: docker-image
         source:
           repository: governmentpaas/self-update-pipelines
-          tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+          tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
       inputs:
       - name: paas-cf
       params:

--- a/concourse/scripts/pipecleaner.py
+++ b/concourse/scripts/pipecleaner.py
@@ -102,7 +102,7 @@ class Pipecleaner(object):
                 discovered_blocks = []
 
                 # Flatten array blocks as we don't care
-                for block_type in ('aggregate', 'do'):
+                for block_type in ('aggregate', 'in_parallel', 'do'):
                     if block_type in item:
                         discovered_blocks.extend(item[block_type])
                         del item[block_type]

--- a/concourse/scripts/unbind_job.rb
+++ b/concourse/scripts/unbind_job.rb
@@ -10,7 +10,7 @@ def remove_passed(obj)
     if obj.has_key?('get') && obj['get'] == 'paas-cf'
       obj.delete('passed')
     else
-      obj.each { |k, v| remove_passed(v) if %w[do aggregate].include?(k) }
+      obj.each { |k, v| remove_passed(v) if %w[do aggregate in_parallel].include?(k) }
     end
   end
 end

--- a/concourse/tasks/create_admin.yml
+++ b/concourse/tasks/create_admin.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/cf-uaac
-    tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+    tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
 inputs:
   - name: paas-cf
   - name: cf-manifest

--- a/concourse/tasks/custom-acceptance-tests-run.yml
+++ b/concourse/tasks/custom-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/cf-acceptance-tests
-    tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+    tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
 inputs:
   - name: paas-cf
   - name: test-config

--- a/concourse/tasks/custom-broker-acceptance-tests-run.yml
+++ b/concourse/tasks/custom-broker-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/cf-acceptance-tests
-    tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+    tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
 inputs:
   - name: paas-cf
   - name: test-config

--- a/concourse/tasks/delete_admin.yml
+++ b/concourse/tasks/delete_admin.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/cf-cli
-    tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+    tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
 inputs:
   - name: paas-cf
   - name: cf-manifest

--- a/concourse/tasks/forget-access-keys.yml
+++ b/concourse/tasks/forget-access-keys.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/terraform
-    tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+    tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
 inputs:
   - name: paas-cf
   - name: cf-tfstate

--- a/concourse/tasks/generate-test-config.yml
+++ b/concourse/tasks/generate-test-config.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/bosh-cli-v2
-    tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+    tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
 inputs:
   - name: paas-cf
   - name: admin-creds

--- a/concourse/tasks/remove-db.yml
+++ b/concourse/tasks/remove-db.yml
@@ -7,7 +7,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/cf-cli
-    tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+    tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
 run:
   path: sh
   args:

--- a/concourse/tasks/set-smoke-test-creds.yml
+++ b/concourse/tasks/set-smoke-test-creds.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/cf-cli
-    tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+    tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
 inputs:
   - name: config
 outputs:

--- a/concourse/tasks/smoke-tests-run.yml
+++ b/concourse/tasks/smoke-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/cf-acceptance-tests
-    tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+    tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
 inputs:
   - name: paas-cf
   - name: cf-smoke-tests-release

--- a/concourse/tasks/upload-test-artifacts.yml
+++ b/concourse/tasks/upload-test-artifacts.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/awscli
-    tag: 54cc3c9f49f9032e46dd4538c626f2533bf90a94
+    tag: ba9a734b3e7017b4ce75e444c1c018853ed144ba
 inputs:
   - name: paas-cf
   - name: artifacts

--- a/manifests/prometheus/dashboards.d/user-impact.json
+++ b/manifests/prometheus/dashboards.d/user-impact.json
@@ -2,14 +2,45 @@
     "dashboard": {
         "annotations": {
             "list": [{
-                "builtIn": 1,
-                "datasource": "-- Grafana --",
-                "enable": true,
-                "hide": true,
-                "iconColor": "rgba(0, 211, 255, 1)",
-                "name": "Annotations & Alerts",
-                "type": "dashboard"
-            }]
+                    "builtIn": 1,
+                    "datasource": "-- Grafana --",
+                    "enable": true,
+                    "hide": true,
+                    "iconColor": "rgba(0, 211, 255, 1)",
+                    "limit": 100,
+                    "name": "Annotations & Alerts",
+                    "showIn": 0,
+                    "type": "dashboard"
+                },
+                {
+                    "datasource": "-- Grafana --",
+                    "enable": false,
+                    "hide": false,
+                    "iconColor": "rgba(255, 96, 96, 1)",
+                    "limit": 100,
+                    "name": "Deployment - Detailed",
+                    "showIn": 0,
+                    "tags": [
+                        "deployment",
+                        "concourse"
+                    ],
+                    "type": "tags"
+                },
+                {
+                    "datasource": "-- Grafana --",
+                    "enable": true,
+                    "hide": false,
+                    "iconColor": "#37872D",
+                    "limit": 100,
+                    "name": "Deployment - Overview",
+                    "showIn": 0,
+                    "tags": [
+                        "deployment-overview",
+                        "concourse"
+                    ],
+                    "type": "tags"
+                }
+            ]
         },
         "editable": false,
         "gnetId": null,
@@ -470,8 +501,7 @@
                 "spaceLength": 10,
                 "stack": false,
                 "steppedLine": false,
-                "targets": [
-                    {
+                "targets": [{
                         "expr": "count(firehose_value_metric_rep_capacity_total_memory)",
                         "format": "time_series",
                         "instant": false,
@@ -505,8 +535,7 @@
                     "show": true,
                     "values": []
                 },
-                "yaxes": [
-                    {
+                "yaxes": [{
                         "decimals": 0,
                         "format": "short",
                         "label": null,

--- a/scripts/credhub_shell.sh
+++ b/scripts/credhub_shell.sh
@@ -3,7 +3,7 @@
 set -eu
 
 CONTAINER_REPO="governmentpaas/bosh-shell"
-CONTAINER_TAG="54cc3c9f49f9032e46dd4538c626f2533bf90a94"
+CONTAINER_TAG="ba9a734b3e7017b4ce75e444c1c018853ed144ba"
 CONTAINER="${CONTAINER_REPO}:${CONTAINER_TAG}"
 
 # Setup Bosh variables

--- a/scripts/upload_secrets.rb
+++ b/scripts/upload_secrets.rb
@@ -74,7 +74,7 @@ def import_to_credhub credhub_secrets
     '--rm',
     *env_params,
     '-v', "#{credhub_secrets_file.path}:/root/import.yml",
-    'governmentpaas/bosh-shell:54cc3c9f49f9032e46dd4538c626f2533bf90a94',
+    'governmentpaas/bosh-shell:ba9a734b3e7017b4ce75e444c1c018853ed144ba',
     '-c', 'credhub import -f /root/import.yml'
   )
 end


### PR DESCRIPTION
What
----

The changes should be fairly self-explanatory when looking at the commits, but the nuts and bolts are:

* The tasks are created in meta and are referred to as anchors throughout (because of reuse);
* The annotations are created in grafana's internal data store - this removes the need for it to be 'pulled' by prometheus, meaning it should all be pretty real-time;
* Annotations are created as a 'point', with `*add-grafana-job-annotation` and `*add-grafana-overview-annotation`, with the start and end time being the same. Once the respective `end-*` tasks are run, the end time for the annotation is updated to the current time, and the annotation changes to a range. This happens in real-time, so you can watch the deploy on grafana;
* Job annotations are for each individual build job;
* Overview annotations show the start and end of the whole pipeline.

How to review
-------------

We seem to think this is good to go. Maybe deploy to a dev env if you really want to.

Who can review
--------------

Not @tnwhitwell.