### PR TITLE
Scale up doppler in both regions

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -2,7 +2,7 @@
 cell_instances: 33
 router_instances: 3
 api_instances: 12
-doppler_instances: 27
+doppler_instances: 33
 log_api_instances: 6
 cc_hourly_rate_limit: 15000
 paas_region_name: london

--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -2,7 +2,7 @@
 cell_instances: 30
 router_instances: 3
 api_instances: 6
-doppler_instances: 16
+doppler_instances: 24
 log_api_instances: 6
 cc_hourly_rate_limit: 55000
 paas_region_name: ireland


### PR DESCRIPTION
What
----

Doppler is the component in our system that handles logs from tenant
applications. When it's overloaded it will drop some logs, so tenants
will not recieve all the logs they expect.

Looking at `ALERTS{alertstate="firing",layer="",alertname="DopplerDroppedEnvelopes"}`
shows that our alert for dropped log messages have been firing almost
constantly for the last 90 days in both regions:

* [Ireland](https://grafana-1.cloud.service.gov.uk/explore?left=%5B%22now-90d%22,%22now%22,%22prometheus%22,%7B%22expr%22:%22ALERTS%7Balertstate%3D%5C%22firing%5C%22,layer%3D%5C%22%5C%22,alertname%3D%5C%22DopplerDroppedEnvelopes%5C%22%7D%22,%22format%22:%22time_series%22,%22instant%22:true,%22intervalFactor%22:1,%22legendFormat%22:null,%22step%22:null%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D)
* [London](https://grafana-1.london.cloud.service.gov.uk/explore?left=%5B%22now-90d%22,%22now%22,%22prometheus%22,%7B%22expr%22:%22ALERTS%7Balertstate%3D%5C%22firing%5C%22,layer%3D%5C%22%5C%22,alertname%3D%5C%22DopplerDroppedEnvelopes%5C%22%7D%22,%22format%22:%22time_series%22,%22instant%22:true,%22intervalFactor%22:1,%22legendFormat%22:null,%22step%22:null%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D)

This is not good because:

* We should only really be dropping log messages occasionally, not constantly
* Having the alert firing all the time is causeing alert blindness

Doppler instances are `m5.large`.

I had a quick look, and it seems that the dopplers are using a
reasonable amount of their CPU and memory, so it looks like the
instances are roughly the right size.

Each unreserved `m5.large` costs $70.28 (~£56). We did reserve quite a
few `m5.large` instances for this year, which reduces the cost to ~£33
per instance.

Thinking about costs:

* We're currently spending in the order of `(27 + 16) * £33 =` `£1,419 / month`
  on doppler VMs across both regions (because most should be reserved instances)
* This commit will increase the number of instances by `(6 + 8) = 14`
* Since these instances won't be reserved, this will increase monthly
  spend by `14 * 56 = £784 / month`
* This will get cheaper again the next time we reserve some instances by
  £322 / month

This is worth the extra spend because our users expect a reliable
logging system, and we expect not to have constant alerts about dropped
messages.

How to review
-------------

* Check the big description above

Who can review
--------------

I think anyone can (other than @richardtowers). Probably a good idea to
make sure Luke knows about the extra spend before merging.