### PR TITLE
Deploy app shipping audit events to Splunk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,7 @@ showenv: ## Display environment information
 	@scripts/showenv.sh
 
 .PHONY: upload-all-secrets
-upload-all-secrets: upload-google-oauth-secrets upload-microsoft-oauth-secrets upload-notify-secrets upload-aiven-secrets upload-logit-secrets upload-pagerduty-secrets
+upload-all-secrets: upload-google-oauth-secrets upload-microsoft-oauth-secrets upload-splunk-secrets upload-notify-secrets upload-aiven-secrets upload-logit-secrets upload-pagerduty-secrets
 
 .PHONY: upload-google-oauth-secrets
 upload-google-oauth-secrets: check-env ## Decrypt and upload Google Admin Console credentials to Credhub
@@ -271,6 +271,12 @@ upload-microsoft-oauth-secrets: check-env ## Decrypt and upload Microsoft Identi
 	$(if $(wildcard ${PAAS_PASSWORD_STORE_DIR}),,$(error Password store ${PAAS_PASSWORD_STORE_DIR} (PAAS_PASSWORD_STORE_DIR) does not exist))
 	$(eval export PASSWORD_STORE_DIR=${PAAS_PASSWORD_STORE_DIR})
 	@scripts/upload-microsoft-oauth-secrets.rb
+
+.PHONY: upload-splunk-secrets
+upload-splunk-secrets: check-env ## Decrypt and upload Microsoft Identity credentials to Credhub
+	$(if $(wildcard ${PAAS_PASSWORD_STORE_DIR}),,$(error Password store ${PAAS_PASSWORD_STORE_DIR} (PAAS_PASSWORD_STORE_DIR) does not exist))
+	$(eval export PASSWORD_STORE_DIR=${PAAS_PASSWORD_STORE_DIR})
+	@scripts/upload-splunk-secrets.rb
 
 .PHONY: upload-notify-secrets
 upload-notify-secrets: check-env ## Decrypt and upload Notify Credentials to Credhub

--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,7 @@ stg-lon: ## Set Environment to stg-lon
 	$(eval export PAAS_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
 	$(eval export PAAS_HIGH_PASSWORD_STORE_DIR?=${HOME}/.paas-pass-high)
 	$(eval export AWS_DEFAULT_REGION=eu-west-2)
+	$(eval export AWS_REGION=eu-west-2)
 	@true
 
 .PHONY: prod
@@ -197,6 +198,7 @@ prod: ## Set Environment to Production
 	$(eval export PAAS_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
 	$(eval export PAAS_HIGH_PASSWORD_STORE_DIR?=${HOME}/.paas-pass-high)
 	$(eval export AWS_DEFAULT_REGION=eu-west-1)
+	$(eval export AWS_REGION=eu-west-1)
 	@true
 
 .PHONY: prod-lon
@@ -216,6 +218,7 @@ prod-lon: ## Set Environment to prod-lon
 	$(eval export PAAS_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
 	$(eval export PAAS_HIGH_PASSWORD_STORE_DIR?=${HOME}/.paas-pass-high)
 	$(eval export AWS_DEFAULT_REGION=eu-west-2)
+	$(eval export AWS_REGION=eu-west-2)
 	@true
 
 .PHONY: bosh-cli
@@ -273,9 +276,9 @@ upload-microsoft-oauth-secrets: check-env ## Decrypt and upload Microsoft Identi
 	@scripts/upload-microsoft-oauth-secrets.rb
 
 .PHONY: upload-splunk-secrets
-upload-splunk-secrets: check-env ## Decrypt and upload Microsoft Identity credentials to Credhub
-	$(if $(wildcard ${PAAS_PASSWORD_STORE_DIR}),,$(error Password store ${PAAS_PASSWORD_STORE_DIR} (PAAS_PASSWORD_STORE_DIR) does not exist))
-	$(eval export PASSWORD_STORE_DIR=${PAAS_PASSWORD_STORE_DIR})
+upload-splunk-secrets: check-env ## Decrypt and upload Splunk HEC Tokens to Credhub
+	$(if $(wildcard ${PAAS_HIGH_PASSWORD_STORE_DIR}),,$(error Password store ${PAAS_HIGH_PASSWORD_STORE_DIR} (PAAS_HIGH_PASSWORD_STORE_DIR) does not exist))
+	$(eval export PASSWORD_STORE_DIR=${PAAS_HIGH_PASSWORD_STORE_DIR})
 	@scripts/upload-splunk-secrets.rb
 
 .PHONY: upload-notify-secrets

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -292,6 +292,7 @@ groups:
       - post-deploy
       - deploy-paas-accounts
       - deploy-paas-admin
+      - deploy-paas-audit-to-splunk
       - deploy-paas-billing
       - deploy-paas-metrics
       - smoke-tests
@@ -325,6 +326,7 @@ groups:
     jobs:
       - deploy-paas-accounts
       - deploy-paas-admin
+      - deploy-paas-audit-to-splunk
       - deploy-paas-billing
       - deploy-paas-metrics
   - name: operator
@@ -621,6 +623,13 @@ resources:
       uri: https://github.com/alphagov/paas-accounts.git
       branch: master
       tag_filter: v0.14.0
+
+  - name: paas-audit-to-splunk
+    type: git
+    source:
+      uri: https://github.com/alphagov/paas-audit-to-splunk.git
+      branch: master
+      tag_filter: v0.1.0
 
   - name: paas-admin
     type: git
@@ -1649,6 +1658,7 @@ jobs:
                 S3_BROKER_PASS=$(credhub get -q -n "${BOSH_NS}/secrets_s3_broker_admin_password")
                 UAA_ADMIN_CLIENT_SECRET=$(credhub get -q -n "${BOSH_NS}/uaa_admin_client_secret")
                 UAA_CLIENTS_PAAS_ADMIN_SECRET=$(credhub get -q -n "${BOSH_NS}/uaa_clients_paas_admin_secret")
+                UAA_CLIENTS_PAAS_AUDITOR_SECRET=$(credhub get -q -n "${BOSH_NS}/secrets_uaa_clients_paas_auditor_secret")
                 SECRETS_TEST_USER_PASSWORD=$(credhub get -q -n "${BOSH_NS}/secrets_test_user_password")
 
 
@@ -1677,6 +1687,7 @@ jobs:
                 credhub set --name="${PIPELINE_NS}/secrets_s3_broker_admin_password" --type password --password "${S3_BROKER_PASS}"
                 credhub set --name="${PIPELINE_NS}/uaa_admin_client_secret" --type password --password "${UAA_ADMIN_CLIENT_SECRET}"
                 credhub set --name="${PIPELINE_NS}/uaa_clients_paas_admin_secret" --type password --password "${UAA_CLIENTS_PAAS_ADMIN_SECRET}"
+                credhub set --name="${PIPELINE_NS}/uaa_clients_paas_auditor_secret" --type password --password "${UAA_CLIENTS_PAAS_AUDITOR_SECRET}"
                 credhub set --name="${PIPELINE_NS}/secrets_test_user_password" --type password --password "${SECRETS_TEST_USER_PASSWORD}"
 
                 echo 'Accessible secrets'
@@ -3108,6 +3119,71 @@ jobs:
                 else
                   echo "Success: All VMs are up and running."
                 fi
+
+  - name: deploy-paas-audit-to-splunk
+    serial: true
+    plan:
+      - *add-grafana-job-annotation
+      - in_parallel:
+        - get: paas-audit-to-splunk
+          trigger: true
+
+        - get: paas-cf
+          trigger: true
+          passed: ['post-deploy']
+
+      - task: deploy-paas-audit-to-splunk
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *cf-cli-image-resource
+          params:
+            UAA_API_URL: https://uaa.((system_dns_zone_name))
+            UAA_CLIENT_ID: "paas-auditor"
+            UAA_CLIENT_SECRET: ((uaa_clients_paas_auditor_secret))
+            CLOUDFOUNDRY_API_URL: https://api.((system_dns_zone_name))
+            SPLUNK_URL: https://http-inputs-gds.splunkcloud.com/services/collector
+            SPLUNK_KEY: ((splunk_key))
+            DEPLOY_ENV: ((deploy_env))
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
+          inputs:
+            - name: paas-cf
+            - name: paas-audit-to-splunk
+          run:
+            path: sh
+            args:
+              - -e
+              - -u
+              - -c
+              - |
+                echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}" -o admin -s monitoring
+
+                (
+                cd paas-audit-to-splunk
+
+                ruby -ryaml -e "
+                  env = {
+                    'UAA_API_URL' => '${UAA_API_URL}',
+                    'UAA_CLIENT_ID' => '${UAA_CLIENT_ID}',
+                    'UAA_CLIENT_SECRET' => '${UAA_CLIENT_SECRET}',
+                    'CLOUDFOUNDRY_API_URL' => '${CLOUDFOUNDRY_API_URL}',
+                    'ENVIRONMENT' => '${DEPLOY_ENV}',
+                    'SPLUNK_URL' => '${SPLUNK_URL}',
+                    'SPLUNK_KEY' => '${SPLUNK_KEY}',
+                  }
+                  manifest = YAML.load_file('manifest.yml')
+                  manifest['applications'].each { |app|
+                    app['env'] = {} unless app['env']
+                    app['env'].merge!(env)
+                  }
+                  File.write('manifest.yml', manifest.to_yaml)
+                "
+
+                cf zero-downtime-push paas-audit-to-splunk -f manifest.yml
+                )
+      - *end-grafana-job-annotation
 
   - name: deploy-paas-accounts
     serial: true

--- a/scripts/upload-splunk-secrets.rb
+++ b/scripts/upload-splunk-secrets.rb
@@ -10,7 +10,7 @@ credhub_namespaces = [
   "/#{deploy_env}/#{deploy_env}",
 ]
 
-splunk_key = ENV['SPLUNK_KEY'] || `pass "splunk/${MAKEFILE_ENV_TARGET}/key"`
+splunk_key = ENV['SPLUNK_KEY'] || `pass "splunk/${MAKEFILE_ENV_TARGET}/hec_token"`
 
 upload_secrets(
   credhub_namespaces,

--- a/scripts/upload-splunk-secrets.rb
+++ b/scripts/upload-splunk-secrets.rb
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative 'upload_secrets.rb'
+
+deploy_env = ENV.fetch('DEPLOY_ENV')
+
+credhub_namespaces = [
+  '/concourse/main/create-cloudfoundry',
+  "/#{deploy_env}/#{deploy_env}",
+]
+
+splunk_key = ENV['SPLUNK_KEY'] || `pass "splunk/${MAKEFILE_ENV_TARGET}/key"`
+
+upload_secrets(
+  credhub_namespaces,
+  'splunk_key' => splunk_key,
+)


### PR DESCRIPTION
What
----

We'd like to be constantly pushing this to our environment allowing
splunk to receive the audit events from CF API.

We're adding set of credentials into the system, that will be then used.

Splunk URL is not really a secret, therefore doesn't deserve a place in
our secret store.

How to review
-------------

- Sanity check
- See `rafalp` environment

**Note:** I have uploaded the certs to all envs, but doesn't hurt to do again.