### PR TITLE
Improve debugging and operating paas-metrics

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2102,6 +2102,8 @@ jobs:
                       health-check-type: http
                       health-check-http-endpoint: /
                       stack: cflinuxfs3
+                      services:
+                        - logit-syslog-drain
                       env:
                         GOPACKAGENAME: github.com/alphagov/paas-yet-another-cloudwatch-exporter/src
                         AWS_ACCESS_KEY_ID: "${YACE_AWS_ACCESS_KEY_ID}"
@@ -4273,6 +4275,8 @@ jobs:
             METRICS_AWS_ACCESS_KEY_ID: ((metrics_aws_access_key_id))
             METRICS_AWS_SECRET_ACCESS_KEY: ((metrics_aws_secret_access_key))
 
+            LOGIT_ADDRESS: ((logit_syslog_address))
+            LOGIT_PORT: ((logit_syslog_port))
             LOGIT_ELASTICSEARCH_URL: ((logit_elasticsearch_url))
             LOGIT_ELASTICSEARCH_API_KEY: ((logit_elasticsearch_api_key))
           inputs:
@@ -4288,6 +4292,16 @@ jobs:
                 cf auth "${CF_ADMIN}" "${CF_PASS}"
 
                 cf target -o admin -s monitoring
+
+                if ! cf service logit-syslog-drain > /dev/null; then
+                  cf create-user-provided-service \
+                    logit-syslog-drain \
+                    -l "syslog-tls://${LOGIT_ADDRESS}:${LOGIT_PORT}"
+                else
+                  cf update-user-provided-service \
+                    logit-syslog-drain \
+                    -l "syslog-tls://${LOGIT_ADDRESS}:${LOGIT_PORT}"
+                fi
 
                 cd paas-cf/tools/metrics
 
@@ -4321,6 +4335,7 @@ jobs:
                     app['routes'] = [
                       { 'route' => 'paas-metrics.${APPS_DNS_ZONE_NAME}' },
                     ]
+                    app['services'] = ['logit-syslog-drain']
                   }
                   File.write('manifest.yml', manifest.to_yaml)
                 "
@@ -4436,6 +4451,7 @@ jobs:
                   --var aws_region="$AWS_REGION" \
                   --var aws_access_key_id="$AWS_ACCESS_KEY_ID" \
                   --var aws_secret_access_key="$AWS_SECRET_ACCESS_KEY"
+                cf bind-service paas-prometheus-endpoint-redis logit-syslog-drain
 
       - *end-grafana-job-annotation
 

--- a/tools/metrics/acceptance/acceptance_suite_test.go
+++ b/tools/metrics/acceptance/acceptance_suite_test.go
@@ -35,8 +35,8 @@ var (
 var _ = BeforeSuite(func() {
 	log.Printf("Running BeforeSuite")
 
-	SetDefaultEventuallyTimeout(2 * time.Minute)          // Fail after 1m
-	SetDefaultEventuallyPollingInterval(10 * time.Second) // Try every 10s
+	SetDefaultEventuallyTimeout(10 * time.Minute)         // Fail after 10m
+	SetDefaultEventuallyPollingInterval(20 * time.Second) // Try every 10s
 
 	SetDefaultConsistentlyDuration(10 * time.Second)       // Test for 10s
 	SetDefaultConsistentlyPollingInterval(1 * time.Second) // Try every 1s

--- a/tools/metrics/acceptance/aws_test.go
+++ b/tools/metrics/acceptance/aws_test.go
@@ -9,7 +9,7 @@ var _ = Describe("AWS", func() {
 	It("should return CloudFront metrics", func() {
 		Skip("Exporter does not always return these metrics, traffic dependent")
 
-		Expect(metricFamilies).To(SatisfyAll(
+		Eventually(metricFamilies).Should(SatisfyAll(
 			HaveKey("paas_aws_cloudfront_4xxerrorrate_ratio"),
 			HaveKey("paas_aws_cloudfront_5xxerrorrate_ratio"),
 			HaveKey("paas_aws_cloudfront_bytesdownloaded_bytes"),
@@ -20,21 +20,21 @@ var _ = Describe("AWS", func() {
 	})
 
 	It("should return ElastiCache metrics", func() {
-		Expect(metricFamilies).To(SatisfyAll(
+		Eventually(metricFamilies).Should(SatisfyAll(
 			HaveKey("paas_aws_elasticache_cache_parameter_group_count"),
 			HaveKey("paas_aws_elasticache_node_count"),
 		))
 	})
 
 	It("should return ELB metrics", func() {
-		Expect(metricFamilies).To(SatisfyAll(
+		Eventually(metricFamilies).Should(SatisfyAll(
 			HaveKey("paas_aws_elb_healthy_node_count"),
 			HaveKey("paas_aws_elb_unhealthy_node_count"),
 		))
 	})
 
 	It("should return S3 metrics", func() {
-		Expect(metricFamilies).To(SatisfyAll(
+		Eventually(metricFamilies).Should(SatisfyAll(
 			HaveKey("paas_aws_s3_buckets_count"),
 		))
 	})

--- a/tools/metrics/acceptance/cdn_broker_test.go
+++ b/tools/metrics/acceptance/cdn_broker_test.go
@@ -9,7 +9,7 @@ var _ = Describe("CDN broker", func() {
 	It("should return CDN TLS cert metrics", func() {
 		Skip("Exporter does not always return these metrics, service dependent")
 
-		Expect(metricFamilies).To(SatisfyAll(
+		Eventually(metricFamilies).Should(SatisfyAll(
 			HaveKey("paas_cdn_tls_certificates_expiry_days"),
 			HaveKey("paas_cdn_tls_certificates_validity"),
 		))

--- a/tools/metrics/acceptance/cf_test.go
+++ b/tools/metrics/acceptance/cf_test.go
@@ -7,7 +7,7 @@ import (
 
 var _ = Describe("Cloud Foundry", func() {
 	It("should return CF quota metrics", func() {
-		Expect(metricFamilies).To(SatisfyAll(
+		Eventually(metricFamilies).Should(SatisfyAll(
 			HaveKey("paas_op_quota_memory_allocated_megabytes"),
 			HaveKey("paas_op_quota_memory_reserved_megabytes"),
 			HaveKey("paas_op_quota_routes_reserved_count"),
@@ -17,14 +17,14 @@ var _ = Describe("Cloud Foundry", func() {
 	})
 
 	It("should return CF application metrics", func() {
-		Expect(metricFamilies).To(SatisfyAll(
+		Eventually(metricFamilies).Should(SatisfyAll(
 			HaveKey("paas_op_apps_count"),
 			HaveKey("paas_op_events_app_crash_count"),
 		))
 	})
 
 	It("should return CF org metrics", func() {
-		Expect(metricFamilies).To(SatisfyAll(
+		Eventually(metricFamilies).Should(SatisfyAll(
 			HaveKey("paas_op_orgs_count"),
 			HaveKey("paas_op_spaces_count"),
 			HaveKey("paas_op_services_provisioned_count"),
@@ -33,14 +33,14 @@ var _ = Describe("Cloud Foundry", func() {
 	})
 
 	It("should return CF service metrics", func() {
-		Expect(metricFamilies).To(SatisfyAll(
+		Eventually(metricFamilies).Should(SatisfyAll(
 			HaveKey("paas_op_services_provisioned_count"),
 			HaveKey("paas_op_users_count"),
 		))
 	})
 
 	It("should return CF user metrics", func() {
-		Expect(metricFamilies).To(SatisfyAll(
+		Eventually(metricFamilies).Should(SatisfyAll(
 			HaveKey("paas_op_users_count"),
 		))
 	})

--- a/tools/metrics/acceptance/currency_test.go
+++ b/tools/metrics/acceptance/currency_test.go
@@ -7,7 +7,7 @@ import (
 
 var _ = Describe("Currency", func() {
 	It("should return currency metrics", func() {
-		Expect(metricFamilies).To(SatisfyAll(
+		Eventually(metricFamilies).Should(SatisfyAll(
 			HaveKey("paas_currency_real_ratio"),
 		))
 	})

--- a/tools/metrics/acceptance/tls_test.go
+++ b/tools/metrics/acceptance/tls_test.go
@@ -7,7 +7,7 @@ import (
 
 var _ = Describe("TLS =", func() {
 	It("should return TLS cert metrics", func() {
-		Expect(metricFamilies).To(SatisfyAll(
+		Eventually(metricFamilies).Should(SatisfyAll(
 			HaveKey("paas_tls_certificates_validity_days"),
 		))
 	})

--- a/tools/metrics/acceptance/uaa_test.go
+++ b/tools/metrics/acceptance/uaa_test.go
@@ -7,7 +7,7 @@ import (
 
 var _ = Describe("UAA", func() {
 	It("should return UAA user metrics", func() {
-		Expect(metricFamilies).To(SatisfyAll(
+		Eventually(metricFamilies).Should(SatisfyAll(
 			HaveKey("paas_uaa_users_count"),
 			HaveKey("paas_uaa_active_users_count"),
 		))


### PR DESCRIPTION
What
----

This PR does two things:

* Ship logs to Logit from `paas-metrics` and the other apps in the `admin/monitoring` space
* Allow up to 10 minutes for `paas-metrics` to start emitting its metrics

Both of these will help with recent pipeline failures in London:

* Some causes of pipeline failures were from metrics which did show up after a few minutes. Allowing 10 minutes will stop the pipeline failing
* Another cause of pipeline failures is the `paas_aws_elasticache_cache_parameter_group_count` metric breaking for a day at a time. Shipping logs will allow us to debug if that happens again

How to review
-------------

Try deploy it

Who can review
--------------

Not @46bit