### PR TITLE
[#169572618] Update buildpacks [waiting until 2019/11/13]

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -620,7 +620,7 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-accounts.git
       branch: master
-      tag_filter: v0.10.0
+      tag_filter: v0.14.0
 
   - name: paas-admin
     type: git

--- a/config/buildpacks.yml
+++ b/config/buildpacks.yml
@@ -2,18 +2,18 @@ buildpacks:
 - name: binary_buildpack
   repo_name: binary-buildpack
   stack: cflinuxfs3
-  version: v1.0.33
-  sha: 9643ee5ee1dfe652b13db68969880882261f18e43e329a58b89e9138a852870d
-  filename: binary-buildpack-cflinuxfs3-v1.0.33.zip
-  url: https://github.com/cloudfoundry/binary-buildpack/releases/download/v1.0.33/binary-buildpack-cflinuxfs3-v1.0.33.zip
+  version: v1.0.35
+  sha: 27e6774cde4c6adb6c5e54b51763fd204992a9ddb5bd2014447a7eefcb99d04e
+  filename: binary-buildpack-cflinuxfs3-v1.0.35.zip
+  url: https://github.com/cloudfoundry/binary-buildpack/releases/download/v1.0.35/binary-buildpack-cflinuxfs3-v1.0.35.zip
   dependencies: []
 - name: dotnet_core_buildpack
   repo_name: dotnet-core-buildpack
   stack: cflinuxfs3
-  version: v2.2.13
-  sha: 0a911b302a5143ac54807b3ccd4ac1984da4d280837938c6ec2ccff841d4be94
-  filename: dotnet-core-buildpack-cflinuxfs3-v2.2.13.zip
-  url: https://github.com/cloudfoundry/dotnet-core-buildpack/releases/download/v2.2.13/dotnet-core-buildpack-cflinuxfs3-v2.2.13.zip
+  version: v2.3.2
+  sha: a32ddc9524fc05f53b22233b10584861fcbe14048d84f85db8ca4174e0d3f859
+  filename: dotnet-core-buildpack-cflinuxfs3-v2.3.2.zip
+  url: https://github.com/cloudfoundry/dotnet-core-buildpack/releases/download/v2.3.2/dotnet-core-buildpack-cflinuxfs3-v2.3.2.zip
   dependencies:
   - name: bower
     version: 1.8.8
@@ -206,10 +206,10 @@ buildpacks:
 - name: go_buildpack
   repo_name: go-buildpack
   stack: cflinuxfs3
-  version: v1.8.42
-  sha: e58331dc86919bf96ddabd15c4ea9be97da22605557d60f3d4861ca8157111b9
-  filename: go-buildpack-cflinuxfs3-v1.8.42.zip
-  url: https://github.com/cloudfoundry/go-buildpack/releases/download/v1.8.42/go-buildpack-cflinuxfs3-v1.8.42.zip
+  version: v1.9.2
+  sha: e5bb712590f031d6747baa7a3677356359a963c7210a395a06b07cb8292db1d6
+  filename: go-buildpack-cflinuxfs3-v1.9.2.zip
+  url: https://github.com/cloudfoundry/go-buildpack/releases/download/v1.9.2/go-buildpack-cflinuxfs3-v1.9.2.zip
   dependencies:
   - name: dep
     version: 0.5.4
@@ -270,18 +270,18 @@ buildpacks:
 - name: java_buildpack
   repo_name: java-buildpack
   stack: cflinuxfs3
-  version: v4.20
-  sha: 58036bc99ade005e62df4303a85883eb8bab8c82c01834e7db662e6987c3f251
-  filename: java-buildpack-v4.20.zip
-  url: https://github.com/cloudfoundry/java-buildpack/releases/download/v4.20/java-buildpack-v4.20.zip
+  version: v4.25
+  sha: a239443da655ac89c7bf5f8e2e345608f3fdf7a8f196536211a7966306ec8ad9
+  filename: java-buildpack-v4.25.zip
+  url: https://github.com/cloudfoundry/java-buildpack/releases/download/v4.25/java-buildpack-v4.25.zip
   dependencies: []
 - name: nodejs_buildpack
   repo_name: nodejs-buildpack
   stack: cflinuxfs3
-  version: v1.6.54
-  sha: a0f58426693d54e9e76d818edaf1f6f1623adb9704084c36dcd6e11d9a75efba
-  filename: nodejs-buildpack-cflinuxfs3-v1.6.54.zip
-  url: https://github.com/cloudfoundry/nodejs-buildpack/releases/download/v1.6.54/nodejs-buildpack-cflinuxfs3-v1.6.54.zip
+  version: v1.7.2
+  sha: 28e1ce9cf6ea99ac626207bac4fde1569680ee92803b47d7e14f734c8649c993
+  filename: nodejs-buildpack-cflinuxfs3-v1.7.2.zip
+  url: https://github.com/cloudfoundry/nodejs-buildpack/releases/download/v1.7.2/nodejs-buildpack-cflinuxfs3-v1.7.2.zip
   dependencies:
   - name: node
     version: 8.16.0
@@ -331,10 +331,10 @@ buildpacks:
 - name: php_buildpack
   repo_name: php-buildpack
   stack: cflinuxfs3
-  version: v4.3.80
-  sha: 75ca7a4b711ad49f7703495e68c548e2d914d14c6f04b13cc744463c83307c0d
-  filename: php-buildpack-cflinuxfs3-v4.3.80.zip
-  url: https://github.com/cloudfoundry/php-buildpack/releases/download/v4.3.80/php-buildpack-cflinuxfs3-v4.3.80.zip
+  version: v4.4.1
+  sha: f2bed200848e7c8491ed65b4629b971537adc7d97ba5fb6b7f2eb8bda865ce32
+  filename: php-buildpack-cflinuxfs3-v4.4.1.zip
+  url: https://github.com/cloudfoundry/php-buildpack/releases/download/v4.4.1/php-buildpack-cflinuxfs3-v4.4.1.zip
   dependencies:
   - name: CAAPM
     version: 10.7.0
@@ -431,10 +431,10 @@ buildpacks:
 - name: python_buildpack
   repo_name: python-buildpack
   stack: cflinuxfs3
-  version: v1.6.36
-  sha: 3628a429f7b3c357e1acdbe2cc620c0c15a8463e68e762f4443c0ed7a39356e8
-  filename: python-buildpack-cflinuxfs3-v1.6.36.zip
-  url: https://github.com/cloudfoundry/python-buildpack/releases/download/v1.6.36/python-buildpack-cflinuxfs3-v1.6.36.zip
+  version: v1.7.0
+  sha: adbffc564e1dd3a1bd89181c81298b912130a1e72077d917053694cf49ce8f6c
+  filename: python-buildpack-cflinuxfs3-v1.7.0.zip
+  url: https://github.com/cloudfoundry/python-buildpack/releases/download/v1.7.0/python-buildpack-cflinuxfs3-v1.7.0.zip
   dependencies:
   - name: libffi
     version: 3.2.1
@@ -544,10 +544,10 @@ buildpacks:
 - name: ruby_buildpack
   repo_name: ruby-buildpack
   stack: cflinuxfs3
-  version: v1.7.42
-  sha: ad1e736567f7415ac62f208cbc61972089499acc80112c20b12286503477bab9
-  filename: ruby-buildpack-cflinuxfs3-v1.7.42.zip
-  url: https://github.com/cloudfoundry/ruby-buildpack/releases/download/v1.7.42/ruby-buildpack-cflinuxfs3-v1.7.42.zip
+  version: v1.8.2
+  sha: c1570b8f9ce883aa102752e1aee24fe523a46e3341f77d0cda125a7b7ed13537
+  filename: ruby-buildpack-cflinuxfs3-v1.8.2.zip
+  url: https://github.com/cloudfoundry/ruby-buildpack/releases/download/v1.8.2/ruby-buildpack-cflinuxfs3-v1.8.2.zip
   dependencies:
   - name: bundler
     version: 1.17.3
@@ -649,10 +649,10 @@ buildpacks:
 - name: staticfile_buildpack
   repo_name: staticfile-buildpack
   stack: cflinuxfs3
-  version: v1.4.44
-  sha: b859805d2b7bb9cd115b6e5891ed716906a7aad212125f6688fd94b8126b55df
-  filename: staticfile-buildpack-cflinuxfs3-v1.4.44.zip
-  url: https://github.com/cloudfoundry/staticfile-buildpack/releases/download/v1.4.44/staticfile-buildpack-cflinuxfs3-v1.4.44.zip
+  version: v1.5.1
+  sha: 76385476238870ba7d31f44096c49c6f5eb8f27d7c0d636dec2b15e2a82fc576
+  filename: staticfile-buildpack-cflinuxfs3-v1.5.1.zip
+  url: https://github.com/cloudfoundry/staticfile-buildpack/releases/download/v1.5.1/staticfile-buildpack-cflinuxfs3-v1.5.1.zip
   dependencies:
   - name: nginx
     version: 1.15.12
@@ -673,10 +673,10 @@ buildpacks:
 - name: nginx_buildpack
   repo_name: nginx-buildpack
   stack: cflinuxfs3
-  version: v1.0.17
-  sha: 6fa9f995f103c6a42e9c131f514f000fd5563a2a525f1867253785b5706ce690
-  filename: nginx-buildpack-cflinuxfs3-v1.0.17.zip
-  url: https://github.com/cloudfoundry/nginx-buildpack/releases/download/v1.0.17/nginx-buildpack-cflinuxfs3-v1.0.17.zip
+  version: v1.1.1
+  sha: 2214afd5edd96b03fb6399f339b92cd1fa38d483516afb46374e1b10c949885d
+  filename: nginx-buildpack-cflinuxfs3-v1.1.1.zip
+  url: https://github.com/cloudfoundry/nginx-buildpack/releases/download/v1.1.1/nginx-buildpack-cflinuxfs3-v1.1.1.zip
   dependencies:
   - name: nginx
     version: 1.16.1
@@ -713,10 +713,10 @@ buildpacks:
 - name: r_buildpack
   repo_name: r-buildpack
   stack: cflinuxfs3
-  version: v1.0.12
-  sha: 09b08068fe34a0c5767aaf1b218c2ad7b07f1c4c5166da70e947fc3641ad610f
-  filename: r-buildpack-cflinuxfs3-v1.0.12.zip
-  url: https://github.com/cloudfoundry/r-buildpack/releases/download/v1.0.12/r-buildpack-cflinuxfs3-v1.0.12.zip
+  version: v1.0.13
+  sha: b046e2c8bd25297273c3b514ea770a6ca12c44630869aa487b682b749d5d9e13
+  filename: r-buildpack-cflinuxfs3-v1.0.13.zip
+  url: https://github.com/cloudfoundry/r-buildpack/releases/download/v1.0.13/r-buildpack-cflinuxfs3-v1.0.13.zip
   dependencies:
   - name: r
     version: 3.4.3

--- a/platform-tests/example-apps/healthcheck/manifest.yml
+++ b/platform-tests/example-apps/healthcheck/manifest.yml
@@ -8,5 +8,5 @@ applications:
    buildpack: go_buildpack
    stack: cflinuxfs3
    env:
-     GOVERSION: go1.11
+     GOVERSION: go1.13
      GOPACKAGENAME: github.com/alphagov/paas-cf/platform-tests/example-apps/healthcheck

--- a/platform-tests/example-apps/http_tester/Godeps/Godeps.json
+++ b/platform-tests/example-apps/http_tester/Godeps/Godeps.json
@@ -1,9 +1,0 @@
-{
-	"ImportPath": "github.com/alphagov/paas-cf/platform-tests/example-apps/http_tester",
-	"GoVersion": "go1.11",
-	"GodepVersion": "v79",
-	"Packages": [
-		"./..."
-	],
-	"Deps": []
-}

--- a/platform-tests/example-apps/http_tester/Godeps/Readme
+++ b/platform-tests/example-apps/http_tester/Godeps/Readme
@@ -1,5 +1,0 @@
-This directory tree is generated automatically by godep.
-
-Please do not edit.
-
-See https://github.com/tools/godep for more information.

--- a/platform-tests/example-apps/http_tester/go.mod
+++ b/platform-tests/example-apps/http_tester/go.mod
@@ -1,0 +1,3 @@
+module github.com/alphagov/paas-cf/platform-tests/example-apps/http_tester
+
+go 1.13

--- a/platform-tests/example-apps/http_tester/manifest.yml
+++ b/platform-tests/example-apps/http_tester/manifest.yml
@@ -1,8 +1,10 @@
 ---
 applications:
-- name: http_tester
-  memory: 64M
-  disk_quota: 64M
-  instances: 1
-  buildpack: go_buildpack
-  command: ./bin/http_tester; sleep 1; echo 'done'
+  - name: http_tester
+    memory: 64M
+    disk_quota: 64M
+    instances: 1
+    buildpack: go_buildpack
+    command: ./bin/http_tester; sleep 1; echo 'done'
+    env:
+      GOVERSION: 1.13

--- a/platform-tests/example-apps/logging-pipeline/manifest.yml
+++ b/platform-tests/example-apps/logging-pipeline/manifest.yml
@@ -8,5 +8,5 @@ applications:
    buildpack: go_buildpack
    stack: cflinuxfs3
    env:
-     GOVERSION: go1.12
+     GOVERSION: go1.13
      GOPACKAGENAME: github.com/alphagov/paas-cf/platform-tests/example-apps/logging-pipeline

--- a/tools/buildpacks/go.mod
+++ b/tools/buildpacks/go.mod
@@ -5,3 +5,5 @@ require (
 	golang.org/x/oauth2 v0.0.0-20190115181402-5dab4167f31c
 	gopkg.in/yaml.v2 v2.2.2
 )
+
+go 1.13

--- a/tools/metrics/go.mod
+++ b/tools/metrics/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-cf/tools/metrics
 
-go 1.12
+go 1.13
 
 require (
 	code.cloudfoundry.org/lager v1.0.0


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/169572618)

🐝 [Review this PR](https://github.com/alphagov/paas-accounts/pull/12) in paas-accounts, then this commit will have to be updated

What
----

This is specifically for `ruby_buildpack` version: `v1.8.2` (we were asked by a tenant)

I had to update Go versions for the following microservices:

- paas-accounts
- paas-metrics
- platform-tests/example-apps/http_tester
- platform-tests/example-apps/healthcheck
- platform-tests/example-apps/logging-pipeline

How to review
-------------

Code review

Throw it down your pipeline

See [tlwr pipeline](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/tag-release/builds/79)

Who can review
--------------

Not @tlwr