### PR TITLE
Revert change to exchange rate

### DIFF
--- a/config/billing/config-parts/currency_rates.json.erb
+++ b/config/billing/config-parts/currency_rates.json.erb
@@ -8,10 +8,5 @@
 			"code": "USD",
 			"valid_from": "epoch",
 			"rate": 0.8
-		},
-		{
-			"code": "USD",
-			"valid_from": "2019-10-18",
-			"rate": 0.78
 		}
 ]

--- a/config/billing/output/eu-west-1.json
+++ b/config/billing/output/eu-west-1.json
@@ -10,11 +10,6 @@
 			"code": "USD",
 			"valid_from": "epoch",
 			"rate": 0.8
-		},
-		{
-			"code": "USD",
-			"valid_from": "2019-10-18",
-			"rate": 0.78
 		}
 	],
 	"vat_rates": [

--- a/config/billing/output/eu-west-2.json
+++ b/config/billing/output/eu-west-2.json
@@ -10,11 +10,6 @@
 			"code": "USD",
 			"valid_from": "epoch",
 			"rate": 0.8
-		},
-		{
-			"code": "USD",
-			"valid_from": "2019-10-18",
-			"rate": 0.78
 		}
 	],
 	"vat_rates": [


### PR DESCRIPTION
What
----

We think it's better for us to charge the exchange rate that we get when
we pay for our AWS usage, rather than the rate from the central bank.
This better reflects the costs which we're passing on to tenants.

This means we should not have changed the exchange rate to 0.78, and
going forwards we should update the rate whenever we make a new AWS
prepayment.

How to review
-------------

* Code review

Who can review
--------------

Not @richardtowers