### PR TITLE
Scale up CF prometheus when not in dev

### DIFF
--- a/manifests/cf-manifest/operations.d/500-prometheus.yml
+++ b/manifests/cf-manifest/operations.d/500-prometheus.yml
@@ -35,7 +35,7 @@
     stemcell: default
 
     persistent_disk_type: 100GB
-    vm_type: medium
+    vm_type: large
 
     networks:
       - name: cf

--- a/manifests/cf-manifest/spec/manifest/dev_scaling_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/dev_scaling_spec.rb
@@ -28,6 +28,6 @@ RSpec.describe 'dev environment scaling' do
     expect(dev_manifest.fetch('instance_groups.rds_broker.instances')).not_to eq(1)
     expect(dev_manifest.fetch('instance_groups.s3_broker.instances')).not_to eq(1)
 
-    expect(dev_manifest.fetch('instance_groups.prometheus.vm_type')).to eq('medium')
+    expect(dev_manifest.fetch('instance_groups.prometheus.vm_type')).to eq('large')
   end
 end


### PR DESCRIPTION
What
----

Our cf prometheus (the one scraping elasticsearch) is using a considerable amount of swap space, because it does not have enough memory

This PR scales it up when we are not in dev, to a large vm, so that it has enough memory to do its duty

How to review
-------------

Code review

Who can review
--------------

Not @tlwr