### PR TITLE
Fix "cf_pass is not set" on first pipeline run

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -818,6 +818,30 @@ jobs:
                     credhub set --type password --name "/$DEPLOY_ENV/$DEPLOY_ENV/$secret_name" --password "$value"
                   done
 
+        - task: generate-cf-admin-password
+          tags: [colocated-with-web]
+          config:
+            platform: linux
+            image_resource: *gov-paas-bosh-cli-v2-image-resource
+            inputs:
+              - name: paas-cf
+            params:
+              CREDHUB_CLIENT: credhub-admin
+              CREDHUB_SECRET: ((bosh-credhub-admin))
+              CREDHUB_CA_CERT: ((bosh-credhub-ca-cert))
+              CREDHUB_SERVER: "https://((bosh_fqdn)):8844/api"
+              DEPLOY_ENV: ((deploy_env))
+            run:
+              path: bash
+              args:
+                - -c
+                - -e
+                - |
+                  credhub login
+                  credhub generate -n "/${DEPLOY_ENV}/${DEPLOY_ENV}/cf_admin_password" -t password --no-overwrite
+                  credhub get -q -n "/${DEPLOY_ENV}/${DEPLOY_ENV}/cf_admin_password" | tr -d '[:space:]' > cf-admin-password
+                  credhub set -t password -n "/concourse/main/cf_pass" -w "$(cat cf-admin-password)"
+
   - name: pre-deploy
     plan:
       - in_parallel:


### PR DESCRIPTION
What
----

The first time the `create-cloudfoundry` pipeline runs, it doesn't have
a value for `cf_pass` in credhub. This is required in the `pre-deploy`
step, which causes the pipeline to fail.

Ordinarily `cf_pass` would be generated by bosh as part of `cf-deploy`,
but since that happens later it's not much help.

Instead, this commit adds a task to generate secrets which uses credhub
to generate a value for the cf admin password (in the bosh namespace),
using the `--no-overwrite` flag to prevent this from clobbering the old
value. It then copies this secret from the bosh namespace to the
concourse namespace so it can be used in the pipeline.

How to review
-------------

* Code review
* Bootstrap a cloudfoundry using this commit to show it works (@46Bit is doing this)

Who can review
--------------

Probably best to leave it to @46Bit