### PR TITLE
Declare in code orgs allowed the splunk broker

### DIFF
--- a/config/service-brokers/csls-splunk/prod-config.json
+++ b/config/service-brokers/csls-splunk/prod-config.json
@@ -1,5 +1,9 @@
 {
   "allowed_orgs": [
-
+    "digitalmarketplace",
+    "gds-tech-ops",
+    "govuk_development",
+    "govuk-corona-backend-consumers",
+    "govuk-pay"
   ]
 }

--- a/config/service-brokers/csls-splunk/prod-lon-config.json
+++ b/config/service-brokers/csls-splunk/prod-lon-config.json
@@ -1,4 +1,5 @@
 {
   "allowed_orgs": [
+    "x-co-authentication"
   ]
 }

--- a/config/service-brokers/csls-splunk/prod-lon-config.json
+++ b/config/service-brokers/csls-splunk/prod-lon-config.json
@@ -1,5 +1,10 @@
 {
   "allowed_orgs": [
+    "cabinet-office-nsra",
+    "cabinet-office-people-finder",
+    "ccs-conclave-cii",
+    "ccs-digital-services-team",
+    "ccs-report-management-info",
     "x-co-authentication"
   ]
 }


### PR DESCRIPTION
What
----

This has previously been done manually, by enabling certain services
access to splunk.

In order to generate that list, we need to track down these services
firts.

This is achievable by running:

```
→ cf service-access -b splunk
Getting service access for broker splunk as rafal.proszowski@digital.cabinet-office.gov.uk...
broker: splunk
   service   plan        access    orgs
   splunk    unlimited   limited   digitalmarketplace,gds-tech-ops,govuk-corona-backend-consumers,govuk-pay,govuk_development
```

My assumption, is that there will be a job responsible for syncing up
the organisations with these files.

How to review
-------------

- Sanity check