### PR TITLE
Use paas-trusted-people user configuration file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ showenv: ## Display environment information
 	@scripts/showenv.sh
 
 .PHONY: upload-all-secrets
-upload-all-secrets: upload-google-oauth-secrets upload-microsoft-oauth-secrets upload-splunk-secrets upload-notify-secrets upload-aiven-secrets upload-logit-secrets upload-pagerduty-secrets
+upload-all-secrets: upload-google-oauth-secrets upload-microsoft-oauth-secrets upload-splunk-secrets upload-notify-secrets upload-aiven-secrets upload-logit-secrets upload-pagerduty-secrets upload-cyber-secrets upload-paas-trusted-people
 
 .PHONY: upload-google-oauth-secrets
 upload-google-oauth-secrets: check-env ## Decrypt and upload Google Admin Console credentials to Credhub
@@ -310,6 +310,10 @@ upload-pagerduty-secrets: check-env ## Decrypt and upload pagerduty credentials 
 	$(if $(wildcard ${PAAS_PASSWORD_STORE_DIR}),,$(error Password store ${PAAS_PASSWORD_STORE_DIR} (PAAS_PASSWORD_STORE_DIR) does not exist))
 	$(eval export PASSWORD_STORE_DIR=${PAAS_PASSWORD_STORE_DIR})
 	@scripts/upload-pagerduty-secrets.rb
+
+.PHONY: upload-paas-trusted-people
+upload-paas-trusted-people: check-env
+	@scripts/upload-paas-trusted-people.sh
 
 .PHONY: pingdom
 pingdom: check-env ## Use custom Terraform provider to set up Pingdom check

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -519,6 +519,15 @@ resources:
       region_name: ((aws_region))
       versioned_file: paas-cf-cloud-config.yml
 
+  - name: paas-trusted-people
+    type: s3-iam
+    source:
+      bucket: ((state_bucket))
+      region_name: ((aws_region))
+      versioned_file: paas-trusted-people/users.yml
+      initial_version: "-"
+      initial_content_text: ""
+
   - name: deployed-healthcheck
     type: s3-iam
     source:
@@ -1975,6 +1984,7 @@ jobs:
       - get: cf-tfstate
         passed: ['generate-cf-config']
       - get: paas-aiven-broker
+      - get: paas-trusted-people
 
     - task: retrieve-config
       tags: [colocated-with-web]
@@ -2508,10 +2518,12 @@ jobs:
           inputs:
             - name: paas-cf
             - name: cf-manifest
+            - name: paas-trusted-people
           params:
             UAA_API_URL: https://uaa.((system_dns_zone_name))
             UAA_ADMIN_CLIENT_SECRET: ((uaa_admin_client_secret))
-            USERS_CONFIG_PATH: ../../config/users.yml
+            USERS_CONFIG_PATH: paas-trusted-people/users.yml
+            ENV_TARGET: ((aws_account))
           run:
             path: sh
             args:
@@ -2523,9 +2535,8 @@ jobs:
                 uaac token client get admin -s "${UAA_ADMIN_CLIENT_SECRET}"
                 CF_TOKEN="bearer $(uaac contexts | awk '$1 ~ /access_token/ {print $2}')"
                 export CF_TOKEN
-                cd paas-cf/tools/user_management
-                bundle --quiet
-                bundle exec main.rb
+                (cd paas-cf && bundle --quiet)
+                paas-cf/tools/user_management/main.rb
 
       - task: deploy-healthcheck
         tags: [colocated-with-web]

--- a/scripts/upload-paas-trusted-people.sh
+++ b/scripts/upload-paas-trusted-people.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(mktemp -d -t paas-trusted-people-XXXXX)"
+
+git clone --depth 1 --branch "${PAAS_TRUSTED_PEOPLE_BRANCH:-master}" git@github.com:alphagov/paas-trusted-people.git
+aws s3 cp ./paas-trusted-people/users.yml "s3://gds-paas-${DEPLOY_ENV}-state/paas-trusted-people/users.yml"
+

--- a/tools/user_management/lib/user.rb
+++ b/tools/user_management/lib/user.rb
@@ -3,12 +3,12 @@ require 'json'
 require_relative 'uaa_resource'
 
 class User < UAAResource
-  attr_reader :email, :google_id, :cf_admin
+  attr_reader :email, :google_id
 
   def initialize(obj)
     @email = obj.fetch('email')
     @google_id = obj.fetch('google_id')
-    @cf_admin = obj.fetch('cf_admin', false)
+    @roles_by_env = obj.fetch("roles", {})
   end
 
   def exists?(uaa_client)
@@ -18,6 +18,10 @@ class User < UAAResource
       return false
     end
     true
+  end
+
+  def has_role_for_env?(env, role)
+    @roles_by_env.fetch(env, []).any? { |x| x['role'] == role }
   end
 
   def create(uaa_client)

--- a/tools/user_management/spec/user_spec.rb
+++ b/tools/user_management/spec/user_spec.rb
@@ -11,6 +11,35 @@ RSpec.describe User do
     })
   end
 
+  it 'checks if a role for a user exists in an environment' do
+    u = User.new(
+      'email' => 'jeff.jefferson@example.com',
+      'google_id' => '000000000000000000000',
+      'roles' => {
+        'dev' => [{ 'role' => 'some_role' }],
+        'prod' => [{ 'role' => 'some_other_role' }],
+      },
+    )
+    expect(u.has_role_for_env?('dev', 'some_role')).to be(true)
+    expect(u.has_role_for_env?('dev', 'some_other_role')).to be(false)
+    expect(u.has_role_for_env?('prod', 'some_other_role')).to be(true)
+    expect(u.has_role_for_env?('prod', 'some_role')).to be(false)
+    expect(u.has_role_for_env?('some_env_that_does_not_exist', 'some_role_that_does_not_exist')).to be(false)
+  end
+
+  it 'does not give any roles to users without roles' do
+    u = User.new(
+      'email' => 'jeff.jefferson@example.com',
+      'google_id' => '000000000000000000000',
+      'roles' => {},
+    )
+    expect(u.has_role_for_env?('dev', 'some_role')).to be(false)
+    expect(u.has_role_for_env?('dev', 'some_other_role')).to be(false)
+    expect(u.has_role_for_env?('prod', 'some_other_role')).to be(false)
+    expect(u.has_role_for_env?('prod', 'some_role')).to be(false)
+    expect(u.has_role_for_env?('some_env_that_does_not_exist', 'some_role_that_does_not_exist')).to be(false)
+  end
+
   it 'checks if exists in UAA' do
     stub_request(:get, 'http://fake-uaa.internal/Users?filter=origin%20eq%20%22google%22%20and%20userName%20eq%20%22000000000000000000000%22')
       .to_return(body: JSON.generate(
@@ -23,7 +52,7 @@ RSpec.describe User do
     u = User.new(
       'email' => 'jeff.jefferson@example.com',
       'google_id' => '000000000000000000000',
-      'cf_admin' => true
+      'roles' => { 'dev' => [{ 'role' => 'some_role' }] },
     )
 
     expect(u.exists?(@fake_uaa_client)).to be true
@@ -46,7 +75,7 @@ RSpec.describe User do
     u = User.new(
       'email' => 'jeff.jefferson@example.com',
       'google_id' => '000000000000000000000',
-      'cf_admin' => true
+      'roles' => { 'dev' => [{ 'role' => 'some_role' }] },
     )
 
     expect(u.create(@fake_uaa_client)).to be true
@@ -90,7 +119,7 @@ RSpec.describe User do
     u = User.new(
       'email' => 'jeff.jefferson@example.com',
       'google_id' => '000000000000000000000',
-      'cf_admin' => true
+      'roles' => { 'dev' => [{ 'role' => 'some_role' }] },
     )
 
     expect { u.get_user(@fake_uaa_client) }.to raise_error(Exception)


### PR DESCRIPTION
What
----

We had to handle a slightly different configuration file format, so:

```
- email: ''
  roles: []
```

instead of:

```
- email: ''
  cf_admin: true
```

so we're fixing the tools/user_management scripts to work with the new
format.

paas-trusted-people is a private repo, so we have to upload it to S3 and
then download it in the pipeline (because the pipeline can't clone
private repos).

How to review
-------------

* Code review
* Upload paas-trusted-people to S3 in your dev env by running `make upload-paas-trusted-people DEPLOY_ENV=blah`
* Run the create-cloudfoundry pipeline and check that the `post-deploy/sync-admin-users` task does something sensible

Who can review
--------------

Not @richardtowers or @schmie