### PR TITLE
Revert "Increase gorouter number of idle connections"

### DIFF
--- a/manifests/cf-manifest/operations.d/310-router.yml
+++ b/manifests/cf-manifest/operations.d/310-router.yml
@@ -52,20 +52,6 @@
           value: max-age=31536000; includeSubDomains; preload
 
 - type: replace
-  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/max_idle_connections?
-  # See this page
-  # https://docs.cloudfoundry.org/adminguide/routing-keepalive.html
-  #
-  # Default value is 100, means each router maintains 100 conns with backends
-  #
-  # Recommended value for 1000 rps with 1s latency is 2000
-  #
-  # Increase this to 2500 which means connections between router and envoy
-  # is more likely to be re-used, should reduce latency and memory consumption
-  #
-  value: 2500
-
-- type: replace
   path: /instance_groups/name=router/networks/0/name
   value: router
 


### PR DESCRIPTION
What
----

This reverts commit 8488aefaeffdc80a766ec35658683dc91ccd1b8e.

Some of our users are using HTTP/1.0, which doesn't support keepalives
properly. When we increased the number of idle conenctions this caused
an increase in 502s for these users.

This has already been rolled back by hand with Bosh.

How to review
-------------

* Code review is probably enough

Who can review
--------------

Not @richardtowers