### PR TITLE
prometheus should scrape bosh-auditor

### DIFF
--- a/manifests/prometheus/operations.d/303-scrape-bosh-auditor.yml
+++ b/manifests/prometheus/operations.d/303-scrape-bosh-auditor.yml
@@ -1,0 +1,11 @@
+---
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  value:
+    job_name: bosh-auditor
+    scrape_interval: 30s
+    scheme: http
+    static_configs:
+      - targets:
+          # This is the BOSH director
+          - "10.0.0.6:9275"


### PR DESCRIPTION
What
----

Since https://github.com/alphagov/paas-bootstrap/pull/356 we have a microservice running on the BOSH VM which exposes metrics about how many audit events have been shipped.

The prometheis we use for operator metrics should scrape these exposed metric(s).

Who worked on this
----

Pair with @schmie