### PR TITLE
bosh: blackbox exporter is a runtime config addon

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1543,6 +1543,7 @@ jobs:
             params:
               AWS_ACCOUNT: ((aws_account))
               DEPLOY_ENV: ((deploy_env))
+              SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
             run:
               path: sh
               args:

--- a/manifests/cf-manifest/operations.d/500-prometheus.yml
+++ b/manifests/cf-manifest/operations.d/500-prometheus.yml
@@ -1,6 +1,14 @@
 - type: replace
   path: /releases/-
   value:
+    name: "prometheus"
+    version: "26.2.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=26.2.0"
+    sha1: "9a57a9c74ebcb53baaa9cf8eb22f8ef353460169"
+
+- type: replace
+  path: /releases/-
+  value:
     name: caddy
     version: "0.7.0"
     url: "https://bosh.io/d/github.com/dpb587/caddy-bosh-release?v=0.7.0"

--- a/manifests/runtime-config/operations.d/510-add-prometheus-blackbox-exporter.yml
+++ b/manifests/runtime-config/operations.d/510-add-prometheus-blackbox-exporter.yml
@@ -11,6 +11,10 @@
   path: /addons?/-
   value:
     name: prometheus-blackbox-exporter
+    exclude:
+      deployments:
+        - concourse  # from paas-bootstrap
+        - prometheus # has a separate version
     jobs:
       - name: blackbox_exporter
         release: prometheus

--- a/manifests/runtime-config/scripts/generate-runtime-config.sh
+++ b/manifests/runtime-config/scripts/generate-runtime-config.sh
@@ -14,5 +14,6 @@ done
 bosh interpolate \
   --vars-file="${PAAS_CF_DIR}/manifests/variables.yml" \
   --var bosh_director_name="${DEPLOY_ENV}" \
+  --var system_domain="${SYSTEM_DNS_ZONE_NAME}" \
   ${opsfile_args} \
   "${PAAS_CF_DIR}/manifests/runtime-config/paas-cf-runtime-config.yml"

--- a/manifests/runtime-config/spec/support/runtime_config_helpers.rb
+++ b/manifests/runtime-config/spec/support/runtime_config_helpers.rb
@@ -17,11 +17,17 @@ module RuntimeConfigHelpers
 
     old_aws_account = ENV["AWS_ACCOUNT"]
     old_deploy_env = ENV["DEPLOY_ENV"]
+    old_system_dns_zone_name = ENV["SYSTEM_DNS_ZONE_NAME"]
+
     ENV["AWS_ACCOUNT"] = account
     ENV["DEPLOY_ENV"] = account
+    ENV["SYSTEM_DNS_ZONE_NAME"] = "system.example.com"
+
     Cache.instance[sym] ||= render_runtime_config
+
     ENV["AWS_ACCOUNT"] = old_aws_account
     ENV["DEPLOY_ENV"] = old_deploy_env
+    ENV["SYSTEM_DNS_ZONE_NAME"] = old_system_dns_zone_name
 
     Cache.instance[sym]
   end


### PR DESCRIPTION
What
----

We use bosh dns in multiple deployments

We should canary dns in all those deployments

So we should deploy the blackbox exporter in all deployments using a runtime config addon

How to review
-------------

Code review

Check `count(ALERTS{alertstate="firing", alertname="PrometheusScrapeError"})` in your environment before and after the deployment

Who can review
--------------

Not @tlwr
