### PR TITLE
Check if $OWNER contains an @ and reject it if so

### DIFF
--- a/scripts/create-org.sh
+++ b/scripts/create-org.sh
@@ -160,6 +160,10 @@ while [[ $# -gt 0 ]]; do
     --owner)
       OWNER="$1"
       shift
+      if [[ "$OWNER" == *"@"* ]]; then
+        >&2 echo "--owner $OWNER should be the name of the department or authority that manages this org, not the email of the owner"
+        exit 1
+      fi
     ;;
     *)
       # unknown option


### PR DESCRIPTION
What
----

We accidentally added some orgs with the email of their owner instead of
the name of the department that owns the org. Making the script reject
things that look like emails should prevent this in the future.

How to review
-------------

* Code review
* In a dev env, check that the script rejects emails and accepts other things

Who can review
--------------

Not @richardtowers