### PR TITLE
Correctly (un)pin deployment kick off resource in Concourse

### DIFF
--- a/concourse/scripts/pause-kick-off.sh
+++ b/concourse/scripts/pause-kick-off.sh
@@ -30,7 +30,12 @@ $("${SCRIPT_DIR}/environment.sh")
 "${SCRIPT_DIR}/fly_sync_and_login.sh"
 FLY="$FLY_CMD -t ${FLY_TARGET}"
 
-VERSION="$(${FLY} resource-versions -r deployment-kick-off/deployment-timer | grep time | cut -d ' ' -f3 | head -n 1)"
+if [ "${action}" == "pin" ]; then
+  VERSION="$(${FLY} resource-versions -r deployment-kick-off/deployment-timer | grep time | cut -d ' ' -f3 | head -n 1)"
 
-${FLY} "${action}-resource" -r "deployment-kick-off/deployment-timer" -v "${VERSION}"
+  ${FLY} pin-resource -r "deployment-kick-off/deployment-timer" -v "${VERSION}"
+elif [ "${action}" == "unpin" ]; then
+  ${FLY} unpin-resource -r "deployment-kick-off/deployment-timer"
+fi
+
 


### PR DESCRIPTION
What
----

In Fly v5.6.0, the `unpin-resource` action does not take a `-v|--version`
argument, but `pin-resource` does. The way the script was written did not
distinguish between the two actions, and provided the same arguments for both.
This resulted in the `unpin-resource` action doing nothing but printing out the
version of Fly.

```
$ ./bin/fly -t andyhunt unpin-resource \
  -r deployment-kick-off/deployment-timer \
  -v 2019-10-25T07:00:39.704321576+01:00

5.6.0
```

This commit recognises the difference between the required arguments, so that
the `unpin-resource` actually does something.

How to review
-------------

Use the `make` targets to pause an unpause your kick off deployment timer resource, and check that does what it should.

Who can review
--------------
Anyone
