### PR TITLE
Correct unit of paas_aws_cost_explorer_by_service

### DIFF
--- a/manifests/prometheus/alerts.d/paas-billing-costs.yml
+++ b/manifests/prometheus/alerts.d/paas-billing-costs.yml
@@ -7,7 +7,7 @@
     name: PaaSBillingDBCostsExceedRDSCosts
     rules:
       - alert: PaaSBillingDBCostsExceedRDSCosts
-        expr: sum(increase(paas_billing_total_costs_pounds{name=~"mysql.+|postgres.+"}[24h])) / sum(paas_aws_cost_explorer_by_service_pounds{service="Amazon Relational Database Service"}) > 1
+        expr: sum(increase(paas_billing_total_costs_pounds{name=~"mysql.+|postgres.+"}[24h])) / sum(paas_aws_cost_explorer_by_service_dollars{service="Amazon Relational Database Service"}) > 1
         labels:
           severity: warning
           layer: billing
@@ -21,7 +21,7 @@
     name: PaaSBillingDBCostsFallsShortOfRDSCosts
     rules:
       - alert: PaaSBillingDBCostsFallsShortOfRDSCosts
-        expr: sum(increase(paas_billing_total_costs_pounds{name=~"mysql.+|postgres.+"}[24h])) / sum(paas_aws_cost_explorer_by_service_pounds{service="Amazon Relational Database Service"}) < .6
+        expr: sum(increase(paas_billing_total_costs_pounds{name=~"mysql.+|postgres.+"}[24h])) / sum(paas_aws_cost_explorer_by_service_dollars{service="Amazon Relational Database Service"}) < .6
         labels:
           severity: warning
           layer: billing
@@ -35,7 +35,7 @@
     name: PaaSBillingAppCostsExceedEC2Costs
     rules:
       - alert: PaaSBillingAppCostsExceedEC2Costs
-        expr: sum(increase(paas_billing_total_costs_pounds{name="app"}[24h])) / sum(paas_aws_cost_explorer_by_service_pounds{service=~"Amazon Elastic Compute Cloud - Compute"}) > 1.4
+        expr: sum(increase(paas_billing_total_costs_pounds{name="app"}[24h])) / sum(paas_aws_cost_explorer_by_service_dollars{service=~"Amazon Elastic Compute Cloud - Compute"}) > 1.4
         labels:
           severity: warning
           layer: billing
@@ -49,7 +49,7 @@
     name: PaaSBillingAppCostsFallsShortOfEC2Costs
     rules:
       - alert: PaaSBillingAppCostsFallsShortOfEC2Costs
-        expr: sum(increase(paas_billing_total_costs_pounds{name="app"}[24h])) / sum(paas_aws_cost_explorer_by_service_pounds{service=~"Amazon Elastic Compute Cloud - Compute"}) < .6
+        expr: sum(increase(paas_billing_total_costs_pounds{name="app"}[24h])) / sum(paas_aws_cost_explorer_by_service_dollars{service=~"Amazon Elastic Compute Cloud - Compute"}) < .6
         labels:
           severity: warning
           layer: billing

--- a/tools/metrics/gauges_aws_cost_explorer.go
+++ b/tools/metrics/gauges_aws_cost_explorer.go
@@ -41,7 +41,7 @@ func AWSCostExplorerGauge(
 				Time:  twoDaysAgo,
 				Name:  "aws.cost_explorer.by_service",
 				Value: amortizedCost,
-				Unit:  "pounds",
+				Unit:  "dollars",
 				Tags: m.MetricTags{
 					{Label: "type", Value: "AmortizedCost"},
 					{Label: "service", Value: serviceName},


### PR DESCRIPTION
What
----

There's no currency conversion happening on the results of the AWS Cost
Explorer call, so the results are still in dollars.

Fixing the unit will change the name of the metric, which is a bit
annoying, but it's better than it being wrong forever.

I've fixed the alerts which refer to the metric by name - I'm not
dealing with the currency conversion in the alerts for now because I
think I'll change the way they work a bit in a future commit.

How to review
-------------

* Have a look at the surrounding code and check I'm right about the units
* That's probably enough to be honest

Who can review
--------------

Not @richardtowers