### PR TITLE
[#170070487] Aiven service discovery only discover same region

### DIFF
--- a/manifests/cf-manifest/operations.d/500-prometheus.yml
+++ b/manifests/cf-manifest/operations.d/500-prometheus.yml
@@ -10,9 +10,9 @@
   path: /releases/-
   value:
     name: observability
-    version: 0.1.7
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/observability-0.1.7.tgz
-    sha1: a066c69960410764cf0a2eb8bfb20ea22eec0250
+    version: 0.1.8
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/observability-0.1.8.tgz
+    sha1: f5488f128cbc0cd906519ced14a8ddfd863af9aa
 
 - type: replace
   path: /variables/-
@@ -74,6 +74,11 @@
                     target_label: __address__
                     replacement: ${1}:9273
                     action: replace
+
+                  - source_labels: [aiven_cloud]
+                    separator: ;
+                    regex: 'aws-((terraform_outputs_region))'
+                    action: keep
 
       - name: route_registrar
         release: routing

--- a/manifests/cf-manifest/spec/manifest/prometheus_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/prometheus_spec.rb
@@ -99,6 +99,15 @@ RSpec.describe 'prometheus' do
       expect(targets).to eq(
         aiven_sd_config['target_path'] + '/' + aiven_sd_config['target_filename']
       )
+
+      relabel_configs = aiven_scrape_config['relabel_configs']
+
+      expect(relabel_configs).to include(
+        'source_labels' => ['aiven_cloud'],
+        'separator' => ';',
+        'regex' => 'aws-sealand-1',
+        'action' => 'keep',
+      )
     end
   end
 


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/170070487)

What
----

We have a single aiven project for prod and prod-lon

This mean aiven service discovery was discovering both regions and the
CF prometheus was trying to scrape all prometheis, even those in a
different region. It cannot scrape those in a different region due to ip
restrictions

This commit updates the service discovery version to a version which
labels the targets using the cloud name exposed by aiven, and uses a
prometheus relabel to only keep instances that are in the same region

How to review
-------------

Code review

Review this screenshot of my dev environment (London), not discovering Rafal's Elasticsearch (Ireland)
![image](https://user-images.githubusercontent.com/1482692/71822314-7eda1e80-308c-11ea-8699-3191e525f94f.png)

Check [my custom acceptance test passed](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/custom-broker-acceptance-tests/builds/47)

Who can review
--------------

Not @tlwr
