### PR TITLE
Make shipping logs via logit actually work

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1924,6 +1924,7 @@ jobs:
           params:
             APPS_DNS_ZONE_NAME: ((apps_dns_zone_name))
             LOGIT_ADDRESS: ((logit_syslog_address))
+            LOGIT_PORT: ((logit_syslog_port))
             API_ENDPOINT: ((api_endpoint))
             CF_ADMIN: ((cf_admin))
             CF_PASS: ((cf_pass))
@@ -1967,9 +1968,13 @@ jobs:
 
                 cf target -o admin -s public
                 if ! cf service logit-syslog-drain > /dev/null; then
-                  cf create-user-provided-service logit-syslog-drain -l "${LOGIT_ADDRESS}"
+                  cf create-user-provided-service \
+                    logit-syslog-drain \
+                    -l "syslog-tls://${LOGIT_ADDRESS}:${LOGIT_PORT}"
                 else
-                  cf update-user-provided-service logit-syslog-drain -l "${LOGIT_ADDRESS}"
+                  cf update-user-provided-service \
+                    logit-syslog-drain \
+                    -l "syslog-tls://${LOGIT_ADDRESS}:${LOGIT_PORT}"
                 fi
 
       - task: register-rds-broker
@@ -3362,6 +3367,7 @@ jobs:
             DEPLOY_ENV: ((deploy_env))
             CF_CLIENT_SECRET: ((cf_client_secret))
             LOGIT_ADDRESS: ((logit_syslog_address))
+            LOGIT_PORT: ((logit_syslog_port))
             API_ENDPOINT: ((api_endpoint))
             CF_ADMIN: ((cf_admin))
             CF_PASS: ((cf_pass))
@@ -3395,7 +3401,11 @@ jobs:
                 if ! cf service billing-logit-ssl-drain > /dev/null; then
                   cf create-user-provided-service \
                     billing-logit-ssl-drain \
-                    -l "${LOGIT_ADDRESS}"
+                    -l "syslog-tls://${LOGIT_ADDRESS}:${LOGIT_PORT}"
+                else
+                  cf update-user-provided-service \
+                    billing-logit-ssl-drain \
+                    -l "syslog-tls://${LOGIT_ADDRESS}:${LOGIT_PORT}"
                 fi
 
                 cp "paas-cf/config/billing/output/${AWS_REGION}.json" paas-billing/config.json


### PR DESCRIPTION
What
----

When we were converting our pipelines to use Credhub I think we messed up how we create/update our logit drains:

- PaaS-admin was updated properly in the pipeline but with bad credentials
- PaaS-billing was not updated after it was first created so never got the bad credentials

This PR ensures the drains are always properly created/updated and that the credentials are good

How to review
-------------

Code review

Check that both tlwr paas-admin and paas-billing are shipping logs into Logit:

```
https://kibana.logit.io/s/c7358874-2b30-44a6-8271-554ad3996e50/app/kibana#/visualize/create?type=line&indexPattern=logstash-*&_g=()&_a=(filters:!(),linked:!f,query:(query_string:(analyze_wildcard:!t,query:'@source.app_name:"paas-admin"%20OR%20@source.app_name:"paas-billing-api"')),uiState:(),vis:(aggs:!((enabled:!t,id:'1',params:(),schema:metric,type:count),(enabled:!t,id:'2',params:(customInterval:'2h',extended_bounds:(),field:'@timestamp',interval:auto,min_doc_count:1),schema:segment,type:date_histogram),(enabled:!t,id:'3',params:(field:'@source.app_name.keyword',order:desc,orderBy:'1',size:5),schema:group,type:terms)),listeners:(),params:(addLegend:!t,addTimeMarker:!f,addTooltip:!t,categoryAxes:!((id:CategoryAxis-1,labels:(show:!t,truncate:100),position:bottom,scale:(type:linear),show:!t,style:(),title:(text:'@timestamp%20per%2030%20seconds'),type:category)),grid:(categoryLines:!f,style:(color:%23eee)),legendPosition:right,seriesParams:!((data:(id:'1',label:Count),drawLinesBetweenPoints:!t,mode:normal,show:true,showCircles:!t,type:histogram,valueAxis:ValueAxis-1)),times:!(),type:line,valueAxes:!((id:ValueAxis-1,labels:(filter:!f,rotate:0,show:!t,truncate:100),name:LeftAxis-1,position:left,scale:(mode:normal,type:linear),show:!t,style:(),title:(text:Count),type:value))),title:'New%20Visualization',type:line))
```

Who can review
--------------

Not @tlwr
