### PR TITLE
[#168372375] Pin version of cloud foundry's postgres

### DIFF
--- a/terraform/cloudfoundry/cf_rds.tf
+++ b/terraform/cloudfoundry/cf_rds.tf
@@ -29,12 +29,6 @@ resource "aws_security_group" "cf_rds" {
   }
 }
 
-resource "aws_db_parameter_group" "cf_pg_9_5" {
-  name        = "${var.env}-pg95-cf"
-  family      = "postgres9.5"
-  description = "RDS CF Postgres 9.5 parameter group"
-}
-
 resource "aws_db_parameter_group" "cf_pg_11" {
   name        = "${var.env}-pg11-cf"
   family      = "postgres11"
@@ -61,8 +55,8 @@ resource "aws_db_instance" "cf" {
   skip_final_snapshot       = "${var.cf_db_skip_final_snapshot}"
   vpc_security_group_ids    = ["${aws_security_group.cf_rds.id}"]
 
-  allow_major_version_upgrade = true
-  auto_minor_version_upgrade  = true
+  allow_major_version_upgrade = false
+  auto_minor_version_upgrade  = false
   apply_immediately           = false
 
   tags {


### PR DESCRIPTION
What
----

Since even minor version upgrades can cause downtime which we'd like to
announce ahead of time, we think it's better if we set
`auto_minor_version_upgrade` to false. This will ensure AWS don't
upgrade our database for us, but it will mean we have to schedule
updates ourselves.

We'll need to play follow up stories to upgrade to later versions of the
11.x stream.

At the moment 11.1 won't auto upgrade, according to `aws describe-db-engine-versions`:

```
{
  "Engine": "postgres",
  "EngineVersion": "11.1",
  "DBParameterGroupFamily": "postgres11",
  "DBEngineDescription": "PostgreSQL",
  "DBEngineVersionDescription": "PostgreSQL 11.1-R1",
  "ValidUpgradeTarget": [
    {
      "Engine": "postgres",
      "EngineVersion": "11.2",
      "Description": "PostgreSQL 11.2-R1",
      "AutoUpgrade": false,
      "IsMajorVersionUpgrade": false
    },
    {
      "Engine": "postgres",
      "EngineVersion": "11.4",
      "Description": "PostgreSQL 11.4-R1",
      "AutoUpgrade": false,
      "IsMajorVersionUpgrade": false
    },
    {
      "Engine": "postgres",
      "EngineVersion": "11.5",
      "Description": "PostgreSQL 11.5-R1",
      "AutoUpgrade": false,
      "IsMajorVersionUpgrade": false
    }
  ],
  "ExportableLogTypes": [
    "postgresql",
    "upgrade"
  ],
  "SupportsLogExportsToCloudwatchLogs": true,
  "SupportsReadReplica": true
}
```

Also cleans up the old cf_pg_9_5 parameter group.


How to review
-------------

* Code review
* Deploy to a dev env and check that terraform doesn't do anything unexpected

Who can review
--------------

Not @richardtowers