### PR TITLE
cf: horizontally scale scheduler VM

### DIFF
--- a/manifests/cf-manifest/env-specific/default.yml
+++ b/manifests/cf-manifest/env-specific/default.yml
@@ -4,6 +4,7 @@ router_instances: 2
 api_instances: 2
 doppler_instances: 6
 log_api_instances: 2
+scheduler_instances: 2
 cc_worker_instances: 2
 cc_hourly_rate_limit: 15000
 paas_region_name: dev

--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -4,6 +4,7 @@ router_instances: 6
 api_instances: 12
 doppler_instances: 33
 log_api_instances: 6
+scheduler_instances: 4
 cc_worker_instances: 4
 cc_hourly_rate_limit: 20000
 paas_region_name: london

--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -4,6 +4,7 @@ router_instances: 12
 api_instances: 6
 doppler_instances: 33
 log_api_instances: 6
+scheduler_instances: 4
 cc_worker_instances: 4
 cc_hourly_rate_limit: 20000
 paas_region_name: ireland

--- a/manifests/cf-manifest/env-specific/stg-lon.yml
+++ b/manifests/cf-manifest/env-specific/stg-lon.yml
@@ -4,6 +4,7 @@ router_instances: 3
 api_instances: 2
 doppler_instances: 3
 log_api_instances: 3
+scheduler_instances: 3
 cc_worker_instances: 2
 cc_hourly_rate_limit: 100000
 paas_region_name: staging

--- a/manifests/cf-manifest/operations.d/380-scale-scheduler.yml
+++ b/manifests/cf-manifest/operations.d/380-scale-scheduler.yml
@@ -1,0 +1,12 @@
+---
+
+# scheduler instances run auctioneer which is a single process that fails over
+# via locket, so if auctioneer is under load we should vertically scale
+#
+# scheduler instances also run service-discovery-controller which is vital for
+# internal DNS and container-to-container networking, so if
+# service-discovery-controller is under load then we should horizontally scale
+#
+- type: replace
+  path: /instance_groups/name=scheduler/instances
+  value: ((scheduler_instances))

--- a/manifests/cf-manifest/spec/manifest/scheduler_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/scheduler_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe "scheduler" do
+  let(:manifest) { manifest_with_defaults }
+  let(:instance_groups) { manifest.fetch("instance_groups") }
+
+  let(:scheduler_instance_group) { manifest.fetch("instance_groups.scheduler") }
+
+  describe "instance_group" do
+    describe "when the deployment is stg-lon" do
+      subject { manifest_for_env("stg-lon").fetch("instance_groups.scheduler") }
+
+      it_behaves_like("a highly available instance group", min_instances: 3)
+    end
+
+    context "when the deployment is prod" do
+      subject { manifest_for_env("prod").fetch("instance_groups.scheduler") }
+
+      it_behaves_like("a highly available instance group", min_instances: 3)
+    end
+
+    context "when the deployment is prod-lon" do
+      subject { manifest_for_env("prod-lon").fetch("instance_groups.scheduler") }
+
+      it_behaves_like("a highly available instance group", min_instances: 3)
+    end
+  end
+end

--- a/manifests/shared/spec/support/shared_examples.rb
+++ b/manifests/shared/spec/support/shared_examples.rb
@@ -1,0 +1,17 @@
+RSpec.shared_examples "a highly available instance group" do |opts|
+  let(:instances) { subject.dig("instances") }
+
+  it "has instances defined" do
+    expect(instances).not_to be_nil
+  end
+
+  it "is highly available" do
+    expect(instances).to be >= 2
+  end
+
+  unless opts[:min_instances].nil?
+    it "has more instances than the minimum" do
+      expect(instances).to be >= opts[:min_instances]
+    end
+  end
+end


### PR DESCRIPTION
What
----

We want to support more DNS requests per second served by service-discovery-controller

We want to have more instances, so that when we deploy we do not have a single instance of scheduler

Context
----

Yesterday one of our users (GOV.UK Notify) experienced an outage pertaining to internal DNS

The DNS request path is like this
![image](https://user-images.githubusercontent.com/1482692/85685495-05c89500-b6c7-11ea-8486-ec3ac4b6029c.png)

During the incident we experienced a high rate of DNS failures
![image](https://user-images.githubusercontent.com/1482692/85682862-98b40000-b6c4-11ea-80bf-689528636ad0.png)

During the incident the number of DNS requests went up by roughly 4x (this is important)
![image](https://user-images.githubusercontent.com/1482692/85682959-aec1c080-b6c4-11ea-9c4f-42633b6bf67b.png)

We can observe that these are DNS requests to service-discovery-controller (that's what backs the DNS requests made by bosh-dns-adapter). We can observe that there was a spike in requests
![image](https://user-images.githubusercontent.com/1482692/85683337-0b24e000-b6c5-11ea-81d4-0fb457e55385.png)

We can correlate this to the number of concurrent socket allocations on the scheduler instances
![image](https://user-images.githubusercontent.com/1482692/85683456-24c62780-b6c5-11ea-928c-75023ff9c265.png)

We can correlate this to TCP listen overflows on the scheduler instances
![image](https://user-images.githubusercontent.com/1482692/85683529-38718e00-b6c5-11ea-90c1-d174a19a34a0.png)

We can observe in our logs lots of messages about `TLS handshake failure`
![image](https://user-images.githubusercontent.com/1482692/85683630-50e1a880-b6c5-11ea-9fc9-6184cbfccc46.png)

We can correlate these failures to `http: Accept error: accept tcp 0.0.0.0:8054: accept4: too many open files; retrying in 10ms`
![image](https://user-images.githubusercontent.com/1482692/85683691-5d660100-b6c5-11ea-8853-3d2666f8b876.png)

`service-discovery-controller` runs via `bpm` with the default `ulimit` (number of open files/sockets) which for us is a soft limit of `1024`. The controller does not attempt to increase the limit, the controller has a limit of 1024 connections open.

If `bosh-dns-adapter` has a DNS request failure, it has a [naive retry mechanism](https://github.com/cloudfoundry/cf-networking-release/blob/develop/src/bosh-dns-adapter/sdcclient/service_discovery_client.go#L80-L94) that can denial of service (DoS) the DNS server. It retries 4 times in quick succession

Summary:
- GOV.UK Notify making many DNS requests
- BOSH deploy happens, one service-discovery-controller is available, one is being redeployed
- number of concurrent DNS requests is greater than the ulimit
- service-discovery-controller cannot handle any more DNS requests
- bosh-dns-adapter naively retries, immediately quadrupling the number of DNS requests being made
- ‼️ 

The above summary would also explain the reason why GOV.UK Notify experiences 502s when we re-deploy the scheduler instances

In the short term, we should increase the number of scheduler instances deployed, so that we can serve more internal DNS requests


How to review
-------------

Code review

CI



Who can review
--------------

@LeePorte 