### PR TITLE
Upgrade cf-prometheus release

### DIFF
--- a/manifests/cf-manifest/operations.d/510-add-prometheus-blackbox-exporter.yml
+++ b/manifests/cf-manifest/operations.d/510-add-prometheus-blackbox-exporter.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: "prometheus"
-    version: "26.1.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=26.1.0"
-    sha1: "59fd836ac3ae5ae9d95ba4a41a7436bee6c3e873"
+    version: "26.2.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=26.2.0"
+    sha1: "9a57a9c74ebcb53baaa9cf8eb22f8ef353460169"
 
 - type: replace
   path: /addons?/-


### PR DESCRIPTION
What
----

Our Prometheus in the CF BOSH deployment is responsible for scraping a large quantity of metrics from Elasticsearch (ES) instances. Our users query Prometheus to see metrics about their ES instances.

Periodically, Prometheus compacts metrics it has collected into smaller blocks. We see really high memory during TSDB compaction:

![image](https://user-images.githubusercontent.com/1482692/75020339-78f89b00-548a-11ea-8f06-921c592fcd98.png)

Which is fixed in Prometheus 2.15:
- [Release](https://github.com/prometheus/prometheus/releases/tag/v2.15.0)
  - See "TSDB: Significantly reduced memory footprint of loaded TSDB blocks"
  - See "TSDB: Significantly optimized what we buffer during compaction which should result in lower memory footprint during compaction"
  - See "TSDB: Improve replay latency"
  - See "TSDB: WAL size is now used for size based retention calculation"

Prometheus BOSH deployment v26.2 is the earliest release with Prometheus >= 2.15 in it
- [Release](https://github.com/bosh-prometheus/prometheus-boshrelease/releases/tag/v26.2.0)
  - "prometheus to v2.15.2"

How to review
-------------

Code review

I'm running this down my development environment, and will update the PR once the acceptance tests pass.

Who can review
--------------

Not @tlwr
