### PR TITLE
Move the DopplerDroppedEnvelopes alert to "Other"

### DIFF
--- a/manifests/prometheus/alerts.d/doppler-dropped-envelopes.yml
+++ b/manifests/prometheus/alerts.d/doppler-dropped-envelopes.yml
@@ -9,6 +9,7 @@
       - alert: DopplerDroppedEnvelopes
         expr: sum(increase(firehose_counter_event_loggregator_doppler_dropped_total[1h])) > 100
         labels:
+          layer: logging
           severity: warning
         annotations:
           summary: "Doppler - dropped envelopes"

--- a/manifests/prometheus/dashboards.d/user-impact.json
+++ b/manifests/prometheus/dashboards.d/user-impact.json
@@ -723,8 +723,8 @@
                 "colorValue": false,
                 "colors": [
                     "#299c46",
-                    "#fa6400",
-                    "#fa6400"
+                    "#1f1f1f",
+                    "#1f1f1f"
                 ],
                 "datasource": "prometheus",
                 "format": "none",

--- a/manifests/prometheus/spec/alerts/doppler-dropped-envelopes.test.yml
+++ b/manifests/prometheus/spec/alerts/doppler-dropped-envelopes.test.yml
@@ -35,6 +35,7 @@ tests:
         alertname: DopplerDroppedEnvelopes
         exp_alerts:
           - exp_labels:
+              layer: logging
               severity: warning
             exp_annotations:
               summary: "Doppler - dropped envelopes"


### PR DESCRIPTION
What
----

It's constantly firing which is causing alert blindness. Ideally we'd
fix it, rather than ignoring it. We are going to raise a story to do
that. In the meantime though it's more important that we notice the other
alerts when they fire.

Also makes the "Other" alert have a dark grey background instead of the
almost-red orange we were using before.

How to review
-------------

* Code review is probs enough

Who can review
--------------

Not @richardtowers