### PR TITLE
Increase Aiven billing alert to £28,500

### DIFF
--- a/manifests/prometheus/alerts.d/aiven-cost.yml
+++ b/manifests/prometheus/alerts.d/aiven-cost.yml
@@ -7,7 +7,7 @@
     name: AivenEstimatedCostHigh
     rules:
       - alert: AivenEstimatedCostHigh
-        expr: delta(paas_aiven_estimated_cost_pounds[24h]) * 30 > 25000
+        expr: delta(paas_aiven_estimated_cost_pounds[24h]) * 30 > 28500
         labels:
           severity: critical
         annotations:


### PR DESCRIPTION
What
----

This alert went off because a tenant created a large new Elasticsearch. We actually can spend a bit more now without problems, so we don't have to do anything. This commit increases where the alert goes off to be more relevant to our current finance limits.

How to review
-------------

See [discussion on Slack](https://gds.slack.com/archives/CAEHMHGJ2/p1600969001063200).

Who can review
--------------

Not @46bit 