### PR TITLE
Use --fix when running bosh deploy

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1750,7 +1750,7 @@ jobs:
                 BOSH_CLIENT='admin'
                 export BOSH_CLIENT
 
-                bosh -n deploy cf-manifest/cf-manifest.yml
+                bosh -n deploy --fix cf-manifest/cf-manifest.yml
 
       - task: copy-cf-secrets-to-concourse-credhub-ns
         tags: [colocated-with-web]
@@ -1978,7 +1978,7 @@ jobs:
                 BOSH_CLIENT='admin'
                 export BOSH_CLIENT
 
-                bosh -n deploy prometheus-manifest/prometheus-manifest.yml
+                bosh -n deploy --fix prometheus-manifest/prometheus-manifest.yml
 
       - task: copy-prometheus-secrets-to-concourse-credhub-ns
         tags: [colocated-with-web]
@@ -2211,7 +2211,7 @@ jobs:
                 BOSH_CLIENT='admin'
                 export BOSH_CLIENT
 
-                bosh -n deploy app-autoscaler-manifest/app-autoscaler-manifest.yml
+                bosh -n deploy --fix app-autoscaler-manifest/app-autoscaler-manifest.yml
 
       - task: copy-app-autoscaler-secrets-to-concourse-credhub-ns
         tags: [colocated-with-web]

--- a/concourse/pipelines/test-certificate-rotation.yml
+++ b/concourse/pipelines/test-certificate-rotation.yml
@@ -346,7 +346,7 @@ jobs:
                 export BOSH_CLIENT
 
                 bosh -n manifest > manifest.yml
-                bosh -n deploy manifest.yml
+                bosh -n deploy --fix manifest.yml
 
   - name: rotate-1
     serial: true
@@ -512,7 +512,7 @@ jobs:
                 export BOSH_CLIENT
 
                 bosh -n manifest > manifest.yml
-                bosh -n deploy manifest.yml
+                bosh -n deploy --fix manifest.yml
 
   - name: done
     serial: true


### PR DESCRIPTION
What
----

We are using the BOSH resurrector to automatically restart/recreate VMs that need recreating. During deployment there is a lock in place which prevents this from occurring.

If a VM is not available during a deployment, then the deployment is stopped prematurely, with the following resolutions available:

1. An operator deletes the VM using the BOSH CLI
1. An operator deletes the VM using the AWS Console
1. An operator `fly hijack`s the Concourse job and reruns `bosh deploy` with `--fix`
1. An operator `make bosh-cli`s from `paas-bootstrap` and runs `bosh recreate` or `bosh cck`

There is no automatic resolution, and each approach has its own pros/cons, although some cons are not immediately obvious. For example running `bosh recreate --fix instance/guid` could rollback versions of software on other VMs indirectly (bit of a footcannon).

Using `--fix` during deployment means BOSH will automatically recreate the instance if the agent is unresponsive, obviating the need for potentially hazardous operator action.

How to review
-------------

Code review

- Read the [`bosh deploy` documentation](https://bosh.io/docs/cli-v2/#deploy)
- Read the [`bosh recreate` documentation](https://bosh.io/docs/cli-v2/#recreate)
- Read [a helpful article on the BOSH lifecycle](https://community.pivotal.io/s/article/understanding-bosh-start-stop-restart-and-recreate?language=en_US)

Who can review
--------------

Not @tlwr
