### PR TITLE
[DO NOT MERGE UNTIL 2020-06-01 1630] Reenable CDN broker actions

### DIFF
--- a/manifests/cf-manifest/operations.d/720-cdn-broker.yml
+++ b/manifests/cf-manifest/operations.d/720-cdn-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: cdn-broker
-    version: 0.0.1590747562
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.0.1590747562.tgz
-    sha1: 6ed99c811a668c3d484b6c3d4d3e080a756826c1
+    version: 0.1.33
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.33.tgz
+    sha1: c43f595b4e08cf3eada2ab10f2982be38539ecdd
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-


### PR DESCRIPTION
🚨 **DO NOT MERGE UNTIL 2020-06-01 1630** 🚨 

What
----
This reverts commit 202c479501cedd37dc7fd5477c88aef2a5ac9bcd, which disabled the CDN brokers actions during the maintenance window.

How to review
-------------
1. Doesn't really need one

Who can review
--------------
Anyone
