### PR TITLE
[#170622539] Increase cdn-route response timeouts to 60 seconds

### DIFF
--- a/manifests/cf-manifest/operations.d/720-cdn-broker.yml
+++ b/manifests/cf-manifest/operations.d/720-cdn-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: cdn-broker
-    version: 0.1.25
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.25.tgz
-    sha1: 9b73314d7bafebd61e2b69bbfdd2b3f017369fb2
+    version: 0.1.27
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.27.tgz
+    sha1: c85fc617bc4ed205656791769c2206c6c2f53c4d
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-


### PR DESCRIPTION
What
----

Ship https://github.com/alphagov/paas-cdn-broker-boshrelease/pull/25 to increase request timeouts through new CDN Route instances to 60 seconds.

How to review
-------------

1. Review https://github.com/alphagov/paas-cdn-broker-boshrelease/pull/25
2. Update the boshrelease build YAML in this to the final build once https://github.com/alphagov/paas-cdn-broker-boshrelease/pull/25 is merged

Who can review
--------------

Not @46bit