### PR TITLE
sqs: bump broker to fix fifo queues

### DIFF
--- a/manifests/cf-manifest/operations.d/760-sqs-broker.yml
+++ b/manifests/cf-manifest/operations.d/760-sqs-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: sqs-broker
-    version: 0.1.5
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/sqs-broker-0.1.5.tgz
-    sha1: 3ebe2200182b8d9b0df8bb06b09e61e286290d64
+    version: 0.1.6
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/sqs-broker-0.1.6.tgz
+    sha1: 00f49f6597f6858a88c63825706a94a639a31dc0
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-


### PR DESCRIPTION
## What

updates the sqs-broker boshrelease to pull in the latest version that resolves issues with FIFO queues being unable to be provisioned.

## How

* check you are happy with [recent changes to the broker](https://github.com/alphagov/paas-sqs-broker/pull/14)
* It'll be deployed on [autom8foundary](https://deployer.autom8.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry) soon

## Who

Not me