### PR TITLE
Slow start router ALBs

### DIFF
--- a/terraform/cloudfoundry/lbs.tf
+++ b/terraform/cloudfoundry/lbs.tf
@@ -167,6 +167,7 @@ resource "aws_lb_target_group" "cf_router_app_domain_https" {
   protocol             = "HTTPS"
   vpc_id               = "${var.vpc_id}"
   deregistration_delay = 110
+  slow_start           = 45
 
   health_check {
     port                = 8080
@@ -241,6 +242,7 @@ resource "aws_lb_target_group" "cf_router_system_domain_https" {
   protocol             = "HTTPS"
   vpc_id               = "${var.vpc_id}"
   deregistration_delay = 110
+  slow_start           = 45
 
   health_check {
     port                = 8080

--- a/terraform/spec/alb_spec.rb
+++ b/terraform/spec/alb_spec.rb
@@ -73,6 +73,7 @@ describe 'alb' do
       .map { |val| val.gsub('${var.env}', 'prod-lon') }
 
 
+    expect(lb_names).not_to be_empty
     expect(lb_names).to all(match(/^[-a-z]{4,32}$/))
     expect(lb_names).not_to include(match('var.env'))
   end
@@ -81,6 +82,7 @@ describe 'alb' do
     access_logs = get_lbs(terraform)
       .map { |r| r.dig('access_logs') }
 
+    expect(access_logs).not_to be_empty
     expect(access_logs).not_to include(nil)
   end
 
@@ -88,6 +90,7 @@ describe 'alb' do
     deletion_protection = get_lbs(terraform)
       .map { |r| r.dig('enable_deletion_protection') }
 
+    expect(deletion_protection).not_to be_empty
     expect(deletion_protection).to all(be(nil))
   end
 end
@@ -116,6 +119,7 @@ describe 'alb_tgs' do
       .reject { |r| r.dig('port') == 83 } # This is temporary port
       .map { |r| r.dig('deregistration_delay') }
 
+    expect(deregistration_delay).not_to be_empty
     expect(deregistration_delay).to all(be < 120)
   end
 end


### PR DESCRIPTION
What
----

When registering new gorouters in the ALB, let's give them 45s to warm up before getting a full share of traffic. This will help us reduce the impact of the rare case where a gorouter has an incomplete routing table and doesn't know about all endpoints.

In the case where there is only a single target, then slow start mode is not activated.

How to review
-------------

Code review

Inspect the documentation on [slow start mode](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html)

Who can review
--------------

Not @tlwr