### PR TITLE
cf: prometheus in london has big disk

### DIFF
--- a/manifests/cf-manifest/env-specific/default.yml
+++ b/manifests/cf-manifest/env-specific/default.yml
@@ -8,3 +8,6 @@ scheduler_instances: 2
 cc_worker_instances: 2
 cc_hourly_rate_limit: 15000
 paas_region_name: dev
+
+prometheus_disk_size: 100GB
+prometheus_retention_size: 90GB

--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -8,3 +8,6 @@ scheduler_instances: 4
 cc_worker_instances: 4
 cc_hourly_rate_limit: 20000
 paas_region_name: london
+
+prometheus_disk_size: 750GB
+prometheus_retention_size: 700GB

--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -8,3 +8,6 @@ scheduler_instances: 4
 cc_worker_instances: 4
 cc_hourly_rate_limit: 20000
 paas_region_name: ireland
+
+prometheus_disk_size: 500GB
+prometheus_retention_size: 475GB

--- a/manifests/cf-manifest/env-specific/stg-lon.yml
+++ b/manifests/cf-manifest/env-specific/stg-lon.yml
@@ -8,3 +8,6 @@ scheduler_instances: 3
 cc_worker_instances: 2
 cc_hourly_rate_limit: 100000
 paas_region_name: staging
+
+prometheus_disk_size: 500GB
+prometheus_retention_size: 475GB

--- a/manifests/cf-manifest/operations.d/500-prometheus.yml
+++ b/manifests/cf-manifest/operations.d/500-prometheus.yml
@@ -40,7 +40,7 @@
     azs: [z1, z2, z3]
     stemcell: default
 
-    persistent_disk_type: 500GB
+    persistent_disk_type: ((prometheus_disk_size))
     vm_type: xlarge
 
     networks:
@@ -55,7 +55,7 @@
               tsdb:
                 retention:
                   time: 370d
-                  size: 475GB
+                  size: ((prometheus_retention_size))
 
             rule_files: []
 

--- a/manifests/cf-manifest/operations/change-vm-types-dev.yml
+++ b/manifests/cf-manifest/operations/change-vm-types-dev.yml
@@ -44,11 +44,3 @@
 - type: replace
   path: /instance_groups/name=prometheus/vm_type
   value: small
-
-- type: replace
-  path: /instance_groups/name=prometheus/persistent_disk_type
-  value: 100GB
-
-- type: replace
-  path: /instance_groups/name=prometheus/jobs/name=prometheus2/properties/prometheus/storage/tsdb/retention/size
-  value: 90GB

--- a/manifests/cf-manifest/spec/manifest/dev_scaling_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/dev_scaling_spec.rb
@@ -15,12 +15,6 @@ RSpec.describe "dev environment scaling" do
     # It scales back brokers to 1
     expect(dev_manifest.fetch("instance_groups.rds_broker.instances")).to eq(1)
     expect(dev_manifest.fetch("instance_groups.s3_broker.instances")).to eq(1)
-
-    # It scales back cf-prometheus to 1
-    expect(dev_manifest.fetch("instance_groups.prometheus.instances")).to eq(1)
-    expect(dev_manifest.fetch("instance_groups.prometheus.vm_type")).to eq("small")
-    expect(dev_manifest.fetch("instance_groups.prometheus.persistent_disk_type")).to eq("100GB")
-    expect(dev_manifest.fetch("instance_groups.prometheus.jobs.prometheus2.properties.prometheus.storage.tsdb.retention.size")).to eq("90GB")
   end
 
   it "does not scale back dev otherwise" do
@@ -29,9 +23,5 @@ RSpec.describe "dev environment scaling" do
     expect(dev_manifest.fetch("instance_groups.diego-cell.instances")).not_to eq(2)
     expect(dev_manifest.fetch("instance_groups.rds_broker.instances")).not_to eq(1)
     expect(dev_manifest.fetch("instance_groups.s3_broker.instances")).not_to eq(1)
-
-    expect(dev_manifest.fetch("instance_groups.prometheus.vm_type")).to eq("xlarge")
-    expect(dev_manifest.fetch("instance_groups.prometheus.persistent_disk_type")).to eq("500GB")
-    expect(dev_manifest.fetch("instance_groups.prometheus.jobs.prometheus2.properties.prometheus.storage.tsdb.retention.size")).to eq("475GB")
   end
 end

--- a/manifests/cf-manifest/spec/manifest/prometheus_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/prometheus_spec.rb
@@ -44,9 +44,38 @@ RSpec.describe "prometheus" do
   end
 
   describe "instance_group" do
-    it "has a persistent disk" do
+    it "has a small persistent disk" do
       disk_type = prometheus_instance_group.dig("persistent_disk_type")
-      expect(disk_type).to eq("500GB")
+      expect(disk_type).to eq("100GB")
+
+      retention_size = prometheus_config.dig("storage", "tsdb", "retention", "size")
+      expect(retention_size).to eq("90GB")
+    end
+
+    context "when the deploy environment is prod-lon" do
+      let(:manifest) { manifest_for_env("prod-lon") }
+
+      it "has a larger persistent disk" do
+        disk_type = prometheus_instance_group.dig("persistent_disk_type")
+        expect(disk_type).to eq("750GB")
+
+        retention_size = prometheus_config.dig("storage", "tsdb", "retention", "size")
+        expect(retention_size).to eq("700GB")
+      end
+    end
+
+    %w[prod stg-lon].each do |deploy_env|
+      context "when the deploy environment is #{deploy_env}" do
+        let(:manifest) { manifest_for_env(deploy_env) }
+
+        it "has a persistent disk" do
+          disk_type = prometheus_instance_group.dig("persistent_disk_type")
+          expect(disk_type).to eq("500GB")
+
+          retention_size = prometheus_config.dig("storage", "tsdb", "retention", "size")
+          expect(retention_size).to eq("475GB")
+        end
+      end
     end
 
     it "is highly available" do

--- a/manifests/cloud-config/paas-cf-cloud-config.yml
+++ b/manifests/cloud-config/paas-cf-cloud-config.yml
@@ -31,6 +31,10 @@ disk_types:
   disk_size: 512000
   cloud_properties:
     type: gp2
+- name: 750GB
+  disk_size: 768000
+  cloud_properties:
+    type: gp2
 
 networks:
 - name: cf


### PR DESCRIPTION
What
----

We have 370d retention on the metrics for our users

We are reaching 85% prometheus disk capacity, we should increase max capacity

Ireland does not need more disk, just London, so make it specific to London

How to review
-------------

[Check grafana](https://grafana-1.london.cloud.service.gov.uk/explore?left=%5B%22now-6h%22,%22now%22,%22prometheus%22,%7B%22expr%22:%22bosh_job_persistent_disk_percent%7Bbosh_job_name%3D%5C%22prometheus%5C%22%7D%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D)

CI

Who can review
--------------

Not @tlwr
