### PR TITLE
Setup secrets upload for ZenDesk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,7 +283,7 @@ showenv: ## Display environment information
 	@scripts/showenv.sh
 
 .PHONY: upload-all-secrets
-upload-all-secrets: upload-google-oauth-secrets upload-microsoft-oauth-secrets upload-splunk-secrets upload-notify-secrets upload-aiven-secrets upload-logit-secrets upload-pagerduty-secrets upload-cyber-secrets upload-paas-trusted-people
+upload-all-secrets: upload-google-oauth-secrets upload-microsoft-oauth-secrets upload-splunk-secrets upload-notify-secrets upload-aiven-secrets upload-logit-secrets upload-pagerduty-secrets upload-cyber-secrets upload-paas-trusted-people upload-zendesk-secrets
 
 .PHONY: upload-google-oauth-secrets
 upload-google-oauth-secrets: check-env ## Decrypt and upload Google Admin Console credentials to Credhub
@@ -336,6 +336,12 @@ upload-pagerduty-secrets: check-env ## Decrypt and upload pagerduty credentials 
 .PHONY: upload-paas-trusted-people
 upload-paas-trusted-people: check-env
 	@scripts/upload-secrets/upload-paas-trusted-people.sh
+
+.PHONY: upload-zendesk-secrets
+upload-zendesk-secrets: check-env ## Decrypt and upload ZenDesk secrets to Credhub
+	$(if $(wildcard ${PAAS_PASSWORD_STORE_DIR}),,$(error Password store ${PAAS_PASSWORD_STORE_DIR} (PAAS_PASSWORD_STORE_DIR) does not exist))
+	$(eval export PASSWORD_STORE_DIR=${PAAS_PASSWORD_STORE_DIR})
+	@scripts/upload-secrets/upload-zendesk-secrets.rb
 
 .PHONY: pingdom
 pingdom: check-env ## Use custom Terraform provider to set up Pingdom check

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -3517,6 +3517,8 @@ jobs:
                     PROMETHEUS_USERNAME: paas-admin
                     PROMETHEUS_PASSWORD: ((paas_admin_prometheus_password))
                     PROMETHEUS_ENDPOINT: "https://prometheus.${SYSTEM_DNS_ZONE_NAME}"
+                    ZENDESK_API_TOKEN: ((zendesk_api_token))
+                    ZENDESK_USERNAME: ((zendesk_username))
                 EOF
 
                 spruce merge \

--- a/scripts/upload-secrets/upload-zendesk-secrets.rb
+++ b/scripts/upload-secrets/upload-zendesk-secrets.rb
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+script_path = File.absolute_path(__FILE__).sub!(Dir.pwd + "/", "")
+File.open(File.expand_path("~/.paas-script-usage"), "a") { |f| f.puts script_path }
+
+require_relative "upload_secrets.rb"
+
+deploy_env = ENV.fetch("DEPLOY_ENV")
+
+credhub_namespaces = [
+  "/concourse/main/create-cloudfoundry",
+  "/#{deploy_env}/#{deploy_env}",
+]
+
+zendesk_api_token = ENV["ZENDESK_API_TOKEN"] || `pass "zendesk/api_key"`
+zendesk_username = ENV["ZENDESK_USERNAME"] || `pass "zendesk/api_user"`
+
+upload_secrets(
+  credhub_namespaces,
+  "zendesk_api_token" => zendesk_api_token,
+  "zendesk_username" => zendesk_username,
+)


### PR DESCRIPTION
What
----

We'd be using the ZenDesk integration in our PaaS Admin application to
have a better and accessible support form for our tenants.

How to review
-------------

- `make dev upload-zendesk-secrets`
- run `create-cloudfoundry` pipeline
- expect appropriate secrets set for PaaS Admin (zendesk ones)