### PR TITLE
Provide metadata to our services and plans

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -623,7 +623,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-aiven-broker.git
-      tag_filter: v0.22.0
+      tag_filter: v0.23.0
 
   - name: paas-billing
     type: git

--- a/config/service-brokers/aiven/config.json
+++ b/config/service-brokers/aiven/config.json
@@ -11,8 +11,17 @@
         "plan_updateable": true,
         "metadata": {
           "displayName": "Elasticsearch",
-          "providerDisplayName": "GOV.UK PaaS",
-          "supportUrl": "https://www.cloud.service.gov.uk/support"
+          "providerDisplayName": "Aiven",
+          "longDescription": "Elasticsearch is a search engine based on the Lucene library. It provides a distributed, multitenant-capable full-text search engine with an HTTP web interface and schema-free JSON documents.",
+          "documentationUrl": "https://docs.cloud.service.gov.uk/deploying_services/elasticsearch/",
+          "supportUrl": "https://www.cloud.service.gov.uk/support",
+          "AdditionalMetadata": {
+            "otherDocumentation": [
+              "https://www.elastic.co/guide/en/elasticsearch/",
+              "https://help.aiven.io/en/"
+            ],
+            "usecase": ["Search engines"]
+          }
         },
         "plans": [
           {
@@ -23,7 +32,17 @@
             "description": "NOT Highly Available, 1 dedicated VM, 1 CPU per VM, 4GB RAM per VM, 80GB disk space.",
             "free": true,
             "metadata": {
-              "displayName": "Tiny, NOT Highly Available single-node Elasticsearch 6 cluster"
+              "displayName": "Tiny",
+              "AdditionalMetadata": {
+                "backups": true,
+                "encrypted": true,
+                "highlyAvailable": false,
+                "nodes": 1,
+                "cpu": 1,
+                "memory": {"amount": 4, "unit": "GB"},
+                "storage": {"amount": 80, "unit": "GB"},
+                "version": "6"
+              }
             }
           },
           {
@@ -34,7 +53,17 @@
             "description": "3 dedicated VMs, 1 CPU per VM, 4GB RAM per VM, 240GB disk space.",
             "free": false,
             "metadata": {
-              "displayName": "Small, highly available Elasticsearch 6 cluster"
+              "displayName": "Small",
+              "AdditionalMetadata": {
+                "backups": true,
+                "encrypted": true,
+                "highlyAvailable": true,
+                "nodes": 3,
+                "cpu": 1,
+                "memory": {"amount": 4, "unit": "GB"},
+                "storage": {"amount": 240, "unit": "GB"},
+                "version": "6"
+              }
             }
           },
           {
@@ -45,7 +74,17 @@
             "description": "3 dedicated VMs, 2 CPU per VM, 8GB RAM per VM, 525GB disk space.",
             "free": false,
             "metadata": {
-              "displayName": "Medium, highly available Elasticsearch 6 cluster"
+              "displayName": "Medium",
+              "AdditionalMetadata": {
+                "backups": true,
+                "encrypted": true,
+                "highlyAvailable": true,
+                "nodes": 3,
+                "cpu": 2,
+                "memory": {"amount": 8, "unit": "GB"},
+                "storage": {"amount": 525, "unit": "GB"},
+                "version": "6"
+              }
             }
           },
           {
@@ -56,7 +95,17 @@
             "description": "3 dedicated VMs, 2 CPU per VM, 15GB RAM per VM, 1050GB disk space.",
             "free": false,
             "metadata": {
-              "displayName": "Large, highly available Elasticsearch 6 cluster"
+              "displayName": "Large",
+              "AdditionalMetadata": {
+                "backups": true,
+                "encrypted": true,
+                "highlyAvailable": true,
+                "nodes": 3,
+                "cpu": 2,
+                "memory": {"amount": 15, "unit": "GB"},
+                "storage": {"amount": 1050, "unit": "GB"},
+                "version": "6"
+              }
             }
           }
         ]
@@ -69,8 +118,21 @@
         "plan_updateable": true,
         "metadata": {
           "displayName": "InfluxDB",
-          "providerDisplayName": "GOV.UK PaaS",
-          "supportUrl": "https://www.cloud.service.gov.uk/support"
+          "providerDisplayName": "Aiven",
+          "longDescription": "InfluxDB is optimized for fast, high-availability storage and retrieval of time series data in fields such as operations monitoring, application metrics, Internet of Things sensor data, and real-time analytics. It also has support for processing data from Graphite.",
+          "documentationUrl": "https://docs.cloud.service.gov.uk/deploying_services/influxdb/",
+          "supportUrl": "https://www.cloud.service.gov.uk/support",
+          "AdditionalMetadata": {
+            "otherDocumentation": [
+              "https://docs.influxdata.com/influxdb/v1.7/",
+              "https://help.aiven.io/en/"
+            ],
+            "usecase": [
+              "Metrics",
+              "Prometheus",
+              "Grafana"
+            ]
+          }
         },
         "plans": [
           {
@@ -80,7 +142,17 @@
             "description": "NOT Highly Available, 1 dedicated VM, 2 CPU per VM, 4GB RAM per VM, 16GB disk space.",
             "free": true,
             "metadata": {
-              "displayName": "Tiny, single InfluxDB instance"
+              "displayName": "Tiny",
+              "AdditionalMetadata": {
+                "backups": true,
+                "encrypted": true,
+                "highlyAvailable": false,
+                "nodes": 1,
+                "cpu": 2,
+                "memory": {"amount": 4, "unit": "GB"},
+                "storage": {"amount": 16, "unit": "GB"},
+                "version": "1"
+              }
             }
           }
         ]

--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 0.1.60
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.60.tgz
-    sha1: c08661a2e3e7cec721a6929e2676aa288779d11e
+    version: 0.1.64
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.64.tgz
+    sha1: ad84dfc9ddd6bd24bec7fa4cdb6eacd88fdb4152
 
 - type: replace
   path: /instance_groups/-

--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 0.1.64
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.64.tgz
-    sha1: ad84dfc9ddd6bd24bec7fa4cdb6eacd88fdb4152
+    version: 0.1.65
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.65.tgz
+    sha1: 105531f8c47c5a2c714f3ad8bac871042beeebd6
 
 - type: replace
   path: /instance_groups/-

--- a/manifests/cf-manifest/operations.d/711-rds-broker-postgres95-plans.yml
+++ b/manifests/cf-manifest/operations.d/711-rds-broker-postgres95-plans.yml
@@ -92,20 +92,26 @@
 - type: replace
   path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog?/services?/-
   value:
-    id: "ce71b484-d542-40f7-9dd4-5526e38c81ba"
-    name: "postgres"
     description: "AWS RDS PostgreSQL service"
+    id: ce71b484-d542-40f7-9dd4-5526e38c81ba
+    name: postgres
     bindable: true
     tags:
-      - "postgres"
-      - "relational"
+      - postgres
+      - relational
     metadata:
-      displayName: "AWS RDS Postgres"
-      imageUrl: ""
-      longDescription: "AWS RDS postgres service"
-      providerDisplayName: "Amazon Web Services"
-      documentationUrl: "https://aws.amazon.com/documentation/rds/"
-      supportUrl: "https://forums.aws.amazon.com/forum.jspa?forumID=60"
+      displayName: AWS RDS Postgres
+      longDescription: |
+        Postgres, is a free and open-source relational database management system (RDBMS) emphasizing extensibility and
+        technical standards compliance. It is designed to handle a range of workloads, from single machines to data
+        warehouses or Web services with many concurrent users.
+      providerDisplayName: Amazon Web Services
+      documentationUrl: https://docs.cloud.service.gov.uk/deploying_services/postgres/
+      supportUrl: https://www.cloud.service.gov.uk/support
+      AdditionalMetadata:
+        otherDocumentation:
+          - https://www.postgresql.org/docs/
+          - https://aws.amazon.com/documentation/rds/
     plan_updateable: true
 
 - type: replace
@@ -116,6 +122,17 @@
     description: "5GB Storage, NOT BACKED UP, Dedicated Instance, Max 50 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t2.micro."
     free: true
     metadata:
+      AdditionalMetadata:
+        backups: false
+        concurrentConnections: 50
+        encrypted: false
+        highlyAvailable: false
+        instanceClass: db.t2.micro
+        storage:
+          amount: 5
+          unit: GB
+        version: 9.5
+      displayName: Tiny
       bullets:
         - "Dedicated Postgres 9.5 server"
         - "AWS RDS"
@@ -131,6 +148,17 @@
     description: "20GB Storage, Dedicated Instance, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t2.small."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 200
+        encrypted: true
+        highlyAvailable: false
+        instanceClass: db.t2.small
+        storage:
+          amount: 20
+          unit: GB
+        version: 9.5
+      displayName: Small
       costs:
         - amount:
             usd: 0.039
@@ -152,6 +180,17 @@
     description: "20GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t2.small."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 200
+        encrypted: true
+        highlyAvailable: true
+        instanceClass: db.t2.small
+        storage:
+          amount: 20
+          unit: GB
+        version: 9.5
+      displayName: Small highly-available
       costs:
         - amount:
             usd: 0.078
@@ -173,6 +212,17 @@
     description: "100GB Storage, Dedicated Instance, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.large."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 500
+        encrypted: true
+        highlyAvailable: false
+        instanceClass: db.m4.large
+        storage:
+          amount: 100
+          unit: GB
+        version: 9.5
+      displayName: Medium
       costs:
         - amount:
             usd: 0.201
@@ -194,6 +244,17 @@
     description: "100GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.large."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 500
+        encrypted: true
+        highlyAvailable: true
+        instanceClass: db.m4.large
+        storage:
+          amount: 100
+          unit: GB
+        version: 9.5
+      displayName: Medium highly-available
       costs:
         - amount:
             usd: 0.402
@@ -216,6 +277,17 @@
     description: "512GB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.2xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: false
+        instanceClass: db.m4.2xlarge
+        storage:
+          amount: 512
+          unit: GB
+        version: 9.5
+      displayName: Large
       costs:
         - amount:
             usd: 0.806
@@ -237,6 +309,17 @@
     description: "512GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.2xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: true
+        instanceClass: db.m4.2xlarge
+        storage:
+          amount: 512
+          unit: GB
+        version: 9.5
+      displayName: Large highly-available
       costs:
         - amount:
             usd: 1.612
@@ -259,6 +342,17 @@
     description: "2TB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.4xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: false
+        instanceClass: db.m4.4xlarge
+        storage:
+          amount: 2
+          unit: TB
+        version: 9.5
+      displayName: Extra Large
       costs:
         - amount:
             usd: 1.612
@@ -280,6 +374,17 @@
     description: "2TB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.4xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: true
+        instanceClass: db.m4.4xlarge
+        storage:
+          amount: 2
+          unit: TB
+        version: 9.5
+      displayName: Extra Large highly-available
       costs:
         - amount:
             usd: 3.224
@@ -303,6 +408,7 @@
     name: "small-unencrypted-9.5"
     description: "20GB Storage, Dedicated Instance, Max 200 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t2.small."
     free: false
+    active: false
     metadata:
       costs:
         - amount:
@@ -322,6 +428,7 @@
     name: "small-ha-unencrypted-9.5"
     description: "20GB Storage, Dedicated Instance, Highly Available, Max 200 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t2.small."
     free: false
+    active: false
     metadata:
       costs:
         - amount:
@@ -342,6 +449,7 @@
     name: "medium-unencrypted-9.5"
     description: "100GB Storage, Dedicated Instance, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.large."
     free: false
+    active: false
     metadata:
       costs:
         - amount:
@@ -361,6 +469,7 @@
     name: "medium-ha-unencrypted-9.5"
     description: "100GB Storage, Dedicated Instance, Highly Available, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.large."
     free: false
+    active: false
     metadata:
       costs:
         - amount:
@@ -381,6 +490,7 @@
     name: "large-unencrypted-9.5"
     description: "512GB Storage, Dedicated Instance, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.2xlarge."
     free: false
+    active: false
     metadata:
       costs:
         - amount:
@@ -400,6 +510,7 @@
     name: "large-ha-unencrypted-9.5"
     description: "512GB Storage, Dedicated Instance, Highly Available, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.2xlarge."
     free: false
+    active: false
     metadata:
       costs:
         - amount:
@@ -420,6 +531,7 @@
     name: "xlarge-unencrypted-9.5"
     description: "2TB Storage, Dedicated Instance, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.4xlarge."
     free: false
+    active: false
     metadata:
       costs:
         - amount:
@@ -439,6 +551,7 @@
     name: "xlarge-ha-unencrypted-9.5"
     description: "2TB Storage, Dedicated Instance, Highly Available, Max 5000 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.4xlarge."
     free: false
+    active: false
     metadata:
       costs:
         - amount:

--- a/manifests/cf-manifest/operations.d/712-rds-broker-mysql57-plans.yml
+++ b/manifests/cf-manifest/operations.d/712-rds-broker-mysql57-plans.yml
@@ -40,19 +40,22 @@
   path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog?/services?/-
   value:
     id: 4b888513-1dc3-4b9b-bdcd-51f4c03675a4
-    name: "mysql"
     description: "AWS RDS MySQL service"
+    name: mysql
     bindable: true
     tags:
-      - "mysql"
-      - "relational"
+      - mysql
+      - relational
     metadata:
-      displayName: "AWS RDS MySQL"
-      imageUrl: ""
-      longDescription: "AWS RDS MySQL service"
-      providerDisplayName: "Amazon Web Services"
-      documentationUrl: "https://aws.amazon.com/documentation/rds/"
-      supportUrl: "https://forums.aws.amazon.com/forum.jspa?forumID=60"
+      displayName: AWS RDS MySQL
+      longDescription: MySQL is an open-source relational database management system (RDBMS).
+      providerDisplayName: Amazon Web Services
+      documentationUrl: https://docs.cloud.service.gov.uk/deploying_services/mysql/
+      supportUrl: https://www.cloud.service.gov.uk/support
+      AdditionalMetadata:
+        otherDocumentation:
+          - https://dev.mysql.com/doc/
+          - https://aws.amazon.com/documentation/rds/
     plan_updateable: true
 
 - type: replace
@@ -63,6 +66,16 @@
     description: "5GB Storage, NOT BACKED UP, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.t2.micro."
     free: true
     metadata:
+      AdditionalMetadata:
+        backups: false
+        encrypted: false
+        highlyAvailable: false
+        instanceClass: db.t2.micro
+        storage:
+          amount: 5
+          unit: GB
+        version: 5.7
+      displayName: Tiny
       bullets:
         - "Dedicated MySQL 5.7 server"
         - "AWS RDS"
@@ -78,6 +91,16 @@
     description: "20GB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.t2.small."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: false
+        instanceClass: db.t2.small
+        storage:
+          amount: 20
+          unit: GB
+        version: 5.7
+      displayName: Small
       costs:
         - amount:
             usd: 0.036
@@ -99,6 +122,16 @@
     description: "20GB Storage, Dedicated Instance, Highly Available. Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.t2.small."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: true
+        instanceClass: db.t2.small
+        storage:
+          amount: 20
+          unit: GB
+        version: 5.7
+      displayName: Small highly-available
       costs:
         - amount:
             usd: 0.072
@@ -120,6 +153,16 @@
     description: "100GB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.large."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: false
+        instanceClass: db.m4.large
+        storage:
+          amount: 100
+          unit: GB
+        version: 5.7
+      displayName: Medium
       costs:
         - amount:
             usd: 0.193
@@ -141,6 +184,16 @@
     description: "100GB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.large."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: true
+        instanceClass: db.m4.large
+        storage:
+          amount: 100
+          unit: GB
+        version: 5.7
+      displayName: Medium highly-available
       costs:
         - amount:
             usd: 0.386
@@ -163,6 +216,16 @@
     description: "512GB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.2xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: false
+        instanceClass: db.m4.2xlarge
+        storage:
+          amount: 512
+          unit: GB
+        version: 5.7
+      displayName: Large
       costs:
         - amount:
             usd: 0.772
@@ -184,6 +247,16 @@
     description: "512GB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.2xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: true
+        instanceClass: db.m4.2xlarge
+        storage:
+          amount: 512
+          unit: GB
+        version: 5.7
+      displayName: Large highly-available
       costs:
         - amount:
             usd: 1.544
@@ -206,6 +279,16 @@
     description: "2TB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.4xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: false
+        instanceClass: db.m4.4xlarge
+        storage:
+          amount: 2
+          unit: TB
+        version: 5.7
+      displayName: Extra Large
       costs:
         - amount:
             usd: 1.545
@@ -227,6 +310,16 @@
     description: "2TB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.4xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: true
+        instanceClass: db.m4.4xlarge
+        storage:
+          amount: 2
+          unit: TB
+        version: 5.7
+      displayName: Extra Large highly-available
       costs:
         - amount:
             usd: 3.090
@@ -250,6 +343,7 @@
     name: "small-ha-unencrypted-5.7"
     description: "20GB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.t2.small."
     free: false
+    active: false
     metadata:
       costs:
         - amount:
@@ -271,6 +365,7 @@
     name: "medium-unencrypted-5.7"
     description: "100GB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.m4.large."
     free: false
+    active: false
     metadata:
       costs:
         - amount:
@@ -291,6 +386,7 @@
     name: "medium-ha-unencrypted-5.7"
     description: "100GB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.m4.large."
     free: false
+    active: false
     metadata:
       costs:
         - amount:
@@ -312,6 +408,7 @@
     name: "large-unencrypted-5.7"
     description: "512GB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.m4.2xlarge."
     free: false
+    active: false
     metadata:
       costs:
         - amount:
@@ -332,6 +429,7 @@
     name: "large-ha-unencrypted-5.7"
     description: "512GB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.m4.2xlarge."
     free: false
+    active: false
     metadata:
       costs:
         - amount:
@@ -353,6 +451,7 @@
     name: "xlarge-unencrypted-5.7"
     description: "2TB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.m4.4xlarge."
     free: false
+    active: false
     metadata:
       costs:
         - amount:
@@ -373,6 +472,7 @@
     name: "xlarge-ha-unencrypted-5.7"
     description: "2TB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.m4.4xlarge."
     free: false
+    active: false
     metadata:
       costs:
         - amount:
@@ -394,6 +494,7 @@
     name: "small-unencrypted-5.7"
     description: "20GB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.t2.small."
     free: false
+    active: false
     metadata:
       costs:
         - amount:

--- a/manifests/cf-manifest/operations.d/713-rds-broker-mysql57-plans-high-iops.yml
+++ b/manifests/cf-manifest/operations.d/713-rds-broker-mysql57-plans-high-iops.yml
@@ -44,6 +44,17 @@
     description: "25GB Storage, NOT BACKED UP, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.t3.micro."
     free: true
     metadata:
+      AdditionalMetadata:
+        backups: false
+        encrypted: false
+        highlyAvailable: false
+        highIOPS: true
+        instanceClass: db.t3.micro
+        storage:
+          amount: 25
+          unit: GB
+        version: 5.7
+      displayName: Tiny high-IOPS
       bullets:
         - "Dedicated MySQL 5.7 server"
         - "AWS RDS"
@@ -59,6 +70,17 @@
     description: "100GB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.t3.small."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: false
+        highIOPS: true
+        instanceClass: db.t3.small
+        storage:
+          amount: 100
+          unit: GB
+        version: 5.7
+      displayName: Small high-IOPS
       costs:
         - amount:
             usd: 0.038
@@ -80,6 +102,17 @@
     description: "100GB Storage, Dedicated Instance, Highly Available. Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.t3.small."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: true
+        highIOPS: true
+        instanceClass: db.t3.small
+        storage:
+          amount: 100
+          unit: GB
+        version: 5.7
+      displayName: Small highly-available high-IOPS
       costs:
         - amount:
             usd: 0.076
@@ -101,6 +134,17 @@
     description: "500GB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m5.large."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: false
+        highIOPS: true
+        instanceClass: db.m5.large
+        storage:
+          amount: 500
+          unit: GB
+        version: 5.7
+      displayName: Medium high-IOPS
       costs:
         - amount:
             usd: 0.198
@@ -122,6 +166,17 @@
     description: "500GB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m5.large."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: true
+        highIOPS: true
+        instanceClass: db.m5.large
+        storage:
+          amount: 500
+          unit: GB
+        version: 5.7
+      displayName: Medium highly-available high-IOPS
       costs:
         - amount:
             usd: 0.396
@@ -144,6 +199,17 @@
     description: "2.5TB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m5.2xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: false
+        highIOPS: true
+        instanceClass: db.m5.2xlarge
+        storage:
+          amount: 2.5
+          unit: TB
+        version: 5.7
+      displayName: Large high-IOPS
       costs:
         - amount:
             usd: 0.792
@@ -165,6 +231,17 @@
     description: "2.5TB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m5.2xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: true
+        highIOPS: true
+        instanceClass: db.m5.2xlarge
+        storage:
+          amount: 2.5
+          unit: TB
+        version: 5.7
+      displayName: Large highly-available high-IOPS
       costs:
         - amount:
             usd: 1.584
@@ -187,6 +264,17 @@
     description: "10TB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m5.4xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: false
+        highIOPS: true
+        instanceClass: db.m5.4xlarge
+        storage:
+          amount: 10
+          unit: TB
+        version: 5.7
+      displayName: Extra Large high-IOPS
       costs:
         - amount:
             usd: 1.584
@@ -208,6 +296,17 @@
     description: "10TB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m5.4xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: true
+        highIOPS: true
+        instanceClass: db.m5.4xlarge
+        storage:
+          amount: 10
+          unit: TB
+        version: 5.7
+      displayName: Extra Large highly-available high-IOPS
       costs:
         - amount:
             usd: 3.168

--- a/manifests/cf-manifest/operations.d/714-rds-broker-postgres10-high-iops-plans.yml
+++ b/manifests/cf-manifest/operations.d/714-rds-broker-postgres10-high-iops-plans.yml
@@ -106,6 +106,18 @@
     description: "25GB Storage, NOT BACKED UP, Dedicated Instance, Max 50 Concurrent Connections. Postgres Version 10. DB Instance Class: db.t3.micro."
     free: true
     metadata:
+      AdditionalMetadata:
+        backups: false
+        concurrentConnections: 50
+        encrypted: false
+        highlyAvailable: false
+        highIOPS: true
+        instanceClass: db.t3.micro
+        storage:
+          amount: 25
+          unit: GB
+        version: 10
+      displayName: Tiny high-IOPS
       bullets:
         - "Dedicated Postgres 10 server"
         - "AWS RDS"
@@ -121,6 +133,18 @@
     description: "100GB Storage, Dedicated Instance, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 10. DB Instance Class: db.t3.small."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 200
+        encrypted: true
+        highlyAvailable: false
+        highIOPS: true
+        instanceClass: db.t3.small
+        storage:
+          amount: 100
+          unit: GB
+        version: 10
+      displayName: Small high-IOPS
       costs:
         - amount:
             usd: 0.039
@@ -142,6 +166,18 @@
     description: "100GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 10. DB Instance Class: db.t3.small."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 200
+        encrypted: true
+        highlyAvailable: true
+        highIOPS: true
+        instanceClass: db.t3.small
+        storage:
+          amount: 100
+          unit: GB
+        version: 10
+      displayName: Small highly-available high-IOPS
       costs:
         - amount:
             usd: 0.078
@@ -163,6 +199,18 @@
     description: "500GB Storage, Dedicated Instance, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m5.large."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 500
+        encrypted: true
+        highlyAvailable: false
+        highIOPS: true
+        instanceClass: db.m5.large
+        storage:
+          amount: 500
+          unit: GB
+        version: 10
+      displayName: Medium high-IOPS
       costs:
         - amount:
             usd: 0.197
@@ -184,6 +232,18 @@
     description: "500GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m5.large."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 500
+        encrypted: true
+        highlyAvailable: true
+        highIOPS: true
+        instanceClass: db.m5.large
+        storage:
+          amount: 500
+          unit: GB
+        version: 10
+      displayName: Medium highly-available high-IOPS
       costs:
         - amount:
             usd: 0.394
@@ -206,6 +266,18 @@
     description: "2.5TB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m5.2xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: false
+        highIOPS: true
+        instanceClass: db.m5.2xlarge
+        storage:
+          amount: 2.5
+          unit: TB
+        version: 10
+      displayName: Large high-IOPS
       costs:
         - amount:
             usd: 0.788
@@ -227,6 +299,18 @@
     description: "2.5TB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m5.2xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: true
+        highIOPS: true
+        instanceClass: db.m5.2xlarge
+        storage:
+          amount: 2.5
+          unit: TB
+        version: 10
+      displayName: Large highly-available high-IOPS
       costs:
         - amount:
             usd: 1.576
@@ -249,6 +333,18 @@
     description: "10TB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m5.4xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: false
+        highIOPS: true
+        instanceClass: db.m5.4xlarge
+        storage:
+          amount: 10
+          unit: TB
+        version: 10
+      displayName: Extra Large high-IOPS
       costs:
         - amount:
             usd: 1.576
@@ -270,6 +366,18 @@
     description: "10TB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m5.4xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: true
+        highIOPS: true
+        instanceClass: db.m5.4xlarge
+        storage:
+          amount: 10
+          unit: TB
+        version: 10
+      displayName: Extra Large highly-available high-IOPS
       costs:
         - amount:
             usd: 3.152

--- a/manifests/cf-manifest/operations.d/715-rds-broker-postgres10-plans.yml
+++ b/manifests/cf-manifest/operations.d/715-rds-broker-postgres10-plans.yml
@@ -106,6 +106,17 @@
     description: "5GB Storage, NOT BACKED UP, Dedicated Instance, Max 50 Concurrent Connections. Postgres Version 10. DB Instance Class: db.t2.micro."
     free: true
     metadata:
+      AdditionalMetadata:
+        backups: false
+        concurrentConnections: 50
+        encrypted: false
+        highlyAvailable: false
+        instanceClass: db.t2.micro
+        storage:
+          amount: 5
+          unit: GB
+        version: 10
+      displayName: Tiny
       bullets:
         - "Dedicated Postgres 10 server"
         - "AWS RDS"
@@ -121,6 +132,17 @@
     description: "20GB Storage, Dedicated Instance, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 10. DB Instance Class: db.t2.small."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 200
+        encrypted: true
+        highlyAvailable: false
+        instanceClass: db.t2.small
+        storage:
+          amount: 20
+          unit: GB
+        version: 10
+      displayName: Small
       costs:
         - amount:
             usd: 0.039
@@ -142,6 +164,17 @@
     description: "20GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 10. DB Instance Class: db.t2.small."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 200
+        encrypted: true
+        highlyAvailable: true
+        instanceClass: db.t2.small
+        storage:
+          amount: 20
+          unit: GB
+        version: 10
+      displayName: Small highly-available
       costs:
         - amount:
             usd: 0.078
@@ -163,6 +196,17 @@
     description: "100GB Storage, Dedicated Instance, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m4.large."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 500
+        encrypted: true
+        highlyAvailable: false
+        instanceClass: db.m4.large
+        storage:
+          amount: 100
+          unit: GB
+        version: 10
+      displayName: Medium
       costs:
         - amount:
             usd: 0.201
@@ -184,6 +228,17 @@
     description: "100GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m4.large."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 500
+        encrypted: true
+        highlyAvailable: true
+        instanceClass: db.m4.large
+        storage:
+          amount: 100
+          unit: GB
+        version: 10
+      displayName: Medium highly-available
       costs:
         - amount:
             usd: 0.402
@@ -206,6 +261,17 @@
     description: "512GB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m4.2xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: false
+        instanceClass: db.m4.2xlarge
+        storage:
+          amount: 512
+          unit: GB
+        version: 10
+      displayName: Large
       costs:
         - amount:
             usd: 0.806
@@ -227,6 +293,17 @@
     description: "512GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m4.2xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: true
+        instanceClass: db.m4.2xlarge
+        storage:
+          amount: 512
+          unit: GB
+        version: 10
+      displayName: Large highly-available
       costs:
         - amount:
             usd: 1.612
@@ -249,6 +326,17 @@
     description: "2TB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m4.4xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: false
+        instanceClass: db.m4.4xlarge
+        storage:
+          amount: 2
+          unit: TB
+        version: 10
+      displayName: Extra Large
       costs:
         - amount:
             usd: 1.612
@@ -270,6 +358,17 @@
     description: "2TB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m4.4xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: true
+        instanceClass: db.m4.4xlarge
+        storage:
+          amount: 2
+          unit: TB
+        version: 10
+      displayName: Extra Large highly-available
       costs:
         - amount:
             usd: 3.224

--- a/manifests/cf-manifest/operations.d/716-rds-broker-postgres11-plans.yml
+++ b/manifests/cf-manifest/operations.d/716-rds-broker-postgres11-plans.yml
@@ -106,6 +106,17 @@
     description: "5GB Storage, NOT BACKED UP, Dedicated Instance, Max 50 Concurrent Connections. Postgres Version 11. DB Instance Class: db.t3.micro."
     free: true
     metadata:
+      AdditionalMetadata:
+        backups: false
+        concurrentConnections: 50
+        encrypted: false
+        highlyAvailable: false
+        instanceClass: db.t3.micro
+        storage:
+          amount: 5
+          unit: GB
+        version: 11
+      displayName: Tiny
       bullets:
         - "Dedicated Postgres 11 server"
         - "AWS RDS"
@@ -121,6 +132,21 @@
     description: "100GB Storage, Dedicated Instance, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 11. DB Instance Class: db.t3.small."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 200
+        encrypted: true
+        highlyAvailable: false
+        instanceClass: db.t3.small
+        storage:
+          amount: 100
+          unit: GB
+        version: 11
+      displayName: Small
+      costs:
+        - amount:
+            usd: 0.039
+          unit: "HOUR"
       bullets:
         - "Dedicated Postgres 11 server"
         - "Storage Encrypted"
@@ -138,6 +164,21 @@
     description: "100GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 11. DB Instance Class: db.t3.small."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 200
+        encrypted: true
+        highlyAvailable: true
+        instanceClass: db.t3.small
+        storage:
+          amount: 100
+          unit: GB
+        version: 11
+      displayName: Small highly-available
+      costs:
+        - amount:
+            usd: 0.078
+          unit: "HOUR"
       bullets:
         - "Dedicated Postgres 11 server"
         - "AWS RDS"
@@ -155,6 +196,21 @@
     description: "100GB Storage, Dedicated Instance, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 11. DB Instance Class: db.m5.large."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 500
+        encrypted: true
+        highlyAvailable: false
+        instanceClass: db.m5.large
+        storage:
+          amount: 100
+          unit: GB
+        version: 11
+      displayName: Medium
+      costs:
+        - amount:
+            usd: 0.201
+          unit: "HOUR"
       bullets:
         - "Dedicated Postgres 11 server"
         - "Storage Encrypted"
@@ -172,6 +228,21 @@
     description: "100GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 11. DB Instance Class: db.m5.large."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 500
+        encrypted: true
+        highlyAvailable: true
+        instanceClass: db.m5.large
+        storage:
+          amount: 100
+          unit: GB
+        version: 11
+      displayName: Medium highly-available
+      costs:
+        - amount:
+            usd: 0.402
+          unit: "HOUR"
       bullets:
         - "Dedicated Postgres 11 server"
         - "Storage Encrypted"
@@ -190,6 +261,21 @@
     description: "512GB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 11. DB Instance Class: db.m5.2xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: false
+        instanceClass: db.m5.2xlarge
+        storage:
+          amount: 512
+          unit: GB
+        version: 11
+      displayName: Large
+      costs:
+        - amount:
+            usd: 0.806
+          unit: "HOUR"
       bullets:
         - "Dedicated Postgres 11 server"
         - "Storage Encrypted"
@@ -207,6 +293,21 @@
     description: "512GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 11. DB Instance Class: db.m5.2xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: true
+        instanceClass: db.m5.2xlarge
+        storage:
+          amount: 512
+          unit: GB
+        version: 11
+      displayName: Large highly-available
+      costs:
+        - amount:
+            usd: 1.612
+          unit: "HOUR"
       bullets:
         - "Dedicated Postgres 11 server"
         - "Storage Encrypted"
@@ -225,6 +326,21 @@
     description: "2TB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 11. DB Instance Class: db.m5.4xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: false
+        instanceClass: db.m5.4xlarge
+        storage:
+          amount: 2
+          unit: TB
+        version: 11
+      displayName: Extra Large
+      costs:
+        - amount:
+            usd: 1.612
+          unit: "HOUR"
       bullets:
         - "Dedicated Postgres 11 server"
         - "Storage Encrypted"
@@ -242,6 +358,21 @@
     description: "2TB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 11. DB Instance Class: db.m5.4xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: true
+        instanceClass: db.m5.4xlarge
+        storage:
+          amount: 2
+          unit: TB
+        version: 11
+      displayName: Extra Large highly-available
+      costs:
+        - amount:
+            usd: 3.224
+          unit: "HOUR"
       bullets:
         - "Dedicated Postgres 11 server"
         - "Storage Encrypted"

--- a/manifests/cf-manifest/operations.d/717-rds-broker-postgres11-high-iops-plans.yml
+++ b/manifests/cf-manifest/operations.d/717-rds-broker-postgres11-high-iops-plans.yml
@@ -106,10 +106,18 @@
     description: "25GB Storage, NOT BACKED UP, Dedicated Instance, Max 50 Concurrent Connections. Postgres Version 11. DB Instance Class: db.t3.micro."
     free: true
     metadata:
-      costs:
-        - amount:
-            usd: 0.039
-          unit: "HOUR"
+      AdditionalMetadata:
+        backups: false
+        concurrentConnections: 50
+        encrypted: false
+        highlyAvailable: false
+        highIOPS: true
+        instanceClass: db.t3.micro
+        storage:
+          amount: 25
+          unit: GB
+        version: 11
+      displayName: Tiny high-IOPS
       bullets:
         - "Dedicated Postgres 11 server"
         - "AWS RDS"
@@ -125,9 +133,21 @@
     description: "100GB Storage, Dedicated Instance, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 11. DB Instance Class: db.t3.small."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 200
+        encrypted: true
+        highlyAvailable: false
+        highIOPS: true
+        instanceClass: db.t3.small
+        storage:
+          amount: 100
+          unit: GB
+        version: 11
+      displayName: Small high-IOPS
       costs:
         - amount:
-            usd: 0.078
+            usd: 0.039
           unit: "HOUR"
       bullets:
         - "Dedicated Postgres 11 server"
@@ -146,6 +166,22 @@
     description: "100GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 11. DB Instance Class: db.t3.small."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 200
+        encrypted: true
+        highlyAvailable: true
+        highIOPS: true
+        instanceClass: db.t3.small
+        storage:
+          amount: 100
+          unit: GB
+        version: 11
+      displayName: Small highly-available high-IOPS
+      costs:
+        - amount:
+            usd: 0.078
+          unit: "HOUR"
       bullets:
         - "Dedicated Postgres 11 server"
         - "AWS RDS"
@@ -163,6 +199,18 @@
     description: "500GB Storage, Dedicated Instance, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 11. DB Instance Class: db.m5.large."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 500
+        encrypted: true
+        highlyAvailable: false
+        highIOPS: true
+        instanceClass: db.m5.large
+        storage:
+          amount: 500
+          unit: GB
+        version: 11
+      displayName: Medium high-IOPS
       costs:
         - amount:
             usd: 0.197
@@ -184,6 +232,18 @@
     description: "500GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 11. DB Instance Class: db.m5.large."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 500
+        encrypted: true
+        highlyAvailable: true
+        highIOPS: true
+        instanceClass: db.m5.large
+        storage:
+          amount: 500
+          unit: GB
+        version: 11
+      displayName: Medium highly-available high-IOPS
       costs:
         - amount:
             usd: 0.394
@@ -206,6 +266,18 @@
     description: "2.5TB Storage Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 11. DB Instance Class: db.m5.2xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: false
+        highIOPS: true
+        instanceClass: db.m5.2xlarge
+        storage:
+          amount: 2.5
+          unit: TB
+        version: 11
+      displayName: Large high-IOPS
       costs:
         - amount:
             usd: 0.788
@@ -227,6 +299,18 @@
     description: "2.5TB Storage Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 11. DB Instance Class: db.m5.2xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: true
+        highIOPS: true
+        instanceClass: db.m5.2xlarge
+        storage:
+          amount: 2.5
+          unit: TB
+        version: 11
+      displayName: Large highly-available high-IOPS
       costs:
         - amount:
             usd: 1.576
@@ -249,6 +333,18 @@
     description: "10TB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 11. DB Instance Class: db.m5.4xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: false
+        highIOPS: true
+        instanceClass: db.m5.4xlarge
+        storage:
+          amount: 10
+          unit: TB
+        version: 11
+      displayName: Extra Large high-IOPS
       costs:
         - amount:
             usd: 1.576
@@ -270,6 +366,18 @@
     description: "10TB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 11. DB Instance Class: db.m5.4xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: true
+        highIOPS: true
+        instanceClass: db.m5.4xlarge
+        storage:
+          amount: 10
+          unit: TB
+        version: 11
+      displayName: Extra Large highly-available high-IOPS
       costs:
         - amount:
             usd: 3.152

--- a/manifests/cf-manifest/operations.d/718-rds-broker-mysql80-plans.yml
+++ b/manifests/cf-manifest/operations.d/718-rds-broker-mysql80-plans.yml
@@ -44,6 +44,16 @@
     description: "5GB Storage, NOT BACKED UP, Dedicated Instance. MySQL Version 8.0. DB Instance Class: db.t3.micro."
     free: true
     metadata:
+      AdditionalMetadata:
+        backups: false
+        encrypted: false
+        highlyAvailable: false
+        instanceClass: db.t3.micro
+        storage:
+          amount: 5
+          unit: GB
+        version: 8.0
+      displayName: Tiny
       bullets:
         - "Dedicated MySQL 8.0 server"
         - "AWS RDS"
@@ -59,6 +69,16 @@
     description: "100GB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 8.0. DB Instance Class: db.t3.small."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: false
+        instanceClass: db.t3.small
+        storage:
+          amount: 100
+          unit: GB
+        version: 8.0
+      displayName: Small
       costs:
         - amount:
             usd: 0.036
@@ -80,6 +100,16 @@
     description: "100GB Storage, Dedicated Instance, Highly Available. Storage Encrypted. MySQL Version 8.0. DB Instance Class: db.t3.small."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: true
+        instanceClass: db.t3.small
+        storage:
+          amount: 100
+          unit: GB
+        version: 8.0
+      displayName: Small highly-available
       costs:
         - amount:
             usd: 0.072
@@ -101,6 +131,16 @@
     description: "100GB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 8.0. DB Instance Class: db.m5.large."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: false
+        instanceClass: db.m5.large
+        storage:
+          amount: 100
+          unit: GB
+        version: 8.0
+      displayName: Medium
       costs:
         - amount:
             usd: 0.193
@@ -122,6 +162,16 @@
     description: "100GB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 8.0. DB Instance Class: db.m5.large."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: true
+        instanceClass: db.m5.large
+        storage:
+          amount: 100
+          unit: GB
+        version: 8.0
+      displayName: Medium highly-available
       costs:
         - amount:
             usd: 0.386
@@ -144,6 +194,16 @@
     description: "512GB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 8.0. DB Instance Class: db.m5.2xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: false
+        instanceClass: db.m5.2xlarge
+        storage:
+          amount: 512
+          unit: GB
+        version: 8.0
+      displayName: Large
       costs:
         - amount:
             usd: 0.772
@@ -165,6 +225,16 @@
     description: "512GB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 8.0. DB Instance Class: db.m5.2xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: true
+        instanceClass: db.m5.2xlarge
+        storage:
+          amount: 512
+          unit: GB
+        version: 8.0
+      displayName: Large highly-available
       costs:
         - amount:
             usd: 1.544
@@ -187,6 +257,16 @@
     description: "2TB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 8.0. DB Instance Class: db.m5.4xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: false
+        instanceClass: db.m5.4xlarge
+        storage:
+          amount: 2
+          unit: TB
+        version: 8.0
+      displayName: Extra Large
       costs:
         - amount:
             usd: 1.545
@@ -208,6 +288,16 @@
     description: "2TB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 8.0. DB Instance Class: db.m5.4xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: true
+        instanceClass: db.m5.4xlarge
+        storage:
+          amount: 2
+          unit: TB
+        version: 8.0
+      displayName: Extra Large highly-available
       costs:
         - amount:
             usd: 3.090

--- a/manifests/cf-manifest/operations.d/719-rds-broker-mysql80-plans-high-iops.yml
+++ b/manifests/cf-manifest/operations.d/719-rds-broker-mysql80-plans-high-iops.yml
@@ -44,6 +44,17 @@
     description: "25GB Storage, NOT BACKED UP, Dedicated Instance. MySQL Version 8.0. DB Instance Class: db.t3.micro."
     free: true
     metadata:
+      AdditionalMetadata:
+        backups: false
+        encrypted: false
+        highlyAvailable: false
+        highIOPS: true
+        instanceClass: db.t3.micro
+        storage:
+          amount: 25
+          unit: GB
+        version: 8.0
+      displayName: Tiny high-IOPS
       bullets:
         - "Dedicated MySQL 8.0 server"
         - "AWS RDS"
@@ -59,6 +70,17 @@
     description: "100GB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 8.0. DB Instance Class: db.t3.small."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: false
+        highIOPS: true
+        instanceClass: db.t3.small
+        storage:
+          amount: 100
+          unit: GB
+        version: 8.0
+      displayName: Small high-IOPS
       costs:
         - amount:
             usd: 0.038
@@ -80,6 +102,17 @@
     description: "100GB Storage, Dedicated Instance, Highly Available. Storage Encrypted. MySQL Version 8.0. DB Instance Class: db.t3.small."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: true
+        highIOPS: true
+        instanceClass: db.t3.small
+        storage:
+          amount: 100
+          unit: GB
+        version: 8.0
+      displayName: Small highly-available high-IOPS
       costs:
         - amount:
             usd: 0.076
@@ -101,6 +134,17 @@
     description: "500GB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 8.0. DB Instance Class: db.m5.large."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: false
+        highIOPS: true
+        instanceClass: db.m5.large
+        storage:
+          amount: 500
+          unit: GB
+        version: 8.0
+      displayName: Medium high-IOPS
       costs:
         - amount:
             usd: 0.198
@@ -122,6 +166,17 @@
     description: "500GB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 8.0. DB Instance Class: db.m5.large."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: true
+        highIOPS: true
+        instanceClass: db.m5.large
+        storage:
+          amount: 500
+          unit: GB
+        version: 8.0
+      displayName: Medium highly-available high-IOPS
       costs:
         - amount:
             usd: 0.396
@@ -144,6 +199,17 @@
     description: "2.5TB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 8.0. DB Instance Class: db.m5.2xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: false
+        highIOPS: true
+        instanceClass: db.m5.2xlarge
+        storage:
+          amount: 2.5
+          unit: TB
+        version: 8.0
+      displayName: Large high-IOPS
       costs:
         - amount:
             usd: 0.792
@@ -165,6 +231,17 @@
     description: "2.5TB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 8.0. DB Instance Class: db.m5.2xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: true
+        highIOPS: true
+        instanceClass: db.m5.2xlarge
+        storage:
+          amount: 2.5
+          unit: TB
+        version: 8.0
+      displayName: Large highly-available high-IOPS
       costs:
         - amount:
             usd: 1.584
@@ -187,6 +264,17 @@
     description: "10TB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 8.0. DB Instance Class: db.m5.4xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: false
+        highIOPS: true
+        instanceClass: db.m5.4xlarge
+        storage:
+          amount: 10
+          unit: TB
+        version: 8.0
+      displayName: Extra Large high-IOPS
       costs:
         - amount:
             usd: 1.584
@@ -208,6 +296,17 @@
     description: "10TB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 8.0. DB Instance Class: db.m5.4xlarge."
     free: false
     metadata:
+      AdditionalMetadata:
+        backups: true
+        encrypted: true
+        highlyAvailable: true
+        highIOPS: true
+        instanceClass: db.m5.4xlarge
+        storage:
+          amount: 10
+          unit: TB
+        version: 8.0
+      displayName: Extra Large highly-available high-IOPS
       costs:
         - amount:
             usd: 3.168

--- a/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
+++ b/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
@@ -52,9 +52,9 @@
   path: /releases/-
   value:
     name: elasticache-broker
-    version: 0.1.13
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/elasticache-broker-0.1.13.tgz
-    sha1: 09efc6337cd4ef2d56632807d8bab622d522393e
+    version: 0.1.14
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/elasticache-broker-0.1.14.tgz
+    sha1: eb853ce373fdd735a7b0166345935150265ec06d
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-

--- a/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
+++ b/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
@@ -96,11 +96,22 @@
                   description: AWS ElastiCache Redis service
                   metadata:
                     displayName: Redis
-                    imageUrl: https://redis.io/images/redis-white.png
-                    longDescription: AWS ElastiCache Redis cluster
-                    providerDisplayName: GOV.UK PaaS
-                    documentationUrl: https://docs.cloud.service.gov.uk/#redis
-                    supportUrl: https://www.cloud.service.gov.uk/support.html
+                    longDescription: |
+                      Redis is an in-memory data structure project implementing a distributed, in-memory key-value 
+                      database with optional durability. Redis supports different kinds of abstract data structures,
+                      such as strings, lists, maps, sets, sorted sets, HyperLogLogs, bitmaps, streams, and spatial
+                      indexes.
+                    providerDisplayName: Amazon Web Services
+                    documentationUrl: https://docs.cloud.service.gov.uk/deploying_services/redis/
+                    supportUrl: https://www.cloud.service.gov.uk/support
+                    AdditionalMetadata:
+                      otherDocumentation:
+                        - https://redis.io/documentation
+                        - https://docs.aws.amazon.com/elasticache
+                      usecase:
+                        - Cache
+                        - Session management
+                        - Queues
                   tags:
                     - elasticache
                     - redis
@@ -110,10 +121,11 @@
                     # Deprecated
                     - id: 3a51701c-eef3-447c-882b-907ad2bcb7ab
                       name: tiny-clustered-3.2
+                      active: false
                       description: DEPRECATED - do not use, 568MB RAM, clustered (1 shard), single node, no failover, daily backups
                       free: true
                       metadata:
-                        displayName: Redis 3.2 Clustered Tiny
+                        displayName: Clustered Tiny
 
                     # 3.2
                     - id: c84d1bef-9500-4ce9-88b2-c0bd421bbf8a
@@ -121,25 +133,57 @@
                       description: 568MB RAM, single node, no failover, daily backups (for instances created after 21/1/2019)
                       free: true
                       metadata:
-                        displayName: Redis 3.2 tiny
+                        displayName: Tiny
+                        AdditionalMetadata:
+                          backups: true
+                          encrypted: true
+                          highlyAvailable: false
+                          memory:
+                            amount: 568
+                            unit: MB
+                          version: 3.2
                     - id: ea5c8cc3-74e6-4b15-bd61-bbe244cfe63d
                       name: tiny-ha-3.2
                       description: 1.5GB RAM, highly-available, daily backups
                       free: false
                       metadata:
-                        displayName: Redis 3.2 tiny highly-available
+                        displayName: Tiny
+                        AdditionalMetadata:
+                          backups: true
+                          encrypted: true
+                          highlyAvailable: true
+                          memory:
+                            amount: 1.5
+                            unit: GB
+                          version: 3.2
                     - id: 9162ed5b-0c88-4f43-bcaf-c6d4a45dd243
                       name: small-ha-3.2
                       description: 3GB RAM, highly-available, daily backups
                       free: false
                       metadata:
-                        displayName: Redis 3.2 small highly-available
+                        displayName: Small
+                        AdditionalMetadata:
+                          backups: true
+                          encrypted: true
+                          highlyAvailable: true
+                          memory:
+                            amount: 3
+                            unit: GB
+                          version: 3.2
                     - id: b6949ea7-5c98-4c69-b981-4b5318ea8b7c
                       name: medium-ha-3.2
                       description: 6.37GB RAM, highly-available, daily backups
                       free: false
                       metadata:
-                        displayName: Redis 3.2 medium highly-available
+                        displayName: Medium
+                        AdditionalMetadata:
+                          backups: true
+                          encrypted: true
+                          highlyAvailable: true
+                          memory:
+                            amount: 6.37
+                            unit: GB
+                          version: 3.2
 
                     # 4.x
                     - id: b78c9d07-a031-495f-937c-28613905431c
@@ -147,37 +191,85 @@
                       description: 568MB RAM, single node, no failover, daily backups (for instances created after 21/1/2019)
                       free: true
                       metadata:
-                        displayName: Redis 4.x tiny
+                        displayName: Tiny
+                        AdditionalMetadata:
+                          backups: true
+                          encrypted: true
+                          highlyAvailable: false
+                          memory:
+                            amount: 568
+                            unit: MB
+                          version: 4
                     - id: e31d1a05-4f75-4bca-93a0-661bc233d25c
                       name: tiny-ha-4.x
                       description: 1.5GB RAM, highly-available, daily backups
                       free: false
                       metadata:
-                        displayName: Redis 4.x tiny highly-available
+                        displayName: Tiny
+                        AdditionalMetadata:
+                          backups: true
+                          encrypted: true
+                          highlyAvailable: true
+                          memory:
+                            amount: 1.5
+                            unit: GB
+                          version: 4
                     - id: 09e7088e-125e-4805-9eff-02bf61ee0146
                       name: small-ha-4.x
                       description: 3GB RAM, highly-available, daily backups
                       free: false
                       metadata:
-                        displayName: Redis 4.x small highly-available
+                        displayName: Small
+                        AdditionalMetadata:
+                          backups: true
+                          encrypted: true
+                          highlyAvailable: true
+                          memory:
+                            amount: 3
+                            unit: GB
+                          version: 4
                     - id: f210be07-8ea3-4295-a929-2dec0ae4cd30
                       name: medium-ha-4.x
                       description: 6.37GB RAM, highly-available, daily backups
                       free: false
                       metadata:
-                        displayName: Redis 4.x medium highly-available
+                        displayName: Medium
+                        AdditionalMetadata:
+                          backups: true
+                          encrypted: true
+                          highlyAvailable: true
+                          memory:
+                            amount: 6.37
+                            unit: GB
+                          version: 4
                     - id: 4b5913cd-c39b-457c-8f77-eb9a95d63ba8
                       name: large-ha-4.x
                       description: 12.93GB RAM, highly-available, daily backups
                       free: false
                       metadata:
-                        displayName: Redis 4.x large highly-available
+                        displayName: Large
+                        AdditionalMetadata:
+                          backups: true
+                          encrypted: true
+                          highlyAvailable: true
+                          memory:
+                            amount: 12.93
+                            unit: GB
+                          version: 4
                     - id: e6e8e4c4-5f2e-4add-89d6-ce417f145c19
                       name: xlarge-ha-4.x
                       description: 26.04GB RAM, highly-available, daily backups
                       free: false
                       metadata:
-                        displayName: Redis 4.x xlarge highly-available
+                        displayName: XLarge
+                        AdditionalMetadata:
+                          backups: true
+                          encrypted: true
+                          highlyAvailable: true
+                          memory:
+                            amount: 26.04
+                            unit: GB
+                          version: 4
 
                     # 5.x
                     - id: 1f2cccd7-d9a9-4b9a-b517-73b381848b73
@@ -185,37 +277,85 @@
                       description: 568MB RAM, single node, no failover, daily backups (for instances created after 21/1/2019)
                       free: true
                       metadata:
-                        displayName: Redis 5.x tiny
+                        displayName: Tiny
+                        AdditionalMetadata:
+                          backups: true
+                          encrypted: true
+                          highlyAvailable: false
+                          memory:
+                            amount: 568
+                            unit: MB
+                          version: 5
                     - id: c12a6a40-fb53-4e1e-b0a9-ba5e3180e3b7
                       name: tiny-ha-5.x
                       description: 1.5GB RAM, highly-available, daily backups
                       free: false
                       metadata:
-                        displayName: Redis 5.x tiny highly-available
+                        displayName: Tiny
+                        AdditionalMetadata:
+                          backups: true
+                          encrypted: true
+                          highlyAvailable: true
+                          memory:
+                            amount: 1.5
+                            unit: GB
+                          version: 5
                     - id: 07479e46-0169-4395-91d8-e125efb17e2c
                       name: small-ha-5.x
                       description: 3GB RAM, highly-available, daily backups
                       free: false
                       metadata:
-                        displayName: Redis 5.x small highly-available
+                        displayName: Small
+                        AdditionalMetadata:
+                          backups: true
+                          encrypted: true
+                          highlyAvailable: true
+                          memory:
+                            amount: 3
+                            unit: GB
+                          version: 5
                     - id: a5ee300e-9c75-45f3-939b-d74ca4c178e7
                       name: medium-ha-5.x
                       description: 6.37GB RAM, highly-available, daily backups
                       free: false
                       metadata:
-                        displayName: Redis 5.x medium highly-available
+                        displayName: Medium
+                        AdditionalMetadata:
+                          backups: true
+                          encrypted: true
+                          highlyAvailable: true
+                          memory:
+                            amount: 6.37
+                            unit: GB
+                          version: 5
                     - id: 883c0549-cacd-4d73-adf8-85096a3c39a4
                       name: large-ha-5.x
                       description: 12.93GB RAM, highly-available, daily backups
                       free: false
                       metadata:
-                        displayName: Redis 5.x large highly-available
+                        displayName: Large
+                        AdditionalMetadata:
+                          backups: true
+                          encrypted: true
+                          highlyAvailable: true
+                          memory:
+                            amount: 12.93
+                            unit: GB
+                          version: 5
                     - id: f60443d9-3e9f-4c9b-8653-c83b6418292e
                       name: xlarge-ha-5.x
                       description: 26.04GB RAM, highly-available, daily backups
                       free: false
                       metadata:
-                        displayName: Redis 5.x xlarge highly-available
+                        displayName: XLarge
+                        AdditionalMetadata:
+                          backups: true
+                          encrypted: true
+                          highlyAvailable: true
+                          memory:
+                            amount: 26.04
+                            unit: GB
+                          version: 5
 
             plan_configs:
               3a51701c-eef3-447c-882b-907ad2bcb7ab: #tiny-clustered-3.2

--- a/manifests/cf-manifest/operations.d/750-s3-broker.yml
+++ b/manifests/cf-manifest/operations.d/750-s3-broker.yml
@@ -52,10 +52,18 @@
                   description: Object storage with AWS S3
                   metadata:
                     displayName: AWS S3 Object Store
-                    longDescription: AWS S3 Object Store
-                    providerDisplayName: GOV.UK PaaS
-                    documentationUrl: https://docs.cloud.service.gov.uk/#s3
-                    supportUrl: https://www.cloud.service.gov.uk/support.html
+                    longDescription: |
+                      Amazon Simple Storage Service (AWS S3) is a service offered by Amazon Web Services (AWS) that 
+                      provides object storage through a web service interface.
+                    providerDisplayName: Amazon Web Services
+                    documentationUrl: https://docs.cloud.service.gov.uk/deploying_services/s3/
+                    supportUrl: https://www.cloud.service.gov.uk/support
+                    AdditionalMetadata:
+                      otherDocumentation:
+                        - https://docs.aws.amazon.com/s3
+                      usecase:
+                        - Assets storage
+                        - File Uploads persistance
                   tags:
                     - s3
                   bindable: true
@@ -66,7 +74,12 @@
                       description: A single S3 bucket
                       free: true
                       metadata:
-                        displayName: A single S3 bucket
+                        displayName: Default
+                        AdditionalMetadata:
+                          backups: true
+                          encrypted: true
+                          highlyAvailable: true
+                          version: standard
 
 - type: replace
   path: /variables/-

--- a/manifests/cf-manifest/operations.d/750-s3-broker.yml
+++ b/manifests/cf-manifest/operations.d/750-s3-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: s3-broker
-    version: 0.1.12
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/s3-broker-0.1.12.tgz
-    sha1: 07d3d7d89e0381f4b337f2d24abf9c8b37e3e561
+    version: 0.1.13
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/s3-broker-0.1.13.tgz
+    sha1: 987580a4f67544139baddf3e55f2782fea20d675
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-


### PR DESCRIPTION
What
----

The goal is to have some nicely presented data in our PaaS Admin tool.
The ServiceBroker API supports metadata bag of keys, so we're coming up
with our custom schema for that data to be presented.

This should be non-invasive procedure provided we're not removing GUIDs
or plans.

One potentially drastic change, is me setting the `active: false` flag
to the deprecated plans, with hope that these will no longer be
available for consumption. Tell me off.

How to review
-------------

- Sanity check