### PR TITLE
Bump the paas-audit-to-splunk app

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -634,7 +634,7 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-audit-to-splunk.git
       branch: master
-      tag_filter: v0.1.0
+      tag_filter: v0.3.0
 
   - name: paas-admin
     type: git


### PR DESCRIPTION
What
----

Currently, the design of this application is not perfect. Upon crash or
restart it's job will be to re-ingest all the audit events from CF to
Splunk over and over again. This is limited by a specific date, which
now is almost a month ago, meaning the number of duplicated logs will
get insane soon...

There is an improvement, which instead of locking down to a date, will
lock down to N minutes ago, which should sanitise the ingestion but not
eliminate the problem fully.

How to review
-------------

- Sanity check