### PR TITLE
Increase broker acceptance timeouts

### DIFF
--- a/platform-tests/src/platform/broker-acceptance/run_tests.sh
+++ b/platform-tests/src/platform/broker-acceptance/run_tests.sh
@@ -7,10 +7,10 @@ nodes=5
 if [ -n "${GINKGO_FOCUS:-}" ]; then
   ginkgo -p \
     -nodes="${nodes}" \
-    -timeout=40m \
+    -timeout=60m \
     -focus="${GINKGO_FOCUS}"
 else
   ginkgo -p \
     -nodes="${nodes}" \
-    -timeout=40m
+    -timeout=60m
 fi


### PR DESCRIPTION
What
----

We have been hitting the limit on the current timeout for the broker acceptance tests since adding the new ElastiCache plans due to the additional work that is happening in the broker acceptance tests. I have increased the timeout as a result.

How to review
-------------

Code review

Who can review
--------------

Anyone
