### PR TITLE
Remove extraneous slash in CF_HOME set by subshell script

### DIFF
--- a/scripts/cf_subshell_scoped_login.sh
+++ b/scripts/cf_subshell_scoped_login.sh
@@ -32,7 +32,7 @@ case $TARGET in
 esac
 
 TMPDIR=${TMPDIR:-/tmp}
-CF_HOME=$(mktemp -d "${TMPDIR}/cf_home.XXXXXX")
+CF_HOME=$(mktemp -d "${TMPDIR}cf_home.XXXXXX")
 cleanup() {
   echo "Cleaning up temporary CF_HOME..."
   cf logout || true


### PR DESCRIPTION
What
----
The extra slash was creating a value for CF_HOME which was not the actual path.

How to review
-------------
1. Look at the one character I removed

Who can review
--------------
Me, probably.
