### PR TITLE
Update VPC peering for govuk_development

### DIFF
--- a/terraform/prod.vpc_peering.json
+++ b/terraform/prod.vpc_peering.json
@@ -63,6 +63,6 @@
         "peer_name": "govuk-infrastructure-test",
         "account_id": "430354129336",
         "vpc_id": "vpc-9e62bcf8",
-        "subnet_cidr": "172.16.36.0/22"
+        "subnet_cidr": "10.200.0.0/16"
     }
 ]


### PR DESCRIPTION
What:
Update to the VPC subnet configured for GOV.UK Development peering.

Why:
"subnet_cidr" represents client subnet as per: step 1&2 of PaaS guide at https://team-manual.cloud.service.gov.uk/guides/vpc_peering/#content


