### PR TITLE
Add peered VPC for GOV.UK Pay staging environment to PaaS Ireland

### DIFF
--- a/terraform/prod.vpc_peering.json
+++ b/terraform/prod.vpc_peering.json
@@ -64,5 +64,11 @@
         "account_id": "430354129336",
         "vpc_id": "vpc-9e62bcf8",
         "subnet_cidr": "10.200.0.0/16"
+    },
+    {
+        "peer_name": "govuk-pay-staging",
+        "account_id": "234617505259",
+        "vpc_id": "vpc-08b7d799f1691fd11",
+        "subnet_cidr": "172.16.36.0/22"
     }
 ]


### PR DESCRIPTION
What
----
This change adds GOV.UK Pay's staging account to the list of peered VPCs in the PaaS Ireland region. A subnet CIDR of `172.16.36.0/22` has been selected following the guidance in the PaaS team manual.

This will be used to test connectivity between PaaS applications and  RDS instances managed by GOV.UK Pay in a separate account.

Who can review
--------------

Anyone on the PaaS team responsible for infrastructure.
