### PR TITLE
[#170700038] Allow pazmin password resets

### DIFF
--- a/manifests/cf-manifest/operations.d/200-paas-admin-uaa-client.yml
+++ b/manifests/cf-manifest/operations.d/200-paas-admin-uaa-client.yml
@@ -6,7 +6,7 @@
     autoapprove: true
     secret: "((uaa_clients_paas_admin_secret))"
     scope: cloud_controller.read,cloud_controller.admin_read_only,cloud_controller.global_auditor,cloud_controller.write,scim.me,openid,profile,uaa.user,cloud_controller.admincloud_controller.read,cloud_controller.admin_read_only,cloud_controller.global_auditor,cloud_controller.write,scim.me,openid,profile,uaa.user,cloud_controller.admin
-    authorities: scim.userids,scim.invite,scim.read,scim.write
+    authorities: scim.userids,scim.invite,scim.read,scim.write,oauth.login
     redirect-uri: "https://admin.((system_domain))/auth/login/callback"
 
 - type: replace


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/170700038)

What
----

We'd like to moce the forgotten password functionality from UAA to
Pazmin, to gain more control of what's happening and how it's being
presented to our beloved users.

The Password Reset API call requires either: `uaa.admin`, `oauth.login`
or `zones.uaa.admin` scope to perform it's action.

Now that we've moved that functionality into Pazmin, we need to make
sure our login page points to it.

We'll be sending new email from pazmin to our beloved tenants. We need
to point to the template in notify, which should be used for that action
to be performed.

How to review
-------------

- Deploy to your dev environment
- Review alphagov/paas-admin#893


⚠️ This needs to be merged after the alphagov/paas-admin#893 ⚠️ 
--------------------------------------------------------------------