### PR TITLE
Scale Diego cells in London to 36

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -1,5 +1,5 @@
 ---
-cell_instances: 33
+cell_instances: 36
 router_instances: 6
 api_instances: 12
 doppler_instances: 33


### PR DESCRIPTION
What
----
Over the last 180 days we've seen a steady upward trend of memory consumption
on the Diego cells (see GitHub PR). Today, the alarm for <30% availability was
triggered, indicating that we should scale up.

We are scaling from 33 to 36, so that we get one new cell in each AZ.

![image](https://user-images.githubusercontent.com/1747386/67682321-fc93f680-f986-11e9-9df4-9af774c0c7b1.png)

How to review
-------------

1. Code review

Who can review
--------------
Anyone
