### PR TITLE
[#173684528] cf: cf-networking and silk to 2.31

### DIFF
--- a/manifests/cf-manifest/operations.d/350-networking.yml
+++ b/manifests/cf-manifest/operations.d/350-networking.yml
@@ -4,14 +4,14 @@
   path: /releases/name=silk
   value:
     name: "silk"
-    version: "2.30.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.30.0"
-    sha1: "277e8ec42a58a4e08814a697c762d87366761a4c"
+    version: "2.31.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.31.0"
+    sha1: "8935189b632a8c805e46b8079f5c459d6b70784f"
 
 - type: replace
   path: /releases/name=cf-networking
   value:
     name: "cf-networking"
-    version: "2.30.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.30.0"
-    sha1: "41116681554ee548c261625134a43048d93da498"
+    version: "2.31.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.31.0"
+    sha1: "f27406853aee40c38615d61cf648936c0ef63d2f"


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/173684528)

Signed-off-by: Toby Lorne <toby.lornewelch-richards@digital.cabinet-office.gov.uk>

What
----

`silk` and `cf-networking` are released together

`cf-networking` 2.31 contains:

* https://github.com/cloudfoundry/cf-networking-release/pull/80
* https://github.com/cloudfoundry/cf-networking-release/pull/81

which were raised from our recent Ireland DNS outage

and

* https://github.com/cloudfoundry/cf-networking-release/issues/78

which has caused one (1) support ticket in the past

How to review
-------------

Read the [story](https://www.pivotaltracker.com/story/show/173684528)

Read the [release notes](https://github.com/cloudfoundry/cf-networking-release/releases/tag/2.31.0)

Deploy to your development environment

Who can review
--------------

Not @tlwr