### PR TITLE
Correct initial terraform state file

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -492,7 +492,7 @@ resources:
             "terraform_version": "0.12.29",
             "serial": 0,
             "outputs": {},
-            "resources": {}
+            "resources": []
         }
 
   - name: cyber-tfstate
@@ -508,7 +508,7 @@ resources:
             "terraform_version": "0.12.29",
             "serial": 0,
             "outputs": {},
-            "resources": {}
+            "resources": []
         }
 
   - name: cf-manifest


### PR DESCRIPTION
What
----

If "resources" in a version 4 tfstate file is of type object instead of list, it causes

```
Error: Error loading state: Invalid state file format:
The state file field "resources" has invalid value object
```

when running create-cloudfoundry/cf-terraform/terraform-apply. This only is an issue in a new environment.

How to review
-------------

Code review
Optionally completely destroy dev env (including destroy-bosh-concourse) and re-create.

Who can review
--------------

Not @schmie 
