### PR TITLE
Scrape alertmanager to subtract suppressed alerts from the user-impact dashboard

### DIFF
--- a/manifests/prometheus/dashboards.d/user-impact.json
+++ b/manifests/prometheus/dashboards.d/user-impact.json
@@ -700,7 +700,7 @@
                 },
                 "tableColumn": "",
                 "targets": [{
-                    "expr": "count(ALERTS{alertstate=\"firing\",layer=\"\",alertname!~\"^CFApp.*$\"}) or vector(0)",
+                    "expr": "(count(ALERTS{alertstate=\"firing\",layer=\"\",alertname!~\"^CFApp.*$\"}) - sum(alertmanager_alerts{state=\"suppressed\"} or vector(0))) or vector(0)",
                     "format": "time_series",
                     "instant": true,
                     "intervalFactor": 1,

--- a/manifests/prometheus/operations.d/207-monitor-alertmanager.yml
+++ b/manifests/prometheus/operations.d/207-monitor-alertmanager.yml
@@ -1,0 +1,31 @@
+---
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  value:
+    job_name: alertmanager
+
+    file_sd_configs:
+      - files:
+          - "/var/vcap/store/bosh_exporter/bosh_target_groups.json"
+
+    relabel_configs:
+      - source_labels:
+          - __meta_bosh_job_process_name
+        regex: alertmanager
+        action: keep
+
+      - source_labels:
+          - __meta_bosh_deployment
+        regex: prometheus
+        action: keep
+
+      - source_labels:
+          - __meta_bosh_deployment
+        regex: "(.*)"
+        target_label: bosh_deployment
+
+      - source_labels:
+          - __address__
+        regex: "(.*)"
+        target_label: __address__
+        replacement: "${1}:9093"


### PR DESCRIPTION
What
----

If we have a long running noisy alert that we are waiting for upstream to fix, we would like to silence it, so that we do not succumb to alert blindness.

However, currently, our user impact dashboard naively displays the number of firing alerts (with some extra filtering), and does not know about alertmanager at all.

If we silence alerts in alertmanager, we should subtract the number of suppressed alerts on the user impact dashboard alerts tile.

Example
-------

Consider the following alerts firing:

```
log-api/0 BoshHighCPUUtilisation
log-api/1 BoshHighCPUUtilisation
log-api/2 BoshHighCPUUtilisation
log-api/3 BoshHighCPUUtilisation
log-api/4 BoshHighCPUUtilisation
log-api/5 BoshHighCPUUtilisation
scheduler/0 AuctioneerLockHeldOnce
```

there are 7 alerts firing.

If we had a silence in alertmanager for `bosh_job_name=log-api alert_name=BoshHighCPUUtilisation`, we would have the metric `alertmanager_alerts{state="suppressed"}` = 6️⃣ 

Therefore the tile would display 1️⃣ instead of 7️⃣ 

How to review
-------------

Code review

Maybe deploy to your dev env

Consider if this is too hacky? :trollface: 

Who can review
--------------

Not @tlwr 