### PR TITLE
[#171180051] Add a concourse job to rotate broker credentials

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -362,6 +362,7 @@ groups:
     jobs:
       - set-smoke-test-creds
       - rotate-cloudfoundry-credentials
+      - rotate-broker-credentials
       - rotate-database-encryption-keys
       - rotate-prometheus-credentials
       - expire-aws-keys
@@ -4219,6 +4220,39 @@ jobs:
         put: cf-tfstate
         params:
           file: updated-tfstate/cf.tfstate
+
+  - name: rotate-broker-credentials
+    serial: true
+    serial_groups: [smoke-tests]
+    plan:
+    - task: rotate-broker-credentials
+      tags: [colocated-with-web]
+      config:
+        platform: linux
+        image_resource: *gov-paas-bosh-cli-v2-image-resource
+        params:
+          CREDHUB_CLIENT: credhub-admin
+          CREDHUB_SECRET: ((bosh-credhub-admin))
+          CREDHUB_CA_CERT: ((bosh-credhub-ca-cert))
+          CREDHUB_SERVER: "https://((bosh_fqdn)):8844/api"
+          DEPLOY_ENV: ((deploy_env))
+        run:
+          path: sh
+          args:
+            - -e
+            - -c
+            - |
+              BOSH_NS="/${DEPLOY_ENV}/${DEPLOY_ENV}"
+              credhub login
+
+              credhub generate -n "${BOSH_NS}/secrets_rds_broker_admin_password" -t password
+              credhub generate -n "${BOSH_NS}/secrets_cdn_broker_admin_password" -t password
+              credhub generate -n "${BOSH_NS}/secrets_aiven_broker_admin_password" -t password
+              credhub generate -n "${BOSH_NS}/secrets_elasticache_broker_admin_password" -t password
+              credhub generate -n "${BOSH_NS}/secrets_s3_broker_admin_password" -t password
+
+              echo "Broker credentials will be updated on the next deployment pipeline run."
+              echo "WARNING: Broker users will experience some downtime during the deploy. Our brokers do not support hot-swapping of credentials."
 
   - name: rotate-database-encryption-keys
     serial: true


### PR DESCRIPTION
What
----

We want to rotate the broker passwords. This commit adds a new job that will rotate the passwords in Credhub. When the main `create-cloudfoundry` deploy pipeline is next run it will update the brokers to use the new credentials and update Cloud Controller to use those new credentials too.

This operation is not zero-downtime; our brokers do not support multiple credentials at once. But for the cases when we want to rotate it's OK to have brief downtime for creating or updating services. Apps talking to existing services aren't affected.

This does not rotate every broker-related secret. The RDS Broker's `master_password_seed` property is not rotated. Thankfully we don't need to rotate that right now because there is no easy way to rotate it.

How to review
-------------

* [ ] Code review;
* [x] ~Check this works in a dev environment.~ I've checked it in `miki`.

## How to release

This can be merged safely at any time, but rotating broker credentials involves downtime. You pause the smoke tests, run the `rotate-broker-credentials` job, unpause the smoke tests, and then run the full `create-cloudfoundry` pipeline.

The following error appears when trying to interact with a broker after `cf-deploy` but before `post-deploy`:

```
$ cf create-service postgres tiny-unencrypted-9.5 test-pg-$(date +%s)
Creating service instance test-pg-158273238
Unexpected Response
Response code: 502
CC code:       0
CC error code:
Request ID:    e069d3df-a2bb-471c-5371-becb2b52c0c9::9225dd70-9116-4a6d-9dc1-bc944f2709c6
Description:   {
  "description": "Authentication with the service broker failed. Double-check that the username and password are correct: https://rds-broker.[…]/v2/service_instances/2621d8e0-a1d7-4717-8bc2-a09d9b0c3310?accepts_incomplete=true",
  "error_code": "CF-ServiceBrokerApiAuthenticationFailed",
  "code": 10001,
  "http": {
    "uri": "https://rds-broker.[…]/v2/service_instances/2621d8e0-a1d7-4717-8bc2-a09d9b0c3310?accepts_incomplete=true",
    "method": "PUT",
    "status": 401
  }
}
```

This then resolves itself once `post-deploy` has re-registered all the brokers and their new passwords with Cloud Controller.

Who can review
--------------

Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.
