### PR TITLE
Continuously deploy paas-billing

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -339,6 +339,7 @@ groups:
     jobs:
       - generate-git-keys
       - generate-paas-admin-git-keys
+      - generate-paas-billing-git-keys
       - show-release-version
       - bump-minor-version
       - bump-major-version
@@ -630,7 +631,8 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-billing.git
       branch: master
-      tag_filter: v0.72.0
+      tag_filter: ((deploy_env_tag_prefix))
+      commit_verification_keys: ((gpg_public_keys))
 
   - name: paas-accounts
     type: git
@@ -3801,6 +3803,20 @@ jobs:
                 export BILLING_API_URL="https://billing.${SYSTEM_DNS_ZONE_NAME}"
                 cd src/github.com/alphagov/paas-billing
                 make acceptance
+
+      - task: tag-repo
+        tags: [colocated-with-web]
+        file: paas-cf/concourse/tasks/tag-repo.yml
+        input_mapping:
+          git-repo: paas-billing
+        params:
+          DEPLOY_ENV: ((deploy_env))
+          GIT_EMAIL: the-multi-cloud-paas-team+deployer-ci@digital.cabinet-office.gov.uk
+          GIT_REPO_SSH: git@github.com:alphagov/paas-billing.git
+          GIT_SSH_PRIVATE_KEY: ((paas-billing-git-keys.private_key))
+          GIT_SSH_PUBLIC_KEY: ((paas-billing-git-keys.public_key))
+          GIT_USER: gov-paas-((deploy_env))
+
       - *end-grafana-job-annotation
 
   - name: deploy-paas-metrics
@@ -4492,6 +4508,20 @@ jobs:
         file: paas-cf/concourse/tasks/generate-git-keys.yml
         params:
           DESTINATION: /concourse/main/paas-admin-git-keys
+          CREDHUB_CLIENT: credhub-admin
+          CREDHUB_SECRET: ((bosh-credhub-admin))
+          CREDHUB_CA_CERT: ((bosh-credhub-ca-cert))
+          CREDHUB_SERVER: "https://((bosh_fqdn)):8844/api"
+          DEPLOY_ENV: ((deploy_env))
+
+  - name: generate-paas-billing-git-keys
+    plan:
+      - get: paas-cf
+      - task: generate-git-keys
+        tags: [colocated-with-web]
+        file: paas-cf/concourse/tasks/generate-git-keys.yml
+        params:
+          DESTINATION: /concourse/main/paas-billing-git-keys
           CREDHUB_CLIENT: credhub-admin
           CREDHUB_SECRET: ((bosh-credhub-admin))
           CREDHUB_CA_CERT: ((bosh-credhub-ca-cert))

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -338,6 +338,7 @@ groups:
   - name: operator
     jobs:
       - generate-git-keys
+      - generate-paas-admin-git-keys
       - show-release-version
       - bump-minor-version
       - bump-major-version
@@ -574,16 +575,6 @@ resources:
       bucket: ((state_bucket))
       region_name: ((aws_region))
       versioned_file: git-keys.tar.gz
-      initial_version: "-"
-      # This is an empty tar.gz file base64 encoded
-      initial_content_binary: "H4sICMtSp1YAA2NvbmNvdXJzZS1jZXJ0cy50YXIA7cEBDQAAAMKg909tDjegAAAAAAAAAAAAgDcDmt4dJwAoAAA="
-
-  - name: paas-admin-git-keys
-    type: s3-iam
-    source:
-      bucket: ((state_bucket))
-      region_name: ((aws_region))
-      versioned_file: paas-admin-git-keys.tar.gz
       initial_version: "-"
       # This is an empty tar.gz file base64 encoded
       initial_content_binary: "H4sICMtSp1YAA2NvbmNvdXJzZS1jZXJ0cy50YXIA7cEBDQAAAMKg909tDjegAAAAAAAAAAAAgDcDmt4dJwAoAAA="
@@ -3650,67 +3641,19 @@ jobs:
             CF_ADMIN: ((cf_admin))
             CF_PASS: ((cf_pass))
 
-      - get: paas-admin-git-keys
-
-      - task: tag-app-repo
+      - task: tag-repo
         tags: [colocated-with-web]
-        config: &tag-app-repo-config
-          platform: linux
-          image_resource: *git-ssh-image-resource
-          inputs:
-            - name: paas-admin-git-keys
+        file: paas-cf/concourse/tasks/tag-repo.yml
+        input_mapping:
+          git-repo: paas-admin
+        params:
+          DEPLOY_ENV: ((deploy_env))
+          GIT_EMAIL: the-multi-cloud-paas-team+deployer-ci@digital.cabinet-office.gov.uk
+          GIT_REPO_SSH: git@github.com:alphagov/paas-admin.git
+          GIT_SSH_PRIVATE_KEY: ((paas-admin-git-keys.private_key))
+          GIT_SSH_PUBLIC_KEY: ((paas-admin-git-keys.public_key))
+          GIT_USER: gov-paas-((deploy_env))
 
-            - name: paas-admin
-              path: repo
-          params:
-            DEPLOY_ENV: ((deploy_env))
-            REPO: paas-admin
-            GIT_REPO_SSH: git@github.com:alphagov/paas-admin.git
-            GIT_EMAIL: the-multi-cloud-paas-team+deployer-ci@digital.cabinet-office.gov.uk
-            GIT_USER: gov-paas-((deploy_env))
-            GIT_KEYS: ./paas-admin-git-keys
-          run:
-            path: sh
-            args:
-              - -e
-              - -u
-              - -c
-              - |
-                new_tag="${DEPLOY_ENV}-$(date +%Y-%m-%d-%H-%M-%S)"
-
-                num_git_keys="$(tar -tzf "${GIT_KEYS}/${GIT_KEYS}.tar.gz" | wc -l)"
-                echo "Found ${num_git_keys} files in git-keys"
-
-                echo "Extracting ${num_git_keys} into .ssh"
-                tar xzf "${GIT_KEYS}/${GIT_KEYS}.tar.gz"
-                mkdir -p ~/.ssh
-
-                echo 'Configuring .ssh/config'
-                cat <<EOF > ~/.ssh/config
-                Host github.com
-                  StrictHostKeyChecking no
-                  IdentityFile $(pwd)/private-key
-                EOF
-
-                cd repo
-
-                if [ "$DEPLOY_ENV" = "stg-lon" ]; then
-                  echo 'Going to tag repo'
-                else
-                  echo 'Skipping: create-cloudfoundry only tags in staging'
-                  exit 0
-                fi
-
-                echo 'Configuring git'
-                git config --global user.email "${GIT_EMAIL}"
-                git config --global user.name "${GIT_USER}"
-                git remote add tag_origin "${GIT_REPO_SSH}"
-
-                echo "New tag for ${REPO} is ${new_tag}"
-                git tag "${new_tag}"
-
-                echo "Pushing tag refs/tags/${new_tag} to ${REPO}"
-                git push tag_origin "refs/tags/${new_tag}"
       - *end-grafana-job-annotation
 
   - name: deploy-paas-billing
@@ -4540,6 +4483,20 @@ jobs:
           put: git-keys
           params:
             file: generated-git-keys/git-keys.tar.gz
+
+  - name: generate-paas-admin-git-keys
+    plan:
+      - get: paas-cf
+      - task: generate-git-keys
+        tags: [colocated-with-web]
+        file: paas-cf/concourse/tasks/generate-git-keys.yml
+        params:
+          DESTINATION: /concourse/main/paas-admin-git-keys
+          CREDHUB_CLIENT: credhub-admin
+          CREDHUB_SECRET: ((bosh-credhub-admin))
+          CREDHUB_CA_CERT: ((bosh-credhub-ca-cert))
+          CREDHUB_SERVER: "https://((bosh_fqdn)):8844/api"
+          DEPLOY_ENV: ((deploy_env))
 
   - name: bump-major-version
     plan:

--- a/concourse/tasks/generate-git-keys.yml
+++ b/concourse/tasks/generate-git-keys.yml
@@ -1,0 +1,17 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/bosh-cli-v2
+    tag: 5b44bd954693937ddd07ee6c9e113923bc620aed
+
+run:
+  path: sh
+  args:
+    - -e
+    - -c
+    - |
+      credhub login
+      credhub generate --name "$DESTINATION" --type ssh
+      credhub get --name "$DESTINATION" --key public_key

--- a/concourse/tasks/tag-repo.yml
+++ b/concourse/tasks/tag-repo.yml
@@ -1,0 +1,56 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/git-ssh
+    tag: 5b44bd954693937ddd07ee6c9e113923bc620aed
+
+inputs:
+  - name: git-repo
+
+params:
+  DEPLOY_ENV:
+  GIT_EMAIL:
+  GIT_SSH_PRIVATE_KEY:
+  GIT_USER:
+  GIT_REPO_SSH:
+
+run:
+  path: sh
+  args:
+    - -e
+    - -u
+    - -c
+    - |
+      new_tag="${DEPLOY_ENV}-$(date +%Y-%m-%d-%H-%M-%S)"
+
+      echo 'Configuring .ssh/config'
+      echo "${GIT_SSH_PRIVATE_KEY}" > private-key
+      echo "${GIT_SSH_PUBLIC_KEY}" > private-key.pub
+      cat <<EOF > ~/.ssh/config
+      Host github.com
+        StrictHostKeyChecking no
+        IdentityFile $(pwd)/private-key
+      EOF
+
+      cd git-repo
+
+      if [ "$DEPLOY_ENV" = "stg-lon" ]; then
+        echo 'Going to tag repo'
+      else
+        echo 'Skipping: create-cloudfoundry only tags in staging'
+        exit 0
+      fi
+
+      echo 'Configuring git'
+      git config --global user.email "${GIT_EMAIL}"
+      git config --global user.name "${GIT_USER}"
+      git remote add tag_origin "${GIT_REPO_SSH}"
+
+      echo "New tag for ${GIT_REPO_SSH} is ${new_tag}"
+      git tag "${new_tag}"
+
+      echo "Pushing tag refs/tags/${new_tag} to ${GIT_REPO_SSH}"
+      git push tag_origin "refs/tags/${new_tag}"


### PR DESCRIPTION
What
----

In https://github.com/alphagov/paas-cf/pull/1968 we got paas-admin continuously deployed. This has been working well and reduced toil / increased speed at which we can do changes

So that we can iterate on paas-billing faster, we should continuously deploy it. We didn't do this at the same time as paas-admin because we didn't have acceptance tests and altering, now we do.

Soon we are going to kick off some work on dynamic billing, so being able to make changes faster will be good

This PR:

* moves the paas-admin `tag-app-repo` task into a task file, and makes it more generic
* re-uses the task for paas-billing
* adds a task for generating git keys, this is only really used in stg-lon
* uses credhub for app repo git keys instead of s3

How to review
-------------

Code review, commit by commit

Who can review
--------------

Not @tlwr
