### PR TITLE
Promote paas-auditor tag with fast informer metric

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -643,7 +643,7 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-auditor.git
       branch: master
-      tag_filter: v0.59.0
+      tag_filter: v0.62.0
 
   - name: paas-admin
     type: git


### PR DESCRIPTION
What
----

The informer database metric did a naive `COUNT(*)` which takes ages, we've used `relcount` to amortise this

This PR promotes the tag

Done as pair with @paroxp 