### PR TITLE
Use upload-runtime-config in cf-deploy

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1724,8 +1724,7 @@ jobs:
                   BOSH_CLIENT='admin'
                   export BOSH_CLIENT
 
-                  bosh -n update-config \
-                    --type=runtime \
+                  bosh -n update-runtime-config \
                     --name=paas-cf \
                     paas-cf-runtime-config/paas-cf-runtime-config.yml
 


### PR DESCRIPTION
What
----

Use upload-runtime-config instead of upload-config in cf-deploy.
The latter does not upload releases configured in the runtime config
(See [discussion on this GitHub issue](https://github.com/cloudfoundry/bosh/issues/2209)).

How to review
-------------

- Code review
- To test in dev (requires destroyed cloudfoundry) - or [see it working in my dev env](https://deployer.schmie.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/cf-deploy/builds/6)
  - `BOSH (your_dev) $ bosh delete-release syslog`
  - Run create-cloudfoundry and see the release uploaded in `update-paas-cf-runtime-config` / `cf-deploy` not failing with `Error: Release 'syslog' doesn't exist`

Who can review
--------------

Not @schmie