### PR TITLE
Raise max app disk space to 6gb

### DIFF
--- a/manifests/cf-manifest/operations.d/320-cc-increase-max-app-disk.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-increase-max-app-disk.yml
@@ -1,7 +1,7 @@
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/maximum_app_disk_in_mb?
-  value: 4096
+  value: 6144
 
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/maximum_app_disk_in_mb?
-  value: 4096
+  value: 6144

--- a/manifests/cf-manifest/operations.d/320-cc-increase-max-app-disk.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-increase-max-app-disk.yml
@@ -1,3 +1,7 @@
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/maximum_app_disk_in_mb?
   value: 4096
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/maximum_app_disk_in_mb?
+  value: 4096


### PR DESCRIPTION
What
----
Sets the max disk space property in both places that it's needed. Sets that value to 6gb, because we have legitimate use cases for slightly bigger max disk sizes.

How to review
-------------

1. Deploy this branch to your dev env.
2. Test you can request 6gb worth of disk, both initially and in an update

```
cd $(mktemp -d)
echo "Hi" > index.html

cf push six-gig-app -b staticfile_buildpack -k 6G

cf push two-gig-app -b staticfile_buildpack -k 2G; cf scale two-gig-app -k 6G;

cf delete -f -r six-gig-app
cf delete -f -r two-gig-app
```

This is deployed in the `andyhunt` dev env, so you could try it there [and check my pipeline](https://deployer.andyhunt.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/cf-deploy/builds/4). It may not be up and running when you're reviewing though.

Who can review
--------------
Anyone with a dev env