### PR TITLE
Scale CC workers in production

### DIFF
--- a/manifests/cf-manifest/env-specific/default.yml
+++ b/manifests/cf-manifest/env-specific/default.yml
@@ -5,5 +5,6 @@ api_instances: 2
 doppler_instances: 6
 log_api_instances: 2
 adapter_instances: 2
+cc_worker_instances: 2
 cc_hourly_rate_limit: 15000
 paas_region_name: dev

--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -5,5 +5,6 @@ api_instances: 12
 doppler_instances: 33
 log_api_instances: 6
 adapter_instances: 4 # Scaled to a multiple of 2 to balance out the AZs
+cc_worker_instances: 4
 cc_hourly_rate_limit: 20000
 paas_region_name: london

--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -5,5 +5,6 @@ api_instances: 6
 doppler_instances: 33
 log_api_instances: 6
 adapter_instances: 2
+cc_worker_instances: 4
 cc_hourly_rate_limit: 20000
 paas_region_name: ireland

--- a/manifests/cf-manifest/env-specific/stg-lon.yml
+++ b/manifests/cf-manifest/env-specific/stg-lon.yml
@@ -5,5 +5,6 @@ api_instances: 2
 doppler_instances: 3
 log_api_instances: 3
 adapter_instances: 2
+cc_worker_instances: 2
 cc_hourly_rate_limit: 100000
 paas_region_name: staging

--- a/manifests/cf-manifest/operations.d/320-cc-worker-scaling.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-worker-scaling.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=cc-worker/instances
+  value: ((cc_worker_instances))

--- a/manifests/cf-manifest/spec/manifest/cc_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/cc_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe "cloud controller" do
+  context "worker" do
+    context("dev") do
+      let(:manifest) { manifest_for_dev }
+      let(:cc_worker) { manifest.fetch("instance_groups.cc-worker") }
+
+      it "has 2 instances" do
+        expect(cc_worker['instances']).to be == 2
+      end
+    end
+
+    context("prod") do
+      let(:manifest) { manifest_for_env("prod") }
+      let(:cc_worker) { manifest.fetch("instance_groups.cc-worker") }
+
+      it "has more instances" do
+        expect(cc_worker['instances']).to be > 2
+      end
+    end
+
+    context("prod-lon") do
+      let(:manifest) { manifest_for_env("prod-lon") }
+      let(:cc_worker) { manifest.fetch("instance_groups.cc-worker") }
+
+      it "has more instances" do
+        expect(cc_worker['instances']).to be > 2
+      end
+    end
+  end
+end


### PR DESCRIPTION
What
----

The V3 API uses tasks a lot more, and we have seen our cc job queue increase in length

Adding more workers in production will ensure jobs are completed in a timely manner

How to review
-------------

Code review

CI

Who can review
--------------

Not @tlwr