### PR TITLE
Enable `service_instance_sharing` flag

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2430,6 +2430,29 @@ jobs:
 
                 cf enable-feature-flag diego_docker
 
+      - task: enable-service_instance_sharing-feature-flag
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          inputs:
+            - name: paas-cf
+          params:
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
+          image_resource: *cf-cli-image-resource
+          run:
+            path: sh
+            args:
+              - -e
+              - -u
+              - -c
+              - |
+                echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}"
+
+                cf enable-feature-flag service_instance_sharing
+
+
       - task: ensure-internal-apps-domain-created
         tags: [colocated-with-web]
         config:


### PR DESCRIPTION
What
----

The ability to share service instances between spaces has been requested by some tenants as it enables some of our tenants to speed up the creation of PR test instances to aid in their CI/CD workflow.

How to review
-------------

Code review
Have deployed to my dev env without issue. feel free to check there

Who can review
--------------

Anyone
