### PR TITLE
[#171896989] Scale Ireland up for new services

### DIFF
--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -1,6 +1,6 @@
 ---
 cell_instances: 30
-router_instances: 6
+router_instances: 12
 api_instances: 6
 doppler_instances: 24
 log_api_instances: 6

--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -2,7 +2,7 @@
 cell_instances: 30
 router_instances: 12
 api_instances: 6
-doppler_instances: 24
+doppler_instances: 27
 log_api_instances: 6
 adapter_instances: 2
 cc_hourly_rate_limit: 20000


### PR DESCRIPTION
What
----

We expect Ireland to receive new services soon with lots of traffic. Scaling up now will give us plenty of capacity when that happens.

Routing: This PR scales us from 6 to 12 gorouters. My belief is these 12 routers will cope with 1,200–3,600rps. If CDN route caching is setup properly that should be enough. It's very possible this will expose other bottlenecks within PaaS.

Logging: This PR scales us from 24 to 27 dopplers. We don't expect them to log massively, but expanding our ability to process logs will reduce the chance of nasty surprises affecting other tenants.

How to review
-------------

Consider whether this scale is appropriate. If you need to discuss details of the new services I suggest talking in the [Pivotal story](https://www.pivotaltracker.com/story/show/171896989) or [Slack thread](https://gds.slack.com/archives/CAEHMHGJ2/p1584703513233500).

Who can review
--------------

Not @46bit.