### PR TITLE
[#173469867] RDS broker supports read only roles for Postgres databases

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -55,6 +55,7 @@
       rds-broker:
         allow_user_provision_parameters: true
         allow_user_update_parameters: true
+        allow_user_bind_parameters: true
         aws_region: "((terraform_outputs_region))"
         password: ((secrets_rds_broker_admin_password))
         state_encryption_key: ((secrets_rds_broker_state_encryption_key))

--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 0.1.68
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.68.tgz
-    sha1: 7aea07aee96c412817fcf8600045c593dbd6e2a4
+    version: 0.1.69
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.69.tgz
+    sha1: 2b1b93c028dbcc0eefcfa351fe7b1e3c703cb3a8
 
 - type: replace
   path: /instance_groups/-


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/173469867)

What
----

Releases the RDS broker such that Postgres service bindings can use `-c '{ "read_only": true }'` as a bind parameter

How to review
-------------

Read the story

Ensure you have the latest version of `cf conduit` via`cf install-plugin conduit`

Ensure the broker acceptance tests pass

Ensure that paas-billing is working as expected (it is an app which makes use of a Postgres database, and should have an existing binding)

Attempt to use the `read_only` feature on `billing-db`:
```
$ cf t -o admin -s billing
$ cf conduit billing-db -c '{ "read_only": true }' -- psql
> \d -- should list tables
> SELECT * FROM services LIMIT 10 -- queries should still work
> CREATE SCHEMA foo -- should fail
> CREATE TABLE my_table (id TEXT) -- should fail
```

Who can review
--------------

Not @tlwr
