### PR TITLE
Use v0.203.0 of routing-release

### DIFF
--- a/manifests/cf-manifest/operations.d/310-router.yml
+++ b/manifests/cf-manifest/operations.d/310-router.yml
@@ -1,4 +1,12 @@
 ---
+- type: replace
+  path: /releases/name=routing
+  value:
+    name: "routing"
+    version: "0.203.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.203.0"
+    sha1: "f4c081c39f64c368fab7a2553b074e8850d1f5f5"
+
 - type: remove
   path: /instance_groups/name=router/vm_extensions
 


### PR DESCRIPTION
What
----

CVE-2020-15586 [1] is mitigated by using a release >= 0.203.0

[1] https://www.cloudfoundry.org/blog/cve-2020-15586/

How to review
-------------
Run the branch down your pipeline

Who can review
--------------
Anyone