### PR TITLE
upgrading CAPI to 1.96 to fix a bug.

### DIFF
--- a/manifests/cf-manifest/operations.d/320-cc-release.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-release.yml
@@ -1,0 +1,8 @@
+---
+- type: replace
+  path: /releases/name=capi
+  value:
+    name: "capi"
+    version: "1.96.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.96.0"
+    sha1: "879b50c2ba103826dd32c7e65d9eefc7797f67e7"


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/173659071)

What
----
updating CAPI to 1.96 release to get the fix for the bug when CC issues an orphaned mitigation on service instances with failed updates resulting in the removal of the service instance.

The original issue in the upstream is [here](https://github.com/cloudfoundry/cloud_controller_ng/issues/1690)

Detailed release notes for CAPI 1.96 is [here](https://github.com/cloudfoundry/capi-release/releases/tag/1.96.0)

How to review
-------------
Code review.

[Optional] Apply this fix to your DEV environment. 
*Assumptions - you have control of the domain (E.g.: example.com) and can add CNAME records.*
Steps to verify that failed update to service instance is not triggering removal of the service instance :

 - create a first cdn service instance pointing at kuku.example.com - `cf create-service cdn-route cdn-route kuku-cdn-route-si -c '{"domain": "kuku.example.com"}'`
 - create a second cdn service instance pointing at kiki.example.com - `cf create-service cdn-route cdn-route kiki-cdn-route-si -c '{"domain": "kiki.example.com"}'`
 - make sure that both service instances created successfully
 - add another domain to both cdn service instances, so now the update command should look like `cf update-service kuku-cdn-route-si -c '{"domain": "koko.example.com,kuku.example.com"}'` and `cf update-service kiki-cdn-route-si -c '{"domain": "koko.example.com,kiki.example.com"}'` respectively.
  
The expected result:

 - the `kuku-cdn-route-si` was successfully updated
 - the `kiki-cdn-route-si` *FAILED* to update, but still exist

the output of `cf services` command should look like:
```
cf services
Getting services in org ORG_NAME / space SPACE_NAME as USER_NAME...

name                service     plan                  bound apps   last operation     broker       upgrade available
kiki-cdn-route-si   cdn-route   cdn-route                          update failed      cdn-broker   
kuku-cdn-route-si   cdn-route   cdn-route                          update succeeded   cdn-broker   
```

Who can review
--------------

not @barsutka 