### PR TITLE
Add usage analytics to scripts

### DIFF
--- a/scripts/audit-services.rb
+++ b/scripts/audit-services.rb
@@ -1,6 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+script_path = File.absolute_path(__FILE__).sub!(Dir.pwd + "/", "")
+File.open(File.expand_path('~/.paas-script-usage'), 'a') { |f| f.puts script_path }
+
 require 'httparty'
 require 'optparse'
 require 'json'

--- a/scripts/cf_subshell_scoped_login.sh
+++ b/scripts/cf_subshell_scoped_login.sh
@@ -1,6 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
+
+echo "${0#$PWD}" >> ~/.paas-script-usage
 
 if [ $# -lt 1 ]; then
   echo "Usage $0 <target>" 1>&2

--- a/scripts/cleanup-deleted-cf-users.sh
+++ b/scripts/cleanup-deleted-cf-users.sh
@@ -2,6 +2,8 @@
 
 set -e -u -o pipefail
 
+echo "${0#$PWD}" >> ~/.paas-script-usage
+
 delete=no
 
 for i in "$@"

--- a/scripts/cleanup_unused_cdn_broker_iam_certs.rb
+++ b/scripts/cleanup_unused_cdn_broker_iam_certs.rb
@@ -1,5 +1,8 @@
 #!/usr/bin/env ruby
 
+script_path = File.absolute_path(__FILE__).sub!(Dir.pwd + "/", "")
+File.open(File.expand_path('~/.paas-script-usage'), 'a') { |f| f.puts script_path }
+
 require 'json'
 
 unless system "aws iam list-account-aliases > /dev/null"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+echo "${0#$PWD}" >> ~/.paas-script-usage
+
 load_colors() {
   if [ -t 1 ] ; then
     export ESC_SEQ="\\x1b["

--- a/scripts/create-org.sh
+++ b/scripts/create-org.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -euo pipefail
+
+echo "${0#$PWD}" >> ~/.paas-script-usage
+
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 SCRIPT=$0
 

--- a/scripts/create_buildpacks_email.sh
+++ b/scripts/create_buildpacks_email.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e -u -o pipefail
 
+echo "${0#$PWD}" >> ~/.paas-script-usage
+
 MIN_GO_VERSION=1.11
 
 GORAWVERSION=$(go version)

--- a/scripts/create_sts_token.sh
+++ b/scripts/create_sts_token.sh
@@ -2,6 +2,8 @@
 
 set -eo pipefail
 
+echo "${0#$PWD}" >> ~/.paas-script-usage
+
 ensure_env_vars() {
   if [ -z "${AWS_ACCOUNT}" ] || [ -z "${AWS_ACCESS_KEY_ID}" ] || [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
     echo "Must set AWS_ACCOUNT, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY"

--- a/scripts/credhub_shell.sh
+++ b/scripts/credhub_shell.sh
@@ -2,6 +2,8 @@
 
 set -eu
 
+echo "${0#$PWD}" >> ~/.paas-script-usage
+
 tunnel_mux='/tmp/bosh-ssh-tunnel.mux'
 
 function cleanup () {

--- a/scripts/find-gov-department-name.rb
+++ b/scripts/find-gov-department-name.rb
@@ -1,5 +1,8 @@
 #!/usr/bin/env ruby
 
+script_path = File.absolute_path(__FILE__).sub!(Dir.pwd + "/", "")
+File.open(File.expand_path('~/.paas-script-usage'), 'a') { |f| f.puts script_path }
+
 require 'register_client_manager'
 require 'fuzzy_match'
 require 'tty-prompt'

--- a/scripts/find_diverged_forks.py
+++ b/scripts/find_diverged_forks.py
@@ -2,6 +2,12 @@
 import argparse
 from github import Github
 
+import os
+
+script_path = os.path.relpath(__file__)
+with open(os.path.expanduser('~/.paas-script-usage'), 'a') as f:
+  f.write(script_path + "\n")
+
 BOLD = '\033[1m'
 ENDC = '\033[0m'
 

--- a/scripts/generate_logit_filters.sh
+++ b/scripts/generate_logit_filters.sh
@@ -5,6 +5,8 @@
 
 set -eo pipefail
 
+echo "${0#$PWD}" >> ~/.paas-script-usage
+
 logsearch_boshrelease_tag=$1
 logsearch_for_cloudfoundry_tag=$2
 

--- a/scripts/get-all-app-stacks.sh
+++ b/scripts/get-all-app-stacks.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+echo "${0#$PWD}" >> ~/.paas-script-usage
+
 cflinuxfs3_uuid=$(cf stack cflinuxfs3 --guid)
 all_orgs_next_url="/v2/organizations?order-by=name"
 echo "org,space,appname,stack,"

--- a/scripts/get-instance-details.sh
+++ b/scripts/get-instance-details.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+
+echo "${0#$PWD}" >> ~/.paas-script-usage
 
 SCRIPT=$0
 RDS_INSTANCE_ID=$1

--- a/scripts/lib/mail_credentials_helper.rb
+++ b/scripts/lib/mail_credentials_helper.rb
@@ -5,6 +5,9 @@ require 'tempfile'
 require 'aws-sdk'
 require 'mail'
 
+script_path = File.absolute_path(__FILE__).sub!(Dir.pwd + "/", "")
+File.open(File.expand_path('~/.paas-script-usage'), 'a') { |f| f.puts script_path }
+
 module EmailCredentialsHelper
   DEFAULT_REGION = "eu-west-1".freeze
 

--- a/scripts/list-all-users.sh
+++ b/scripts/list-all-users.sh
@@ -2,6 +2,8 @@
 
 set -e -u -o pipefail
 
+echo "${0#$PWD}" >> ~/.paas-script-usage
+
 uaac_endpoint=$(cf curl /v2/info | jq -r '.authorization_endpoint')
 oauth_token=$(cf oauth-token)
 

--- a/scripts/list-dev-envs.sh
+++ b/scripts/list-dev-envs.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+
+echo "${0#$PWD}" >> ~/.paas-script-usage
 
 if [ -z "${AWS_ACCESS_KEY_ID:-}" ]; then
   >&2 echo "Must be run with AWS dev account creds"

--- a/scripts/list-org-owners.sh
+++ b/scripts/list-org-owners.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+echo "${0#$PWD}" >> ~/.paas-script-usage
+
 if ! cf orgs >/dev/null 2>&1; then
   abort "You need to be logged into CF CLI"
 fi

--- a/scripts/list-routes.rb
+++ b/scripts/list-routes.rb
@@ -1,5 +1,8 @@
 #!/usr/bin/env ruby
 
+script_path = File.absolute_path(__FILE__).sub!(Dir.pwd + "/", "")
+File.open(File.expand_path('~/.paas-script-usage'), 'a') { |f| f.puts script_path }
+
 require 'json'
 require 'set'
 

--- a/scripts/org-usage-report.rb
+++ b/scripts/org-usage-report.rb
@@ -1,4 +1,8 @@
 #!/usr/bin/env ruby
+
+script_path = File.absolute_path(__FILE__).sub!(Dir.pwd + "/", "")
+File.open(File.expand_path('~/.paas-script-usage'), 'a') { |f| f.puts script_path }
+
 # rubocop:disable Style/MultilineBlockChain
 # rubocop:disable Lint/EachWithObjectArgument
 gem 'activerecord'

--- a/scripts/reset-org.py
+++ b/scripts/reset-org.py
@@ -5,6 +5,11 @@ import re
 import subprocess
 import sys
 import time
+import os
+
+script_path = os.path.relpath(__file__)
+with open(os.path.expanduser('~/.paas-script-usage'), 'a') as f:
+  f.write(script_path + "\n")
 
 # python2 compatibility
 try: input = raw_input

--- a/scripts/reset-user-testing.sh
+++ b/scripts/reset-user-testing.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+echo "${0#$PWD}" >> ~/.paas-script-usage
+
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
 TARGET_EMAIL_USER=${TARGET_EMAIL_USER:-holly.challenger}

--- a/scripts/reset-user.sh
+++ b/scripts/reset-user.sh
@@ -2,6 +2,8 @@
 
 set -e -u -o pipefail
 
+echo "${0#$PWD}" >> ~/.paas-script-usage
+
 if [[ $# -lt 2 ]]; then
   >&2 echo "Usage: $0 <organisation> <email of user to reset>"
   exit 1

--- a/scripts/rotate-user-password.sh
+++ b/scripts/rotate-user-password.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -euo pipefail
+
+echo "${0#$PWD}" >> ~/.paas-script-usage
+
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
 # shellcheck disable=SC1090

--- a/scripts/show-vars-store-secrets.sh
+++ b/scripts/show-vars-store-secrets.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+echo "${0#$PWD}" >> ~/.paas-script-usage
+
 vars_store=$1
 shift
 requested_secrets="$*"

--- a/scripts/showenv.sh
+++ b/scripts/showenv.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+echo "${0#$PWD}" >> ~/.paas-script-usage
+
 cat <<EOF
 == FOR SECRETS, SEE "make [ENV] credhub" ==
 

--- a/scripts/test_posix_newline.sh
+++ b/scripts/test_posix_newline.sh
@@ -1,5 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 RET_CODE=0
+
+echo "${0#$PWD}" >> ~/.paas-script-usage
 
 test_posix_newline() {
   if [ -L "$1" ]; then

--- a/scripts/test_symlinks.sh
+++ b/scripts/test_symlinks.sh
@@ -2,6 +2,8 @@
 
 set -ueo pipefail
 
+echo "${0#$PWD}" >> ~/.paas-script-usage
+
 R=0
 while read -r LINK; do
   if [ ! -r "$LINK" ]; then

--- a/scripts/uaa_lock_user.rb
+++ b/scripts/uaa_lock_user.rb
@@ -1,5 +1,8 @@
 #!/usr/bin/env ruby
 
+script_path = File.absolute_path(__FILE__).sub!(Dir.pwd + "/", "")
+File.open(File.expand_path('~/.paas-script-usage'), 'a') { |f| f.puts script_path }
+
 require 'optparse'
 require 'uaa'
 require 'ostruct'

--- a/scripts/update-user-origin.rb
+++ b/scripts/update-user-origin.rb
@@ -1,4 +1,8 @@
 #!/usr/bin/env ruby
+
+script_path = File.absolute_path(__FILE__).sub!(Dir.pwd + "/", "")
+File.open(File.expand_path('~/.paas-script-usage'), 'a') { |f| f.puts script_path }
+
 require 'json'
 
 def usage

--- a/scripts/update_buildpacks.sh
+++ b/scripts/update_buildpacks.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e -u -o pipefail
 
+echo "${0#$PWD}" >> ~/.paas-script-usage
+
 MIN_GO_VERSION=1.11
 
 GORAWVERSION=$(go version)

--- a/scripts/upload-secrets/upload-aiven-secrets.rb
+++ b/scripts/upload-secrets/upload-aiven-secrets.rb
@@ -1,6 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+script_path = File.absolute_path(__FILE__).sub!(Dir.pwd + "/", "")
+File.open(File.expand_path('~/.paas-script-usage'), 'a') { |f| f.puts script_path }
+
 require_relative 'upload_secrets.rb'
 
 deploy_env = ENV.fetch('DEPLOY_ENV')

--- a/scripts/upload-secrets/upload-cyber-secrets.rb
+++ b/scripts/upload-secrets/upload-cyber-secrets.rb
@@ -1,6 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+script_path = File.absolute_path(__FILE__).sub!(Dir.pwd + "/", "")
+File.open(File.expand_path('~/.paas-script-usage'), 'a') { |f| f.puts script_path }
+
 require_relative 'upload_secrets.rb'
 
 credhub_namespaces = [

--- a/scripts/upload-secrets/upload-google-oauth-secrets.rb
+++ b/scripts/upload-secrets/upload-google-oauth-secrets.rb
@@ -1,6 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+script_path = File.absolute_path(__FILE__).sub!(Dir.pwd + "/", "")
+File.open(File.expand_path('~/.paas-script-usage'), 'a') { |f| f.puts script_path }
+
 require_relative 'upload_secrets.rb'
 
 deploy_env = ENV.fetch('DEPLOY_ENV')

--- a/scripts/upload-secrets/upload-logit-secrets.rb
+++ b/scripts/upload-secrets/upload-logit-secrets.rb
@@ -1,6 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+script_path = File.absolute_path(__FILE__).sub!(Dir.pwd + "/", "")
+File.open(File.expand_path('~/.paas-script-usage'), 'a') { |f| f.puts script_path }
+
 require_relative 'upload_secrets.rb'
 
 deploy_env = ENV.fetch('DEPLOY_ENV')

--- a/scripts/upload-secrets/upload-microsoft-oauth-secrets.rb
+++ b/scripts/upload-secrets/upload-microsoft-oauth-secrets.rb
@@ -1,6 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+script_path = File.absolute_path(__FILE__).sub!(Dir.pwd + "/", "")
+File.open(File.expand_path('~/.paas-script-usage'), 'a') { |f| f.puts script_path }
+
 require_relative 'upload_secrets.rb'
 
 deploy_env = ENV.fetch('DEPLOY_ENV')

--- a/scripts/upload-secrets/upload-notify-secrets.rb
+++ b/scripts/upload-secrets/upload-notify-secrets.rb
@@ -1,6 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+script_path = File.absolute_path(__FILE__).sub!(Dir.pwd + "/", "")
+File.open(File.expand_path('~/.paas-script-usage'), 'a') { |f| f.puts script_path }
+
 require_relative 'upload_secrets.rb'
 
 deploy_env = ENV.fetch('DEPLOY_ENV')

--- a/scripts/upload-secrets/upload-paas-trusted-people.sh
+++ b/scripts/upload-secrets/upload-paas-trusted-people.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+echo "${0#$PWD}" >> ~/.paas-script-usage
+
 set -euo pipefail
 
 cd "$(mktemp -d -t paas-trusted-people-XXXXX)"

--- a/scripts/upload-secrets/upload-pagerduty-secrets.rb
+++ b/scripts/upload-secrets/upload-pagerduty-secrets.rb
@@ -1,6 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+script_path = File.absolute_path(__FILE__).sub!(Dir.pwd + "/", "")
+File.open(File.expand_path('~/.paas-script-usage'), 'a') { |f| f.puts script_path }
+
 require_relative 'upload_secrets.rb'
 
 deploy_env = ENV.fetch('DEPLOY_ENV')

--- a/scripts/upload-secrets/upload-splunk-secrets.rb
+++ b/scripts/upload-secrets/upload-splunk-secrets.rb
@@ -1,6 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+script_path = File.absolute_path(__FILE__).sub!(Dir.pwd + "/", "")
+File.open(File.expand_path('~/.paas-script-usage'), 'a') { |f| f.puts script_path }
+
 require_relative 'upload_secrets.rb'
 
 deploy_env = ENV.fetch('DEPLOY_ENV')

--- a/scripts/upload-secrets/upload_secrets.rb
+++ b/scripts/upload-secrets/upload_secrets.rb
@@ -1,6 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+script_path = File.absolute_path(__FILE__).sub!(Dir.pwd + "/", "")
+File.open(File.expand_path('~/.paas-script-usage'), 'a') { |f| f.puts script_path }
+
 require 'base64'
 require 'English'
 require 'json'

--- a/scripts/validate_aws_credentials.sh
+++ b/scripts/validate_aws_credentials.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+echo "${0#$PWD}" >> ~/.paas-script-usage
+
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
 if [ "${SKIP_AWS_CREDENTIAL_VALIDATION:-}" == "true" ]  ; then


### PR DESCRIPTION
What
----
We don't know which scripts in the `scripts/` directory are being used, and which are dead and broken. To get a handle on this, we're introducing super super basic analytics, in the form of logging the name of the script to a file (`~/.paas-script-usage`) whenever it's executed. In a month or so, we'll combine everyone's logs, and count the entries. Any scripts not used in a month we can assume are fair game to remove.

How to review
-------------
1. Code review
2. Run one of each type of script and check it logs the relative-to-paas-cf name to `~/.paas-script-usage`

Who can review
--------------
Anyone