### PR TITLE
[#172528011] Enable Postgres 9.5 upgrades

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 0.1.65
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.65.tgz
-    sha1: 105531f8c47c5a2c714f3ad8bac871042beeebd6
+    version: 0.1.66
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.66.tgz
+    sha1: a1513c811cf3300e3dcf7ecd6d918ba29c6eb608
 
 - type: replace
   path: /instance_groups/-

--- a/manifests/cf-manifest/operations.d/711-rds-broker-postgres95-plans.yml
+++ b/manifests/cf-manifest/operations.d/711-rds-broker-postgres95-plans.yml
@@ -17,7 +17,7 @@
       engine: "postgres"
       engine_version: "9.5"
       engine_family: "postgres9.5"
-      default_extensions: ["uuid-ossp", "postgis"]
+      default_extensions: ["uuid-ossp"]
       allowed_extensions: [
         "address_standardizer",
         "address_standardizer_data_us",


### PR DESCRIPTION
What
----
Bumps the version of the RDS broker being deployed to include the changes that allow Postgres 9.5 databases to be upgraded.

Removes the `postgis` extension from the list of default extensions for Postgres 9.5 plans. This is necessary for the upgrades to work.

How to review
-------------
Deploy to your dev env and follow the tests I performed below

* Can create databases with and without extension
    ```
    $ cf cs postgres tiny-unencrypted-9.5 without-postgis
    $ cf cs postgres tiny-unencrypted-9.5 with-postgis -c '{"enable_extensions": ["postgis"]}'
    ```

*   Can’t go straight to 11 
    ```
     $ cf update-service without-postgis -p tiny-unencrypted-11
    Updating service instance without-postgis as andy.hunt@digital.cabinet-office.gov.uk...
    FAILED
    Server error, status code: 502, error code: 10001, message: Service broker error: InvalidParameterCombination: RDS does not support creating a DB instance with the following combination: DBInstanceClass=db.t3.micro, Engine=postgres, EngineVersion=9.5.19, LicenseModel=postgresql-license. For supported combinations of instance class and database engine version, see the documentation.
    ```

* Correctly can’t upgrade with postgis enabled
    ```
    $ cf update-service with-postgis -p tiny-unencrypted-10
    Updating service instance with-postgis as andy.hunt@digital.cabinet-office.gov.uk...
    FAILED
    Server error, status code: 502, error code: 10001, message: Service broker error: Cannot upgrade from postgres 9 when the postgis extension is enabled. Disable the extension, or contact support.
    ```

* Can disable `postgis`
    ```
    $ cf update-service with-postgis -c '{"disable_extensions": ["postgis"]}'
    Updating service instance with-postgis as andy.hunt@digital.cabinet-office.gov.uk...
    OK
    
    Update in progress. Use 'cf services' or 'cf service with-postgis' to check operation status.
    ```

*   Then can upgrade to 10
    ```
     $ cf update-service with-postgis -p tiny-unencrypted-10
    Updating service instance with-postgis as andy.hunt@digital.cabinet-office.gov.uk...
    OK
    
    Update in progress. Use 'cf services' or 'cf service with-postgis' to check operation status.
    ```

*   Both upgrades succeed 
    ```
     $ cf s
    Getting services in org govuk-paas / space tools as andy.hunt@digital.cabinet-office.gov.uk...
    
    name              service    plan                  bound apps   last operation     broker       upgrade available
    with-postgis      postgres   tiny-unencrypted-10                update succeeded   rds-broker   
    without-postgis   postgres   tiny-unencrypted-10                update succeeded   rds-broker 
    ```

* Upgrading to 11
    ```
     $ cf update-service with-postgis -p tiny-unencrypted-11
    Updating service instance with-postgis as andy.hunt@digital.cabinet-office.gov.uk...
    OK
    
    Update in progress. Use 'cf services' or 'cf service with-postgis' to check operation status.  

    $ cf update-service without-postgis -p tiny-unencrypted-11
    Updating service instance without-postgis as andy.hunt@digital.cabinet-office.gov.uk...
    OK
    
    Update in progress. Use 'cf services' or 'cf service without-postgis' to check operation status.
     
     $ cf s
    Getting services in org govuk-paas / space tools as andy.hunt@digital.cabinet-office.gov.uk...
    
    name              service    plan                  bound apps   last operation     broker       upgrade available
    with-postgis      postgres   tiny-unencrypted-11                update succeeded   rds-broker   
    without-postgis   postgres   tiny-unencrypted-11                update succeeded   rds-broker 
    ```

After review
---
1. Review [the `paas-rds-broker` PR](https://github.com/alphagov/paas-rds-broker/pull/115)
1. Update the [`paas-rds-broker-boshrelease` PR](https://github.com/alphagov/paas-rds-broker-boshrelease/pull/91)
1. Update this PR

Who can review
--------------
Not @AP-Hunt 
