### PR TITLE
[SUPPORT] Create custom UAA clients for tenants in different deployments

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1400,6 +1400,26 @@ jobs:
 
                   cat vpc-peering-opsfile/vpc-peers.yml
 
+        - task: generate-tenant-uaa-clients-opsfile
+          tags: [colocated-with-web]
+          config:
+            platform: linux
+            image_resource: *ruby-slim-image-resource
+            inputs:
+              - name: paas-cf
+            outputs:
+              - name: tenant-uaa-clients-opsfile
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  ruby paas-cf/manifests/cf-manifest/scripts/generate-tenant-uaa-client-ops-file.rb \
+                    "paas-cf/manifests/cf-manifest/data/100-tenant-uaa-client-config.yml" \
+                    "((makefile_env_target))" \
+                  > tenant-uaa-clients-opsfile/tenant-uaa-opsfile.yml
+
         - task: generate-microsoft-oauth-endpoints
           tags: [colocated-with-web]
           config:
@@ -1461,6 +1481,7 @@ jobs:
               - name: ipsec-CA
               - name: terraform-outputs
               - name: vpc-peering-opsfile
+              - name: tenant-uaa-clients-opsfile
               - name: ms-oauth-endpoints
             outputs:
               - name: cf-manifest

--- a/manifests/cf-manifest/data/100-tenant-uaa-client-config.yml
+++ b/manifests/cf-manifest/data/100-tenant-uaa-client-config.yml
@@ -1,0 +1,31 @@
+---
+# This file contains configurations for individual UAA clients for tenants in different deployments.
+#
+# To add a new client, add a new entry to the deployment in question like the below
+#
+#  - name: uaa-client-name
+#    secret_name: secrets_uaa_clients_uaa_client_name
+#    uaa_client:
+#      scope: openid,cloud_controller.read,cloud_controller.write
+#      authorized-grant-types: refresh_token,authorization_code
+#      redirect-uri: https://APP_NAME.((app_domain))/callback/URL
+#      override: true
+#
+# If the tenant is deploying the app on a custom URL, provide an array for the `uaa_client.redirect-uri` property, e.g.
+#
+#   redirect-uri:
+#     - https://APP_NAME.((app_domain))/callback/URL
+#     - https://CUSTOM_DOMA.in/callback/URL
+
+stg-lon: []
+
+prod: []
+
+prod-lon:
+  - name: dit-stratos-deployment
+    secret_name: secrets_uaa_clients_dit_console_secret
+    uaa_client:
+      scope: openid,cloud_controller.read,cloud_controller.write
+      authorized-grant-types: refresh_token,authorization_code
+      redirect-uri: https://dit-console.((app_domain))/pp/v1/auth/sso_login_callback
+      override: true

--- a/manifests/cf-manifest/scripts/generate-manifest.sh
+++ b/manifests/cf-manifest/scripts/generate-manifest.sh
@@ -32,4 +32,5 @@ bosh interpolate \
   --ops-file="${CF_DEPLOYMENT_DIR}/operations/use-internal-lookup-for-route-services.yml" \
   ${opsfile_args} \
   --ops-file="${WORKDIR}/vpc-peering-opsfile/vpc-peers.yml" \
+  --ops-file="${WORKDIR}/tenant-uaa-clients-opsfile/tenant-uaa-opsfile.yml" \
   "${CF_DEPLOYMENT_DIR}/cf-deployment.yml"

--- a/manifests/cf-manifest/scripts/generate-tenant-uaa-client-ops-file.rb
+++ b/manifests/cf-manifest/scripts/generate-tenant-uaa-client-ops-file.rb
@@ -1,0 +1,42 @@
+#!/usr/bin/env ruby
+
+require "yaml"
+
+config_file = ARGV[0]
+deploy_env = ARGV[1]
+
+if File.file?(config_file)
+  config = YAML.load_file(config_file)
+  if config == nil
+    warn "could not parse config file at #{config_file}"
+    exit(1)
+  end
+
+  if config[deploy_env] == nil
+    exit(0)
+  end
+
+  ops = config[deploy_env].flat_map { |client|
+    client["uaa_client"]["secret"] = "((#{client['secret_name']}))"
+
+    [
+      {
+        "type" => "replace",
+        "path" => "/instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/#{client['name']}?",
+        "value" => client["uaa_client"]
+      },
+      {
+        "type" => "replace",
+        "path" => "/variables/-",
+        "value" => {
+          "name" => client["secret_name"],
+          "type" => "password"
+        }
+      }
+    ]
+  }
+  puts YAML.dump(ops)
+else
+  warn "config file not found at #{config_file}"
+  exit(1)
+end

--- a/manifests/cf-manifest/spec/fixtures/tenant-uaa-client-fixtures.yml
+++ b/manifests/cf-manifest/spec/fixtures/tenant-uaa-client-fixtures.yml
@@ -1,0 +1,20 @@
+---
+stg-lon: []
+prod: []
+prod-lon:
+  - name: prod-lon-uaa-client
+    secret_name: secrets_prod-lon_uaa_client
+    uaa_client:
+      scope: openid,cloud_controller.read,cloud_controller.write
+      authorized-grant-types: refresh_token,authorization_code
+      redirect-uri: https://prod-lon-uaa.((app_domain))/callback
+      override: true
+
+dev:
+  - name: dev-uaa-client
+    secret_name: secrets_dev_uaa_client
+    uaa_client:
+      scope: openid,cloud_controller.read,cloud_controller.write
+      authorized-grant-types: refresh_token,authorization_code
+      redirect-uri: https://dev-uaa.((app_domain))/callback
+      override: true

--- a/manifests/cf-manifest/spec/manifest/tenant_uaa_clients_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/tenant_uaa_clients_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe "Tenant UAA clients" do
+  let(:manifest) { manifest_with_defaults }
+  let(:properties) { manifest.fetch("instance_groups.uaa.jobs.uaa.properties") }
+
+  it "creates a new UAA client for each entry in the deployment env config" do
+    uaa_clients = properties.fetch("uaa").fetch("clients")
+    expect(uaa_clients["dev-uaa-client"]).not_to be_nil
+  end
+
+  it "does not create new UAA clients for entries not in the deployment env config" do
+    uaa_clients = properties.fetch("uaa").fetch("clients")
+    expect(uaa_clients["prod-lon-uaa-client"]).to be_nil
+  end
+
+  it "creates secrets for the UAA clients it creates" do
+    variables = manifest.fetch("variables")
+    expect(variables.any? { |var|
+      var["name"] == "secrets_dev_uaa_client"
+    }).to be true
+  end
+end


### PR DESCRIPTION
What
----
In some cases, we'll grant a tenant a custom UAA client. The client should only
exist in a specific environmen, and its secret is managed in by our credhub
instance.

The configuration of the clients is managed in
`manifests/cf-manifest/data/100-tenant-uaa-client-config.yml`, and a task in
the `generate-cf-config` stage of the pipeline generates an ops file for Bosh
based on that config, for the given deployment env.

How to review
-------------
1. Code review 
2. Do a proper pipeline review

Who can review
--------------
Anyone
