### PR TITLE
cf: use spot instances for dev environments

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1494,6 +1494,8 @@ jobs:
               - name: terraform-outputs
             outputs:
               - name: paas-cf-cloud-config
+            params:
+              AWS_ACCOUNT: ((aws_account))
             run:
               path: sh
               args:

--- a/manifests/cloud-config/operations/use-spot-instances-in-dev.yml
+++ b/manifests/cloud-config/operations/use-spot-instances-in-dev.yml
@@ -1,0 +1,63 @@
+- type: replace
+  path: /vm_types/name=nano/cloud_properties/spot_ondemand_fallback?
+  value: true
+
+- type: replace
+  path: /vm_types/name=nano/cloud_properties/spot_bid_price?
+  value: ((nano_vm_spot_bid_price))
+
+- type: replace
+  path: /vm_types/name=small/cloud_properties/spot_ondemand_fallback?
+  value: true
+
+- type: replace
+  path: /vm_types/name=small/cloud_properties/spot_bid_price?
+  value: ((small_vm_spot_bid_price))
+
+- type: replace
+  path: /vm_types/name=medium/cloud_properties/spot_ondemand_fallback?
+  value: true
+
+- type: replace
+  path: /vm_types/name=medium/cloud_properties/spot_bid_price?
+  value: ((medium_vm_spot_bid_price))
+
+- type: replace
+  path: /vm_types/name=large/cloud_properties/spot_ondemand_fallback?
+  value: true
+
+- type: replace
+  path: /vm_types/name=large/cloud_properties/spot_bid_price?
+  value: ((large_vm_spot_bid_price))
+
+- type: replace
+  path: /vm_types/name=xlarge/cloud_properties/spot_ondemand_fallback?
+  value: true
+
+- type: replace
+  path: /vm_types/name=xlarge/cloud_properties/spot_bid_price?
+  value: ((xlarge_vm_spot_bid_price))
+
+- type: replace
+  path: /vm_types/name=router/cloud_properties/spot_ondemand_fallback?
+  value: true
+
+- type: replace
+  path: /vm_types/name=router/cloud_properties/spot_bid_price?
+  value: ((router_vm_spot_bid_price))
+
+- type: replace
+  path: /vm_types/name=slim_router/cloud_properties/spot_ondemand_fallback?
+  value: true
+
+- type: replace
+  path: /vm_types/name=slim_router/cloud_properties/spot_bid_price?
+  value: ((slim_router_vm_spot_bid_price))
+
+- type: replace
+  path: /vm_types/name=cell/cloud_properties/spot_ondemand_fallback?
+  value: true
+
+- type: replace
+  path: /vm_types/name=cell/cloud_properties/spot_bid_price?
+  value: ((cell_vm_spot_bid_price))

--- a/manifests/cloud-config/scripts/generate-cloud-config.sh
+++ b/manifests/cloud-config/scripts/generate-cloud-config.sh
@@ -10,6 +10,10 @@ for i in "${PAAS_CF_DIR}"/manifests/cloud-config/operations.d/*.yml; do
   opsfile_args+="-o $i "
 done
 
+if [ "$AWS_ACCOUNT" = "dev" ]; then
+  opsfile_args+="-o ${PAAS_CF_DIR}/manifests/cloud-config/operations/use-spot-instances-in-dev.yml"
+fi
+
 # shellcheck disable=SC2086
 bosh interpolate \
   --var-errs \

--- a/manifests/cloud-config/spec/support/cloud_config_helpers.rb
+++ b/manifests/cloud-config/spec/support/cloud_config_helpers.rb
@@ -9,7 +9,18 @@ module CloudConfigHelpers
   end
 
   def cloud_config_with_defaults
-    Cache.instance[:cloud_config_with_defaults] ||= render_cloud_config
+    cloud_config_for_account("prod")
+  end
+
+  def cloud_config_for_account(account)
+    sym = "cloud_config_for_#{account}".to_sym
+
+    old_aws_account = ENV["AWS_ACCOUNT"]
+    ENV["AWS_ACCOUNT"] = account
+    Cache.instance[sym] ||= render_cloud_config
+    ENV["AWS_ACCOUNT"] = old_aws_account
+
+    Cache.instance[sym]
   end
 
 private

--- a/manifests/cloud-config/spec/vm_types_spec.rb
+++ b/manifests/cloud-config/spec/vm_types_spec.rb
@@ -32,4 +32,36 @@ RSpec.describe "vm_types" do
       end
     end
   end
+
+  %w[staging prod].each do |aws_acc|
+    context "when generating cloud config for non-development environments" do
+      let(:vm_types) { cloud_config_for_account(aws_acc).fetch("vm_types") }
+
+      it "does not use spot instances" do
+        vm_types.each do |vm_type|
+          name = vm_type["name"]
+          cloud_props = vm_type["cloud_properties"]
+          expect(cloud_props["spot_bid_price"]).to be_nil, "#{name} should not set spot price"
+          expect(cloud_props["spot_ondemand_fallback"]).to be_nil, "#{name} should not set spot fallback"
+        end
+      end
+    end
+  end
+
+  context "when generating cloud config for development environments" do
+    let(:vm_types) { cloud_config_for_account("dev").fetch("vm_types") }
+
+    it "uses spot instances" do
+      vm_types.each do |vm_type|
+        name = vm_type["name"]
+
+        next if name == "compilation"
+        next if name == "errand"
+
+        cloud_props = vm_type["cloud_properties"]
+        expect(cloud_props["spot_bid_price"]).to be_a(Numeric), "#{name} should set spot price"
+        expect(cloud_props["spot_ondemand_fallback"]).to eq(true), "#{name} should set spot fallback"
+      end
+    end
+  end
 end

--- a/manifests/variables.yml
+++ b/manifests/variables.yml
@@ -1,14 +1,29 @@
 ---
 compilation_vm_instance_type: c5.large
+
 nano_vm_instance_type: t3.nano
+nano_vm_spot_bid_price: 0.004
+
 small_vm_instance_type: t3.small
+small_vm_spot_bid_price: 0.01
+
 medium_vm_instance_type: t3.medium
+medium_vm_spot_bid_price: 0.02
+
 large_vm_instance_type: m5.large
+large_vm_spot_bid_price: 0.05
+
 xlarge_vm_instance_type: m5.xlarge
-router_instance_type: c5.large
+xlarge_vm_spot_bid_price: 0.1
+
 cell_instance_type: r5.xlarge
+cell_vm_spot_bid_price: 0.15
+
+router_instance_type: c5.large
+router_vm_spot_bid_price: 0.042
 
 slim_router_instance_type: t3.medium
+slim_router_vm_spot_bid_price: 0.02
 
 # Advertised memory capacity of the cells.
 #


### PR DESCRIPTION
What
----

⚠️  https://github.com/alphagov/paas-bootstrap/pull/376 must be deployed first ⚠️ 

Use spot instances in development environments, to save money

This doesn't affect BOSH Director or Concourse deployments

![EC2 costs in my development environment](https://user-images.githubusercontent.com/1482692/87924572-fb57ac00-ca76-11ea-8532-85933813bfc1.png)
_EC2 costs in my development environment_


How to review
-------------

Deploy to your development environment

Do a `bosh recreate` just for fun

Code review, ensure spot is not used for prod (double check tests)

Look at the spot bid pricing history, and EC2 pricing tables, to check that we are not overpaying, or underpaying

Who can review
--------------

Not @tlwr