### PR TITLE
Add `aws_limits_rds_instances` variable to Prometheus env-specific vars

### DIFF
--- a/manifests/prometheus/env-specific/default.yml
+++ b/manifests/prometheus/env-specific/default.yml
@@ -4,3 +4,4 @@
 aws_limits_elasticache_cache_parameter_groups: 20
 aws_limits_elasticache_nodes: 100
 aws_limits_s3_buckets: 150
+aws_limits_rds_instances: 40

--- a/manifests/prometheus/env-specific/prod-lon.yml
+++ b/manifests/prometheus/env-specific/prod-lon.yml
@@ -4,3 +4,4 @@
 aws_limits_elasticache_cache_parameter_groups: 400
 aws_limits_elasticache_nodes: 500
 aws_limits_s3_buckets: 250
+aws_limits_rds_instances: 550

--- a/manifests/prometheus/env-specific/prod.yml
+++ b/manifests/prometheus/env-specific/prod.yml
@@ -4,3 +4,4 @@
 aws_limits_elasticache_cache_parameter_groups: 400
 aws_limits_elasticache_nodes: 400
 aws_limits_s3_buckets: 250
+aws_limits_rds_instances: 550

--- a/manifests/prometheus/env-specific/stg-lon.yml
+++ b/manifests/prometheus/env-specific/stg-lon.yml
@@ -4,3 +4,4 @@
 aws_limits_elasticache_cache_parameter_groups: 20
 aws_limits_elasticache_nodes: 100
 aws_limits_s3_buckets: 100
+aws_limits_rds_instances: 40


### PR DESCRIPTION
What
----
We had a small incident where our proudction environments reached the limit on
the number of AWS RDS instances they could create in their respective regions.
This happened because we didn't have an alert for it, like we do for the number
of ElastiCache nodes and S3 buckets. We didn't have an alert because we didn't
have data.

This commit adds a new `aws_limits_rds_instances` variable, so that when we get
a metric for the number of RDS instances in a region, we can create alerts. It
also acts as a bit of documentation about our limits.

How to review
-------------
1. Just check I've not somehow mucked something up. There are no changes in behaviour.

Who can review
--------------
Anyone