### PR TITLE
Correct pricing plans for InfluxDB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,11 @@ platform_tests_spec:
 	cd platform-tests &&\
 		./run_tests.sh src/platform/availability/monitor/
 
-spec: scripts_spec tools_spec concourse_spec manifests_spec terraform_spec platform_tests_spec
+config_spec:
+	cd config &&\
+		bundle exec rspec
+
+spec: config_spec scripts_spec tools_spec concourse_spec manifests_spec terraform_spec platform_tests_spec
 
 compile_platform_tests:
 	GOPATH="$$(pwd)/platform-tests" \

--- a/config/.rspec
+++ b/config/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/config/billing/config-parts/influxdb_pricing_plans.json.erb
+++ b/config/billing/config-parts/influxdb_pricing_plans.json.erb
@@ -1,6 +1,6 @@
 {
 	"name": "influxdb tiny-1.x",
-	"valid_from": "2019-11-07",
+	"valid_from": "2019-11-01",
 	"plan_guid": "f636ed93-3354-4173-b8bd-031f54866528",
 	"components": [
 		{

--- a/config/billing/output/eu-west-1.json
+++ b/config/billing/output/eu-west-1.json
@@ -1666,7 +1666,7 @@
 		},
 		{
 			"name": "influxdb tiny-1.x",
-			"valid_from": "2019-11-07",
+			"valid_from": "2019-11-01",
 			"plan_guid": "f636ed93-3354-4173-b8bd-031f54866528",
 			"components": [
 				{

--- a/config/billing/output/eu-west-2.json
+++ b/config/billing/output/eu-west-2.json
@@ -1666,7 +1666,7 @@
 		},
 		{
 			"name": "influxdb tiny-1.x",
-			"valid_from": "2019-11-07",
+			"valid_from": "2019-11-01",
 			"plan_guid": "f636ed93-3354-4173-b8bd-031f54866528",
 			"components": [
 				{

--- a/config/spec/billing_spec.rb
+++ b/config/spec/billing_spec.rb
@@ -1,0 +1,40 @@
+require 'json'
+
+BILLING_PATH = File.expand_path(File.join(__dir__, '..', 'billing', 'output'))
+BILLING_FILES = Dir.glob(File.join(BILLING_PATH, '*.json'))
+
+describe 'billing' do
+  let :billing_config_by_region do
+    BILLING_FILES
+      .map { |r| [File.basename(r), File.read(r)] }
+      .to_h
+  end
+
+  let :pricing_plans_by_region do
+    BILLING_FILES
+      .map { |r| [File.basename(r), JSON.parse(File.read(r))] }
+      .map { |region, config| [region, config.dig('pricing_plans')] }
+      .to_h
+  end
+
+  it 'should be valid json' do
+    billing_config_by_region.each do |region, config|
+      expect { JSON.parse(config) }.not_to raise_exception,
+        "#{region} is invalid JSON"
+    end
+  end
+
+  describe 'pricing_plans' do
+    it 'should be valid from the start of the month' do
+      pricing_plans_by_region.each do |region, plans|
+        plans.each do |plan|
+          plan_name = plan.dig('name')
+          valid_from = plan.dig('valid_from')
+
+          expect(valid_from).to match(/\d{4}-\d{2}-01/),
+            "#{region}/#{plan_name} is not valid from the start of the month"
+        end
+      end
+    end
+  end
+end

--- a/config/spec/spec_helper.rb
+++ b/config/spec/spec_helper.rb
@@ -1,0 +1,24 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+=begin
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
+  config.example_status_persistence_file_path = "spec/examples.txt"
+  config.disable_monkey_patching!
+  config.warnings = true
+  if config.files_to_run.one?
+    config.default_formatter = 'doc'
+  end
+
+  config.profile_examples = 10
+  config.order = :random
+  Kernel.srand config.seed
+=end
+end


### PR DESCRIPTION
What
----

Richard discovered that the billing collector has been stopped since InfluxDB was released to beta

This is because the pricing plans are violating the DB constraint that they must be valid from the start of the month

This PR fixes this, and adds a test

How to review
-------------

Code review

Who can review
--------------

Not @tlwr