### PR TITLE
Better alerts for billing that don't misrepresent how well we recharge

### DIFF
--- a/manifests/prometheus/alerts.d/paas-billing-costs.yml
+++ b/manifests/prometheus/alerts.d/paas-billing-costs.yml
@@ -27,7 +27,7 @@
           layer: billing
         annotations:
           summary: "PaaS Billing DB costs exceed AWS RDS costs"
-          description: "PaaS Billing DB costs exceed AWS RDS costs. The difference is currently: £{{ $value | printf \"%.2f\" }}, which indicates there may be an issue with paas-billing's costs"
+          description: "PaaS Billing DB costs exceed AWS RDS costs. There may be an issue with paas-billing or our recharging."
 
 - type: replace
   path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
@@ -35,13 +35,13 @@
     name: PaaSBillingDBCostsFallsShortOfRDSCosts
     rules:
       - alert: PaaSBillingDBCostsFallsShortOfRDSCosts
-        expr: sum(increase(paas_billing_total_costs_pounds{name=~"mysql.+|postgres.+"}[24h])) / sum(paas_aws_cost_explorer_by_service_dollars{service="Amazon Relational Database Service"}) < .6
+        expr: sum(increase(paas_billing_total_costs_pounds{name=~"mysql.+|postgres.+"}[24h])) / sum(paas_aws_cost_explorer_by_service_dollars{service="Amazon Relational Database Service"}) < 0.5
         labels:
           severity: warning
           layer: billing
         annotations:
-          summary: "PaaS Billing DB costs fall short of AWS RDS costs by > 40%"
-          description: "PaaS Billing DB costs fall short of AWS RDS costs by > 40%. The difference is currently: £{{ $value | printf \"%.2f\" }}, which indicates there may be an issue with paas-billing's costs"
+          summary: "PaaS Billing DB costs fall short of AWS RDS costs by > 50%"
+          description: "PaaS Billing DB costs fall short of AWS RDS costs by > 50%. There may be an issue with paas-billing or our recharging."
 
 - type: replace
   path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
@@ -55,7 +55,7 @@
           layer: billing
         annotations:
           summary: "PaaS Billing App costs exceed AWS EC2 costs by > 40%"
-          description: "PaaS Billing App costs exceed AWS EC2 costs by > 40%. The difference is currently: £{{ $value | printf \"%.2f\" }}, which indicates there may be an issue with paas-billing's costs"
+          description: "PaaS Billing App costs exceed AWS EC2 costs by > 40%. There may be an issue with paas-billing or our recharging."
 
 - type: replace
   path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
@@ -69,4 +69,4 @@
           layer: billing
         annotations:
           summary: "PaaS Billing App costs fall short of AWS EC2 costs by > 40%"
-          description: "PaaS Billing App costs fall short of AWS EC2 costs by > 40%. The difference is currently: £{{ $value | printf \"%.2f\" }}, which indicates there may be an issue with paas-billing's costs"
+          description: "PaaS Billing App costs fall short of AWS EC2 costs by > 40%. There may be an issue with paas-billing or our recharging."

--- a/manifests/prometheus/alerts.d/paas-billing-costs.yml
+++ b/manifests/prometheus/alerts.d/paas-billing-costs.yml
@@ -4,6 +4,20 @@
 - type: replace
   path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
   value:
+    name: PaaSBillingIsNotIncreasing
+    rules:
+      - alert: PaaSBillingCostsAreNotIncreasing
+        expr: sum(increase(paas_billing_total_costs_pounds[24h])) < 1
+        labels:
+          severity: critical
+          layer: billing
+        annotations:
+          summary: "PaaS Billing charges are not increasing"
+          description: "The total cost to all tenants from PaaS Billing has increased by less than £1 in 24 hours. There may be an issue with paas-billing."
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
     name: PaaSBillingDBCostsExceedRDSCosts
     rules:
       - alert: PaaSBillingDBCostsExceedRDSCosts


### PR DESCRIPTION
What
----

This improves our alerts for problems with billing and recharging:

1. Adds a `PaaSBillingIsNotIncreasing` alert that will warn us if `paas-billing`'s totals have stopped increasing. This would have alerted us to #2428 much earlier
2. Fixes the alert message of the existing AWS recharge alerts. They have been converting a percentage to currency and misrepresenting a 50% recharge rate as us recharging all but 50p. 🤦🏻‍♀️
3. Reduces the expected RDS recharge rate to 50%, as this is in line with what I see in Grafana.

It may be that (3) needs further investigating and there are more costs to recoup, but right now all that is happening is the RDS recharge alert is going off constantly and isn't actionable.

How to review
-------------

See what you think 🤷 

Who can review
--------------

Not @46bit 