### PR TITLE
Add xlarge instance type and use for cf-prometheus

### DIFF
--- a/manifests/cf-manifest/operations.d/500-prometheus.yml
+++ b/manifests/cf-manifest/operations.d/500-prometheus.yml
@@ -35,7 +35,7 @@
     stemcell: default
 
     persistent_disk_type: 100GB
-    vm_type: large
+    vm_type: xlarge
 
     networks:
       - name: cf

--- a/manifests/cf-manifest/spec/manifest/dev_scaling_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/dev_scaling_spec.rb
@@ -28,6 +28,6 @@ RSpec.describe 'dev environment scaling' do
     expect(dev_manifest.fetch('instance_groups.rds_broker.instances')).not_to eq(1)
     expect(dev_manifest.fetch('instance_groups.s3_broker.instances')).not_to eq(1)
 
-    expect(dev_manifest.fetch('instance_groups.prometheus.vm_type')).to eq('large')
+    expect(dev_manifest.fetch('instance_groups.prometheus.vm_type')).to eq('xlarge')
   end
 end

--- a/manifests/cloud-config/paas-cf-cloud-config.yml
+++ b/manifests/cloud-config/paas-cf-cloud-config.yml
@@ -168,6 +168,13 @@ vm_types:
       size: 10240
       type: gp2
 
+- name: xlarge
+  cloud_properties:
+    instance_type: ((xlarge_vm_instance_type))
+    ephemeral_disk:
+      size: 10240
+      type: gp2
+
 - name: router
   cloud_properties:
     instance_type: ((router_instance_type))

--- a/manifests/variables.yml
+++ b/manifests/variables.yml
@@ -4,6 +4,7 @@ nano_vm_instance_type: t3.nano
 small_vm_instance_type: t3.small
 medium_vm_instance_type: t3.medium
 large_vm_instance_type: m5.large
+xlarge_vm_instance_type: m5.xlarge
 router_instance_type: c5.large
 cell_instance_type: r5.xlarge
 


### PR DESCRIPTION
What
----

We are experiencing scaling issues with our CF prometheus in London

It is doing a lot of work, and tsdb compaction (or something else) seems to be using most of its resources, whilst it is also trying to collect metrics for >~ 100 ES instances

Giving it some more resources will let it do its job

![image](https://user-images.githubusercontent.com/1482692/72713213-8c030d00-3b64-11ea-9290-96c8d217904f.png)
_An image of Grafana showing metrics of the CF Prometheus BOSH instance; CPU is pegged to the 50% alloted via bpm, and memory is almost maxed, after something (probably compaction)_

How to review
-------------

Code review

CI

Who can review
--------------

Not @tlwr
