### PR TITLE
Grant Global Auditor to Satwinder in PMO

### DIFF
--- a/config/users.yml
+++ b/config/users.yml
@@ -65,3 +65,6 @@
 
 - email: jake.mccann@digital.cabinet-office.gov.uk
   google_id: 110058378478974615296
+
+- email: satwinder.bharaj@digital.cabinet-office.gov.uk
+  google_id: 117679332904544013345


### PR DESCRIPTION
What
----

This commit adds Global Auditor to Satwinder in PMO. This will allow them to see things such as billing reports. The Google ID is sourced from their existing PaaS account in London, which they already switched to signing in with Google SSO.

How to review
-------------

* Code review.

Who can review
--------------

Not @46bit.