### PR TITLE
Set LB deregistration timeout

### DIFF
--- a/manifests/cf-manifest/operations.d/350-diego-cell.yml
+++ b/manifests/cf-manifest/operations.d/350-diego-cell.yml
@@ -48,5 +48,9 @@
   path: /instance_groups/name=diego-cell/jobs/name=route_emitter/properties/uaa
 
 - type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=route_emitter/properties/diego/route_emitter/sync_interval_in_seconds?
+  value: 30
+
+- type: replace
   path: /instance_groups/name=diego-cell/networks/0/name
   value: cell

--- a/terraform/cloudfoundry/lbs.tf
+++ b/terraform/cloudfoundry/lbs.tf
@@ -13,10 +13,11 @@ resource "aws_lb" "cf_loggregator" {
 }
 
 resource "aws_lb_target_group" "cf_loggregator_rlp" {
-  name     = "${var.env}-cf-loggregator-rlp"
-  port     = 8088
-  protocol = "HTTPS"
-  vpc_id   = "${var.vpc_id}"
+  name                 = "${var.env}-cf-loggregator-rlp"
+  port                 = 8088
+  protocol             = "HTTPS"
+  vpc_id               = "${var.vpc_id}"
+  deregistration_delay = 60
 
   health_check {
     matcher = "200-499"
@@ -150,9 +151,8 @@ resource "aws_lb_listener" "cf_router_app_domain_https" {
   load_balancer_arn = "${aws_lb.cf_router_app_domain.arn}"
   port              = "443"
   protocol          = "HTTPS"
-
-  ssl_policy      = "${var.default_elb_security_policy}"
-  certificate_arn = "${aws_acm_certificate.apps.arn}"
+  ssl_policy        = "${var.default_elb_security_policy}"
+  certificate_arn   = "${aws_acm_certificate.apps.arn}"
 
   default_action {
     type             = "forward"
@@ -161,10 +161,11 @@ resource "aws_lb_listener" "cf_router_app_domain_https" {
 }
 
 resource "aws_lb_target_group" "cf_router_app_domain_https" {
-  name     = "${var.env}-app-tls-tg"
-  port     = 8443
-  protocol = "HTTPS"
-  vpc_id   = "${var.vpc_id}"
+  name                 = "${var.env}-app-tls-tg"
+  port                 = 8443
+  protocol             = "HTTPS"
+  vpc_id               = "${var.vpc_id}"
+  deregistration_delay = 110
 
   health_check {
     port                = 8080
@@ -224,9 +225,8 @@ resource "aws_lb_listener" "cf_router_system_domain_https" {
   load_balancer_arn = "${aws_lb.cf_router_system_domain.arn}"
   port              = "443"
   protocol          = "HTTPS"
-
-  ssl_policy      = "${var.default_elb_security_policy}"
-  certificate_arn = "${data.aws_acm_certificate.system.arn}"
+  ssl_policy        = "${var.default_elb_security_policy}"
+  certificate_arn   = "${data.aws_acm_certificate.system.arn}"
 
   default_action {
     type             = "forward"
@@ -235,10 +235,11 @@ resource "aws_lb_listener" "cf_router_system_domain_https" {
 }
 
 resource "aws_lb_target_group" "cf_router_system_domain_https" {
-  name     = "${var.env}-system-tls-tg"
-  port     = 8443
-  protocol = "HTTPS"
-  vpc_id   = "${var.vpc_id}"
+  name                 = "${var.env}-system-tls-tg"
+  port                 = 8443
+  protocol             = "HTTPS"
+  vpc_id               = "${var.vpc_id}"
+  deregistration_delay = 110
 
   health_check {
     port                = 8080


### PR DESCRIPTION
What
----

We should sync the routing table more often to avoid the situation where gorouter misses a message from NATS about a route deregistration (during instance evacuation)

We should specify a value for `deregistration_delay` for our `aws_lb`s which is equivalent for the `aws_elb`s that they replace (I added one for loggregator as well, which is less crucial) (read the commit for this one).

How to review
-------------

Code review

Run down your pipeline

Who can review
--------------

Not @tlwr