### PR TITLE
Update silk and cf-networking to 2.30

### DIFF
--- a/manifests/cf-manifest/operations.d/350-networking.yml
+++ b/manifests/cf-manifest/operations.d/350-networking.yml
@@ -1,0 +1,17 @@
+---
+
+- type: replace
+  path: /releases/name=silk
+  value:
+    name: "silk"
+    version: "2.30.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.30.0"
+    sha1: "277e8ec42a58a4e08814a697c762d87366761a4c"
+
+- type: replace
+  path: /releases/name=cf-networking
+  value:
+    name: "cf-networking"
+    version: "2.30.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.30.0"
+    sha1: "41116681554ee548c261625134a43048d93da498"


### PR DESCRIPTION
What
----

The releases are built with Go 1.14 and also include a fix for https://github.com/cloudfoundry/cf-networking-release/issues/76

Which will fix the long-standing issue that @uktrade have with unreliability during cell rolling

How to review
-------------

Run this down your development environment

Read the release notes
- [silk](https://github.com/cloudfoundry/silk-release/releases/tag/2.30.0)
- [cf-networking](https://github.com/cloudfoundry/cf-networking-release/releases/tag/2.30.0)

Who can review
--------------

Not @tlwr