### PR TITLE
Disable keepalives again

### DIFF
--- a/manifests/cf-manifest/operations.d/310-router.yml
+++ b/manifests/cf-manifest/operations.d/310-router.yml
@@ -35,8 +35,8 @@
   # When this is non-zero, gorouter maintains the configured value idle
   # connections
   #
-  # 2500 was picked arbitrarily
-  value: 2500
+  # Enabling this will introduce some base unreliability due to keepalives
+  value: 0
 
 - type: replace
   path: /instance_groups/name=router/networks/0/name

--- a/manifests/cf-manifest/spec/manifest/router_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/router_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe 'router' do
     let(:manifest) { manifest_with_defaults }
     let(:gorouter_props) { manifest.fetch('instance_groups.router.jobs.gorouter.properties.router') }
 
-    it 'has max_idle_connections set' do
-      expect(gorouter_props.dig('max_idle_connections')).to eq(2500)
+    it 'has max_idle_connections set to disable keepalives' do
+      expect(gorouter_props.dig('max_idle_connections')).to eq(0)
     end
   end
 end


### PR DESCRIPTION
What
----

We enable keepalives and they caused some base 502s due to keepalives

We validated this was a problem for 45 minutes with Notify and noticed ~39
random 502s which couldn't be correlated to anything else

How to review
-------------

CI

Code review

Who can review
--------------

@paroxp
