### PR TITLE
[Support] Bump Elasticache Node Limit In London

### DIFF
--- a/manifests/prometheus/alerts.d/elasticache-node-count.yml
+++ b/manifests/prometheus/alerts.d/elasticache-node-count.yml
@@ -13,4 +13,4 @@
           severity: warning
         annotations:
           summary: "Number of elasticache nodes is close to the limit"
-          description: "We are using {{ $value | printf \"%.0f\" }} of 100 Elasticache nodes. We might have to contact AWS support to raise the limit."
+          description: "We are using {{ $value | printf \"%.0f\" }} of ((aws_limits_elasticache_nodes)) Elasticache nodes. We might have to contact AWS support to raise the limit."

--- a/manifests/prometheus/env-specific/prod-lon.yml
+++ b/manifests/prometheus/env-specific/prod-lon.yml
@@ -2,5 +2,5 @@
 
 # AWS Limits not accesible via API
 aws_limits_elasticache_cache_parameter_groups: 400
-aws_limits_elasticache_nodes: 400
+aws_limits_elasticache_nodes: 500
 aws_limits_s3_buckets: 250


### PR DESCRIPTION
What
----

The ElastiCache nodes limit in London has been increased to 500. This updates
the config to reflect the new limit.

How to review
-------------

Code review

Who can review
--------------

Not me
