### PR TITLE
Make travis faster [citation needed]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,12 @@ env:
     - SHELLCHECK_VERSION="0.7.1"
     - TMPDIR="/tmp"
 
+cache:
+  directories:
+    - /home/travis/.rvm/
+    - /home/travis/gopath/pkg
+    - /home/travis/.cache/pip
+
 addons:
   apt:
     sources:
@@ -22,8 +28,16 @@ addons:
 
 before_install:
   - |
-    mkdir ~/bin
-    export PATH=~/bin:$PATH
+    mkdir -p /home/travis/.cache/pip/wheels
+    for d in .cache/pip/wheels gopath .rvm; do
+      sudo chown -fR $USER /home/travis/$d
+    done
+  - |
+    mkdir /home/travis/bin
+    export PATH=/home/travis/bin:$PATH
+  - |
+  - export GOPATH=$HOME/gopath
+  - export PATH=$HOME/gopath/bin:$PATH
   - |
     echo "Fetching shellcheck"
     wget -qO- "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar -xJv
@@ -52,15 +66,9 @@ before_install:
        --strip-components=1 \
        '*promtool'
     set +e
-  - pip install --user yamllint
   - GIMME_OUTPUT=$(gimme 1.13 | tee -a $HOME/.bashrc) && eval "$GIMME_OUTPUT"
-  - export GOPATH=$HOME/gopath
-  - export PATH=$HOME/gopath/bin:$PATH
-  - mkdir -p $HOME/gopath/src/github.com/alphagov/paas-cf
-  - rsync -az ${TRAVIS_BUILD_DIR}/ $HOME/gopath/src/github.com/alphagov/paas-cf/
-  - export TRAVIS_BUILD_DIR=$HOME/gopath/src/github.com/alphagov/paas-cf
-  - cd $HOME/gopath/src/github.com/alphagov/paas-cf
   - (cd tools/pipecleaner && go install -mod=vendor)
+  - pip install --user yamllint
   - bundle install
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,5 +63,39 @@ before_install:
   - (cd tools/pipecleaner && go install -mod=vendor)
   - bundle install
 
-script:
-  - make test
+jobs:
+  - stage: ci
+    name: 'Config spec'
+    script: make config_spec
+
+  - stage: ci
+    name: 'Scripts spec'
+    script: make scripts_spec
+
+  - stage: ci
+    name: 'Tools spec'
+    script: make tools_spec
+
+  - stage: ci
+    name: 'Concourse spec'
+    script: make concourse_spec
+
+  - stage: ci
+    name: 'Manifests spec'
+    script: make manifests_spec
+
+  - stage: ci
+    name: 'Terraform spec'
+    script: make terraform_spec
+
+  - stage: ci
+    name: 'Platform tests spec'
+    script: make platform_tests_spec
+
+  - stage: ci
+    name: 'Platform tests compilation'
+    script: make compile_platform_tests
+
+  - stage: ci
+    name: 'Lint'
+    script: make lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,6 @@ env:
     - SHELLCHECK_VERSION="0.7.1"
     - TMPDIR="/tmp"
 
-cache:
-  directories:
-    - /home/travis/.rvm/
-    - /home/travis/gopath/pkg
-    - /home/travis/.cache/pip
-
 addons:
   apt:
     sources:

--- a/Makefile
+++ b/Makefile
@@ -108,8 +108,8 @@ spec: config_spec scripts_spec tools_spec concourse_spec manifests_spec terrafor
 
 .PHONY: compile_platform_tests
 compile_platform_tests:
-	go test -run ^$$ \
-		github.com/alphagov/paas-cf/platform-tests/...
+	cd platform-tests &&\
+		go vet ./...
 
 .PHONY: lint_yaml
 lint_yaml:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ check-env:
 	@./scripts/validate_aws_credentials.sh
 
 .PHONY: test
-test: spec compile_platform_tests lint
+test:
+	make $$(cat .travis.yml  | ruby -ryaml -e 'puts YAML.load(STDIN.read)["jobs"].map { |j| j["script"] }.map { |j| j.gsub("make ", "") }.join(" ")')
 
 .PHONY: scripts_spec
 scripts_spec:
@@ -102,9 +103,6 @@ platform_tests_spec:
 config_spec:
 	cd config &&\
 		bundle exec rspec
-
-.PHONY: spec
-spec: config_spec scripts_spec tools_spec concourse_spec manifests_spec terraform_spec platform_tests_spec
 
 .PHONY: compile_platform_tests
 compile_platform_tests:


### PR DESCRIPTION
What
----

We have one large monolithic travis job which does all the things.

This means all of our tests run in serial, and we wait a long time for things to install. If we experience a flake during a test, we have to re-run everything.

This PR does some questionable things to the Makefile, as well as `travis.yml` with the goal of

- caching dependencies
- avoid misusing `GOPATH`
- split out the `make test` single job into multiple jobs which can (in theory) be run in parallel
- steps can be re-run individually

How to review
-------------

Code review

Travis should pass

Travis should do what it is supposed to

Who can review
--------------

Not @tlwr
