### PR TITLE
[#173220501] Shareable rds broker

### DIFF
--- a/manifests/cf-manifest/operations.d/711-rds-broker-postgres95-plans.yml
+++ b/manifests/cf-manifest/operations.d/711-rds-broker-postgres95-plans.yml
@@ -108,6 +108,7 @@
       providerDisplayName: Amazon Web Services
       documentationUrl: https://docs.cloud.service.gov.uk/deploying_services/postgresql/
       supportUrl: https://www.cloud.service.gov.uk/support
+      shareable: true
       AdditionalMetadata:
         otherDocumentation:
           - https://www.postgresql.org/docs/

--- a/manifests/cf-manifest/operations.d/712-rds-broker-mysql57-plans.yml
+++ b/manifests/cf-manifest/operations.d/712-rds-broker-mysql57-plans.yml
@@ -52,6 +52,7 @@
       providerDisplayName: Amazon Web Services
       documentationUrl: https://docs.cloud.service.gov.uk/deploying_services/mysql/
       supportUrl: https://www.cloud.service.gov.uk/support
+      shareable: true
       AdditionalMetadata:
         otherDocumentation:
           - https://dev.mysql.com/doc/

--- a/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
@@ -1525,4 +1525,20 @@ RSpec.describe "RDS broker properties" do
       end
     end
   end
+
+  describe "service broker is set to be shareable" do
+    let(:services) {
+      manifest.fetch("instance_groups.rds_broker.jobs.rds-broker.properties.rds-broker.catalog.services")
+    }
+
+    it "each service of the rds-broker service broker is shareable" do
+      services.each do |service|
+        service_name = service['name']
+        shareable = service.dig('metadata', 'shareable')
+
+        expect(shareable).not_to be(nil), "Service '#{service_name}' has to be shareable, but the 'shareable' parameter is missing in catalog/services/metadata"
+        expect(shareable).to be(true), "Service '#{service_name}' has to be shareable, but the value of the parameter is #{shareable}"
+      end
+    end
+  end
 end

--- a/platform-tests/src/platform/broker-acceptance/common_service_test.go
+++ b/platform-tests/src/platform/broker-acceptance/common_service_test.go
@@ -18,8 +18,8 @@ var _ = Describe("Common service tests", func() {
 		shareableServices := map[string]bool{
 			"elasticsearch": true,
 			"influxdb":      true,
-			"mysql":         false,
-			"postgres":      false,
+			"mysql":         true,
+			"postgres":      true,
 			"redis":         true,
 			"aws-s3-bucket": false,
 			"cdn-route":     false,

--- a/platform-tests/src/platform/broker-acceptance/common_service_test.go
+++ b/platform-tests/src/platform/broker-acceptance/common_service_test.go
@@ -27,18 +27,22 @@ var _ = Describe("Common service tests", func() {
 
 		It("is service shareable", func() {
 
-			retrieveServicesCommand := cf.Cf("curl", "/v2/services")
+			retrieveServicesCommand := cf.Cf("curl", "/v3/service_offerings")
 
 			Expect(retrieveServicesCommand.Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
 
 			var servicesCommandResp struct {
-				TotalResults int `json:"total_results"`
-				Resources    []struct {
-					Entity struct {
-						Label       string `json:"label"`
-						Description string `json:"description"`
-						Extra       string `json:"extra"`
-					}
+				Pagination struct {
+					TotalResults int `json:"total_results"`
+				}
+				Resources []struct {
+					Name          string `json:"name"`
+					Description   string `json:"description"`
+					BrokerCatalog struct {
+						Metadata struct {
+							Shareable bool `json:"shareable"`
+						}
+					} `json:"broker_catalog"`
 				}
 			}
 
@@ -54,25 +58,26 @@ var _ = Describe("Common service tests", func() {
 			fakeServicesCount := 0
 			for _, service := range servicesCommandResp.Resources {
 
-				if service.Entity.Description == "fake service" {
+				if service.Description == "fake service" {
 					fakeServicesCount++
 					continue
 				}
 
-				message = fmt.Sprintf("verifying that %s backing service is shareable", service.Entity.Label)
+				message = fmt.Sprintf("verifying that %s backing service is shareable", service.Name)
 				By(message)
-				if shareableServices[service.Entity.Label] {
-					Expect(service.Entity.Extra).To(ContainSubstring("\"shareable\":"),
-						"Expected %s to have 'shareable' parameter", service.Entity.Label)
-					Expect(service.Entity.Extra).To(ContainSubstring("\"shareable\": true"),
-						"Expected %s to be shareable - i.e.: 'shareable' parameter set to 'true'", service.Entity.Label)
+				if shareableServices[service.Name] {
+					Expect(service.BrokerCatalog.Metadata.Shareable).NotTo(BeNil(),
+						"Expected %s to have 'shareable' parameter", service.Name)
+
+					Expect(service.BrokerCatalog.Metadata.Shareable).To(BeTrue(),
+						"Expected %s to be shareable - i.e.: 'shareable' parameter set to 'true'", service.Name)
 				} else {
-					Expect(service.Entity.Extra).ToNot(ContainSubstring("\"shareable\": false"),
-						"Expected %s NOT to have 'shareable' parameter or to be set to 'false'", service.Entity.Label)
+					Expect(service.BrokerCatalog.Metadata.Shareable).To(BeFalse(),
+						"Expected %s NOT to have 'shareable' parameter or to be set to 'false'", service.Name)
 				}
 			}
 
-			Expect(servicesCommandResp.TotalResults-fakeServicesCount).To(BeNumerically("==", len(shareableServices)), "the amount of services doesn't match")
+			Expect(servicesCommandResp.Pagination.TotalResults-fakeServicesCount).To(BeNumerically("==", len(shareableServices)), "the amount of services doesn't match")
 		})
 	})
 })


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/173220501)

What
----
The services that we provide as part of our platform are not shareable by default.
As service broker authors we have to implicitly opt-in for the broker to create 'shareable' service instances. To do that, we have to change the metadata of the service broker catalog definitions to make it a shareable service.
This PR will make the `postgres` & `mysql` (based on Amazon Relational Database Service) services to become shareable.

How to review
-------------

1. Code review
2. Deploy this branch to your dev environment
3. Make sure that custom-broker-acceptance-test job in create-cloudfoundry pipeline is passing.
4. Issue `cf curl /v3/service_offerings?names=mysql,postgres | jq '.resources[] | [.name , .broker_catalog.metadata.shareable]'` command, the expected output is: 
```
[
  "postgres",
  true
]
[
  "mysql",
  true
]
```
5. [Optional Step] After you deployed this branch to your dev env - you can create an instance of postgres and/or mysql service. Then run `cf service <SERVICE-INSTANCE-NAME>` , in the output you should see this line `This service is not currently shared.` just before the info about the last operation.

Who can review
--------------

Not @barsutka 
