### PR TITLE
Increase app staging times

### DIFF
--- a/manifests/cf-manifest/env-specific/default.yml
+++ b/manifests/cf-manifest/env-specific/default.yml
@@ -10,6 +10,7 @@ log_api_instances: 2
 scheduler_instances: 2
 cc_worker_instances: 2
 cc_hourly_rate_limit: 15000
+cc_staging_timeout_in_seconds: 900
 paas_region_name: dev
 
 prometheus_disk_size: 100GB

--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -10,6 +10,7 @@ log_api_instances: 6
 scheduler_instances: 4
 cc_worker_instances: 4
 cc_hourly_rate_limit: 20000
+cc_staging_timeout_in_seconds: 1800
 paas_region_name: london
 
 prometheus_disk_size: 750GB

--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -10,6 +10,7 @@ log_api_instances: 6
 scheduler_instances: 4
 cc_worker_instances: 4
 cc_hourly_rate_limit: 20000
+cc_staging_timeout_in_seconds: 1800
 paas_region_name: ireland
 
 prometheus_disk_size: 500GB

--- a/manifests/cf-manifest/env-specific/stg-lon.yml
+++ b/manifests/cf-manifest/env-specific/stg-lon.yml
@@ -10,6 +10,7 @@ log_api_instances: 3
 scheduler_instances: 3
 cc_worker_instances: 2
 cc_hourly_rate_limit: 100000
+cc_staging_timeout_in_seconds: 1800
 paas_region_name: staging
 
 prometheus_disk_size: 500GB

--- a/manifests/cf-manifest/operations.d/320-cc-set-staging-timeout.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-set-staging-timeout.yml
@@ -1,0 +1,4 @@
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/staging_timeout_in_seconds?
+  value: ((cc_staging_timeout_in_seconds))
+


### PR DESCRIPTION
What
----

Having been pushing a large R Shiny app it takes more than the default
of 900 seconds to compile all the dependencies that it needs. This PR
doubles the time to 1800 seconds and makes it configurable via the env
specific files we have.

How to review
-------------

Code review

Who can review
--------------

@paroxp 
