### PR TITLE
Drop unnecessary metrics from cf prometheus

### DIFF
--- a/manifests/cf-manifest/operations.d/500-prometheus.yml
+++ b/manifests/cf-manifest/operations.d/500-prometheus.yml
@@ -92,6 +92,21 @@
                     regex: 'aws-((terraform_outputs_region))'
                     action: keep
 
+                  - source_labels: [__name__]
+                    separator: ;
+                    regex: 'elasticsearch_(breakers|thread|fs|indices|os)_.*'
+                    action: drop
+
+                  - source_labels: [__name__]
+                    separator: ;
+                    regex: 'net_(icmp|udplite)_.*'
+                    action: drop
+
+                  - source_labels: [__name__]
+                    separator: ;
+                    regex: 'prometheus_sd_(consul|kubernetes)_.*'
+                    action: drop
+
       - name: route_registrar
         release: routing
         properties:


### PR DESCRIPTION
What
----

Our prometheus uses a lot of memory in london because it has to deal with a lot of metrics

We do not care about a lot of these metrics, as we only surface 8 of them to our users

We can drop a few metrics to save on disk space and memory usage (cache + compaction)

How to review
-------------

Code review

Look at the tests

[Evaluate this query as an example](https://prometheus.london.cloud.service.gov.uk/graph?g0.range_input=1h&g0.expr=count%20by%20(__name__)(%7B__name__%3D~%22elasticsearch_(breakers%7Cthread%7Cfs%7Cindices%7Cos)_.*%22%7D)&g0.tab=1)

[Review this chart](https://grafana-1.london.cloud.service.gov.uk/explore?left=%5B%22now-30d%22,%22now%22,%22prometheus%22,%7B%22expr%22:%22max%20by%20(bosh_job_process_name)%20(bosh_job_process_mem_percent%7Bbosh_job_name%3D%5C%22prometheus%5C%22%7D)%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D)

![image](https://user-images.githubusercontent.com/1482692/73295491-afcaf080-41ff-11ea-83a9-50851c8299b5.png)

Who can review
--------------

Done as pair with @paroxp 