### PR TITLE
Use `bash` instead of `sh` in `register-csls-splunk-broker` task

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2424,7 +2424,7 @@ jobs:
             CSLS_SPLUNK_BROKER_PASSWORD: ((csls_splunk_broker_password))
             CSLS_SPLUNK_BROKER_URL: ((csls_splunk_broker_url))
           run:
-            path: sh
+            path: bash
             args:
               - -e
               - -u


### PR DESCRIPTION
What
----

We silenced Shellcheck rule SC2039 because it alerts on us using features that
aren't defined in the POSIX spec, but we still wanted to use those features.

But we were still using the `sh` shell to run the task, so the behaviour was
still undefined, and it still didn't work. Using `bash` ought to fix that.

How to review
-------------
Code review

Who can review
--------------
Anyone