### PR TITLE
[#169401847] Release a fix for upgrading RDS instances

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -3,10 +3,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 0.1.59
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.59.tgz
-    sha1: 77cd9dc39794acb635f45eb759e088db95c900b0
-
+    version: 0.1.60
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.60.tgz
+    sha1: c08661a2e3e7cec721a6929e2676aa288779d11e
 
 - type: replace
   path: /instance_groups/-


### PR DESCRIPTION
What
----

This commit includes fixes for issues that were preventing upgrading tenant databases from Postgres 10 to 11 and MySQL 5.7 to 8.0 [1]. It also prevents people attempting an upgrade from Postgres 9.5 as we know that doesn't work due to issues upgrading PostGIS [2].

[1] https://github.com/alphagov/paas-rds-broker/pull/109
[2] https://www.pivotaltracker.com/story/show/169477843

How to review
-------------

Check this matches the hash of the release build of https://github.com/alphagov/paas-rds-broker-boshrelease/pull/87.

Who can review
--------------

Not @46bit