### PR TITLE
[#173220478] Making Elasticache service shareable

### DIFF
--- a/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
+++ b/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
@@ -104,6 +104,7 @@
                     providerDisplayName: Amazon Web Services
                     documentationUrl: https://docs.cloud.service.gov.uk/deploying_services/redis/
                     supportUrl: https://www.cloud.service.gov.uk/support
+                    shareable: true
                     AdditionalMetadata:
                       otherDocumentation:
                         - https://redis.io/documentation

--- a/manifests/cf-manifest/spec/manifest/elasticache_broker_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/elasticache_broker_spec.rb
@@ -98,4 +98,20 @@ RSpec.describe "ElastiCache broker properties" do
       }
     end
   end
+
+  describe "service broker is set to be shareable" do
+    let(:services) {
+      properties.fetch("catalog").fetch("services")
+    }
+
+    it "each service of the elasticache service broker is shareable" do
+      services.each do |service|
+        service_name = service['name']
+        shareable = service.dig('metadata', 'shareable')
+
+        expect(shareable).not_to be(nil), "Service '#{service_name}' has to be shareable, but the 'shareable' parameter is missing in catalog/services/metadata"
+        expect(shareable).to be(true), "Service '#{service_name}' has to be shareable, but the value of the parameter is #{shareable}"
+      end
+    end
+  end
 end

--- a/platform-tests/src/platform/broker-acceptance/common_service_test.go
+++ b/platform-tests/src/platform/broker-acceptance/common_service_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Common service tests", func() {
 			"influxdb":      true,
 			"mysql":         false,
 			"postgres":      false,
-			"redis":         false,
+			"redis":         true,
 			"aws-s3-bucket": false,
 			"cdn-route":     false,
 		}


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/173220478)

What
----

The services that we provide as part of our platform are not shareable by default.
As service broker authors we have to implicitly opt-in for the broker to create 'shareable' service instances. To do that, we have to change the metadata of the service broker catalog definitions to make it a shareable service.
This PR will make the redis (based on Amazon ElastiCache) service to become shareable.

How to review
-------------

1. Code review
2. Deploy this branch to your dev environment
3. Make sure that `custom-broker-acceptance-test` job in `create-cloudfoundry` pipeline is passing.
4. [Optional Step] After you deployed this branch to your dev env - you can create an instance of redis service. Then run cf service <service-instance-name>, in the output you should see this line `This service is not currently shared.` just before the info about the last operation.


Who can review
--------------

@barsutka 
