### PR TITLE
Fix tfstate file parsing for self-update-pipelines

### DIFF
--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -21,9 +21,20 @@ get_git_concourse_pool_clone_full_url_ssh() {
 
   aws s3 cp "s3://${state_bucket}/concourse.tfstate" "${tfstate_file}"
 
-  git_concourse_pool_clone_full_url_ssh=$(ruby < "${tfstate_file}" -rjson -e \
-    'puts JSON.load(STDIN)["modules"][0]["outputs"]["git_concourse_pool_clone_full_url_ssh"]["value"]'
+  terraform_state_version=$(ruby < "${tfstate_file}" -rjson -e \
+    'puts JSON.load(STDIN)["version"]'
   )
+
+  if [ "${terraform_state_version}" == "4" ]
+  then
+    git_concourse_pool_clone_full_url_ssh=$(ruby < "${tfstate_file}" -rjson -e \
+      'puts JSON.load(STDIN)["outputs"]["git_concourse_pool_clone_full_url_ssh"]["value"]'
+    )
+  else
+    git_concourse_pool_clone_full_url_ssh=$(ruby < "${tfstate_file}" -rjson -e \
+      'puts JSON.load(STDIN)["modules"][0]["outputs"]["git_concourse_pool_clone_full_url_ssh"]["value"]'
+    )
+  fi
 
   rm -f "${tfstate_file}"
 }


### PR DESCRIPTION
What
----

Support both terraform state files version 3 and 4 in the `self-update-pipelines` task in `pipeline-lock`.
The data structure of terraform state files has changed with version 4 / terraform 0.12. This occurrence was overlooked in the 0.12 upgrade.

How to review
-------------

Code review
Check branch in dev ([works in `schmie`](https://deployer.schmie.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/pipeline-lock/builds/14))

Who can review
--------------

Not @schmie 
