### PR TITLE
[#172599318] Check certs in pipeline

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -306,6 +306,7 @@ groups:
       - custom-broker-acceptance-tests
       - bosh-tests
       - rotate-certs
+      - check-certificates-after-rotation
       - tag-release
       - pipeline-unlock
   - name: platform-core
@@ -4013,14 +4014,53 @@ jobs:
                 credhub login
                 ./paas-cf/concourse/scripts/ca-rotation-set-transitional.rb
 
+  - name: check-certificates-after-rotation
+    build_logs_to_retain: 50
+    plan:
+      - in_parallel:
+          - get: pipeline-trigger
+            passed: [rotate-certs]
+            trigger: true
+          - get: paas-cf
+            passed: [rotate-certs]
+          - get: ipsec-CA
+            passed: [generate-cf-config]
+
+      - task: check-certificates
+        tags: [colocated-with-web]
+        config: &check-certificates-config
+          platform: linux
+          image_resource: *gov-paas-bosh-cli-v2-image-resource
+          params:
+            CREDHUB_CLIENT: credhub-admin
+            CREDHUB_SECRET: ((bosh-credhub-admin))
+            CREDHUB_CA_CERT: ((bosh-credhub-ca-cert))
+            CREDHUB_SERVER: "https://((bosh_fqdn)):8844/api"
+          inputs:
+            - name: paas-cf
+            - name: ipsec-CA
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                credhub login
+                ./paas-cf/concourse/scripts/check-certificates.rb 15
+
+                tar -xzf ./ipsec-CA/ipsec-CA.tar.gz -C ./ipsec-CA
+
+                echo "Checking if ipsec-CA.crt expires in the next 30 days"
+                openssl x509 -checkend 2592000 -noout -in ipsec-CA/ipsec-CA.crt
+
   - name: tag-release
     plan:
       - in_parallel:
           - get: pipeline-trigger
-            passed: ['rotate-certs']
+            passed: [check-certificates-after-rotation]
             trigger: true
           - get: paas-cf
-            passed: ['rotate-certs']
+            passed: [check-certificates-after-rotation]
           - get: git-keys
 
       - put: release-version
@@ -4633,30 +4673,7 @@ jobs:
 
       - task: check-certificates
         tags: [colocated-with-web]
-        config:
-          platform: linux
-          image_resource: *gov-paas-bosh-cli-v2-image-resource
-          params:
-            CREDHUB_CLIENT: credhub-admin
-            CREDHUB_SECRET: ((bosh-credhub-admin))
-            CREDHUB_CA_CERT: ((bosh-credhub-ca-cert))
-            CREDHUB_SERVER: "https://((bosh_fqdn)):8844/api"
-          inputs:
-            - name: paas-cf
-            - name: ipsec-CA
-          run:
-            path: sh
-            args:
-              - -e
-              - -c
-              - |
-                credhub login
-                ./paas-cf/concourse/scripts/check-certificates.rb 15
-
-                tar -xzf ./ipsec-CA/ipsec-CA.tar.gz -C ./ipsec-CA
-
-                echo "Checking if ipsec-CA.crt expires in the next 30 days"
-                openssl x509 -checkend 2592000 -noout -in ipsec-CA/ipsec-CA.crt
+        config: *check-certificates-config
 
   - name: cleanup-deleted-cf-users
     serial: true

--- a/concourse/scripts/check-certificates.rb
+++ b/concourse/scripts/check-certificates.rb
@@ -152,6 +152,23 @@ unless invalid_certificate_names.empty?
   invalid_certificate_names.each do |cert|
     puts cert.red
   end
+
+  puts <<~HELP
+    There are #{invalid_certificate_names.length} invalid certificates
+
+    This is a problem and must be remedied manually
+
+    You should:
+    1. use the credhub CLI to get the relevat certificates
+    2. debug why they are invalid using "openssl verify -verbose -issuer_checks -CAfile /path/to/ca /path/to/cert"
+    3. confer with your pair about what to do
+    4. delete/rotate/replace (possibly manually) them depending on the result of (3)
+    5. re-run this job
+
+    You may wish to refer to this previous incident: https://status.cloud.service.gov.uk/incidents/92gmvk51zw19
+
+    Good luck
+  HELP
 end
 
 separator


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/172599318)

What
----

1. Make the `check-certificates` Concourse job use `openssl verify` to check for chain validity
2. Run the `check-certificates` job after the `rotate-certificates`

Why
----

We recently [had an incident](https://status.cloud.service.gov.uk/incidents/92gmvk51zw19) because our certificates were generated in an invalid state.

Our pipeline rotates certificates close to the end, so that new certificates will be deployed on the next run.

After we regenerate the certificates, we should check that they have been generated correctly. This new job happens before the pipeline is unlocked, so any improper certificates will ensure an operator has to intervene before a new pipeline run can happen, thereby preventing invalid certificates from being deployed.

How to review
-------------

Code review

Deploy to your environment:

1. Run the `check-certificates` job in the `health` section
2. Run the pipeline and look at the `check-certificates-after-rotation`

Review the following runs in my dev environment:

1. [There is a new job in the main section of the pipeline](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry)
2. [The new job after a pipeline run](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/check-certificates-after-rotation/builds/3)
3. [Checking certificates also has `(valid)` in the output](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/check-certificates/builds/37)
4. [A simulated run just to print the help text](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/check-certificates/builds/36)

Who can review
--------------

Not @tlwr