### PR TITLE
runtime-config: syslog forwarder has director name

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1513,6 +1513,7 @@ jobs:
               - name: paas-cf-runtime-config
             params:
               AWS_ACCOUNT: ((aws_account))
+              DEPLOY_ENV: ((deploy_env))
             run:
               path: sh
               args:

--- a/config/logit/20_custom_cf_filters.conf
+++ b/config/logit/20_custom_cf_filters.conf
@@ -83,8 +83,7 @@ mutate {
     "syslog6587_msglen",
     "syslog_msgid",
     "syslog_procid",
-    "syslog_sd_id",
-    "[@source][director]"
+    "syslog_sd_id"
   ]
 }
 

--- a/config/logit/output/generated_logit_filters.conf
+++ b/config/logit/output/generated_logit_filters.conf
@@ -1135,8 +1135,7 @@ filter {
       "syslog6587_msglen",
       "syslog_msgid",
       "syslog_procid",
-      "syslog_sd_id",
-      "[@source][director]"
+      "syslog_sd_id"
     ]
   }
 

--- a/manifests/runtime-config/operations.d/100-syslog-forwarder.yml
+++ b/manifests/runtime-config/operations.d/100-syslog-forwarder.yml
@@ -20,6 +20,7 @@
         release: syslog
         properties:
           syslog:
+            director: ((bosh_director_name))
             address: ((logit_syslog_address))
             port: ((logit_syslog_port))
             transport: 'tcp'

--- a/manifests/runtime-config/scripts/generate-runtime-config.sh
+++ b/manifests/runtime-config/scripts/generate-runtime-config.sh
@@ -13,5 +13,6 @@ done
 # shellcheck disable=SC2086
 bosh interpolate \
   --vars-file="${PAAS_CF_DIR}/manifests/variables.yml" \
+  --var bosh_director_name="${DEPLOY_ENV}" \
   ${opsfile_args} \
   "${PAAS_CF_DIR}/manifests/runtime-config/paas-cf-runtime-config.yml"

--- a/manifests/runtime-config/spec/support/runtime_config_helpers.rb
+++ b/manifests/runtime-config/spec/support/runtime_config_helpers.rb
@@ -9,16 +9,19 @@ module RuntimeConfigHelpers
   end
 
   def runtime_config_with_defaults
-    runtime_config_for_account("prod")
+    runtime_config_for_account("test")
   end
 
   def runtime_config_for_account(account)
     sym = "runtime_config_for_#{account}".to_sym
 
     old_aws_account = ENV["AWS_ACCOUNT"]
+    old_deploy_env = ENV["DEPLOY_ENV"]
     ENV["AWS_ACCOUNT"] = account
+    ENV["DEPLOY_ENV"] = account
     Cache.instance[sym] ||= render_runtime_config
     ENV["AWS_ACCOUNT"] = old_aws_account
+    ENV["DEPLOY_ENV"] = old_deploy_env
 
     Cache.instance[sym]
   end

--- a/manifests/runtime-config/spec/syslog_forwarder_spec.rb
+++ b/manifests/runtime-config/spec/syslog_forwarder_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "syslog forwarder" do
     expect(syslog_properties["syslog"]["port"]).to eq "((logit_syslog_port))"
     expect(syslog_properties["syslog"]["permitted_peer"]).to eq "*.logit.io"
     expect(syslog_properties["syslog"]["ca_cert"]).to eq("((logit_ca_cert))")
+    expect(syslog_properties["syslog"]["director"]).to eq("test")
   end
 
   it "excludes the concourse deployment" do


### PR DESCRIPTION
What
----

We currently do not populate the `syslog.director` bosh property, which defaults to the empty string, and in logstash we drop it.

This PR:

- populates `syslog.director`
- does not drop it in logstash

so we now can run the following queries:

- `@source.director:"prod" AND @source.deployment:prometheus`
- `@source.director:"prod-lon" AND @source.deployment:prometheus`

to differentiate between the two different Prometheus deployments in production

How to review
-------------

Code review

Check [Kibana in dev](https://kibana.logit.io/s/c7358874-2b30-44a6-8271-554ad3996e50/app/kibana#/visualize/create?type=pie&indexPattern=logstash-*&_g=()&_a=(filters:!(),linked:!f,query:(query_string:(analyze_wildcard:!t,query:'@source.director:tlwr')),uiState:(),vis:(aggs:!((enabled:!t,id:'1',params:(),schema:metric,type:count),(enabled:!t,id:'2',params:(field:'@source.deployment.keyword',order:desc,orderBy:'1',size:50),schema:segment,type:terms)),listeners:(),params:(addLegend:!t,addTooltip:!t,isDonut:!f,legendPosition:right,type:pie),title:'New%20Visualization',type:pie)))

Who can review
--------------

Not @tlwr
