### PR TITLE
[#169891611] Release feature for users to configure CORS on S3

### DIFF
--- a/manifests/cf-manifest/operations.d/750-s3-broker.yml
+++ b/manifests/cf-manifest/operations.d/750-s3-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: s3-broker
-    version: 0.1.10
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/s3-broker-0.1.10.tgz
-    sha1: 2fc8f16d584f8c1096c5845829d5e870b39fc133
+    version: 0.1.11
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/s3-broker-0.1.11.tgz
+    sha1: 4e4552a755bbdbfa137b02323b4896504366dca8
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-


### PR DESCRIPTION
What
----

This PR fixes up #2172, which sadly shipped a too-old version of the S3 Broker.

This releases version 0.1.11 of the S3 Broker BOSH Release, as built by [1]. The S3 Broker commit used to build that is definitely one that includes the ability to configure CORS [2].

[1] https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/s3-broker-release/jobs/build-final-release/builds/2
[2] https://github.com/alphagov/paas-s3-broker-boshrelease/commit/c2287df6e44c8e44f50841acddf06680b09760f4


How to review
-------------

* Double-check the BOSH Release being shipped does include CORS;
* We *can* deploy this to a dev env to check, but from the story summary I'm pretty sure @richardTowers already successfully did that work for us 🎉 

Who can review
--------------

Not @46bit 