### PR TITLE
[#173692258] Add pinger and ponger health check apps

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2722,6 +2722,20 @@ jobs:
                 cf push --strategy=rolling healthcheck
 
                 cd "${BUILD_ROOT}"
+                cd paas-cf/platform-tests/example-apps/healthcheck-pinger
+                cf cancel-deployment healthcheck-pinger || true
+                cf push --strategy=rolling healthcheck-pinger
+
+                cd "${BUILD_ROOT}"
+                cd paas-cf/platform-tests/example-apps/healthcheck-ponger
+                cf cancel-deployment healthcheck-ponger || true
+                cf push --strategy=rolling healthcheck-ponger
+
+                cf add-network-policy \
+                  healthcheck-pinger healthcheck-ponger \
+                  --protocol tcp --port 8080
+
+                cd "${BUILD_ROOT}"
                 echo "yes" > deployed-healthcheck/healthcheck-deployed
         on_success:
           put: deployed-healthcheck

--- a/platform-tests/example-apps/healthcheck-pinger/main.go
+++ b/platform-tests/example-apps/healthcheck-pinger/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8082"
+	}
+	addr := ":" + port
+
+	upstream := os.Getenv("UPSTREAM")
+	if upstream == "" {
+		upstream = "http://localhost:8081"
+	}
+
+	http.DefaultClient.Timeout = 5 * time.Second
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		var code int
+		resp, err := http.Get(upstream)
+		if err == nil {
+			code = resp.StatusCode
+		} else {
+			log.Printf("Error %s when requesting upstream %s\n", err, upstream)
+		}
+
+		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Cache-Control", "max-age=0,no-store,no-cache")
+
+		if code == http.StatusOK {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("OK"))
+			log.Println("code=200 upstream=200")
+		} else {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			w.Write([]byte("KO"))
+			log.Printf("code=503 upstream=%d", code)
+		}
+	})
+
+	log.Printf("Upstream is %s\n", upstream)
+	log.Printf("Listening on %s\n", addr)
+	err := http.ListenAndServe(addr, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/platform-tests/example-apps/healthcheck-pinger/manifest.yml
+++ b/platform-tests/example-apps/healthcheck-pinger/manifest.yml
@@ -1,0 +1,13 @@
+---
+applications:
+ - name: healthcheck-pinger
+   memory: 64M
+   disk_quota: 256M
+   instances: 2
+   command: "./bin/healthcheck-pinger"
+   buildpacks: [go_buildpack]
+   stack: cflinuxfs3
+   env:
+     GOVERSION: go1.13
+     GOPACKAGENAME: github.com/alphagov/paas-cf/platform-tests/example-apps/healthcheck-pinger
+     UPSTREAM: http://healthcheck-ponger.apps.internal:8080

--- a/platform-tests/example-apps/healthcheck-ponger/main.go
+++ b/platform-tests/example-apps/healthcheck-ponger/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8081"
+	}
+
+	addr := ":" + port
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Cache-Control", "max-age=0,no-store,no-cache")
+
+		w.Write([]byte("OK"))
+		log.Println("code=200")
+	})
+
+	log.Printf("Listening on %s\n", addr)
+	err := http.ListenAndServe(addr, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/platform-tests/example-apps/healthcheck-ponger/manifest.yml
+++ b/platform-tests/example-apps/healthcheck-ponger/manifest.yml
@@ -1,0 +1,16 @@
+---
+applications:
+ - name: healthcheck-ponger
+   memory: 64M
+   disk_quota: 256M
+   instances: 2
+   command: "./bin/healthcheck-ponger"
+   buildpacks: [go_buildpack]
+   stack: cflinuxfs3
+
+   env:
+     GOVERSION: go1.13
+     GOPACKAGENAME: github.com/alphagov/paas-cf/platform-tests/example-apps/healthcheck-ponger
+
+   routes:
+     - route: healthcheck-ponger.apps.internal


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/173692258)

What
----

We are going to availability test internal networking during our pipeline

To do this we need some apps which use internal networking and internal DNS

This PR adds two new example apps:
- healthcheck-pinger
- healthcheck-ponger

The ponger app always returns 200 OK

The pinger app returns 200 OK if the ponger app returns 200 OK, otherwise 503

This PR deploys the two apps as part of the deploy-healthcheck step

In a later PR we will actually availability test them

How to review
-------------

Deploy to your development environment

(⚠️  this requires https://github.com/alphagov/paas-cf/pull/2371 because of how `cf add-network-policy` works ⚠️ )

`curl https://healthcheck-pinger.$env.london.cloudpipelineapps.digital` should return `OK` with status `200`

Who can review
--------------

Not @tlwr
