### PR TITLE
Autoscaler plans

### DIFF
--- a/manifests/app-autoscaler/operations.d/300-set-plans.yml
+++ b/manifests/app-autoscaler/operations.d/300-set-plans.yml
@@ -1,0 +1,9 @@
+---
+
+- type: replace
+  path: /instance_groups/name=asapi/jobs/name=golangapiserver/properties/autoscaler/apiserver/broker/server/catalog/services/name=autoscaler/id
+  value: 656a9276-a1f6-4646-aade-08f0a51b29ed
+
+- type: replace
+  path: /instance_groups/name=asapi/jobs/name=golangapiserver/properties/autoscaler/apiserver/broker/server/catalog/services/name=autoscaler/plans/name=autoscaler-free-plan/id
+  value: 64d9552f-eede-439a-b49d-1efe17fccb1b

--- a/manifests/app-autoscaler/spec/autoscaler_spec.rb
+++ b/manifests/app-autoscaler/spec/autoscaler_spec.rb
@@ -16,8 +16,6 @@ RSpec.describe "autoscaler" do
       let(:scalingengine) { jobs.find { |j| j["name"] == "scalingengine" } }
 
       it "sets the client id and secret" do
-        puts scalingengine.dig("properties", "autoscaler", "cf")
-
         cf = scalingengine.dig("properties", "autoscaler", "cf")
 
         expect(cf["client_id"]).to eq("app_autoscaler")

--- a/manifests/app-autoscaler/spec/autoscaler_spec.rb
+++ b/manifests/app-autoscaler/spec/autoscaler_spec.rb
@@ -1,6 +1,8 @@
 require "ipaddr"
 
 RSpec.describe "autoscaler" do
+  let(:uuid_regexp) { /^\h{8}-\h{4}-\h{4}-\h{4}-\h{12}$/i }
+
   let(:manifest) { manifest_with_defaults }
 
   describe "actors" do
@@ -50,6 +52,33 @@ RSpec.describe "autoscaler" do
 
         expect(cf["client_id"]).to eq("app_autoscaler")
         expect(cf["secret"]).to eq("((/test/test/uaa_clients_app_autoscaler_secret))")
+      end
+
+      describe "catalog" do
+        let(:catalog) do
+          apiserver.dig(
+            "properties", "autoscaler", "apiserver",
+            "broker", "server", "catalog"
+          )
+        end
+
+        let(:services) { catalog["services"] }
+
+        it "has a real guid for each service" do
+          services.each do |service|
+            expect(service["id"]).to match(uuid_regexp),
+              "#{service['name']} should have a guid id instead of #{service['id']}"
+          end
+        end
+
+        it "has a real guid for each plan" do
+          services.each do |service|
+            service["plans"].each do |plan|
+              expect(plan["id"]).to match(uuid_regexp),
+                "#{plan['name']} should have a guid id instead of #{plan['id']}"
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
What
----

Autoscaler plans should be guids

@46bit found that the default guids in the app autoscaler catalog are not guids, and this is causing paas-billing to have a sad time:

```
"error":"/home/vcap/app/eventstore/sql/create_events.sql: invalid input syntax for uuid: \"autoscaler-free-plan-id\""
```

This PR:

- tests that the app-autoscaler catalog uses UUIDs
- makes the app-autoscaler catalog use UUIDs

How to review
-------------

Code review

Who can review
--------------

Not @tlwr
