### PR TITLE
Switch billing costs from `increase` to `delta`

### DIFF
--- a/manifests/prometheus/dashboards.d/billing-compared-to-spending.json
+++ b/manifests/prometheus/dashboards.d/billing-compared-to-spending.json
@@ -71,21 +71,21 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum(increase(paas_billing_total_costs_pounds{name=\"app\"}[7d])) / (sum(avg_over_time(paas_aws_cost_explorer_by_service_pounds{service=\"Amazon Elastic Compute Cloud - Compute\"}[7d]))*7*$exchange_rate)",
+            "expr": "sum(delta(paas_billing_total_costs_pounds{name=\"app\"}[7d])) / (sum(avg_over_time(paas_aws_cost_explorer_by_service_pounds{service=\"Amazon Elastic Compute Cloud - Compute\"}[7d]))*7*$exchange_rate)",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "Proportion of AWS EC2 costs billed (7 day rolling average) (old)",
             "refId": "A"
           },
           {
-            "expr": "sum(increase(paas_billing_total_costs_pounds{name=\"app\"}[7d])) / (sum(avg_over_time(paas_aws_cost_explorer_by_service_dollars{service=\"Amazon Elastic Compute Cloud - Compute\"}[7d]))*7*$exchange_rate)",
+            "expr": "sum(delta(paas_billing_total_costs_pounds{name=\"app\"}[7d])) / (sum(avg_over_time(paas_aws_cost_explorer_by_service_dollars{service=\"Amazon Elastic Compute Cloud - Compute\"}[7d]))*7*$exchange_rate)",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "Proportion of AWS EC2 costs billed (7 day rolling average) (new)",
             "refId": "E"
           },
           {
-            "expr": "sum(increase(paas_billing_total_costs_pounds{name=\"app\"}[7d]))",
+            "expr": "sum(delta(paas_billing_total_costs_pounds{name=\"app\"}[7d]))",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "Compute billed / week",
@@ -199,21 +199,21 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum(increase(paas_billing_total_costs_pounds{name=~\"mysql.+|postgres.+\"}[7d])) / (sum(avg_over_time(paas_aws_cost_explorer_by_service_pounds{service=\"Amazon Relational Database Service\",type=\"AmortizedCost\"}[7d]))* 7*$exchange_rate)",
+            "expr": "sum(delta(paas_billing_total_costs_pounds{name=~\"mysql.+|postgres.+\"}[7d])) / (sum(avg_over_time(paas_aws_cost_explorer_by_service_pounds{service=\"Amazon Relational Database Service\",type=\"AmortizedCost\"}[7d]))* 7*$exchange_rate)",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "Proportion of RDS costs billed (7 day rolling average) (old)",
             "refId": "C"
           },
           {
-            "expr": "sum(increase(paas_billing_total_costs_pounds{name=~\"mysql.+|postgres.+\"}[7d])) / (sum(avg_over_time(paas_aws_cost_explorer_by_service_dollars{service=\"Amazon Relational Database Service\",type=\"AmortizedCost\"}[7d]))* 7*$exchange_rate)",
+            "expr": "sum(delta(paas_billing_total_costs_pounds{name=~\"mysql.+|postgres.+\"}[7d])) / (sum(avg_over_time(paas_aws_cost_explorer_by_service_dollars{service=\"Amazon Relational Database Service\",type=\"AmortizedCost\"}[7d]))* 7*$exchange_rate)",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "Proportion of RDS costs billed (7 day rolling average) (new)",
             "refId": "D"
           },
           {
-            "expr": "sum(increase(paas_billing_total_costs_pounds{name=~\"mysql.+|postgres.+\"}[7d]))",
+            "expr": "sum(delta(paas_billing_total_costs_pounds{name=~\"mysql.+|postgres.+\"}[7d]))",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "RDS billed / week",
@@ -328,7 +328,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum(increase(paas_billing_total_costs_pounds{name=~\"redis.+\"}[7d])) / (sum(avg_over_time(paas_aws_cost_explorer_by_service_pounds{service=\"Amazon ElastiCache\",type=\"AmortizedCost\"}[7d]))* 7*$exchange_rate)",
+            "expr": "sum(delta(paas_billing_total_costs_pounds{name=~\"redis.+\"}[7d])) / (sum(avg_over_time(paas_aws_cost_explorer_by_service_pounds{service=\"Amazon ElastiCache\",type=\"AmortizedCost\"}[7d]))* 7*$exchange_rate)",
             "format": "time_series",
             "interval": "",
             "intervalFactor": 1,
@@ -336,7 +336,7 @@
             "refId": "A"
           },
           {
-            "expr": "sum(increase(paas_billing_total_costs_pounds{name=~\"redis.+\"}[7d])) / (sum(avg_over_time(paas_aws_cost_explorer_by_service_dollars{service=\"Amazon ElastiCache\",type=\"AmortizedCost\"}[7d]))* 7*$exchange_rate)",
+            "expr": "sum(delta(paas_billing_total_costs_pounds{name=~\"redis.+\"}[7d])) / (sum(avg_over_time(paas_aws_cost_explorer_by_service_dollars{service=\"Amazon ElastiCache\",type=\"AmortizedCost\"}[7d]))* 7*$exchange_rate)",
             "format": "time_series",
             "interval": "",
             "intervalFactor": 1,
@@ -344,7 +344,7 @@
             "refId": "D"
           },
           {
-            "expr": "sum(increase(paas_billing_total_costs_pounds{name=~\"redis.+\"}[7d]))",
+            "expr": "sum(delta(paas_billing_total_costs_pounds{name=~\"redis.+\"}[7d]))",
             "format": "time_series",
             "interval": "",
             "intervalFactor": 1,
@@ -460,21 +460,21 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum(increase(paas_billing_total_costs_pounds{name=\"aws-s3-bucket default\"}[7d])) / (sum(avg_over_time(paas_aws_cost_explorer_by_service_pounds{service=\"Amazon Simple Storage Service\"}[7d]))* 7*$exchange_rate)",
+            "expr": "sum(delta(paas_billing_total_costs_pounds{name=\"aws-s3-bucket default\"}[7d])) / (sum(avg_over_time(paas_aws_cost_explorer_by_service_pounds{service=\"Amazon Simple Storage Service\"}[7d]))* 7*$exchange_rate)",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "Proportion of S3 costs billed (7 day rolling average) (old)",
             "refId": "C"
           },
           {
-            "expr": "sum(increase(paas_billing_total_costs_pounds{name=\"aws-s3-bucket default\"}[7d])) / (sum(avg_over_time(paas_aws_cost_explorer_by_service_dollars{service=\"Amazon Simple Storage Service\"}[7d]))* 7*$exchange_rate)",
+            "expr": "sum(delta(paas_billing_total_costs_pounds{name=\"aws-s3-bucket default\"}[7d])) / (sum(avg_over_time(paas_aws_cost_explorer_by_service_dollars{service=\"Amazon Simple Storage Service\"}[7d]))* 7*$exchange_rate)",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "Proportion of S3 costs billed (7 day rolling average) (new)",
             "refId": "D"
           },
           {
-            "expr": "sum(increase(paas_billing_total_costs_pounds{name=\"aws-s3-bucket default\"}[7d]))",
+            "expr": "sum(delta(paas_billing_total_costs_pounds{name=\"aws-s3-bucket default\"}[7d]))",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "S3 billed / week",
@@ -579,14 +579,14 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum(increase(paas_billing_total_costs_pounds{name=~\"elasticsearch.+\"}[1d])) / sum(delta(paas_aiven_estimated_cost_pounds[1d])) > 0",
+            "expr": "sum(delta(paas_billing_total_costs_pounds{name=~\"elasticsearch.+\"}[1d])) / sum(delta(paas_aiven_estimated_cost_pounds[1d])) > 0",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "Proportion of Aiven costs billed (1 day rolling average)",
             "refId": "A"
           },
           {
-            "expr": "sum(increase(paas_billing_total_costs_pounds{name=~\"elasticsearch.+\"}[1d]))",
+            "expr": "sum(delta(paas_billing_total_costs_pounds{name=~\"elasticsearch.+\"}[1d]))",
             "format": "time_series",
             "interval": "",
             "intervalFactor": 1,

--- a/manifests/prometheus/dashboards.d/billing-sli.json
+++ b/manifests/prometheus/dashboards.d/billing-sli.json
@@ -331,7 +331,7 @@
         "tableColumn": "",
         "targets": [
           {
-            "expr": "( sum(increase(paas_billing_total_costs_pounds{name=\"app\"}[7d]))+ sum(increase(paas_billing_total_costs_pounds{name=~\"mysql.+|postgres.+\"}[7d]))+ sum(increase(paas_billing_total_costs_pounds{name=~\"redis.+\"}[7d]))+ sum(increase(paas_billing_total_costs_pounds{name=\"aws-s3-bucket default\"}[7d]))) / (( sum(avg_over_time(paas_aws_cost_explorer_by_service_dollars{service=\"Amazon Elastic Compute Cloud - Compute\"}[7d]))+ sum(avg_over_time(paas_aws_cost_explorer_by_service_dollars{service=\"Amazon Relational Database Service\",type=\"AmortizedCost\"}[7d]))+ sum(avg_over_time(paas_aws_cost_explorer_by_service_dollars{service=\"Amazon ElastiCache\",type=\"AmortizedCost\"}[7d]))+ sum(avg_over_time(paas_aws_cost_explorer_by_service_dollars{service=\"Amazon Simple Storage Service\"}[7d])))*7*$exchange_rate)",
+            "expr": "( sum(delta(paas_billing_total_costs_pounds{name=\"app\"}[7d]))+ sum(delta(paas_billing_total_costs_pounds{name=~\"mysql.+|postgres.+\"}[7d]))+ sum(delta(paas_billing_total_costs_pounds{name=~\"redis.+\"}[7d]))+ sum(delta(paas_billing_total_costs_pounds{name=\"aws-s3-bucket default\"}[7d]))) / (( sum(avg_over_time(paas_aws_cost_explorer_by_service_dollars{service=\"Amazon Elastic Compute Cloud - Compute\"}[7d]))+ sum(avg_over_time(paas_aws_cost_explorer_by_service_dollars{service=\"Amazon Relational Database Service\",type=\"AmortizedCost\"}[7d]))+ sum(avg_over_time(paas_aws_cost_explorer_by_service_dollars{service=\"Amazon ElastiCache\",type=\"AmortizedCost\"}[7d]))+ sum(avg_over_time(paas_aws_cost_explorer_by_service_dollars{service=\"Amazon Simple Storage Service\"}[7d])))*7*$exchange_rate)",
             "format": "time_series",
             "intervalFactor": 1,
             "refId": "A"
@@ -396,7 +396,7 @@
             "displayAliasType": "Warning / Critical",
             "displayType": "Regular",
             "displayValueWithAlias": "Never",
-            "expr": "sum(increase(paas_billing_total_costs_pounds{name=\"app\"}[7d])) / (sum(avg_over_time(paas_aws_cost_explorer_by_service_dollars{service=\"Amazon Elastic Compute Cloud - Compute\"}[7d]))*7*$exchange_rate)",
+            "expr": "sum(delta(paas_billing_total_costs_pounds{name=\"app\"}[7d])) / (sum(avg_over_time(paas_aws_cost_explorer_by_service_dollars{service=\"Amazon Elastic Compute Cloud - Compute\"}[7d]))*7*$exchange_rate)",
             "format": "time_series",
             "instant": false,
             "intervalFactor": 1,
@@ -412,7 +412,7 @@
             "displayAliasType": "Warning / Critical",
             "displayType": "Regular",
             "displayValueWithAlias": "Never",
-            "expr": "sum(increase(paas_billing_total_costs_pounds{name=~\"mysql.+|postgres.+\"}[7d])) / (sum(avg_over_time(paas_aws_cost_explorer_by_service_dollars{service=\"Amazon Relational Database Service\",type=\"AmortizedCost\"}[7d]))* 7*$exchange_rate)",
+            "expr": "sum(delta(paas_billing_total_costs_pounds{name=~\"mysql.+|postgres.+\"}[7d])) / (sum(avg_over_time(paas_aws_cost_explorer_by_service_dollars{service=\"Amazon Relational Database Service\",type=\"AmortizedCost\"}[7d]))* 7*$exchange_rate)",
             "format": "time_series",
             "instant": false,
             "intervalFactor": 1,
@@ -422,7 +422,7 @@
             "valueHandler": "Number Threshold"
           },
           {
-            "expr": "sum(increase(paas_billing_total_costs_pounds{name=~\"redis.+\"}[7d])) / (sum(avg_over_time(paas_aws_cost_explorer_by_service_dollars{service=\"Amazon ElastiCache\",type=\"AmortizedCost\"}[7d]))* 7*$exchange_rate)",
+            "expr": "sum(delta(paas_billing_total_costs_pounds{name=~\"redis.+\"}[7d])) / (sum(avg_over_time(paas_aws_cost_explorer_by_service_dollars{service=\"Amazon ElastiCache\",type=\"AmortizedCost\"}[7d]))* 7*$exchange_rate)",
             "format": "time_series",
             "interval": "",
             "intervalFactor": 1,
@@ -430,14 +430,14 @@
             "refId": "C"
           },
           {
-            "expr": "sum(increase(paas_billing_total_costs_pounds{name=\"aws-s3-bucket default\"}[7d])) / (sum(avg_over_time(paas_aws_cost_explorer_by_service_dollars{service=\"Amazon Simple Storage Service\"}[7d]))* 7*$exchange_rate)",
+            "expr": "sum(delta(paas_billing_total_costs_pounds{name=\"aws-s3-bucket default\"}[7d])) / (sum(avg_over_time(paas_aws_cost_explorer_by_service_dollars{service=\"Amazon Simple Storage Service\"}[7d]))* 7*$exchange_rate)",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "S3 / AWS S3",
             "refId": "D"
           },
           {
-            "expr": "sum(increase(paas_billing_total_costs_pounds{name=~\"elasticsearch.+\"}[7d])) / sum(delta(paas_aiven_estimated_cost_pounds[7d])) > 0",
+            "expr": "sum(delta(paas_billing_total_costs_pounds{name=~\"elasticsearch.+\"}[7d])) / sum(delta(paas_aiven_estimated_cost_pounds[7d])) > 0",
             "format": "time_series",
             "interval": "",
             "intervalFactor": 1,


### PR DESCRIPTION
What
----

`increase` expects the metric to be a counter, which means it should
always either increase or reset to zero.

`paas_billing_total_costs_pounds` sounds like a counter, but it's
actually possible for it to go down (e.g. if we change our historical
exchange rate to be more favourable to tenants). In this case,
prometheus's `increase` function will assume it's a counter reset
followed by an unbelievably massive spend, which throws all the maths
out.

Switching to `delta` fixes this issue as it doesn't assume the metric is
a counter and therefore doesn't handle resets.

How to review
-------------

* Code review
* Compare the metrics computed [with delta](https://grafana-1.cloud.service.gov.uk/explore?left=%5B%22now-30d%22,%22now%22,%22prometheus%22,%7B%22expr%22:%22sum(delta(paas_billing_total_costs_pounds%7Bname%3D~%5C%22postgres.%2B%5C%22%7D%5B7d%5D))%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D), and [with increase](https://grafana-1.cloud.service.gov.uk/explore?left=%5B%22now-30d%22,%22now%22,%22prometheus%22,%7B%22expr%22:%22sum(increase(paas_billing_total_costs_pounds%7Bname%3D~%5C%22postgres.%2B%5C%22%7D%5B7d%5D))%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D)


Who can review
--------------

Not @richardtowers