### PR TITLE
Eventually metrics acceptance

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2051,6 +2051,8 @@ jobs:
                       health-check-type: http
                       health-check-http-endpoint: /
                       stack: cflinuxfs3
+                      services:
+                        - logit-syslog-drain
                       env:
                         GOPACKAGENAME: github.com/alphagov/paas-yet-another-cloudwatch-exporter/src
                         AWS_ACCESS_KEY_ID: "${YACE_AWS_ACCESS_KEY_ID}"
@@ -4222,6 +4224,8 @@ jobs:
             METRICS_AWS_ACCESS_KEY_ID: ((metrics_aws_access_key_id))
             METRICS_AWS_SECRET_ACCESS_KEY: ((metrics_aws_secret_access_key))
 
+            LOGIT_ADDRESS: ((logit_syslog_address))
+            LOGIT_PORT: ((logit_syslog_port))
             LOGIT_ELASTICSEARCH_URL: ((logit_elasticsearch_url))
             LOGIT_ELASTICSEARCH_API_KEY: ((logit_elasticsearch_api_key))
           inputs:
@@ -4237,6 +4241,16 @@ jobs:
                 cf auth "${CF_ADMIN}" "${CF_PASS}"
 
                 cf target -o admin -s monitoring
+
+                if ! cf service logit-syslog-drain > /dev/null; then
+                  cf create-user-provided-service \
+                    logit-syslog-drain \
+                    -l "syslog-tls://${LOGIT_ADDRESS}:${LOGIT_PORT}"
+                else
+                  cf update-user-provided-service \
+                    logit-syslog-drain \
+                    -l "syslog-tls://${LOGIT_ADDRESS}:${LOGIT_PORT}"
+                fi
 
                 cd paas-cf/tools/metrics
 
@@ -4270,6 +4284,7 @@ jobs:
                     app['routes'] = [
                       { 'route' => 'paas-metrics.${APPS_DNS_ZONE_NAME}' },
                     ]
+                    app['services'] = ['logit-syslog-drain']
                   }
                   File.write('manifest.yml', manifest.to_yaml)
                 "
@@ -4385,6 +4400,7 @@ jobs:
                   --var aws_region="$AWS_REGION" \
                   --var aws_access_key_id="$AWS_ACCESS_KEY_ID" \
                   --var aws_secret_access_key="$AWS_SECRET_ACCESS_KEY"
+                cf bind-service paas-prometheus-endpoint-redis logit-syslog-drain
 
       - *end-grafana-job-annotation
 

--- a/tools/metrics/acceptance/acceptance_suite_test.go
+++ b/tools/metrics/acceptance/acceptance_suite_test.go
@@ -28,9 +28,8 @@ func TestAcceptanceTests(t *testing.T) {
 }
 
 var (
-	metricsLog     = log.New(GinkgoWriter, "", log.LstdFlags)
-	metricsURL     = os.Getenv("PAAS_METRICS_URL")
-	metricFamilies map[string]*dto.MetricFamily
+	metricsLog = log.New(GinkgoWriter, "", log.LstdFlags)
+	metricsURL = os.Getenv("PAAS_METRICS_URL")
 )
 
 func getMetrics() (map[string]*dto.MetricFamily, error) {
@@ -101,33 +100,6 @@ var _ = BeforeSuite(func() {
 		},
 		BeNumerically(">=", numExpectedMetricFamilies),
 	),
-		fmt.Sprintf(
-			"It should return >= %d valid prometheus metrics",
-			numExpectedMetricFamilies,
-		),
-	)
-
-	Eventually(func() (int, error) {
-		log.Printf("Getting metrics for parsing from %s", metricsURL)
-
-		resp, err := http.Get(metricsURL)
-		if err != nil {
-			log.Printf("Received error: %s", err)
-			return 0, err
-		}
-
-		log.Printf("Parsing metrics")
-		parser := expfmt.TextParser{}
-		metricFamilies, err = parser.TextToMetricFamilies(resp.Body)
-		if err != nil {
-			log.Printf("Received error: %s", err)
-			return 0, err
-		}
-
-		log.Printf("Parsed %d metric families", len(metricFamilies))
-		return len(metricFamilies), nil
-	}).Should(
-		BeNumerically(">=", numExpectedMetricFamilies),
 		fmt.Sprintf(
 			"It should return >= %d valid prometheus metrics",
 			numExpectedMetricFamilies,

--- a/tools/metrics/acceptance/aiven_test.go
+++ b/tools/metrics/acceptance/aiven_test.go
@@ -7,6 +7,8 @@ import (
 
 var _ = Describe("Aiven", func() {
 	It("should return estimated cost", func() {
-		Expect(metricFamilies).To(HaveKey("paas_aiven_estimated_cost_pounds"))
+		Eventually(getMetrics).Should(
+			HaveKey("paas_aiven_estimated_cost_pounds"),
+		)
 	})
 })

--- a/tools/metrics/acceptance/aiven_test.go
+++ b/tools/metrics/acceptance/aiven_test.go
@@ -7,8 +7,8 @@ import (
 
 var _ = Describe("Aiven", func() {
 	It("should return estimated cost", func() {
-		Eventually(getMetrics).Should(
-			HaveKey("paas_aiven_estimated_cost_pounds"),
+		Eventually(getMetricNames).Should(
+			ContainElement("paas_aiven_estimated_cost_pounds"),
 		)
 	})
 })

--- a/tools/metrics/acceptance/aws_test.go
+++ b/tools/metrics/acceptance/aws_test.go
@@ -9,7 +9,7 @@ var _ = Describe("AWS", func() {
 	It("should return CloudFront metrics", func() {
 		Skip("Exporter does not always return these metrics, traffic dependent")
 
-		Expect(metricFamilies).To(SatisfyAll(
+		Eventually(getMetrics).Should(SatisfyAll(
 			HaveKey("paas_aws_cloudfront_4xxerrorrate_ratio"),
 			HaveKey("paas_aws_cloudfront_5xxerrorrate_ratio"),
 			HaveKey("paas_aws_cloudfront_bytesdownloaded_bytes"),
@@ -20,21 +20,21 @@ var _ = Describe("AWS", func() {
 	})
 
 	It("should return ElastiCache metrics", func() {
-		Expect(metricFamilies).To(SatisfyAll(
+		Eventually(getMetrics).Should(SatisfyAll(
 			HaveKey("paas_aws_elasticache_cache_parameter_group_count"),
 			HaveKey("paas_aws_elasticache_node_count"),
 		))
 	})
 
 	It("should return ELB metrics", func() {
-		Expect(metricFamilies).To(SatisfyAll(
+		Eventually(getMetrics).Should(SatisfyAll(
 			HaveKey("paas_aws_elb_healthy_node_count"),
 			HaveKey("paas_aws_elb_unhealthy_node_count"),
 		))
 	})
 
 	It("should return S3 metrics", func() {
-		Expect(metricFamilies).To(SatisfyAll(
+		Eventually(getMetrics).Should(SatisfyAll(
 			HaveKey("paas_aws_s3_buckets_count"),
 		))
 	})

--- a/tools/metrics/acceptance/aws_test.go
+++ b/tools/metrics/acceptance/aws_test.go
@@ -9,33 +9,33 @@ var _ = Describe("AWS", func() {
 	It("should return CloudFront metrics", func() {
 		Skip("Exporter does not always return these metrics, traffic dependent")
 
-		Eventually(getMetrics).Should(SatisfyAll(
-			HaveKey("paas_aws_cloudfront_4xxerrorrate_ratio"),
-			HaveKey("paas_aws_cloudfront_5xxerrorrate_ratio"),
-			HaveKey("paas_aws_cloudfront_bytesdownloaded_bytes"),
-			HaveKey("paas_aws_cloudfront_bytesuploaded_bytes"),
-			HaveKey("paas_aws_cloudfront_requests"),
-			HaveKey("paas_aws_cloudfront_totalerrorrate_ratio"),
+		Eventually(getMetricNames).Should(SatisfyAll(
+			ContainElement("paas_aws_cloudfront_4xxerrorrate_ratio"),
+			ContainElement("paas_aws_cloudfront_5xxerrorrate_ratio"),
+			ContainElement("paas_aws_cloudfront_bytesdownloaded_bytes"),
+			ContainElement("paas_aws_cloudfront_bytesuploaded_bytes"),
+			ContainElement("paas_aws_cloudfront_requests"),
+			ContainElement("paas_aws_cloudfront_totalerrorrate_ratio"),
 		))
 	})
 
 	It("should return ElastiCache metrics", func() {
-		Eventually(getMetrics).Should(SatisfyAll(
-			HaveKey("paas_aws_elasticache_cache_parameter_group_count"),
-			HaveKey("paas_aws_elasticache_node_count"),
+		Eventually(getMetricNames).Should(SatisfyAll(
+			ContainElement("paas_aws_elasticache_cache_parameter_group_count"),
+			ContainElement("paas_aws_elasticache_node_count"),
 		))
 	})
 
 	It("should return ELB metrics", func() {
-		Eventually(getMetrics).Should(SatisfyAll(
-			HaveKey("paas_aws_elb_healthy_node_count"),
-			HaveKey("paas_aws_elb_unhealthy_node_count"),
+		Eventually(getMetricNames).Should(SatisfyAll(
+			ContainElement("paas_aws_elb_healthy_node_count"),
+			ContainElement("paas_aws_elb_unhealthy_node_count"),
 		))
 	})
 
 	It("should return S3 metrics", func() {
-		Eventually(getMetrics).Should(SatisfyAll(
-			HaveKey("paas_aws_s3_buckets_count"),
+		Eventually(getMetricNames).Should(SatisfyAll(
+			ContainElement("paas_aws_s3_buckets_count"),
 		))
 	})
 })

--- a/tools/metrics/acceptance/cdn_broker_test.go
+++ b/tools/metrics/acceptance/cdn_broker_test.go
@@ -9,7 +9,7 @@ var _ = Describe("CDN broker", func() {
 	It("should return CDN TLS cert metrics", func() {
 		Skip("Exporter does not always return these metrics, service dependent")
 
-		Expect(metricFamilies).To(SatisfyAll(
+		Eventually(getMetrics).Should(SatisfyAll(
 			HaveKey("paas_cdn_tls_certificates_expiry_days"),
 			HaveKey("paas_cdn_tls_certificates_validity"),
 		))

--- a/tools/metrics/acceptance/cdn_broker_test.go
+++ b/tools/metrics/acceptance/cdn_broker_test.go
@@ -9,9 +9,9 @@ var _ = Describe("CDN broker", func() {
 	It("should return CDN TLS cert metrics", func() {
 		Skip("Exporter does not always return these metrics, service dependent")
 
-		Eventually(getMetrics).Should(SatisfyAll(
-			HaveKey("paas_cdn_tls_certificates_expiry_days"),
-			HaveKey("paas_cdn_tls_certificates_validity"),
+		Eventually(getMetricNames).Should(SatisfyAll(
+			ContainElement("paas_cdn_tls_certificates_expiry_days"),
+			ContainElement("paas_cdn_tls_certificates_validity"),
 		))
 	})
 })

--- a/tools/metrics/acceptance/cf_test.go
+++ b/tools/metrics/acceptance/cf_test.go
@@ -7,41 +7,41 @@ import (
 
 var _ = Describe("Cloud Foundry", func() {
 	It("should return CF quota metrics", func() {
-		Eventually(getMetrics).Should(SatisfyAll(
-			HaveKey("paas_op_quota_memory_allocated_megabytes"),
-			HaveKey("paas_op_quota_memory_reserved_megabytes"),
-			HaveKey("paas_op_quota_routes_reserved_count"),
-			HaveKey("paas_op_quota_services_allocated_count"),
-			HaveKey("paas_op_quota_services_reserved_count"),
+		Eventually(getMetricNames).Should(SatisfyAll(
+			ContainElement("paas_op_quota_memory_allocated_megabytes"),
+			ContainElement("paas_op_quota_memory_reserved_megabytes"),
+			ContainElement("paas_op_quota_routes_reserved_count"),
+			ContainElement("paas_op_quota_services_allocated_count"),
+			ContainElement("paas_op_quota_services_reserved_count"),
 		))
 	})
 
 	It("should return CF application metrics", func() {
-		Eventually(getMetrics).Should(SatisfyAll(
-			HaveKey("paas_op_apps_count"),
-			HaveKey("paas_op_events_app_crash_count"),
+		Eventually(getMetricNames).Should(SatisfyAll(
+			ContainElement("paas_op_apps_count"),
+			ContainElement("paas_op_events_app_crash_count"),
 		))
 	})
 
 	It("should return CF org metrics", func() {
-		Eventually(getMetrics).Should(SatisfyAll(
-			HaveKey("paas_op_orgs_count"),
-			HaveKey("paas_op_spaces_count"),
-			HaveKey("paas_op_services_provisioned_count"),
-			HaveKey("paas_op_users_count"),
+		Eventually(getMetricNames).Should(SatisfyAll(
+			ContainElement("paas_op_orgs_count"),
+			ContainElement("paas_op_spaces_count"),
+			ContainElement("paas_op_services_provisioned_count"),
+			ContainElement("paas_op_users_count"),
 		))
 	})
 
 	It("should return CF service metrics", func() {
-		Eventually(getMetrics).Should(SatisfyAll(
-			HaveKey("paas_op_services_provisioned_count"),
-			HaveKey("paas_op_users_count"),
+		Eventually(getMetricNames).Should(SatisfyAll(
+			ContainElement("paas_op_services_provisioned_count"),
+			ContainElement("paas_op_users_count"),
 		))
 	})
 
 	It("should return CF user metrics", func() {
-		Eventually(getMetrics).Should(SatisfyAll(
-			HaveKey("paas_op_users_count"),
+		Eventually(getMetricNames).Should(SatisfyAll(
+			ContainElement("paas_op_users_count"),
 		))
 	})
 })

--- a/tools/metrics/acceptance/cf_test.go
+++ b/tools/metrics/acceptance/cf_test.go
@@ -7,7 +7,7 @@ import (
 
 var _ = Describe("Cloud Foundry", func() {
 	It("should return CF quota metrics", func() {
-		Expect(metricFamilies).To(SatisfyAll(
+		Eventually(getMetrics).Should(SatisfyAll(
 			HaveKey("paas_op_quota_memory_allocated_megabytes"),
 			HaveKey("paas_op_quota_memory_reserved_megabytes"),
 			HaveKey("paas_op_quota_routes_reserved_count"),
@@ -17,14 +17,14 @@ var _ = Describe("Cloud Foundry", func() {
 	})
 
 	It("should return CF application metrics", func() {
-		Expect(metricFamilies).To(SatisfyAll(
+		Eventually(getMetrics).Should(SatisfyAll(
 			HaveKey("paas_op_apps_count"),
 			HaveKey("paas_op_events_app_crash_count"),
 		))
 	})
 
 	It("should return CF org metrics", func() {
-		Expect(metricFamilies).To(SatisfyAll(
+		Eventually(getMetrics).Should(SatisfyAll(
 			HaveKey("paas_op_orgs_count"),
 			HaveKey("paas_op_spaces_count"),
 			HaveKey("paas_op_services_provisioned_count"),
@@ -33,14 +33,14 @@ var _ = Describe("Cloud Foundry", func() {
 	})
 
 	It("should return CF service metrics", func() {
-		Expect(metricFamilies).To(SatisfyAll(
+		Eventually(getMetrics).Should(SatisfyAll(
 			HaveKey("paas_op_services_provisioned_count"),
 			HaveKey("paas_op_users_count"),
 		))
 	})
 
 	It("should return CF user metrics", func() {
-		Expect(metricFamilies).To(SatisfyAll(
+		Eventually(getMetrics).Should(SatisfyAll(
 			HaveKey("paas_op_users_count"),
 		))
 	})

--- a/tools/metrics/acceptance/currency_test.go
+++ b/tools/metrics/acceptance/currency_test.go
@@ -7,8 +7,8 @@ import (
 
 var _ = Describe("Currency", func() {
 	It("should return currency metrics", func() {
-		Eventually(getMetrics).Should(SatisfyAll(
-			HaveKey("paas_currency_real_ratio"),
+		Eventually(getMetricNames).Should(SatisfyAll(
+			ContainElement("paas_currency_real_ratio"),
 		))
 	})
 })

--- a/tools/metrics/acceptance/currency_test.go
+++ b/tools/metrics/acceptance/currency_test.go
@@ -7,7 +7,7 @@ import (
 
 var _ = Describe("Currency", func() {
 	It("should return currency metrics", func() {
-		Expect(metricFamilies).To(SatisfyAll(
+		Eventually(getMetrics).Should(SatisfyAll(
 			HaveKey("paas_currency_real_ratio"),
 		))
 	})

--- a/tools/metrics/acceptance/tls_test.go
+++ b/tools/metrics/acceptance/tls_test.go
@@ -7,8 +7,8 @@ import (
 
 var _ = Describe("TLS =", func() {
 	It("should return TLS cert metrics", func() {
-		Eventually(getMetrics).Should(SatisfyAll(
-			HaveKey("paas_tls_certificates_validity_days"),
+		Eventually(getMetricNames).Should(SatisfyAll(
+			ContainElement("paas_tls_certificates_validity_days"),
 		))
 	})
 })

--- a/tools/metrics/acceptance/tls_test.go
+++ b/tools/metrics/acceptance/tls_test.go
@@ -7,7 +7,7 @@ import (
 
 var _ = Describe("TLS =", func() {
 	It("should return TLS cert metrics", func() {
-		Expect(metricFamilies).To(SatisfyAll(
+		Eventually(getMetrics).Should(SatisfyAll(
 			HaveKey("paas_tls_certificates_validity_days"),
 		))
 	})

--- a/tools/metrics/acceptance/uaa_test.go
+++ b/tools/metrics/acceptance/uaa_test.go
@@ -7,7 +7,7 @@ import (
 
 var _ = Describe("UAA", func() {
 	It("should return UAA user metrics", func() {
-		Expect(metricFamilies).To(SatisfyAll(
+		Eventually(getMetrics).Should(SatisfyAll(
 			HaveKey("paas_uaa_users_count"),
 			HaveKey("paas_uaa_active_users_count"),
 		))

--- a/tools/metrics/acceptance/uaa_test.go
+++ b/tools/metrics/acceptance/uaa_test.go
@@ -7,9 +7,9 @@ import (
 
 var _ = Describe("UAA", func() {
 	It("should return UAA user metrics", func() {
-		Eventually(getMetrics).Should(SatisfyAll(
-			HaveKey("paas_uaa_users_count"),
-			HaveKey("paas_uaa_active_users_count"),
+		Eventually(getMetricNames).Should(SatisfyAll(
+			ContainElement("paas_uaa_users_count"),
+			ContainElement("paas_uaa_active_users_count"),
 		))
 	})
 })


### PR DESCRIPTION
What
----

:one: Our paas-metrics acceptance tests use the `HaveKey` matcher which produces massive test output. We only care about the metric name, so using `ContainElement` produces more readable test output.

:two: Our acceptance tests currently work via getting all the metrics once at the beginning. Taking inspiration from #2455 I refactored the tests to check metrics each time, so that `Eventually` is possible to use within each test.

3️⃣  I cherry picked the commit adding logging from #2455 thanks to @46bit

Why
---

I want to debug why https://deployer.london.cloud.service.gov.uk/teams/main/pipelines/create-cloudfoundry/jobs/deploy-paas-metrics/builds/268 is consistently failing, but it is difficult because the test output will not load on my computer, due to 1️⃣ .

How to review
-------------

Code review

```
git checkout -b eventually-metrics-acceptance origin/eventually-metrics-acceptance
cd tools/metrics/acceptance
PAAS_METRICS_URL=https://paas-metrics.london.cloudapps.digital/metrics ginkgo -v -progress
```

Check [Kibana that logs are getting through](https://kibana.logit.io/s/c7358874-2b30-44a6-8271-554ad3996e50/app/kibana#/discover?_g=()&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:'@source.app_name',negate:!f,type:phrase,value:paas-metrics),query:(match:('@source.app_name':(query:paas-metrics,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:syslog_sd_params.deployment,negate:!f,type:phrase,value:tlwr),query:(match:(syslog_sd_params.deployment:(query:tlwr,type:phrase))))),index:'logstash-*',interval:auto,query:(match_all:()),sort:!('@timestamp',desc)))

---

⚠️ Please do not merge this pull request via the GitHub UI ⚠️
