### PR TITLE
Add idle timeout to our application LBs

### DIFF
--- a/terraform/cloudfoundry/lbs.tf
+++ b/terraform/cloudfoundry/lbs.tf
@@ -119,6 +119,7 @@ resource "aws_lb" "cf_router_app_domain" {
   load_balancer_type = "application"
   security_groups    = ["${aws_security_group.web.id}"]
   subnets            = ["${split(",", var.infra_subnet_ids)}"]
+  idle_timeout       = 900
 
   access_logs {
     bucket  = "${aws_s3_bucket.elb_access_log.id}"
@@ -210,6 +211,7 @@ resource "aws_lb" "cf_router_system_domain" {
   load_balancer_type = "application"
   security_groups    = ["${aws_security_group.cf_api_elb.id}"]
   subnets            = ["${split(",", var.infra_subnet_ids)}"]
+  idle_timeout       = 900
 
   access_logs {
     bucket  = "${aws_s3_bucket.elb_access_log.id}"


### PR DESCRIPTION
What
----

We should change our idle timeout to 900 seconds, which matches HAProxy, the default is 60

How to review
-------------

See the [docs](https://www.terraform.io/docs/providers/aws/r/lb.html#idle_timeout)

See [my pipeline](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/tag-release/builds/63)

Who can review
--------------

Not @tlwr