### PR TITLE
Ignore CATS GUIDs in tests

### DIFF
--- a/platform-tests/broker-acceptance/common_service_test.go
+++ b/platform-tests/broker-acceptance/common_service_test.go
@@ -116,7 +116,7 @@ var _ = Describe("Common service tests", func() {
 					continue
 				}
 
-				if strings.HasPrefix(plan.Name, "fake-") {
+				if strings.HasPrefix(plan.Name, "fake-") || strings.HasPrefix(plan.UniqueId, "CATS-") {
 					continue
 				}
 


### PR DESCRIPTION
What
----

In 52b98b9 we've added a test to find any non-unique IDs to prevent some
issues in billing.

This test, is also validating weather the GUID is an actual GUID. This
sadly is not true, for any of our stubs and tests that create a GUID in
a form of: `CATS-2-SVC-PLAN-c73c869d65f9762e`.

To prevent the pipeline from erroring out, we can skip the GUID if it
starts with `CATS-`.

How to review
-------------

- Sanity check (https://play.golang.com/p/S2DHlFBdZpr)