### PR TITLE
App autoscaler pipeline

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -868,7 +868,6 @@ jobs:
                     external_uaa_database_password
                     external_silk_controller_database_password
                     external_policy_server_database_password
-                    external_credhub_database_password
                   )
 
                   app_autoscaler_credentials=(

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -878,6 +878,7 @@ jobs:
                     secrets_cf_db_master_password
                     secrets_cdn_db_master_password
                     "${bosh_credentials[@]}"
+                    "${app_autoscaler_credentials[@]}"
                   )
 
                   for secret_name in ${concourse_credentials[*]}; do


### PR DESCRIPTION
What
----

During a rebase, `external_credhub_database_password` was [added to our secrets generation script erroneously](https://github.com/alphagov/paas-cf/commit/2c4bf4f15ee450eebe01e3944e84263b4b958ec4)

Additionally we need to add `external_app_autoscaler_database_password` to concourse secrets generation

How to review
-------------

Code review

Who can review
--------------

@LeePorte 