### PR TITLE
Vertically scale the CF scheduler VM

### DIFF
--- a/manifests/cf-manifest/operations.d/100-cf-update-vm-types.yml
+++ b/manifests/cf-manifest/operations.d/100-cf-update-vm-types.yml
@@ -22,15 +22,15 @@
   value: medium
 - type: replace
   path: /instance_groups/name=scheduler/vm_type
-  value: medium
+  value: large
 - type: replace
   path: /instance_groups/name=uaa/vm_type
   value: medium
+
 - type: replace
   path: /instance_groups/name=rotate-cc-database-key/vm_type
   value: errand
 
-# TODO: Remove the router vm_type. Not needed with extensions
 - type: replace
   path: /instance_groups/name=router/vm_type
   value: router


### PR DESCRIPTION
What
----
The scheduler VM in prod has a high load average on the active instance.

There are singleton components which run on the scheduler VM, as such
horizontally scaling it will not solve the problem.

Changing it from a medium to a large takes it from a t3.medium to an
m5.large which adds some cost, however increases the vCPU shares
allocated to it.

Additionally, when we schedule t3 instances they start with 0 CPU
credits, which means that it has no capacity to burst when under high
load. This is especially problematic when we are doing a deployment and
the scheduler VM is rolled, a new one comes up with no capacity for
bursting CPU

![Screen Shot 2019-10-31 at 13 27 57](https://user-images.githubusercontent.com/1482692/67950808-4298c680-fbe2-11e9-94f4-5f95de7ff6ea.png)
_Image of CPU usage from Amazon, where >100% is burst_

![Screen Shot 2019-10-31 at 13 40 20](https://user-images.githubusercontent.com/1482692/67951778-0c5c4680-fbe4-11e9-9a13-7f82fca97bc2.png)

_Image of CPU usage from BOSH/Prometheus, review user CPU usage and load average_

The load average chart is particularly worrying, the t3.medium has 2 vCPUs, so it reaching a load average of 6 means that it is overloaded by 300% during this time period.

Note: I have not scaled the dev machine type as this does not seem to be a problem during development

How to review
-------------

Code review

Chart review

Who can review
--------------

Not @tlwr