### PR TITLE
[#171132351] Drop unnecessary CDN Broker log line

### DIFF
--- a/manifests/cf-manifest/operations.d/720-cdn-broker.yml
+++ b/manifests/cf-manifest/operations.d/720-cdn-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: cdn-broker
-    version: 0.1.24
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.24.tgz
-    sha1: 2fb2b00a36a079ace921eff807106dfd39e3a980
+    version: 0.1.25
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.25.tgz
+    sha1: 9b73314d7bafebd61e2b69bbfdd2b3f017369fb2
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-


### PR DESCRIPTION
What
----

This releases https://github.com/alphagov/paas-cdn-broker/pull/27, which removes an unwanted log line from the CDN Broker.

How to review
-------------

Double-check the boshrelease build matches the output from https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/cdn-broker-release/jobs/build-final-release/builds/3.

Who can review
--------------

Not @46bit 