### PR TITLE
block-routes: disabling create account route

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2910,32 +2910,25 @@ jobs:
                 cd paas-cf/platform-tests/example-apps/create-account-holding-page/
                 cf push
 
-                if ! cf domains | grep -q "login.((system_dns_zone_name))"; then
-                  cf create-domain admin "login.((system_dns_zone_name))"
-                fi
-                if ! cf domains | grep -q "uaa.((system_dns_zone_name))"; then
-                  cf create-domain admin "uaa.((system_dns_zone_name))"
-                fi
-
                 cf target -s assets
 
-                if ! cf routes | grep -qE "\\s+login.((system_dns_zone_name))\\s+/create_account(\\s+|$)"; then
-                  cf create-route "login.((system_dns_zone_name))" --path create_account
+                if ! cf routes | grep -qE "\\s+login\\s+((system_dns_zone_name))\\s+/create_account(\\s+|$)"; then
+                  cf create-route "((system_dns_zone_name))" --hostname "login" --path create_account
                 fi
-                if ! cf routes | grep -qE "\\s+login.((system_dns_zone_name))\\s+/create_account\\.do(\\s+|$)"; then
-                  cf create-route "login.((system_dns_zone_name))" --path create_account.do
+                if ! cf routes | grep -qE "\\s+login\\s+((system_dns_zone_name))\\s+/create_account\\.do(\\s+|$)"; then
+                  cf create-route "((system_dns_zone_name))" --hostname "login" --path create_account.do
                 fi
-                if ! cf routes | grep -qE "\\s+uaa.((system_dns_zone_name))\\s+/create_account(\\s+|$)"; then
-                  cf create-route "uaa.((system_dns_zone_name))" --path create_account
+                if ! cf routes | grep -qE "\\s+uaa\\s+((system_dns_zone_name))\\s+/create_account(\\s+|$)"; then
+                  cf create-route "((system_dns_zone_name))" --hostname "uaa" --path create_account
                 fi
-                if ! cf routes | grep -qE "\\s+uaa.((system_dns_zone_name))\\s+/create_account\\.do(\\s+|$)"; then
-                  cf create-route "uaa.((system_dns_zone_name))" --path create_account.do;
+                if ! cf routes | grep -qE "\\s+uaa\\s+((system_dns_zone_name))\\s+/create_account\\.do(\\s+|$)"; then
+                  cf create-route "((system_dns_zone_name))" --hostname "uaa" --path create_account.do;
                 fi
 
-                cf map-route create-account-holding-page "login.((system_dns_zone_name))" --path create_account
-                cf map-route create-account-holding-page "login.((system_dns_zone_name))" --path create_account.do
-                cf map-route create-account-holding-page "uaa.((system_dns_zone_name))" --path create_account
-                cf map-route create-account-holding-page "uaa.((system_dns_zone_name))" --path create_account.do
+                cf map-route create-account-holding-page "((system_dns_zone_name))" --hostname "login" --path create_account
+                cf map-route create-account-holding-page "((system_dns_zone_name))" --hostname "login" --path create_account.do
+                cf map-route create-account-holding-page "((system_dns_zone_name))" --hostname "uaa" --path create_account
+                cf map-route create-account-holding-page "((system_dns_zone_name))" --hostname "uaa" --path create_account.do
 
       - task: deploy-simulated-load-application
         tags: [colocated-with-web]


### PR DESCRIPTION

What
----

changes how the "create account" routes are being blocked, by reserving
routes directly on the system domain instead of by creating a new
domain.

a [recent change][1] has prevented the creation of a domain that overlaps
with the system domain, which has broken how the create account routes
were being masked and is preventing the creation of a new env

[1]: https://github.com/cloudfoundry/cloud_controller_ng/commit/666bcd57ee8abf200b22863bc5f91ef3dcd202d4

How to review
-------------

After applying it should not be possible to visit:

* https://login.$DEPLOY_ENV.dev.cloudpipeline.digital/create_account
* https://login.$DEPLOY_ENV.dev.cloudpipeline.digital/create_account.do
* https://uaa.$DEPLOY_ENV.dev.cloudpipeline.digital/create_account
* https://uaa.$DEPLOY_ENV.dev.cloudpipeline.digital/create_account.do

Consider:

* Is anything lost by not reserving the route as a domain?
* What will the impact of this change be to an existing long-lived environment that has already managed to create the overlapping domain? We may need to delete the existing domains/routes for this to apply cleanly?

Who can review
--------------

Not @chrisfarms 
