### PR TITLE
[#171281178] Ship Prometheus endpoint for Redis

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -4276,19 +4276,45 @@ jobs:
           trigger: true
           passed: ['post-deploy']
 
+      - task: create-metrics-domain
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *cf-cli-image-resource
+          params:
+            CF_CLIENT_ID: "paas-prometheus-endpoints"
+            CF_CLIENT_SECRET: ((uaa_clients_paas_prometheus_endpoints_secret))
+            CF_API_ADDRESS: https://api.((system_dns_zone_name))
+
+            DOMAIN_FOR_PROMETHEUS_ENDPOINTS: metrics.((system_dns_zone_name))
+
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
+          run:
+            path: bash
+            args:
+              - -c
+              - |
+                set -ueo pipefail
+
+                echo | cf login -a "${CF_API_ADDRESS}" -u "${CF_ADMIN}" -p "${CF_PASS}" -o admin -s monitoring
+
+                if ! cf domains | grep "${DOMAIN_FOR_PROMETHEUS_ENDPOINTS}" > /dev/null; then
+                  cf create-private-domain admin "${DOMAIN_FOR_PROMETHEUS_ENDPOINTS}"
+                fi
+
       - task: deploy-paas-prometheus-endpoint-redis
         tags: [colocated-with-web]
         config:
           platform: linux
           image_resource: *cf-cli-image-resource
           params:
-            UAA_API_URL: https://uaa.((system_dns_zone_name))
-
             CF_CLIENT_ID: "paas-prometheus-endpoints"
             CF_CLIENT_SECRET: ((uaa_clients_paas_prometheus_endpoints_secret))
             CF_API_ADDRESS: https://api.((system_dns_zone_name))
 
             DEPLOY_ENV: ((deploy_env))
+            DOMAIN_FOR_PROMETHEUS_ENDPOINTS: metrics.((system_dns_zone_name))
 
             CF_ADMIN: ((cf_admin))
             CF_PASS: ((cf_pass))
@@ -4309,8 +4335,12 @@ jobs:
 
                 echo | cf login -a "${CF_API_ADDRESS}" -u "${CF_ADMIN}" -p "${CF_PASS}" -o admin -s monitoring
 
-                cf push paas-prometheus-endpoint-redis \
-                  -f ./redis-manifest.yml \
+                cf cancel-deployment paas-prometheus-endpoint-redis || true
+                cf push \
+                  paas-prometheus-endpoint-redis \
+                  --strategy=rolling \
+                  -f manifest-redis.yml \
+                  --var route="redis.${DOMAIN_FOR_PROMETHEUS_ENDPOINTS}" \
                   --var cf_client_id="$CF_CLIENT_ID" \
                   --var cf_client_secret="$CF_CLIENT_SECRET" \
                   --var cf_api_address="$CF_API_ADDRESS" \
@@ -4318,6 +4348,7 @@ jobs:
                   --var aws_region="$AWS_REGION" \
                   --var aws_access_key_id="$AWS_ACCESS_KEY_ID" \
                   --var aws_secret_access_key="$AWS_SECRET_ACCESS_KEY"
+
       - *end-grafana-job-annotation
 
   - name: deploy-paas-aiven-broker

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -309,6 +309,7 @@ groups:
       - deploy-paas-billing
       - deploy-paas-metrics
       - deploy-paas-aiven-broker
+      - deploy-paas-prometheus-endpoints
       - smoke-tests
       - acceptance-tests
       - custom-acceptance-tests
@@ -665,6 +666,13 @@ resources:
       branch: master
       tag_filter: ((deploy_env_tag_prefix))
       commit_verification_keys: ((gpg_public_keys))
+
+  - name: paas-prometheus-endpoints
+    type: git
+    source:
+      uri: https://github.com/alphagov/paas-prometheus-endpoints.git
+      branch: main
+      tag_filter: v0.10.0
 
   - name: prometheus-manifest-pre-vars
     type: s3-iam
@@ -1798,6 +1806,8 @@ jobs:
                 PAAS_ADMIN_AWS_ACCESS_KEY_ID=$($VAL_FROM_YAML terraform_outputs_paas_admin_metrics_aws_access_key_id cf-terraform-outputs.yml)
                 PAAS_ADMIN_AWS_SECRET_ACCESS_KEY=$($VAL_FROM_YAML terraform_outputs_paas_admin_metrics_aws_secret_access_key cf-terraform-outputs.yml)
                 PAAS_ADMIN_PROMETHEUS_PASSWORD=$(credhub get -q -n "${BOSH_NS}/paas_admin_prometheus_password")
+                PAAS_PROMETHEUS_ENDPOINTS_AWS_ACCESS_KEY_ID=$($VAL_FROM_YAML terraform_outputs_paas_prometheus_endpoints_aws_access_key_id cf-terraform-outputs.yml)
+                PAAS_PROMETHEUS_ENDPOINTS_AWS_SECRET_ACCESS_KEY=$($VAL_FROM_YAML terraform_outputs_paas_prometheus_endpoints_aws_secret_access_key cf-terraform-outputs.yml)
                 UAA_CLIENTS_CF_EXPORTER_SECRET=$(credhub get -q -n "${BOSH_NS}/uaa_clients_cf_exporter_secret")
                 UAA_CLIENTS_FIREHOSE_EXPORTER_SECRET=$(credhub get -q -n "${BOSH_NS}/uaa_clients_firehose_exporter_secret")
                 RDS_BROKER_PASS=$(credhub get -q -n "${BOSH_NS}/secrets_rds_broker_admin_password")
@@ -1808,6 +1818,7 @@ jobs:
                 UAA_ADMIN_CLIENT_SECRET=$(credhub get -q -n "${BOSH_NS}/uaa_admin_client_secret")
                 UAA_CLIENTS_PAAS_ADMIN_SECRET=$(credhub get -q -n "${BOSH_NS}/uaa_clients_paas_admin_secret")
                 UAA_CLIENTS_PAAS_AUDITOR_SECRET=$(credhub get -q -n "${BOSH_NS}/secrets_uaa_clients_paas_auditor_secret")
+                UAA_CLIENTS_PAAS_PROMETHEUS_ENDPOINTS_SECRET=$(credhub get -q -n "${BOSH_NS}/secrets_uaa_clients_paas_prometheus_endpoints_secret")
                 SECRETS_TEST_USER_PASSWORD=$(credhub get -q -n "${BOSH_NS}/secrets_test_user_password")
                 CUSTOM_BROKER_ACCEPTANCE_PROMETHEUS_PASSWORD=$(credhub get -q -n "${BOSH_NS}/custom_broker_acceptance_prometheus_password")
 
@@ -1827,8 +1838,10 @@ jobs:
                 credhub set --name="${PIPELINE_NS}/metrics_aws_access_key_id" --type password --password "${METRICS_AWS_ACCESS_KEY_ID}"
                 credhub set --name="${PIPELINE_NS}/metrics_aws_secret_access_key" --type password --password "${METRICS_AWS_SECRET_ACCESS_KEY}"
                 credhub set --name="${PIPELINE_NS}/paas_admin_aws_access_key_id" --type password --password "${PAAS_ADMIN_AWS_ACCESS_KEY_ID}"
-                credhub set --name="${PIPELINE_NS}/paas_admin_prometheus_password" --type password --password "${PAAS_ADMIN_PROMETHEUS_PASSWORD}"
                 credhub set --name="${PIPELINE_NS}/paas_admin_aws_secret_access_key" --type password --password "${PAAS_ADMIN_AWS_SECRET_ACCESS_KEY}"
+                credhub set --name="${PIPELINE_NS}/paas_admin_prometheus_password" --type password --password "${PAAS_ADMIN_PROMETHEUS_PASSWORD}"
+                credhub set --name="${PIPELINE_NS}/paas_prometheus_endpoints_aws_access_key_id" --type password --password "${PAAS_PROMETHEUS_ENDPOINTS_AWS_ACCESS_KEY_ID}"
+                credhub set --name="${PIPELINE_NS}/paas_prometheus_endpoints_aws_secret_access_key" --type password --password "${PAAS_PROMETHEUS_ENDPOINTS_AWS_SECRET_ACCESS_KEY}"
                 credhub set --name="${PIPELINE_NS}/uaa_clients_cf_exporter_secret" --type password --password "${UAA_CLIENTS_CF_EXPORTER_SECRET}"
                 credhub set --name="${PIPELINE_NS}/uaa_clients_firehose_exporter_secret" --type password --password "${UAA_CLIENTS_FIREHOSE_EXPORTER_SECRET}"
                 credhub set --name="${PIPELINE_NS}/secrets_rds_broker_admin_password" --type password --password "${RDS_BROKER_PASS}"
@@ -1839,6 +1852,7 @@ jobs:
                 credhub set --name="${PIPELINE_NS}/uaa_admin_client_secret" --type password --password "${UAA_ADMIN_CLIENT_SECRET}"
                 credhub set --name="${PIPELINE_NS}/uaa_clients_paas_admin_secret" --type password --password "${UAA_CLIENTS_PAAS_ADMIN_SECRET}"
                 credhub set --name="${PIPELINE_NS}/uaa_clients_paas_auditor_secret" --type password --password "${UAA_CLIENTS_PAAS_AUDITOR_SECRET}"
+                credhub set --name="${PIPELINE_NS}/uaa_clients_paas_prometheus_endpoints_secret" --type password --password "${UAA_CLIENTS_PAAS_PROMETHEUS_ENDPOINTS_SECRET}"
                 credhub set --name="${PIPELINE_NS}/secrets_test_user_password" --type password --password "${SECRETS_TEST_USER_PASSWORD}"
 
                 credhub set --name="${PIPELINE_NS}/custom_broker_acceptance_prometheus_password" --type password --password "${CUSTOM_BROKER_ACCEPTANCE_PROMETHEUS_PASSWORD}"
@@ -4250,6 +4264,62 @@ jobs:
                 ginkgo acceptance
       - *end-grafana-job-annotation
 
+  - name: deploy-paas-prometheus-endpoints
+    serial: true
+    plan:
+      - *add-grafana-job-annotation
+      - in_parallel:
+        - get: paas-prometheus-endpoints
+          trigger: true
+
+        - get: paas-cf
+          trigger: true
+          passed: ['post-deploy']
+
+      - task: deploy-paas-prometheus-endpoint-redis
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *cf-cli-image-resource
+          params:
+            UAA_API_URL: https://uaa.((system_dns_zone_name))
+
+            CF_CLIENT_ID: "paas-prometheus-endpoints"
+            CF_CLIENT_SECRET: ((uaa_clients_paas_prometheus_endpoints_secret))
+            CF_API_ADDRESS: https://api.((system_dns_zone_name))
+
+            DEPLOY_ENV: ((deploy_env))
+
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
+
+            AWS_REGION: ((aws_region))
+            AWS_ACCESS_KEY_ID: ((paas_prometheus_endpoints_aws_access_key_id))
+            AWS_SECRET_ACCESS_KEY: ((paas_prometheus_endpoints_aws_secret_access_key))
+          inputs:
+            - name: paas-cf
+            - name: paas-prometheus-endpoints
+          run:
+            path: bash
+            dir: paas-prometheus-endpoints
+            args:
+              - -c
+              - |
+                set -ueo pipefail
+
+                echo | cf login -a "${CF_API_ADDRESS}" -u "${CF_ADMIN}" -p "${CF_PASS}" -o admin -s monitoring
+
+                cf push paas-prometheus-endpoint-redis \
+                  -f ./redis-manifest.yml \
+                  --var cf_client_id="$CF_CLIENT_ID" \
+                  --var cf_client_secret="$CF_CLIENT_SECRET" \
+                  --var cf_api_address="$CF_API_ADDRESS" \
+                  --var deploy_env="$DEPLOY_ENV" \
+                  --var aws_region="$AWS_REGION" \
+                  --var aws_access_key_id="$AWS_ACCESS_KEY_ID" \
+                  --var aws_secret_access_key="$AWS_SECRET_ACCESS_KEY"
+      - *end-grafana-job-annotation
+
   - name: deploy-paas-aiven-broker
     serial: true
     plan:
@@ -4795,6 +4865,7 @@ jobs:
               credhub generate -n "${BOSH_NS}/secrets_uaa_clients_paas_auditor_secret" -t password
               credhub generate -n "${BOSH_NS}/secrets_uaa_clients_paas_billing_secret" -t password
               credhub generate -n "${BOSH_NS}/secrets_uaa_clients_paas_metrics_secret" -t password
+              credhub generate -n "${BOSH_NS}/secrets_uaa_clients_paas_prometheus_endpoints_secret" -t password
               credhub generate -n "${BOSH_NS}/uaa_clients_cf_exporter_secret" -t password
               credhub generate -n "${BOSH_NS}/uaa_clients_cf_smoke_tests_secret" -t password
               credhub generate -n "${BOSH_NS}/uaa_clients_firehose_exporter_secret" -t password

--- a/manifests/cf-manifest/operations.d/330-uaa.yml
+++ b/manifests/cf-manifest/operations.d/330-uaa.yml
@@ -141,6 +141,18 @@
     secret: ((secrets_uaa_clients_paas_metrics_secret))
 
 - type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/paas-prometheus-endpoints?
+  value:
+    access-token-validity: 1209600
+    authorities: oauth.login,cloud_controller.global_auditor,scim.read
+    authorized-grant-types: client_credentials,refresh_token
+    autoapprove: true
+    override: true
+    redirect-uri: https://metrics.((system_domain))/oauth/callback
+    scope: openid,oauth.approvals,cloud_controller.global_auditor
+    secret: ((secrets_uaa_clients_paas_prometheus_endpoints_secret))
+
+- type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/user_invitation?
   value:
     authorities: oauth.login,scim.write,emails.write,scim.userids
@@ -290,6 +302,11 @@
   path: /variables/-
   value:
     name: secrets_uaa_clients_paas_auditor_secret
+    type: password
+- type: replace
+  path: /variables/-
+  value:
+    name: secrets_uaa_clients_paas_prometheus_endpoints_secret
     type: password
 
 - type: replace

--- a/terraform/cloudfoundry/acm.tf
+++ b/terraform/cloudfoundry/acm.tf
@@ -26,3 +26,22 @@ resource "aws_acm_certificate_validation" "apps" {
   ]
 }
 
+resource "aws_acm_certificate" "metrics" {
+  domain_name               = "*.metrics.${var.system_dns_zone_name}"
+  subject_alternative_names = ["metrics.${var.system_dns_zone_name}"]
+  validation_method         = "DNS"
+}
+
+resource "aws_route53_record" "metrics_cert_validation" {
+  name    = aws_acm_certificate.metrics.domain_validation_options.0.resource_record_name
+  type    = aws_acm_certificate.metrics.domain_validation_options.0.resource_record_type
+  zone_id = var.system_dns_zone_id
+  records = [aws_acm_certificate.metrics.domain_validation_options.0.resource_record_value]
+  ttl     = 60
+}
+
+resource "aws_acm_certificate_validation" "metrics" {
+  certificate_arn = aws_acm_certificate.metrics.arn
+
+  validation_record_fqdns = [aws_route53_record.metrics_cert_validation.fqdn]
+}

--- a/terraform/cloudfoundry/lbs.tf
+++ b/terraform/cloudfoundry/lbs.tf
@@ -239,6 +239,11 @@ resource "aws_lb_listener" "cf_router_system_domain_https" {
   }
 }
 
+resource "aws_lb_listener_certificate" "cf_router_metrics_domain_https" {
+  listener_arn    = "${aws_lb_listener.cf_router_system_domain_https.arn}"
+  certificate_arn = "${aws_acm_certificate.metrics.arn}"
+}
+
 resource "aws_lb_target_group" "cf_router_system_domain_https" {
   name                 = "${var.env}-system-tls-tg"
   port                 = 8443

--- a/terraform/cloudfoundry/outputs.tf
+++ b/terraform/cloudfoundry/outputs.tf
@@ -213,3 +213,12 @@ output "paas_admin_metrics_aws_secret_access_key" {
   value     = aws_iam_access_key.paas_admin_metrics.secret
 }
 
+output "paas_prometheus_endpoints_aws_access_key_id" {
+  sensitive = true
+  value     = aws_iam_access_key.paas_prometheus_endpoints.id
+}
+
+output "paas_prometheus_endpoints_aws_secret_access_key" {
+  sensitive = true
+  value     = aws_iam_access_key.paas_prometheus_endpoints.secret
+}

--- a/terraform/cloudfoundry/paas-prometheus-endpoints.tf
+++ b/terraform/cloudfoundry/paas-prometheus-endpoints.tf
@@ -1,0 +1,14 @@
+resource "aws_iam_user" "paas_prometheus_endpoints" {
+  name = "paas-prometheus-endpoints-${var.env}"
+
+  force_destroy = true
+}
+
+resource "aws_iam_user_group_membership" "paas_prometheus_endpoints" {
+  user   = "${aws_iam_user.paas_prometheus_endpoints.name}"
+  groups = ["paas-prometheus-endpoints"]
+}
+
+resource "aws_iam_access_key" "paas_prometheus_endpoints" {
+  user = "${aws_iam_user.paas_prometheus_endpoints.name}"
+}


### PR DESCRIPTION
What
----

This deploys the Redis prometheus endpoint from https://github.com/alphagov/paas-prometheus-endpoints. A tenant can scrape metrics about Redis services by targeting a Prometheus at `https://redis.metrics.${SYSTEM_DNS_ZONE_NAME}/metrics`. They get Prometheus to do basic auth with a PaaS username/password for a user with "Space Auditor" privileges.

How to review
-------------

* [x] Miki has to decided the Redis endpoint is production-ready
* [x] Someone else has looked over https://github.com/alphagov/paas-prometheus-endpoints and given it the thumbs up
* [x] https://github.com/alphagov/paas-aws-account-wide-terraform/pull/219 must have been merged and applied

Who can review
--------------

Not @46bit.