### PR TITLE
Fix BOSH DNS CA certificate rotation

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -343,6 +343,8 @@ groups:
       - bump-patch-version
       - pipeline-check-lock
       - pipeline-release-lock
+      - healthcheck-check-state
+      - healthcheck-disable
       - cleanup-deleted-cf-users
   - name: tests
     jobs:
@@ -4683,3 +4685,45 @@ jobs:
               echo | cf login -a "${API_ENDPOINT}" -u "${CF_USER}" -p "${CF_PASS}"
 
               ./paas-cf/scripts/cleanup-deleted-cf-users.sh --delete
+
+  - name: healthcheck-check-state
+    serial: true
+    plan:
+      - get: deployed-healthcheck
+
+      - task: show-state
+        config:
+          platform: linux
+          image_resource: *cf-cli-image-resource
+          inputs:
+            - name: deployed-healthcheck
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                echo 'healthcheck is currently set to'
+                cat deployed-healthcheck/healthcheck-deployed
+
+  - name: healthcheck-disable
+    serial: true
+    plan:
+      - task: set-state
+        config:
+          platform: linux
+          image_resource: *cf-cli-image-resource
+          outputs:
+            - name: deployed-healthcheck
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                echo 'setting healthcheck to no'
+                echo "no" > deployed-healthcheck/healthcheck-deployed
+
+      - put: deployed-healthcheck
+        params:
+          file: deployed-healthcheck/healthcheck-deployed

--- a/manifests/cf-manifest/operations.d/030-bosh-dns.yml
+++ b/manifests/cf-manifest/operations.d/030-bosh-dns.yml
@@ -19,12 +19,12 @@
         api:
           client:
             tls:
-              ca: ((dns_api_tls_ca.certificate))
+              ca: ((dns_api_client_tls.ca))
               certificate: ((dns_api_client_tls.certificate))
               private_key: ((dns_api_client_tls.private_key))
           server:
             tls:
-              ca: ((dns_api_tls_ca.certificate))
+              ca: ((dns_api_server_tls.ca))
               certificate: ((dns_api_server_tls.certificate))
               private_key: ((dns_api_server_tls.private_key))
         cache:
@@ -32,13 +32,13 @@
         health:
           client:
             tls:
-              ca: ((dns_healthcheck_tls_ca.certificate))
+              ca: ((dns_healthcheck_client_tls.ca))
               certificate: ((dns_healthcheck_client_tls.certificate))
               private_key: ((dns_healthcheck_client_tls.private_key))
           enabled: true
           server:
             tls:
-              ca: ((dns_healthcheck_tls_ca.certificate))
+              ca: ((dns_healthcheck_server_tls.ca))
               certificate: ((dns_healthcheck_server_tls.certificate))
               private_key: ((dns_healthcheck_server_tls.private_key))
 

--- a/manifests/cf-manifest/spec/manifest/certificates_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/certificates_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe "certificates" do
+  def get_all_cas_usages(o)
+    return o.flat_map { |v| get_all_cas_usages(v) } if o.is_a? Array
+
+    if o.is_a? Hash
+      return o.values.flat_map { |v| get_all_cas_usages(v) } unless o.key? 'ca'
+      # Match checks if it is a usage ("name.value") or a variable ("name")
+      return [o['ca']] if o['ca'].match?(/[.]/)
+    end
+
+    []
+  end
+
+  context "ca certificates" do
+    let(:manifest) { manifest_with_defaults }
+
+    let(:ca_usages) do
+      get_all_cas_usages(manifest.fetch('.')).map do |usage|
+        usage.gsub(/[()]/, '') # delete surrounding parens
+      end
+    end
+
+    it "should use .ca for every usage of a ca certificate" do
+      ca_usages.each do |ca_usage|
+        expect(ca_usage).to match(/[.]ca$/),
+          "Usage of CA #{ca_usage} should be cert_name.ca not ca_name.certificate, otherwise credhub rotation will fail"
+      end
+    end
+  end
+end

--- a/manifests/cf-manifest/spec/manifest/certificates_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/certificates_spec.rb
@@ -3,9 +3,11 @@ RSpec.describe "certificates" do
     return o.flat_map { |v| get_all_cas_usages(v) } if o.is_a? Array
 
     if o.is_a? Hash
-      return o.values.flat_map { |v| get_all_cas_usages(v) } unless o.key? 'ca'
       # Match checks if it is a usage ("name.value") or a variable ("name")
-      return [o['ca']] if o['ca'].match?(/[.]/)
+      return [o['ca']] if o['ca']&.match?(/[.]/)
+      return [o['ca_cert']] if o['ca_cert']&.match?(/[.]/)
+
+      return o.values.flat_map { |v| get_all_cas_usages(v) }
     end
 
     []
@@ -18,6 +20,10 @@ RSpec.describe "certificates" do
       get_all_cas_usages(manifest.fetch('.')).map do |usage|
         usage.gsub(/[()]/, '') # delete surrounding parens
       end
+    end
+
+    it "should detect some ca certificate usages" do
+      expect(ca_usages).not_to eq([])
     end
 
     it "should use .ca for every usage of a ca certificate" do


### PR DESCRIPTION
What
----

1. Add 2 pipeline jobs to manage the healthcheck deployment

During debugging of this problem, the logging pipeline was broken in staging. I wanted to re-run the pipeline, but could not because the healthcheck was set to "deployed".

The healthcheck could not be ascertained to be available by the pipeline because the logging pipeline was broken.

Add a task to check the state, and set the healthcheck deployed status to false, to allow us to run the pipeline in such situations.

2. Fix BOSH DNS CA certificate rotation

If you use `((ca.certificate))` when refering to a certificate's CA cert, then you will only get the latest CA certificate interpolated in the manifest.

You must instead use `((certficate.ca))`

When you use `((certificate.ca))` and the latest CA has the "transitional" flag, then BOSH will put the latest ca cert (transitional) and the latest non-transitional CA certificate.

As a practical example, imagine `my_ca` has been updated with `transitional`.

If you refer to it in a manifest:

```
ca: ((my_ca.certificate))
```

You will get:

```
ca: ----- BEGIN CERTIFICATE -----...----- END CERTIFICATE -----
```

If you refer instead to the `.ca` from the leaf:

```
ca: ((my_certificate.ca))
```

You will get:

```
ca: ----- BEGIN CERTIFICATE -----...----- END CERTIFICATE -----\n----- BEGIN CERTIFICATE -----...----- END CERTIFICATE -----
```

3. Add a test to stop this from happening in future

The test is kind of janky, but it finds all CA certificate usages (`ca:`) which are not variables, and checks that they use `var_name.ca` instead of `var_name.certificate`

How to review
-------------

Code review

CI

I'm currently running this in my pipeline

Check that my understanding is consistent with other certificates

Who can review
--------------

Not @tlwr

Appendix
----

The rough timeline which brought this to our attention:

- Smoke tests fail in staging because logs cannot be retrieved
- CA certificate rotation job had market BOSH DNS cert as transitional in previous run
- Investigation on VM saw many invalid TLS certificate error messages
- `/var/vcap/jobs/bosh-dns/config/certs/{server,client}_ca.crt` was not the CA certificate which signed the healthcheck server certificate
- `/var/vcap/jobs/bosh-dns/config/certs/{server,client}_ca.crt` only contained one certificate, but `/stg-lon/stg-lon/dns_healthcheck_tls_ca` had a transitional version
- Checked the manifest, and saw it referenced the certificate directly instead of `certificate.ca`