### PR TITLE
[#171183319]Configure redis 4x 5x plans

### DIFF
--- a/config/billing/config-parts/redis_pricing_plans.json.erb
+++ b/config/billing/config-parts/redis_pricing_plans.json.erb
@@ -1,4 +1,5 @@
 <% plans = [
+	# Redis 3.2
 	{
 		"name" => "tiny-clustered-3.2",
 		"valid_from" => "2017-01-01",
@@ -34,6 +35,66 @@
     "ha" => true,
     "aws_price" => price("elasticache_m5_large")
   },
+
+	# Redis 4.x
+	{
+	  "name" => "tiny-4.x",
+	  "valid_from" => "2020-03-01",
+	  "guid" => "b78c9d07-a031-495f-937c-28613905431c",
+	  "ha" => false,
+	  "aws_price" => price("elasticache_t2_small")
+	},
+	{
+	  "name" => "tiny-ha-4.x",
+	  "valid_from" => "2020-03-01",
+	  "guid" => "e31d1a05-4f75-4bca-93a0-661bc233d25c",
+	  "ha" => true,
+	  "aws_price" => price("elasticache_t2_small")
+	},
+	{
+	  "name" => "small-ha-4.x",
+	  "valid_from" => "2020-03-01",
+	  "guid" => "09e7088e-125e-4805-9eff-02bf61ee0146",
+	  "ha" => true,
+	  "aws_price" => price("elasticache_t2_medium")
+	},
+	{
+	  "name" => "medium-ha-4.x",
+	  "valid_from" => "2020-03-01",
+	  "guid" => "f210be07-8ea3-4295-a929-2dec0ae4cd30",
+	  "ha" => true,
+	  "aws_price" => price("elasticache_m5_large")
+	},
+
+	# Redis 5.x
+	{
+	  "name" => "tiny-5.x",
+	  "valid_from" => "2020-03-01",
+	  "guid" => "1f2cccd7-d9a9-4b9a-b517-73b381848b73",
+	  "ha" => false,
+	  "aws_price" => price("elasticache_t2_small")
+	},
+	{
+	  "name" => "tiny-ha-5.x",
+	  "valid_from" => "2020-03-01",
+	  "guid" => "c12a6a40-fb53-4e1e-b0a9-ba5e3180e3b7",
+	  "ha" => true,
+	  "aws_price" => price("elasticache_t2_small")
+	},
+	{
+	  "name" => "small-ha-5.x",
+	  "valid_from" => "2020-03-01",
+	  "guid" => "07479e46-0169-4395-91d8-e125efb17e2c",
+	  "ha" => true,
+		"aws_price" => price("elasticache_t2_medium")
+	},
+	{
+	  "name" => "medium-ha-5.x",
+	  "valid_from" => "2020-03-01",
+	  "guid" => "a5ee300e-9c75-45f3-939b-d74ca4c178e7",
+	  "ha" => true,
+    "aws_price" => price("elasticache_m5_large")
+	}
 
 ] %>
 

--- a/config/billing/config-parts/redis_pricing_plans.json.erb
+++ b/config/billing/config-parts/redis_pricing_plans.json.erb
@@ -1,70 +1,55 @@
-{
-	"name": "redis tiny-clustered-3.2",
-	"valid_from": "2017-01-01",
-	"plan_guid": "3a51701c-eef3-447c-882b-907ad2bcb7ab",
-	"number_of_nodes": 1,
-	"components": [
-		{
-			"name": "instance",
-			"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * <%= price("elasticache_t2_micro") %>",
-			"currency_code": "USD",
-			"vat_code": "Standard"
-		}
-	]
-},
-{
-	"name": "redis tiny-3.2",
-	"valid_from": "2017-01-01",
-	"plan_guid": "c84d1bef-9500-4ce9-88b2-c0bd421bbf8a",
-	"number_of_nodes": 1,
-	"components": [
-		{
-			"name": "instance",
-			"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * <%= price("elasticache_t2_micro") %>",
-			"currency_code": "USD",
-			"vat_code": "Standard"
-		}
-	]
-},
-{
-	"name": "redis medium-ha-3.2",
-	"valid_from": "2019-01-01",
-	"plan_guid": "b6949ea7-5c98-4c69-b981-4b5318ea8b7c",
-	"number_of_nodes": 2,
-	"components": [
-		{
-			"name": "instance",
-			"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * <%= price("elasticache_m5_large") %>",
-			"currency_code": "USD",
-			"vat_code": "Standard"
-		}
-	]
-},
-{
-	"name": "redis tiny-ha-3.2",
-	"valid_from": "2019-08-01",
-	"plan_guid": "ea5c8cc3-74e6-4b15-bd61-bbe244cfe63d",
-	"number_of_nodes": 2,
-	"components": [
-		{
-			"name": "instance",
-			"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * <%= price("elasticache_t2_small") %>",
-			"currency_code": "USD",
-			"vat_code": "Standard"
-		}
-	]
-},
-{
-	"name": "redis small-ha-3.2",
-	"valid_from": "2019-08-01",
-	"plan_guid": "9162ed5b-0c88-4f43-bcaf-c6d4a45dd243",
-	"number_of_nodes": 2,
-	"components": [
-		{
-			"name": "instance",
-			"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * <%= price("elasticache_t2_medium") %>",
-			"currency_code": "USD",
-			"vat_code": "Standard"
-		}
-	]
-},
+<% plans = [
+	{
+		"name" => "tiny-clustered-3.2",
+		"valid_from" => "2017-01-01",
+		"guid" => "3a51701c-eef3-447c-882b-907ad2bcb7ab",
+		"ha" => false,
+		"aws_price" => price("elasticache_t2_micro")
+	},
+	{
+    "name" => "tiny-3.2",
+    "valid_from" => "2017-01-01",
+    "guid" => "c84d1bef-9500-4ce9-88b2-c0bd421bbf8a",
+    "ha" => false,
+    "aws_price" => price("elasticache_t2_micro")
+  },
+  {
+    "name" => "tiny-ha-3.2",
+    "valid_from" => "2019-08-01",
+    "guid" => "ea5c8cc3-74e6-4b15-bd61-bbe244cfe63d",
+    "ha" => true,
+    "aws_price" => price("elasticache_t2_small")
+  },
+  {
+    "name" => "small-ha-3.2",
+    "valid_from" => "2019-08-01",
+    "guid" => "9162ed5b-0c88-4f43-bcaf-c6d4a45dd243",
+    "ha" => true,
+    "aws_price" => price("elasticache_t2_medium")
+  },
+  {
+    "name" => "medium-ha-3.2",
+    "valid_from" => "2019-08-01",
+    "guid" => "b6949ea7-5c98-4c69-b981-4b5318ea8b7c",
+    "ha" => true,
+    "aws_price" => price("elasticache_m5_large")
+  },
+
+] %>
+
+<% for @plan in plans %>
+	{
+		"name": "redis <%= @plan["name"] %>",
+		"valid_from": "<%= @plan["valid_from"] %>",
+		"plan_guid": "<%= @plan["guid"] %>",
+		"number_of_nodes": <%= if @plan["ha"] then 2 else 1 end%>,
+		"components": [
+			{
+				"name": "instance",
+				"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * <%= @plan["aws_price"] %>",
+				"currency_code": "USD",
+				"vat_code": "Standard"
+			}
+		]
+	},
+<% end %>

--- a/config/billing/output/eu-west-1.json
+++ b/config/billing/output/eu-west-1.json
@@ -2317,6 +2317,118 @@
 			]
 		},
 		{
+			"name": "redis tiny-4.x",
+			"valid_from": "2020-03-01",
+			"plan_guid": "b78c9d07-a031-495f-937c-28613905431c",
+			"number_of_nodes": 1,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.036",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis tiny-ha-4.x",
+			"valid_from": "2020-03-01",
+			"plan_guid": "e31d1a05-4f75-4bca-93a0-661bc233d25c",
+			"number_of_nodes": 2,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.036",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis small-ha-4.x",
+			"valid_from": "2020-03-01",
+			"plan_guid": "09e7088e-125e-4805-9eff-02bf61ee0146",
+			"number_of_nodes": 2,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.073",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis medium-ha-4.x",
+			"valid_from": "2020-03-01",
+			"plan_guid": "f210be07-8ea3-4295-a929-2dec0ae4cd30",
+			"number_of_nodes": 2,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.172",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis tiny-5.x",
+			"valid_from": "2020-03-01",
+			"plan_guid": "1f2cccd7-d9a9-4b9a-b517-73b381848b73",
+			"number_of_nodes": 1,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.036",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis tiny-ha-5.x",
+			"valid_from": "2020-03-01",
+			"plan_guid": "c12a6a40-fb53-4e1e-b0a9-ba5e3180e3b7",
+			"number_of_nodes": 2,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.036",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis small-ha-5.x",
+			"valid_from": "2020-03-01",
+			"plan_guid": "07479e46-0169-4395-91d8-e125efb17e2c",
+			"number_of_nodes": 2,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.073",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis medium-ha-5.x",
+			"valid_from": "2020-03-01",
+			"plan_guid": "a5ee300e-9c75-45f3-939b-d74ca4c178e7",
+			"number_of_nodes": 2,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.172",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
 			"name": "cloudfront cdn-route",
 			"valid_from": "2017-01-01",
 			"plan_guid": "fc055c72-1075-44c9-9aee-bddd52e1b053",

--- a/config/billing/output/eu-west-1.json
+++ b/config/billing/output/eu-west-1.json
@@ -2275,20 +2275,6 @@
 			]
 		},
 		{
-			"name": "redis medium-ha-3.2",
-			"valid_from": "2019-01-01",
-			"plan_guid": "b6949ea7-5c98-4c69-b981-4b5318ea8b7c",
-			"number_of_nodes": 2,
-			"components": [
-				{
-					"name": "instance",
-					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.172",
-					"currency_code": "USD",
-					"vat_code": "Standard"
-				}
-			]
-		},
-		{
 			"name": "redis tiny-ha-3.2",
 			"valid_from": "2019-08-01",
 			"plan_guid": "ea5c8cc3-74e6-4b15-bd61-bbe244cfe63d",
@@ -2311,6 +2297,20 @@
 				{
 					"name": "instance",
 					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.073",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis medium-ha-3.2",
+			"valid_from": "2019-08-01",
+			"plan_guid": "b6949ea7-5c98-4c69-b981-4b5318ea8b7c",
+			"number_of_nodes": 2,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.172",
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}

--- a/config/billing/output/eu-west-2.json
+++ b/config/billing/output/eu-west-2.json
@@ -2317,6 +2317,118 @@
 			]
 		},
 		{
+			"name": "redis tiny-4.x",
+			"valid_from": "2020-03-01",
+			"plan_guid": "b78c9d07-a031-495f-937c-28613905431c",
+			"number_of_nodes": 1,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.038",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis tiny-ha-4.x",
+			"valid_from": "2020-03-01",
+			"plan_guid": "e31d1a05-4f75-4bca-93a0-661bc233d25c",
+			"number_of_nodes": 2,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.038",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis small-ha-4.x",
+			"valid_from": "2020-03-01",
+			"plan_guid": "09e7088e-125e-4805-9eff-02bf61ee0146",
+			"number_of_nodes": 2,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.077",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis medium-ha-4.x",
+			"valid_from": "2020-03-01",
+			"plan_guid": "f210be07-8ea3-4295-a929-2dec0ae4cd30",
+			"number_of_nodes": 2,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.18",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis tiny-5.x",
+			"valid_from": "2020-03-01",
+			"plan_guid": "1f2cccd7-d9a9-4b9a-b517-73b381848b73",
+			"number_of_nodes": 1,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.038",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis tiny-ha-5.x",
+			"valid_from": "2020-03-01",
+			"plan_guid": "c12a6a40-fb53-4e1e-b0a9-ba5e3180e3b7",
+			"number_of_nodes": 2,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.038",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis small-ha-5.x",
+			"valid_from": "2020-03-01",
+			"plan_guid": "07479e46-0169-4395-91d8-e125efb17e2c",
+			"number_of_nodes": 2,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.077",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis medium-ha-5.x",
+			"valid_from": "2020-03-01",
+			"plan_guid": "a5ee300e-9c75-45f3-939b-d74ca4c178e7",
+			"number_of_nodes": 2,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.18",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
 			"name": "cloudfront cdn-route",
 			"valid_from": "2017-01-01",
 			"plan_guid": "fc055c72-1075-44c9-9aee-bddd52e1b053",

--- a/config/billing/output/eu-west-2.json
+++ b/config/billing/output/eu-west-2.json
@@ -2275,20 +2275,6 @@
 			]
 		},
 		{
-			"name": "redis medium-ha-3.2",
-			"valid_from": "2019-01-01",
-			"plan_guid": "b6949ea7-5c98-4c69-b981-4b5318ea8b7c",
-			"number_of_nodes": 2,
-			"components": [
-				{
-					"name": "instance",
-					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.18",
-					"currency_code": "USD",
-					"vat_code": "Standard"
-				}
-			]
-		},
-		{
 			"name": "redis tiny-ha-3.2",
 			"valid_from": "2019-08-01",
 			"plan_guid": "ea5c8cc3-74e6-4b15-bd61-bbe244cfe63d",
@@ -2311,6 +2297,20 @@
 				{
 					"name": "instance",
 					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.077",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis medium-ha-3.2",
+			"valid_from": "2019-08-01",
+			"plan_guid": "b6949ea7-5c98-4c69-b981-4b5318ea8b7c",
+			"number_of_nodes": 2,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.18",
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}

--- a/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
+++ b/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
@@ -27,6 +27,21 @@
     medium_plan: &elasticache_medium_plan
       instance_type: cache.m5.large
 
+    redis_3_2: &elasticache_redis_3_2
+      engine: redis
+      engine_version: 3.2.6
+      cache_parameter_group_family: redis3.2
+
+    redis_4_x: &elasticache_redis_4_x
+      engine: redis
+      engine_version: 4.0.10
+      cache_parameter_group_family: redis4.0
+
+    redis_5_x: &elasticache_redis_5_x
+      engine: redis
+      engine_version: 5.0.6
+      cache_parameter_group_family: redis5.0
+
 - type: replace
   path: /releases/-
   value:
@@ -86,65 +101,173 @@
                   bindable: true
                   plan_updateable: true
                   plans:
+                    # Deprecated
                     - id: 3a51701c-eef3-447c-882b-907ad2bcb7ab
                       name: tiny-clustered-3.2
                       description: DEPRECATED - do not use, 568MB RAM, clustered (1 shard), single node, no failover, daily backups
                       free: true
                       metadata:
                         displayName: Redis 3.2 Clustered Tiny
+
+                    # 3.2
                     - id: c84d1bef-9500-4ce9-88b2-c0bd421bbf8a
                       name: tiny-3.2
                       description: 568MB RAM, single node, no failover, daily backups (for instances created after 21/1/2019)
                       free: true
                       metadata:
                         displayName: Redis 3.2 tiny
-                    - id: b6949ea7-5c98-4c69-b981-4b5318ea8b7c
-                      name: medium-ha-3.2
-                      description: 6.37GB RAM, highly-available, daily backups
-                      free: false
-                      metadata:
-                        displayName: Redis 3.2 medium highly-available
                     - id: ea5c8cc3-74e6-4b15-bd61-bbe244cfe63d
                       name: tiny-ha-3.2
                       description: 1.5GB RAM, highly-available, daily backups
                       free: false
                       metadata:
-                        displayName: Redis tiny highly-available
+                        displayName: Redis 3.2 tiny highly-available
                     - id: 9162ed5b-0c88-4f43-bcaf-c6d4a45dd243
                       name: small-ha-3.2
                       description: 3GB RAM, highly-available, daily backups
                       free: false
                       metadata:
                         displayName: Redis 3.2 small highly-available
+                    - id: b6949ea7-5c98-4c69-b981-4b5318ea8b7c
+                      name: medium-ha-3.2
+                      description: 6.37GB RAM, highly-available, daily backups
+                      free: false
+                      metadata:
+                        displayName: Redis 3.2 medium highly-available
+
+                    # 4.x
+                    - id: b78c9d07-a031-495f-937c-28613905431c
+                      name: tiny-4.x
+                      description: 568MB RAM, single node, no failover, daily backups (for instances created after 21/1/2019)
+                      free: true
+                      metadata:
+                        displayName: Redis 4.x tiny
+                    - id: e31d1a05-4f75-4bca-93a0-661bc233d25c
+                      name: tiny-ha-4.x
+                      description: 1.5GB RAM, highly-available, daily backups
+                      free: false
+                      metadata:
+                        displayName: Redis 4.x tiny highly-available
+                    - id: 09e7088e-125e-4805-9eff-02bf61ee0146
+                      name: small-ha-4.x
+                      description: 3GB RAM, highly-available, daily backups
+                      free: false
+                      metadata:
+                        displayName: Redis 4.x small highly-available
+                    - id: f210be07-8ea3-4295-a929-2dec0ae4cd30
+                      name: medium-ha-4.x
+                      description: 6.37GB RAM, highly-available, daily backups
+                      free: false
+                      metadata:
+                        displayName: Redis 4.x medium highly-available
+
+                    # 5.x
+                    - id: 1f2cccd7-d9a9-4b9a-b517-73b381848b73
+                      name: tiny-5.x
+                      description: 568MB RAM, single node, no failover, daily backups (for instances created after 21/1/2019)
+                      free: true
+                      metadata:
+                        displayName: Redis 5.x tiny
+                    - id: c12a6a40-fb53-4e1e-b0a9-ba5e3180e3b7
+                      name: tiny-ha-5.x
+                      description: 1.5GB RAM, highly-available, daily backups
+                      free: false
+                      metadata:
+                        displayName: Redis 5.x tiny highly-available
+                    - id: 07479e46-0169-4395-91d8-e125efb17e2c
+                      name: small-ha-5.x
+                      description: 3GB RAM, highly-available, daily backups
+                      free: false
+                      metadata:
+                        displayName: Redis 5.x small highly-available
+                    - id: a5ee300e-9c75-45f3-939b-d74ca4c178e7
+                      name: medium-ha-5.x
+                      description: 6.37GB RAM, highly-available, daily backups
+                      free: false
+                      metadata:
+                        displayName: Redis 5.x medium highly-available
 
             plan_configs:
-              3a51701c-eef3-447c-882b-907ad2bcb7ab:
+              3a51701c-eef3-447c-882b-907ad2bcb7ab: #tiny-clustered-3.2
                 <<: *elasticache_cache_cluster_config # yamllint disable-line
+                <<: *elasticache_redis_3_2 # yamllint disable-line
                 <<: *elasticache_non_ha_plan # yamllint disable-line
                 instance_type: cache.t2.micro
                 parameters:
                   cluster-enabled: 'yes'
 
-              c84d1bef-9500-4ce9-88b2-c0bd421bbf8a:
+              c84d1bef-9500-4ce9-88b2-c0bd421bbf8a: #tiny-3.2
                 <<: *elasticache_cache_cluster_config # yamllint disable-line
+                <<: *elasticache_redis_3_2 # yamllint disable-line
                 <<: *elasticache_non_ha_plan # yamllint disable-line
                 instance_type: cache.t2.micro
                 automatic_failover_enabled: false
 
-              b6949ea7-5c98-4c69-b981-4b5318ea8b7c:
+              ea5c8cc3-74e6-4b15-bd61-bbe244cfe63d: #tiny-ha-3.2
                 <<: *elasticache_cache_cluster_config # yamllint disable-line
-                <<: *elasticache_ha_plan # yamllint disable-line
-                <<: *elasticache_medium_plan # yamllint disable-line
-
-              ea5c8cc3-74e6-4b15-bd61-bbe244cfe63d:
-                <<: *elasticache_cache_cluster_config # yamllint disable-line
+                <<: *elasticache_redis_3_2 # yamllint disable-line
                 <<: *elasticache_ha_plan # yamllint disable-line
                 <<: *elasticache_tiny_plan # yamllint disable-line
 
-              9162ed5b-0c88-4f43-bcaf-c6d4a45dd243:
+              9162ed5b-0c88-4f43-bcaf-c6d4a45dd243: #small-ha-3.2
                 <<: *elasticache_cache_cluster_config # yamllint disable-line
+                <<: *elasticache_redis_3_2 # yamllint disable-line
                 <<: *elasticache_ha_plan # yamllint disable-line
                 <<: *elasticache_small_plan # yamllint disable-line
+
+              b6949ea7-5c98-4c69-b981-4b5318ea8b7c: #medium-ha-3.2
+                <<: *elasticache_cache_cluster_config # yamllint disable-line
+                <<: *elasticache_redis_3_2 # yamllint disable-line
+                <<: *elasticache_ha_plan # yamllint disable-line
+                <<: *elasticache_medium_plan # yamllint disable-line
+
+              b78c9d07-a031-495f-937c-28613905431c: #tiny-4.x
+                <<: *elasticache_cache_cluster_config # yamllint disable-line
+                <<: *elasticache_redis_4_x # yamllint disable-line
+                <<: *elasticache_non_ha_plan # yamllint disable-line
+                <<: *elasticache_tiny_plan # yamllint disable-line
+
+              e31d1a05-4f75-4bca-93a0-661bc233d25c: #tiny-ha-4.x
+                <<: *elasticache_cache_cluster_config # yamllint disable-line
+                <<: *elasticache_redis_4_x # yamllint disable-line
+                <<: *elasticache_ha_plan # yamllint disable-line
+                <<: *elasticache_tiny_plan # yamllint disable-line
+
+              09e7088e-125e-4805-9eff-02bf61ee0146: #small-ha-4.x
+                <<: *elasticache_cache_cluster_config # yamllint disable-line
+                <<: *elasticache_redis_4_x # yamllint disable-line
+                <<: *elasticache_ha_plan # yamllint disable-line
+                <<: *elasticache_small_plan # yamllint disable-line
+
+              f210be07-8ea3-4295-a929-2dec0ae4cd30: #medium-ha-4.x
+                <<: *elasticache_cache_cluster_config # yamllint disable-line
+                <<: *elasticache_redis_4_x # yamllint disable-line
+                <<: *elasticache_ha_plan # yamllint disable-line
+                <<: *elasticache_medium_plan # yamllint disable-line
+
+              1f2cccd7-d9a9-4b9a-b517-73b381848b73: #tiny-5.x
+                <<: *elasticache_cache_cluster_config # yamllint disable-line
+                <<: *elasticache_redis_5_x # yamllint disable-line
+                <<: *elasticache_non_ha_plan # yamllint disable-line
+                <<: *elasticache_tiny_plan # yamllint disable-line
+
+              c12a6a40-fb53-4e1e-b0a9-ba5e3180e3b7: #tiny-ha-5.x
+                <<: *elasticache_cache_cluster_config # yamllint disable-line
+                <<: *elasticache_redis_5_x # yamllint disable-line
+                <<: *elasticache_ha_plan # yamllint disable-line
+                <<: *elasticache_tiny_plan # yamllint disable-line
+
+              07479e46-0169-4395-91d8-e125efb17e2c: #small-ha-5.x
+                <<: *elasticache_cache_cluster_config # yamllint disable-line
+                <<: *elasticache_redis_5_x # yamllint disable-line
+                <<: *elasticache_ha_plan # yamllint disable-line
+                <<: *elasticache_small_plan # yamllint disable-line
+
+              a5ee300e-9c75-45f3-939b-d74ca4c178e7: #medium-ha-5.x
+                <<: *elasticache_cache_cluster_config # yamllint disable-line
+                <<: *elasticache_redis_5_x # yamllint disable-line
+                <<: *elasticache_ha_plan # yamllint disable-line
+                <<: *elasticache_medium_plan # yamllint disable-line
 
 
 - type: replace

--- a/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
+++ b/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
@@ -1,4 +1,31 @@
 ---
+- type: replace
+  path: /meta?/elasticache_broker
+  value:
+    cache_cluster_config: &elasticache_cache_cluster_config
+      shard_count: 1
+      snapshot_retention_limit: 7
+      parameters:
+        cluster-enabled: 'no'
+        maxmemory-policy: volatile-lru
+        reserved-memory: '0'
+
+    non_ha_plan: &elasticache_non_ha_plan
+      replicas_per_node_group: 0
+      automatic_failover_enabled: false
+
+    ha_plan: &elasticache_ha_plan
+      replicas_per_node_group: 1
+      automatic_failover_enabled: true
+
+    tiny_plan: &elasticache_tiny_plan
+      instance_type: cache.t2.small
+
+    small_plan: &elasticache_small_plan
+      instance_type: cache.t2.medium
+
+    medium_plan: &elasticache_medium_plan
+      instance_type: cache.m5.large
 
 - type: replace
   path: /releases/-
@@ -64,19 +91,19 @@
                       description: DEPRECATED - do not use, 568MB RAM, clustered (1 shard), single node, no failover, daily backups
                       free: true
                       metadata:
-                        displayName: Redis Clustered Tiny
+                        displayName: Redis 3.2 Clustered Tiny
                     - id: c84d1bef-9500-4ce9-88b2-c0bd421bbf8a
                       name: tiny-3.2
                       description: 568MB RAM, single node, no failover, daily backups (for instances created after 21/1/2019)
                       free: true
                       metadata:
-                        displayName: Redis tiny
+                        displayName: Redis 3.2 tiny
                     - id: b6949ea7-5c98-4c69-b981-4b5318ea8b7c
                       name: medium-ha-3.2
                       description: 6.37GB RAM, highly-available, daily backups
                       free: false
                       metadata:
-                        displayName: Redis medium highly-available
+                        displayName: Redis 3.2 medium highly-available
                     - id: ea5c8cc3-74e6-4b15-bd61-bbe244cfe63d
                       name: tiny-ha-3.2
                       description: 1.5GB RAM, highly-available, daily backups
@@ -88,59 +115,36 @@
                       description: 3GB RAM, highly-available, daily backups
                       free: false
                       metadata:
-                        displayName: Redis small highly-available
+                        displayName: Redis 3.2 small highly-available
 
             plan_configs:
               3a51701c-eef3-447c-882b-907ad2bcb7ab:
+                <<: *elasticache_cache_cluster_config # yamllint disable-line
+                <<: *elasticache_non_ha_plan # yamllint disable-line
                 instance_type: cache.t2.micro
-                replicas_per_node_group: 0
-                shard_count: 1
-                snapshot_retention_limit: 7
-                automatic_failover_enabled: true
                 parameters:
                   cluster-enabled: 'yes'
-                  maxmemory-policy: volatile-lru
-                  reserved-memory: '0'
+
               c84d1bef-9500-4ce9-88b2-c0bd421bbf8a:
+                <<: *elasticache_cache_cluster_config # yamllint disable-line
+                <<: *elasticache_non_ha_plan # yamllint disable-line
                 instance_type: cache.t2.micro
-                replicas_per_node_group: 0
-                shard_count: 1
-                snapshot_retention_limit: 7
                 automatic_failover_enabled: false
-                parameters:
-                  cluster-enabled: 'no'
-                  maxmemory-policy: volatile-lru
-                  reserved-memory: '0'
+
               b6949ea7-5c98-4c69-b981-4b5318ea8b7c:
-                instance_type: cache.m5.large
-                replicas_per_node_group: 1
-                shard_count: 1
-                snapshot_retention_limit: 7
-                automatic_failover_enabled: true
-                parameters:
-                  cluster-enabled: 'no'
-                  maxmemory-policy: volatile-lru
-                  reserved-memory: '0'
+                <<: *elasticache_cache_cluster_config # yamllint disable-line
+                <<: *elasticache_ha_plan # yamllint disable-line
+                <<: *elasticache_medium_plan # yamllint disable-line
+
               ea5c8cc3-74e6-4b15-bd61-bbe244cfe63d:
-                instance_type: cache.t2.small
-                replicas_per_node_group: 1
-                shard_count: 1
-                snapshot_retention_limit: 7
-                automatic_failover_enabled: true
-                parameters:
-                  cluster-enabled: 'no'
-                  maxmemory-policy: volatile-lru
-                  reserved-memory: '0'
+                <<: *elasticache_cache_cluster_config # yamllint disable-line
+                <<: *elasticache_ha_plan # yamllint disable-line
+                <<: *elasticache_tiny_plan # yamllint disable-line
+
               9162ed5b-0c88-4f43-bcaf-c6d4a45dd243:
-                instance_type: cache.t2.medium
-                replicas_per_node_group: 1
-                shard_count: 1
-                snapshot_retention_limit: 7
-                automatic_failover_enabled: true
-                parameters:
-                  cluster-enabled: 'no'
-                  maxmemory-policy: volatile-lru
-                  reserved-memory: '0'
+                <<: *elasticache_cache_cluster_config # yamllint disable-line
+                <<: *elasticache_ha_plan # yamllint disable-line
+                <<: *elasticache_small_plan # yamllint disable-line
 
 
 - type: replace

--- a/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
+++ b/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
@@ -46,9 +46,9 @@
   path: /releases/-
   value:
     name: elasticache-broker
-    version: 0.1.8
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/elasticache-broker-0.1.8.tgz
-    sha1: a1b83e8f8972b71756bc622442590f34ff72a551
+    version: 0.1.13 
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/elasticache-broker-0.1.13.tgz
+    sha1: 09efc6337cd4ef2d56632807d8bab622d522393e
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-

--- a/platform-tests/src/platform/broker-acceptance/redis_service_test.go
+++ b/platform-tests/src/platform/broker-acceptance/redis_service_test.go
@@ -1,6 +1,7 @@
 package acceptance_test
 
 import (
+	"fmt"
 	"io/ioutil"
 
 	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
@@ -13,84 +14,108 @@ import (
 )
 
 var _ = Describe("Redis backing service", func() {
-	const (
-		serviceName  = "redis"
-		testPlanName = "tiny-clustered-3.2"
+	var (
+		plansToTestAgainst = []string {
+			"tiny-3.2",
+			"tiny-4.x",
+			"tiny-5.x",
+		}
+
+		knownPlanNames = []string {
+			"tiny-clustered-3.2",
+			"tiny-3.2",
+			"tiny-ha-3.2",
+			"small-ha-3.2",
+			"medium-ha-3.2",
+			"tiny-4.x",
+			"tiny-ha-4.x",
+			"small-ha-4.x",
+			"medium-ha-4.x",
+			"tiny-5.x",
+			"tiny-ha-5.x",
+			"small-ha-5.x",
+			"medium-ha-5.x",			
+		}
 	)
 
 	It("is registered in the marketplace", func() {
 		plans := cf.Cf("marketplace").Wait(testConfig.DefaultTimeoutDuration())
 		Expect(plans).To(Exit(0))
-		Expect(plans).To(Say(serviceName))
+		Expect(plans).To(Say("redis"))
 	})
 
 	It("has the expected plans available", func() {
-		plans := cf.Cf("marketplace", "-s", serviceName).Wait(testConfig.DefaultTimeoutDuration())
+		plans := cf.Cf("marketplace", "-s", "redis").Wait(testConfig.DefaultTimeoutDuration())
 		Expect(plans).To(Exit(0))
-		Expect(plans.Out.Contents()).To(ContainSubstring("tiny"))
+
+		for _, name := range knownPlanNames {
+			Expect(plans.Out.Contents()).To(ContainSubstring(name))
+		}
 	})
 
-	Context("creating a database instance", func() {
-		// Avoid creating additional tests in this block because this setup and
-		// teardown is slow (several minutes).
+	for _, planName := range plansToTestAgainst {
+		Context(fmt.Sprintf("creating %s instance", planName), func() {
+			// Avoid creating additional tests in this block because this setup and
+			// teardown is slow (several minutes).
 
-		var (
-			appName        string
-			dbInstanceName string
-		)
+			var (
+				appName        string
+				dbInstanceName string
+			)
 
-		It("is accessible from the healthcheck app", func() {
+			It("is accessible from the healthcheck app", func() {
 
-			appName = generator.PrefixedRandomName(testConfig.GetNamePrefix(), "APP")
-			dbInstanceName = generator.PrefixedRandomName(testConfig.GetNamePrefix(), "test-redis")
+				appName = generator.PrefixedRandomName(testConfig.GetNamePrefix(), "APP")
+				dbInstanceName = generator.PrefixedRandomName(testConfig.GetNamePrefix(), "test-redis")
 
-			By("creating the service: "+dbInstanceName, func() {
-				Expect(cf.Cf("create-service", serviceName, testPlanName, dbInstanceName, "-c", `{"maxmemory_policy": "noeviction"}`).Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
-				pollForServiceCreationCompletion(dbInstanceName)
+				By("creating the service: "+dbInstanceName, func() {
+					Expect(cf.Cf("create-service", "redis", planName, dbInstanceName, "-c", `{"maxmemory_policy": "noeviction"}`).Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
+					pollForServiceCreationCompletion(dbInstanceName)
+				})
+
+				defer By("deleting the service", func() {
+					Expect(cf.Cf("delete-service", dbInstanceName, "-f").Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
+					pollForServiceDeletionCompletion(dbInstanceName)
+				})
+
+				By("updating the service: "+dbInstanceName, func() {
+					Expect(cf.Cf("update-service", dbInstanceName, "-c", `{"maxmemory_policy": "volatile-ttl"}`).Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
+					pollForServiceUpdateCompletion(dbInstanceName)
+				})
+
+				By("pushing the healthcheck app", func() {
+					Expect(cf.Cf(
+						"push", appName,
+						"--no-start",
+						"-b", testConfig.GetGoBuildpackName(),
+						"-p", "../../../example-apps/healthcheck",
+						"-f", "../../../example-apps/healthcheck/manifest.yml",
+						"-d", testConfig.GetAppsDomain(),
+					).Wait(testConfig.CfPushTimeoutDuration())).To(Exit(0))
+				})
+
+				defer By("deleting the app", func() {
+					cf.Cf("delete", appName, "-f").Wait(testConfig.DefaultTimeoutDuration())
+				})
+
+				By("binding the service", func() {
+					Expect(cf.Cf("bind-service", appName, dbInstanceName).Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
+				})
+
+				By("starting the app", func() {
+					Expect(cf.Cf("start", appName).Wait(testConfig.CfPushTimeoutDuration())).To(Exit(0))
+				})
+
+				By("allowing connections with TLS", func() {
+					resp, err := httpClient.Get(helpers.AppUri(appName, "/redis-test", testConfig))
+					Expect(err).NotTo(HaveOccurred())
+					body, err := ioutil.ReadAll(resp.Body)
+					Expect(err).NotTo(HaveOccurred())
+					resp.Body.Close()
+					Expect(resp.StatusCode).To(Equal(200), "Got %d response from healthcheck app. Response body:\n%s\n", resp.StatusCode, string(body))
+				})
+
 			})
-
-			defer By("deleting the service", func() {
-				Expect(cf.Cf("delete-service", dbInstanceName, "-f").Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
-				pollForServiceDeletionCompletion(dbInstanceName)
-			})
-
-			By("updating the service: "+dbInstanceName, func() {
-				Expect(cf.Cf("update-service", dbInstanceName, "-c", `{"maxmemory_policy": "volatile-ttl"}`).Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
-				pollForServiceUpdateCompletion(dbInstanceName)
-			})
-
-			By("pushing the healthcheck app", func() {
-				Expect(cf.Cf(
-					"push", appName,
-					"--no-start",
-					"-b", testConfig.GetGoBuildpackName(),
-					"-p", "../../../example-apps/healthcheck",
-					"-f", "../../../example-apps/healthcheck/manifest.yml",
-					"-d", testConfig.GetAppsDomain(),
-				).Wait(testConfig.CfPushTimeoutDuration())).To(Exit(0))
-			})
-
-			defer By("deleting the app", func() {
-				cf.Cf("delete", appName, "-f").Wait(testConfig.DefaultTimeoutDuration())
-			})
-
-			By("binding the service", func() {
-				Expect(cf.Cf("bind-service", appName, dbInstanceName).Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
-			})
-
-			By("starting the app", func() {
-				Expect(cf.Cf("start", appName).Wait(testConfig.CfPushTimeoutDuration())).To(Exit(0))
-			})
-
-			By("allowing connections with TLS", func() {
-				resp, err := httpClient.Get(helpers.AppUri(appName, "/redis-test", testConfig))
-				Expect(err).NotTo(HaveOccurred())
-				body, err := ioutil.ReadAll(resp.Body)
-				Expect(err).NotTo(HaveOccurred())
-				resp.Body.Close()
-				Expect(resp.StatusCode).To(Equal(200), "Got %d response from healthcheck app. Response body:\n%s\n", resp.StatusCode, string(body))
-			})
-
 		})
-	})
+	}
 })


### PR DESCRIPTION
What
----
Enables and configures Redis 4.x and 5.x plans

Blockers
---
- [ ] @LeePorte has pointed out there's no billing config included 

How to review
-------------
1. Code review
2. Check it ran down [my pipeline](https://deployer.andyhunt.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry) successfully
3. Check paas-elasticache-broker-boshrelease is using a prod release, and not a dev release.

After review
---
1. Merge the [`paas-elasticache-broker` PR](https://github.com/alphagov/paas-elasticache-broker/pull/21)
2. Bump the version in the [`paas-elasticache-broker-boshrelease` PR](https://github.com/alphagov/paas-elasticache-broker-boshrelease/pull/11) and merge it
3. Update [the commit setting the version of `paas-elasticache-broker-boshrelease`](https://github.com/alphagov/paas-cf/pull/2268/commits/3cf9d17b8f85780053a97c7ace87b10d3d587db6) used in this PR

Who can review
--------------
Anyone