### PR TITLE
Increase size of  CF prometheus persistent disk

### DIFF
--- a/manifests/cf-manifest/operations.d/500-prometheus.yml
+++ b/manifests/cf-manifest/operations.d/500-prometheus.yml
@@ -40,7 +40,7 @@
     azs: [z1, z2, z3]
     stemcell: default
 
-    persistent_disk_type: 100GB
+    persistent_disk_type: 500GB
     vm_type: xlarge
 
     networks:
@@ -55,7 +55,7 @@
               tsdb:
                 retention:
                   time: 370d
-                  size: 90GB
+                  size: 475GB
 
             rule_files: []
 

--- a/manifests/cf-manifest/operations/change-vm-types-dev.yml
+++ b/manifests/cf-manifest/operations/change-vm-types-dev.yml
@@ -48,3 +48,11 @@
 - type: replace
   path: /instance_groups/name=prometheus/vm_type
   value: small
+
+- type: replace
+  path: /instance_groups/name=prometheus/persistent_disk_type
+  value: 100GB
+
+- type: replace
+  path: /instance_groups/name=prometheus/jobs/name=prometheus2/properties/prometheus/storage/tsdb/retention/size
+  value: 90GB

--- a/manifests/cf-manifest/spec/manifest/dev_scaling_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/dev_scaling_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe 'dev environment scaling' do
     # It scales back cf-prometheus to 1
     expect(dev_manifest.fetch('instance_groups.prometheus.instances')).to eq(1)
     expect(dev_manifest.fetch('instance_groups.prometheus.vm_type')).to eq('small')
+    expect(dev_manifest.fetch('instance_groups.prometheus.persistent_disk_type')).to eq('100GB')
+    expect(dev_manifest.fetch('instance_groups.prometheus.jobs.prometheus2.properties.prometheus.storage.tsdb.retention.size')).to eq('90GB')
   end
 
   it 'does not scale back dev otherwise' do
@@ -29,5 +31,7 @@ RSpec.describe 'dev environment scaling' do
     expect(dev_manifest.fetch('instance_groups.s3_broker.instances')).not_to eq(1)
 
     expect(dev_manifest.fetch('instance_groups.prometheus.vm_type')).to eq('xlarge')
+    expect(dev_manifest.fetch('instance_groups.prometheus.persistent_disk_type')).to eq('500GB')
+    expect(dev_manifest.fetch('instance_groups.prometheus.jobs.prometheus2.properties.prometheus.storage.tsdb.retention.size')).to eq('475GB')
   end
 end

--- a/manifests/cf-manifest/spec/manifest/prometheus_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/prometheus_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'prometheus' do
   context 'instance_group' do
     it 'should have a persistent disk' do
       disk_type = prometheus_instance_group.dig('persistent_disk_type')
-      expect(disk_type).to eq('100GB')
+      expect(disk_type).to eq('500GB')
     end
 
     it 'should be highly available' do
@@ -177,6 +177,7 @@ RSpec.describe 'prometheus' do
       retention_size_gb = retention_size.gsub(/GB/, '').to_i
 
       expect(retention_size_gb).to be < disk_size_gb
+      expect(retention_size_gb).to be >= (disk_size_gb * 0.75)
     end
 
     it 'should have retention time greater than one year' do

--- a/manifests/cloud-config/paas-cf-cloud-config.yml
+++ b/manifests/cloud-config/paas-cf-cloud-config.yml
@@ -23,6 +23,10 @@ disk_types:
   disk_size: 102400
   cloud_properties:
     type: gp2
+- name: 500GB
+  disk_size: 512000
+  cloud_properties:
+    type: gp2
 
 networks:
 - name: cf


### PR DESCRIPTION
What
----

We are now storing up to 370 days of metrics, which will require > 100GB of storage

This will also give us more IOPS, which should reduce resource usage during compaction

The cost implications in prod are:
- before: 4 * 100 GB = 42.92USD
- after:  4 * 500 GB = 288.52USD

There are no cost implications in development environments

We also have recently had problems with memory usage, when [prometheus is compacting](https://prometheus.io/docs/prometheus/latest/storage/#compaction). The increased disk size will give us more IOPS, by a factor of 5 (because we are increasing the disk size by 5). This may make compaction a bit more efficient and require less memory usage.

How to review
-------------

Code review

Who can review
--------------

Not @tlwr