### PR TITLE
[Support] Scale Diego cells in London to 48

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -1,5 +1,5 @@
 ---
-cell_instances: 45
+cell_instances: 48
 router_instances: 6
 api_instances: 12
 doppler_instances: 33


### PR DESCRIPTION
What
----

Scaling due to memory alert for diego cells. Our chart also shows that it's time to increase the number of cells.

How to review
-------------

Code review

Who can review
--------------

Not me