### PR TITLE
[SUPPORT] Update CFSyslogDrains alert to track adapter numbers

### DIFF
--- a/manifests/prometheus/alerts.d/cf-syslog-drains.yml
+++ b/manifests/prometheus/alerts.d/cf-syslog-drains.yml
@@ -6,11 +6,15 @@
   value:
     name: CFSyslogDrains
     rules:
+    - record: "firehose_value_metric_cf_syslog_drain_scheduler_drains:required_adapters"
+      expr: ceil(sum(firehose_value_metric_cf_syslog_drain_scheduler_drains) / 250)
+
     - alert: CFSyslogDrains
-      expr: firehose_value_metric_cf_syslog_drain_scheduler_drains > 250
+      expr: "firehose_value_metric_cf_syslog_drain_scheduler_drains:required_adapters > ((adapter_instances))"
       labels:
         severity: warning
       annotations:
         summary: "Syslog drain count is high"
-        description: "Consider scaling the adapters to cope with the number of syslog drains."
+        description: "Consider scaling the adapters to cope with the number of syslog drains. There are currently ((adapter_instances)) adapter instances."
+        required_adapters: "{{ humanize $value }}"
         url: "https://github.com/cloudfoundry/cf-syslog-drain-release/tree/v6.4#syslog-adapter"

--- a/manifests/prometheus/scripts/generate-manifest.sh
+++ b/manifests/prometheus/scripts/generate-manifest.sh
@@ -52,6 +52,7 @@ bosh interpolate \
   --vars-file="${variables_file}" \
   --vars-file="${WORKDIR}/terraform-outputs/cf.yml" \
   --vars-file="${PAAS_CF_DIR}/manifests/prometheus/env-specific/${ENV_SPECIFIC_BOSH_VARS_FILE}" \
+  --vars-file="${PAAS_CF_DIR}/manifests/cf-manifest/env-specific/${ENV_SPECIFIC_BOSH_VARS_FILE}" \
   ${opsfile_args} \
   ${alerts_opsfile_args} \
   "${PROM_BOSHRELEASE_DIR}/manifests/prometheus.yml"

--- a/manifests/prometheus/spec/alerts/cf-syslog-drains.test.yml
+++ b/manifests/prometheus/spec/alerts/cf-syslog-drains.test.yml
@@ -1,0 +1,34 @@
+---
+rule_files:
+  # See alerts_validation_spec.rb for details of how this gets set:
+  - spec/alerts/fixtures/rules.yml
+
+evaluation_interval: 1h
+
+tests:
+  - interval: 1h
+    input_series:
+      - series: 'firehose_value_metric_cf_syslog_drain_scheduler_drains{bosh_job_id="1"}'
+        values: 0 75 260
+
+      - series: 'firehose_value_metric_cf_syslog_drain_scheduler_drains{bosh_job_id="2"}'
+        values: 0 75 260
+
+    alert_rule_test:
+
+      # Alert should not be firing initially
+      - eval_time: 1h
+        alertname: CFSyslogDrains
+
+      # Alert should be firing when there are more drains than the
+      # number of adapters can handle: ceil(drains / 250)
+      - eval_time: 2h
+        alertname: CFSyslogDrains
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: "Syslog drain count is high"
+              description: "Consider scaling the adapters to cope with the number of syslog drains. There are currently 2 adapter instances."
+              required_adapters: 3
+              url: "https://github.com/cloudfoundry/cf-syslog-drain-release/tree/v6.4#syslog-adapter"


### PR DESCRIPTION
What
----

The alert was hardcoded to go off when any of the schedulers reached more than
250 drains. However, the documentation that we link to in the alert indicates
that the number of adapters should be:

    (cf-syslog-drain.scheduler.drains / 250) + 2

Previously, we were running only 2 instances across the 2 availability zones,
and it was running fine, so experience suggests that the below is probably fine
as a gauge of the number adapters needed:

    (sum(drains) / 250)

In this commit, I've included the
`manifests/cf-manifest/env-specific/${ENV_SPECIFIC_BOSH_VARS_FILE}` in the vars
used to generate the Prometheus manifest, so that the alerts have access to
useful variables about the scale of different components. I've then used the
`adapter_instances` variable in the alert ops file so that in future the alert
threshold will automatically scale with the number of instances of the adapter.


How to review
-------------

1. Code review
2. This ought to be run down a dev env, just in case the variables from the newly included vars file override something in an unintended way.

Who can review
--------------
Anyone
