### PR TITLE
Fix HTTP healthcheck in CF CLI v7 manifests

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1979,6 +1979,7 @@ jobs:
                       instances: 1
                       buildpacks: [go_buildpack]
                       health-check-type: http
+                      health-check-http-endpoint: /
                       stack: cflinuxfs3
                       env:
                         GOPACKAGENAME: github.com/alphagov/paas-yet-another-cloudwatch-exporter/src
@@ -3772,6 +3773,7 @@ jobs:
                     app['routes'] = [
                       { 'route' => 'billing.${SYSTEM_DNS_ZONE_NAME}' }
                     ]
+                    app['health-check-http-endpoint'] = '/'
                   }
                   File.write('manifest-api.yml', api.to_yaml)
 


### PR DESCRIPTION
What
----

We configure many of our apps to use HTTP healthchecks. There is a change in how this has to be configured which only became apparent when deploying a new PaaS dev environment.

In CF CLI v6, we specify `health-check-type: http` in the app manifest and CF will automatically health check the `/` route.

In CF CLI v7, the endpoint to be used for HTTP healthchecks now has to be specified (there is no default.)

This only became apparent when Miki deployed a new environment because in all existing environments CF has probably stored the default endpoint value from when we still used CF CLI v6.

How to review
-------------

Code review.

Who can review
--------------

Not @46bit.