### PR TITLE
[#173469867] RDS Binding with read only user

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -55,6 +55,7 @@
       rds-broker:
         allow_user_provision_parameters: true
         allow_user_update_parameters: true
+        allow_user_bind_parameters: true
         aws_region: "((terraform_outputs_region))"
         password: ((secrets_rds_broker_admin_password))
         state_encryption_key: ((secrets_rds_broker_state_encryption_key))

--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 0.1.68
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.68.tgz
-    sha1: 7aea07aee96c412817fcf8600045c593dbd6e2a4
+    version: 0.0.1598004412
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.0.1598004412.tgz
+    sha1: 1052baa4bcdb3110a868dcf65d9c53c564714fe9
 
 - type: replace
   path: /instance_groups/-


### PR DESCRIPTION
What
----

Deploy a version of RDS Broker that supports read-only users when binding to Postgres DB.

How to review
-------------

1. Before deploying this branch make sure that the internal administration applications with their respective databases (e.g.: accounts, billing, auditor) are deployed successfully from master branch.
2. Deploy this branch
3. Run the manual tests outlined in alphagov/paas-rds-broker/pull/117

Who can review
--------------
Non @barsutka 