### PR TITLE
Scale up CF prometheus in non-dev environments

### DIFF
--- a/manifests/cf-manifest/operations.d/500-prometheus.yml
+++ b/manifests/cf-manifest/operations.d/500-prometheus.yml
@@ -30,12 +30,12 @@
   path: /instance_groups/-
   value:
     name: prometheus
-    instances: 1
+    instances: 2
     azs: [z1, z2, z3]
     stemcell: default
 
     persistent_disk_type: 100GB
-    vm_type: small
+    vm_type: medium
 
     networks:
       - name: cf

--- a/manifests/cf-manifest/operations/change-vm-types-dev.yml
+++ b/manifests/cf-manifest/operations/change-vm-types-dev.yml
@@ -44,3 +44,7 @@
 - type: replace
   path: /instance_groups/name=router/vm_type
   value: slim_router
+
+- type: replace
+  path: /instance_groups/name=prometheus/vm_type
+  value: small

--- a/manifests/cf-manifest/operations/scale-down-dev.yml
+++ b/manifests/cf-manifest/operations/scale-down-dev.yml
@@ -80,3 +80,7 @@
 - type: replace
   path: /instance_groups/name=s3_broker/instances
   value: 1
+
+- type: replace
+  path: /instance_groups/name=prometheus/instances
+  value: 1

--- a/manifests/cf-manifest/spec/manifest/dev_scaling_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/dev_scaling_spec.rb
@@ -1,27 +1,33 @@
-RSpec.describe "dev environment scaling" do
+RSpec.describe 'dev environment scaling' do
   after :each do
     ENV.delete('SLIM_DEV_DEPLOYMENT')
   end
 
-  it "scales back dev environment when requested" do
-    ENV['SLIM_DEV_DEPLOYMENT'] = "true"
+  it 'scales back dev environment when requested' do
+    ENV['SLIM_DEV_DEPLOYMENT'] = 'true'
     dev_manifest = manifest_for_dev
 
     # It scales back CF components to two instances
-    expect(dev_manifest.fetch("instance_groups.api.instances")).to eq(2)
-    expect(dev_manifest.fetch("instance_groups.doppler.instances")).to eq(2)
-    expect(dev_manifest.fetch("instance_groups.diego-cell.instances")).to eq(2)
+    expect(dev_manifest.fetch('instance_groups.api.instances')).to eq(2)
+    expect(dev_manifest.fetch('instance_groups.doppler.instances')).to eq(2)
+    expect(dev_manifest.fetch('instance_groups.diego-cell.instances')).to eq(2)
 
     # It scales back brokers to 1
-    expect(dev_manifest.fetch("instance_groups.rds_broker.instances")).to eq(1)
-    expect(dev_manifest.fetch("instance_groups.s3_broker.instances")).to eq(1)
+    expect(dev_manifest.fetch('instance_groups.rds_broker.instances')).to eq(1)
+    expect(dev_manifest.fetch('instance_groups.s3_broker.instances')).to eq(1)
+
+    # It scales back cf-prometheus to 1
+    expect(dev_manifest.fetch('instance_groups.prometheus.instances')).to eq(1)
+    expect(dev_manifest.fetch('instance_groups.prometheus.vm_type')).to eq('small')
   end
 
-  it "does not scale back dev otherwise" do
+  it 'does not scale back dev otherwise' do
     dev_manifest = manifest_for_dev
 
-    expect(dev_manifest.fetch("instance_groups.diego-cell.instances")).not_to eq(2)
-    expect(dev_manifest.fetch("instance_groups.rds_broker.instances")).not_to eq(1)
-    expect(dev_manifest.fetch("instance_groups.s3_broker.instances")).not_to eq(1)
+    expect(dev_manifest.fetch('instance_groups.diego-cell.instances')).not_to eq(2)
+    expect(dev_manifest.fetch('instance_groups.rds_broker.instances')).not_to eq(1)
+    expect(dev_manifest.fetch('instance_groups.s3_broker.instances')).not_to eq(1)
+
+    expect(dev_manifest.fetch('instance_groups.prometheus.vm_type')).to eq('medium')
   end
 end

--- a/manifests/cf-manifest/spec/manifest/prometheus_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/prometheus_spec.rb
@@ -49,9 +49,9 @@ RSpec.describe 'prometheus' do
       expect(disk_type).to eq('100GB')
     end
 
-    it 'should have more than one instance' do
+    it 'shoudl be highly available' do
       disk_type = prometheus_instance_group.dig('instances')
-      expect(disk_type).to be > 0
+      expect(disk_type).to be > 1
     end
 
     it 'should have access to the CF network ' do


### PR DESCRIPTION
What
----

The CF Prometheus for our users should be highly available, which it currently isn't with 1 instance. This commit makes it highly available but only 2 instances which is probably enough

The CF Prometheus in London is currently running quite hot (85% memory) usage due to Prometheus. This is causing it to use swap lots. In non-dev environments make it a t3.medium

In dev, we will rarely scrape anything, so we can keep the values as they are

How to review
-------------

Travis

Code review

Look at [prod-lon](https://grafana-1.london.cloud.service.gov.uk/explore?left=%5B%22now-6h%22,%22now%22,%22prometheus%22,%7B%22expr%22:%22bosh_job_mem_percent%7Bbosh_job_name%3D%5C%22prometheus%5C%22%7D%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D)

Who can review
--------------

Not @tlwr
