### PR TITLE
Automatically scale the Y-axis of the app instances chart

### DIFF
--- a/manifests/prometheus/dashboards.d/user-impact.json
+++ b/manifests/prometheus/dashboards.d/user-impact.json
@@ -339,7 +339,7 @@
                         "label": null,
                         "logBase": 1,
                         "max": null,
-                        "min": "0",
+                        "min": null,
                         "show": true
                     },
                     {


### PR DESCRIPTION
What
----
We have a chart on the user impact dashboard in Grafana which shows the number
of application instances that are running, versus how many should be running.
At the moment, the y-axis is scaled from zero to the maximum number of
instances in the time range. We have >1000 application instances in London and
>800 in Ireland, so the granularity of the y-axis is pretty coarse; 250 in
London, 200 in Ireland). This makes it difficult to see anything but the most
drastic changes in the number of instances.

Instead, in this commit we allow Grafana to pick a sensible scale for the axis
based on the data being charted.

Below is an example of how it would look in Grafana

![image](https://user-images.githubusercontent.com/1747386/69730009-37708200-111f-11ea-8535-4a615a197340.png)

Versus how it looks now

![image](https://user-images.githubusercontent.com/1747386/69730214-90d8b100-111f-11ea-85de-de77e779498d.png)


How to review
-------------
1. Code review
2. Discuss if we think this is a good thing

Who can review
--------------
Everyone