### PR TITLE
Correctly aggregate multiple alertmanager silences

### DIFF
--- a/manifests/prometheus/dashboards.d/user-impact.json
+++ b/manifests/prometheus/dashboards.d/user-impact.json
@@ -700,7 +700,7 @@
                 },
                 "tableColumn": "",
                 "targets": [{
-                    "expr": "(count(ALERTS{alertstate=\"firing\",layer=\"\",alertname!~\"^CFApp.*$\"}) - sum(alertmanager_alerts{state=\"suppressed\"} or vector(0))) or vector(0)",
+                    "expr": "(count(ALERTS{alertstate=\"firing\",layer=\"\",alertname!~\"^CFApp.*$\"}) - (avg(alertmanager_alerts{state=\"suppressed\"}) or vector(0))) or vector(0)",
                     "format": "time_series",
                     "instant": true,
                     "intervalFactor": 1,


### PR DESCRIPTION
What
----

We run multiple alertmanagers in non-dev so summing the number of silenced alerts duplicates the number of silences

How to review
-------------

Calculate that `7 - sum(7, 7)` is not 0

Calculate that `7 - avg(7, 7)` is 0

Code review

Who can review
--------------

Pair with @schmie 