### PR TITLE
[WIP] [#171896697] Ship CDN Broker with OriginKeepaliveTimeout fix

### DIFF
--- a/manifests/cf-manifest/operations.d/720-cdn-broker.yml
+++ b/manifests/cf-manifest/operations.d/720-cdn-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: cdn-broker
-    version: 0.1.27
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.27.tgz
-    sha1: c85fc617bc4ed205656791769c2206c6c2f53c4d
+    version: 0.0.1584707726
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.0.1584707726.tgz
+    sha1: 307e04038a491ac652caa28a10da9a56add2b988
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-


### PR DESCRIPTION
What
----

This commit ships a new boshrelease with an updated paas-cdn-broker. Hopefully it fixes a bug around updating CDN routes. 

How to review
-------------

Before deploying this, create or find an existing CDN route instance. Make sure its Origin Read Timeout is set to 60 seconds (we didn't do that to existing dev CDN routes.) Try changing the headers and check you get this error:

```
$ cf update-service my-cdn-route -c '{"headers": ["Accept", "Authorization", "Host"]}'
Server error, status code: 502, error code: 10001, message: Service broker error: IllegalUpdate: OriginKeepaliveTimeout is required for updates.
	status code: 400, request id: 5a76887e-1e3d-4d8b-af86-9eece2291d06
```

Then deploy this change. See if the command above works. We don't have good testing around the CDN broker, so create a new CDN Route too just to be sure it's all working.

How to merge
--------------

Before merging, you need to review and merge the following PRs:

1. https://github.com/alphagov/paas-cdn-broker/pull/31
2. https://github.com/alphagov/paas-cdn-broker-boshrelease/pull/28

Once those are merged the `cdn-broker-release/build-final-release` job in our build Concourse will run. Copy the YAML output from that, update this PR's commit with it, and remove `[WIP]` from the commit name. Then you can merge this.

Who can review
--------------

Not @46bit.