### PR TITLE
User emails tool outputs JSON

### DIFF
--- a/tools/user_emails/.gitignore
+++ b/tools/user_emails/.gitignore
@@ -1,0 +1,1 @@
+user_emails

--- a/tools/user_emails/emails/emails.go
+++ b/tools/user_emails/emails/emails.go
@@ -11,6 +11,7 @@ import (
 type UserDetails struct {
 	Email string `csv:"email"`
 	Org string `csv:"org"`
+	OrgId string `csv:"org_id"`
 	Role string `csv:"role"`
 	Admin string `csv:"admin"`
 	Region string `csv:"region"`
@@ -49,7 +50,7 @@ func FetchEmails(client Client, isCritical bool, isManagement bool, adminEndpoin
 					if _, ok := usersIdentity[usr]; !ok {
 						users = append(users, usr)
 						usersIdentity[usr] = true
-						record := UserDetails{ Email: usr.Username, Org: org.Name, Role: usr.Role, Admin: usr.Admin, Region: usr.Region}
+						record := UserDetails{ Email: usr.Username, Org: org.Name, OrgId: org.Guid, Role: usr.Role, Admin: usr.Admin, Region: usr.Region}
 						data = append(data, record)
 					}
 				}
@@ -59,7 +60,7 @@ func FetchEmails(client Client, isCritical bool, isManagement bool, adminEndpoin
 					if _, ok := usersIdentity[usr]; !ok {
 						users = append(users, usr)
 						usersIdentity[usr] = true
-						record := UserDetails{ Email: usr.Username, Org: org.Name, Role: usr.Role, Admin: usr.Admin, Region: usr.Region}
+						record := UserDetails{ Email: usr.Username, Org: org.Name, OrgId: org.Guid, Role: usr.Role, Admin: usr.Admin, Region: usr.Region}
 						data = append(data, record)
 					}
 				}
@@ -71,7 +72,7 @@ func FetchEmails(client Client, isCritical bool, isManagement bool, adminEndpoin
 				if _, ok := usersIdentity[usr]; !ok {
 					users = append(users, usr)
 					usersIdentity[usr] = true
-					record := UserDetails{ Email: usr.Username, Org: org.Name, Role: usr.Role, Admin: usr.Admin, Region: usr.Region}
+					record := UserDetails{ Email: usr.Username, Org: org.Name, OrgId: org.Guid, Role: usr.Role, Admin: usr.Admin, Region: usr.Region}
 					data = append(data, record)
 				}
 			}

--- a/tools/user_emails/emails/emails.go
+++ b/tools/user_emails/emails/emails.go
@@ -9,19 +9,19 @@ import (
 )
 
 type UserDetails struct {
-	Email string `csv:"email"`
-	Org string `csv:"org"`
-	OrgId string `csv:"org_id"`
-	Role string `csv:"role"`
-	Admin string `csv:"admin"`
+	Email  string `csv:"email"`
+	Org    string `csv:"org"`
+	OrgId  string `csv:"org_id"`
+	Role   string `csv:"role"`
+	Admin  string `csv:"admin"`
 	Region string `csv:"region"`
 }
 
 type userInfo struct {
 	Username string
-	Role string
-	Admin string
-	Region string
+	Role     string
+	Admin    string
+	Region   string
 }
 
 var email_regex = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
@@ -35,7 +35,7 @@ func FetchEmails(client Client, isCritical bool, isManagement bool, adminEndpoin
 	}
 
 	var users []userInfo
-	var usersIdentity map[userInfo]bool = map[userInfo]bool{}
+	var usersIdentity = map[userInfo]bool{}
 	data := []UserDetails{}
 
 	status := utils.NewStatus(os.Stderr, false)
@@ -50,7 +50,7 @@ func FetchEmails(client Client, isCritical bool, isManagement bool, adminEndpoin
 					if _, ok := usersIdentity[usr]; !ok {
 						users = append(users, usr)
 						usersIdentity[usr] = true
-						record := UserDetails{ Email: usr.Username, Org: org.Name, OrgId: org.Guid, Role: usr.Role, Admin: usr.Admin, Region: usr.Region}
+						record := UserDetails{Email: usr.Username, Org: org.Name, OrgId: org.Guid, Role: usr.Role, Admin: usr.Admin, Region: usr.Region}
 						data = append(data, record)
 					}
 				}
@@ -60,7 +60,7 @@ func FetchEmails(client Client, isCritical bool, isManagement bool, adminEndpoin
 					if _, ok := usersIdentity[usr]; !ok {
 						users = append(users, usr)
 						usersIdentity[usr] = true
-						record := UserDetails{ Email: usr.Username, Org: org.Name, OrgId: org.Guid, Role: usr.Role, Admin: usr.Admin, Region: usr.Region}
+						record := UserDetails{Email: usr.Username, Org: org.Name, OrgId: org.Guid, Role: usr.Role, Admin: usr.Admin, Region: usr.Region}
 						data = append(data, record)
 					}
 				}
@@ -72,7 +72,7 @@ func FetchEmails(client Client, isCritical bool, isManagement bool, adminEndpoin
 				if _, ok := usersIdentity[usr]; !ok {
 					users = append(users, usr)
 					usersIdentity[usr] = true
-					record := UserDetails{ Email: usr.Username, Org: org.Name, OrgId: org.Guid, Role: usr.Role, Admin: usr.Admin, Region: usr.Region}
+					record := UserDetails{Email: usr.Username, Org: org.Name, OrgId: org.Guid, Role: usr.Role, Admin: usr.Admin, Region: usr.Region}
 					data = append(data, record)
 				}
 			}
@@ -88,11 +88,11 @@ func validEmail(address string) bool {
 	return valid
 }
 
-func normal(client Client, orgs string, adminEndpoint string, region string ) []userInfo {
+func normal(client Client, orgs string, adminEndpoint string, region string) []userInfo {
 	var devs []userInfo
 
-	targetOrg := map[string] []string {
-		"organization_guid": { orgs },
+	targetOrg := map[string][]string{
+		"organization_guid": {orgs},
 	}
 	spaces, err := client.ListSpacesByQuery(targetOrg)
 	if err != nil {
@@ -106,8 +106,8 @@ func normal(client Client, orgs string, adminEndpoint string, region string ) []
 
 		for _, dev := range spaceDevs {
 			if validEmail(dev.Username) {
-				pazmin := strings.Join([]string{adminEndpoint, orgs},"")
-				data := userInfo{ Username: dev.Username, Role: "Developer", Admin: pazmin, Region: region}
+				pazmin := strings.Join([]string{adminEndpoint, orgs}, "")
+				data := userInfo{Username: dev.Username, Role: "Developer", Admin: pazmin, Region: region}
 				devs = append(devs, data)
 			}
 		}
@@ -116,12 +116,12 @@ func normal(client Client, orgs string, adminEndpoint string, region string ) []
 	return devs
 }
 
-func critical(client Client, orgs string, adminEndpoint string, region string ) []userInfo {
+func critical(client Client, orgs string, adminEndpoint string, region string) []userInfo {
 
 	var users []userInfo
 
-	targetOrg := map[string] []string {
-		"organization_guid": { orgs },
+	targetOrg := map[string][]string{
+		"organization_guid": {orgs},
 	}
 	spaces, err := client.ListSpacesByQuery(targetOrg)
 	if err != nil {
@@ -135,8 +135,8 @@ func critical(client Client, orgs string, adminEndpoint string, region string ) 
 
 		for _, dev := range spaceDevs {
 			if validEmail(dev.Username) {
-				pazmin := strings.Join([]string{adminEndpoint, orgs},"")
-				data := userInfo{ Username: dev.Username, Role: "Developer", Admin: pazmin, Region: region}
+				pazmin := strings.Join([]string{adminEndpoint, orgs}, "")
+				data := userInfo{Username: dev.Username, Role: "Developer", Admin: pazmin, Region: region}
 				users = append(users, data)
 			}
 		}
@@ -147,8 +147,8 @@ func critical(client Client, orgs string, adminEndpoint string, region string ) 
 
 		for _, manager := range spaceManagers {
 			if validEmail(manager.Username) {
-				pazmin := strings.Join([]string{adminEndpoint, orgs},"")
-				data := userInfo{ Username: manager.Username, Role: "Space Manager", Admin: pazmin, Region: region}
+				pazmin := strings.Join([]string{adminEndpoint, orgs}, "")
+				data := userInfo{Username: manager.Username, Role: "Space Manager", Admin: pazmin, Region: region}
 				users = append(users, data)
 			}
 		}
@@ -159,8 +159,8 @@ func critical(client Client, orgs string, adminEndpoint string, region string ) 
 
 		for _, auditor := range spaceAuditors {
 			if validEmail(auditor.Username) {
-				pazmin := strings.Join([]string{adminEndpoint, orgs},"")
-				data := userInfo{ Username: auditor.Username, Role: "Space Auditor", Admin: pazmin, Region: region}
+				pazmin := strings.Join([]string{adminEndpoint, orgs}, "")
+				data := userInfo{Username: auditor.Username, Role: "Space Auditor", Admin: pazmin, Region: region}
 				users = append(users, data)
 			}
 		}
@@ -171,8 +171,8 @@ func critical(client Client, orgs string, adminEndpoint string, region string ) 
 
 		for _, orgManager := range orgManagers {
 			if validEmail(orgManager.Username) {
-				pazmin := strings.Join([]string{adminEndpoint, orgs},"")
-				data := userInfo{ Username: orgManager.Username, Role: "Org Manager", Admin: pazmin, Region: region}
+				pazmin := strings.Join([]string{adminEndpoint, orgs}, "")
+				data := userInfo{Username: orgManager.Username, Role: "Org Manager", Admin: pazmin, Region: region}
 				users = append(users, data)
 			}
 		}
@@ -183,8 +183,8 @@ func critical(client Client, orgs string, adminEndpoint string, region string ) 
 
 		for _, orgAuditor := range orgAuditors {
 			if validEmail(orgAuditor.Username) {
-				pazmin := strings.Join([]string{adminEndpoint, orgs},"")
-				data := userInfo{ Username: orgAuditor.Username, Role: "Org Auditor", Admin: pazmin, Region: region}
+				pazmin := strings.Join([]string{adminEndpoint, orgs}, "")
+				data := userInfo{Username: orgAuditor.Username, Role: "Org Auditor", Admin: pazmin, Region: region}
 				users = append(users, data)
 			}
 		}
@@ -204,8 +204,8 @@ func management(client Client, orgs string, adminEndpoint string, region string)
 
 	for _, orgManager := range orgManagers {
 		if validEmail(orgManager.Username) {
-			pazmin := strings.Join([]string{adminEndpoint, orgs},"")
-			data := userInfo{ Username: orgManager.Username, Role: "Org Manager", Admin: pazmin, Region: region}
+			pazmin := strings.Join([]string{adminEndpoint, orgs}, "")
+			data := userInfo{Username: orgManager.Username, Role: "Org Manager", Admin: pazmin, Region: region}
 			users = append(users, data)
 		}
 	}
@@ -216,8 +216,8 @@ func management(client Client, orgs string, adminEndpoint string, region string)
 
 	for _, orgAuditor := range orgAuditors {
 		if validEmail(orgAuditor.Username) {
-			pazmin := strings.Join([]string{adminEndpoint, orgs},"")
-			data := userInfo{ Username: orgAuditor.Username, Role: "Org Auditor", Admin: pazmin, Region: region}
+			pazmin := strings.Join([]string{adminEndpoint, orgs}, "")
+			data := userInfo{Username: orgAuditor.Username, Role: "Org Auditor", Admin: pazmin, Region: region}
 			users = append(users, data)
 		}
 	}
@@ -229,8 +229,8 @@ func management(client Client, orgs string, adminEndpoint string, region string)
 
 	for _, orgBillingManager := range orgBillingManagers {
 		if validEmail(orgBillingManager.Username) {
-			pazmin := strings.Join([]string{adminEndpoint, orgs},"")
-			data := userInfo{ Username: orgBillingManager.Username, Role: "Billing Manager", Admin: pazmin, Region: region}
+			pazmin := strings.Join([]string{adminEndpoint, orgs}, "")
+			data := userInfo{Username: orgBillingManager.Username, Role: "Billing Manager", Admin: pazmin, Region: region}
 			users = append(users, data)
 		}
 	}

--- a/tools/user_emails/emails/emails.go
+++ b/tools/user_emails/emails/emails.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-type Csv struct {
+type UserDetails struct {
 	Email string `csv:"email"`
 	Org string `csv:"org"`
 	Role string `csv:"role"`
@@ -25,7 +25,7 @@ type userInfo struct {
 
 var email_regex = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
 
-func FetchEmails(client Client, isCritical bool, isManagement bool, adminEndpoint string, region string) []Csv {
+func FetchEmails(client Client, isCritical bool, isManagement bool, adminEndpoint string, region string) []UserDetails {
 	orgs, err := client.ListOrgs()
 
 	if err != nil {
@@ -35,7 +35,7 @@ func FetchEmails(client Client, isCritical bool, isManagement bool, adminEndpoin
 
 	var users []userInfo
 	var usersIdentity map[userInfo]bool = map[userInfo]bool{}
-	data := []Csv{}
+	data := []UserDetails{}
 
 	status := utils.NewStatus(os.Stderr, false)
 	for _, org := range orgs {
@@ -49,7 +49,7 @@ func FetchEmails(client Client, isCritical bool, isManagement bool, adminEndpoin
 					if _, ok := usersIdentity[usr]; !ok {
 						users = append(users, usr)
 						usersIdentity[usr] = true
-						record := Csv{ Email: usr.Username, Org: org.Name, Role: usr.Role, Admin: usr.Admin, Region: usr.Region}
+						record := UserDetails{ Email: usr.Username, Org: org.Name, Role: usr.Role, Admin: usr.Admin, Region: usr.Region}
 						data = append(data, record)
 					}
 				}
@@ -59,7 +59,7 @@ func FetchEmails(client Client, isCritical bool, isManagement bool, adminEndpoin
 					if _, ok := usersIdentity[usr]; !ok {
 						users = append(users, usr)
 						usersIdentity[usr] = true
-						record := Csv{ Email: usr.Username, Org: org.Name, Role: usr.Role, Admin: usr.Admin, Region: usr.Region}
+						record := UserDetails{ Email: usr.Username, Org: org.Name, Role: usr.Role, Admin: usr.Admin, Region: usr.Region}
 						data = append(data, record)
 					}
 				}
@@ -71,7 +71,7 @@ func FetchEmails(client Client, isCritical bool, isManagement bool, adminEndpoin
 				if _, ok := usersIdentity[usr]; !ok {
 					users = append(users, usr)
 					usersIdentity[usr] = true
-					record := Csv{ Email: usr.Username, Org: org.Name, Role: usr.Role, Admin: usr.Admin, Region: usr.Region}
+					record := UserDetails{ Email: usr.Username, Org: org.Name, Role: usr.Role, Admin: usr.Admin, Region: usr.Region}
 					data = append(data, record)
 				}
 			}

--- a/tools/user_emails/emails/emails_test.go
+++ b/tools/user_emails/emails/emails_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 var _ = Describe("Emails", func() {
-	Context("with 'normal' urgency", func(){
-		It("gets the spaces for each organisation", func(){
+	Context("with 'normal' urgency", func() {
+		It("gets the spaces for each organisation", func() {
 			_, cfFake := stubs.CreateFakeWithStubData()
 
 			emails.FetchEmails(&cfFake, false, false, "https://admin.example.com/organisations/", "prod")
@@ -30,14 +30,14 @@ var _ = Describe("Emails", func() {
 			}
 		})
 
-		It("only returns usernames which are valid email addresses", func(){
+		It("only returns usernames which are valid email addresses", func() {
 			_, cfFake := stubs.CreateFakeWithStubData()
 
 			names := emails.FetchEmails(&cfFake, false, false, "https://admin.example.com/organisations/", "prod")
 			Expect(names).ToNot(ContainElement("admin"))
 		})
 
-		It("catches addresses that are known to be problematic", func(){
+		It("catches addresses that are known to be problematic", func() {
 			_, cfFake := stubs.CreateFakeWithStubData()
 
 			names := emails.FetchEmails(&cfFake, false, false, "https://admin.example.com/organisations/", "prod")
@@ -50,11 +50,11 @@ var _ = Describe("Emails", func() {
 		})
 	})
 
-	Context("with 'critical' urgency", func(){
-		It("includes the username of each org manager", func(){
+	Context("with 'critical' urgency", func() {
+		It("includes the username of each org manager", func() {
 			_, cfFake := stubs.CreateFakeWithStubData()
 
-			names := emails.FetchEmails(&cfFake, true,false, "https://admin.example.com/organisations/", "prod")
+			names := emails.FetchEmails(&cfFake, true, false, "https://admin.example.com/organisations/", "prod")
 			Expect(names[6].Email).To(ContainSubstring("org-1-manager-1@paas.gov"))
 			Expect(names[6].Org).To(ContainSubstring("Org 1"))
 			Expect(names[6].Role).To(ContainSubstring("Org Manager"))
@@ -77,7 +77,7 @@ var _ = Describe("Emails", func() {
 			Expect(names[19].Region).To(ContainSubstring("prod"))
 		})
 
-		It("includes the username of each org auditor", func(){
+		It("includes the username of each org auditor", func() {
 			_, cfFake := stubs.CreateFakeWithStubData()
 
 			names := emails.FetchEmails(&cfFake, true, false, "https://admin.example.com/organisations/", "prod")
@@ -103,7 +103,7 @@ var _ = Describe("Emails", func() {
 			Expect(names[20].Region).To(ContainSubstring("prod"))
 		})
 
-		It("includes the username of each space manager in each space", func(){
+		It("includes the username of each space manager in each space", func() {
 			_, cfFake := stubs.CreateFakeWithStubData()
 
 			names := emails.FetchEmails(&cfFake, true, false, "https://admin.example.com/organisations/", "prod")
@@ -129,10 +129,10 @@ var _ = Describe("Emails", func() {
 			Expect(names[17].Region).To(ContainSubstring("prod"))
 		})
 
-		It("includes the username of each space auditor in each space", func(){
+		It("includes the username of each space auditor in each space", func() {
 			_, cfFake := stubs.CreateFakeWithStubData()
 
-			names := emails.FetchEmails(&cfFake, true,false, "https://admin.example.com/organisations/", "prod")
+			names := emails.FetchEmails(&cfFake, true, false, "https://admin.example.com/organisations/", "prod")
 			Expect(names[4].Email).To(ContainSubstring("org-1-space-1-auditor-1@paas.gov"))
 			Expect(names[4].Org).To(ContainSubstring("Org 1"))
 			Expect(names[4].Role).To(ContainSubstring("Space Auditor"))
@@ -177,8 +177,8 @@ var _ = Describe("Emails", func() {
 		})
 	})
 
-	Context("with 'management' message", func(){
-		It("includes the username of each org manager", func(){
+	Context("with 'management' message", func() {
+		It("includes the username of each org manager", func() {
 			_, cfFake := stubs.CreateFakeWithStubData()
 
 			names := emails.FetchEmails(&cfFake, false, true, "https://admin.example.com/organisations/", "prod")
@@ -204,7 +204,7 @@ var _ = Describe("Emails", func() {
 			Expect(names[9].Region).To(ContainSubstring("prod"))
 		})
 
-		It("includes the username of each org auditor", func(){
+		It("includes the username of each org auditor", func() {
 			_, cfFake := stubs.CreateFakeWithStubData()
 
 			names := emails.FetchEmails(&cfFake, false, true, "https://admin.example.com/organisations/", "prod")
@@ -230,7 +230,7 @@ var _ = Describe("Emails", func() {
 			Expect(names[10].Region).To(ContainSubstring("prod"))
 		})
 
-		It("includes the username of each org auditor", func(){
+		It("includes the username of each org auditor", func() {
 			_, cfFake := stubs.CreateFakeWithStubData()
 
 			names := emails.FetchEmails(&cfFake, false, true, "https://admin.example.com/organisations/", "prod")

--- a/tools/user_emails/emails/stubs/cf.go
+++ b/tools/user_emails/emails/stubs/cf.go
@@ -29,15 +29,15 @@ func CreateFakeWithStubData() (StubCF, fakes.FakeClient) {
 
 func (cf *StubCF) ListSpaceManagers(spaceGUID string) ([]cfclient.User, error) {
 	spaceManagers := map[string][]cfclient.User{
-		"org-1-space-1": []cfclient.User{
-			cfclient.User{Username: "org-1-space-1-manager-1@paas.gov"},
-			cfclient.User{Username: "org-1-space-1-manager-2@paas.gov"},
+		"org-1-space-1": {
+			{Username: "org-1-space-1-manager-1@paas.gov"},
+			{Username: "org-1-space-1-manager-2@paas.gov"},
 		},
-		"org-2-space-1": []cfclient.User{
-			cfclient.User{Username: "org-2-space-1-manager-1@paas.gov"},
+		"org-2-space-1": {
+			{Username: "org-2-space-1-manager-1@paas.gov"},
 		},
-		"org-3-space-1": []cfclient.User{
-			cfclient.User{Username: "org-3-space-1-manager-1@paas.gov"},
+		"org-3-space-1": {
+			{Username: "org-3-space-1-manager-1@paas.gov"},
 		},
 	}
 
@@ -50,15 +50,15 @@ func (cf *StubCF) ListSpaceManagers(spaceGUID string) ([]cfclient.User, error) {
 
 func (cf *StubCF) ListSpaceAuditors(spaceGUID string) ([]cfclient.User, error) {
 	spaceAuditors := map[string][]cfclient.User{
-		"org-1-space-1": []cfclient.User{
-			cfclient.User{Username: "org-1-space-1-auditor-1@paas.gov"},
-			cfclient.User{Username: "org-1-space-1-auditor-2@paas.gov"},
+		"org-1-space-1": {
+			{Username: "org-1-space-1-auditor-1@paas.gov"},
+			{Username: "org-1-space-1-auditor-2@paas.gov"},
 		},
-		"org-2-space-1": []cfclient.User{
-			cfclient.User{Username: "org-2-space-1-auditor-1@paas.gov"},
+		"org-2-space-1": {
+			{Username: "org-2-space-1-auditor-1@paas.gov"},
 		},
-		"org-3-space-1": []cfclient.User{
-			cfclient.User{Username: "org-3-space-1-auditor-1@paas.gov"},
+		"org-3-space-1": {
+			{Username: "org-3-space-1-auditor-1@paas.gov"},
 		},
 	}
 
@@ -71,17 +71,17 @@ func (cf *StubCF) ListSpaceAuditors(spaceGUID string) ([]cfclient.User, error) {
 
 func (cf *StubCF) ListSpaceDevelopers(spaceGUID string) ([]cfclient.User, error) {
 	spaceDevs := map[string][]cfclient.User{
-		"org-1-space-1": []cfclient.User{
-			cfclient.User{Username: "user-1@paas.gov"},
-			cfclient.User{Username: "user-2@paas.gov"},
+		"org-1-space-1": {
+			{Username: "user-1@paas.gov"},
+			{Username: "user-2@paas.gov"},
 		},
-		"org-2-space-1": []cfclient.User{
-			cfclient.User{Username: "user-1@paas.gov"},
-			cfclient.User{Username: "test@homeoffice.x.gsi.gov.uk"},
+		"org-2-space-1": {
+			{Username: "user-1@paas.gov"},
+			{Username: "test@homeoffice.x.gsi.gov.uk"},
 		},
-		"org-3-space-1": []cfclient.User{
-			cfclient.User{Username: "user-3@paas.gov"},
-			cfclient.User{Username: "admin"},
+		"org-3-space-1": {
+			{Username: "user-3@paas.gov"},
+			{Username: "admin"},
 		},
 	}
 
@@ -98,16 +98,16 @@ func (cf *StubCF) ListSpacesByQuery(query url.Values) ([]cfclient.Space, error) 
 	}
 
 	spaces := map[string][]cfclient.Space{
-		"org-1": []cfclient.Space{
-			cfclient.Space{Guid: "org-1-space-1"},
+		"org-1": {
+			{Guid: "org-1-space-1"},
 		},
 
-		"org-2": []cfclient.Space{
-			cfclient.Space{Guid: "org-2-space-1"},
+		"org-2": {
+			{Guid: "org-2-space-1"},
 		},
 
-		"org-3": []cfclient.Space{
-			cfclient.Space{Guid: "org-3-space-1"},
+		"org-3": {
+			{Guid: "org-3-space-1"},
 		},
 	}
 
@@ -122,9 +122,9 @@ func (cf *StubCF) ListSpacesByQuery(query url.Values) ([]cfclient.Space, error) 
 
 func (cf *StubCF) ListOrgs() ([]cfclient.Org, error) {
 	return []cfclient.Org{
-		cfclient.Org{Guid: "org-1", Name: "Org 1"},
-		cfclient.Org{Guid: "org-2", Name: "Org 2"},
-		cfclient.Org{Guid: "org-3", Name: "Org 3"},
+		{Guid: "org-1", Name: "Org 1"},
+		{Guid: "org-2", Name: "Org 2"},
+		{Guid: "org-3", Name: "Org 3"},
 	}, nil
 }
 
@@ -134,15 +134,15 @@ func (cf *StubCF) ListOrgUsers(orgGUID string) ([]cfclient.User, error) {
 
 func (cf *StubCF) ListOrgManagers(orgGUID string) ([]cfclient.User, error) {
 	managers := map[string][]cfclient.User{
-		"org-1": []cfclient.User{
-			cfclient.User{Username: "org-1-manager-1@paas.gov"},
-			cfclient.User{Username: "org-1-manager-2@paas.gov"},
+		"org-1": {
+			{Username: "org-1-manager-1@paas.gov"},
+			{Username: "org-1-manager-2@paas.gov"},
 		},
-		"org-2": []cfclient.User{
-			cfclient.User{Username: "org-2-manager-1@paas.gov"},
+		"org-2": {
+			{Username: "org-2-manager-1@paas.gov"},
 		},
-		"org-3": []cfclient.User{
-			cfclient.User{Username: "org-3-manager-1@paas.gov"},
+		"org-3": {
+			{Username: "org-3-manager-1@paas.gov"},
 		},
 	}
 
@@ -155,15 +155,15 @@ func (cf *StubCF) ListOrgManagers(orgGUID string) ([]cfclient.User, error) {
 
 func (cf *StubCF) ListOrgAuditors(orgGUID string) ([]cfclient.User, error) {
 	auditors := map[string][]cfclient.User{
-		"org-1": []cfclient.User{
-			cfclient.User{Username: "org-1-auditor-1@paas.gov"},
-			cfclient.User{Username: "org-1-auditor-2@paas.gov"},
+		"org-1": {
+			{Username: "org-1-auditor-1@paas.gov"},
+			{Username: "org-1-auditor-2@paas.gov"},
 		},
-		"org-2": []cfclient.User{
-			cfclient.User{Username: "org-2-auditor-1@paas.gov"},
+		"org-2": {
+			{Username: "org-2-auditor-1@paas.gov"},
 		},
-		"org-3": []cfclient.User{
-			cfclient.User{Username: "org-3-auditor-1@paas.gov"},
+		"org-3": {
+			{Username: "org-3-auditor-1@paas.gov"},
 		},
 	}
 
@@ -176,15 +176,15 @@ func (cf *StubCF) ListOrgAuditors(orgGUID string) ([]cfclient.User, error) {
 
 func (cf *StubCF) ListOrgBillingManagers(orgGUID string) ([]cfclient.User, error) {
 	billingManagers := map[string][]cfclient.User{
-		"org-1": []cfclient.User{
-			cfclient.User{Username: "org-1-billing-manager-1@paas.gov"},
-			cfclient.User{Username: "org-1-billing-manager-2@paas.gov"},
+		"org-1": {
+			{Username: "org-1-billing-manager-1@paas.gov"},
+			{Username: "org-1-billing-manager-2@paas.gov"},
 		},
-		"org-2": []cfclient.User{
-			cfclient.User{Username: "org-2-billing-manager-1@paas.gov"},
+		"org-2": {
+			{Username: "org-2-billing-manager-1@paas.gov"},
 		},
-		"org-3": []cfclient.User{
-			cfclient.User{Username: "org-3-billing-manager-1@paas.gov"},
+		"org-3": {
+			{Username: "org-3-billing-manager-1@paas.gov"},
 		},
 	}
 

--- a/tools/user_emails/main.go
+++ b/tools/user_emails/main.go
@@ -12,23 +12,22 @@ import (
 )
 
 var (
-	apiEndpoint = kingpin.Flag("api-endpoint", "API endpoint").Default("").Envar("API_ENDPOINT").String()
-	apiToken = kingpin.Flag("api-token", "CF OAuth API token").Default("").Envar("API_TOKEN").String()
+	apiEndpoint   = kingpin.Flag("api-endpoint", "API endpoint").Default("").Envar("API_ENDPOINT").String()
+	apiToken      = kingpin.Flag("api-token", "CF OAuth API token").Default("").Envar("API_TOKEN").String()
 	adminEndpoint = kingpin.Flag("admin-endpoint", "PaaS Admin base URI").Default("").Envar("ADMIN_ENDPOINT").String()
-	critical = kingpin.Flag("critical", "Print the contact list for a critical message").Default("false").Envar("CRITICAL").Bool()
-	management = kingpin.Flag("management", "Print the contact list for a message to org management").Default("false").Envar("MANAGEMENT").Bool()
-	region = kingpin.Flag("region-info", "PaaS region targeted").Default("").Envar("MAKEFILE_ENV_TARGET").String()
-	format = kingpin.Flag("format", "Output format. Defaults to CSV. Options: csv, json").Default("csv").Envar("FORMAT").String()
+	critical      = kingpin.Flag("critical", "Print the contact list for a critical message").Default("false").Envar("CRITICAL").Bool()
+	management    = kingpin.Flag("management", "Print the contact list for a message to org management").Default("false").Envar("MANAGEMENT").Bool()
+	region        = kingpin.Flag("region-info", "PaaS region targeted").Default("").Envar("MAKEFILE_ENV_TARGET").String()
+	format        = kingpin.Flag("format", "Output format. Defaults to CSV. Options: csv, json").Default("csv").Envar("FORMAT").String()
 )
 
 var (
-	FORMAT_CSV = "csv"
-	FORMAT_JSON = "json"
+	FORMAT_CSV    = "csv"
+	FORMAT_JSON   = "json"
 	VALID_FORMATS = []string{FORMAT_CSV, FORMAT_JSON}
 )
 
-
-func main(){
+func main() {
 	kingpin.Parse()
 
 	if !apiTokenPresent(apiToken) {
@@ -113,7 +112,7 @@ func location(location string) string {
 }
 
 func apiEndpointPresent(apiEndpoint *string) bool {
-	if apiEndpoint == nil ||*apiEndpoint == "" {
+	if apiEndpoint == nil || *apiEndpoint == "" {
 		return false
 	}
 

--- a/tools/user_emails/main.go
+++ b/tools/user_emails/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/alphagov/paas-cf/tools/user_emails/emails"
 	"github.com/cloudfoundry-community/go-cfclient"
@@ -17,6 +18,13 @@ var (
 	critical = kingpin.Flag("critical", "Print the contact list for a critical message").Default("false").Envar("CRITICAL").Bool()
 	management = kingpin.Flag("management", "Print the contact list for a message to org management").Default("false").Envar("MANAGEMENT").Bool()
 	region = kingpin.Flag("region-info", "PaaS region targeted").Default("").Envar("MAKEFILE_ENV_TARGET").String()
+	format = kingpin.Flag("format", "Output format. Defaults to CSV. Options: csv, json").Default("csv").Envar("FORMAT").String()
+)
+
+var (
+	FORMAT_CSV = "csv"
+	FORMAT_JSON = "json"
+	VALID_FORMATS = []string{FORMAT_CSV, FORMAT_JSON}
 )
 
 
@@ -33,6 +41,10 @@ func main(){
 		os.Exit(1)
 	}
 
+	if !validFormat(format) {
+		log.Fatalf("Invalid format '%s'", format)
+	}
+
 	client, err := cfclient.NewClient(&cfclient.Config{
 		ApiAddress: *apiEndpoint,
 		Token:      *apiToken,
@@ -45,12 +57,45 @@ func main(){
 
 	addresses := emails.FetchEmails(client, *critical, *management, *adminEndpoint, location(*region))
 
+	if *format == FORMAT_CSV {
+		outputCsv(addresses)
+	}
 
+	if *format == FORMAT_JSON {
+		outputJson(addresses)
+	}
+}
+
+func outputJson(addresses []emails.UserDetails) {
+	b, err := json.Marshal(addresses)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(string(b))
+}
+
+func outputCsv(addresses []emails.UserDetails) {
 	b, err := csvutil.Marshal(addresses)
 	if err != nil {
 		fmt.Println("error:", err)
+		return
 	}
 	fmt.Println(string(b))
+}
+
+func validFormat(format *string) bool {
+	if format == nil {
+		return false
+	}
+
+	for _, valid := range VALID_FORMATS {
+		if valid == *format {
+			return true
+		}
+	}
+
+	return false
 }
 
 func location(location string) string {

--- a/tools/user_emails/utils/status.go
+++ b/tools/user_emails/utils/status.go
@@ -2,13 +2,12 @@ package utils
 
 import (
 	"fmt"
+	"github.com/briandowns/spinner"
+	"github.com/fatih/color"
 	"io"
 	"os"
 	"time"
-	"github.com/briandowns/spinner"
-	"github.com/fatih/color"
 )
-
 
 // This file was taken as a copy from
 // https://github.com/alphagov/paas-cf-conduit/blob/a20379de044ee452ef054c08af08e1567008b402/util/status.go


### PR DESCRIPTION
What
----
Output user email details in JSON
    
Sometimes we want to get an output from the user emails tool which is machine easily parseable. JSON output fits that bill nicely.
    
Usage:

    make [env] show-tenant-comms-addresses FORMAT=json

How to review
-------------

1. Code review. It's probably easiest to review it commit by commit because the last commit runs `go fmt` across the codebase.
2. Give it a go!

Who can review
--------------
Anyone