### PR TITLE
Upgrade BOSH DNS, set log level, update stemcells

### DIFF
--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-xenial
-      version: "621.26"
+      version: "621.29"

--- a/manifests/cf-manifest/operations.d/030-bosh-dns.yml
+++ b/manifests/cf-manifest/operations.d/030-bosh-dns.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: bosh-dns
-    sha1: 3b77329a772483d6c949f1a47ba9734976bc2b31
-    url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-release?v=1.8.0
-    version: 1.8.0
+    version: "1.16.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/bosh-dns-release?v=1.16.0"
+    sha1: "574dae0618a98d0dc725ecbcfdd0fa72ae288bce"
 
 - type: replace
   path: /addons/-
@@ -15,6 +15,7 @@
     - name: bosh-dns
       release: bosh-dns
       properties:
+        log_level: WARN
         api:
           client:
             tls:

--- a/manifests/cf-manifest/spec/manifest/bosh_dns_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/bosh_dns_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe 'bosh dns addon' do
+  let(:manifest) { manifest_with_defaults }
+  let(:bosh_dns_addon) { manifest.fetch('addons').find { |a| a['name'] == 'bosh-dns' } }
+  let(:bosh_dns_properties) { bosh_dns_addon.fetch('jobs').find { |j| j['name'] == 'bosh-dns' }.fetch('properties') }
+
+  it 'sets up bosh dns' do
+    expect(bosh_dns_addon).to_not be_nil
+  end
+
+  it 'enables caching' do
+    expect(bosh_dns_properties.dig('cache', 'enabled')).to eq(true)
+  end
+
+  it 'sets the log level correctly' do
+    # We do not want to log every single DNS request because that generates
+    # many logs and is not particularly useful
+    expect(bosh_dns_properties.dig('log_level')).to eq('WARN')
+  end
+end


### PR DESCRIPTION
What
----

See https://github.com/alphagov/paas-bootstrap/pull/331 for info WRT stemcells

Since we did #2197 the log-api instance has had high CPU, and has been generating many logs, this is because of changes to trafficcontroller (a partially deprecated loggregator component).

The reason for this is that many successful DNS requests are being logged, which is a bit pointless, and very noisy. In 1 hour it generated 8 million DNS requests in my development environment.

We're updating BOSH DNS because we were a bit behind, and we are setting the log level to WARN instead of DEBUG/INFO

Problems with DNS resolution should be caught by the blackbox DNS canary on each VM. We added some spec tests for BOSH DNS as well

Because BOSH DNS is an addon, we are doing it in the same PR as a stemcell upgrade, so that we don't have to roll all instances multiple times.

How to review
-------------

Code review

Who can review
--------------

Done as pair with @schmie 