### PR TITLE
Pin pool resource to 1.1.1

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -371,6 +371,12 @@ groups:
       - expire-aws-keys
       - rotate-cf-admin-password
 resource_types:
+- name: pinned-pool
+  type: docker-image
+  source:
+    repository: concourse/pool-resource
+    tag: 1.1.1
+
 - name: metadata
   type: docker-image
   source:
@@ -591,7 +597,7 @@ resources:
       initial_version: 0.0.0
 
   - name: pipeline-pool
-    type: pool
+    type: pinned-pool
     source:
       uri: ((git_concourse_pool_clone_full_url_ssh))
       branch: master


### PR DESCRIPTION
What
----

In concourse 6.3 the bundled pool resource was updated to 1.1.2 which is
broken for our use-case (unintentionally)

See:
https://github.com/concourse/pool-resource/issues/54
https://github.com/concourse/pool-resource/issues/55

Pin to 1.1.1 fixes the issue

How to review
-------------

Code review

See https://deployer.london.staging.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/pipeline-release-lock/builds/8 is green

Who can review
--------------

@LeePorte 
