### PR TITLE
sqs: bump broker to v0.1.5

### DIFF
--- a/manifests/cf-manifest/operations.d/760-sqs-broker.yml
+++ b/manifests/cf-manifest/operations.d/760-sqs-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: sqs-broker
-    version: 0.1.4
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/sqs-broker-0.1.4.tgz
-    sha1: d329ec42b262af46eeb0acb3ea13d52ed2936974
+    version: 0.1.5
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/sqs-broker-0.1.5.tgz
+    sha1: 3ebe2200182b8d9b0df8bb06b09e61e286290d64
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-

--- a/platform-tests/example-apps/healthcheck/sqs.go
+++ b/platform-tests/example-apps/healthcheck/sqs.go
@@ -13,11 +13,11 @@ import (
 )
 
 type SQSCredentials struct {
-	AccessKeyID     string
-	SecretAccessKey string
-	QueueURL        string
-	DLQueueURL      string
-	Region          string
+	AWSAccessKeyID     string `json:"aws_access_key_id"`
+	AWSSecretAccessKey string `json:"aws_secret_access_key"`
+	PrimaryQueueURL    string `json:"primary_queue_url"`
+	SecondaryQueueURL  string `json:"secondary_queue_url"`
+	AWSRegion          string `json:"aws_region"`
 }
 
 func sqsHandler(w http.ResponseWriter, r *http.Request) {
@@ -41,14 +41,18 @@ func testSQSQueueAccess() error {
 	}
 
 	sess := session.Must(session.NewSession(&aws.Config{
-		Region:      aws.String(creds.Region),
-		Credentials: credentials.NewStaticCredentials(creds.AccessKeyID, creds.SecretAccessKey, ""),
+		Region: aws.String(creds.AWSRegion),
+		Credentials: credentials.NewStaticCredentials(
+			creds.AWSAccessKeyID,
+			creds.AWSSecretAccessKey,
+			"",
+		),
 	}))
 	sqsClient := sqs.New(sess)
 
 	queueURLS := []string{
-		creds.QueueURL,
-		creds.DLQueueURL,
+		creds.PrimaryQueueURL,
+		creds.SecondaryQueueURL,
 	}
 
 	for _, queueURL := range queueURLS {


### PR DESCRIPTION
## What

* Updates sqs-broker to v0.1.5 which includes changes to how binding credentials for queue access are stored/fetched to use secrets manager instead of cloudformation outputs.
* Updates binding credentials to be `snake_case` not `CamelCase` for consistancy with other brokers (required updating broker acceptance test in this PR to match)

See: https://github.com/alphagov/paas-sqs-broker/pull/7

:warning: this change requires a policy change for the broker's IAM role.

* [x] See: https://github.com/alphagov/paas-aws-account-wide-terraform/pull/229 :heavy_check_mark: DONE

## How to review

* I ~~am just running~~ have run this [through the `autom8` dev env now](https://deployer.autom8.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/custom-broker-acceptance-tests/builds/31)
* Ensure that the account-wide policy changes are merged and applied to all environments.
* You may wish to check the code changes in the [broker PR](https://github.com/alphagov/paas-sqs-broker/pull/7)

## Who can review

Not @chrisfarms 
