### PR TITLE
Open SSO passcode URL when using subshell login

### DIFF
--- a/scripts/cf_subshell_scoped_login.sh
+++ b/scripts/cf_subshell_scoped_login.sh
@@ -12,16 +12,20 @@ TARGET=${1}
 case $TARGET in
   prod)
     API_URL="https://api.cloud.service.gov.uk"
+    PASSCODE_URL="https://login.cloud.service.gov.uk/passcode"
     ;;
   prod-lon)
     API_URL="https://api.london.cloud.service.gov.uk"
+    PASSCODE_URL="https://login.london.cloud.service.gov.uk/passcode"
     ;;
   stg-lon)
     API_URL="https://api.london.staging.cloudpipeline.digital"
+    PASSCODE_URL="https://login.london.staging.cloudpipeline.digital/passcode"
     ;;
   *)
     echo "\"${TARGET}\" is not a named environment. Assuming this is a development environment." 1>&2
     API_URL="https://api.${TARGET}.dev.cloudpipeline.digital"
+    PASSCODE_URL="https://login.${TARGET}.dev.cloudpipeline.digital/passcode"
     ;;
 esac
 
@@ -41,7 +45,7 @@ export CF_HOME
 export CF_SUBSHELL_TARGET=$TARGET
 
 cf api "${API_URL}"
-cf login --sso
+open "${PASSCODE_URL}" && cf login --sso
 
 echo
 echo "You are now in a subshell with CF_HOME set to ${CF_HOME}"


### PR DESCRIPTION
What
----
When logging in to CloudFoundry using SSO at the command line, users are
required to provide an authentication code that they're given at the end of the
browser-based login flow. The URL to begin the flow is given at command line,
and highlighting it to open it with the browser is annoying. This commit opens
that URL in the user's browser as a convenience, before running `cf login`.

How to review
-------------

1. Code review
2. Give it a whirl

Who can review
--------------
Anyone