### PR TITLE
Add xlarge elasticsearch 6 plan

### DIFF
--- a/config/billing/config-parts/elasticsearch_pricing_plans.json.erb
+++ b/config/billing/config-parts/elasticsearch_pricing_plans.json.erb
@@ -89,3 +89,16 @@
 		}
 	]
 },
+{
+	"name": "elasticsearch xlarge-ha-6.x",
+	"valid_from": "2018-10-01",
+	"plan_guid": "b036fe1d-0a82-44ac-a70b-1d997b2e0c02",
+	"components": [
+		{
+			"name": "instance",
+			"formula": "ceil($time_in_seconds/3600) * <%= price("aiven_elasticsearch_business_32") %>",
+			"currency_code": "USD",
+			"vat_code": "Standard"
+		}
+	]
+},

--- a/config/billing/pricing_data.yml
+++ b/config/billing/pricing_data.yml
@@ -10,6 +10,7 @@ defaults: &defaults
   aiven_elasticsearch_business_4: "0.548"
   aiven_elasticsearch_business_8: "1.096"
   aiven_elasticsearch_business_16: "2.192"
+  aiven_elasticsearch_business_32: "4.384"
   aiven_influxdb_startup_4: "0.130"
 
 eu-west-1:

--- a/config/service-brokers/aiven/config.json
+++ b/config/service-brokers/aiven/config.json
@@ -108,6 +108,27 @@
                 "version": "6"
               }
             }
+          },
+          {
+            "id": "b036fe1d-0a82-44ac-a70b-1d997b2e0c02",
+            "name": "xlarge-ha-6.x",
+            "aiven_plan": "business-32",
+            "elasticsearch_version": "6",
+            "description": "3 dedicated VMs, 4 CPU per VM, 31GB RAM per VM, 2100GB disk space.",
+            "free": false,
+            "metadata": {
+              "displayName": "Large",
+              "AdditionalMetadata": {
+                "backups": true,
+                "encrypted": true,
+                "highlyAvailable": true,
+                "nodes": 3,
+                "cpu": 4,
+                "memory": {"amount": 31, "unit": "GB"},
+                "storage": {"amount": 2100, "unit": "GB"},
+                "version": "6"
+              }
+            }
           }
         ]
       },


### PR DESCRIPTION
What
----

This adds an `elasticsearch xlarge-ha-6.x` plan mapping onto Aiven's Business-32 offering.

A tenant is reporting performance issues with one of their clusters and Aiven are suggesting that the cluster might actually hit a performance limit due to sharding.

How to review
-------------

- Code review
- (Check if this change is indeed sufficient to add the new plan/ that I have not overlooked sth)

Who can review
--------------

not @schmie 