### PR TITLE
Switch DNS to point to ALB

### DIFF
--- a/terraform/cloudfoundry/dns-records.tf
+++ b/terraform/cloudfoundry/dns-records.tf
@@ -43,7 +43,7 @@ resource "aws_route53_record" "apps_wildcard" {
   name    = "*.${var.apps_dns_zone_name}"
   type    = "CNAME"
   ttl     = "60"
-  records = ["${aws_elb.cf_router.dns_name}"]
+  records = ["${aws_lb.cf_router_app_domain.dns_name}"]
 
   set_identifier = "apps-wildcard"
 

--- a/terraform/dev.tfvars
+++ b/terraform/dev.tfvars
@@ -13,8 +13,8 @@ cdn_db_skip_final_snapshot = "true"
 cdn_db_maintenance_window = "Mon:07:00-Mon:08:00"
 support_email="govpaas-alerting-dev@digital.cabinet-office.gov.uk"
 
-apps_wildcard_weight="50"
-apps_wildcard_canary_weight="50"
+apps_wildcard_weight="0"
+apps_wildcard_canary_weight="100"
 
 # 14313350 - GOV.UK PaaS Contact - dev
 pingdom_contact_ids = [ 14313350 ]

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -15,8 +15,8 @@ bosh_db_backup_retention_period = "35"
 bosh_db_skip_final_snapshot = "false"
 support_email="gov-uk-paas-support@digital.cabinet-office.gov.uk"
 
-apps_wildcard_weight="100"
-apps_wildcard_canary_weight="0"
+apps_wildcard_weight="0"
+apps_wildcard_canary_weight="100"
 
 # 14313358 - GOV.UK PaaS Contact - prod
 # 14270734 - PaaS PagerDuty 24x7

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -15,8 +15,8 @@ bosh_db_backup_retention_period = "35"
 bosh_db_skip_final_snapshot = "false"
 support_email="govpaas-alerting-staging@digital.cabinet-office.gov.uk"
 
-apps_wildcard_weight="50"
-apps_wildcard_canary_weight="50"
+apps_wildcard_weight="0"
+apps_wildcard_canary_weight="100"
 
 # 14313354 - GOV.UK PaaS Contact - staging
 # 14270725 - PaaS PagerDuty in hours


### PR DESCRIPTION
What
----

This was done via ClickOps and now we should put it in code

A follow up PR will remove the canary weighted set record and all traffic will go to the ALB

How to review
-------------

Code review

Who can review
--------------

Not @tlwr