### PR TITLE
Use credhub shell for uploading secrets

### DIFF
--- a/scripts/upload-secrets/upload_secrets.rb
+++ b/scripts/upload-secrets/upload_secrets.rb
@@ -1,16 +1,12 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-script_path = File.absolute_path(__FILE__).sub!(Dir.pwd + "/", "")
+script_path = File.absolute_path(__FILE__).sub!(Dir.pwd + '/', '')
 File.open(File.expand_path('~/.paas-script-usage'), 'a') { |f| f.puts script_path }
 
-require 'base64'
 require 'English'
-require 'json'
 require 'yaml'
 require 'tempfile'
-require 'aws-sdk'
-require 'base64'
 
 def upload_secrets(credhub_namespaces, secrets)
   credentials = secrets.flat_map do |secret, value|
@@ -26,63 +22,21 @@ def upload_secrets(credhub_namespaces, secrets)
   import_to_credhub('credentials' => credentials)
 end
 
-def import_to_credhub credhub_secrets
-  deploy_env = ENV.fetch('DEPLOY_ENV')
-  region = ENV.fetch('AWS_REGION') { ENV.fetch('AWS_DEFAULT_REGION') }
-  system_dns_zone_name = ENV.fetch('SYSTEM_DNS_ZONE_NAME')
+def import_to_credhub(credhub_secrets)
+  unless ENV.key? 'CREDHUB_CA_CERT'
+    raise 'CREDHUB_CA_CERT not set, are you in a shell? (make <env> credhub)'
+  end
 
-  s3 = Aws::S3::Resource.new(region: region)
+  Tempfile.create('credhub-secrets') do |f|
+    f.write(credhub_secrets.to_yaml)
+    f.flush
 
-  state_bucket = s3.bucket("gds-paas-#{deploy_env}-state")
-  bosh_ca_cert = state_bucket.object('bosh-CA.crt').get.body.read
+    pid = spawn(
+      "credhub import -f '#{f.path}'",
+      in: STDIN, out: STDOUT, err: STDERR,
+    )
 
-  bosh_secrets = YAML.safe_load(state_bucket.object('bosh-secrets.yml').get.body)
-  credhub_secret = bosh_secrets.dig('secrets', 'bosh_credhub_admin_client_password')
-
-  bosh_vars_store = YAML.safe_load(state_bucket.object('bosh-vars-store.yml').get.body)
-  bosh_client_secret = bosh_vars_store.fetch('admin_password')
-  credhub_ca_cert = bosh_vars_store.dig('credhub_tls', 'ca') + bosh_vars_store.dig('uaa_ssl', 'ca')
-
-  ec2 = Aws::EC2::Resource.new(region: region)
-
-  bosh_ip = ec2.instances(filters: [
-    { name: 'tag:deploy_env', values: [deploy_env] },
-    { name: 'tag:instance_group', values: ['bosh'] },
-  ]).first.public_ip_address
-
-  env_params = {
-    'USER'        => ENV.fetch('USER'),
-    'USER_ID_RSA' => Base64.encode64(File.read("#{ENV['HOME']}/.ssh/id_rsa")),
-
-    'BOSH_IP'            => bosh_ip,
-    'BOSH_CLIENT'        => 'admin',
-    'BOSH_CLIENT_SECRET' => bosh_client_secret,
-    'BOSH_ENVIRONMENT'   => "bosh.#{system_dns_zone_name}",
-    'BOSH_CA_CERT'       => bosh_ca_cert,
-    'BOSH_DEPLOYMENT'    => deploy_env,
-
-    'CREDHUB_SERVER'  => "https://bosh.#{system_dns_zone_name}:8844/api",
-    'CREDHUB_CLIENT'  => "credhub-admin",
-    'CREDHUB_SECRET'  => credhub_secret,
-    'CREDHUB_CA_CERT' => credhub_ca_cert,
-    'CREDHUB_PROXY'   => "socks5://localhost:25555",
-  }.flat_map { |k, v| "--env #{k}='#{v}'" }
-
-  credhub_secrets_file = Tempfile.new('credhub-secrets', '/tmp')
-  credhub_secrets_file.write(credhub_secrets.to_yaml)
-  credhub_secrets_file.close
-
-  pid = spawn(
-    %(
-      docker run \
-      -it \
-      --rm #{env_params.join(' ')} \
-      -v '#{credhub_secrets_file.path}:/root/import.yml' \
-      governmentpaas/bosh-shell:91fe1e826f39798986d95a02fb1ccab6f0e7c746 \
-      -c 'credhub import -f /root/import.yml'
-    ),
-    in: STDIN, out: STDOUT, err: STDERR
-  )
-  Process.wait pid
-  raise 'Child process did not exit successfully' unless $CHILD_STATUS.success?
+    Process.wait pid
+    raise 'Child process did not exit successfully' unless $CHILD_STATUS.success?
+  end
 end


### PR DESCRIPTION
What
----

This PR was made in the context of us now using individual IDP identities rather than shared credentials for accessing credhub

We do not need the layers of docker to do things, we can just compose the shell tasks

i.e. the workflow shouldnt be:

```
- make dev upload-all-secrets # do all the things
```

instead we can rely on people to compose the steps correctly, with appropriate pointers along the way. This way the code is easier to follow and is less fragile to change:

```
- make dev credhub
> credhub login --sso
> make upload-all-secrets
```

(where > represents a subshell)

How to review
-------------

You might need the latest paas-bootstrap to do this, or try against staging:

```
$ make stg-lon credhub
credhub subshell $ credhub login --sso
credhub subshell $ make upload-paas-trusted-people # or another set of secrets
```

Who can review
--------------

Not @tlwr