### PR TITLE
prometheus: actually drop the metrics properly

### DIFF
--- a/manifests/cf-manifest/operations.d/500-prometheus.yml
+++ b/manifests/cf-manifest/operations.d/500-prometheus.yml
@@ -92,6 +92,7 @@
                     regex: 'aws-((terraform_outputs_region))'
                     action: keep
 
+                metric_relabel_configs:
                   - source_labels: [__name__]
                     separator: ;
                     regex: 'elasticsearch_(breakers|thread|fs|indices|os)_.*'

--- a/manifests/cf-manifest/spec/manifest/prometheus_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/prometheus_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe "prometheus" do
         prometheus_config
           .dig("scrape_configs")
           .find { |sc| sc["job_name"] == "aiven" }
-          .dig("relabel_configs")
+          .dig("metric_relabel_configs")
           .select { |rlc| rlc["action"] == "drop" }
           .select { |rlc| rlc["source_labels"].include? "__name__" }
           .map { |rlc| rlc["regex"] }


### PR DESCRIPTION
What
----

Miki was looking into this for a tenant broker story

relabel_configs only applies to dropping targets, we want to drop metrics instead

fix the test and the dropping to actually drop the metrics

How to review
-------------

Code review

Check [tlwr pipeline is green](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/prometheus-deploy/builds/139)

Review timeseries showing number of metrics, before and after relabelling changes:
![an elasticsearch instance being scraped](https://user-images.githubusercontent.com/1482692/87307940-5edf5800-c512-11ea-83bb-f1f716105d89.png)


Who can review
--------------

@46bit 