### PR TITLE
[do-not-merge] [#174320941] Vault for testing

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1781,6 +1781,7 @@ jobs:
                 UAA_CLIENTS_PAAS_AUDITOR_SECRET=$(credhub get -q -n "${BOSH_NS}/secrets_uaa_clients_paas_auditor_secret")
                 SECRETS_TEST_USER_PASSWORD=$(credhub get -q -n "${BOSH_NS}/secrets_test_user_password")
                 CUSTOM_BROKER_ACCEPTANCE_PROMETHEUS_PASSWORD=$(credhub get -q -n "${BOSH_NS}/custom_broker_acceptance_prometheus_password")
+                VAULT_ADMIN_PASSWORD=$(credhub get -q -n "${BOSH_NS}/vault_admin_password")
 
 
                 echo 'Setting secrets'
@@ -1789,6 +1790,7 @@ jobs:
                 credhub set --name="${TEAM_NS}/cf_admin" --type value --value "${CF_ADMIN}"
                 credhub set --name="${TEAM_NS}/cf_pass" --type password --password "${CF_PASS}"
                 credhub set --name="${PIPELINE_NS}/cf_client_secret" --type password --password "${CF_CLIENT_SECRET}"
+                credhub set --name="${PIPELINE_NS}/vault_admin_password" --type password --password "${VAULT_ADMIN_PASSWORD}"
 
                 credhub set --name="${PIPELINE_NS}/paas_accounts_password" --type password --password "${PAAS_ACCOUNTS_PASSWORD}"
                 credhub set --name="${TEAM_NS}/api_endpoint" --type value --value "${API_ENDPOINT}"

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1,5 +1,11 @@
 ---
 meta:
+  resources:
+    get-paas-cf: &get-paas-cf
+      get: paas-cf
+      params: &get-paas-cf-params
+        submodule_recursive: 'false'  # git-resource issue 307
+
   containers:
     awscli: &awscli-image-resource
       type: docker-image

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -51,6 +51,11 @@ meta:
       source:
         repository: governmentpaas/curl-ssl
         tag: e1ffec0d1940706f157a8c1e0ab8131b7084fa1c
+    vault: &vault-image-resource
+      type: docker-image
+      source:
+        repository: vault
+        tag: '1.5.0'
 
   tasks:
     - &add-grafana-job-annotation
@@ -302,6 +307,7 @@ groups:
       - deploy-paas-billing
       - deploy-paas-metrics
       - deploy-paas-aiven-broker
+      - deploy-vault-broker
       - smoke-tests
       - acceptance-tests
       - custom-acceptance-tests
@@ -339,6 +345,7 @@ groups:
       - deploy-paas-billing
       - deploy-paas-metrics
       - deploy-paas-aiven-broker
+      - deploy-vault-broker
   - name: operator
     jobs:
       - generate-git-keys
@@ -667,6 +674,13 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-yet-another-cloudwatch-exporter.git
       branch: gds_master
+
+  - name: vault-service-broker
+    type: git
+    source:
+      uri: https://github.com/hashicorp/vault-service-broker.git
+      branch: master
+      tag_filter: v0.5.3
 
 jobs:
   - name: pipeline-lock
@@ -4209,6 +4223,136 @@ jobs:
           GIT_SSH_PRIVATE_KEY: ((paas-aiven-broker-git-keys.private_key))
           GIT_SSH_PUBLIC_KEY: ((paas-aiven-broker-git-keys.public_key))
           GIT_USER: gov-paas-((deploy_env))
+
+      - *end-grafana-job-annotation
+
+  - name: deploy-vault-broker
+    serial: true
+    plan:
+      - *add-grafana-job-annotation
+
+      - <<: *get-paas-cf
+        trigger: true
+        passed: ['post-deploy']
+
+      - get: vault-service-broker
+
+      - task: create-broker-policy
+        config:
+          platform: linux
+          image_resource: *vault-image-resource
+          inputs:
+            - name: paas-cf
+          outputs:
+            - name: vault-broker-token
+          params:
+            VAULT_ADMIN_PASSWORD: ((vault_admin_password))
+            VAULT_ADDR: https://vault.((system_dns_zone_name))
+          run:
+            path: sh
+            args:
+              - -c
+              - |
+                set -eu
+
+                vault login \
+                  -method=userpass \
+                  -no-print \
+                  username=admin \
+                  "password=$VAULT_ADMIN_PASSWORD"
+
+                vault policy write \
+                  broker \
+                  paas-cf/config/service-brokers/vault/policy.hcl
+
+                tok="$(vault token create -policy=broker -display-name=broker)"
+                token="$(echo "$tok" \
+                                    | grep 'token\s' \
+                                    | head -n 1 \
+                                    | awk '{print $2}')"
+
+                echo "$token" > vault-broker-token/token
+
+      - task: generate-vault-broker-secrets
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *gov-paas-bosh-cli-v2-image-resource
+          params:
+            CREDHUB_CLIENT: credhub-admin
+            CREDHUB_SECRET: ((bosh-credhub-admin))
+            CREDHUB_CA_CERT: ((bosh-credhub-ca-cert))
+            CREDHUB_SERVER: "https://((bosh_fqdn)):8844/api"
+            DEPLOY_ENV: ((deploy_env))
+          run:
+            path: bash
+            args:
+              - -c
+              - -e
+              - |
+                credhub login
+
+                credhub generate \
+                  --type password \
+                  --length=64 \
+                  --name "/concourse/main/vault_broker_password" \
+                  --no-overwrite
+
+      - task: deploy-vault-broker
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *cf-cli-image-resource
+          inputs:
+            - name: paas-cf
+            - name: vault-broker-token
+            - name: vault-service-broker
+          params:
+            APPS_DNS_ZONE_NAME: ((apps_dns_zone_name))
+            SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
+            CF_CLIENT_SECRET: ((cf_client_secret))
+
+            VAULT_BROKER_PASSWORD: ((vault_broker_password))
+            VAULT_ADDR: https://vault.((system_dns_zone_name))
+          run:
+            path: sh
+            args:
+              - -e
+              - -u
+              - -c
+              - |
+                cf api "${API_ENDPOINT}"
+                cf auth "${CF_ADMIN}" "${CF_PASS}"
+                cf target -o admin -s service-brokers
+
+                spruce merge \
+                  vault-service-broker/manifest.yml \
+                  paas-cf/config/service-brokers/vault/env.yml \
+                  > manifest.yml
+
+                cf cancel-deployment vault-broker || true
+                cf push vault-broker \
+                  --strategy=rolling \
+                  --var "vault-addr=$VAULT_ADDR" \
+                  --var "vault-token=$(cat vault-broker-token/token)" \
+                  --var "vault-broker-password=$VAULT_BROKER_PASSWORD" \
+                  -f manifest.yml -p vault-service-broker
+
+                if cf service-brokers | grep 'vault-broker\s'; then
+                  cf update-service-broker vault-broker \
+                    vault-broker "$VAULT_BROKER_PASSWORD" \
+                    "https://vault-broker.${APPS_DNS_ZONE_NAME}"
+                else
+                  cf create-service-broker vault-broker \
+                    vault-broker "$VAULT_BROKER_PASSWORD" \
+                    "https://vault-broker.${APPS_DNS_ZONE_NAME}"
+                fi
+
+                cf enable-service-access hashicorp-vault
 
       - *end-grafana-job-annotation
 

--- a/config/service-brokers/vault/env.yml
+++ b/config/service-brokers/vault/env.yml
@@ -1,0 +1,8 @@
+---
+applications:
+  - name: vault-broker
+    env:
+      VAULT_ADDR: ((vault-addr))
+      VAULT_TOKEN: ((vault-token))
+      SECURITY_USER_NAME: vault-broker
+      SECURITY_USER_PASSWORD: ((vault-broker-password))

--- a/config/service-brokers/vault/policy.hcl
+++ b/config/service-brokers/vault/policy.hcl
@@ -1,0 +1,39 @@
+# Manage internal state under "/broker", but since this token is going to
+# generate children, it needs full management of the "/cf/*" space
+path "/cf/" {
+  capabilities = ["list"]
+}
+
+path "/cf/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+
+# List all mounts
+path "sys/mounts" {
+  capabilities = ["read", "list"]
+}
+
+# Create mounts under the "/cf/" prefix
+path "sys/mounts/cf/*" {
+  capabilities = ["create", "update", "delete"]
+}
+
+# Create policies with the "cf-*" prefix
+path "sys/policies/acl/cf-*" {
+  capabilities = ["create", "update", "delete"]
+}
+
+# Create token role
+path "/auth/token/roles/cf-*" {
+  capabilities = ["create", "update", "delete"]
+}
+
+# Create tokens from role
+path "/auth/token/create/cf-*" {
+  capabilities = ["create", "update"]
+}
+
+# Revoke tokens by accessor
+path "/auth/token/revoke-accessor" {
+  capabilities = ["create", "update"]
+}

--- a/manifests/cf-manifest/operations.d/200-vault.yml
+++ b/manifests/cf-manifest/operations.d/200-vault.yml
@@ -63,7 +63,7 @@
           vault:
             config: |
               storage "file" {
-                  path = "/var/vcap/store/vault/data"
+                path = "/var/vcap/store/vault/data"
               }
 
               ui = true
@@ -75,20 +75,9 @@
                 tls_min_version = "tls12"
               }
 
-            additional_config:
-              - name: kms.json
-                config: |
-                  {
-                    "seal": [
-                      {
-                        "awskms": [
-                          {
-                            "kms_key_id": "b1380431-d93c-4428-85b7-3589deb42e70"
-                          }
-                        ]
-                      }
-                    ]
-                  }
+              seal "awskms" {
+                kms_key_id = "b1380431-d93c-4428-85b7-3589deb42e70"
+              }
 
       - name: route_registrar
         release: routing

--- a/manifests/cf-manifest/operations.d/200-vault.yml
+++ b/manifests/cf-manifest/operations.d/200-vault.yml
@@ -36,6 +36,14 @@
         - vault.service.cf.internal
 
 - type: replace
+  path: /variables/-
+  value:
+    name: vault_admin_password
+    type: password
+    options:
+      length: 64
+
+- type: replace
   path: /instance_groups/-
   value:
     name: vault
@@ -91,3 +99,79 @@
                 uris:
                   - vault.((system_domain))
                 server_cert_domain_san: vault.service.cf.internal
+
+      - name: scripting
+        release: generic-scripting
+        properties:
+          scripting:
+            post-start-script: |
+              set -ueo pipefail
+              vault="/var/vcap/packages/vault/bin/vault"
+              vault_ca_path_arg="-ca-path=/var/vcap/jobs/vault/tls/vault/cert.pem"
+
+              for i in $(seq 60); do
+                if [ $i -eq "60" ]; then
+                  echo "vault not installed after $i attempts...giving up"
+                  exit 1
+                fi
+
+                if [ -x $vault ]; then
+                  break
+                fi
+
+                echo "waiting for vault to be installed"
+                sleep 1
+              done
+
+              for i in $(seq 60); do
+                if [ $i -eq "60" ]; then
+                  echo "vault not up after $i attempts...giving up"
+                  exit 1
+                fi
+
+                if $vault status $vault_ca_path_arg || [ $? = 2 ]; then
+                  break
+                fi
+
+                echo "waiting for vault to be up"
+                sleep 1
+              done
+
+              if grep -q 'Initialized\s*false' <<< $($vault status $vault_ca_path_arg); then
+                echo "Vault not initialized, bootstrapping"
+                init_output=$($vault operator init $vault_ca_path_arg -n 1 -t 1)
+
+                if [ $? != 0]; then
+                  echo "Attempted to init vault but did not succeed"
+                  echo "$init_output"
+                  exit 1
+                fi
+
+                token=$(echo "$init_output" | grep -o 'Token: .*' | awk '{print $2}')
+
+                $vault login $vault_ca_path_arg $token
+                if [ $? != 0 ]; then
+                  echo "Attempted to log in to vault but did not succeed"
+                  exit 1
+                fi
+
+                $vault auth enable $vault_ca_path_arg userpass
+                if [ $? != 0 ]; then
+                  echo "Attempted to enable userpass but did not succeed"
+                  exit 1
+                fi
+
+                $vault write $vault_ca_path_arg auth/userpass/users/admin "password=((vault_admin_password))" policies=admins
+                if [ $? != 0 ]; then
+                  echo "Attempted to add admin user but did not succeed"
+                  exit 1
+                fi
+
+              else
+                echo "Vault already initialized"
+              fi
+
+              if grep -q 'Sealed\s*true' <<< $($vault status $vault_ca_path_arg); then
+                echo "Vault should be unsealed but is sealed...giving up"
+                exit 1
+              fi

--- a/manifests/cf-manifest/operations.d/200-vault.yml
+++ b/manifests/cf-manifest/operations.d/200-vault.yml
@@ -54,6 +54,12 @@
       - name: vault
         release: vault
         properties:
+          tls:
+            - name: vault
+              key: ((vault_tls.private_key))
+              cert: |
+                ((vault_tls.certificate))
+                ((vault_tls.ca))
           vault:
             config: |
               storage "file" {
@@ -83,12 +89,6 @@
                       }
                     ]
                   }
-            tls:
-              - name: vault
-                key: ((vault_tls.private_key))
-                cert: |
-                  ((vault_tls.certificate))
-                  ((vault_tls.ca))
 
       - name: route_registrar
         release: routing

--- a/manifests/cf-manifest/operations.d/200-vault.yml
+++ b/manifests/cf-manifest/operations.d/200-vault.yml
@@ -4,9 +4,10 @@
   path: /releases/-
   value:
     name: vault
-    version: 1.1.6
-    url: https://github.com/cloudfoundry-community/vault-boshrelease/releases/download/v1.1.6/vault-1.1.6.tgz
-    sha1: f2a1fbf8797a63f4a99386c552a2459108d7541a
+    # FIXME
+    version: 0.1.1
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/vault-0.1.1.tgz
+    sha1: 1ec4d38c327110bf54e1eec25a3f10f162b1ed4c
 
 - type: replace
   path: /variables/-

--- a/manifests/cf-manifest/operations.d/200-vault.yml
+++ b/manifests/cf-manifest/operations.d/200-vault.yml
@@ -219,3 +219,11 @@
                 echo "Vault should be unsealed but is sealed...giving up"
                 exit 1
               fi
+
+- type: replace
+  path: /releases/-
+  value:
+    name: "generic-scripting"
+    version: "3"
+    url: "https://bosh.io/d/github.com/orange-cloudfoundry/generic-scripting-release?v=3"
+    sha1: "3198161324c49c670282f5c64b471204a3c510bb"

--- a/manifests/cf-manifest/operations.d/200-vault.yml
+++ b/manifests/cf-manifest/operations.d/200-vault.yml
@@ -1,0 +1,81 @@
+---
+
+- type: replace
+  path: /releases/-
+  value:
+    name: vault
+    version: 1.1.6
+    url: https://github.com/cloudfoundry-community/vault-boshrelease/releases/download/v1.1.6/vault-1.1.6.tgz
+    sha1: f2a1fbf8797a63f4a99386c552a2459108d7541a
+
+- type: replace
+  path: /variables/-
+  value:
+    name: vault_ca
+    type: certificate
+    options:
+      is_ca: true
+      common_name: vaultCA
+
+- type: replace
+  path: /variables/-
+  value:
+    name: vault_tls
+    type: certificate
+    options:
+      ca: vault_ca
+      common_name: vault
+      extended_key_usage:
+        - client_auth
+        - server_auth
+      alternative_names:
+        - 127.0.0.1
+        - localhost
+        - "*.vault.service.cf.internal"
+        - vault.service.cf.internal
+
+- type: replace
+  path: /instance_groups/-
+  value:
+    name: vault
+    instances: 1
+    azs: [z1, z2, z3]
+    networks: [{name: cf}]
+
+    persistent_disk_type: 10GB
+
+    jobs:
+      - name: vault
+        release: vault
+        properties:
+          vault:
+            config: |
+              storage "file" {
+                path = "/var/vcap/store/vault/data"
+                }
+                ui = true
+                listener "tcp" {
+                  address = "0.0.0.0:8200"
+                  tls_cert_file = "/var/vcap/jobs/vault/tls/vault/cert.pem"
+                  tls_key_file  = "/var/vcap/jobs/vault/tls/vault/key.pem"
+                  tls_min_version = "tls12"
+                  }
+            tls:
+              - name: vault
+                key: ((vault_tls.private_key))
+                cert: |
+                  ((vault_tls.certificate))
+                  ((vault_tls.ca))
+
+      - name: route_registrar
+        release: routing
+        properties:
+          route_registrar:
+            routes:
+              - name: vault
+                tls_port: 8200
+                prepend_instance_index: false
+                registration_interval: 10s
+                uris:
+                  - vault.((system_domain))
+                server_cert_domain_san: vault.service.cf.internal

--- a/manifests/cf-manifest/operations.d/200-vault.yml
+++ b/manifests/cf-manifest/operations.d/200-vault.yml
@@ -44,6 +44,9 @@
 
     persistent_disk_type: 10GB
 
+    vm_extensions:
+      - vault_instance_profile
+
     jobs:
       - name: vault
         release: vault
@@ -51,14 +54,31 @@
           vault:
             config: |
               storage "file" {
-                path = "/var/vcap/store/vault/data"
-                }
-                ui = true
-                listener "tcp" {
-                  address = "0.0.0.0:8200"
-                  tls_cert_file = "/var/vcap/jobs/vault/tls/vault/cert.pem"
-                  tls_key_file  = "/var/vcap/jobs/vault/tls/vault/key.pem"
-                  tls_min_version = "tls12"
+                  path = "/var/vcap/store/vault/data"
+              }
+
+              ui = true
+
+              listener "tcp" {
+                address = "0.0.0.0:8200"
+                tls_cert_file = "/var/vcap/jobs/vault/tls/vault/cert.pem"
+                tls_key_file  = "/var/vcap/jobs/vault/tls/vault/key.pem"
+                tls_min_version = "tls12"
+              }
+
+            additional_config:
+              - name: kms.json
+                config: |
+                  {
+                    "seal": [
+                      {
+                        "awskms": [
+                          {
+                            "kms_key_id": "b1380431-d93c-4428-85b7-3589deb42e70"
+                          }
+                        ]
+                      }
+                    ]
                   }
             tls:
               - name: vault

--- a/manifests/cf-manifest/operations.d/200-vault.yml
+++ b/manifests/cf-manifest/operations.d/200-vault.yml
@@ -161,7 +161,51 @@
                   exit 1
                 fi
 
-                $vault write $vault_ca_path_arg auth/userpass/users/admin "password=((vault_admin_password))" policies=admins
+                $vault policy write $vault_ca_path_arg admin <(cat <<POLICY
+              # yes this indentation is correct
+              path "auth/*" {
+                capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+              }
+
+              path "sys/auth/*" {
+                capabilities = ["create", "update", "delete", "sudo"]
+              }
+
+              path "sys/auth" {
+                capabilities = ["read"]
+              }
+
+              path "sys/policies/acl/*" {
+                capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+              }
+
+              path "sys/policies/acl" {
+                capabilities = ["list"]
+              }
+
+              path "secret/*" {
+                capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+              }
+
+              path "sys/mounts/*" {
+                capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+              }
+
+              path "sys/health" {
+                capabilities = ["read", "sudo"]
+              }
+
+              path "sys/capabilities" {
+                capabilities = ["create", "update"]
+              }
+
+              path "sys/capabilities-self" {
+                capabilities = ["create", "update"]
+              }
+              POLICY
+                )
+
+                $vault write $vault_ca_path_arg auth/userpass/users/admin "password=((vault_admin_password))" policies=admin
                 if [ $? != 0 ]; then
                   echo "Attempted to add admin user but did not succeed"
                   exit 1

--- a/manifests/cf-manifest/operations.d/200-vault.yml
+++ b/manifests/cf-manifest/operations.d/200-vault.yml
@@ -44,6 +44,8 @@
 
     persistent_disk_type: 10GB
 
+    stemcell: default
+    vm_type: small
     vm_extensions:
       - vault_instance_profile
 

--- a/manifests/cf-manifest/operations.d/310-router.yml
+++ b/manifests/cf-manifest/operations.d/310-router.yml
@@ -53,3 +53,12 @@
 - type: replace
   path: /instance_groups/name=router/vm_extensions?/-
   value: cf_router_target_groups
+
+- type: replace
+  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/ca_certs
+  value: |
+    ((diego_instance_identity_ca.ca))
+    ((cc_tls.ca))
+    ((uaa_ssl.ca))
+    ((network_policy_server_external.ca))
+    ((vault_tls.ca))

--- a/manifests/cf-manifest/operations.d/800-set-vcap-password.yml
+++ b/manifests/cf-manifest/operations.d/800-set-vcap-password.yml
@@ -47,3 +47,6 @@
 - type: replace
   path: /instance_groups/name=prometheus/env?/bosh/password
   value: ((vcap_password))
+- type: replace
+  path: /instance_groups/name=vault/env?/bosh/password
+  value: ((vcap_password))

--- a/manifests/cloud-config/paas-cf-cloud-config.yml
+++ b/manifests/cloud-config/paas-cf-cloud-config.yml
@@ -223,6 +223,10 @@ vm_extensions:
   cloud_properties:
     iam_instance_profile: cf-cloudcontroller
 
+- name: vault_instance_profile
+  cloud_properties:
+    iam_instance_profile: tlwr-vault
+
 - name: cf_rds_client_sg
   cloud_properties:
     security_groups:

--- a/platform-tests/broker-acceptance/common_service_test.go
+++ b/platform-tests/broker-acceptance/common_service_test.go
@@ -16,13 +16,14 @@ var _ = Describe("Common service tests", func() {
 	Context("Shareable services", func() {
 
 		shareableServices := map[string]bool{
-			"elasticsearch": true,
-			"influxdb":      true,
-			"mysql":         true,
-			"postgres":      true,
-			"redis":         true,
-			"aws-s3-bucket": true,
-			"cdn-route":     false,
+			"elasticsearch":   true,
+			"influxdb":        true,
+			"mysql":           true,
+			"postgres":        true,
+			"redis":           true,
+			"aws-s3-bucket":   true,
+			"cdn-route":       false,
+			"hashicorp-vault": false,
 		}
 
 		It("is service shareable", func() {


### PR DESCRIPTION
What
----

This PR is a reference for [Story](https://www.pivotaltracker.com/story/show/174320941)

Other developers can cherry pick these commits to their development branches, and get Vault in their CF deployment, and a Vault service broker

Hacks
----

I have snowflaked `PassCFCloudcontrollerRole` to include the policy `"arn:aws:iam:::role/tlwr-vault"` which allows management of a KMS key, this should work for you out of the box, but may not if your development environment is in Ireland (mine is in London).

Info
----

The `vault_admin_password` is in the `/concourse/main/` credhub namespace

Vault is deployed to `vault.((system_domain))`

The Vault service broker is deployed and enabled automatically