### PR TITLE
[#170423077] Convert gorouter {gorouter,app}_time metrics to floats

### DIFF
--- a/config/logit/20_custom_cf_filters.conf
+++ b/config/logit/20_custom_cf_filters.conf
@@ -74,6 +74,8 @@ mutate {
 mutate {
   convert => {
     "[gorouter][header][response_time]" => "float"
+    "[gorouter][header][gorouter_time]" => "float"
+    "[gorouter][header][app_time]" => "float"
     "[gorouter][bytessent]" => "integer"
     "[gorouter][bytesreceived]" => "integer"
   }

--- a/config/logit/output/generated_logit_filters.conf
+++ b/config/logit/output/generated_logit_filters.conf
@@ -1064,6 +1064,8 @@ filter {
   mutate {
     convert => {
       "[gorouter][header][response_time]" => "float"
+      "[gorouter][header][gorouter_time]" => "float"
+      "[gorouter][header][app_time]" => "float"
       "[gorouter][bytessent]" => "integer"
       "[gorouter][bytesreceived]" => "integer"
     }


### PR DESCRIPTION
What
----

In routing-release 0.196.0, gorouter began logging two new metrics:
`gorouter_time` and `app_time`. These metrics tell operators how long a request
spent in the gorouter and the app, respectively. Previously, it was only
possible to see a `response_time` metric, which showed the time for the full
roundtrip.

We have been receiving the fields since we upgraded to routing-release 0.196.0,
but we haven't been correctly indexing them. This commit addresses that, by
converting the fields in to floats.

What you should know
-------------
I've applied the filter in the `dev` ELK stack and refreshed the fields. I think that, since we've been ingesting this field for a while, it already exists, and its type can't be (trivially) changed in the current index. The next time an index is created, it should have the right type. In prod, I think this is daily.

How to review
-------------

1. Code review

Who can review
--------------
Anyone


