### PR TITLE
[#169180189] Add PaaS Admin IAM User

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1564,6 +1564,8 @@ jobs:
                 METRICS_SECRET=$(credhub get -q -n "${BOSH_NS}/secrets_uaa_clients_paas_metrics_secret")
                 METRICS_AWS_ACCESS_KEY_ID=$($VAL_FROM_YAML terraform_outputs_metrics_exporter_aws_access_key_id cf-terraform-outputs.yml)
                 METRICS_AWS_SECRET_ACCESS_KEY=$($VAL_FROM_YAML terraform_outputs_metrics_exporter_aws_secret_access_key cf-terraform-outputs.yml)
+                PAAS_ADMIN_AWS_ACCESS_KEY_ID=$($VAL_FROM_YAML terraform_outputs_paas_admin_metrics_aws_access_key_id cf-terraform-outputs.yml)
+                PAAS_ADMIN_AWS_SECRET_ACCESS_KEY=$($VAL_FROM_YAML terraform_outputs_paas_admin_metrics_aws_secret_access_key cf-terraform-outputs.yml)
                 UAA_CLIENTS_CF_EXPORTER_SECRET=$(credhub get -q -n "${BOSH_NS}/uaa_clients_cf_exporter_secret")
                 UAA_CLIENTS_FIREHOSE_EXPORTER_SECRET=$(credhub get -q -n "${BOSH_NS}/uaa_clients_firehose_exporter_secret")
                 RDS_BROKER_PASS=$(credhub get -q -n "${BOSH_NS}/secrets_rds_broker_admin_password")
@@ -1590,6 +1592,8 @@ jobs:
                 credhub set --name="${PIPELINE_NS}/metrics_secret" --type password --password "${METRICS_SECRET}"
                 credhub set --name="${PIPELINE_NS}/metrics_aws_access_key_id" --type password --password "${METRICS_AWS_ACCESS_KEY_ID}"
                 credhub set --name="${PIPELINE_NS}/metrics_aws_secret_access_key" --type password --password "${METRICS_AWS_SECRET_ACCESS_KEY}"
+                credhub set --name="${PIPELINE_NS}/paas_admin_aws_access_key_id" --type password --password "${PAAS_ADMIN_AWS_ACCESS_KEY_ID}"
+                credhub set --name="${PIPELINE_NS}/paas_admin_aws_secret_access_key" --type password --password "${PAAS_ADMIN_AWS_SECRET_ACCESS_KEY}"
                 credhub set --name="${PIPELINE_NS}/uaa_clients_cf_exporter_secret" --type password --password "${UAA_CLIENTS_CF_EXPORTER_SECRET}"
                 credhub set --name="${PIPELINE_NS}/uaa_clients_firehose_exporter_secret" --type password --password "${UAA_CLIENTS_FIREHOSE_EXPORTER_SECRET}"
                 credhub set --name="${PIPELINE_NS}/secrets_rds_broker_admin_password" --type password --password "${RDS_BROKER_PASS}"
@@ -3237,6 +3241,8 @@ jobs:
                     GOOGLE_CLIENT_ID: ((google_paas_admin_client_id))
                     GOOGLE_CLIENT_SECRET: ((google_paas_admin_client_secret))
                     DOMAIN_NAME: "https://admin.${SYSTEM_DNS_ZONE_NAME}"
+                    AWS_ACCESS_KEY_ID: ((paas_admin_aws_access_key_id))
+                    AWS_SECRET_ACCESS_KEY: ((paas_admin_aws_secret_access_key))
                 EOF
 
                 spruce merge \

--- a/terraform/cloudfoundry/outputs.tf
+++ b/terraform/cloudfoundry/outputs.tf
@@ -200,3 +200,13 @@ output "yace_aws_secret_access_key" {
   sensitive = true
   value     = "${aws_iam_access_key.yace.secret}"
 }
+
+output "paas_admin_metrics_aws_access_key_id" {
+  sensitive = true
+  value     = "${aws_iam_access_key.paas_admin_metrics.id}"
+}
+
+output "paas_admin_metrics_aws_secret_access_key" {
+  sensitive = true
+  value     = "${aws_iam_access_key.paas_admin_metrics.secret}"
+}

--- a/terraform/cloudfoundry/paas-admin-metrics.tf
+++ b/terraform/cloudfoundry/paas-admin-metrics.tf
@@ -1,0 +1,14 @@
+resource "aws_iam_user" "paas_admin_metrics" {
+  name = "paas-admin-metrics-${var.env}"
+
+  force_destroy = true
+}
+
+resource "aws_iam_user_group_membership" "paas_admin_metrics" {
+  user   = "${aws_iam_user.paas_admin_metrics.name}"
+  groups = ["paas-admin-metrics"]
+}
+
+resource "aws_iam_access_key" "paas_admin_metrics" {
+  user = "${aws_iam_user.paas_admin_metrics.name}"
+}


### PR DESCRIPTION
What
----

This adds an IAM user with read access to cloudwatch metrics, stores the AWS creds in credhub and passes them to paas-admin.

Related PR: https://github.com/alphagov/paas-admin/pull/493

How to review
-------------

Deploy to your dev env

Who can review
--------------

Not me
