### PR TITLE
[WIP] Move PaaS environment config out of the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,87 +138,22 @@ update_merge_keys:
 
 .PHONY: dev
 dev: ## Set Environment to DEV
-	$(eval export AWS_DEFAULT_REGION ?= eu-west-1)
-	$(eval export AWS_ACCOUNT=dev)
-	$(eval export MAKEFILE_ENV_TARGET=dev)
-	$(eval export PERSISTENT_ENVIRONMENT=false)
-	$(eval export ENABLE_DESTROY=true)
-	$(eval export ENABLE_AUTODELETE=true)
-	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
-	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipelineapps.digital)
-	$(eval export ALERT_EMAIL_ADDRESS?=govpaas-alerting-dev@digital.cabinet-office.gov.uk)
-	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS?=the-multi-cloud-paas-team+dev@digital.cabinet-office.gov.uk)
-	$(eval export ENABLE_ALERT_NOTIFICATIONS ?= false)
-	$(eval export SKIP_COMMIT_VERIFICATION=true)
-	$(eval export ENV_SPECIFIC_BOSH_VARS_FILE=default.yml)
-	$(eval export DISABLE_HEALTHCHECK_DB=true)
-	$(eval export CONCOURSE_AUTH_DURATION=48h)
-	$(eval export DISABLE_PIPELINE_LOCKING=true)
-	$(eval export TEST_HEAVY_LOAD=true)
-	$(eval export PAAS_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
-	$(eval export PAAS_HIGH_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
-	$(eval export ENABLE_MORNING_DEPLOYMENT=true)
-	$(eval export SLIM_DEV_DEPLOYMENT ?= true)
+	$(foreach definition,$(shell config/print_env_vars_for_environment.rb any-dev-env true),$(eval export $(definition)))
 	@true
 
 .PHONY: stg-lon
 stg-lon: ## Set Environment to stg-lon
-	$(eval export AWS_ACCOUNT=staging)
-	$(eval export MAKEFILE_ENV_TARGET=stg-lon)
-	$(eval export PERSISTENT_ENVIRONMENT=true)
-	$(eval export ENABLE_AUTO_DEPLOY=true)
-	$(eval export OUTPUT_TAG_PREFIX=prod-)
-	$(eval export SYSTEM_DNS_ZONE_NAME=london.staging.cloudpipeline.digital)
-	$(eval export APPS_DNS_ZONE_NAME=london.staging.cloudpipelineapps.digital)
-	$(eval export ALERT_EMAIL_ADDRESS=the-multi-cloud-paas-team+stg-lon@digital.cabinet-office.gov.uk)
-	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS=${ALERT_EMAIL_ADDRESS})
-	$(eval export ENV_SPECIFIC_BOSH_VARS_FILE=stg-lon.yml)
-	$(eval export DEPLOY_ENV=stg-lon)
-	$(eval export TEST_HEAVY_LOAD=true)
-	$(eval export PAAS_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
-	$(eval export PAAS_HIGH_PASSWORD_STORE_DIR?=${HOME}/.paas-pass-high)
-	$(eval export AWS_DEFAULT_REGION=eu-west-2)
-	$(eval export AWS_REGION=eu-west-2)
+	$(foreach definition,$(shell config/print_env_vars_for_environment.rb stg-lon true),$(eval export $(definition)))
 	@true
 
 .PHONY: prod
 prod: ## Set Environment to Production
-	$(eval export AWS_ACCOUNT=prod)
-	$(eval export MAKEFILE_ENV_TARGET=prod)
-	$(eval export PERSISTENT_ENVIRONMENT=true)
-	$(eval export ENABLE_AUTO_DEPLOY=true)
-	$(eval export INPUT_TAG_PREFIX=prod-)
-	$(eval export SYSTEM_DNS_ZONE_NAME=cloud.service.gov.uk)
-	$(eval export APPS_DNS_ZONE_NAME=cloudapps.digital)
-	$(eval export ALERT_EMAIL_ADDRESS=the-multi-cloud-paas-team+prod@digital.cabinet-office.gov.uk)
-	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS=${ALERT_EMAIL_ADDRESS})
-	$(eval export ENV_SPECIFIC_BOSH_VARS_FILE=prod.yml)
-	$(eval export DISABLE_CF_ACCEPTANCE_TESTS=true)
-	$(eval export DEPLOY_ENV=prod)
-	$(eval export PAAS_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
-	$(eval export PAAS_HIGH_PASSWORD_STORE_DIR?=${HOME}/.paas-pass-high)
-	$(eval export AWS_DEFAULT_REGION=eu-west-1)
-	$(eval export AWS_REGION=eu-west-1)
+	$(foreach definition,$(shell config/print_env_vars_for_environment.rb prod true),$(eval export $(definition)))
 	@true
 
 .PHONY: prod-lon
 prod-lon: ## Set Environment to prod-lon
-	$(eval export AWS_ACCOUNT=prod)
-	$(eval export MAKEFILE_ENV_TARGET=prod-lon)
-	$(eval export PERSISTENT_ENVIRONMENT=true)
-	$(eval export ENABLE_AUTO_DEPLOY=true)
-	$(eval export INPUT_TAG_PREFIX=prod-)
-	$(eval export SYSTEM_DNS_ZONE_NAME=london.cloud.service.gov.uk)
-	$(eval export APPS_DNS_ZONE_NAME=london.cloudapps.digital)
-	$(eval export ALERT_EMAIL_ADDRESS=the-multi-cloud-paas-team+prod-lon@digital.cabinet-office.gov.uk)
-	$(eval export NEW_ACCOUNT_EMAIL_ADDRESS=${ALERT_EMAIL_ADDRESS})
-	$(eval export ENV_SPECIFIC_BOSH_VARS_FILE=prod-lon.yml)
-	$(eval export DISABLE_CF_ACCEPTANCE_TESTS=true)
-	$(eval export DEPLOY_ENV=prod-lon)
-	$(eval export PAAS_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
-	$(eval export PAAS_HIGH_PASSWORD_STORE_DIR?=${HOME}/.paas-pass-high)
-	$(eval export AWS_DEFAULT_REGION=eu-west-2)
-	$(eval export AWS_REGION=eu-west-2)
+	$(foreach definition,$(shell config/print_env_vars_for_environment.rb prod-lon true),$(eval export $(definition)))
 	@true
 
 .PHONY: bosh-cli

--- a/config/environments.yml
+++ b/config/environments.yml
@@ -1,0 +1,91 @@
+---
+# To only set an environment variable if it isn't already set, append
+# a ? to its name.
+
+meta:
+  ireland: &ireland
+    AWS_DEFAULT_REGION: eu-west-1
+    AWS_REGION: eu-west-1
+  london: &london
+    AWS_DEFAULT_REGION: eu-west-2
+    AWS_REGION: eu-west-2
+  persistent: &persistent
+    PERSISTENT_ENVIRONMENT: true
+    ENABLE_AUTO_DEPLOY: true
+  stagify: &stagify
+    TEST_HEAVY_LOAD: true
+  productionise: &productionise
+    DISABLE_CF_ACCEPTANCE_TESTS: true
+  full_password_stores: &full_password_stores
+    PAAS_PASSWORD_STORE_DIR?: ${HOME}/.paas-pass
+    PAAS_HIGH_PASSWORD_STORE_DIR?: ${HOME}/.paas-pass-high
+
+environments:
+  any-dev-env:
+    AWS_DEFAULT_REGION?: eu-west-1
+    AWS_REGION?: eu-west-1
+    AWS_ACCOUNT: dev
+    MAKEFILE_ENV_TARGET: dev
+    ENV_SPECIFIC_BOSH_VARS_FILE: default.yml
+    PERSISTENT_ENVIRONMENT: false
+    ENABLE_DESTROY: true
+    ENABLE_AUTODELETE: true
+    ENABLE_ALERT_NOTIFICATIONS?: false
+    SKIP_COMMIT_VERIFICATION: true
+    DISABLE_HEALTHCHECK_DB: true
+    DISABLE_PIPELINE_LOCKING: true
+    TEST_HEAVY_LOAD: true
+    ENABLE_MORNING_DEPLOYMENT: true
+    SLIM_DEV_DEPLOYMENT?: true
+    CONCOURSE_AUTH_DURATION: 48h
+    PAAS_PASSWORD_STORE_DIR?: ${HOME}/.paas-pass
+    PAAS_HIGH_PASSWORD_STORE_DIR?: ${HOME}/.paas-pass
+    SYSTEM_DNS_ZONE_NAME: ${DEPLOY_ENV}.dev.cloudpipeline.digital
+    APPS_DNS_ZONE_NAME: ${DEPLOY_ENV}.dev.cloudpipelineapps.digital
+    ALERT_EMAIL_ADDRESS?: govpaas-alerting-dev@digital.cabinet-office.gov.uk
+    NEW_ACCOUNT_EMAIL_ADDRESS?: the-multi-cloud-paas-team+dev@digital.cabinet-office.gov.uk
+
+  stg-lon:
+    <<: *ireland
+    <<: *persistent
+    <<: *stagify
+    <<: *full_password_stores
+    OUTPUT_TAG_PREFIX: prod-
+    AWS_ACCOUNT: staging
+    MAKEFILE_ENV_TARGET: stg-lon
+    DEPLOY_ENV: stg-lon
+    ENV_SPECIFIC_BOSH_VARS_FILE: stg-lon.yml
+    SYSTEM_DNS_ZONE_NAME: london.staging.cloudpipeline.digital
+    APPS_DNS_ZONE_NAME: london.staging.cloudpipelineapps.digital
+    ALERT_EMAIL_ADDRESS: the-multi-cloud-paas-team+stg-lon@digital.cabinet-office.gov.uk
+    NEW_ACCOUNT_EMAIL_ADDRESS: the-multi-cloud-paas-team+stg-lon@digital.cabinet-office.gov.uk
+
+  prod:
+    <<: *ireland
+    <<: *persistent
+    <<: *productionise
+    <<: *full_password_stores
+    INPUT_TAG_PREFIX: prod-
+    AWS_ACCOUNT: prod
+    MAKEFILE_ENV_TARGET: prod
+    DEPLOY_ENV: prod
+    ENV_SPECIFIC_BOSH_VARS_FILE: prod.yml
+    SYSTEM_DNS_ZONE_NAME: cloud.service.gov.uk
+    APPS_DNS_ZONE_NAME: cloudapps.digital
+    ALERT_EMAIL_ADDRESS: the-multi-cloud-paas-team+prod@digital.cabinet-office.gov.uk
+    NEW_ACCOUNT_EMAIL_ADDRESS: the-multi-cloud-paas-team+prod@digital.cabinet-office.gov.uk
+
+  prod-lon:
+    <<: *london
+    <<: *persistent
+    <<: *productionise
+    <<: *full_password_stores
+    INPUT_TAG_PREFIX: prod-
+    AWS_ACCOUNT: prod
+    MAKEFILE_ENV_TARGET: prod-lon
+    DEPLOY_ENV: prod-lon
+    ENV_SPECIFIC_BOSH_VARS_FILE: prod-lon.yml
+    SYSTEM_DNS_ZONE_NAME: london.cloud.service.gov.uk
+    APPS_DNS_ZONE_NAME: london.cloudapps.digital
+    ALERT_EMAIL_ADDRESS: the-multi-cloud-paas-team+prod-lon@digital.cabinet-office.gov.uk
+    NEW_ACCOUNT_EMAIL_ADDRESS: the-multi-cloud-paas-team+prod-lon@digital.cabinet-office.gov.uk

--- a/config/print_env_vars_for_environment.rb
+++ b/config/print_env_vars_for_environment.rb
@@ -1,0 +1,43 @@
+#!/usr/bin/env ruby
+
+require 'yaml'
+
+def print_assign_if_not_set(name, value, emit_makefile_syntax = false)
+  if emit_makefile_syntax
+    puts "#{name}?=#{value}"
+  else
+    puts "export #{name}=${#{name}:-#{value.inspect}}"
+  end
+end
+
+def print_assign(name, value, emit_makefile_syntax = false)
+  if emit_makefile_syntax
+    puts "#{name}=#{value}"
+  else
+    puts "export #{name}=#{value.inspect}"
+  end
+end
+
+environment_name = ARGV.fetch(0)
+emit_makefile_syntax = ARGV.fetch(1, false)
+
+#STDERR.puts "environment_name=#{environment_name.inspect}"
+#STDERR.puts "emit_makefile_syntax=#{emit_makefile_syntax.inspect}"
+
+environments_config_path = File.expand_path(File.join(__dir__, 'environments.yml'))
+environments_config = YAML.safe_load(File.read(environments_config_path), [], [], true)
+environments = environments_config.fetch('environments')
+
+environment = environments.fetch(environment_name)
+environment.each do |environment_variable_name, value|
+  if emit_makefile_syntax && (environment_variable_name.inspect.match(/\s/) || value.inspect.match(/\s/))
+    raise 'makefile foreach interprets whitespace as the end of a line. environment variable definitions cannot contain whitespace.'
+  end
+
+  if environment_variable_name.end_with? '?'
+    environment_variable_name = environment_variable_name.delete_suffix '?'
+    print_assign_if_not_set(environment_variable_name, value, emit_makefile_syntax)
+  else
+    print_assign(environment_variable_name, value, emit_makefile_syntax)
+  end
+end


### PR DESCRIPTION
What
----

This PR moves our `make dev`/`make stg-lon`/etc environment variables from the Makefile into a separate YAML file. It isn't a long-term solution, but it makes it easy to go on and experiment with not using a Makefile at all (or at least revising how we use it.)

The motivation for doing this now is that we plan to merge paas-cf, paas-bootstrap and paas-release-ci. They have Make targets with the same name and some rethinking is probably needed. Moving our config out of the Makefiles allows us to try and find a neater solution.

More info is in the commit message.

How to review
-------------

* Code review;
* See if the `make dev`/etc Make targets still work fine for you;
* Check that all the env variables removed from the Makefile are in the YAML.

Who can review
--------------

Not @46bit.