### PR TITLE
alerts: lock held once must breach for duration

### DIFF
--- a/manifests/prometheus/alerts.d/auctioneer-lock-held-once.yml
+++ b/manifests/prometheus/alerts.d/auctioneer-lock-held-once.yml
@@ -8,6 +8,7 @@
     rules:
       - alert: AuctioneerLockHeldOnce_Critical
         expr: "sum(firehose_value_metric_auctioneer_lock_held) != 1"
+        for: 10m
         labels:
           severity: critical
         annotations:

--- a/manifests/prometheus/alerts.d/bbs-lock-held-once.yml
+++ b/manifests/prometheus/alerts.d/bbs-lock-held-once.yml
@@ -8,6 +8,7 @@
     rules:
       - alert: BbsLockHeldOnce_Critical
         expr: "sum(firehose_value_metric_bbs_lock_held) != 1"
+        for: 10m
         labels:
           severity: critical
         annotations:


### PR DESCRIPTION
What
----

These alerts are noisy

The firehose exporter has a bit of latency built into it, and so if a deployment happens, then the locks always appear held twice, even though a swap has happened

adding a 10m caveat to these alerts will reduce noise and hopefully make us trust these alerts more

For example, the following should not alert us, as it is a deployment happening:
![auctioneer locks held in London](https://user-images.githubusercontent.com/1482692/95188821-e7456000-07c4-11eb-956a-6d4ef3a7f32a.png)

How to review
-------------

Code review

CI

---

⚠️ Please do not merge this pull request via the GitHub UI ⚠️
