### PR TITLE
Add SKIP_AWAIT flag for AutoDeletion

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -111,6 +111,7 @@ jobs:
             - name: paas-cf
           params:
             DEPLOY_ENV: ((deploy_env))
+            SKIP_AWAIT: ((skip_autodelete_await))
           run:
             path: ./paas-cf/concourse/scripts/sleep_for_deploy_env.sh
 

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -96,6 +96,7 @@ monitored_state_bucket: ${MONITORED_STATE_BUCKET:-}
 monitored_aws_region: ${MONITORED_AWS_REGION:-}
 monitored_deploy_env: ${MONITORED_DEPLOY_ENV:-}
 deploy_env_tag_prefix: "${deploy_env_tag_prefix}"
+skip_autodelete_await: "${SKIP_AUTODELETE_AWAIT:-false}"
 EOF
   echo -e "pipeline_lock_git_private_key: |\\n  ${git_id_rsa//$'\n'/$'\n'  }"
 }

--- a/concourse/scripts/sleep_for_deploy_env.sh
+++ b/concourse/scripts/sleep_for_deploy_env.sh
@@ -2,6 +2,11 @@
 
 set -eu
 
+if [ "${SKIP_AWAIT:-false}" = "true" ]; then
+    echo "You're evil... But that's OK. Skipping the await."
+    exit 0
+fi
+
 splay=$((60*60))
 # The following sleep monstrosity deterministically sleeps for a
 # period of time between 0-${splay} seconds in order to prevent all our


### PR DESCRIPTION
What
-----

🙊 

This change should only affect the DEV environments. The await is useful and serves a purpose. But there are times, where you need to run crazy and waiting 45 minutes and 25 seconds in my case is just insaaaane.

How to review
-------------

- Code review
- `SKIP_AUTODELETE_AWAIT=true make dev pipelines`
