### PR TITLE
[#169397386] Add node exporter

### DIFF
--- a/manifests/prometheus/operations.d/201-monitor-bosh.yml
+++ b/manifests/prometheus/operations.d/201-monitor-bosh.yml
@@ -8,3 +8,11 @@
       - "10.0.0.6"
     labels:
       __meta_bosh_job_process_name: node_exporter
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/job_name=node/relabel_configs?/-
+  value:
+    source_labels:
+    - __address__
+    regex: "^10[.].*"
+    action: keep

--- a/manifests/prometheus/operations.d/201-monitor-bosh.yml
+++ b/manifests/prometheus/operations.d/201-monitor-bosh.yml
@@ -1,0 +1,7 @@
+# By default the BOSH director is not scraped by Prometheus
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/job_name=node/static_configs?/-
+  value:
+    targets:
+      - "10.0.0.6:9100"

--- a/manifests/prometheus/operations.d/201-monitor-bosh.yml
+++ b/manifests/prometheus/operations.d/201-monitor-bosh.yml
@@ -4,4 +4,7 @@
   path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/job_name=node/static_configs?/-
   value:
     targets:
-      - "10.0.0.6:9100"
+      # The port will be added in the upstream relabel configuration
+      - "10.0.0.6"
+    labels:
+      __meta_bosh_job_process_name: node_exporter

--- a/manifests/prometheus/operations.d/205-monitor-node-UPSTREAM.yml
+++ b/manifests/prometheus/operations.d/205-monitor-node-UPSTREAM.yml
@@ -1,0 +1,1 @@
+../upstream/manifests/operators/monitor-node.yml

--- a/manifests/prometheus/operations.d/206-monitor-node.yml
+++ b/manifests/prometheus/operations.d/206-monitor-node.yml
@@ -20,3 +20,13 @@
     - __address__
     regex: "^(10|127)[.].*"
     action: keep
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/job_name=node/relabel_configs?/-
+  value:
+    source_labels:
+    - __meta_bosh_deployment
+    target_label: bosh_deployment
+    regex: (.*)
+    replacement: ${1}
+    action: replace

--- a/manifests/prometheus/operations.d/206-monitor-node.yml
+++ b/manifests/prometheus/operations.d/206-monitor-node.yml
@@ -5,7 +5,11 @@
   value:
     targets:
       # The port will be added in the upstream relabel configuration
+      #
+      # This is the BOSH director
       - "10.0.0.6"
+      # This is the Prometheus monitoring its own node exporter
+      - "127.0.0.1"
     labels:
       __meta_bosh_job_process_name: node_exporter
 
@@ -14,5 +18,5 @@
   value:
     source_labels:
     - __address__
-    regex: "^10[.].*"
+    regex: "^(10|127)[.].*"
     action: keep


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/169397386)

What
----

We are deploying the Prometheus node exporter as an addon, since https://github.com/alphagov/paas-bootstrap/pull/350

We need to:
- Add the director as a scrape target
- Add the local prometheus node exporter as a scrape target
- Only scrape internally (i.e. no external IPs - only 10/8 127.0.0.1)

How to review
-------------

Deploy https://github.com/alphagov/paas-bootstrap/pull/350

Run CF pipeline

Check Prometheus is scraping all the node exporters in all deployments

Who can review
--------------

Not @tlwr