### PR TITLE
Update cf-deployment to 12.19 and bump syslog release to 11.6

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -541,7 +541,7 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-acceptance-tests
-      branch: cf12.15
+      branch: cf12.19
 
   - name: cf-smoke-tests-release
     type: git

--- a/manifests/cf-manifest/operations.d/500-syslog-forwarder.yml
+++ b/manifests/cf-manifest/operations.d/500-syslog-forwarder.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: syslog
-    version: "11.3.2"
-    url: https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=11.3.2
-    sha1: 64cf40d44746b50edffa78cb0e0dd6f072fee695
+    version: "11.6.1"
+    url: "https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=11.6.1"
+    sha1: "e2649e48c49aedcbd0ff96b00f56b028682f1dd6"
 
 - type: replace
   path: /addons/-


### PR DESCRIPTION
What
----

Updates cf-deployment to 12.19

Updates syslog release to 11.6

How to review
-------------

See [hackmd](https://hackmd.cloudapps.digital/xX3r3HQOSZqxVwgJy3yTkg)

Check that [TLWR](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/acceptance-tests/builds/32) went green (except for custom domain CATS because I have an extra shared domain)

Maybe run it down a dev env

Who can review
--------------

@LeePorte 
