### PR TITLE
Expose metric for the number of CDN route TLS certs issued by different certificate authorities

### DIFF
--- a/tools/metrics/main.go
+++ b/tools/metrics/main.go
@@ -165,6 +165,7 @@ func Main() error {
 			Timeout: 5 * time.Second,
 		}, 30*time.Second),
 		CDNTLSValidityGauge(logger, tlsChecker, cfs, 1*time.Hour),
+		CDNTLSCertificateAuthorityGauge(logger, tlsChecker, cfs, 1*time.Hour),
 		ElasticacheInstancesGauge(logger, ecs, cfAPI, 5*time.Minute),
 		ElasticacheUpdatesGauge(logger, ecs, cfAPI, 5*time.Minute),
 		S3BucketsGauge(logger, s3, 1*time.Hour),

--- a/tools/metrics/pkg/tlscheck/fakes/fake_cert_checker.go
+++ b/tools/metrics/pkg/tlscheck/fakes/fake_cert_checker.go
@@ -9,6 +9,20 @@ import (
 )
 
 type FakeCertChecker struct {
+	CertificateAuthorityStub        func(string, *tls.Config) (string, error)
+	certificateAuthorityMutex       sync.RWMutex
+	certificateAuthorityArgsForCall []struct {
+		arg1 string
+		arg2 *tls.Config
+	}
+	certificateAuthorityReturns struct {
+		result1 string
+		result2 error
+	}
+	certificateAuthorityReturnsOnCall map[int]struct {
+		result1 string
+		result2 error
+	}
 	DaysUntilExpiryStub        func(string, *tls.Config) (float64, error)
 	daysUntilExpiryMutex       sync.RWMutex
 	daysUntilExpiryArgsForCall []struct {
@@ -25,6 +39,70 @@ type FakeCertChecker struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeCertChecker) CertificateAuthority(arg1 string, arg2 *tls.Config) (string, error) {
+	fake.certificateAuthorityMutex.Lock()
+	ret, specificReturn := fake.certificateAuthorityReturnsOnCall[len(fake.certificateAuthorityArgsForCall)]
+	fake.certificateAuthorityArgsForCall = append(fake.certificateAuthorityArgsForCall, struct {
+		arg1 string
+		arg2 *tls.Config
+	}{arg1, arg2})
+	fake.recordInvocation("CertificateAuthority", []interface{}{arg1, arg2})
+	fake.certificateAuthorityMutex.Unlock()
+	if fake.CertificateAuthorityStub != nil {
+		return fake.CertificateAuthorityStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.certificateAuthorityReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeCertChecker) CertificateAuthorityCallCount() int {
+	fake.certificateAuthorityMutex.RLock()
+	defer fake.certificateAuthorityMutex.RUnlock()
+	return len(fake.certificateAuthorityArgsForCall)
+}
+
+func (fake *FakeCertChecker) CertificateAuthorityCalls(stub func(string, *tls.Config) (string, error)) {
+	fake.certificateAuthorityMutex.Lock()
+	defer fake.certificateAuthorityMutex.Unlock()
+	fake.CertificateAuthorityStub = stub
+}
+
+func (fake *FakeCertChecker) CertificateAuthorityArgsForCall(i int) (string, *tls.Config) {
+	fake.certificateAuthorityMutex.RLock()
+	defer fake.certificateAuthorityMutex.RUnlock()
+	argsForCall := fake.certificateAuthorityArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeCertChecker) CertificateAuthorityReturns(result1 string, result2 error) {
+	fake.certificateAuthorityMutex.Lock()
+	defer fake.certificateAuthorityMutex.Unlock()
+	fake.CertificateAuthorityStub = nil
+	fake.certificateAuthorityReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeCertChecker) CertificateAuthorityReturnsOnCall(i int, result1 string, result2 error) {
+	fake.certificateAuthorityMutex.Lock()
+	defer fake.certificateAuthorityMutex.Unlock()
+	fake.CertificateAuthorityStub = nil
+	if fake.certificateAuthorityReturnsOnCall == nil {
+		fake.certificateAuthorityReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.certificateAuthorityReturnsOnCall[i] = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeCertChecker) DaysUntilExpiry(arg1 string, arg2 *tls.Config) (float64, error) {
@@ -94,6 +172,8 @@ func (fake *FakeCertChecker) DaysUntilExpiryReturnsOnCall(i int, result1 float64
 func (fake *FakeCertChecker) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.certificateAuthorityMutex.RLock()
+	defer fake.certificateAuthorityMutex.RUnlock()
 	fake.daysUntilExpiryMutex.RLock()
 	defer fake.daysUntilExpiryMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/tools/metrics/pkg/tlscheck/tls_test.go
+++ b/tools/metrics/pkg/tlscheck/tls_test.go
@@ -68,4 +68,12 @@ var _ = Describe("TLSCheck", func() {
 			Expect(err).To(HaveOccurred())
 		})
 	})
+
+	Context("CertificateAuthority", func(){
+		It("returns the root certificate authority which signed the certificate", func() {
+			authority, err := checker.CertificateAuthority("healthcheck.london.cloudapps.digital:443", &tls.Config{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(authority).To(Equal("Amazon"))
+		})
+	})
 })


### PR DESCRIPTION
What
----
We've asked our tenants to perform a `cf update-service` call to migrate their
CDN route services between certificate authorities. By exposing a metric for
the number of CloudFront instances presenting certificates signed by different
authorities, we can track how many tenants have performed the migration.

How to review
-------------
1. Code review

Unless you have an old CDN route service in your dev env, you won't be able to test that it counts >1 certificate authority. The unit tests should test that.

Who can review
--------------
Anyone
