### PR TITLE
Fix the stemcells not in sync alert

### DIFF
--- a/manifests/prometheus/alerts.d/bosh-stemcells-not-in-sync.yml
+++ b/manifests/prometheus/alerts.d/bosh-stemcells-not-in-sync.yml
@@ -7,7 +7,7 @@
     name: BoshStemcellsNotInSync
     rules:
       - alert: BoshStemcellsNotInSync
-        expr: "sum by (bosh_stemcell_version) (bosh_deployment_stemcell_info) != 3"
+        expr: "count (count by (bosh_stemcell_version) (bosh_deployment_stemcell_info)) != 1"
         for: 12h
         labels:
           severity: warning


### PR DESCRIPTION
What
----

We have an alert that warns us if we are running multiple Stemcells (OS base images.) This alert was hardcoded to expect 3 BOSH Deployments.

We recently deployed the CF Autoscaler using BOSH. It is a separate BOSH deployment, our fourth. When that was deployed the "multiple stemcell" alert went off.

This commit edits that alert so that it directly counts the number of stemcells in use, rather than being hacky. Credit to @tlwr.

How to review
-------------

Code review :)

Who can review
--------------

Not @46bit.
