### PR TITLE
[#169775886] Upgrade to cf v12.15.0

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -532,13 +532,13 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-acceptance-tests
-      branch: cf12.1
+      branch: cf12.15
 
   - name: cf-smoke-tests-release
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-smoke-tests-release
-      tag_filter: "40.0.119"
+      tag_filter: "40.0.123"
       submodules:
       - "src/smoke_tests"
 

--- a/concourse/pipelines/monitor-remote.yml
+++ b/concourse/pipelines/monitor-remote.yml
@@ -19,7 +19,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloudfoundry/cf-smoke-tests-release
-    tag_filter: "40.0.119"
+    tag_filter: "40.0.123"
     submodules:
       - "src/smoke_tests"
 

--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-xenial
-      version: "621.23"
+      version: "621.26"

--- a/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
+++ b/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
@@ -1,8 +1,0 @@
----
-- type: replace
-  path: /releases/name=cflinuxfs3
-  value:
-    name: "cflinuxfs3"
-    version: "0.150.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.150.0"
-    sha1: "6421766b2120009c6d422c4b1ed5a12c4290eda4"

--- a/manifests/cf-manifest/operations.d/310-router.yml
+++ b/manifests/cf-manifest/operations.d/310-router.yml
@@ -1,13 +1,4 @@
 ---
-
-- type: replace
-  path: /releases/name=routing
-  value:
-    name: routing
-    version: "0.193.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry-incubator/cf-routing-release?v=0.193.0"
-    sha1: "eb74a7c1f2775382daea61dc2f666833febe2dc9"
-
 - type: remove
   path: /instance_groups/name=router/vm_extensions
 

--- a/manifests/cf-manifest/operations.d/329-capi-release.yml
+++ b/manifests/cf-manifest/operations.d/329-capi-release.yml
@@ -1,7 +1,0 @@
-- type: replace
-  path: /releases/name=capi
-  value:
-    name: "capi"
-    version: "1.87.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.87.0"
-    sha1: "03ac801323cd23205dde357cc7d2dc9e92bc0c93"

--- a/manifests/cf-manifest/operations.d/360-log-api.yml
+++ b/manifests/cf-manifest/operations.d/360-log-api.yml
@@ -17,12 +17,3 @@
 - type: replace
   path: /instance_groups/name=log-api/instances
   value: ((log_api_instances))
-
-- type: replace
-  path: /releases/name=loggregator
-  value:
-    name: "loggregator"
-    version: "105.6"
-    url: "https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=105.6"
-    sha1: "eccfbd65e1d217a2b46afd414163e82553fb3084"
-

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -27,10 +27,6 @@ RSpec.describe "release versions" do
     end
 
     pinned_releases = {
-      'capi' => {
-        local: '1.87.0',
-        upstream: '1.86.0',
-      },
       'uaa' => {
         local: '0.1.18',
         upstream: '74.2.0',

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "release versions" do
     pinned_releases = {
       'uaa' => {
         local: '0.1.18',
-        upstream: '74.2.0',
+        upstream: '74.12.0',
       }
     }
 


### PR DESCRIPTION
What
----
v12.18.0 was released 7 days ago (2019-12-04) relative to now (2019-12-10). There are more recent releases 2 days ago, 18 hours ago and 16 hours ago, but I’m choosing v12.15.0 for the sake of not releasing something which other people haven’t had chance to test.

Upgrade notes are in [this hackmd document](https://hackmd.cloudapps.digital/AOadTZQPTOGidskEPFSAnQ?view)

How to review
-------------
1. Review my notes
1. Review the PR
1. Check my pipeline (N.B. acceptance tests failed because I'd pushed a custom buildpack whilst it was running. There's a second run which passes once I deleted the buildpack)
1. Run it down your pipeline

Who can review
--------------
Anyone