### PR TITLE
Add PaaS Auditor alerts

### DIFF
--- a/manifests/prometheus/alerts.d/cf-audit-events-collecting.yml
+++ b/manifests/prometheus/alerts.d/cf-audit-events-collecting.yml
@@ -1,0 +1,15 @@
+# Source: paas-auditor
+---
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: CFAuditEventsCollectingStopped
+    rules:
+      - alert: CFAuditEventsCollectingStopped
+        expr: sum(increase(cf_audit_event_collector_events_collected_total[10m])) < 100
+        labels:
+          severity: warning
+        annotations:
+          summary: "CF Audit Events collected count"
+          description: "Amount of CF Audit Events collected has decreased considerably over the last 10 minutes: {{ $value | printf \"%.0f\" }}"

--- a/manifests/prometheus/alerts.d/cf-audit-events-shipping.yml
+++ b/manifests/prometheus/alerts.d/cf-audit-events-shipping.yml
@@ -1,0 +1,15 @@
+# Source: paas-auditor
+---
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: CFAuditEventsShippingStopped
+    rules:
+      - alert: CFAuditEventsShippingStopped
+        expr: sum(increase(cf_audit_events_to_splunk_shipper_events_shipped_total[10m])) < 2000
+        labels:
+          severity: warning
+        annotations:
+          summary: "CF Audit Events shipped count"
+          description: "Amount of CF Audit Events shipped has decreased considerably over the last 10 minutes: {{ $value | printf \"%.0f\" }}"


### PR DESCRIPTION
What
----

We'd like to be notified if:

* we aren't collecting events we should have a warning alert
* we aren't shipping events we should have a warning alert

Setting up these two alerts should trigger a warning, if the above are
true.

This particular change is making me concerned, as we appear to be
shipping 20 times more events than we collect on average.

How to review
-------------

- Sanity check
- Visit our prometheus and run the queries
  - play with the time frames and values to see sweet spots
