### PR TITLE
Check secrets are interpolated in pipecleaner

### DIFF
--- a/concourse/scripts/pipecleaner_test.go
+++ b/concourse/scripts/pipecleaner_test.go
@@ -74,4 +74,18 @@ var _ = Describe("PipeCleaner", func() {
 			})
 		})
 	})
+
+	Context("secret-interpolation", func() {
+		Context("when there's a param that looks like a secret but is not interpolated", func () {
+			BeforeEach(func () {
+				command = exec.Command("./pipecleaner.py", "spec/fixtures/pipecleaner_secrets_interpolation.yml")
+			})
+
+			It("should report a warning", func () {
+				Expect(session).To(gexec.Exit(0))
+				Expect(session.Out).To(gbytes.Say("WARNING.*?job='secrets-interpolate', task='bad-secrets-interpolate'"))
+				Expect(session.Err.Contents()).To(BeEmpty())
+			})
+		})
+	})
 })

--- a/concourse/scripts/spec/fixtures/pipecleaner_secrets_interpolation.yml
+++ b/concourse/scripts/spec/fixtures/pipecleaner_secrets_interpolation.yml
@@ -1,0 +1,12 @@
+---
+resources: {}
+
+jobs:
+  - name: secrets-interpolate
+    plan:
+      - task: bad-secrets-interpolate
+        config:
+          params:
+            SOME_KEY_THING: some-non-interpolated-value
+            SOME_SECRET: some-non-interpolated-value
+            SECRET_THING: some-non-interpolated-value


### PR DESCRIPTION
What
----

We want to avoid accidentally writing bits of the pipeline like this:

```
jobs:
  - name: secrets-interpolate
    plan:
      - task: bad-secrets-interpolate
        config:
          params:
            SOME_KEY_THING: some-non-interpolated-value
```

It's quite likely that if the parameter key contains `KEY` or `SECRET`
the developer meant to interpolate the value with parens, like:

```
SOME_KEY_THING: ((some-interpolated-value))
```

In some cases this could cause a broken pipeline, in others it could
cause a security issue.

It's possible that there might be some legitimate use cases that cause
this test to fail in the future - it should be fine to update the test
to ignore these specifics when they come up.

How to review
-------------

* Code review
* Check the tests pass

Who can review
--------------

Not @richardtowers