### PR TITLE
[support] Allow apps to be bound when in `storage-optimization` state

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 0.1.66
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.66.tgz
-    sha1: a1513c811cf3300e3dcf7ecd6d918ba29c6eb608
+    version: 0.1.67 
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.67.tgz
+    sha1: 5c799f5cbaacd1c001bf035c69a21cbea352773a
 
 - type: replace
   path: /instance_groups/-


### PR DESCRIPTION
What
----

In the previous broker behaviour instances that were in
`storage-optimization` remained in `InProgress` which prevented
applications from being bound to the instance.

However according to AWS support

```
While the instance is in the 'storage-optimization' state,
- The instance is fully operational.
- You cannot make any 'storage' related modifications but other modifications are allowed.
```

So we should enable tenants to bind applications whilst this background
operation is happening.


How to review
-------------

Code review against https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/rds-broker-release/jobs/build-final-release/builds/5

Who can review
--------------

Anyone
