### PR TITLE
Scale up routers

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -1,6 +1,6 @@
 ---
 cell_instances: 33
-router_instances: 3
+router_instances: 6
 api_instances: 12
 doppler_instances: 27
 log_api_instances: 6

--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -1,6 +1,6 @@
 ---
 cell_instances: 30
-router_instances: 3
+router_instances: 6
 api_instances: 6
 doppler_instances: 16
 log_api_instances: 6


### PR DESCRIPTION
What
----

For 4 reasons:

- We foresee traffic increasing until the end of october, and possibly
thereafter. This has been communicated to us by
  a) the news
  b) our tenants

- There are some instances of a single Gorouter randomly throwing bad
gateways for a second.

- Gorouter currently sees daily peaks of just over 50% CPU. If we were
in the middle of rolling cells, and there were only 2 gorouter
instances, we might start dropping requests.

- If we were rolling cells and we only had 2 gorouter instances, we
would only have two AZs active

The cost impliciations of this are $210USD per environment per month as
we have not reserved more router instances

How to review
-------------

Code review

Who can review
--------------

Not @tlwr

@lukemalchergds has approved this