### PR TITLE
Alphabetise users with the same permissions

### DIFF
--- a/config/spec/users_spec.rb
+++ b/config/spec/users_spec.rb
@@ -1,0 +1,42 @@
+require 'yaml'
+require 'uri'
+
+USERS_CONFIG_FILE_PATH = File.expand_path(File.join(__dir__, '..', 'users.yml'))
+
+describe 'users config' do
+  let :users_file_contents do
+    File.read(USERS_CONFIG_FILE_PATH)
+  end
+
+  let :users do
+    YAML.safe_load(users_file_contents)
+  end
+
+  let :users_grouped_by_permissions do
+    users.group_by { |user| user['cf_admin'] }
+  end
+
+  it 'should be valid YAML' do
+    expect { users }.not_to raise_exception, 'users config is invalid yaml'
+  end
+
+  it 'should provide a valid email for each user' do
+    users.each do |user|
+      expect(user['email']).to match URI::MailTo::EMAIL_REGEXP
+    end
+  end
+
+  it 'should not have any unexpected fields' do
+    fields = users.map(&:keys).flatten.uniq.sort
+    expect(fields).to eq %w[cf_admin email google_id]
+  end
+
+  it 'should list users with the same permissions in alphabetical order' do
+    users_grouped_by_permissions.each do |_, user_group|
+      user_group.each_cons(2) do |user, following_user|
+        emails = [user['email'], following_user['email']]
+        expect(emails.sort).to eq emails
+      end
+    end
+  end
+end

--- a/config/users.yml
+++ b/config/users.yml
@@ -47,44 +47,44 @@
   google_id: 115270948065632839284
   cf_admin: true
 
-- email: venus.bailey@digital.cabinet-office.gov.uk
-  google_id: 108001189081160962219
-
-- email: luke.malcher@digital.cabinet-office.gov.uk
-  google_id: 110778878978931011243
-
-- email: paul.dougan@digital.cabinet-office.gov.uk
-  google_id: 104206899246339571570
-
-- email: emma.pearce@digital.cabinet-office.gov.uk
-  google_id: 116361542740992904571
-
-- email: mark.buckley@digital.cabinet-office.gov.uk
-  google_id: 113316348446994386136
-
-- email: lucien.west@digital.cabinet-office.gov.uk
-  google_id: 109330715895600878233
-
-- email: kirsty.armstrong@digital.cabinet-office.gov.uk
-  google_id: 117328248009254641031
-
-- email: miriam.raines@digital.cabinet-office.gov.uk
-  google_id: 116058669793311669994
-
-- email: laura.payten@digital.cabinet-office.gov.uk
-  google_id: 104063198711253168471
-
 - email: agatha.blake@digital.cabinet-office.gov.uk
   google_id: 115206840979594971564
 
 - email: connie.briggs@digital.cabinet-office.gov.uk
   google_id: 103867560811643836157
 
-- email: neil.edwards@digital.cabinet-office.gov.uk
-  google_id: 116276543621958296809
+- email: emma.pearce@digital.cabinet-office.gov.uk
+  google_id: 116361542740992904571
 
 - email: jake.mccann@digital.cabinet-office.gov.uk
   google_id: 110058378478974615296
 
+- email: kirsty.armstrong@digital.cabinet-office.gov.uk
+  google_id: 117328248009254641031
+
+- email: laura.payten@digital.cabinet-office.gov.uk
+  google_id: 104063198711253168471
+
+- email: lucien.west@digital.cabinet-office.gov.uk
+  google_id: 109330715895600878233
+
+- email: luke.malcher@digital.cabinet-office.gov.uk
+  google_id: 110778878978931011243
+
+- email: mark.buckley@digital.cabinet-office.gov.uk
+  google_id: 113316348446994386136
+
+- email: miriam.raines@digital.cabinet-office.gov.uk
+  google_id: 116058669793311669994
+
+- email: neil.edwards@digital.cabinet-office.gov.uk
+  google_id: 116276543621958296809
+
+- email: paul.dougan@digital.cabinet-office.gov.uk
+  google_id: 104206899246339571570
+
 - email: satwinder.bharaj@digital.cabinet-office.gov.uk
   google_id: 117679332904544013345
+
+- email: venus.bailey@digital.cabinet-office.gov.uk
+  google_id: 108001189081160962219


### PR DESCRIPTION
What
----

This commit adds some tests that entries in the `config/users.yml` file are sensible. It ensures that users _with the same permissions_ are listed with their emails in alphabetical order.

This means we can still cluster similar users (e.g., people with `cf_admin: true`) while keeping those clusters alphabetical.

I'm fairly confident this is compatible with @richardTowers current work to drop the `cf_admin` boolean and use YAML anchors instead. The expected fields and the fields used to group permissions will need changing, but not the approach.

I did this as part of adding two new joiners as Global Auditors, but then I realised we don't have their Google IDs yet.

How to review
-------------

* Code review;
* See that the tests pass.

Who can review
--------------

Not @46bit.