### PR TITLE
Add cf prom info/docs to showenv/credhub shell

### DIFF
--- a/manifests/cf-manifest/operations.d/500-prometheus.yml
+++ b/manifests/cf-manifest/operations.d/500-prometheus.yml
@@ -27,6 +27,12 @@
     type: password
 
 - type: replace
+  path: /variables/-
+  value:
+    name: operator_prometheus_password
+    type: password
+
+- type: replace
   path: /instance_groups/-
   value:
     name: prometheus
@@ -102,6 +108,7 @@
 
               basicauth / paas-admin ((paas_admin_prometheus_password))
               basicauth / custom-broker-acceptance ((custom_broker_acceptance_prometheus_password))
+              basicauth / operator ((operator_prometheus_password))
 
               proxy / http://q-s3-i0.prometheus.*.((environment)).bosh:9090 http://localhost:9090 {
                 policy first

--- a/scripts/credhub_shell.sh
+++ b/scripts/credhub_shell.sh
@@ -57,10 +57,11 @@ Basic usage:
 Some useful credentials path are listed below.
 
 $(column -t -s "|" <<PATHS
-PROMETHEUS PASSWORD|/$DEPLOY_ENV/prometheus/prometheus_password
-GRAFANA PASSWORD|/$DEPLOY_ENV/prometheus/grafana_password
-GRAFANA MONITOR PASSWORD|/$DEPLOY_ENV/prometheus/grafana_mon_password
-ALERTMANAGER PASSWORD|/$DEPLOY_ENV/prometheus/alertmanager_password
+CF PROMETHEUS PASSWORD|/$DEPLOY_ENV/$DEPLOY_ENV/operator_prometheus_password|Username: operator
+PLATFORM PROMETHEUS PASSWORD|/$DEPLOY_ENV/prometheus/prometheus_password|Username: admin
+GRAFANA PASSWORD|/$DEPLOY_ENV/prometheus/grafana_password|Username: admin
+ALERTMANAGER PASSWORD|/$DEPLOY_ENV/prometheus/alertmanager_password|Username: admin
+GRAFANA MONITOR PASSWORD|/$DEPLOY_ENV/prometheus/grafana_mon_password|Username: mon
 CF ADMIN PASSWORD|/$DEPLOY_ENV/$DEPLOY_ENV/cf_admin_password
 UAA ADMIN CLIENT SECRET|/concourse/main/create-cloudfoundry/uaa_admin_client_secret
 CONCOURSE ADMIN USER PASSWORD|/concourse/main/concourse_web_password

--- a/scripts/showenv.sh
+++ b/scripts/showenv.sh
@@ -7,7 +7,8 @@ Here are some useful facts about your environment:
 $(column -t -s "|" <<FACTS
   DEPLOY ENV | ${DEPLOY_ENV}
   CONCOURSE DEPLOYER | https://deployer.${SYSTEM_DNS_ZONE_NAME}
-  PROMETHEUS | https://prometheus-1.${SYSTEM_DNS_ZONE_NAME}, https://prometheus-2.${SYSTEM_DNS_ZONE_NAME}
+  CF PROMETHEUS | https://prometheus.${SYSTEM_DNS_ZONE_NAME}
+  PLATFORM PROMETHEUS | https://prometheus-1.${SYSTEM_DNS_ZONE_NAME}, https://prometheus-2.${SYSTEM_DNS_ZONE_NAME}
   GRAFANA | https://grafana-1.${SYSTEM_DNS_ZONE_NAME}, https://grafana-2.${SYSTEM_DNS_ZONE_NAME}
   PAAS ADMIN | https://admin.${SYSTEM_DNS_ZONE_NAME}
   API ENDPOINT | https://api.${SYSTEM_DNS_ZONE_NAME}


### PR DESCRIPTION
What
----

Adds a new user to the CF prometheus with username `operator`

Documents the URL for the CF prometheus in `make showenv`

Documents the usernames for various things in `make credhub`

How to review
-------------

Run this down your pipeline

Verify `make dev showenv` has the URL for CF prometheus

Log into the CF prometheus using the URL, and the username/password from `make credhub`

Who can review
--------------

Not @tlwr