### PR TITLE
[#173938510]  Keep patch level when modifying similar engine versions

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 0.1.67 
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.67.tgz
-    sha1: 5c799f5cbaacd1c001bf035c69a21cbea352773a
+    version: 0.1.68
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.68.tgz
+    sha1: 7aea07aee96c412817fcf8600045c593dbd6e2a4
 
 - type: replace
   path: /instance_groups/-


### PR DESCRIPTION
What
----

We are not prescribing the patch level in the RDS service catalog plans in order to make use of the auto minor version upgrade feature.

This means that AWS chooses the patch level when creating or modifying an instance. If the patch-level chosen for the modification is for some reason lower than the patch-level of the current instance cf update-service will fail.

This change preserves the patch-level of the current instance when updating the plan, if the major and minor versions are the same. It also adds tests.

See https://github.com/alphagov/paas-rds-broker/pull/118 for further info

How to review
-------------

Code review

Who can review
--------------

Me
