### PR TITLE
Add lifecycle to Shield resources

### DIFF
--- a/terraform/cloudfoundry/shield_and_waf.tf
+++ b/terraform/cloudfoundry/shield_and_waf.tf
@@ -1,11 +1,19 @@
 resource "aws_shield_protection" "shield_for_app_gorouter_alb" {
   name         = "${var.env}-app-gorouter-shield"
   resource_arn = "${aws_lb.cf_router_app_domain.arn}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_shield_protection" "shield_for_system_gorouter_alb" {
   name         = "${var.env}-system-gorouter-shield"
   resource_arn = "${aws_lb.cf_router_system_domain.arn}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_wafregional_rate_based_rule" "wafregional_max_request_rate_rule" {


### PR DESCRIPTION
What
----

We didn't have a lifecycle on shield resources with would cause a failed
delete run to not be able to complete the teraform destroy.

How to review
-------------

code review
destroy your CF if you wish and check that it works

Who can review
--------------

Anyone
