### PR TITLE
Upgrade bosh-dns-release to 1.17

### DIFF
--- a/manifests/cf-manifest/operations.d/030-bosh-dns.yml
+++ b/manifests/cf-manifest/operations.d/030-bosh-dns.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: bosh-dns
-    version: "1.16.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/bosh-dns-release?v=1.16.0"
-    sha1: "574dae0618a98d0dc725ecbcfdd0fa72ae288bce"
+    version: "1.17.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/bosh-dns-release?v=1.17.0"
+    sha1: "d514ab3ae376778e106e17c22b78a8705690ae1d"
 
 - type: replace
   path: /addons/-

--- a/manifests/cf-manifest/operations.d/230-loggregator-deployment.yml
+++ b/manifests/cf-manifest/operations.d/230-loggregator-deployment.yml
@@ -17,6 +17,6 @@
   path: /releases/name=loggregator
   value:
     name: "loggregator"
-    version: "106.3.4"
-    url: "https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.3.4"
-    sha1: "47b2b6c5c98805dff617403a8807fa1cde49a7cc"
+    version: "106.3.6"
+    url: "https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.3.6"
+    sha1: "ba64ea33a88429a1031f4041dcb7665519da4aa2"


### PR DESCRIPTION
What
----

Since we most recently upgraded `cf-deployment` we have had a long running issue with high CPU utilisation on `log-api` instances.

This release:

* https://github.com/cloudfoundry/bosh-dns-release/releases/tag/v1.17.0

Contains the following fixes:

* stop redundant health check retries between poll intervals
* stop redundant health check requests when querying a domain
* Fix compilation error on windows due to broken symlinks
* health server should shutdown cleanly on sigterm

The following fixes:

* stop redundant health check retries between poll intervals
* stop redundant health check requests when querying a domain

cause loggregator component trafficcontroller's very chatty dns
healthcheck to be cached by bosh-dns, which will reduce the currently
high cpu usage (there is another fix coming in a later loggregator
release)

See https://github.com/cloudfoundry/loggregator-release/issues/401#issuecomment-577111884 which includes this image

![An image of bosh-dns 1.17 on log-api CPU utilization](https://user-images.githubusercontent.com/1482692/72897637-4ee07b80-3d1a-11ea-886d-fac0e327a768.png)

I expect this to reduce but not resolve the log-api issue

How to review
-------------

Code review

Have a noodle in [my dev env Grafana](https://grafana-1.tlwr.dev.cloudpipeline.digital/explore?left=%5B%22now-7d%22,%22now%22,%22prometheus%22,%7B%22expr%22:%22avg%20by%20(bosh_job_process_name)%20(bosh_job_process_cpu_total%7Bbosh_job_name%3D%5C%22log-api%5C%22%7D)%22%7D,%7B%22ui%22:%5Btrue,true,false,%22none%22%5D%7D%5D&right=%5B%22now-7d%22,%22now%22,%22prometheus%22,%7B%22expr%22:%22bosh_deployment_release_info%7Bbosh_release_name%3D%5C%22bosh-dns%5C%22%7D%22%7D,%7B%22ui%22:%5Btrue,true,false,%22none%22%5D%7D%5D)

Who can review
--------------

Not @tlwr
