### PR TITLE
Revert the change to RDS database kick off in 0242505330c7

### DIFF
--- a/concourse/scripts/rds_instances.sh
+++ b/concourse/scripts/rds_instances.sh
@@ -1,6 +1,5 @@
-#!/bin/bash
-
-set -euo pipefail
+#!/bin/sh
+set -euo
 
 ACTION=$1
 CMD=""


### PR DESCRIPTION
What
----
In commit 0242505330c72550b85d817c81c5328b5ee66bf2, the shebang for
`concourse/scripts/rds_instances.sh` was changed to `/bin/bash`. However, the
container iin which this script runs does not contain `/bin/bash`, only
`/bin/sh`. This resulted in environment kickoffs being broken.


How to review
-------------

1. Code review

Who can review
--------------
Anyone but me
