### PR TITLE
[#170702697] Fix admin google OIDC claim

### DIFF
--- a/manifests/cf-manifest/operations.d/333-uaa-add-oauth.yml
+++ b/manifests/cf-manifest/operations.d/333-uaa-add-oauth.yml
@@ -49,14 +49,27 @@
     relyingPartySecret: ((admin_google_oauth_client_secret))
     skipSslValidation: false
     attributeMappings:
-      # UAA will attempt to find an existing user with a username matching the
-      # attribute from Google named below (e.g., `sub`.) If that fails it will
-      # attempt to find an existing UAA user whose email matches the email
-      # attribute from Google.
+      # See commit 1e9fb2176a721600f20149914d83b1374450da56 for some history
       #
-      # This is secure because Google verifies email addresses and appears to
-      # forbid multiple accounts from having the same email address.
-      user_name: sub
+      # We have two separate roles for administrators:
+      # - global auditor
+      # - global administrator
+      #
+      # We use the same identity provider (Google) for both
+      # We use the same email identity (our Google accounts) for both
+      #
+      # Various CF CLI operations which interact with the Cloud Controller API
+      # make some assumptions about the uniqueness of usernames, when they
+      # should instead be using the GUID
+      #
+      # As a result, many operations will error unless our usernames are unique
+      #
+      # In order to get unique usernames we cannot use the same attribute
+      # mappings for both Google IDP configurations.
+      #
+      # We are happy with Google's security to enforce that the email we get
+      # back from Google OAuth is in fact our email address
+      user_name: email
 
 - type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/login/oauth?/providers/microsoft

--- a/manifests/cf-manifest/spec/manifest/oauth_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/oauth_spec.rb
@@ -1,11 +1,32 @@
-RSpec.describe "Google OAuth" do
+RSpec.describe "OAuth" do
   let(:properties) { manifest.fetch("instance_groups.uaa.jobs.uaa.properties") }
 
   describe "by default" do
     let(:manifest) { manifest_with_defaults }
+
     it "enables the Google OAuth provider in UAA" do
       providers = properties.fetch("login").fetch("oauth").fetch("providers")
       expect(providers).to have_key 'google'
+    end
+
+    it "enables the Microsoft OAuth provider in UAA" do
+      providers = properties.fetch("login").fetch("oauth").fetch("providers")
+      expect(providers).to have_key 'microsoft'
+    end
+
+    it "enables a Google OAuth provider for administators in UAA" do
+      providers = properties.fetch("login").fetch("oauth").fetch("providers")
+      expect(providers).to have_key 'admin-google'
+    end
+
+    it "ensures unique username attr mappings to ensure unique usernames" do
+      providers = properties.fetch("login").fetch("oauth").fetch("providers")
+
+      mappings = providers
+        .values
+        .map { |p| p.dig('attributeMappings', 'user_name') }
+
+      expect(mappings).to eq(mappings.uniq)
     end
   end
 end

--- a/tools/user_management/lib/actions.rb
+++ b/tools/user_management/lib/actions.rb
@@ -5,7 +5,7 @@ require_relative 'group'
 def ensure_users_exist_in_uaa(users, uaa_client)
   users.each do |user|
     unless user.exists?(uaa_client)
-      puts "Creating new user '#{user.email}' with Google ID '#{user.google_id}'".green
+      puts "Creating new user '#{user.email}' with Google ID '#{user.username}'".green
       user.create(uaa_client)
       user.get_user(uaa_client)
       puts "  CREATED WITH GUID #{user.guid}".green

--- a/tools/user_management/lib/group.rb
+++ b/tools/user_management/lib/group.rb
@@ -65,7 +65,7 @@ class Group < UAAResource
       puts "* guid=#{user.guid}".green
       puts "  email='#{user.email}'".green
       puts "  origin='#{user.origin}'".green
-      puts "  userName='#{user.google_id}'".green
+      puts "  userName='#{user.username}'".green
       add_member(user.guid, uaa_client)
       puts "  USER GIVEN MEMBERSHIP OF GROUP".green
     end

--- a/tools/user_management/lib/user.rb
+++ b/tools/user_management/lib/user.rb
@@ -3,11 +3,11 @@ require 'json'
 require_relative 'uaa_resource'
 
 class User < UAAResource
-  attr_reader :email, :google_id, :origin
+  attr_reader :email, :username, :origin
 
   def initialize(obj)
     @email = obj.fetch('email')
-    @google_id = obj.fetch('google_id')
+    @username = obj.fetch('username')
     @roles_by_env = obj.fetch('roles', {})
     @origin = obj.fetch('origin', 'google')
   end
@@ -29,7 +29,7 @@ class User < UAAResource
     resp = uaa_client['/Users'].post({
       emails: [{ value: @email }],
       origin: @origin,
-      userName: @google_id
+      userName: @username
     }.to_json)
     resp.code == 201
   end
@@ -37,7 +37,7 @@ class User < UAAResource
   def get_user(uaa_client)
     scim_filter = [
       "origin+eq+\"#{@origin}\"",
-      "userName+eq+\"#{@google_id}\""
+      "userName+eq+\"#{@username}\""
     ].join('+and+')
     get_resource("/Users?filter=#{scim_filter}", uaa_client)
   end

--- a/tools/user_management/spec/group_spec.rb
+++ b/tools/user_management/spec/group_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Group do
       stub_searching_for_group(200, '__test__', 'guid-of-__test__-group')
 
       stub_searching_for_user(200, 'google', '11111111111111', 'user-guid')
-      @user = User.new('email' => 'user-one@na.me', 'google_id' => '11111111111111')
+      @user = User.new('email' => 'user-one@na.me', 'username' => '11111111111111')
       @user.get_user(@fake_uaa_client)
     end
 
@@ -68,12 +68,12 @@ RSpec.describe Group do
     before do
       stub_searching_for_user(200, 'google', '11111111111111', 'user-1-guid')
       stub_getting_user_by_id(200, 'user-1-guid', 'google', '11111111111111', Time.now)
-      @u1 = User.new('email' => 'user-one@na.me', 'google_id' => '11111111111111')
+      @u1 = User.new('email' => 'user-one@na.me', 'username' => '11111111111111')
       @u1.get_user(@fake_uaa_client)
 
       stub_searching_for_user(200, 'google', '22222222222222', 'user-2-guid')
       stub_getting_user_by_id(200, 'user-2-guid', 'google', '22222222222222', Time.now)
-      @u2 = User.new('email' => 'user-two@na.me', 'google_id' => '22222222222222')
+      @u2 = User.new('email' => 'user-two@na.me', 'username' => '22222222222222')
       @u2.get_user(@fake_uaa_client)
     end
 
@@ -100,7 +100,7 @@ RSpec.describe Group do
 
       stub_searching_for_user(200, 'google', '11111111111111', 'desired-user-guid')
       stub_getting_user_by_id(200, 'desired-user-guid', 'google', '11111111111111', Time.now)
-      @u1 = User.new('email' => 'user-one@na.me', 'google_id' => '11111111111111')
+      @u1 = User.new('email' => 'user-one@na.me', 'username' => '11111111111111')
 
       stub_getting_user_by_id(200, 'unwanted-google-user-guid', 'google', '22222222222222', Time.now - 86400)
       stub_searching_for_user(200, 'google', '22222222222222', 'unwanted-google-user-guid')

--- a/tools/user_management/spec/user_spec.rb
+++ b/tools/user_management/spec/user_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe User do
   it 'checks if a role for a user exists in an environment' do
     u = User.new(
       'email' => 'jeff.jefferson@example.com',
-      'google_id' => '000000000000000000000',
+      'username' => '000000000000000000000',
       'roles' => {
         'dev' => [{ 'role' => 'some_role' }],
         'prod' => [{ 'role' => 'some_other_role' }],
@@ -30,7 +30,7 @@ RSpec.describe User do
   it 'does not give any roles to users without roles' do
     u = User.new(
       'email' => 'jeff.jefferson@example.com',
-      'google_id' => '000000000000000000000',
+      'username' => '000000000000000000000',
       'roles' => {},
     )
     expect(u.has_role_for_env?('dev', 'some_role')).to be(false)
@@ -51,7 +51,7 @@ RSpec.describe User do
 
     u = User.new(
       'email' => 'jeff.jefferson@example.com',
-      'google_id' => '000000000000000000000',
+      'username' => '000000000000000000000',
       'roles' => { 'dev' => [{ 'role' => 'some_role' }] },
     )
 
@@ -63,7 +63,7 @@ RSpec.describe User do
 
     u2 = User.new(
       'email' => 'rich.richardson@example.com',
-      'google_id' => '999999999999999999999'
+      'username' => '999999999999999999999'
     )
 
     expect(u2.exists?(@fake_uaa_client)).to be false
@@ -74,7 +74,7 @@ RSpec.describe User do
 
     u = User.new(
       'email' => 'jeff.jefferson@example.com',
-      'google_id' => '000000000000000000000',
+      'username' => '000000000000000000000',
       'roles' => { 'dev' => [{ 'role' => 'some_role' }] },
     )
 
@@ -88,7 +88,7 @@ RSpec.describe User do
 
     u2 = User.new(
       'email' => 'rich.richardson',
-      'google_id' => '999999999999999999999'
+      'username' => '999999999999999999999'
     )
 
     expect { u2.create(@fake_uaa_client) }.to raise_error(Exception, /Bad Request/)
@@ -98,7 +98,7 @@ RSpec.describe User do
 
     u3 = User.new(
       'email' => 'jeff.jefferson@example.com',
-      'google_id' => '000000000000000000000'
+      'username' => '000000000000000000000'
     )
 
     expect(u3.create(@fake_uaa_client)).to be false
@@ -118,7 +118,7 @@ RSpec.describe User do
 
     u = User.new(
       'email' => 'jeff.jefferson@example.com',
-      'google_id' => '000000000000000000000',
+      'username' => '000000000000000000000',
       'roles' => { 'dev' => [{ 'role' => 'some_role' }] },
     )
 


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/170702697)

What
----

Read the code for full context, however:

- We now have two identity providers which are both Google
- We were using `sub` as the UAA username, which meant we had duplicate usernames between origins
- Cloud Controller and the CF CLI do not deal well with duplicate usernames _at all_
- Admin users cannot use `cf create-space` as a result, due to duplicate usernames, because it attempts to assign space manager to the creator, but fails when the usernames are not unique

This PR:

- More thoroughly tests the OAuth operations
- Adds a test to ensure that the attribute mappings across identity providers is unique
- Updates the user management tool to use `username` which is determined by `main.rb` using the `cf-admin` role as a heuristic for who is an admin.

How to review
-------------

Code review

Look at [the sync admin users job](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/post-deploy/builds/110) in my development environment, which shows the removal of all of the admin users using `sub` as a username, and adds new users using `email` as the username

Who can review
--------------

Not @tlwr 

Preferably someone who is familiar with recent changes to user management