### PR TITLE
[SUPPORT] Increase Diego cells in London to 42

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -1,5 +1,5 @@
 ---
-cell_instances: 39
+cell_instances: 42
 router_instances: 6
 api_instances: 12
 doppler_instances: 33


### PR DESCRIPTION
What
----
Since the last cell count bump on 2019-10-28, we've seen a steady climb in cell
memory usage. Our chart is now showing that it's time to increase the number of
cells again.

The cell count is increasing by 3, from 39 to 42, so that we get 1 new cell in
each AZ.

![image](https://user-images.githubusercontent.com/1747386/69721709-58c87280-110d-11ea-8483-ffac542d6dba.png)

How to review
-------------

Code review

Who can review
--------------
Anyone