### PR TITLE
Update create-org.sh to annotate orgs with their owner

### DIFF
--- a/scripts/list-org-owners.sh
+++ b/scripts/list-org-owners.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+if ! cf orgs >/dev/null 2>&1; then
+  abort "You need to be logged into CF CLI"
+fi
+
+pages=$(cf curl /v3/organizations | jq '.pagination.total_pages')
+
+results=""
+for page in $(seq 1 "$pages"); do
+  results="$results
+$(cf curl "/v3/organizations?page=$page" | jq -r '.resources[] | [.metadata.annotations.owner // "Unknown", .name] | @tsv')"
+done
+
+sort <<< "$results" | column -t -s '	'


### PR DESCRIPTION
What
----

So when we create new organisations they're tagged with the right owner.

Also adds a script to get the current list of orgs and their owners.

How to review
-------------

* Code review
* Run `scripts/list-org-owners.sh` against the prod environments
* Run `scripts/create-org.sh` against your dev environment
* Check that the org created has the right annotation

Who can review
--------------

Not @richardtowers