### PR TITLE
Update logstash filters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ DEPLOY_ENV_MAX_LENGTH=8
 DEPLOY_ENV_VALID_LENGTH=$(shell if [ $$(printf "%s" $(DEPLOY_ENV) | wc -c) -gt $(DEPLOY_ENV_MAX_LENGTH) ]; then echo ""; else echo "OK"; fi)
 DEPLOY_ENV_VALID_CHARS=$(shell if echo $(DEPLOY_ENV) | grep -q '^[a-zA-Z0-9-]*$$'; then echo "OK"; else echo ""; fi)
 
-LOGSEARCH_BOSHRELEASE_TAG=v209.0.0
-LOGSEARCH_FOR_CLOUDFOUNDRY_TAG=v207.0.0
+LOGSEARCH_BOSHRELEASE_TAG=v211.1.0
+LOGSEARCH_FOR_CLOUDFOUNDRY_TAG=v211.1.0
 
 .PHONY: check-env
 check-env:
@@ -376,7 +376,7 @@ logit-filters:
 		-v $(CURDIR):/mnt:ro \
 		-v $(CURDIR)/config/logit/output:/output:rw \
 		-w /mnt \
-		jruby:9.1-alpine ./scripts/generate_logit_filters.sh $(LOGSEARCH_BOSHRELEASE_TAG) $(LOGSEARCH_FOR_CLOUDFOUNDRY_TAG)
+		jruby:9.2-alpine ./scripts/generate_logit_filters.sh $(LOGSEARCH_BOSHRELEASE_TAG) $(LOGSEARCH_FOR_CLOUDFOUNDRY_TAG)
 	@echo "updated $(CURDIR)/config/logit/output/generated_logit_filters.conf"
 
 .PHONY: show-tenant-comms-addresses

--- a/config/logit/20_custom_cf_filters.conf
+++ b/config/logit/20_custom_cf_filters.conf
@@ -37,8 +37,20 @@ if [@source][component] == "vcap_nginx_access" {
   grok {
     match => {
       "@message" =>
-      '%{IPORHOST:[nginx][clientip]} - \[%{HTTPDATE:[nginx][timestamp]}\] "%{WORD:[nginx][verb]} %{URIPATHPARAM:[nginx][request]} HTTP/%{NUMBER:[nginx][httpversion]}" %{NUMBER:[nginx][response]} (?:%{NUMBER:[nginx][bytes]}|-) (?:"(?:%{URI:[nginx][referrer]}|-)"|%{QS:[nginx][referrer]}) %{QS:[nginx][agent]} %{DATA:[nginx][x_forwarded_for]} vcap_request_id:%{UUID:[nginx][vcap_request_id]} response_time:%{NUMBER:[nginx][response_time]}'
+      '%{IPORHOST:[nginx][clientip]} - \[%{HTTPDATE:[nginx][timestamp]}\] "%{WORD:[nginx][verb]} %{URIPATHPARAM:[nginx][request]} HTTP/%{NUMBER:[nginx][httpversion]}" %{NUMBER:[nginx][response]} (?:%{NUMBER:[nginx][bytes]}|-) (?:"(?:%{URI:[nginx][referrer]}|-)"|%{QS:[nginx][referrer]}) %{QS:[nginx][agent]} %{DATA:[nginx][x_forwarded_for]} vcap_request_id:%{UUID:[nginx][external_vcap_request_id]}(::%{UUID:[nginx][internal_vcap_request_id]})? response_time:%{NUMBER:[nginx][response_time]}'
       }
+  }
+
+  if ([nginx][internal_vcap_request_id]) {
+    mutate {
+      add_field => {
+        "[nginx][vcap_request_id]" => "%{[nginx][external_vcap_request_id}::%{[nginx][internal_vcap_request_id]}"
+      }
+    }
+  } else {
+    mutate {
+      copy => { "[nginx][external_vcap_request_id]" => "[nginx][vcap_request_id]" }
+    }
   }
 }
 if [@source][component] == "cloud_controller_ng" {
@@ -72,7 +84,6 @@ mutate {
     "syslog_msgid",
     "syslog_procid",
     "syslog_sd_id",
-    "syslog_sd_params",
     "[@source][director]"
   ]
 }

--- a/config/logit/output/generated_logit_filters.conf
+++ b/config/logit/output/generated_logit_filters.conf
@@ -119,7 +119,7 @@ filter {
           # structured-data
           if [syslog_sd] {
               grok {
-                  match => [ "syslog_sd", "\[%{DATA:syslog_sd_id} (?<syslog_sd_params_raw]>[^\]]+)\]" ]
+                  match => [ "syslog_sd", "\[%{DATA:syslog_sd_id} (?<syslog_sd_params_raw>[^\]]+)\]" ]
                   remove_field => [
                       "syslog_sd"
                   ]
@@ -348,10 +348,15 @@ filter {
             rename => { "[parsed_json_field][origin]"      => "[@source][component]" }
           }
 
+          if ![parsed_json_field][event_type] {
+            mutate {
+              add_field => { "[parsed_json_field][event_type]" => "UnknownEvent" }
+            }
+          }
+
           # Set @type (based on event_type)
-          alter {
-            coalesce => [ "@type", "%{[parsed_json_field][event_type]}", "UnknownEvent" ]
-            remove_field => "[parsed_json_field][event_type]"
+          mutate {
+            replace => { "@type" => "%{[parsed_json_field][event_type]}" }
           }
 
           # Set [@source][type] (based on @type by default,
@@ -534,7 +539,13 @@ filter {
         match => [ "@message", "%{HOSTNAME:[rtr][hostname]} - \[(?<rtr_time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[rtr][verb]} %{URIPATHPARAM:[rtr][path]} %{PROG:[rtr][http_spec]}\" %{BASE10NUM:[rtr][status]:int} %{BASE10NUM:[rtr][request_bytes_received]:int} %{BASE10NUM:[rtr][body_bytes_sent]:int} \"%{GREEDYDATA:[rtr][referer]}\" \"%{GREEDYDATA:[rtr][http_user_agent]}\" \"(%{HOSTPORT}|-)\" \"(%{HOSTPORT}|-)\" x_forwarded_for:\"%{GREEDYDATA:[rtr][x_forwarded_for]}\" x_forwarded_proto:\"%{GREEDYDATA:[rtr][x_forwarded_proto]}\" vcap_request_id:\"%{NOTSPACE:[rtr][vcap_request_id]}\" response_time:%{NUMBER:[rtr][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}" ]
 
         # cf-release v252+
-        match => [ "@message", "%{HOSTNAME:[rtr][hostname]} - \[(?<rtr_time>%{YEAR}-%{MONTHNUM}-%{MONTHDAY}T%{TIME}+%{INT})\] \"%{WORD:[rtr][verb]} %{URIPATHPARAM:[rtr][path]} %{PROG:[rtr][http_spec]}\" %{BASE10NUM:[rtr][status]:int} %{BASE10NUM:[rtr][request_bytes_received]:int} %{BASE10NUM:[rtr][body_bytes_sent]:int} \"%{GREEDYDATA:[rtr][referer]}\" \"%{GREEDYDATA:[rtr][http_user_agent]}\" \"%{IPORHOST:[rtr][src][host]}:%{POSINT:[rtr][src][port]:int}\" \"%{IPORHOST:[rtr][dst][host]}:%{POSINT:[rtr][dst][port]:int}\" x_forwarded_for:\"%{GREEDYDATA:[rtr][x_forwarded_for]}\" x_forwarded_proto:\"%{GREEDYDATA:[rtr][x_forwarded_proto]}\" vcap_request_id:\"%{NOTSPACE:[rtr][vcap_request_id]}\" response_time:%{NUMBER:[rtr][response_time_sec]:float} app_id:\"%{NOTSPACE:[rtr][app][id]}\" app_index:\"%{BASE10NUM:[rtr][app][index]:int}\""]
+        match => [ "@message", "%{HOSTNAME:[rtr][hostname]} - \[(?<rtr_time>%{YEAR}-%{MONTHNUM}-%{MONTHDAY}T%{TIME}+%{INT})\] \"%{WORD:[rtr][verb]} %{URIPATHPARAM:[rtr][path]} %{PROG:[rtr][http_spec]}\" %{BASE10NUM:[rtr][status]:int} %{BASE10NUM:[rtr][request_bytes_received]:int} %{BASE10NUM:[rtr][body_bytes_sent]:int} \"%{GREEDYDATA:[rtr][referer]}\" \"%{GREEDYDATA:[rtr][http_user_agent]}\" \"(%{IPORHOST:[rtr][src][host]}:%{POSINT:[rtr][src][port]:int}|-)\" \"%{IPORHOST:[rtr][dst][host]}:%{POSINT:[rtr][dst][port]:int}\" x_forwarded_for:\"%{GREEDYDATA:[rtr][x_forwarded_for]}\" x_forwarded_proto:\"%{GREEDYDATA:[rtr][x_forwarded_proto]}\" vcap_request_id:\"%{NOTSPACE:[rtr][vcap_request_id]}\" response_time:%{NUMBER:[rtr][response_time_sec]:float} app_id:\"%{NOTSPACE:[rtr][app][id]}\" app_index:\"(%{BASE10NUM:[rtr][app][index]:int}|-)\""]
+
+        # cf-deployment v12.17.0+
+        match => [ "@message", "%{HOSTNAME:[rtr][hostname]} - \[(?<rtr_time>%{YEAR}-%{MONTHNUM}-%{MONTHDAY}T%{TIME}+%{INT})\] \"%{WORD:[rtr][verb]} %{URIPATHPARAM:[rtr][path]} %{PROG:[rtr][http_spec]}\" %{BASE10NUM:[rtr][status]:int} %{BASE10NUM:[rtr][request_bytes_received]:int} %{BASE10NUM:[rtr][body_bytes_sent]:int} \"%{GREEDYDATA:[rtr][referer]}\" \"%{GREEDYDATA:[rtr][http_user_agent]}\" \"%{IPORHOST:[rtr][src][host]}:%{POSINT:[rtr][src][port]:int}\" \"%{IPORHOST:[rtr][dst][host]}:%{POSINT:[rtr][dst][port]:int}\" x_forwarded_for:\"%{GREEDYDATA:[rtr][x_forwarded_for]}\" x_forwarded_proto:\"%{GREEDYDATA:[rtr][x_forwarded_proto]}\" vcap_request_id:\"%{NOTSPACE:[rtr][vcap_request_id]}\" response_time:%{NUMBER:[rtr][response_time_sec]:float} gorouter_time:%{NUMBER:[rtr][gorouter_time_sec]:float} app_time:%{NUMBER:[rtr][app_time_sec]:float} app_id:\"%{NOTSPACE:[rtr][app][id]}\" app_index:\"%{BASE10NUM:[rtr][app][index]:int}\""]
+
+        # cf-deployment v12.27.0+
+        match => [ "@message", "%{HOSTNAME:[rtr][hostname]} - \[(?<rtr_time>%{TIMESTAMP_ISO8601})\] \"%{WORD:[rtr][verb]} %{URIPATHPARAM:[rtr][path]} %{PROG:[rtr][http_spec]}\" %{BASE10NUM:[rtr][status]:int} %{BASE10NUM:[rtr][request_bytes_received]:int} %{BASE10NUM:[rtr][body_bytes_sent]:int} \"%{GREEDYDATA:[rtr][referer]}\" \"%{GREEDYDATA:[rtr][http_user_agent]}\" \"%{IPORHOST:[rtr][src][host]}:%{POSINT:[rtr][src][port]:int}\" \"%{IPORHOST:[rtr][dst][host]}:%{POSINT:[rtr][dst][port]:int}\" x_forwarded_for:\"%{GREEDYDATA:[rtr][x_forwarded_for]}\" x_forwarded_proto:\"%{GREEDYDATA:[rtr][x_forwarded_proto]}\" vcap_request_id:\"%{NOTSPACE:[rtr][vcap_request_id]}\" response_time:%{NUMBER:[rtr][response_time_sec]:float} gorouter_time:%{NUMBER:[rtr][gorouter_time_sec]:float} app_id:\"%{NOTSPACE:[rtr][app][id]}\" app_index:\"%{BASE10NUM:[rtr][app][index]:int}\"( %{GREEDYDATA:kvpairs})?"]
 
         tag_on_failure => [ "fail/cloudfoundry/app-rtr/grok" ]
       }
@@ -573,16 +584,45 @@ filter {
             convert => { "[rtr][response_time_ms]" => "float" }
           }
 
+          # Set [rtr][gorouter_time_ms]
+          if [rtr][gorouter_time_sec] =~ /.+/ {
+            mutate {
+              add_field => { "[rtr][gorouter_time_ms]" => "%{[rtr][gorouter_time_sec]}000" }
+            }
+            mutate {
+              gsub => ["[rtr][gorouter_time_ms]", "\.(\d)(\d)(\d)([\d]{0,3}).*","\1\2\3.\4"]
+            }
+            mutate {
+              convert => { "[rtr][gorouter_time_ms]" => "float" }
+            }
+          }
+
+          # Process extra headers based on the following 2 properties available in CF-Deployment
+          #   https://bosh.io/jobs/gorouter?source=github.com/cloudfoundry/routing-release&version=0.198.0#p%3drouter.extra_headers_to_log
+          #   https://bosh.io/jobs/gorouter?source=github.com/cloudfoundry/routing-release&version=0.198.0#p%3drouter.tracing.enable_zipkin
+          if [kvpairs] =~ /.+/ {
+            kv {
+              source => "kvpairs"
+              remove_field => [ "kvpairs" ]
+              include_brackets => false
+              value_split => ":"
+              target => "[rtr][extra]"
+            }
+          }
+
           # Set @message
           mutate {
             replace => {"@message" => "%{[rtr][status]} %{[rtr][verb]} %{[rtr][path]} (%{[rtr][response_time_ms]} ms)"}
           }
 
-
           # Set @level (based on HTTP status)
-          if [rtr][status] >= 400 {
+          if [rtr][status] >= 500 {
               mutate {
                 replace => { "@level" => "ERROR" }
+              }
+          } else if [rtr][status] >= 400 {
+              mutate {
+                replace => { "@level" => "WARN" }
               }
           } else {
               mutate {
@@ -903,6 +943,28 @@ filter {
                 fallback => "%{[parsed_json_field][log_level]}"
                 remove_field => "[parsed_json_field][log_level]"
               }
+          }
+
+      }
+  }
+
+  ##------------------------------------+
+  # Gorouter conf. Parses gorouter logs.|
+  ##------------------------------------+
+
+  if [@index_type] == "platform" and [@source][component] == "gorouter" {
+              if [@message] =~ "\A\{.+\}\z" {
+                    json {
+                        source => "@message"
+                        add_tag => [ "router/syslog" ]
+                        tag_on_failure => [ "router/parsing_failed" ]
+                    }
+      } else {
+          grok {
+              match => { "@message" => "%{URIHOST:Request_Host} %{NOTSPACE} \[%{TIMESTAMP_ISO8601:access_timestamp}\] \"%{WORD:Request_Method} %{URIPATHPARAM:Request_URL} %{SYSLOGPROG:Request_Protocol}\" %{NUMBER:Status_Code:int} %{NUMBER:Bytes_Received:int} %{NUMBER:Bytes_Sent:int} \"%{NOTSPACE:Referer}\" \"%{DATA:User_Agent}\" \"%{URIHOST:Remote_Address}\" \"%{URIHOST:Backend_Address}\" x_forwarded_for:\"%{DATA:X_Forwarded_For}\" x_forwarded_proto:\"%{WORD:X_Forwarded_Proto}\" vcap_request_id:\"%{DATA:X_Vcap_Request_ID}\" response_time:%{NUMBER:Response_Time:float} app_id:\"%{DATA:app_id}\" app_index:\"%{DATA:app_index}\" %{GREEDYDATA:@message}" }
+              overwrite => [ "@message" ]
+              add_tag => "router/accesslog"
+              tag_on_failure => "router/parsing_failed"
           }
 
       }

--- a/config/logit/output/generated_logit_filters.conf
+++ b/config/logit/output/generated_logit_filters.conf
@@ -1089,8 +1089,20 @@ filter {
     grok {
       match => {
         "@message" =>
-        '%{IPORHOST:[nginx][clientip]} - \[%{HTTPDATE:[nginx][timestamp]}\] "%{WORD:[nginx][verb]} %{URIPATHPARAM:[nginx][request]} HTTP/%{NUMBER:[nginx][httpversion]}" %{NUMBER:[nginx][response]} (?:%{NUMBER:[nginx][bytes]}|-) (?:"(?:%{URI:[nginx][referrer]}|-)"|%{QS:[nginx][referrer]}) %{QS:[nginx][agent]} %{DATA:[nginx][x_forwarded_for]} vcap_request_id:%{UUID:[nginx][vcap_request_id]} response_time:%{NUMBER:[nginx][response_time]}'
+        '%{IPORHOST:[nginx][clientip]} - \[%{HTTPDATE:[nginx][timestamp]}\] "%{WORD:[nginx][verb]} %{URIPATHPARAM:[nginx][request]} HTTP/%{NUMBER:[nginx][httpversion]}" %{NUMBER:[nginx][response]} (?:%{NUMBER:[nginx][bytes]}|-) (?:"(?:%{URI:[nginx][referrer]}|-)"|%{QS:[nginx][referrer]}) %{QS:[nginx][agent]} %{DATA:[nginx][x_forwarded_for]} vcap_request_id:%{UUID:[nginx][external_vcap_request_id]}(::%{UUID:[nginx][internal_vcap_request_id]})? response_time:%{NUMBER:[nginx][response_time]}'
         }
+    }
+
+    if ([nginx][internal_vcap_request_id]) {
+      mutate {
+        add_field => {
+          "[nginx][vcap_request_id]" => "%{[nginx][external_vcap_request_id}::%{[nginx][internal_vcap_request_id]}"
+        }
+      }
+    } else {
+      mutate {
+        copy => { "[nginx][external_vcap_request_id]" => "[nginx][vcap_request_id]" }
+      }
     }
   }
   if [@source][component] == "cloud_controller_ng" {
@@ -1124,7 +1136,6 @@ filter {
       "syslog_msgid",
       "syslog_procid",
       "syslog_sd_id",
-      "syslog_sd_params",
       "[@source][director]"
     ]
   }

--- a/scripts/generate_logit_filters.sh
+++ b/scripts/generate_logit_filters.sh
@@ -29,6 +29,7 @@ apk update && apk add git
 cd /tmp
 git clone --branch="${logsearch_for_cloudfoundry_tag}" --depth=1 https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry.git
 cd logsearch-for-cloudfoundry/src/logsearch-config
+rm Gemfile.lock
 bundle install
 bundle exec rake build
 
@@ -66,3 +67,6 @@ sed -i \
 sed -i \
     "s/vcap\.uaa/uaa/" \
     /output/generated_logit_filters.conf
+
+# FIXME: Allowed in Logstash 6
+sed -i '/tag_on_failure.*kv/d' /output/generated_logit_filters.conf


### PR DESCRIPTION
What
----

Update to latest version of logsearch-for-cloudfoundry and logsearch-boshrelease which supports cf-deployment v12.27

Add logstash config to index `vcap_request_id` correctly in `cloud_controller_ng`/`vcap_nginx_access`

Do not delete `syslog_sd_params` from logs

How to review
-------------

I have updated the logstash config in the development logit instance, so our dev envs use this config

Review [a kibana visualisation showing grokparsefailures](https://kibana.logit.io/s/c7358874-2b30-44a6-8271-554ad3996e50/goto/a1ede4876bdd5dedabe3f28222b0d1d2) check that the `vcap_nginx_access` grokparsefailures have been eliminated

Review [a RTR log from paas-admin](https://kibana.logit.io/s/c7358874-2b30-44a6-8271-554ad3996e50/app/kibana#/doc/logstash-*/logstash-2020.07.01/logs?id=AXMLTrqVj_RYKaAt9AQW&_g=()) is indexed correctly

Review [a APP log from paas-admin](https://kibana.logit.io/s/c7358874-2b30-44a6-8271-554ad3996e50/app/kibana#/doc/logstash-*/logstash-2020.07.01/logs?id=AXMLTrrJ7h2JZm8r4iTX&_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-48h,mode:relative,to:now)))

Who can review
--------------

Not @tlwr
