### PR TITLE
[SUPPORT] Scale adapter instances in London to 4

### DIFF
--- a/manifests/cf-manifest/env-specific/default.yml
+++ b/manifests/cf-manifest/env-specific/default.yml
@@ -4,5 +4,6 @@ router_instances: 2
 api_instances: 2
 doppler_instances: 6
 log_api_instances: 2
+adapter_instances: 2
 cc_hourly_rate_limit: 15000
 paas_region_name: dev

--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -4,5 +4,6 @@ router_instances: 6
 api_instances: 12
 doppler_instances: 33
 log_api_instances: 6
+adapter_instances: 4 # Scaled to a multiple of 2 to balance out the AZs
 cc_hourly_rate_limit: 15000
 paas_region_name: london

--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -4,5 +4,6 @@ router_instances: 6
 api_instances: 6
 doppler_instances: 24
 log_api_instances: 6
+adapter_instances: 2
 cc_hourly_rate_limit: 55000
 paas_region_name: ireland

--- a/manifests/cf-manifest/env-specific/stg-lon.yml
+++ b/manifests/cf-manifest/env-specific/stg-lon.yml
@@ -4,5 +4,6 @@ router_instances: 3
 api_instances: 2
 doppler_instances: 3
 log_api_instances: 3
+adapter_instances: 2
 cc_hourly_rate_limit: 100000
 paas_region_name: staging

--- a/manifests/cf-manifest/operations.d/380-scale-adapter.yml
+++ b/manifests/cf-manifest/operations.d/380-scale-adapter.yml
@@ -1,0 +1,5 @@
+---
+- type: replace
+  path: /instance_groups/name=adapter/instances
+  value: ((adapter_instances))
+


### PR DESCRIPTION
What
----

Adapter instances are only deployed in z1 and z2. By default there are two of
them, so we think it makes sense to keep them at a multiple of 2, in order to
prevent one zone from receiving a majority of the traffic.

This [documentation linked in the alert](https://github.com/cloudfoundry/cf-syslog-drain-release/tree/v6.4#syslog-adapter) suggests we scale it slightly less, but I think balancing the AZs is more important than sticking exactly to the formula.

How to review
-------------

1. Code review

Deploying in a dev env won't have any effect. This will 

Who can review
--------------
Anyone
