### PR TITLE
Bump loggregator to version which does not DOS DNS

### DIFF
--- a/manifests/cf-manifest/operations.d/230-loggregator-deployment.yml
+++ b/manifests/cf-manifest/operations.d/230-loggregator-deployment.yml
@@ -17,6 +17,6 @@
   path: /releases/name=loggregator
   value:
     name: "loggregator"
-    version: "106.3.6"
-    url: "https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.3.6"
-    sha1: "ba64ea33a88429a1031f4041dcb7665519da4aa2"
+    version: "106.3.8"
+    url: "https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.3.8"
+    sha1: "2a3a526ee17b8f3994e396ef81ef79cbb378358d"


### PR DESCRIPTION
What
----

See https://github.com/cloudfoundry/loggregator-release/issues/401 and https://github.com/cloudfoundry/loggregator-release/releases/tag/v106.3.8

![image](https://user-images.githubusercontent.com/1482692/73543634-492c1980-442f-11ea-8e46-87fdaf8f37da.png)
_Image of `log-api` instance CPU usage in my development environment, where the reduction in CPU usage is the change_

See #2233 for another `log-api` DNS related change

How to review
-------------

Code review

CI

Read the links above

Who can review
--------------

Not @tlwr