### PR TITLE
Tweak bosh high cpu alert

### DIFF
--- a/manifests/prometheus/alerts.d/bosh-high-cpu-utilisation.yml
+++ b/manifests/prometheus/alerts.d/bosh-high-cpu-utilisation.yml
@@ -7,7 +7,7 @@
     name: BoshHighCPUUtilisation
     rules:
       - record: "bosh_job:bosh_job_cpu:avg1h"
-        expr: avg_over_time(bosh_job_cpu_sys{bosh_job_name!="diego-cell",bosh_job_name!="concourse"}[1h]) + avg_over_time(bosh_job_cpu_user{bosh_job_name!="diego-cell",bosh_job_name!="concourse"}[1h]) + avg_over_time(bosh_job_cpu_wait{bosh_job_name!="diego-cell",bosh_job_name!="concourse"}[1h])
+        expr: avg_over_time(bosh_job_cpu_sys{bosh_job_name!="diego-cell",bosh_job_name!~"^concourse.*",bosh_job_name!~"^compilation-.*"}[1h]) + avg_over_time(bosh_job_cpu_user{bosh_job_name!="diego-cell",bosh_job_name!~"^concourse.*",bosh_job_name!~"^compilation-.*"}[1h]) + avg_over_time(bosh_job_cpu_wait{bosh_job_name!="diego-cell",bosh_job_name!~"^concourse.*",bosh_job_name!~"^compilation-.*"}[1h])
 
       - alert: BoshHighCPUUtilisation
         expr: "bosh_job:bosh_job_cpu:avg1h > 70"

--- a/manifests/prometheus/spec/alerts/bosh-high-cpu-utilisation.test.yml
+++ b/manifests/prometheus/spec/alerts/bosh-high-cpu-utilisation.test.yml
@@ -6,6 +6,9 @@ rule_files:
 evaluation_interval: 1m
 
 tests:
+  # When CPU usage is above 80% for >= 60m
+  # when the VM is not a compilation VM
+  # then an alert should fire with the name of the VM
   - interval: 1h
     input_series:
       - series: "bosh_job_cpu_sys{bosh_job_name='test',bosh_job_index='0'}"
@@ -31,3 +34,87 @@ tests:
             exp_annotations:
               summary: "High cpu utilisation on test/0"
               description: "test/0 CPU utilisation was over 80% in the last hour on average"
+
+  # When CPU usage is above 80% for >= 60m
+  # when the VM is a compilation VM
+  # then no alerts should fire
+  - interval: 1h
+    input_series:
+      - series: "bosh_job_cpu_sys{bosh_job_name='compilation-00000000',bosh_job_index='0'}"
+        values: 60 80 95
+
+      - series: "bosh_job_cpu_user{bosh_job_name='compilation-00000000',bosh_job_index='0'}"
+        values: 0 0 0 0 0
+
+      - series: "bosh_job_cpu_wait{bosh_job_name='compilation-00000000',bosh_job_index='0'}"
+        values: 0 0 0 0 0
+
+
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: BoshHighCPUUtilisation
+      - eval_time: 61m
+        alertname: BoshHighCPUUtilisation
+
+  # When CPU usage is above 80% for >= 60m
+  # when the VM is a concourse VM
+  # then no alerts should fire
+  - interval: 1h
+    input_series:
+      - series: "bosh_job_cpu_sys{bosh_job_name='concourse',bosh_job_index='0'}"
+        values: 60 80 95
+
+      - series: "bosh_job_cpu_user{bosh_job_name='concourse',bosh_job_index='0'}"
+        values: 0 0 0 0 0
+
+      - series: "bosh_job_cpu_wait{bosh_job_name='concourse',bosh_job_index='0'}"
+        values: 0 0 0 0 0
+
+
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: BoshHighCPUUtilisation
+      - eval_time: 61m
+        alertname: BoshHighCPUUtilisation
+
+  # When CPU usage is above 80% for >= 60m
+  # when the VM is a concourse-worker VM
+  # then no alerts should fire
+  - interval: 1h
+    input_series:
+      - series: "bosh_job_cpu_sys{bosh_job_name='concourse-worker',bosh_job_index='0'}"
+        values: 60 80 95
+
+      - series: "bosh_job_cpu_user{bosh_job_name='concourse-worker',bosh_job_index='0'}"
+        values: 0 0 0 0 0
+
+      - series: "bosh_job_cpu_wait{bosh_job_name='concourse-worker',bosh_job_index='0'}"
+        values: 0 0 0 0 0
+
+
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: BoshHighCPUUtilisation
+      - eval_time: 61m
+        alertname: BoshHighCPUUtilisation
+
+  # When CPU usage is above 80% for >= 60m
+  # when the VM is a diego-cell VM
+  # then no alerts should fire
+  - interval: 1h
+    input_series:
+      - series: "bosh_job_cpu_sys{bosh_job_name='diego-cell',bosh_job_index='0'}"
+        values: 60 80 95
+
+      - series: "bosh_job_cpu_user{bosh_job_name='diego-cell',bosh_job_index='0'}"
+        values: 0 0 0 0 0
+
+      - series: "bosh_job_cpu_wait{bosh_job_name='deigo-cell',bosh_job_index='0'}"
+        values: 0 0 0 0 0
+
+
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: BoshHighCPUUtilisation
+      - eval_time: 61m
+        alertname: BoshHighCPUUtilisation


### PR DESCRIPTION
What
----

We have an alert which tells us if a BOSH managed instance is under load.

Before this PR Diego cells and Concourse VMs were exempt from the alert.

After this PR the following instances are exempt from the alert:

- Diego cells (no change)
- Concourse (no change)
- Concourse workers (if Concourse is exempt the workers should be too)
- Compilation VMs (deploys are noisy, they should have high CPU anyway)

How to review
-------------

- Behaviour review
- Code review
- [Review this dashboard](https://grafana-1.london.cloud.service.gov.uk/d/HnfjWh0Zz/noisy-alerts?orgId=1&from=now-2d&to=now)

Who can review
--------------

Not @tlwr
