### PR TITLE
Fix bug in paas-metrics CDNTLSCertificateAuthorityGauge

### DIFF
--- a/tools/metrics/gauges_tls.go
+++ b/tools/metrics/gauges_tls.go
@@ -122,6 +122,10 @@ func CDNTLSCertificateAuthorityGauge(
 
 		certAuthorityCounter := map[string]int{}
 		for _, customDomain := range customDomains {
+			logger.Info("get-certificate-authority", lager.Data{
+				"cloudfront-domain": customDomain.CloudFrontDomain,
+				"alias-domain": customDomain.AliasDomain,
+			})
 			authority, err := certChecker.CertificateAuthority(
 				customDomain.CloudFrontDomain+":443",
 				&tls.Config{ServerName: customDomain.AliasDomain},
@@ -132,6 +136,7 @@ func CDNTLSCertificateAuthorityGauge(
 					"alias_domain":      customDomain.AliasDomain,
 					"cloudfront_domain": customDomain.CloudFrontDomain,
 				})
+				continue
 			}
 
 			if _, ok := certAuthorityCounter[authority]; !ok {

--- a/tools/metrics/pkg/tlscheck/tls.go
+++ b/tools/metrics/pkg/tlscheck/tls.go
@@ -34,19 +34,11 @@ func (tc *TLSChecker) DaysUntilExpiry(addr string, tlsConfig *tls.Config) (float
 func (tc *TLSChecker) CertificateAuthority(addr string, tlsConfig *tls.Config) (string, error) {
 	cert, err := GetCertificate(addr, tlsConfig)
 
-	if err == nil {
-		return cert.Issuer.CommonName, nil
+	if err != nil {
+		return "", err
 	}
 
-	switch e := err.(type) {
-	case x509.CertificateInvalidError:
-		if e.Reason == x509.Expired {
-			return cert.Issuer.CommonName, nil
-		}
-	}
-
-	return "", err
-
+	return cert.Issuer.CommonName, err
 }
 
 func GetCertificate(addr string, tlsConfig *tls.Config) (*x509.Certificate, error) {


### PR DESCRIPTION
What
----

When an expired/invalid certificate was encountered, a nil pointer error was
encountered, and the program crashed. The fix is to return an error when the
certificate is invalid.


How to review
-------------
1. Code review

Who can review
--------------
Anyone