### PR TITLE
Upgrade CAPI and increase router max idle connections

### DIFF
--- a/manifests/cf-manifest/operations.d/310-router.yml
+++ b/manifests/cf-manifest/operations.d/310-router.yml
@@ -61,6 +61,20 @@
           value: max-age=31536000; includeSubDomains; preload
 
 - type: replace
+  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/max_idle_connections?
+  # See this page
+  # https://docs.cloudfoundry.org/adminguide/routing-keepalive.html
+  #
+  # Default value is 100, means each router maintains 100 conns with backends
+  #
+  # Recommended value for 1000 rps with 1s latency is 2000
+  #
+  # Increase this to 2500 which means connections between router and envoy
+  # is more likely to be re-used, should reduce latency and memory consumption
+  #
+  value: 2500
+
+- type: replace
   path: /instance_groups/name=router/networks/0/name
   value: router
 

--- a/manifests/cf-manifest/operations.d/329-capi-release.yml
+++ b/manifests/cf-manifest/operations.d/329-capi-release.yml
@@ -1,0 +1,7 @@
+- type: replace
+  path: /releases/name=capi
+  value:
+    name: "capi"
+    version: "1.87.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.87.0"
+    sha1: "03ac801323cd23205dde357cc7d2dc9e92bc0c93"

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe "release versions" do
     end
 
     pinned_releases = {
+      'capi' => {
+        local: '1.87.0',
+        upstream: '1.86.0',
+      },
       'uaa' => {
         local: '0.1.12',
         upstream: '74.0.0',


### PR DESCRIPTION
What
----

### Upgrade CAPI to 187

See [the release notes](https://github.com/cloudfoundry/capi-release/releases/tag/1.87.0)

This release has a number of bug-fixes for internal routes, the ones we care about are:

- failure when pushing an app for the first time with internal route
- updating a docker app will not pass healthchecks in some cases

@andy-paine can provide more context

### Increase `max_idle_connections`

Gorouter talks to Envoy sidecars which in turn talk to app processes.

Gorouter by default keeps 100 TCP connections open to application containers ([see docs](https://docs.cloudfoundry.org/adminguide/routing-keepalive.html))

I've set this somewhat arbitrarily to 2500 which means Gorouter is 25x more likely to keep connections open than it was previously. The cost of this is:

- a small memory increase (but we just scaled out 2x)
- increase the number of open file descriptors by 2400 (Gorouter is allowed about 50k)

I ran a very small benchmark where:

- I sent 15 requests per second to the billing-api healthcheck endpoint
- I watched `ss -tan` (to get TCP connections open)
- We quickly reached 450 connections in `TIME_WAIT` across two instances

I then updated Gorouter to use 2500 max idle connections and ran the same benchmark

- The maximum number of connections in `TIME_WAIT` across two instances was 20
- There were a small number of connections in `ESTABLISHED`

This means Gorouter is properly re-using the TCP connections to Envoy. This should reduce the number of TCP connections that are established between Gorouter and Envoys, which should reduce Envoy memory consumption and reduce request latency and frequency timeouts.

See [this](https://govuk.zendesk.com/agent/tickets/3828157) Zendesk ticket, to see (what I believe to be) the impact of us not re-using connections to Envoy.

This [PCF documentation page](https://docs.pivotal.io/platform/application-service/2-7/concepts/http-routing.html#keepalive) has more information.

You can make Linux recycle and/or re-use connections in `TIME_WAIT` with the options `net.ipv4.tcp_tw_reuse` and `net.ipv4.tcp_tw_recycle`. I feel like we should configure this in Gorouter, rather than the whole VM; gorouter has a bit more contextual information about how it should re-use connections. Currently we aren't re-using these connections, which has a performance implication, which I think is affecting our tenants.

How to review
-------------

Code review

Read the notes linked above

See [my pipeline](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/tag-release/builds/56) is green

Who can review
--------------

Not @tlwr
