### PR TITLE
Avoid CredHub issue to generate CF admin password

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -838,9 +838,13 @@ jobs:
                 - -e
                 - |
                   credhub login
-                  credhub generate -n "/${DEPLOY_ENV}/${DEPLOY_ENV}/cf_admin_password" -t password --no-overwrite
-                  credhub get -q -n "/${DEPLOY_ENV}/${DEPLOY_ENV}/cf_admin_password" | tr -d '[:space:]' > cf-admin-password
-                  credhub set -t password -n "/concourse/main/cf_pass" -w "$(cat cf-admin-password)"
+                  if credhub get -q -n "/${DEPLOY_ENV}/${DEPLOY_ENV}/cf_admin_password" > /dev/null; then
+                    echo "CF Admin Password already set. Skipping."
+                  else
+                    credhub generate -n "/${DEPLOY_ENV}/${DEPLOY_ENV}/cf_admin_password" -t password --no-overwrite
+                    cf_admin_password=$(credhub get -n "/${DEPLOY_ENV}/${DEPLOY_ENV}/cf_admin_password" -q)
+                    credhub set -t password -n "/concourse/main/cf_pass" -w "${cf_admin_password}"
+                  fi
 
   - name: pre-deploy
     plan:


### PR DESCRIPTION
What
----

Fixes #2124, as `credhub generate --no-overwrite` doesn't do what we wanted. See commit message for details.

How to review
-------------

Code review. Ideally deploy to an existing env and check it doesn't update your secrets.

Who can review
--------------

Not @46bit.