### PR TITLE
prometheus: alert when bosh director disk filling

### DIFF
--- a/manifests/prometheus/alerts.d/bosh-director-disk.yml
+++ b/manifests/prometheus/alerts.d/bosh-director-disk.yml
@@ -1,0 +1,15 @@
+---
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: BoshDirectorPersistentDiskFilling
+    rules:
+      - alert: BoshDirectorPersistentDiskFilling_Critical
+        expr: 'predict_linear(node_filesystem_avail_bytes{instance="10.0.0.6:9100", mountpoint="/var/vcap/store"}[1h], 3 * 24 * 60 * 60) < 0'
+        for: 1h
+        labels:
+          severity: critical
+        annotations:
+          summary: "BOSH director's persistent disk will fill within the next 3 days"
+          description: "In 3 days time the BOSH director's persistent disk will have {{ $value | printf \"%.0f\" }} bytes available"

--- a/manifests/prometheus/spec/bosh-director-disk.test.yml
+++ b/manifests/prometheus/spec/bosh-director-disk.test.yml
@@ -1,0 +1,28 @@
+---
+rule_files:
+  # See alerts_validation_spec.rb for details of how stdin gets set:
+  - spec/alerts/fixtures/rules.yml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 30m
+    input_series:
+      - series: 'node_filesystem_avail_bytes{instance="10.0.0.6:9100", mountpoint="/var/vcap/store"}'
+        values: 2048 1024 512 256 128 64 32 16 8 4 2 1
+
+    alert_rule_test:
+      # Does not fire without enough data
+      - eval_time: 0m
+        alertname: BoshDirectorPersistentDiskFilling_Critical
+      - eval_time: 55m
+        alertname: BoshDirectorPersistentDiskFilling_Critical
+      # Does not fire until consistently not scaling
+      - eval_time: 90m
+        alertname: BoshDirectorPersistentDiskFilling_Critical
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+            exp_annotations:
+              summary: "BOSH director's persistent disk will fill within the next 3 days"
+              description: "In 3 days time the BOSH director's persistent disk will have 0 bytes available"


### PR DESCRIPTION
What
----

We saw our bosh director disk fill up, we should have an alert that predicts when it will fill

How to review
-------------

Code review

[Check the curve](https://grafana-1.tlwr.dev.cloudpipeline.digital/explore?left=%5B%22now-6h%22,%22now%22,%22prometheus%22,%7B%22expr%22:%22predict_linear(node_filesystem_avail_bytes%7Binstance%3D%5C%2210.0.0.6:9100%5C%22,%20mountpoint%3D%5C%22%2Fvar%2Fvcap%2Fstore%5C%22%7D%5B1h%5D,%203%20*%2024%20*%2060%20*%2060)%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D)

Who can review
--------------

Not @tlwr