### PR TITLE
[#170056541] UAA group member's origin should equal "uaa"

### DIFF
--- a/tools/user_management/lib/group.rb
+++ b/tools/user_management/lib/group.rb
@@ -66,14 +66,14 @@ class Group < UAAResource
       puts "  email='#{user.email}'".green
       puts "  origin=google".green
       puts "  userName='#{user.google_id}'".green
-      add_member(user.guid, 'google', uaa_client)
+      add_member(user.guid, uaa_client)
       puts "  USER GIVEN MEMBERSHIP OF GROUP".green
     end
   end
 
-  def add_member(user_guid, origin, uaa_client)
+  def add_member(user_guid, uaa_client)
     resp = uaa_client["/Groups/#{@guid}/members"].post({
-      origin: origin,
+      origin: 'uaa',
       type: 'USER',
       value: user_guid
     }.to_json)

--- a/tools/user_management/spec/group_spec.rb
+++ b/tools/user_management/spec/group_spec.rb
@@ -12,59 +12,9 @@ RSpec.describe Group do
     })
   end
 
-  context 'get_group' do
-    it 'retrieves the group from UAA' do
-      stub_searching_for_group(200, '__test__', 'guid-of-__test__-group')
-
-      group = Group.new('__test__', [])
-      group.get_group(@fake_uaa_client)
-      expect(group.guid).to eq 'guid-of-__test__-group'
-    end
-  end
-
-  context 'get_members' do
-    before do
-      stub_searching_for_group(200, '__test__', 'guid-of-__test__-group', [{
-        'id' => 'guid-of-member-1',
-        'origin' => 'origin-of-member-1'
-      }, {
-        'id' => 'guid-of-member-2',
-        'origin' => 'origin-of-member-2'
-      }])
-      stub_getting_user_by_id(200, 'guid-of-member-1', 'origin-of-member-1', 'username-of-member-1', Time.now)
-      stub_getting_user_by_id(200, 'guid-of-member-2', 'origin-of-member-2', 'username-of-member-2', Time.now)
-    end
-
-    it 'retrieves members of the group' do
-      group = Group.new('__test__', [])
-      members = group.get_members(@fake_uaa_client)
-      expect(members.length).to eq 2
-      expect(members[0]['id']).to eq 'guid-of-member-1'
-      expect(members[0]['origin']).to eq 'origin-of-member-1'
-      expect(members[0]['userName']).to eq 'username-of-member-1'
-      expect(members[1]['id']).to eq 'guid-of-member-2'
-      expect(members[1]['origin']).to eq 'origin-of-member-2'
-      expect(members[1]['userName']).to eq 'username-of-member-2'
-    end
-
-    it 'does not error when a member does not have a corresponding user' do
-      stub_getting_user_by_id(404, 'guid-of-member-2')
-
-      group = Group.new('__test__', [])
-      members = group.get_members(@fake_uaa_client)
-      expect(members.length).to eq 2
-      expect(members[0]['id']).to eq 'guid-of-member-1'
-      expect(members[0]['origin']).to eq 'origin-of-member-1'
-      expect(members[0]['userName']).to eq 'username-of-member-1'
-      expect(members[1]['id']).to eq 'guid-of-member-2'
-      expect(members[1]['origin']).to eq '*** THE USER BEHIND THIS MEMBERSHIP DOES NOT EXIST ***'
-      expect(members[1]['userName']).to eq '*** THE USER BEHIND THIS MEMBERSHIP DOES NOT EXIST ***'
-    end
-  end
-
   context 'add_member' do
     before do
-      stub_searching_for_group(200, '__test__', 'guid-of-__test__-group', [])
+      stub_searching_for_group(200, '__test__', 'guid-of-__test__-group')
 
       stub_searching_for_user(200, 'google', '11111111111111', 'user-guid')
       @user = User.new('email' => 'user-one@na.me', 'google_id' => '11111111111111')
@@ -91,10 +41,9 @@ RSpec.describe Group do
 
   context 'remove_member' do
     before do
-      stub_searching_for_group(200, '__test__', 'guid-of-__test__-group', [{
-        'id' => 'guid-of-existing-member',
-        'origin' => 'origin-of-existing-member'
-      }])
+      stub_searching_for_group(200, '__test__', 'guid-of-__test__-group', [
+        { 'id' => 'guid-of-existing-member' }
+      ])
     end
 
     it 'removes a member' do
@@ -129,10 +78,9 @@ RSpec.describe Group do
     end
 
     it 'adds its desired users' do
-      stub_searching_for_group(200, '__test__', 'guid-of-__test__-group', [{
-        'id' => 'user-1-guid',
-        'origin' => 'google'
-      }])
+      stub_searching_for_group(200, '__test__', 'guid-of-__test__-group', [
+        { 'id' => 'user-1-guid' }
+      ])
 
       g = Group.new('__test__', [@u1, @u2])
       g.get_group(@fake_uaa_client)
@@ -144,16 +92,11 @@ RSpec.describe Group do
 
   context 'remove_unexpected_members' do
     before do
-      stub_searching_for_group(200, '__test__', 'guid-of-__test__-group', [{
-        'id' => 'desired-user-guid',
-        'origin' => 'google',
-      }, {
-        'id' => 'unwanted-google-user-guid',
-        'origin' => 'google'
-      }, {
-        'id' => 'unwanted-uaa-user-guid',
-        'origin' => 'uaa'
-      }])
+      stub_searching_for_group(200, '__test__', 'guid-of-__test__-group', [
+        { 'id' => 'desired-user-guid' },
+        { 'id' => 'unwanted-google-user-guid' },
+        { 'id' => 'unwanted-uaa-user-guid' }
+      ])
 
       stub_searching_for_user(200, 'google', '11111111111111', 'desired-user-guid')
       stub_getting_user_by_id(200, 'desired-user-guid', 'google', '11111111111111', Time.now)
@@ -186,10 +129,9 @@ RSpec.describe Group do
     end
 
     it 'preserves our admin uaa user' do
-      stub_searching_for_group(200, '__test__', 'guid-of-__test__-group', [{
-        'id' => 'guid-of-user-who-is-the-uaa-admin',
-        'origin' => 'uaa'
-      }])
+      stub_searching_for_group(200, '__test__', 'guid-of-__test__-group', [
+        { 'id' => 'guid-of-user-who-is-the-uaa-admin' }
+      ])
       stub_getting_user_by_id(200, 'guid-of-user-who-is-the-uaa-admin', 'uaa', 'admin', Time.now - 86400)
 
       g = Group.new('__test__', [])
@@ -198,10 +140,9 @@ RSpec.describe Group do
     end
 
     it 'removes non-admin uaa users created more than one hour ago' do
-      stub_searching_for_group(200, '__test__', 'guid-of-__test__-group', [{
-        'id' => 'guid-of-day-old-uaa-user',
-        'origin' => 'uaa'
-      }])
+      stub_searching_for_group(200, '__test__', 'guid-of-__test__-group', [
+        { 'id' => 'guid-of-day-old-uaa-user' }
+      ])
       stub_getting_user_by_id(200, 'guid-of-day-old-uaa-user', 'uaa', 'day-old-uaa-user', Time.now - 86400)
       stub_removing_user_from_group(200, 'guid-of-__test__-group', 'guid-of-day-old-uaa-user')
 
@@ -211,16 +152,118 @@ RSpec.describe Group do
     end
 
     it 'preserves non-admin uaa users created less than an hour ago' do
-      stub_searching_for_group(200, '__test__', 'guid-of-__test__-group', [{
-        'id' => 'guid-of-minute-old-uaa-user',
-        'origin' => 'uaa'
-      }])
+      stub_searching_for_group(200, '__test__', 'guid-of-__test__-group', [
+        { 'id' => 'guid-of-minute-old-uaa-user' }
+      ])
       stub_getting_user_by_id(200, 'guid-of-minute-old-uaa-user', 'uaa', 'minute-old-uaa-user', Time.now - 60)
       stub_removing_user_from_group(200, 'guid-of-__test__-group', 'guid-of-minute-old-uaa-user')
 
       g = Group.new('__test__', [])
       g.remove_unexpected_members(@fake_uaa_client)
       assert_not_requested(:delete, 'http://fake-uaa.internal/Groups/guid-of-__test__-group/members/guid-of-minute-old-uaa-user')
+    end
+
+    it 'removes members with an unusual origin' do
+      stub_searching_for_group(200, '__test__', 'guid-of-__test__-group', [
+        { 'id' => 'guid-of-unusual-member', 'origin' => 'something-that-is-not-uaa' }
+      ])
+      stub_removing_user_from_group(200, 'guid-of-__test__-group', 'guid-of-unusual-member')
+
+      g = Group.new('__test__', [])
+      g.remove_unexpected_members(@fake_uaa_client)
+    end
+
+    it 'removes members with an unusual type' do
+      stub_searching_for_group(200, '__test__', 'guid-of-__test__-group', [
+        { 'id' => 'guid-of-unusual-member', 'type' => 'GROUP' }
+      ])
+      stub_removing_user_from_group(200, 'guid-of-__test__-group', 'guid-of-unusual-member')
+
+      g = Group.new('__test__', [])
+      g.remove_unexpected_members(@fake_uaa_client)
+    end
+  end
+
+  context 'get_group' do
+    it 'retrieves the group from UAA' do
+      stub_searching_for_group(200, '__test__', 'guid-of-__test__-group')
+
+      group = Group.new('__test__', [])
+      group.get_group(@fake_uaa_client)
+      expect(group.guid).to eq 'guid-of-__test__-group'
+    end
+  end
+
+  context 'get_member_users' do
+    before do
+      stub_searching_for_group(200, '__test__', 'guid-of-__test__-group', [
+        { 'id' => 'guid-of-member-1' },
+        { 'id' => 'guid-of-member-2' }
+      ])
+      stub_getting_user_by_id(200, 'guid-of-member-1', 'origin-of-member-1', 'username-of-member-1', Time.now)
+      stub_getting_user_by_id(200, 'guid-of-member-2', 'origin-of-member-2', 'username-of-member-2', Time.now)
+    end
+
+    it 'retrieves users who are members of the group' do
+      group = Group.new('__test__', [])
+      members = group.get_member_users(@fake_uaa_client)
+      expect(members.length).to eq 2
+      expect(members[0]['id']).to eq 'guid-of-member-1'
+      expect(members[0]['origin']).to eq 'origin-of-member-1'
+      expect(members[0]['userName']).to eq 'username-of-member-1'
+      expect(members[1]['id']).to eq 'guid-of-member-2'
+      expect(members[1]['origin']).to eq 'origin-of-member-2'
+      expect(members[1]['userName']).to eq 'username-of-member-2'
+    end
+
+    it 'does not error if the group has a non-user member' do
+      stub_searching_for_group(200, '__test__', 'guid-of-__test__-group', [
+        { 'id' => 'guid-of-member-1' },
+        { 'id' => 'guid-of-member-2', 'type' => 'GROUP' }
+      ])
+      group = Group.new('__test__', [])
+      members = group.get_member_users(@fake_uaa_client)
+      expect(members).to include(
+        'id' => 'guid-of-member-2',
+        'origin' => "*** UNUSUAL MEMBER WITH ORIGIN 'uaa' AND TYPE 'GROUP' ***",
+        'userName' => "*** UNUSUAL MEMBER WITH ORIGIN 'uaa' AND TYPE 'GROUP' ***"
+      )
+    end
+
+    it 'does not error if the group has a member not managed by UAA' do
+      stub_searching_for_group(200, '__test__', 'guid-of-__test__-group', [
+        { 'id' => 'guid-of-member-1' },
+        { 'id' => 'guid-of-member-2', 'origin' => 'something-that-is-not-uaa' }
+      ])
+      group = Group.new('__test__', [])
+      members = group.get_member_users(@fake_uaa_client)
+      expect(members).to include(
+        'id' => 'guid-of-member-2',
+        'origin' => "*** UNUSUAL MEMBER WITH ORIGIN 'something-that-is-not-uaa' AND TYPE 'USER' ***",
+        'userName' => "*** UNUSUAL MEMBER WITH ORIGIN 'something-that-is-not-uaa' AND TYPE 'USER' ***"
+      )
+    end
+  end
+
+  context 'get_uaa_user' do
+    it 'gets users by their id' do
+      stub_getting_user_by_id(200, 'guid-of-member', 'origin-of-member', 'username-of-member', Time.now)
+
+      group = Group.new('__test__', [])
+      user = group.get_uaa_user('guid-of-member', @fake_uaa_client)
+      expect(user['id']).to eq 'guid-of-member'
+      expect(user['origin']).to eq 'origin-of-member'
+      expect(user['userName']).to eq 'username-of-member'
+    end
+
+    it 'does not error when a member does not have a corresponding user' do
+      stub_getting_user_by_id(404, 'guid-of-member-which-does-not-exist')
+
+      group = Group.new('__test__', [])
+      user = group.get_uaa_user('guid-of-member-which-does-not-exist', @fake_uaa_client)
+      expect(user['id']).to eq 'guid-of-member-which-does-not-exist'
+      expect(user['origin']).to eq '*** THE USER BEHIND THIS MEMBERSHIP DOES NOT EXIST ***'
+      expect(user['userName']).to eq '*** THE USER BEHIND THIS MEMBERSHIP DOES NOT EXIST ***'
     end
   end
 end

--- a/tools/user_management/spec/group_spec.rb
+++ b/tools/user_management/spec/group_spec.rb
@@ -72,19 +72,19 @@ RSpec.describe Group do
     end
 
     it 'adds a member' do
-      stub_adding_user_to_group(201, 'guid-of-__test__-group', 'user-guid', 'google')
+      stub_adding_user_to_group(201, 'guid-of-__test__-group', 'user-guid')
 
       g = Group.new('__test__', [@user])
       g.get_group(@fake_uaa_client)
-      g.add_member('user-guid', 'google', @fake_uaa_client)
+      g.add_member('user-guid', @fake_uaa_client)
     end
 
     it 'raises an error when UAA responds with a non-201 status code' do
-      stub_adding_user_to_group(400, 'guid-of-__test__-group', 'user-guid', 'google')
+      stub_adding_user_to_group(400, 'guid-of-__test__-group', 'user-guid')
 
       g = Group.new('__test__', [@user])
       g.get_group(@fake_uaa_client)
-      expect { g.add_member('user-guid', 'google', @fake_uaa_client) }
+      expect { g.add_member('user-guid', @fake_uaa_client) }
         .to raise_error(RestClient::BadRequest, /Bad Request/)
     end
   end
@@ -137,7 +137,7 @@ RSpec.describe Group do
       g = Group.new('__test__', [@u1, @u2])
       g.get_group(@fake_uaa_client)
 
-      stub_adding_user_to_group(201, 'guid-of-__test__-group', 'user-2-guid', 'google')
+      stub_adding_user_to_group(201, 'guid-of-__test__-group', 'user-2-guid')
       g.add_desired_users(@fake_uaa_client)
     end
   end

--- a/tools/user_management/spec/spec_helper.rb
+++ b/tools/user_management/spec/spec_helper.rb
@@ -114,8 +114,8 @@ def stub_searching_for_group(status, display_name, id = nil, members = [])
       'displayName' => display_name,
       'members' => members.map do |member|
         {
-          'type' => 'USER',
-          'origin' => member.fetch('origin'),
+          'type' => member.fetch('type', 'USER'),
+          'origin' => member.fetch('origin', 'uaa'),
           'value' => member.fetch('id')
         }
       end

--- a/tools/user_management/spec/spec_helper.rb
+++ b/tools/user_management/spec/spec_helper.rb
@@ -140,10 +140,10 @@ def stub_getting_user_by_id(status, id, origin = nil, username = nil, created = 
     }
 end
 
-def stub_adding_user_to_group(status, group_id, user_id, origin)
+def stub_adding_user_to_group(status, group_id, user_id)
   url = "http://fake-uaa.internal/Groups/#{group_id}/members"
   stub_request(:post, url)
-    .with(body: { 'type': 'USER', 'origin': origin, 'value': user_id })
+    .with(body: { 'type': 'USER', 'origin': 'uaa', 'value': user_id })
     .to_return(status: status)
 end
 


### PR DESCRIPTION
What
----

The `origin` field of a group member is not the same as the `origin` field of a user. From https://docs.cloudfoundry.org/api/uaa/version/74.4.0/index.html#add-member:

> `origin`: The originating IDP of the entity, or "uaa" for groups and internal users

So users signing in with Google should have an origin of `google`, but their group memberships should have an origin of `uaa`.

How to review
-------------

* See that the tests go green;
* Code review.

I've run this manually against staging and it worked as expected 🎉:
* The existing group memberships with `origin=google` were all removed.
* New group memberships with `origin=uaa` were created.
* Subsequent runs don't make any unexpected changes.

Who can review
--------------

Not @46bit.