### PR TITLE
CC deployment updater should allow 6g of disk

### DIFF
--- a/manifests/cf-manifest/operations.d/320-cc-increase-max-app-disk.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-increase-max-app-disk.yml
@@ -9,3 +9,7 @@
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/maximum_app_disk_in_mb?
   value: 6144
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/cc/maximum_app_disk_in_mb?
+  value: 6144

--- a/manifests/cf-manifest/spec/manifest/cc_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/cc_spec.rb
@@ -4,10 +4,12 @@ RSpec.describe "cloud controller" do
     let(:cc_ng_props) { manifest.fetch("instance_groups.api.jobs.cloud_controller_ng.properties.cc") }
     let(:cc_worker_props) { manifest.fetch("instance_groups.cc-worker.jobs.cloud_controller_worker.properties.cc") }
     let(:cc_clock_props) { manifest.fetch("instance_groups.scheduler.jobs.cloud_controller_clock.properties.cc") }
+    let(:cc_deployment_updater_props) { manifest.fetch("instance_groups.scheduler.jobs.cc_deployment_updater.properties.cc") }
 
-    it "should be the same maximum app disk for clock and worker and api" do
+    it "should be the same maximum app disk for clock and worker and api and deployment updater" do
       expect(cc_ng_props['maximum_app_disk_in_mb']).to be == cc_worker_props['maximum_app_disk_in_mb']
       expect(cc_ng_props['maximum_app_disk_in_mb']).to be == cc_clock_props['maximum_app_disk_in_mb']
+      expect(cc_ng_props['maximum_app_disk_in_mb']).to be == cc_deployment_updater_props['maximum_app_disk_in_mb']
     end
 
     it "should be the same maximum app healthcheck timeout for clock and worker and api" do


### PR DESCRIPTION
What
----

See https://govuk.zendesk.com/agent/tickets/4051938

CC deployment updater handles rolling updates

It is currently cancelling some deployments if the manifest requests "too much disk"

The value for too much disk is wrong, and should be the same as CC API and CC worker

How to review
-------------

Code review

Look at zendesk ticket

Who can review
--------------

Not @tlwr