### PR TITLE
[#167590572] Lower cf_exporter scrape interval

### DIFF
--- a/manifests/prometheus/operations.d/221-monitor-cf.yml
+++ b/manifests/prometheus/operations.d/221-monitor-cf.yml
@@ -11,11 +11,9 @@
   path: /instance_groups/name=firehose/jobs/name=firehose_exporter/properties/firehose_exporter/doppler/idle_timeout?
   value: 5m
 
-# Set the scrape interval of the Prometheus CF scraping config
-# higher so that it doesn't generate as much load so often.
 - type: replace
   path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/job_name=cf/scrape_interval
-  value: 10m
+  value: 4m
 
 # Filter in/enable only the collectors we want.
 # The value must be a CSV without spaces


### PR DESCRIPTION
What
----

The current scrape interval results in gaps of 5 minutes between each data point. This is because prometheus considers it stale. This lowers the scrape interval to 4 minutes.

How to review
-------------

Code review

Who can review
--------------

Not me
