### PR TITLE
[SUPPORT] Update Elasticache node and param group limits

### DIFF
--- a/manifests/prometheus/env-specific/prod-lon.yml
+++ b/manifests/prometheus/env-specific/prod-lon.yml
@@ -1,6 +1,6 @@
 ---
 
 # AWS Limits not accesible via API
-aws_limits_elasticache_cache_parameter_groups: 300
-aws_limits_elasticache_nodes: 300
+aws_limits_elasticache_cache_parameter_groups: 400
+aws_limits_elasticache_nodes: 400
 aws_limits_s3_buckets: 250

--- a/manifests/prometheus/env-specific/prod.yml
+++ b/manifests/prometheus/env-specific/prod.yml
@@ -1,6 +1,6 @@
 ---
 
 # AWS Limits not accesible via API
-aws_limits_elasticache_cache_parameter_groups: 100
-aws_limits_elasticache_nodes: 100
+aws_limits_elasticache_cache_parameter_groups: 400
+aws_limits_elasticache_nodes: 400
 aws_limits_s3_buckets: 250


### PR DESCRIPTION
What
----
On 2019-12-03, AWS support upped our Elasticache node and parameter group
limits in Ireland and London. This commit updates those values in our alarms,
so that we're alerting on them properly.


How to review
-------------

1. Code review

Who can review
--------------

Anyone
