### PR TITLE
Skip DNS records acceptance test

### DIFF
--- a/platform-tests/src/platform/acceptance/apps_domain_dns_tls_test.go
+++ b/platform-tests/src/platform/acceptance/apps_domain_dns_tls_test.go
@@ -11,6 +11,8 @@ import (
 var _ = Describe("The apps apex domain", func() {
 
 	It("should have the same DNS records as the healthcheck app", func() {
+		Skip("FIXME: Stop skipping when we are not canarying the LBs")
+
 		apexIPs, err := net.LookupIP(testConfig.GetAppsDomain())
 		Expect(err).NotTo(HaveOccurred())
 		healthcheckIPs, err := net.LookupIP("healthcheck." + testConfig.GetAppsDomain())


### PR DESCRIPTION
What
----

We have a test which compares DNS records. This test will be flakey when we have canary on the LBs

Skip DNS records acceptance test while we are canarying the LBs

How to review
-------------

Code review

Who can review
--------------

Not @tlwr