### PR TITLE
tests: sqs tests do not use deprecated flag

### DIFF
--- a/platform-tests/broker-acceptance/sqs_broker_test.go
+++ b/platform-tests/broker-acceptance/sqs_broker_test.go
@@ -66,7 +66,6 @@ var _ = Describe("SQS broker", func() {
 					"-b", testConfig.GetGoBuildpackName(),
 					"-p", "../example-apps/healthcheck",
 					"-f", "../example-apps/healthcheck/manifest.yml",
-					"-d", testConfig.GetAppsDomain(),
 				).Wait(testConfig.CfPushTimeoutDuration())).To(Exit(0))
 			})
 
@@ -118,7 +117,6 @@ var _ = Describe("SQS broker", func() {
 					"-b", testConfig.GetGoBuildpackName(),
 					"-p", "../example-apps/healthcheck",
 					"-f", "../example-apps/healthcheck/manifest.yml",
-					"-d", testConfig.GetAppsDomain(),
 				).Wait(testConfig.CfPushTimeoutDuration())).To(Exit(0))
 			})
 
@@ -129,7 +127,6 @@ var _ = Describe("SQS broker", func() {
 					"-b", testConfig.GetGoBuildpackName(),
 					"-p", "../example-apps/healthcheck",
 					"-f", "../example-apps/healthcheck/manifest.yml",
-					"-d", testConfig.GetAppsDomain(),
 				).Wait(testConfig.CfPushTimeoutDuration())).To(Exit(0))
 			})
 

--- a/platform-tests/broker-acceptance/sqs_broker_test.go
+++ b/platform-tests/broker-acceptance/sqs_broker_test.go
@@ -27,7 +27,7 @@ var _ = Describe("SQS broker", func() {
 	})
 
 	It("has the expected plans available", func() {
-		plans := cf.Cf("marketplace", "-s", serviceName).Wait(testConfig.DefaultTimeoutDuration())
+		plans := cf.Cf("marketplace", "-e", serviceName).Wait(testConfig.DefaultTimeoutDuration())
 		Expect(plans).To(Exit(0))
 		Expect(plans.Out.Contents()).To(ContainSubstring(standardPlanName))
 		Expect(plans.Out.Contents()).To(ContainSubstring(fifoPlanName))


### PR DESCRIPTION
What
----

`-d` for domain is deprecated and not supported in cf cli v7 and also unnecessary

How to review
-------------

Code review

Read [error message](https://deployer.london.staging.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/custom-broker-acceptance-tests/builds/252)

Who can review
--------------

Not @tlwr
