### PR TITLE
cf: bump capi to 1.97

### DIFF
--- a/manifests/cf-manifest/operations.d/320-cc-release.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-release.yml
@@ -3,6 +3,6 @@
   path: /releases/name=capi
   value:
     name: "capi"
-    version: "1.96.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.96.0"
-    sha1: "879b50c2ba103826dd32c7e65d9eefc7797f67e7"
+    version: "1.97.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.97.0"
+    sha1: "876530fb5546f9d166ecaca55e5475f0ec5888d3"


### PR DESCRIPTION
What
----

[Ticket](https://govuk.zendesk.com/agent/tickets/4193788)
[Addresses](https://www.cloudfoundry.org/blog/cve-2020-5417/)

How to review
-------------

Code review

[Version](https://api.tlwr.dev.cloudpipeline.digital/)

[Release notes](https://github.com/cloudfoundry/capi-release/releases/tag/1.97.0)

Who can review
--------------

Not @tlwr