### PR TITLE
[#172480682] Rotate certs often dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,7 @@ dev: ## Set Environment to DEV
 	$(eval export PERSISTENT_ENVIRONMENT=false)
 	$(eval export ENABLE_DESTROY=true)
 	$(eval export ENABLE_AUTODELETE=true)
+	$(eval export ENABLE_TEST_PIPELINES=true)
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
 	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipelineapps.digital)
 	$(eval export ALERT_EMAIL_ADDRESS?=govpaas-alerting-dev@digital.cabinet-office.gov.uk)

--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,7 @@ dev: ## Set Environment to DEV
 	$(eval export PAAS_HIGH_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
 	$(eval export ENABLE_MORNING_DEPLOYMENT=true)
 	$(eval export SLIM_DEV_DEPLOYMENT ?= true)
+	$(eval export CA_ROTATION_EXPIRY_DAYS ?= 360)
 	@true
 
 .PHONY: stg-lon
@@ -182,6 +183,7 @@ stg-lon: ## Set Environment to stg-lon
 	$(eval export PAAS_HIGH_PASSWORD_STORE_DIR?=${HOME}/.paas-pass-high)
 	$(eval export AWS_DEFAULT_REGION=eu-west-2)
 	$(eval export AWS_REGION=eu-west-2)
+	$(eval export CA_ROTATION_EXPIRY_DAYS=180)
 	@true
 
 .PHONY: prod
@@ -202,6 +204,7 @@ prod: ## Set Environment to Production
 	$(eval export PAAS_HIGH_PASSWORD_STORE_DIR?=${HOME}/.paas-pass-high)
 	$(eval export AWS_DEFAULT_REGION=eu-west-1)
 	$(eval export AWS_REGION=eu-west-1)
+	$(eval export CA_ROTATION_EXPIRY_DAYS=30)
 	@true
 
 .PHONY: prod-lon
@@ -222,6 +225,7 @@ prod-lon: ## Set Environment to prod-lon
 	$(eval export PAAS_HIGH_PASSWORD_STORE_DIR?=${HOME}/.paas-pass-high)
 	$(eval export AWS_DEFAULT_REGION=eu-west-2)
 	$(eval export AWS_REGION=eu-west-2)
+	$(eval export CA_ROTATION_EXPIRY_DAYS=30)
 	@true
 
 .PHONY: bosh-cli

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ stg-lon: ## Set Environment to stg-lon
 	$(eval export PAAS_HIGH_PASSWORD_STORE_DIR?=${HOME}/.paas-pass-high)
 	$(eval export AWS_DEFAULT_REGION=eu-west-2)
 	$(eval export AWS_REGION=eu-west-2)
-	$(eval export CA_ROTATION_EXPIRY_DAYS=180)
+	$(eval export CA_ROTATION_EXPIRY_DAYS=335)
 	@true
 
 .PHONY: prod

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -3981,6 +3981,7 @@ jobs:
             CREDHUB_SECRET: ((bosh-credhub-admin))
             CREDHUB_CA_CERT: ((bosh-credhub-ca-cert))
             CREDHUB_SERVER: "https://((bosh_fqdn)):8844/api"
+            EXPIRY_DAYS: ((ca_rotation_expiry_days))
           inputs:
             - name: paas-cf
           run:
@@ -4003,6 +4004,7 @@ jobs:
             CREDHUB_SECRET: ((bosh-credhub-admin))
             CREDHUB_CA_CERT: ((bosh-credhub-ca-cert))
             CREDHUB_SERVER: "https://((bosh_fqdn)):8844/api"
+            EXPIRY_DAYS: ((ca_rotation_expiry_days))
           inputs:
             - name: paas-cf
           run:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1032,8 +1032,17 @@ jobs:
 
                 export CONCOURSE_WEB_URL
                 CONCOURSE_WEB_URL=https://deployer.${SYSTEM_DNS_ZONE_NAME}
-                export PIPELINE_TRIGGER_VERSION
+
                 PIPELINE_TRIGGER_VERSION=$(cat pipeline-trigger/number)
+                export PIPELINE_TRIGGER_VERSION
+
+                CONCOURSE_TEAM_NAME="main"
+                CONCOURSE_PIPELINE_NAME="create-cloudfoundry"
+                export CONCOURSE_TEAM_NAME CONCOURSE_PIPELINE_NAME
+
+                CONCOURSE_JOB_NAME="post-deploy"
+                CONCOURSE_RESOURCE_NAME="pipeline-trigger"
+                export CONCOURSE_JOB_NAME CONCOURSE_RESOURCE_NAME
 
                 echo "Running app-availability-tests"
                 ./paas-cf/platform-tests/run_tests.sh ./paas-cf/platform-tests/src/platform/availability/app
@@ -1108,8 +1117,18 @@ jobs:
 
                 export CONCOURSE_WEB_URL="https://deployer.${SYSTEM_DNS_ZONE_NAME}"
                 export CF_USER="admin"
-                export PIPELINE_TRIGGER_VERSION
+
                 PIPELINE_TRIGGER_VERSION=$(cat pipeline-trigger/number)
+                export PIPELINE_TRIGGER_VERSION
+
+                CONCOURSE_TEAM_NAME="main"
+                CONCOURSE_PIPELINE_NAME="create-cloudfoundry"
+                export CONCOURSE_TEAM_NAME CONCOURSE_PIPELINE_NAME
+
+                CONCOURSE_JOB_NAME="post-deploy"
+                CONCOURSE_RESOURCE_NAME="pipeline-trigger"
+                export CONCOURSE_JOB_NAME CONCOURSE_RESOURCE_NAME
+
                 export API_ENDPOINT="https://api.${SYSTEM_DNS_ZONE_NAME}"
 
                 cf login -a "${API_ENDPOINT}" -u "${CF_USER}" -p "${CF_PASS}" -o admin -s healthchecks

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -4075,6 +4075,27 @@ jobs:
                 echo "Checking if ipsec-CA.crt expires in the next 30 days"
                 openssl x509 -checkend 2592000 -noout -in ipsec-CA/ipsec-CA.crt
 
+      - task: check-certificate-hierarchy
+        tags: [colocated-with-web]
+        config: &check-certificate-hierarchy-config
+          platform: linux
+          image_resource: *gov-paas-bosh-cli-v2-image-resource
+          params:
+            CREDHUB_CLIENT: credhub-admin
+            CREDHUB_SECRET: ((bosh-credhub-admin))
+            CREDHUB_CA_CERT: ((bosh-credhub-ca-cert))
+            CREDHUB_SERVER: "https://((bosh_fqdn)):8844/api"
+          inputs:
+            - name: paas-cf
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                credhub login
+                ./paas-cf/concourse/scripts/check-certificate-hierarchy.rb
+
   - name: tag-release
     plan:
       - in_parallel:
@@ -4696,6 +4717,10 @@ jobs:
       - task: check-certificates
         tags: [colocated-with-web]
         config: *check-certificates-config
+
+      - task: check-certificate-hierarchy
+        tags: [colocated-with-web]
+        config: *check-certificate-hierarchy-config
 
   - name: cleanup-deleted-cf-users
     serial: true

--- a/concourse/pipelines/test-certificate-rotation.yml
+++ b/concourse/pipelines/test-certificate-rotation.yml
@@ -1,0 +1,513 @@
+---
+meta:
+  containers:
+    awscli: &awscli-image-resource
+      type: docker-image
+      source:
+        repository: governmentpaas/awscli
+        tag: 91fe1e826f39798986d95a02fb1ccab6f0e7c746
+    bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
+      type: docker-image
+      source:
+        repository: governmentpaas/bosh-cli-v2
+        tag: 91fe1e826f39798986d95a02fb1ccab6f0e7c746
+    cf-acceptance-tests: &cf-acceptance-tests-image-resource
+      type: docker-image
+      source:
+        repository: governmentpaas/cf-acceptance-tests
+        tag: 91fe1e826f39798986d95a02fb1ccab6f0e7c746
+    cf-cli: &cf-cli-image-resource
+      type: docker-image
+      source:
+        repository: governmentpaas/cf-cli
+        tag: 91fe1e826f39798986d95a02fb1ccab6f0e7c746
+
+resource_types:
+  - name: metadata
+    type: docker-image
+    source:
+      repository: olhtbr/metadata-resource
+      tag: 2.0.1
+
+  - name: s3-iam
+    type: docker-image
+    source:
+      repository: governmentpaas/s3-resource
+      tag: 97e441efbfb06ac7fb09786fd74c64b05f9cc907
+
+  - name: semver-iam
+    type: docker-image
+    source:
+      repository: governmentpaas/semver-resource
+      tag: f2a80c95481056aa57d837e3b14f0012b542fdb3
+
+resources:
+  - name: paas-cf
+    type: git
+    source:
+      uri: https://github.com/alphagov/paas-cf.git
+      branch: ((branch_name))
+      tag_filter: ((paas_cf_tag_filter))
+      commit_verification_keys: ((gpg_public_keys))
+
+  - name: pipeline-trigger
+    type: semver-iam
+    source:
+      bucket: ((state_bucket))
+      region_name: ((aws_region))
+      key: ((pipeline_trigger_file))
+
+jobs:
+  - name: begin
+    serial: true
+    plan:
+      - get: paas-cf
+
+      - put: pipeline-trigger
+        params: {bump: patch}
+
+  - name: wait-for-tests
+    serial: true
+    plan:
+      - get: pipeline-trigger
+        passed: [begin]
+        trigger: true
+
+      - get: paas-cf
+        passed: [begin]
+
+      - in_parallel:
+          - task: wait-for-app-availability-tests
+            tags: [colocated-with-web]
+            config:
+              platform: linux
+              inputs:
+                - name: paas-cf
+                - name: pipeline-trigger
+              params:
+                SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+                CF_ADMIN: admin
+                CF_PASS: ((cf_pass))
+              image_resource: *cf-cli-image-resource
+              run:
+                path: sh
+                args:
+                  - -e
+                  - -u
+                  - -c
+                  - |
+                    API_ENDPOINT="https://api.${SYSTEM_DNS_ZONE_NAME}"
+                    PIPELINE_TRIGGER_VERSION=$(cat pipeline-trigger/number)
+
+                    echo | cf login -a "${API_ENDPOINT}" -u "${CF_ADMIN}" -p "${CF_PASS}" > /dev/null
+                    cf target -o admin -s healthchecks > /dev/null
+
+                    echo "Waiting for ~2mins for app-availability-tests job to start:"
+                    for _ in $(seq 24); do
+                      if cf logs healthcheck --recent | grep -q "availability-test=${PIPELINE_TRIGGER_VERSION}"; then
+                        echo "Request detected"
+                        exit 0
+                      fi
+                      printf "."
+                      sleep 5
+                    done
+
+                    echo "timeout waiting for app-availability-tests job to start"
+                    exit 1
+
+          - task: wait-for-api-availability-tests
+            tags: [colocated-with-web]
+            config:
+              platform: linux
+              inputs:
+                - name: paas-cf
+                - name: pipeline-trigger
+              params:
+                AWS_DEFAULT_REGION: ((aws_region))
+              image_resource: *awscli-image-resource
+              run:
+                path: sh
+                args:
+                  - -e
+                  - -c
+                  - |
+                    PIPELINE_TRIGGER_VERSION=$(cat pipeline-trigger/number)
+                    JOB_FILE="jobs/${PIPELINE_TRIGGER_VERSION}/api-availability-tests"
+                    bucket=((state_bucket))
+
+                    echo "Waiting for ~2mins for api-availability-tests job to start by polling for ${bucket}/${JOB_FILE}"
+                    for _ in $(seq 24); do
+                      if aws s3 ls "s3://${bucket}/${JOB_FILE}" ; then
+                        echo "$JOB_FILE detected"
+                        exit 0
+                      fi
+                      printf "."
+                      sleep 5
+                    done
+
+                    echo "timeout waiting for api-availability-tests job to start"
+                    exit 1
+
+  - name: app-availability-tests
+    serial: true
+    plan:
+      - in_parallel:
+          - get: pipeline-trigger
+            passed: [begin]
+            trigger: true
+
+          - get: paas-cf
+            passed: [begin]
+
+      - task: run-tests
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *cf-acceptance-tests-image-resource
+          inputs:
+            - name: paas-cf
+            - name: pipeline-trigger
+          params:
+            SKIP_SSL_VALIDATION: true
+            APPS_DNS_ZONE_NAME: ((apps_dns_zone_name))
+            SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+            CONCOURSE_WEB_USERNAME: admin
+            DEPLOY_ENV: ((deploy_env))
+            BRANCH: ((branch_name))
+            CONCOURSE_WEB_PASSWORD: ((concourse_web_password))
+            SLIM_DEV_DEPLOYMENT: ((slim_dev_deployment))
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                export CONCOURSE_WEB_URL
+                CONCOURSE_WEB_URL=https://deployer.${SYSTEM_DNS_ZONE_NAME}
+
+                PIPELINE_TRIGGER_VERSION=$(cat pipeline-trigger/number)
+                export PIPELINE_TRIGGER_VERSION
+
+                CONCOURSE_TEAM_NAME="main"
+                CONCOURSE_PIPELINE_NAME="test-certificate-rotation"
+                export CONCOURSE_TEAM_NAME CONCOURSE_PIPELINE_NAME
+
+                CONCOURSE_JOB_NAME="done"
+                CONCOURSE_RESOURCE_NAME="pipeline-trigger"
+                export CONCOURSE_JOB_NAME CONCOURSE_RESOURCE_NAME
+
+                echo "Running app-availability-tests"
+                ./paas-cf/platform-tests/run_tests.sh ./paas-cf/platform-tests/src/platform/availability/app
+
+  - name: api-availability-tests
+    serial: true
+    plan:
+      - in_parallel:
+          - get: pipeline-trigger
+            passed: [begin]
+            trigger: true
+
+          - get: paas-cf
+            passed: [begin]
+
+      - task: upload-job-file
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *awscli-image-resource
+          inputs:
+            - name: pipeline-trigger
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                PIPELINE_TRIGGER_VERSION=$(cat pipeline-trigger/number)
+                JOB_FILE="jobs/${PIPELINE_TRIGGER_VERSION}/api-availability-tests"
+                echo "Writing $JOB_FILE to S3 to signal job start"
+                echo 'started' | aws s3 cp - "s3://((state_bucket))/$JOB_FILE"
+
+      - task: run-tests
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *cf-acceptance-tests-image-resource
+          inputs:
+            - name: paas-cf
+            - name: pipeline-trigger
+          params:
+            SKIP_SSL_VALIDATION: true
+            APPS_DNS_ZONE_NAME: ((apps_dns_zone_name))
+            SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+            CONCOURSE_WEB_USERNAME: admin
+            DEPLOY_ENV: ((deploy_env))
+            BRANCH: ((branch_name))
+            CONCOURSE_WEB_PASSWORD: ((concourse_web_password))
+            AWS_DEFAULT_REGION: ((aws_region))
+            SLIM_DEV_DEPLOYMENT: ((slim_dev_deployment))
+            CF_PASS: ((cf_pass))
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                export CONCOURSE_WEB_URL="https://deployer.${SYSTEM_DNS_ZONE_NAME}"
+                export CF_USER="admin"
+                PIPELINE_TRIGGER_VERSION=$(cat pipeline-trigger/number)
+                export PIPELINE_TRIGGER_VERSION
+
+                CONCOURSE_TEAM_NAME="main"
+                CONCOURSE_PIPELINE_NAME="test-certificate-rotation"
+                export CONCOURSE_TEAM_NAME CONCOURSE_PIPELINE_NAME
+
+                CONCOURSE_JOB_NAME="done"
+                CONCOURSE_RESOURCE_NAME="pipeline-trigger"
+                export CONCOURSE_JOB_NAME CONCOURSE_RESOURCE_NAME
+
+                export API_ENDPOINT="https://api.${SYSTEM_DNS_ZONE_NAME}"
+
+                cf login -a "${API_ENDPOINT}" -u "${CF_USER}" -p "${CF_PASS}" -o admin -s healthchecks
+
+                echo "Running api-availability-tests"
+                ./paas-cf/platform-tests/run_tests.sh ./paas-cf/platform-tests/src/platform/availability/api
+        ensure:
+          task: delete-job-file
+          tags: [colocated-with-web]
+          config:
+            platform: linux
+            image_resource: *awscli-image-resource
+            inputs:
+              - name: pipeline-trigger
+            run:
+              path: sh
+              args:
+                - -e
+                - -c
+                - |
+                  PIPELINE_TRIGGER_VERSION=$(cat pipeline-trigger/number)
+                  JOB_FILE="jobs/${PIPELINE_TRIGGER_VERSION}/api-availability-tests"
+                  aws s3 rm "s3://((state_bucket))/${JOB_FILE}"
+
+  - name: deploy-before
+    serial: true
+    serial_groups: [deploy-and-rotate]
+    plan:
+      - get: pipeline-trigger
+        passed: [wait-for-tests]
+        trigger: true
+
+      - get: paas-cf
+        passed: [wait-for-tests]
+
+      - &bosh-deploy
+        task: bosh-deploy
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *gov-paas-bosh-cli-v2-image-resource
+          inputs:
+            - name: paas-cf
+          params:
+            BOSH_ENVIRONMENT: ((bosh_fqdn))
+            BOSH_CA_CERT: ((bosh-ca-cert))
+            BOSH_DEPLOYMENT: ((deploy_env))
+            BOSH_CLIENT_SECRET: ((bosh-client-secret))
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                BOSH_CLIENT='admin'
+                export BOSH_CLIENT
+
+                bosh -n manifest > manifest.yml
+                bosh -n deploy manifest.yml
+
+  - name: rotate-1
+    serial: true
+    serial_groups: [deploy-and-rotate]
+    plan:
+      - get: pipeline-trigger
+        passed: [deploy-before]
+        trigger: true
+
+      - get: paas-cf
+        passed: [deploy-before]
+
+      - &do-step
+        do:
+          - task: remove-transitional-flag-for-ca
+            tags: [colocated-with-web]
+            config:
+              platform: linux
+              image_resource: *gov-paas-bosh-cli-v2-image-resource
+              params:
+                CREDHUB_CLIENT: credhub-admin
+                CREDHUB_SECRET: ((bosh-credhub-admin))
+                CREDHUB_CA_CERT: ((bosh-credhub-ca-cert))
+                CREDHUB_SERVER: "https://((bosh_fqdn)):8844/api"
+              inputs:
+                - name: paas-cf
+              run:
+                path: sh
+                args:
+                  - -e
+                  - -u
+                  - -c
+                  - |
+                    credhub login
+                    ./paas-cf/concourse/scripts/ca-rotation-remove-transitional.rb
+
+          - task: move-transitional-flag-for-ca
+            tags: [colocated-with-web]
+            config:
+              platform: linux
+              image_resource: *gov-paas-bosh-cli-v2-image-resource
+              params:
+                CREDHUB_CLIENT: credhub-admin
+                CREDHUB_SECRET: ((bosh-credhub-admin))
+                CREDHUB_CA_CERT: ((bosh-credhub-ca-cert))
+                CREDHUB_SERVER: "https://((bosh_fqdn)):8844/api"
+                EXPIRY_DAYS: ((ca_rotation_expiry_days))
+              inputs:
+                - name: paas-cf
+              run:
+                path: sh
+                args:
+                  - -e
+                  - -u
+                  - -c
+                  - |
+                    credhub login
+                    ./paas-cf/concourse/scripts/ca-rotation-move-transitional.rb
+
+          - task: set-transitional-flag-for-ca
+            tags: [colocated-with-web]
+            config:
+              platform: linux
+              image_resource: *gov-paas-bosh-cli-v2-image-resource
+              params:
+                CREDHUB_CLIENT: credhub-admin
+                CREDHUB_SECRET: ((bosh-credhub-admin))
+                CREDHUB_CA_CERT: ((bosh-credhub-ca-cert))
+                CREDHUB_SERVER: "https://((bosh_fqdn)):8844/api"
+                EXPIRY_DAYS: ((ca_rotation_expiry_days))
+              inputs:
+                - name: paas-cf
+              run:
+                path: sh
+                args:
+                  - -e
+                  - -u
+                  - -c
+                  - |
+                    credhub login
+                    ./paas-cf/concourse/scripts/ca-rotation-set-transitional.rb
+
+          - task: check-certificates
+            tags: [colocated-with-web]
+            config: &check-certificates-config
+              platform: linux
+              image_resource: *gov-paas-bosh-cli-v2-image-resource
+              params:
+                CREDHUB_CLIENT: credhub-admin
+                CREDHUB_SECRET: ((bosh-credhub-admin))
+                CREDHUB_CA_CERT: ((bosh-credhub-ca-cert))
+                CREDHUB_SERVER: "https://((bosh_fqdn)):8844/api"
+              inputs:
+                - name: paas-cf
+              run:
+                path: sh
+                args:
+                  - -e
+                  - -c
+                  - |
+                    credhub login
+                    ./paas-cf/concourse/scripts/check-certificates.rb 15
+
+          - *bosh-deploy
+
+  - name: rotate-2
+    serial: true
+    serial_groups: [deploy-and-rotate]
+    plan:
+      - get: pipeline-trigger
+        passed: [rotate-1]
+        trigger: true
+
+      - get: paas-cf
+        passed: [rotate-1]
+
+      - *do-step
+
+  - name: rotate-3
+    serial: true
+    serial_groups: [deploy-and-rotate]
+    plan:
+      - get: pipeline-trigger
+        passed: [rotate-2]
+        trigger: true
+
+      - get: paas-cf
+        passed: [rotate-2]
+
+      - *do-step
+
+  - name: deploy-after
+    serial: true
+    serial_groups: [deploy-and-rotate]
+    plan:
+      - get: pipeline-trigger
+        passed: [rotate-3]
+        trigger: true
+
+      - get: paas-cf
+        passed: [rotate-3]
+
+      - &bosh-deploy
+        task: bosh-deploy
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *gov-paas-bosh-cli-v2-image-resource
+          inputs:
+            - name: paas-cf
+          params:
+            BOSH_ENVIRONMENT: ((bosh_fqdn))
+            BOSH_CA_CERT: ((bosh-ca-cert))
+            BOSH_DEPLOYMENT: ((deploy_env))
+            BOSH_CLIENT_SECRET: ((bosh-client-secret))
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                BOSH_CLIENT='admin'
+                export BOSH_CLIENT
+
+                bosh -n manifest > manifest.yml
+                bosh -n deploy manifest.yml
+
+  - name: done
+    serial: true
+    plan:
+      - get: pipeline-trigger
+        passed: [deploy-after]
+        trigger: true
+
+      - get: paas-cf
+        passed: [deploy-after]
+
+  - name: end
+    serial: true
+    plan:
+      - get: pipeline-trigger
+        passed: [done, api-availability-tests, app-availability-tests]
+        trigger: true
+
+      - get: paas-cf
+        passed: [done]

--- a/concourse/pipelines/test-certificate-rotation.yml
+++ b/concourse/pipelines/test-certificate-rotation.yml
@@ -63,6 +63,17 @@ jobs:
     plan:
       - get: paas-cf
 
+      # This task is just to consume paas-cf to stop pipecleaner from whining
+      - task: consume-paas-cf
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          inputs:
+            - name: paas-cf
+          image_resource: *cf-cli-image-resource
+          run:
+            path: echo
+
       - put: pipeline-trigger
         params: {bump: patch}
 

--- a/concourse/scripts/ca-rotation-move-transitional.rb
+++ b/concourse/scripts/ca-rotation-move-transitional.rb
@@ -2,6 +2,7 @@
 
 require 'date'
 require 'json'
+require 'time'
 
 require_relative './lib/credhub'
 require_relative './lib/formatting'
@@ -36,7 +37,7 @@ ca_certs.each do |cert|
   end
 
   sorted_cas = versions
-    .sort_by { |version| Date.parse(version['expiry_date']) }
+    .sort_by { |version| Time.parse(version['expiry_date']) }
     .reverse
 
   new_ca, old_ca, *_other_cas = sorted_cas

--- a/concourse/scripts/ca-rotation-move-transitional.rb
+++ b/concourse/scripts/ca-rotation-move-transitional.rb
@@ -98,7 +98,7 @@ unless transitional_certificate_names.empty?
   separator
 
   puts 'The following certificates have been transitioned:'
-  transitional_certificate_names.each do |cert|
+  transitional_certificate_names.sort.each do |cert|
     puts cert.yellow
   end
 end
@@ -108,7 +108,7 @@ unless regenerated_certificate_names.empty?
 
   puts 'The following certificates have been regenerated:'
 
-  regenerated_certificate_names.each do |cert|
+  regenerated_certificate_names.sort.each do |cert|
     puts cert.yellow
   end
 end

--- a/concourse/scripts/ca-rotation-move-transitional.rb
+++ b/concourse/scripts/ca-rotation-move-transitional.rb
@@ -73,7 +73,6 @@ puts "Checking leaf certs"
 leaf_certs.select do |cert|
   cert_name = cert['name']
 
-  puts "Getting active certs for #{cert_name}"
   versions = client.current_certificates(cert_name)
 
   if versions.length > 1

--- a/concourse/scripts/ca-rotation-move-transitional.rb
+++ b/concourse/scripts/ca-rotation-move-transitional.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# rubocop:disable Metrics/BlockLength
 
 require 'date'
 require 'json'
@@ -112,3 +113,5 @@ unless regenerated_certificate_names.empty?
     puts cert.yellow
   end
 end
+
+# rubocop:enable Metrics/BlockLength

--- a/concourse/scripts/ca-rotation-move-transitional.rb
+++ b/concourse/scripts/ca-rotation-move-transitional.rb
@@ -31,7 +31,7 @@ ca_certs.each do |cert|
   versions = client.current_certificates(cert_name)
 
   if versions.length <= 1
-    puts "#{cert_name.yellow} does not have multiple versions...#{'skipped'.green}"
+    puts "#{cert_name.yellow} does not have multiple versions...#{'skipping'.green}"
     next
   end
 
@@ -42,7 +42,7 @@ ca_certs.each do |cert|
   new_ca, old_ca, *_other_cas = sorted_cas
 
   unless !old_ca['transitional'] && new_ca['transitional']
-    puts "#{cert_name.yellow} does not need transitioning...#{'skipped'.green}"
+    puts "#{cert_name.yellow} does not need transitioning...#{'skipping'.green}"
     next
   end
 
@@ -61,7 +61,7 @@ ca_certs.each do |cert|
       next
     end
 
-    puts "#{leaf.yellow} signed by #{cert_name.yellow}...#{'regenerated'.yellow}"
+    puts "#{leaf.yellow} signed by #{cert_name.yellow}...#{'regenerating'.yellow}"
     `credhub regenerate -n '#{leaf}'`
     regenerated_certificate_names << leaf
   end
@@ -77,7 +77,7 @@ leaf_certs.select do |cert|
   versions = client.current_certificates(cert_name)
 
   if versions.length > 1
-    puts "#{cert_name.yellow} has more than one active cert...#{'skipped'.green}"
+    puts "#{cert_name.yellow} has more than one active cert...#{'skipping'.green}"
     next
   end
 
@@ -85,11 +85,11 @@ leaf_certs.select do |cert|
   expires_in = (expiry_date - Date.today).to_i
 
   if expiry_date > date_of_expiry
-    puts "#{cert_name.yellow} expires on #{expiry_date} (in #{expires_in} days)...#{'skipped'.green}"
+    puts "#{cert_name.yellow} expires on #{expiry_date} (in #{expires_in} days)...#{'skipping'.green}"
     next
   end
 
-  puts "#{cert_name.yellow} expires on #{expiry_date} (in #{expires_in} days)...#{'regenerated'.yellow}"
+  puts "#{cert_name.yellow} expires on #{expiry_date} (in #{expires_in} days)...#{'regenerating'.yellow}"
   `credhub regenerate -n "#{cert_name}"`
   regenerated_certificate_names << cert_name
 end

--- a/concourse/scripts/ca-rotation-move-transitional.rb
+++ b/concourse/scripts/ca-rotation-move-transitional.rb
@@ -41,7 +41,7 @@ ca_certs.each do |cert|
 
   new_ca, old_ca, *_other_cas = sorted_cas
 
-  unless !old_ca['transitional'] && new_ca['transitional']
+  unless new_ca['transitional']
     puts "#{cert_name.yellow} does not need transitioning...#{'skipping'.green}"
     next
   end

--- a/concourse/scripts/ca-rotation-move-transitional.rb
+++ b/concourse/scripts/ca-rotation-move-transitional.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
-require 'json'
 require 'date'
+require 'json'
 
 require_relative './lib/credhub'
 require_relative './lib/formatting'
@@ -14,55 +14,62 @@ date_of_expiry = Date.today + expiry_days
 
 api_url = "#{credhub_server}/v1"
 
-puts "Getting certificates"
 client = CredHubClient.new(api_url)
-certs = client.certificates.reject { |c| c['name'].match?(/_old$/) }
+certs = client
+  .certificates
+  .reject { |c| c['name'].match?(/_old$/) }
 
-puts "Finding CA certs"
-ca_certs = certs.select { |c| c['name'] == c['signed_by'] }
+ca_certs, leaf_certs = certs.partition { |c| c['name'] == c['signed_by'] }
 
-ca_certs.each { |cert|
+transitional_certificate_names = []
+regenerated_certificate_names = []
+
+puts "Checking CA certs"
+ca_certs.each do |cert|
   cert_name = cert['name']
 
-  puts "Getting active ca certs for #{cert_name}"
   versions = client.current_certificates(cert_name)
 
-  if versions.length > 1
-    puts "#{cert_name} has more than one active version"
-
-    sorted_cas = versions
-      .sort_by { |version| Date.parse(version['expiry_date']) }
-      .reverse
-
-    new_ca, old_ca, *_other_cas = sorted_cas
-
-    if !old_ca['transitional'] && new_ca['transitional']
-
-      puts "Version #{old_ca['id']} has an expiry date of #{old_ca['expiry_date']} and the transitional flag is set to #{old_ca['transitional']}"
-      puts "Version #{new_ca['id']} has an expiry date of #{new_ca['expiry_date']} and the transitional flag is set to #{new_ca['transitional']}"
-      puts "#{cert_name} has been regenerated"
-
-      puts "Moving the transitional flag to the old CA certificate: #{old_ca['id']}"
-      `credhub curl -p '#{api_url}/certificates/#{cert['id']}/update_transitional_version' -d '{\"version\": "#{old_ca['id']}"}' -X PUT`
-
-      puts "Regenerating leaf certs"
-      cert['signs'].each do |leaf|
-        unless leaf['signs'].nil?
-          puts "Can't regenerate #{leaf['name']} as it signs #{leaf['signs']}"
-          next
-        end
-
-        puts "Regenerating #{leaf} signed by the #{cert_name}"
-        `credhub regenerate -n '#{leaf}'`
-      end
-    end
+  if versions.length <= 1
+    puts "#{cert_name.yellow} does not have multiple versions...#{'skipped'.green}"
+    next
   end
-}
 
-leaf_certs = certs.reject { |cert| ca_certs.include? cert }
+  sorted_cas = versions
+    .sort_by { |version| Date.parse(version['expiry_date']) }
+    .reverse
+
+  new_ca, old_ca, *_other_cas = sorted_cas
+
+  unless !old_ca['transitional'] && new_ca['transitional']
+    puts "#{cert_name.yellow} does not need transitioning...#{'skipped'.green}"
+    next
+  end
+
+  puts "Version #{old_ca['id']} has an expiry date of #{old_ca['expiry_date']} and the transitional flag is set to #{old_ca['transitional']}"
+  puts "Version #{new_ca['id']} has an expiry date of #{new_ca['expiry_date']} and the transitional flag is set to #{new_ca['transitional']}"
+  puts "#{cert_name} has been regenerated"
+
+  puts "Moving the transitional flag to the old CA certificate: #{old_ca['id']}"
+  `credhub curl -p '#{api_url}/certificates/#{cert['id']}/update_transitional_version' -d '{\"version\": "#{old_ca['id']}"}' -X PUT`
+  transitional_certificate_names << cert_name
+
+  puts "Regenerating leaf certs"
+  cert['signs'].each do |leaf|
+    unless leaf['signs'].nil?
+      puts "Can't regenerate #{leaf['name'].red} as it signs #{leaf['signs'].red}"
+      next
+    end
+
+    puts "#{leaf.yellow} signed by #{cert_name.yellow}...#{'regenerated'.yellow}"
+    `credhub regenerate -n '#{leaf}'`
+    regenerated_certificate_names << leaf
+  end
+end
+
+separator
 
 puts "Checking leaf certs"
-
 leaf_certs.select do |cert|
   cert_name = cert['name']
 
@@ -70,17 +77,38 @@ leaf_certs.select do |cert|
   versions = client.current_certificates(cert_name)
 
   if versions.length > 1
-    puts "Skipping #{cert_name} as it has more than one active cert"
+    puts "#{cert_name.yellow} has more than one active cert...#{'skipped'.green}"
     next
   end
 
   expiry_date = Date.parse(versions.first['expiry_date'])
   expires_in = (expiry_date - Date.today).to_i
 
-  if expiry_date <= date_of_expiry
-    puts "#{cert_name} expires on #{expiry_date}. Expires in #{expires_in} days time. Regenerating #{cert_name}."
-    `credhub regenerate -n "#{cert_name}"`
-  else
-    puts "#{cert_name} expires on #{expiry_date}. Expires in #{expires_in} days time. Doesn't need to be rotated."
+  if expiry_date > date_of_expiry
+    puts "#{cert_name.yellow} expires on #{expiry_date} (in #{expires_in} days)...#{'skipped'.green}"
+    next
+  end
+
+  puts "#{cert_name.yellow} expires on #{expiry_date} (in #{expires_in} days)...#{'regenerated'.yellow}"
+  `credhub regenerate -n "#{cert_name}"`
+  regenerated_certificate_names << cert_name
+end
+
+unless transitional_certificate_names.empty?
+  separator
+
+  puts 'The following certificates have been transitioned:'
+  transitional_certificate_names.each do |cert|
+    puts cert.yellow
+  end
+end
+
+unless regenerated_certificate_names.empty?
+  separator
+
+  puts 'The following certificates have been regenerated:'
+
+  regenerated_certificate_names.each do |cert|
+    puts cert.yellow
   end
 end

--- a/concourse/scripts/ca-rotation-move-transitional.rb
+++ b/concourse/scripts/ca-rotation-move-transitional.rb
@@ -46,22 +46,17 @@ ca_certs.each do |cert|
     next
   end
 
-  puts "Version #{old_ca['id']} has an expiry date of #{old_ca['expiry_date']} and the transitional flag is set to #{old_ca['transitional']}"
-  puts "Version #{new_ca['id']} has an expiry date of #{new_ca['expiry_date']} and the transitional flag is set to #{new_ca['transitional']}"
-  puts "#{cert_name} has been regenerated"
-
-  puts "Moving the transitional flag to the old CA certificate: #{old_ca['id']}"
+  puts "#{cert_name.yellow} needs transitioning...#{'transitioning'.yellow}"
   `credhub curl -p '#{api_url}/certificates/#{cert['id']}/update_transitional_version' -d '{\"version\": "#{old_ca['id']}"}' -X PUT`
   transitional_certificate_names << cert_name
 
-  puts "Regenerating leaf certs"
   cert['signs'].each do |leaf|
     unless leaf['signs'].nil?
-      puts "Can't regenerate #{leaf['name'].red} as it signs #{leaf['signs'].red}"
+      puts "  Can't regenerate #{leaf['name'].red} as it signs #{leaf['signs'].red}"
       next
     end
 
-    puts "#{leaf.yellow} signed by #{cert_name.yellow}...#{'regenerating'.yellow}"
+    puts "  #{leaf.blue} signed by #{cert_name.yellow}...#{'regenerating'.yellow}"
     `credhub regenerate -n '#{leaf}'`
     regenerated_certificate_names << leaf
   end

--- a/concourse/scripts/ca-rotation-move-transitional.rb
+++ b/concourse/scripts/ca-rotation-move-transitional.rb
@@ -52,11 +52,11 @@ ca_certs.each do |cert|
 
   cert['signs'].each do |leaf|
     unless leaf['signs'].nil?
-      puts "  Can't regenerate #{leaf['name'].red} as it signs #{leaf['signs'].red}"
+      puts "Can't regenerate #{leaf['name'].red} as it signs #{leaf['signs'].red}"
       next
     end
 
-    puts "  #{leaf.blue} signed by #{cert_name.yellow}...#{'regenerating'.yellow}"
+    puts "#{leaf.blue} signed by #{cert_name.yellow}...#{'regenerating'.yellow}"
     client.regenerate_certificate(leaf)
     regenerated_certificate_names << leaf
   end

--- a/concourse/scripts/ca-rotation-move-transitional.rb
+++ b/concourse/scripts/ca-rotation-move-transitional.rb
@@ -47,7 +47,7 @@ ca_certs.each do |cert|
   end
 
   puts "#{cert_name.yellow} needs transitioning...#{'transitioning'.yellow}"
-  `credhub curl -p '#{api_url}/certificates/#{cert['id']}/update_transitional_version' -d '{\"version\": "#{old_ca['id']}"}' -X PUT`
+  client.update_certificate_transitional_version(cert['id'], old_ca['id'])
   transitional_certificate_names << cert_name
 
   cert['signs'].each do |leaf|

--- a/concourse/scripts/ca-rotation-move-transitional.rb
+++ b/concourse/scripts/ca-rotation-move-transitional.rb
@@ -57,7 +57,7 @@ ca_certs.each do |cert|
     end
 
     puts "  #{leaf.blue} signed by #{cert_name.yellow}...#{'regenerating'.yellow}"
-    `credhub regenerate -n '#{leaf}'`
+    client.regenerate_certificate(leaf)
     regenerated_certificate_names << leaf
   end
 end
@@ -89,7 +89,7 @@ leaf_certs.select do |cert|
   end
 
   puts "#{cert_name.yellow} expires on #{expiry_date} (in #{expires_in} days)...#{'regenerating'.yellow}"
-  `credhub regenerate -n "#{cert_name}"`
+  client.regenerate_certificate(cert_name)
   regenerated_certificate_names << cert_name
 end
 

--- a/concourse/scripts/ca-rotation-move-transitional.rb
+++ b/concourse/scripts/ca-rotation-move-transitional.rb
@@ -88,6 +88,11 @@ leaf_certs.select do |cert|
     next
   end
 
+  if regenerated_certificate_names.include? cert_name
+    puts "#{cert_name.yellow} already regenerated in this job...#{'skipping'.green}"
+    next
+  end
+
   puts "#{cert_name.yellow} expires on #{expiry_date} (in #{expires_in} days)...#{'regenerating'.yellow}"
   `credhub regenerate -n "#{cert_name}"`
   regenerated_certificate_names << cert_name

--- a/concourse/scripts/ca-rotation-move-transitional.rb
+++ b/concourse/scripts/ca-rotation-move-transitional.rb
@@ -24,7 +24,7 @@ ca_certs, leaf_certs = certs.partition { |c| c['name'] == c['signed_by'] }
 transitional_certificate_names = []
 regenerated_certificate_names = []
 
-puts "Checking CA certs"
+puts 'Checking CA certs'
 ca_certs.each do |cert|
   cert_name = cert['name']
 
@@ -64,7 +64,7 @@ end
 
 separator
 
-puts "Checking leaf certs"
+puts 'Checking leaf certs'
 leaf_certs.select do |cert|
   cert_name = cert['name']
 

--- a/concourse/scripts/ca-rotation-move-transitional.rb
+++ b/concourse/scripts/ca-rotation-move-transitional.rb
@@ -3,6 +3,8 @@
 require 'json'
 require 'date'
 
+require_relative './lib/formatting'
+
 credhub_server = ENV['CREDHUB_SERVER'] || raise("Must set $CREDHUB_SERVER env var")
 
 expiry_days = ENV['EXPIRY_DAYS'].to_i
@@ -48,10 +50,12 @@ def compare_ca_cert_versions(active_certs)
 end
 
 ca_certs.each { |cert|
-  puts "Getting active ca certs for #{cert['name']}"
-  versions = JSON.parse `credhub curl -p '#{api_url}/data?name=#{cert['name']}&current=true'`
+  cert_name = cert['name']
+
+  puts "Getting active ca certs for #{cert_name}"
+  versions = JSON.parse `credhub curl -p '#{api_url}/data?name=#{cert_name}&current=true'`
   if versions['data'].length > 1
-    puts "#{cert['name']} has more than one active version"
+    puts "#{cert_name} has more than one active version"
     v = versions['data'].sort_by { |version| version['expiry_date'] }
 
     old_ca, new_ca = compare_ca_cert_versions(v)
@@ -59,7 +63,7 @@ ca_certs.each { |cert|
     if !old_ca['transitional'] && new_ca['transitional']
       puts "Version #{old_ca['id']} has an expiry date of #{old_ca['expiry_date']} and the transitional flag is set to #{old_ca['transitional']}"
       puts "Version #{new_ca['id']} has an expiry date of #{new_ca['expiry_date']} and the transitional flag is set to #{new_ca['transitional']}"
-      puts "#{cert['name']} has been regenerated"
+      puts "#{cert_name} has been regenerated"
       puts "Moving the transitional flag to the old CA certificate: #{old_ca['id']}"
       `credhub curl -p '#{api_url}/certificates/#{cert['id']}/update_transitional_version' -d '{\"version\": "#{old_ca['id']}"}' -X PUT`
       puts "Regenerating leaf certs"
@@ -67,7 +71,7 @@ ca_certs.each { |cert|
         if !leaf['signs'].nil?
           puts "Can't regenerate #{leaf['name']} as it signs #{leaf['signs']}"
         else
-          puts "Regenerating #{leaf} signed by the #{cert['name']}"
+          puts "Regenerating #{leaf} signed by the #{cert_name}"
           `credhub regenerate -n '#{leaf}'`
         end
       }
@@ -82,18 +86,20 @@ end
 puts "Checking leaf certs"
 
 leaf_certs.select do |cert|
-  puts "Getting active certs for #{cert['name']}"
-  resp = JSON.parse `credhub curl -p "#{api_url}/data?name=#{cert['name']}&current=true"`
+  cert_name = cert['name']
+
+  puts "Getting active certs for #{cert_name}"
+  resp = JSON.parse `credhub curl -p "#{api_url}/data?name=#{cert_name}&current=true"`
   expiry_date = Date.parse(resp['data'][0]['expiry_date'])
   expires_in = (expiry_date - Date.today).to_i
   if resp['data'].length > 1
-    puts "Skipping #{cert['name']} as it has more than one active cert"
+    puts "Skipping #{cert_name} as it has more than one active cert"
     next
   end
   if expiry_date <= date_of_expiry
-    puts "#{cert['name']} expires on #{expiry_date}. Expires in #{expires_in} days time. Regenerating #{cert['name']}."
-    `credhub regenerate -n "#{cert['name']}"`
+    puts "#{cert_name} expires on #{expiry_date}. Expires in #{expires_in} days time. Regenerating #{cert_name}."
+    `credhub regenerate -n "#{cert_name}"`
   else
-    puts "#{cert['name']} expires on #{expiry_date}. Expires in #{expires_in} days time. Doesn't need to be rotated."
+    puts "#{cert_name} expires on #{expiry_date}. Expires in #{expires_in} days time. Doesn't need to be rotated."
   end
 end

--- a/concourse/scripts/ca-rotation-remove-transitional.rb
+++ b/concourse/scripts/ca-rotation-remove-transitional.rb
@@ -22,7 +22,7 @@ updated_certificate_names = []
 puts "Checking CA certs"
 ca_certs.each do |cert|
   cert_name = cert['name']
-  puts "Getting active ca certs for #{cert_name}"
+
   versions = client.current_certificates(cert_name)
 
   if versions.length <= 1

--- a/concourse/scripts/ca-rotation-remove-transitional.rb
+++ b/concourse/scripts/ca-rotation-remove-transitional.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require 'date'
 require 'json'
 
 require_relative './lib/credhub'

--- a/concourse/scripts/ca-rotation-remove-transitional.rb
+++ b/concourse/scripts/ca-rotation-remove-transitional.rb
@@ -10,31 +10,50 @@ credhub_server = ENV['CREDHUB_SERVER'] || raise("Must set $CREDHUB_SERVER env va
 
 api_url = "#{credhub_server}/v1"
 
-puts "Getting certificates"
 client = CredHubClient.new(api_url)
-certs = client.certificates.reject { |c| c['name'].match?(/_old$/) }
 
-puts "Finding CA certs"
-ca_certs = certs.select { |c| c['name'] == c['signed_by'] }
+ca_certs = client
+  .certificates
+  .reject { |c| c['name'].match?(/_old$/) }
+  .select { |c| c['name'] == c['signed_by'] }
 
-ca_certs.each { |cert|
-  puts "Getting active ca certs for #{cert['name']}"
-  versions = client.current_certificates(cert['name'])
+updated_certificate_names = []
 
-  if versions.length > 1
-    puts "#{cert['name']} has more than one active version"
+puts "Checking CA certs"
+ca_certs.each do |cert|
+  cert_name = cert['name']
+  puts "Getting active ca certs for #{cert_name}"
+  versions = client.current_certificates(cert_name)
 
-    sorted_cas = versions
-      .sort_by { |version| Date.parse(version['expiry_date']) }
-      .reverse
-
-    new_ca, old_ca, *_other_cas = sorted_cas
-
-    if old_ca['transitional'] && !new_ca['transitional']
-      puts "Version #{old_ca['id']} has an expiry date of #{old_ca['expiry_date']} and the transitional flag is set to #{old_ca['transitional']}"
-      puts "Version #{new_ca['id']} has an expiry date of #{new_ca['expiry_date']} and the transitional flag is set to #{new_ca['transitional']}"
-      puts "Setting transitional flag for #{cert['name']} to null"
-      `credhub curl -p '#{api_url}/certificates/#{cert['id']}/update_transitional_version' -d '{\"version\": null}' -X PUT`
-    end
+  if versions.length <= 1
+    puts "#{cert_name.yellow} does not have multiple versions...#{'skipped'.green}"
+    next
   end
-}
+
+  sorted_cas = versions
+    .sort_by { |version| Date.parse(version['expiry_date']) }
+    .reverse
+
+  new_ca, old_ca, *_other_cas = sorted_cas
+
+  unless old_ca['transitional'] && !new_ca['transitional']
+    puts "#{cert_name.yellow} does not need transitioning...#{'skipped'.green}"
+    next
+  end
+
+  puts "Version #{old_ca['id']} has an expiry date of #{old_ca['expiry_date']} and the transitional flag is set to #{old_ca['transitional']}"
+  puts "Version #{new_ca['id']} has an expiry date of #{new_ca['expiry_date']} and the transitional flag is set to #{new_ca['transitional']}"
+  puts "#{cert_name.yellow} should not be transitional...#{'updated'.yellow}"
+  `credhub curl -p '#{api_url}/certificates/#{cert['id']}/update_transitional_version' -d '{\"version\": null}' -X PUT`
+  updated_certificate_names << cert_name
+end
+
+unless updated_certificate_names.empty?
+  separator
+
+  puts 'The following certificates have been updated as non-transitional:'
+
+  updated_certificate_names.sort.each do |cert|
+    puts cert.yellow
+  end
+end

--- a/concourse/scripts/ca-rotation-remove-transitional.rb
+++ b/concourse/scripts/ca-rotation-remove-transitional.rb
@@ -2,6 +2,7 @@
 
 require 'json'
 
+require_relative './lib/credhub'
 require_relative './lib/formatting'
 
 credhub_server = ENV['CREDHUB_SERVER'] || raise("Must set $CREDHUB_SERVER env var")
@@ -9,49 +10,24 @@ credhub_server = ENV['CREDHUB_SERVER'] || raise("Must set $CREDHUB_SERVER env va
 api_url = "#{credhub_server}/v1"
 
 puts "Getting certificates"
-
-certs = JSON.parse `credhub curl -p '#{api_url}/certificates'`
-
-ca_certs = []
+client = CredHubClient.new(api_url)
+certs = client.certificates.reject { |c| c['name'].match?(/_old$/) }
 
 puts "Finding CA certs"
-
-certs['certificates'].each { |cert|
-  if cert['name'] == cert['signed_by']
-    puts "Adding #{cert['name']} to the list of CA certs"
-    ca_certs.push(cert)
-  end
-}
-
-def compare_ca_cert_versions(active_certs)
-  if active_certs[0]['expiry_date'] == active_certs[1]['expiry_date']
-    c = active_certs.sort_by { |version| version['version_created_at'] }
-    if c[0]['version_created_at'] < c[1]['version_created_at']
-      old_ca = c[0]
-      new_ca = c[1]
-    else
-      old_ca = c[1]
-      new_ca = c[0]
-    end
-  elsif active_certs[0]['expiry_date'] < active_certs[1]['expiry_date']
-    old_ca = active_certs[0]
-    new_ca = active_certs[1]
-  else
-    old_ca = active_certs[1]
-    new_ca = active_certs[0]
-  end
-
-  [old_ca, new_ca]
-end
+ca_certs = certs.select { |c| c['name'] == c['signed_by'] }
 
 ca_certs.each { |cert|
   puts "Getting active ca certs for #{cert['name']}"
-  versions = JSON.parse `credhub curl -p '#{api_url}/data?name=#{cert['name']}&current=true'`
-  if versions['data'].length > 1
-    puts "#{cert['name']} has more than one active version"
-    v = versions['data'].sort_by { |version| version['expiry_date'] }
+  versions = client.current_certificates(cert['name'])
 
-    old_ca, new_ca = compare_ca_cert_versions(v)
+  if versions.length > 1
+    puts "#{cert['name']} has more than one active version"
+
+    sorted_cas = versions
+      .sort_by { |version| Date.parse(version['expiry_date']) }
+      .reverse
+
+    new_ca, old_ca, *_other_cas = sorted_cas
 
     if old_ca['transitional'] && !new_ca['transitional']
       puts "Version #{old_ca['id']} has an expiry date of #{old_ca['expiry_date']} and the transitional flag is set to #{old_ca['transitional']}"

--- a/concourse/scripts/ca-rotation-remove-transitional.rb
+++ b/concourse/scripts/ca-rotation-remove-transitional.rb
@@ -2,6 +2,8 @@
 
 require 'json'
 
+require_relative './lib/formatting'
+
 credhub_server = ENV['CREDHUB_SERVER'] || raise("Must set $CREDHUB_SERVER env var")
 
 api_url = "#{credhub_server}/v1"

--- a/concourse/scripts/ca-rotation-remove-transitional.rb
+++ b/concourse/scripts/ca-rotation-remove-transitional.rb
@@ -19,7 +19,6 @@ ca_certs = client
 
 updated_certificate_names = []
 
-puts "Checking CA certs"
 ca_certs.each do |cert|
   cert_name = cert['name']
 

--- a/concourse/scripts/ca-rotation-remove-transitional.rb
+++ b/concourse/scripts/ca-rotation-remove-transitional.rb
@@ -35,8 +35,13 @@ ca_certs.each do |cert|
 
   new_ca, old_ca, *_other_cas = sorted_cas
 
-  unless old_ca['transitional'] && !new_ca['transitional']
-    puts "#{cert_name.yellow} does not need transitioning...#{'skipping'.green}"
+  unless sorted_cas.any? { |ca| ca['transitional'] }
+    puts "#{cert_name.yellow} is not in transition...#{'skipping'.green}"
+    next
+  end
+
+  if new_ca['transitional']
+    puts "#{cert_name.yellow} is in another transition step...#{'skipping'.green}"
     next
   end
 

--- a/concourse/scripts/ca-rotation-remove-transitional.rb
+++ b/concourse/scripts/ca-rotation-remove-transitional.rb
@@ -2,6 +2,7 @@
 
 require 'date'
 require 'json'
+require 'time'
 
 require_relative './lib/credhub'
 require_relative './lib/formatting'
@@ -30,7 +31,7 @@ ca_certs.each do |cert|
   end
 
   sorted_cas = versions
-    .sort_by { |version| Date.parse(version['expiry_date']) }
+    .sort_by { |version| Time.parse(version['expiry_date']) }
     .reverse
 
   new_ca, old_ca, *_other_cas = sorted_cas

--- a/concourse/scripts/ca-rotation-remove-transitional.rb
+++ b/concourse/scripts/ca-rotation-remove-transitional.rb
@@ -43,7 +43,7 @@ ca_certs.each do |cert|
   puts "Version #{old_ca['id']} has an expiry date of #{old_ca['expiry_date']} and the transitional flag is set to #{old_ca['transitional']}"
   puts "Version #{new_ca['id']} has an expiry date of #{new_ca['expiry_date']} and the transitional flag is set to #{new_ca['transitional']}"
   puts "#{cert_name.yellow} should not be transitional...#{'updating'.yellow}"
-  `credhub curl -p '#{api_url}/certificates/#{cert['id']}/update_transitional_version' -d '{\"version\": null}' -X PUT`
+  client.update_certificate_transitional_version(cert['id'], nil)
   updated_certificate_names << cert_name
 end
 

--- a/concourse/scripts/ca-rotation-remove-transitional.rb
+++ b/concourse/scripts/ca-rotation-remove-transitional.rb
@@ -26,7 +26,7 @@ ca_certs.each do |cert|
   versions = client.current_certificates(cert_name)
 
   if versions.length <= 1
-    puts "#{cert_name.yellow} does not have multiple versions...#{'skipped'.green}"
+    puts "#{cert_name.yellow} does not have multiple versions...#{'skipping'.green}"
     next
   end
 
@@ -37,13 +37,13 @@ ca_certs.each do |cert|
   new_ca, old_ca, *_other_cas = sorted_cas
 
   unless old_ca['transitional'] && !new_ca['transitional']
-    puts "#{cert_name.yellow} does not need transitioning...#{'skipped'.green}"
+    puts "#{cert_name.yellow} does not need transitioning...#{'skipping'.green}"
     next
   end
 
   puts "Version #{old_ca['id']} has an expiry date of #{old_ca['expiry_date']} and the transitional flag is set to #{old_ca['transitional']}"
   puts "Version #{new_ca['id']} has an expiry date of #{new_ca['expiry_date']} and the transitional flag is set to #{new_ca['transitional']}"
-  puts "#{cert_name.yellow} should not be transitional...#{'updated'.yellow}"
+  puts "#{cert_name.yellow} should not be transitional...#{'updating'.yellow}"
   `credhub curl -p '#{api_url}/certificates/#{cert['id']}/update_transitional_version' -d '{\"version\": null}' -X PUT`
   updated_certificate_names << cert_name
 end

--- a/concourse/scripts/ca-rotation-set-transitional.rb
+++ b/concourse/scripts/ca-rotation-set-transitional.rb
@@ -50,7 +50,7 @@ unless regenerated_certificate_names.empty?
 
   puts 'The following certificates have been regenerated and marked as transitional:'
 
-  regenerated_certificate_names.each do |cert|
+  regenerated_certificate_names.sort.each do |cert|
     puts cert.yellow
   end
 end

--- a/concourse/scripts/ca-rotation-set-transitional.rb
+++ b/concourse/scripts/ca-rotation-set-transitional.rb
@@ -28,7 +28,7 @@ ca_certs.select do |cert|
   versions = client.current_certificates(cert_name)
 
   if versions.length > 1
-    puts "#{cert_name.yellow} has multiple versions...#{'skipped'.green}"
+    puts "#{cert_name.yellow} has multiple versions...#{'skipping'.green}"
     next
   end
 
@@ -36,11 +36,11 @@ ca_certs.select do |cert|
   expires_in = (expiry_date - Date.today).to_i
 
   if expiry_date > date_of_expiry
-    puts "#{cert_name.yellow} expires on #{expiry_date} (in #{expires_in} days)...#{'skipped'.green}"
+    puts "#{cert_name.yellow} expires on #{expiry_date} (in #{expires_in} days)...#{'skipping'.green}"
     next
   end
 
-  puts "#{cert_name.yellow} expires on #{expiry_date} (in #{expires_in} days)...#{'regenerated'.yellow}"
+  puts "#{cert_name.yellow} expires on #{expiry_date} (in #{expires_in} days)...#{'regenerating'.yellow}"
   `credhub curl -p "#{api_url}/certificates/#{cert['id']}/regenerate" -d '{\"set_as_transitional\": true}' -X POST`
   regenerated_certificate_names << cert_name
 end

--- a/concourse/scripts/ca-rotation-set-transitional.rb
+++ b/concourse/scripts/ca-rotation-set-transitional.rb
@@ -41,7 +41,7 @@ ca_certs.select do |cert|
   end
 
   puts "#{cert_name.yellow} expires on #{expiry_date} (in #{expires_in} days)...#{'regenerating'.yellow}"
-  `credhub curl -p "#{api_url}/certificates/#{cert['id']}/regenerate" -d '{\"set_as_transitional\": true}' -X POST`
+  client.regenerate_certificate_as_transitional(cert['id'])
   regenerated_certificate_names << cert_name
 end
 

--- a/concourse/scripts/check-certificate-hierarchy.rb
+++ b/concourse/scripts/check-certificate-hierarchy.rb
@@ -34,7 +34,7 @@ class CertificateHierarchy
     root_certs.each { |root| print_cert(root, 0) }
   end
 
-  private
+private
 
   def root_certs
     @cert_names.select { |c| @signed_by[c].nil? }
@@ -50,9 +50,9 @@ class CertificateHierarchy
     signed_certs = @signs[cert] || []
 
     if signed_certs.empty?
-      puts (' ' * indent) + cert.green
+      puts((' ' * indent) + cert.green)
     else
-      puts (' ' * indent) + cert.blue
+      puts((' ' * indent) + cert.blue)
     end
 
     signed_certs.each { |c| print_cert(c, indent + 2) }

--- a/concourse/scripts/check-certificate-hierarchy.rb
+++ b/concourse/scripts/check-certificate-hierarchy.rb
@@ -1,0 +1,91 @@
+#!/usr/bin/env ruby
+require 'openssl'
+require 'date'
+
+require_relative './lib/credhub'
+require_relative './lib/formatting'
+
+alert = false
+CREDHUB_SERVER = ENV.fetch('CREDHUB_SERVER')
+api_url = "#{CREDHUB_SERVER}/v1"
+
+class CertificateHierarchy
+  def initialize
+    @cert_names = []
+    @signs = {}
+    @signed_by = {}
+  end
+
+  def add_edge(ca, cert)
+    return if ca == cert
+    @cert_names = @cert_names.push(ca).push(cert).uniq
+
+    @signs[ca] ||= []
+    @signs[ca] = @signs[ca].push(cert).uniq
+
+    @signed_by[cert] = ca
+  end
+
+  def depth
+    @cert_names.map { |c| depth_for_cert(c) }.max
+  end
+
+  def print
+    root_certs.each { |root| print_cert(root, 0) }
+  end
+
+  private
+
+  def root_certs
+    @cert_names.select { |c| @signed_by[c].nil? }
+  end
+
+  def depth_for_cert(cert)
+    signer = @signed_by[cert]
+    return 1 if signer.nil?
+    depth_for_cert(signer) + 1
+  end
+
+  def print_cert(cert, indent)
+    signed_certs = @signs[cert] || []
+
+    if signed_certs.empty?
+      puts (' ' * indent) + cert.green
+    else
+      puts (' ' * indent) + cert.blue
+    end
+
+    signed_certs.each { |c| print_cert(c, indent + 2) }
+  end
+end
+
+separator
+
+client = CredHubClient.new(api_url)
+certs = client.certificates
+hierarchy = CertificateHierarchy.new
+
+certs.each do |cert|
+  hierarchy.add_edge(cert['signed_by'], cert['name'])
+end
+
+hierarchy.print
+
+separator
+
+depth = hierarchy.depth
+
+if depth != 2
+  alert = true
+  puts <<~MSG
+    The depth of the certificate hierarchy is #{depth.to_s.red}
+
+    Our certificate rotation process does not work for multiple levels of CAs
+
+    It is likely that during our next certificate rotation something will go wrong
+  MSG
+else
+  puts "The depth of the certificate hierarchy is #{depth.to_s.green} this is good."
+end
+
+exit 1 if alert

--- a/concourse/scripts/check-certificates.rb
+++ b/concourse/scripts/check-certificates.rb
@@ -90,7 +90,7 @@ unless invalid_certificate_names.empty?
     This is a problem and must be remedied manually
 
     You should:
-    1. use the credhub CLI to get the relevat certificates
+    1. use the credhub CLI to get the relevant certificates
     2. debug why they are invalid using "openssl verify -verbose -issuer_checks -CAfile /path/to/ca /path/to/cert"
     3. confer with your pair about what to do
     4. delete/rotate/replace (possibly manually) them depending on the result of (3)

--- a/concourse/scripts/check-certificates.rb
+++ b/concourse/scripts/check-certificates.rb
@@ -82,7 +82,8 @@ expiring_certificate_names = []
 invalid_certificate_names = []
 
 certs.each do |cert|
-  live_certs = client.live_certificates(cert['name'])
+  cert_name = cert['name']
+  live_certs = client.live_certificates(cert_name)
 
   live_certs.each do |live_cert|
     cred = client.credential(live_cert['id'])
@@ -99,18 +100,18 @@ certs.each do |cert|
     cert_is_valid = cert_store.verify(xcert)
     valid_status = cert_is_valid ? 'valid'.green : 'invalid'.red
 
-    puts "#{live_cert['name'].yellow} has #{days_to_expire} days to expire (#{transitional_status}) (#{expiring_status}) (#{valid_status})"
+    puts "#{cert_name.yellow} has #{days_to_expire} days to expire (#{transitional_status}) (#{expiring_status}) (#{valid_status})"
 
-    expiring_certificate_names << live_cert['name'] unless days_to_expire > ALERT_DAYS
-    transitional_certificate_names << live_cert['name'] if live_cert['transitional']
+    expiring_certificate_names << cert_name unless days_to_expire > ALERT_DAYS
+    transitional_certificate_names << cert_name if live_cert['transitional']
 
     unless xcert.extensions.find { |e| e.oid == 'subjectKeyIdentifier' }
-      puts "#{live_cert['name']}: ERROR! Missing Subject Key Identifier".red
+      puts "#{cert_name}: ERROR! Missing Subject Key Identifier".red
       alert = true
     end
 
     unless cert_is_valid
-      invalid_certificate_names << live_cert['name']
+      invalid_certificate_names << cert_name
       alert = true
     end
   end

--- a/concourse/scripts/check-certificates.rb
+++ b/concourse/scripts/check-certificates.rb
@@ -1,51 +1,9 @@
 #!/usr/bin/env ruby
-require 'English'
 require 'openssl'
-require 'json'
 require 'date'
 
+require_relative './lib/credhub'
 require_relative './lib/formatting'
-
-class CredHubClient
-  attr_reader :api_url
-
-  def initialize(api_url)
-    @api_url = api_url
-  end
-
-  def certificates
-    body = `credhub curl -p '#{api_url}/certificates'`
-    raise body unless $CHILD_STATUS.success?
-    JSON.parse(body).fetch('certificates')
-  end
-
-  def current_certificate(name)
-    body = `credhub curl -p '#{api_url}/data?name=#{name}&current=true'`
-    raise body unless $CHILD_STATUS.success?
-    JSON.parse(body).fetch('data').first
-  end
-
-  def transitional_certificates(name)
-    body = `credhub curl -p '#{api_url}/certificates?name=#{name}'`
-    raise body unless $CHILD_STATUS.success?
-    JSON
-      .parse(body)
-      .fetch('certificates').first.fetch('versions')
-      .select { |c| c.fetch('transitional', false) }
-  end
-
-  def live_certificates(name)
-    current = current_certificate(name)
-    transitional = transitional_certificates(name)
-    transitional.concat([current]).uniq { |c| c.fetch('id') }
-  end
-
-  def credential(credential_id)
-    body = `credhub curl -p '#{api_url}/data/#{credential_id}'`
-    raise body unless $CHILD_STATUS.success?
-    JSON.parse(body)
-  end
-end
 
 ALERT_DAYS = (ARGV[0] || '15').to_i
 CREDHUB_SERVER = ENV.fetch('CREDHUB_SERVER')

--- a/concourse/scripts/check-certificates.rb
+++ b/concourse/scripts/check-certificates.rb
@@ -4,27 +4,7 @@ require 'openssl'
 require 'json'
 require 'date'
 
-def separator
-  puts('-' * 80)
-end
-
-class String
-  def red
-    "\e[31m#{self}\e[0m"
-  end
-
-  def green
-    "\e[32m#{self}\e[0m"
-  end
-
-  def yellow
-    "\e[33m#{self}\e[0m"
-  end
-
-  def blue;
-    "\e[34m#{self}\e[0m"
-  end
-end
+require_relative './lib/formatting'
 
 class CredHubClient
   attr_reader :api_url

--- a/concourse/scripts/lib/credhub.rb
+++ b/concourse/scripts/lib/credhub.rb
@@ -49,4 +49,10 @@ class CredHubClient
     body = `credhub regenerate -n "#{cert_name}"`
     raise body unless $CHILD_STATUS.success?
   end
+
+  def update_certificate_transitional_version(cert_id, optional_version_id)
+    payload = { 'version' => optional_version_id }
+    body = `credhub curl -p '#{api_url}/certificates/#{cert_id}/update_transitional_version' -d '#{payload.to_json}' -X PUT`
+    raise body unless $CHILD_STATUS.success?
+  end
 end

--- a/concourse/scripts/lib/credhub.rb
+++ b/concourse/scripts/lib/credhub.rb
@@ -44,4 +44,9 @@ class CredHubClient
     raise body unless $CHILD_STATUS.success?
     JSON.parse(body)
   end
+
+  def regenerate_certificate(cert_name)
+    body = `credhub regenerate -n "#{cert_name}"`
+    raise body unless $CHILD_STATUS.success?
+  end
 end

--- a/concourse/scripts/lib/credhub.rb
+++ b/concourse/scripts/lib/credhub.rb
@@ -1,0 +1,43 @@
+require 'English'
+require 'json'
+
+class CredHubClient
+  attr_reader :api_url
+
+  def initialize(api_url)
+    @api_url = api_url
+  end
+
+  def certificates
+    body = `credhub curl -p '#{api_url}/certificates'`
+    raise body unless $CHILD_STATUS.success?
+    JSON.parse(body).fetch('certificates')
+  end
+
+  def current_certificate(name)
+    body = `credhub curl -p '#{api_url}/data?name=#{name}&current=true'`
+    raise body unless $CHILD_STATUS.success?
+    JSON.parse(body).fetch('data').first
+  end
+
+  def transitional_certificates(name)
+    body = `credhub curl -p '#{api_url}/certificates?name=#{name}'`
+    raise body unless $CHILD_STATUS.success?
+    JSON
+      .parse(body)
+      .fetch('certificates').first.fetch('versions')
+      .select { |c| c.fetch('transitional', false) }
+  end
+
+  def live_certificates(name)
+    current = current_certificate(name)
+    transitional = transitional_certificates(name)
+    transitional.concat([current]).uniq { |c| c.fetch('id') }
+  end
+
+  def credential(credential_id)
+    body = `credhub curl -p '#{api_url}/data/#{credential_id}'`
+    raise body unless $CHILD_STATUS.success?
+    JSON.parse(body)
+  end
+end

--- a/concourse/scripts/lib/credhub.rb
+++ b/concourse/scripts/lib/credhub.rb
@@ -14,10 +14,14 @@ class CredHubClient
     JSON.parse(body).fetch('certificates')
   end
 
-  def current_certificate(name)
+  def current_certificates(name)
     body = `credhub curl -p '#{api_url}/data?name=#{name}&current=true'`
     raise body unless $CHILD_STATUS.success?
-    JSON.parse(body).fetch('data').first
+    JSON.parse(body).fetch('data')
+  end
+
+  def current_certificate(name)
+    current_certificates(name).first
   end
 
   def transitional_certificates(name)

--- a/concourse/scripts/lib/credhub.rb
+++ b/concourse/scripts/lib/credhub.rb
@@ -50,6 +50,12 @@ class CredHubClient
     raise body unless $CHILD_STATUS.success?
   end
 
+  def regenerate_certificate_as_transitional(cert_id)
+    payload = { 'set_as_transitional' => true }
+    body = `credhub curl -p "#{api_url}/certificates/#{cert_id}/regenerate" -d '#{payload.to_json}' -X POST`
+    raise body unless $CHILD_STATUS.success?
+  end
+
   def update_certificate_transitional_version(cert_id, optional_version_id)
     payload = { 'version' => optional_version_id }
     body = `credhub curl -p '#{api_url}/certificates/#{cert_id}/update_transitional_version' -d '#{payload.to_json}' -X PUT`

--- a/concourse/scripts/lib/formatting.rb
+++ b/concourse/scripts/lib/formatting.rb
@@ -1,0 +1,21 @@
+def separator
+  puts('-' * 80)
+end
+
+class String
+  def red
+    "\e[31m#{self}\e[0m"
+  end
+
+  def green
+    "\e[32m#{self}\e[0m"
+  end
+
+  def yellow
+    "\e[33m#{self}\e[0m"
+  end
+
+  def blue;
+    "\e[34m#{self}\e[0m"
+  end
+end

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -33,7 +33,7 @@ prepare_environment() {
 
   export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-eu-west-1}
 
-  pipelines_to_update="${PIPELINES_TO_UPDATE:-create-cloudfoundry deployment-kick-off destroy-cloudfoundry autodelete-cloudfoundry}"
+  pipelines_to_update="${PIPELINES_TO_UPDATE:-create-cloudfoundry deployment-kick-off destroy-cloudfoundry autodelete-cloudfoundry test-certificate-rotation}"
   bosh_az=${BOSH_AZ:-${AWS_DEFAULT_REGION}a}
 
   state_bucket=gds-paas-${DEPLOY_ENV}-state
@@ -123,6 +123,13 @@ update_pipeline() {
     ;;
     deployment-kick-off)
       if [ "${ENABLE_MORNING_DEPLOYMENT:-}" = "true" ]; then
+        upload_pipeline
+      else
+        remove_pipeline
+      fi
+    ;;
+    test-*)
+      if [ "${ENABLE_TEST_PIPELINES:-}" = "true" ]; then
         upload_pipeline
       else
         remove_pipeline

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -97,6 +97,7 @@ monitored_aws_region: ${MONITORED_AWS_REGION:-}
 monitored_deploy_env: ${MONITORED_DEPLOY_ENV:-}
 deploy_env_tag_prefix: "${deploy_env_tag_prefix}"
 skip_autodelete_await: "${SKIP_AUTODELETE_AWAIT:-false}"
+ca_rotation_expiry_days: "${CA_ROTATION_EXPIRY_DAYS}"
 EOF
   echo -e "pipeline_lock_git_private_key: |\\n  ${git_id_rsa//$'\n'/$'\n'  }"
 }


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/172480682)

Summary
----

1. Parameterise availability tests, so they can be re-used
1. Implement a concept of test pipelines, for use in development
1. Create a test pipeline to automate the testing of our certificate rotation process
1. Colourise and reformat the output of certificate rotation scripts, and add action summaries
1. Add more error handling to certificate rotation scripts
1. Add a test to ensure that our certificate hierarchy has a depth of two
1. Fix bug where leaf certificate were regenerated twice
1. Fix bug where certificate rotation ordering depended on string value of expiry date
1. Rotate certificates in development very often
1. Rotate certificates in staging more often

Testing the critical path
-------------

Ensure you are using the latest and greatest paas-bootstrap, with Credhub 2.6 otherwise the certificate rotation that is going to occur in your environment will break for reasons not related to these changes.

Deploy this to your development environment, checking that the expiry days for a cert is parameterised:

```
make dev pipelines BRANCH=rotate-certs-often-dev CA_ROTATION_EXPIRY_DAYS=30
```

then run your `create-cloudfoundry` pipeline, and check that certificate rotation doesn't happen because expiry days is not reached.

Update your development environment without overriding the expiry days

```
make dev pipelines BRANCH=rotate-certs-often-dev
```

Check that the expiry days for a development environment gets set to 360 days (is this a good number, this will rotate certificates every week in dev).

Got to the `test-certificate-rotation` pipeline, and kick it off, using the `begin` job. If your dev environment is very new, or you want to force another certificate rotation, then first update your pipeline using `CA_ROTATION_EXPIRY_DAYS=365`

This will take between 2 or 4 hours, at the end you should check (even if the tests are green) that >99.x% reliability was achieved (depending on how loaded up your dev env is)

Prepared output
----

Our certificate rotation process is [documented](https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR037-automated-certificate-rotation/) and worth reviewing to understand the steps

- When certificates are expiring soon, we _set them as transitional_ - [example `set-transitional`](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/test-certificate-rotation/jobs/rotate-1/builds/27)
- When a new transitional certificates have been deployed, the transitional flag is _moved_ to the old CA - [example `move-transitional`](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/test-certificate-rotation/jobs/rotate-2/builds/22)
- When there are multiple active certificate versions deployed, the _transitional flag is removed_ - [example `remove-transitional`](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/test-certificate-rotation/jobs/rotate-3/builds/21)

We now also [check the certificate hierarchy](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/check-certificates/builds/58)

Checklist
----

- [x] Thorough code review
- [x] Done a `create-cloudfoundry` pipeline run with 30 day expiry - expect no rotation
- [x] Run a certificate rotation using `test-certificate-rotation`
- [x] Forced a certificate rotation using `CA_ROTATION_EXPIRY_DAYS=365` and `test-certificate-rotation`

- [x] Reviewed prepared output links
- [x] Run `check-certificates` and review output
- [ ] BONUS POINTS: using `CA_ROTATION_EXPIRY_DAYS=365` run your `create-cloudfoundry` pipeline 4 times in a row

Gotchas
----

The `test-certificate-rotation` pipeline does not update itself, I think this is fine because we will are not likely to update it often, and the create-cloudfoundry pipeline handles updating pipelines.


Who can review
--------------

Not @tlwr
