### PR TITLE
Separate platform-operator level access login

### DIFF
--- a/concourse/tasks/configure-grafana.yml
+++ b/concourse/tasks/configure-grafana.yml
@@ -79,12 +79,16 @@ run:
         .load_file("#{Dir.pwd}/paas-trusted-people/users.yml")
         .fetch('users')
 
+      # a user might be an admin user and an auditor for different uaa origins
+      # we should union the roles with group_by
       user_roles = users
         .reject { |u| u['email'].nil? }
         .reject { |u| u.dig('roles', aws_account).nil? }
         .select { |u| u.dig('roles', aws_account) & grafana_roles }
-        .map { |u| [u['email'], grafana_role(u.dig('roles', aws_account))] }
-        .to_h
+        .group_by { |u| u['email'] }
+        .transform_values { |usrs| usrs.map { |u| u.dig('roles', aws_account) } }
+        .transform_values(&:flatten)
+        .transform_values { |roles| grafana_role(roles) }
 
       users_that_should_exist = user_roles.keys
 

--- a/manifests/cf-manifest/operations.d/330-uaa.yml
+++ b/manifests/cf-manifest/operations.d/330-uaa.yml
@@ -300,9 +300,9 @@
   path: /releases/-
   value:
     name: uaa-customized
-    version: 0.1.16
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-customized-0.1.16.tgz
-    sha1: 3b0ca98e4510ca0dddeefd29e035dabb8d87191a
+    version: 0.1.19
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-customized-0.1.19.tgz
+    sha1: 774062665d6e7a6233977c76f8d3000750f64c87
 
 - type: replace
   path: /instance_groups/name=uaa/jobs/-

--- a/manifests/cf-manifest/operations.d/333-uaa-add-oauth.yml
+++ b/manifests/cf-manifest/operations.d/333-uaa-add-oauth.yml
@@ -30,6 +30,35 @@
       user_name: sub
 
 - type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/login/oauth?/providers/admin-google
+  value:
+    type: oidc1.0
+    authUrl: https://accounts.google.com/o/oauth2/v2/auth
+    tokenUrl: https://www.googleapis.com/oauth2/v4/token
+    tokenKeyUrl: https://www.googleapis.com/oauth2/v3/certs
+    issuer: https://accounts.google.com
+    redirectUrl: https://login.((system_domain))/uaa
+    scopes:
+      - openid
+      - profile
+      - email
+    linkText: AdminGoogle
+    showLinkText: true
+    addShadowUserOnLogin: false
+    relyingPartyId: ((admin_google_oauth_client_id))
+    relyingPartySecret: ((admin_google_oauth_client_secret))
+    skipSslValidation: false
+    attributeMappings:
+      # UAA will attempt to find an existing user with a username matching the
+      # attribute from Google named below (e.g., `sub`.) If that fails it will
+      # attempt to find an existing UAA user whose email matches the email
+      # attribute from Google.
+      #
+      # This is secure because Google verifies email addresses and appears to
+      # forbid multiple accounts from having the same email address.
+      user_name: sub
+
+- type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/login/oauth?/providers/microsoft
   value:
     type: oidc1.0

--- a/scripts/upload-secrets/upload-google-oauth-secrets.rb
+++ b/scripts/upload-secrets/upload-google-oauth-secrets.rb
@@ -15,6 +15,8 @@ credhub_namespaces = [
 
 google_oauth_client_id = ENV['GOOGLE_OAUTH_CLIENT_ID'] || `pass "google/${MAKEFILE_ENV_TARGET}/oauth/client_id"`
 google_oauth_client_secret = ENV['GOOGLE_OAUTH_CLIENT_SECRET'] || `pass "google/${MAKEFILE_ENV_TARGET}/oauth/client_secret"`
+admin_google_oauth_client_id = ENV['ADMIN_GOOGLE_OAUTH_CLIENT_ID'] || `pass "google/${MAKEFILE_ENV_TARGET}/oauth/admin_client_id"`
+admin_google_oauth_client_secret = ENV['ADMIN_GOOGLE_OAUTH_CLIENT_SECRET'] || `pass "google/${MAKEFILE_ENV_TARGET}/oauth/admin_client_secret"`
 grafana_auth_google_client_id = ENV['GRAFANA_AUTH_GOOGLE_CLIENT_ID'] || `pass "google/${MAKEFILE_ENV_TARGET}/oauth/grafana_client_id"`
 grafana_auth_google_client_secret = ENV['GRAFANA_AUTH_GOOGLE_CLIENT_SECRET'] || `pass "google/${MAKEFILE_ENV_TARGET}/oauth/grafana_client_secret"`
 google_paas_admin_client_id = ENV['GOOGLE_PAAS_ADMIN_CLIENT_ID'] || `pass "google/${MAKEFILE_ENV_TARGET}/oauth/paas_admin_client_id"`
@@ -24,6 +26,8 @@ upload_secrets(
   credhub_namespaces,
   'google_oauth_client_id' => google_oauth_client_id,
   'google_oauth_client_secret' => google_oauth_client_secret,
+  'admin_google_oauth_client_id' => admin_google_oauth_client_id,
+  'admin_google_oauth_client_secret' => admin_google_oauth_client_secret,
   'grafana_auth_google_client_id' => grafana_auth_google_client_id,
   'grafana_auth_google_client_secret' => grafana_auth_google_client_secret,
   'google_paas_admin_client_id' => google_paas_admin_client_id,

--- a/tools/user_management/lib/group.rb
+++ b/tools/user_management/lib/group.rb
@@ -17,7 +17,7 @@ class Group < UAAResource
     unexpected_member_users = get_member_users(uaa_client).select do |member_user|
       if member_user['origin'] == 'uaa' && member_user['userName'] == 'admin'
         false
-      elsif member_user['origin'] == 'google' && desired_user_guids.include?(member_user['id'])
+      elsif (member_user['origin'] == 'google' || member_user['origin'] == 'admin-google') && desired_user_guids.include?(member_user['id'])
         false
       else
         true
@@ -64,7 +64,7 @@ class Group < UAAResource
     new_users_to_add.each do |user|
       puts "* guid=#{user.guid}".green
       puts "  email='#{user.email}'".green
-      puts "  origin=google".green
+      puts "  origin='#{user.origin}'".green
       puts "  userName='#{user.google_id}'".green
       add_member(user.guid, uaa_client)
       puts "  USER GIVEN MEMBERSHIP OF GROUP".green


### PR DESCRIPTION
What
----

We'd like to be able to log into the platform as admins, on rare occasion.
This can be achieved with having another OAuth application.

How to review
-------------

- Sanity check
- Deploy to your own dev env; or
- Log into `rafalp` and play with both roles


🐝🐝🐝 Before merge 🐝🐝🐝
------------

- Make sure that the WIP commit is pointing to stable release
