### PR TITLE
Configure SQS broker to only permit access from local VPC

### DIFF
--- a/manifests/cf-manifest/operations.d/760-sqs-broker.yml
+++ b/manifests/cf-manifest/operations.d/760-sqs-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: sqs-broker
-    version: 0.1.6
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/sqs-broker-0.1.6.tgz
-    sha1: 00f49f6597f6858a88c63825706a94a639a31dc0
+    version: 0.1.8
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/sqs-broker-0.1.8.tgz
+    sha1: 55c741e1c968238cf4c2f03df80e7bfde8f46a75
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-
@@ -37,6 +37,7 @@
             log_level: INFO
             aws_region: "((terraform_outputs_region))"
             resource_prefix: "paas-sqs-broker"
+            additional_user_policy: "((terraform_outputs_restrict_to_local_ips_policy_arn))"
             permissions_boundary: "((terraform_outputs_sqs_broker_permissions_boundary_arn))"
             deploy_environment: "((environment))"
             locket:

--- a/terraform/cloudfoundry/iam.tf
+++ b/terraform/cloudfoundry/iam.tf
@@ -1,0 +1,7 @@
+resource "aws_iam_policy" "restrict_to_local_ips" {
+  policy = templatefile("${path.module}/policies/restrict_to_local_ips.json.tpl", {
+    nat_gateway_public_ips = jsonencode(aws_nat_gateway.cf.*.public_ip)
+  })
+  name        = "${var.env}RestrictToLocalIps"
+  description = "Restricts access to only be permitted from the egress IPs for the local VPC"
+}

--- a/terraform/cloudfoundry/outputs.tf
+++ b/terraform/cloudfoundry/outputs.tf
@@ -145,6 +145,10 @@ output "s3_broker_ip_restriction_policy_arn" {
   value = aws_iam_policy.s3_broker_user_ip_restriction.arn
 }
 
+output "restrict_to_local_ips_policy_arn" {
+  value = aws_iam_policy.restrict_to_local_ips.arn
+}
+
 output "sqs_broker_elb_name" {
   value = aws_elb.sqs_broker.name
 }

--- a/terraform/cloudfoundry/policies/restrict_to_local_ips.json.tpl
+++ b/terraform/cloudfoundry/policies/restrict_to_local_ips.json.tpl
@@ -1,0 +1,15 @@
+{
+   "Version": "2012-10-17",
+   "Statement": [
+     {
+       "Effect": "Deny",
+       "Resource": "*",
+       "Action": "*",
+       "Condition": {
+         "NotIpAddress": {
+           "aws:SourceIp": ${nat_gateway_public_ips}
+         }
+       }
+     }
+   ]
+}


### PR DESCRIPTION
What
----

Depends on https://github.com/alphagov/paas-sqs-broker/pull/15 and a
corresponding boshrelease to push that out.

This adds a new managed policy, local_vpc_access_only, which can be
attached to an IAM User or Role to restrict use of that User/Role to
only be permitted from the local VPC.  This mitigates against
credentials that are leaked.

The S3 broker has a similar feature in
s3_broker_ip_restriction_policy_arn, but I decided to go with an
approach based on `aws:SourceVpc` rather than `aws:SourceIp`.  This is
so that: a) the policy doesn't have to care about specific IP
addresses, and b) the policy will work whether the AWS API is accessed
over public internet or via a private endpoint (at some point in the
future).

I deliberately made the local_vpc_access_only policy's name generic
because it could easily be used as-is for other brokers in future.

Describe what you have changed and why.

How to review
-------------

I guess you could deploy it and verify that SQS-managed users get the appropriate policy restriction.

Who can review
--------------

Do I really have to say "not @philandstuff" for each PR? 😕 