### PR TITLE
[#173220465] Make services in aiven broker 'shareable'

### DIFF
--- a/config/service-brokers/aiven/config.json
+++ b/config/service-brokers/aiven/config.json
@@ -15,6 +15,7 @@
           "longDescription": "Elasticsearch is a search engine based on the Lucene library. It provides a distributed, multitenant-capable full-text search engine with an HTTP web interface and schema-free JSON documents.",
           "documentationUrl": "https://docs.cloud.service.gov.uk/deploying_services/elasticsearch/",
           "supportUrl": "https://www.cloud.service.gov.uk/support",
+          "shareable": true,
           "AdditionalMetadata": {
             "otherDocumentation": [
               "https://www.elastic.co/guide/en/elasticsearch/",
@@ -122,6 +123,7 @@
           "longDescription": "InfluxDB is optimized for fast, high-availability storage and retrieval of time series data in fields such as operations monitoring, application metrics, Internet of Things sensor data, and real-time analytics. It also has support for processing data from Graphite.",
           "documentationUrl": "https://docs.cloud.service.gov.uk/deploying_services/influxdb/",
           "supportUrl": "https://www.cloud.service.gov.uk/support",
+          "shareable": true,
           "AdditionalMetadata": {
             "otherDocumentation": [
               "https://docs.influxdata.com/influxdb/v1.7/",

--- a/config/spec/service_broker_spec.rb
+++ b/config/spec/service_broker_spec.rb
@@ -23,8 +23,8 @@ describe 'service broker' do
 
   describe 'aiven' do
     let(:services) { JSON.parse(AIVEN_JSON).dig('catalog', 'services') }
-    let(:plans) { services.flat_map { |s| s['plans'] } }  
-    let(:serviceIdMap) { services.flat_map { |s| s['id'] } }
+    let(:plans) { services.flat_map { |s| s['plans'] } }
+    let(:service_id_map) { services.flat_map { |s| s['id'] } }
 
     it 'should have description' do
       plans.each do |plan|
@@ -41,16 +41,15 @@ describe 'service broker' do
     end
 
     it 'should be shareable between spaces and/or orgs' do
-      serviceIdMap.each_with_index do |value, index|
-        serviceID = services[index]['id']
-        serviceName = services[index]['name']
+      service_id_map.each_with_index do |value, index|
+        service_id = services[index]['id']
+        service_name = services[index]['name']
         shareable = services[index]['metadata']['shareable']
 
-        expect(serviceID).to eq(value), "The service IDs do not match #{serviceID} != #{value}"
-        expect(shareable).not_to be(nil), "Service '#{serviceName}' has to be shareable, but the 'shareable' parameter is missing in catalog/services/metadata"
-        expect(shareable).to be(true) , "Service '#{serviceName}' has to be shareable, but the value of the parameter is #{shareable}"
+        expect(service_id).to eq(value), "The service IDs do not match #{service_id} != #{value}"
+        expect(shareable).not_to be(nil), "Service '#{service_name}' has to be shareable, but the 'shareable' parameter is missing in catalog/services/metadata"
+        expect(shareable).to be(true), "Service '#{service_name}' has to be shareable, but the value of the parameter is #{shareable}"
       end
     end
-
   end
 end

--- a/config/spec/service_broker_spec.rb
+++ b/config/spec/service_broker_spec.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'pp'
 
 CONFIG_FILES = Dir.glob(
   File.join(
@@ -22,7 +23,8 @@ describe 'service broker' do
 
   describe 'aiven' do
     let(:services) { JSON.parse(AIVEN_JSON).dig('catalog', 'services') }
-    let(:plans) { services.flat_map { |s| s['plans'] } }
+    let(:plans) { services.flat_map { |s| s['plans'] } }  
+    let(:serviceIdMap) { services.flat_map { |s| s['id'] } }
 
     it 'should have description' do
       plans.each do |plan|
@@ -37,5 +39,18 @@ describe 'service broker' do
         expect(version).to be_a(String), "#{plan} needs a version, got #{version}"
       end
     end
+
+    it 'should be shareable between spaces and/or orgs' do
+      serviceIdMap.each_with_index do |value, index|
+        serviceID = services[index]['id']
+        serviceName = services[index]['name']
+        shareable = services[index]['metadata']['shareable']
+
+        expect(serviceID).to eq(value), "The service IDs do not match #{serviceID} != #{value}"
+        expect(shareable).not_to be(nil), "Service '#{serviceName}' has to be shareable, but the 'shareable' parameter is missing in catalog/services/metadata"
+        expect(shareable).to be(true) , "Service '#{serviceName}' has to be shareable, but the value of the parameter is #{shareable}"
+      end
+    end
+
   end
 end

--- a/config/spec/service_broker_spec.rb
+++ b/config/spec/service_broker_spec.rb
@@ -1,5 +1,4 @@
 require 'json'
-require 'pp'
 
 CONFIG_FILES = Dir.glob(
   File.join(
@@ -24,7 +23,6 @@ describe 'service broker' do
   describe 'aiven' do
     let(:services) { JSON.parse(AIVEN_JSON).dig('catalog', 'services') }
     let(:plans) { services.flat_map { |s| s['plans'] } }
-    let(:service_id_map) { services.flat_map { |s| s['id'] } }
 
     it 'should have description' do
       plans.each do |plan|
@@ -41,12 +39,10 @@ describe 'service broker' do
     end
 
     it 'should be shareable between spaces and/or orgs' do
-      service_id_map.each_with_index do |value, index|
-        service_id = services[index]['id']
-        service_name = services[index]['name']
-        shareable = services[index]['metadata']['shareable']
+      services.each do |service|
+        service_name = service['name']
+        shareable = service.dig('metadata', 'shareable')
 
-        expect(service_id).to eq(value), "The service IDs do not match #{service_id} != #{value}"
         expect(shareable).not_to be(nil), "Service '#{service_name}' has to be shareable, but the 'shareable' parameter is missing in catalog/services/metadata"
         expect(shareable).to be(true), "Service '#{service_name}' has to be shareable, but the value of the parameter is #{shareable}"
       end

--- a/platform-tests/src/platform/broker-acceptance/common_service_test.go
+++ b/platform-tests/src/platform/broker-acceptance/common_service_test.go
@@ -1,0 +1,78 @@
+package acceptance_test
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("Common service tests", func() {
+
+	Context("Shareable services", func() {
+
+		shareableServices := map[string]bool{
+			"elasticsearch": true,
+			"influxdb":      true,
+			"mysql":         false,
+			"postgres":      false,
+			"redis":         false,
+			"aws-s3-bucket": false,
+			"cdn-route":     false,
+		}
+
+		It("is service shareable", func() {
+
+			retrieveServicesCommand := cf.Cf("curl", "/v2/services")
+
+			Expect(retrieveServicesCommand.Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
+
+			var servicesCommandResp struct {
+				TotalResults int `json:"total_results"`
+				Resources    []struct {
+					Entity struct {
+						Label       string `json:"label"`
+						Description string `json:"description"`
+						Extra       string `json:"extra"`
+					}
+				}
+			}
+
+			err := json.Unmarshal(retrieveServicesCommand.Buffer().Contents(), &servicesCommandResp)
+			Expect(err).NotTo(HaveOccurred())
+
+			var message string
+			//during the run of the pipeline we are running few acceptance tests in parallel
+			//this can bring a total number of services in the CF instance to greater than 7 (the normal count)
+			//hence, while checking for 'shareable' services - we need to filter out the fake services created
+			//by other tests.
+			// fake service can be identified by having a value 'fake service' in desciption field.
+			fakeServicesCount := 0
+			for _, service := range servicesCommandResp.Resources {
+
+				if service.Entity.Description == "fake service" {
+					fakeServicesCount++
+					continue
+				}
+
+				message = fmt.Sprintf("verifying that %s backing service is shareable", service.Entity.Label)
+				By(message)
+				if shareableServices[service.Entity.Label] {
+					Expect(service.Entity.Extra).To(ContainSubstring("\"shareable\":"),
+						"Expected %s to have 'shareable' parameter", service.Entity.Label)
+					Expect(service.Entity.Extra).To(ContainSubstring("\"shareable\": true"),
+						"Expected %s to be shareable - i.e.: 'shareable' parameter set to 'true'", service.Entity.Label)
+				} else {
+					Expect(service.Entity.Extra).ToNot(ContainSubstring("\"shareable\": false"),
+						"Expected %s NOT to have 'shareable' parameter or to be set to 'false'", service.Entity.Label)
+				}
+			}
+
+			Expect(servicesCommandResp.TotalResults-fakeServicesCount).To(BeNumerically("==", len(shareableServices)), "the amount of services doesn't match")
+		})
+	})
+})

--- a/scripts/uaa_lock_user_test.go
+++ b/scripts/uaa_lock_user_test.go
@@ -79,7 +79,7 @@ var _ = Describe("uaa_lock_user.rb", func() {
 		})
 
 		It("returns an error", func() {
-			Eventually(session).Should(gexec.Exit(1))
+			Eventually(session, "5s").Should(gexec.Exit(1))
 			Expect(session.Err).To(gbytes.Say("Username not found"))
 		})
 	})
@@ -91,7 +91,7 @@ var _ = Describe("uaa_lock_user.rb", func() {
 		})
 
 		It("returns an error", func() {
-			Eventually(session).Should(gexec.Exit(1))
+			Eventually(session, "5s").Should(gexec.Exit(1))
 			Expect(session.Err).To(gbytes.Say("Username is not unique"))
 		})
 	})
@@ -105,7 +105,7 @@ var _ = Describe("uaa_lock_user.rb", func() {
 			})
 
 			It("prints success message", func() {
-				Eventually(session).Should(gexec.Exit(0))
+				Eventually(session, "5s").Should(gexec.Exit(0))
 				Expect(session.Out).To(gbytes.Say("locked jane.smith@gov.uk"))
 			})
 		})
@@ -116,7 +116,7 @@ var _ = Describe("uaa_lock_user.rb", func() {
 			})
 
 			It("prints success message", func() {
-				Eventually(session).Should(gexec.Exit(0))
+				Eventually(session, "5s").Should(gexec.Exit(0))
 				Expect(session.Out).To(gbytes.Say("locked jane.smith@gov.uk"))
 			})
 		})
@@ -133,7 +133,7 @@ var _ = Describe("uaa_lock_user.rb", func() {
 			})
 
 			It("prints success message", func() {
-				Eventually(session).Should(gexec.Exit(0))
+				Eventually(session, "5s").Should(gexec.Exit(0))
 				Expect(session.Out).To(gbytes.Say("unlocked jane.smith@gov.uk"))
 			})
 		})
@@ -146,7 +146,7 @@ var _ = Describe("uaa_lock_user.rb", func() {
 			})
 
 			It("prints success message", func() {
-				Eventually(session).Should(gexec.Exit(0))
+				Eventually(session, "5s").Should(gexec.Exit(0))
 				Expect(session.Out).To(gbytes.Say("unlocked jane.smith@gov.uk"))
 			})
 		})


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/173220465)

What
----

The services that we provide as part of our platform are not shareable by default.
As service broker authors we have to implicitly opt-in for the broker to create 'shareable' service instances. To do that, we have to change the metadata of the service broker catalog definitions to make it a shareable service.
This PR will make two first services - `elasticsearch` & `influxdb` to become shareable.

How to review
-------------

1. Code review
2. Deploy this branch to your dev env.
3. Make sure that `custom-broker-acceptance-test` job in `create-cloudfoundry` pipeline is passing.
4. [Optional Step] After you deployed this branch to your dev env - you can create an instance of `elasticsearch` or `influxdb` service. Then run `cf service <service-instance-name>`, in the output you should see this line `This service is not currently shared.` just before the info about the last operation.

Who can review
--------------
not @barsutka 
