### PR TITLE
Drop debug logs from Cloud Controller job queue

### DIFF
--- a/config/logit/20_custom_cf_filters.conf
+++ b/config/logit/20_custom_cf_filters.conf
@@ -1,3 +1,10 @@
+# Drop potentially sensitive log lines from the Cloud Controller job queue
+if [@source][component] =~ "cloud_controller" {
+  if [@message] =~ "about to run job" {
+    drop { }
+  }
+}
+
 if [garden][data][spec] == "" {
   mutate {
     remove_field => [ "[garden][data][spec]" ]

--- a/config/logit/output/generated_logit_filters.conf
+++ b/config/logit/output/generated_logit_filters.conf
@@ -988,6 +988,13 @@ filter {
     remove_field => [ "@version", "host", "port", "_logstash_input" ]
   }
 
+  # Drop potentially sensitive log lines from the Cloud Controller job queue
+  if [@source][component] =~ "cloud_controller" {
+    if [@message] =~ "about to run job" {
+      drop { }
+    }
+  }
+
   if [garden][data][spec] == "" {
     mutate {
       remove_field => [ "[garden][data][spec]" ]


### PR DESCRIPTION
What
----

You know what.

How to review
-------------

* Code review.
* See that this has worked in staging:

<img width="891" alt="Screenshot 2020-02-07 at 13 10 04" src="https://user-images.githubusercontent.com/163111/74039384-9d984180-49b9-11ea-98b5-e928f1d8d7cf.png">

Who can review
--------------

Not @46bit