### PR TITLE
Ignore CFApp alerts

### DIFF
--- a/manifests/prometheus/dashboards.d/user-impact.json
+++ b/manifests/prometheus/dashboards.d/user-impact.json
@@ -700,7 +700,7 @@
                 },
                 "tableColumn": "",
                 "targets": [{
-                    "expr": "count(ALERTS{alertstate=\"firing\",layer=\"\"}) or vector(0)",
+                    "expr": "count(ALERTS{alertstate=\"firing\",layer=\"\",alertname!~\"^CFApp.*$\"}) or vector(0)",
                     "format": "time_series",
                     "instant": true,
                     "intervalFactor": 1,


### PR DESCRIPTION
What
----

We've enabled the CF exporter, which is now noisy alerting for tenant apps

We should disable it

How to review
-------------

Code review

Check [TLWR](https://grafana-1.tlwr.dev.cloudpipeline.digital/d/paas-user-impact/user-impact-tlwr?orgId=1&refresh=5s)

Who can review
--------------

Not @tlwr