### PR TITLE
Ensure prod is highly available

### DIFF
--- a/manifests/cf-manifest/env-specific/default.yml
+++ b/manifests/cf-manifest/env-specific/default.yml
@@ -1,4 +1,7 @@
 ---
+uaa_instances: 2
+nats_instances: 2
+diego_api_instances: 2
 cell_instances: 3
 router_instances: 2
 api_instances: 2

--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -1,4 +1,7 @@
 ---
+uaa_instances: 3
+nats_instances: 3
+diego_api_instances: 3
 cell_instances: 60
 router_instances: 6
 api_instances: 12

--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -1,4 +1,7 @@
 ---
+uaa_instances: 3
+nats_instances: 3
+diego_api_instances: 3
 cell_instances: 36
 router_instances: 12
 api_instances: 6

--- a/manifests/cf-manifest/env-specific/stg-lon.yml
+++ b/manifests/cf-manifest/env-specific/stg-lon.yml
@@ -1,4 +1,7 @@
 ---
+uaa_instances: 2
+nats_instances: 2
+diego_api_instances: 2
 cell_instances: 6
 router_instances: 3
 api_instances: 2

--- a/manifests/cf-manifest/operations.d/300-nats.yml
+++ b/manifests/cf-manifest/operations.d/300-nats.yml
@@ -7,3 +7,7 @@
 - type: replace
   path: /instance_groups/name=nats/jobs/name=nats/properties/nats/user
   value: nats_user
+
+- type: replace
+  path: /instance_groups/name=nats/instances
+  value: ((nats_instances))

--- a/manifests/cf-manifest/operations.d/330-uaa.yml
+++ b/manifests/cf-manifest/operations.d/330-uaa.yml
@@ -5,6 +5,10 @@
   value: cf_rds_client_sg
 
 - type: replace
+  path: /instance_groups/name=uaa/instances
+  value: ((uaa_instances))
+
+- type: replace
   path: /instance_groups/name=uaa/jobs/name=route_registrar/properties/route_registrar/routes/name=uaa/server_cert_domain_san?
   value: uaa.service.cf.internal
 

--- a/manifests/cf-manifest/operations.d/350-diego-api.yml
+++ b/manifests/cf-manifest/operations.d/350-diego-api.yml
@@ -6,6 +6,10 @@
     cf_rds_client_sg
 
 - type: replace
+  path: /instance_groups/name=diego-api/instances
+  value: ((diego_api_instances))
+
+- type: replace
   path: /instance_groups/name=diego-api/jobs/name=bbs/properties/diego/bbs/require_ssl?
   value: true
 

--- a/manifests/cf-manifest/spec/manifest/ha_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/ha_spec.rb
@@ -1,0 +1,52 @@
+RSpec.describe "high availability" do
+  let(:all_groups) { manifest.fetch("instance_groups") }
+  let(:perm_groups) { all_groups.reject { |i| i["lifecycle"] == "errand" } }
+
+  let(:brokers) { perm_groups.select { |i| i["name"] =~ /broker/ } }
+
+  let(:non_brokers) do
+    perm_groups
+      .reject { |i| i["name"] =~ /broker/ }
+      .reject { |i| i["name"] == "prometheus" }
+  end
+
+  describe "london" do
+    let(:manifest) { manifest_for_env("prod-lon") }
+
+    describe "non-brokers" do
+      it "ensures all instance groups are highly available >= 3" do
+        small_groups = non_brokers.select { |i| i["instances"] < 3 }
+        names = small_groups.map { |i| i["name"] }
+        expect(small_groups).to be_empty, "#{names} should have >= 3 instances"
+      end
+    end
+
+    describe "brokers" do
+      it "ensures all instance groups are highly available >= 2" do
+        small_groups = brokers.select { |i| i["instances"] < 2 }
+        names = small_groups.map { |i| i["name"] }
+        expect(small_groups).to be_empty, "#{names} should have >= 2 instances"
+      end
+    end
+  end
+
+  describe "ireland" do
+    let(:manifest) { manifest_for_env("prod") }
+
+    describe "non-brokers" do
+      it "ensures all instance groups are highly available >= 3" do
+        small_groups = non_brokers.select { |i| i["instances"] < 3 }
+        names = small_groups.map { |i| i["name"] }
+        expect(small_groups).to be_empty, "#{names} should have >= 3 instances"
+      end
+    end
+
+    describe "brokers" do
+      it "ensures all instance groups are highly available >= 2" do
+        small_groups = brokers.select { |i| i["instances"] < 2 }
+        names = small_groups.map { |i| i["name"] }
+        expect(small_groups).to be_empty, "#{names} should have >= 2 instances"
+      end
+    end
+  end
+end


### PR DESCRIPTION
What
----

I'm being sneaky and labelling this BAU PR as [#173621061](https://www.pivotaltracker.com/story/show/173621061)

I noticed during a fit of paranoia that we only had two NATS instances in production, which was especially ~terrifying~ exciting when we moved from using `nats` to `nats-tls` in the recent CF upgrade. All's well that ends well because we didn't see any measured downtime (and it was only for `metrics-discovery-registrar`)

This PR adds some tests which assert that all production(s) instance groups are highly available, and then scales up all components to make the tests pass. The reasoning behind the change is in the commit which implements the tests.

How to review
-------------

Code review

Have a look at `count by (bosh_job_name) (bosh_job_healthy{bosh_deployment="prod-lon"})` in Grafana

Who can review
--------------

Not @tlwr