### PR TITLE
[BLOCKED] Introduce Elasticsearch 7.x plans

### DIFF
--- a/config/service-brokers/aiven/config.json
+++ b/config/service-brokers/aiven/config.json
@@ -58,6 +58,51 @@
             "metadata": {
               "displayName": "Large, highly available Elasticsearch 6 cluster"
             }
+          },
+
+          {
+            "id": "dbe2fd8c-30e8-4b36-9473-81dfbd8ff560",
+            "name": "tiny-7.x",
+            "aiven_plan": "startup-4",
+            "elasticsearch_version": "7",
+            "description": "NOT Highly Available, 1 dedicated VM, 1 CPU per VM, 4GB RAM per VM, 80GB disk space.",
+            "free": true,
+            "metadata": {
+              "displayName": "Tiny, NOT Highly Available single-node Elasticsearch 7 cluster"
+            }
+          },
+          {
+            "id": "28095b16-7324-429a-99bf-75c0b88d58a7",
+            "name": "small-ha-7.x",
+            "aiven_plan": "business-4",
+            "elasticsearch_version": "7",
+            "description": "3 dedicated VMs, 1 CPU per VM, 4GB RAM per VM, 240GB disk space.",
+            "free": false,
+            "metadata": {
+              "displayName": "Small, highly available Elasticsearch 7 cluster"
+            }
+          },
+          {
+            "id": "5705d8e7-0374-48c4-8a2e-f28395c61302",
+            "name": "medium-ha-7.x",
+            "aiven_plan": "business-8",
+            "elasticsearch_version": "7",
+            "description": "3 dedicated VMs, 2 CPU per VM, 8GB RAM per VM, 525GB disk space.",
+            "free": false,
+            "metadata": {
+              "displayName": "Medium, highly available Elasticsearch 7 cluster"
+            }
+          },
+          {
+            "id": "18b45371-ed22-4d6c-93f3-166ed32cc08a",
+            "name": "large-ha-7.x",
+            "aiven_plan": "business-16",
+            "elasticsearch_version": "7",
+            "description": "3 dedicated VMs, 2 CPU per VM, 15GB RAM per VM, 1050GB disk space.",
+            "free": false,
+            "metadata": {
+              "displayName": "Large, highly available Elasticsearch 7 cluster"
+            }
           }
         ]
       },

--- a/platform-tests/src/platform/broker-acceptance/elasticsearch_service_test.go
+++ b/platform-tests/src/platform/broker-acceptance/elasticsearch_service_test.go
@@ -25,7 +25,6 @@ import (
 var _ = Describe("Elasticsearch backing service", func() {
 	const (
 		serviceName  = "elasticsearch"
-		testPlanName = "tiny-6.x"
 	)
 
 	It("is registered in the marketplace", func() {
@@ -35,7 +34,10 @@ var _ = Describe("Elasticsearch backing service", func() {
 	})
 
 	It("has the expected plans available", func() {
-		expectedPlans := []string{"tiny-6.x", "small-ha-6.x", "medium-ha-6.x", "large-ha-6.x"}
+		expectedPlans := []string{
+			"tiny-6.x", "small-ha-6.x", "medium-ha-6.x", "large-ha-6.x",
+			"tiny-7.x", "small-ha-7.x", "medium-ha-7.x", "large-ha-7.x",
+		}
 
 		actualPlans := cf.Cf("marketplace", "-s", serviceName).Wait(testConfig.DefaultTimeoutDuration())
 		Expect(actualPlans).To(Exit(0))
@@ -44,101 +46,106 @@ var _ = Describe("Elasticsearch backing service", func() {
 		}
 	})
 
-	Context("creating a database instance", func() {
-		// Avoid creating additional tests in this block because this setup and
-		// teardown is slow (several minutes).
+	testCreateElasticSearchServiceInstance := func (plan string) {
+		Context(fmt.Sprintf("Creating an Elasticsearch service instance with plan name %s", plan), func() {
+			// Avoid creating additional tests in this block because this setup and
+			// teardown is slow (several minutes).
 
-		var (
-			appName        string
-			dbInstanceName string
-			dbInstanceGUID string
-		)
-		BeforeEach(func() {
-			appName = generator.PrefixedRandomName(testConfig.GetNamePrefix(), "APP")
-			dbInstanceName = generator.PrefixedRandomName(testConfig.GetNamePrefix(), "test-es")
-			Expect(cf.Cf("create-service", serviceName, testPlanName, dbInstanceName).Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
+			var (
+				appName        string
+				dbInstanceName string
+				dbInstanceGUID string
+			)
+			BeforeEach(func() {
+				appName = generator.PrefixedRandomName(testConfig.GetNamePrefix(), "APP")
+				dbInstanceName = generator.PrefixedRandomName(testConfig.GetNamePrefix(), "test-es")
+				Expect(cf.Cf("create-service", serviceName, plan, dbInstanceName).Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
 
-			serviceGUIDSession := cf.Cf("service", dbInstanceName, "--guid")
-			Expect(serviceGUIDSession.Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
-			dbInstanceGUID = strings.TrimSpace(string(serviceGUIDSession.Out.Contents()))
+				serviceGUIDSession := cf.Cf("service", dbInstanceName, "--guid")
+				Expect(serviceGUIDSession.Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
+				dbInstanceGUID = strings.TrimSpace(string(serviceGUIDSession.Out.Contents()))
 
-			pollForServiceCreationCompletion(dbInstanceName)
+				pollForServiceCreationCompletion(dbInstanceName)
 
-			fmt.Fprintf(GinkgoWriter, "Created Elasticsearch instance: %s\n", dbInstanceName)
+				fmt.Fprintf(GinkgoWriter, "Created Elasticsearch instance: %s\n", dbInstanceName)
 
-			Expect(cf.Cf(
-				"push", appName,
-				"--no-start",
-				"-b", testConfig.GetGoBuildpackName(),
-				"-p", "../../../example-apps/healthcheck",
-				"-f", "../../../example-apps/healthcheck/manifest.yml",
-				"-d", testConfig.GetAppsDomain(),
-			).Wait(testConfig.CfPushTimeoutDuration())).To(Exit(0))
+				Expect(cf.Cf(
+					"push", appName,
+					"--no-start",
+					"-b", testConfig.GetGoBuildpackName(),
+					"-p", "../../../example-apps/healthcheck",
+					"-f", "../../../example-apps/healthcheck/manifest.yml",
+					"-d", testConfig.GetAppsDomain(),
+				).Wait(testConfig.CfPushTimeoutDuration())).To(Exit(0))
 
-			Expect(cf.Cf("bind-service", appName, dbInstanceName).Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
+				Expect(cf.Cf("bind-service", appName, dbInstanceName).Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
 
-			Expect(cf.Cf("start", appName).Wait(testConfig.CfPushTimeoutDuration())).To(Exit(0))
-		})
-
-		AfterEach(func() {
-			cf.Cf("delete", appName, "-f").Wait(testConfig.DefaultTimeoutDuration())
-
-			Expect(cf.Cf("delete-service", dbInstanceName, "-f").Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
-
-			// Poll until destruction is complete, otherwise the org cleanup (in AfterSuite) fails.
-			pollForServiceDeletionCompletion(dbInstanceName)
-		})
-
-		It("is accessible from the healthcheck app", func() {
-			By("allowing connections with TLS")
-			resp, err := httpClient.Get(helpers.AppUri(appName, "/elasticsearch-test", testConfig))
-			Expect(err).NotTo(HaveOccurred())
-			body, err := ioutil.ReadAll(resp.Body)
-			Expect(err).NotTo(HaveOccurred())
-			resp.Body.Close()
-			Expect(resp.StatusCode).To(Equal(200), "Got %d response from healthcheck app. Response body:\n%s\n", resp.StatusCode, string(body))
-
-			By("disallowing connections without TLS")
-			resp, err = httpClient.Get(helpers.AppUri(appName, "/elasticsearch-test?tls=false", testConfig))
-			Expect(err).NotTo(HaveOccurred())
-			body, err = ioutil.ReadAll(resp.Body)
-			Expect(err).NotTo(HaveOccurred())
-			resp.Body.Close()
-			Expect(resp.StatusCode).To(Equal(500), "Expected 500, got %d response from healthcheck app. Response body:\n%s\n", resp.StatusCode, string(body))
-			Expect(string(body)).To(ContainSubstring("EOF"), "Connection without TLS did not report a connection error")
-
-			By("checking that metrics are being scraped")
-			prometheusURL := fmt.Sprintf("https://prometheus.%s", systemDomain)
-			promClient, err := prom.NewClient(prom.Config{
-				Address: prometheusURL,
-				RoundTripper: basicAuthRoundTripper{
-					username: prometheusBasicAuthUsername,
-					password: prometheusBasicAuthPassword,
-				},
+				Expect(cf.Cf("start", appName).Wait(testConfig.CfPushTimeoutDuration())).To(Exit(0))
 			})
-			Expect(err).NotTo(HaveOccurred())
-			promv1API := promv1.NewAPI(promClient)
-			By("querying prometheus")
-			Eventually(func() int {
-				ctx, cancelP := context.WithTimeout(context.Background(), 10*time.Second)
-				defer cancelP()
-				query := fmt.Sprintf(`up{aiven_service_name=~".*-%s"}`, dbInstanceGUID)
-				result, warnings, err := promv1API.Query(ctx, query, time.Now())
-				if err != nil {
-					log.Printf("Encountered error querying prometheus: %s", err)
-					return -1
-				}
-				if len(warnings) > 0 {
-					log.Printf("Encountered warnings querying prometheus: %s", warnings)
-					return -1
-				}
-				vector := result.(prommodel.Vector)
-				if len(vector) == 0 {
-					log.Printf("No results from Prometheus")
-					return -1
-				}
-				return int(vector[0].Value)
-			}, "5m", "10s").Should(BeNumerically(">=", 1))
+
+			AfterEach(func() {
+				cf.Cf("delete", appName, "-f").Wait(testConfig.DefaultTimeoutDuration())
+
+				Expect(cf.Cf("delete-service", dbInstanceName, "-f").Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
+
+				// Poll until destruction is complete, otherwise the org cleanup (in AfterSuite) fails.
+				pollForServiceDeletionCompletion(dbInstanceName)
+			})
+
+			It("is accessible from the healthcheck app", func() {
+				By("allowing connections with TLS")
+				resp, err := httpClient.Get(helpers.AppUri(appName, "/elasticsearch-test", testConfig))
+				Expect(err).NotTo(HaveOccurred())
+				body, err := ioutil.ReadAll(resp.Body)
+				Expect(err).NotTo(HaveOccurred())
+				resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(200), "Got %d response from healthcheck app. Response body:\n%s\n", resp.StatusCode, string(body))
+
+				By("disallowing connections without TLS")
+				resp, err = httpClient.Get(helpers.AppUri(appName, "/elasticsearch-test?tls=false", testConfig))
+				Expect(err).NotTo(HaveOccurred())
+				body, err = ioutil.ReadAll(resp.Body)
+				Expect(err).NotTo(HaveOccurred())
+				resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(500), "Expected 500, got %d response from healthcheck app. Response body:\n%s\n", resp.StatusCode, string(body))
+				Expect(string(body)).To(ContainSubstring("EOF"), "Connection without TLS did not report a connection error")
+
+				By("checking that metrics are being scraped")
+				prometheusURL := fmt.Sprintf("https://prometheus.%s", systemDomain)
+				promClient, err := prom.NewClient(prom.Config{
+					Address: prometheusURL,
+					RoundTripper: basicAuthRoundTripper{
+						username: prometheusBasicAuthUsername,
+						password: prometheusBasicAuthPassword,
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+				promv1API := promv1.NewAPI(promClient)
+				By("querying prometheus")
+				Eventually(func() int {
+					ctx, cancelP := context.WithTimeout(context.Background(), 10*time.Second)
+					defer cancelP()
+					query := fmt.Sprintf(`up{aiven_service_name=~".*-%s"}`, dbInstanceGUID)
+					result, warnings, err := promv1API.Query(ctx, query, time.Now())
+					if err != nil {
+						log.Printf("Encountered error querying prometheus: %s", err)
+						return -1
+					}
+					if len(warnings) > 0 {
+						log.Printf("Encountered warnings querying prometheus: %s", warnings)
+						return -1
+					}
+					vector := result.(prommodel.Vector)
+					if len(vector) == 0 {
+						log.Printf("No results from Prometheus")
+						return -1
+					}
+					return int(vector[0].Value)
+				}, "5m", "10s").Should(BeNumerically(">=", 1))
+			})
 		})
-	})
+	}
+
+	testCreateElasticSearchServiceInstance("tiny-6.x")
+	testCreateElasticSearchServiceInstance("tiny-7.x")
 })


### PR DESCRIPTION
Blocker
----
This is blocked by [the Aiven broker](https://github.com/alphagov/paas-aiven-broker) not allowing users to apply updates to their ES6 services. This will be necessary for tenants to upgrade from ES6 to ES7.

Story #170575362 covers the work

What
----
On 14th October 2019, our Elasticsearch provider (Aiven) announced support for
Elasticsearch 7.4.0. Since then, they have announced support for 7.4.2 and
7.5.1.

Our tenants love elasticsearch and we love our tenants, so this commit gives
them access to Elasticsearch 7.x plans!

How to review
-------------
1. Run it down your pipeline (or check mine, `DEPLOY_ENV=andyhunt`)
1. Check the acceptance tests pass
1. Provision yourself an ES 7 cluster using `cf cs elasticsearch tiny-7.x my-es-7`
1. Provision yourself an ES 6 cluster and upgrade it to ES7 using `cf cs elasticsearch tiny-6.x my-es-6; cf update-service my-es-6 -p tiny-7.x`

Who can review
--------------
Anyone
