### PR TITLE
Set Cloud Controller Worker job timeouts

### DIFF
--- a/manifests/cf-manifest/operations.d/320-cc-worker-set-job-timeouts.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-worker-set-job-timeouts.yml
@@ -1,0 +1,8 @@
+---
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/jobs?
+  value:
+    global:
+      timeout_in_seconds: 3600 # 1 hour
+    blobstore_delete:
+      timeout_in_seconds: 3600 # 1 hour


### PR DESCRIPTION
What
----

The default timeout for a job in the cloud controller worker queue is 4 hours.
This is a very long time for a job to be hanging about when it isn't
completing. This commit sets the timeout, and that of deleting from the
blobstore, to 1 hour. This should provide time for a long running job to
complete, without being so long as to clutter the queue with jobs that will
never complete.

How to review
-------------
1. Code review
2. See that [it went out OK in my dev env](https://deployer.andyhunt.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/cf-deploy/builds/5)
3. Run it down your own dev env

Who can review
--------------
Anyone