### PR TITLE
Configure long term storage of CF prometheus

### DIFF
--- a/manifests/cf-manifest/operations.d/500-prometheus.yml
+++ b/manifests/cf-manifest/operations.d/500-prometheus.yml
@@ -45,6 +45,12 @@
         release: prometheus
         properties:
           prometheus:
+            storage:
+              tsdb:
+                retention:
+                  time: 370d
+                  size: 90GB
+
             rule_files: []
 
             scrape_configs:


### PR DESCRIPTION
What
----

We should keep metrics for some time

We should configure both retention time and retention size such that:
- we do not store data for much longer than a year
- we do not attempt to store more data than we have available space on
our persistent volume

The [prometheus documentation](https://prometheus.io/docs/prometheus/latest/storage/) provides the following guidance:

> If both time and size retention policies are specified, whichever policy triggers first will be used at that instant.

so if we start to run out of space, then we will get rid of the oldest metrics, and we will still be able to collect metrics

How to review
-------------

Code review

CI

This has been deployed to my dev environment, where you can check the [command line flags](https://prometheus.tlwr.dev.cloudpipeline.digital/flags):
```
storage.tsdb.path	        /var/vcap/store/prometheus2
storage.tsdb.retention.size	90GiB
storage.tsdb.retention.time	370d
```

Who worked on this
--------------

Paired with @schmie 