### PR TITLE
Make CF target available as bash functions in CF subshell

### DIFF
--- a/scripts/cf_subshell_scoped_login.sh
+++ b/scripts/cf_subshell_scoped_login.sh
@@ -31,6 +31,26 @@ esac
 
 TMPDIR=${TMPDIR:-/tmp}
 CF_HOME=$(mktemp -d "${TMPDIR}/cf_home.XXXXXX")
+
+cat <<EOF > "$CF_HOME/.bashrc"
+__cf_target_env ()
+{
+  echo "$TARGET"
+}
+
+__cf_target_org ()
+{
+  jq -r '.OrganizationFields.Name' "${CF_HOME}/.cf/config.json"
+}
+
+__cf_target_space ()
+{
+  jq -r '.SpaceFields.Name' "${CF_HOME}/.cf/config.json"
+}
+
+source ~/.bashrc
+EOF
+
 cleanup() {
   echo "Cleaning up temporary CF_HOME..."
   cf logout || true
@@ -51,4 +71,5 @@ echo
 echo "You are now in a subshell with CF_HOME set to ${CF_HOME}"
 echo "This will be cleaned up when this shell is closed."
 echo
-${SHELL:-bash} -il
+set -x
+${SHELL:-bash} --rcfile "${CF_HOME}/.bashrc" -i


### PR DESCRIPTION
What
----

Exposes three `_cf_target__*` bash functions in the subshell. They are intended
for users to incorporate in to their command prompts when inside the shell.

- `__cf_target_env`
Outputs the name of the CF deployment, eg "prod-lon"

- `__cf_target_org`
Outputs the org being targeted by CF CLI

- `__cf_target_space`
Outputs the space being targeted by CF CLI

Sample `.bashrc` commands for embedding the information
```
if [ ! -z $CF_HOME ]; then
  # e.g. "prod-lon/admin/billing"
  export PS1+="\$(__cf_target_env)/\$(__cf_target_org)/\$(__cf_target_space)"
fi
```

How to review
-------------
Code review

Who can review
--------------
Anyone