### PR TITLE
Upload dumb secrets in the place of real onses

### DIFF
--- a/scripts/upload-secrets/upload-cyber-secrets.rb
+++ b/scripts/upload-secrets/upload-cyber-secrets.rb
@@ -15,6 +15,10 @@ secrets = {}
 csls_kinesis_destination_arn = `pass "cyber/${MAKEFILE_ENV_TARGET}/csls_kinesis_destination_arn"`
 secrets["cyber_csls_kinesis_destination_arn"] = csls_kinesis_destination_arn
 
+secrets["csls_splunk_broker_url"] = "__STUB_csls_splunk_broker_url__"
+secrets["csls_splunk_broker_username"] = "__STUB_csls_splunk_broker_username__"
+secrets["csls_splunk_broker_password"] = "__STUB_csls_splunk_broker_password__"
+
 if ENV["MAKEFILE_ENV_TARGET"].start_with?("prod")
   csls_splunk_broker_url = `pass "cyber/${MAKEFILE_ENV_TARGET}/csls_broker_url"`
   csls_splunk_broker_username = `pass "cyber/${MAKEFILE_ENV_TARGET}/csls_broker_username"`


### PR DESCRIPTION
What
----

Although the Concourse task is restricted not to perform actions for the
CSLS broker when not in production, Concourse itself, has been
configured with reading secrets where these have not been setup in that
particular environment.

How to review
-------------

- Sanity check
- See staging pipeline's latest builds (215)