### PR TITLE
Autoscaler tweaks

### DIFF
--- a/manifests/app-autoscaler/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/app-autoscaler/operations.d/020-bosh-set-stemcells.yml
@@ -1,0 +1,1 @@
+../../cf-manifest/operations.d/020-bosh-set-stemcells.yml

--- a/manifests/prometheus/alerts.d/app-autoscaler-is-not-scaling.yml
+++ b/manifests/prometheus/alerts.d/app-autoscaler-is-not-scaling.yml
@@ -6,8 +6,8 @@
     name: AppAutoscalingIsNotScaling
     rules:
       - alert: AppAutoscalingIsNotScaling
-        expr: changes(cf_application_instances{organization_name="admin", space_name="healthchecks", application_name="app-autoscaler-cpu-usage"}[30m]) < 1
-        for: 20m
+        expr: changes(cf_application_instances{organization_name="admin", space_name="healthchecks", application_name="app-autoscaler-cpu-usage"}[1h]) < 1
+        for: 30m
         labels:
           severity: critical
         annotations:

--- a/manifests/prometheus/spec/alerts/app-autoscaler-cpu.test.yml
+++ b/manifests/prometheus/spec/alerts/app-autoscaler-cpu.test.yml
@@ -9,14 +9,14 @@ tests:
   - interval: 20m
     input_series:
       - series: 'cf_application_instances{organization_name="admin", space_name="healthchecks", application_name="app-autoscaler-cpu-usage"}'
-        values: 1 1 2 3 4 5
+        values: 1 1 1 1 1 2 3 4 5
 
     alert_rule_test:
       # Does not fire without enough data
       - eval_time: 0m
         alertname: AppAutoscalingIsNotScaling
       # Does not fire until consistently not scaling
-      - eval_time: 30m
+      - eval_time: 90m
         alertname: AppAutoscalingIsNotScaling
         exp_alerts:
           - exp_labels:
@@ -28,5 +28,5 @@ tests:
               summary: "App autoscaler is not scaling our healthcheck app"
               description: "The app autoscaler cpu scaling healthcheck app has scaled 0 times over the last 30 minutes, it should have autoscaled more"
       # Does not fire after scaling
-      - eval_time: 60m
+      - eval_time: 120m
         alertname: AppAutoscalingIsNotScaling

--- a/platform-tests/example-apps/app-autoscaler-cpu-usage/manifest.yml
+++ b/platform-tests/example-apps/app-autoscaler-cpu-usage/manifest.yml
@@ -18,4 +18,4 @@ applications:
       GOVERSION: go1.13
       GOPACKAGENAME: github.com/alphagov/paas-cf/platform-tests/example-apps/app-autoscaler-cpu-usage
 
-      DURATION: 5m
+      DURATION: 11m


### PR DESCRIPTION
What
----

Make explicit the stemcells used by the autoscaler instances, in the same way as the `prometheus` deployment

Relax the autoscaler alert canary from 30m to 1h to avoid instances where:
- the cf_exporter is scraped every 4 mins
- the app autoscales up and down within that time period
- the metric for number of instances does not change
(a proper fix is to scrape the autoscaler directly)

How to review
-------------

Check that [these changes will not make the alert more noisy](https://grafana-1.london.cloud.service.gov.uk/explore?left=%5B%22now-6h%22,%22now%22,%22prometheus%22,%7B%22expr%22:%22avg%20(cf_application_instances%7Bapplication_name%3D%5C%22app-autoscaler-cpu-usage%5C%22%7D)%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D)

CI

Who can review
--------------

Not @tlwr
