### PR TITLE
Move traffic back to non-canary DNS record

### DIFF
--- a/terraform/dev.tfvars
+++ b/terraform/dev.tfvars
@@ -13,8 +13,8 @@ cdn_db_skip_final_snapshot = "true"
 cdn_db_maintenance_window = "Mon:07:00-Mon:08:00"
 support_email="govpaas-alerting-dev@digital.cabinet-office.gov.uk"
 
-apps_wildcard_weight="0"
-apps_wildcard_canary_weight="100"
+apps_wildcard_weight="100"
+apps_wildcard_canary_weight="0"
 
 # 14313350 - GOV.UK PaaS Contact - dev
 pingdom_contact_ids = [ 14313350 ]

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -15,8 +15,8 @@ bosh_db_backup_retention_period = "35"
 bosh_db_skip_final_snapshot = "false"
 support_email="gov-uk-paas-support@digital.cabinet-office.gov.uk"
 
-apps_wildcard_weight="0"
-apps_wildcard_canary_weight="100"
+apps_wildcard_weight="100"
+apps_wildcard_canary_weight="0"
 
 # 14313358 - GOV.UK PaaS Contact - prod
 # 14270734 - PaaS PagerDuty 24x7

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -15,8 +15,8 @@ bosh_db_backup_retention_period = "35"
 bosh_db_skip_final_snapshot = "false"
 support_email="govpaas-alerting-staging@digital.cabinet-office.gov.uk"
 
-apps_wildcard_weight="0"
-apps_wildcard_canary_weight="100"
+apps_wildcard_weight="100"
+apps_wildcard_canary_weight="0"
 
 # 14313354 - GOV.UK PaaS Contact - staging
 # 14270725 - PaaS PagerDuty in hours


### PR DESCRIPTION
What
----

The non-canary DNS record is also pointing back to the ALB

Send all traffic so the canary is not used...

How to review
-------------

Code review: verify that the regular DNS record is pointing to the ALB not the ELB: #2131 

Who can review
--------------

Not @tlwr