### PR TITLE
Update uaa-customized build release details

### DIFF
--- a/manifests/cf-manifest/operations.d/330-uaa.yml
+++ b/manifests/cf-manifest/operations.d/330-uaa.yml
@@ -300,9 +300,9 @@
   path: /releases/-
   value:
     name: uaa-customized
-    version: 0.1.19
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-customized-0.1.19.tgz
-    sha1: 774062665d6e7a6233977c76f8d3000750f64c87
+    version: 0.1.20
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-customized-0.1.20.tgz
+    sha1: 22b53219661ee091dd8746f7444d19d2b6a8da2b
 
 - type: replace
   path: /instance_groups/name=uaa/jobs/-


### PR DESCRIPTION
What
----

We've update the login form fields in alphagov/paas-uaa-customized-boshrelease#16
and this is to update UAA with the latest build release number

How to review
-------------

Compare the updated values with https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/uaa-customized-release/jobs/build-final-release/builds/3
