### PR TITLE
Link monitoring dashboard alerts count to Grafana not Prometheus

### DIFF
--- a/manifests/prometheus/dashboards.d/user-impact.json
+++ b/manifests/prometheus/dashboards.d/user-impact.json
@@ -670,9 +670,9 @@
                 "interval": null,
                 "links": [{
                     "targetBlank": true,
-                    "title": "https://prometheus-1.__SYSTEM_DNS_ZONE_NAME__/alerts",
+                    "title": "Currently firing alerts",
                     "type": "absolute",
-                    "url": "https://prometheus-1.__SYSTEM_DNS_ZONE_NAME__/alerts"
+                    "url": "https://grafana-1.__SYSTEM_DNS_ZONE_NAME__/explore?left=%5B\"now-24h\",\"now\",\"prometheus\",%7B\"expr\":\"ALERTS%7Balertstate%3D%5C\"firing%5C\",layer%3D%5C\"%5C\",alertname!~%5C\"%5ECFApp.*$%5C\"%7D\",\"format\":\"time_series\",\"instant\":true,\"intervalFactor\":1,\"legendFormat\":null,\"step\":null%7D,%7B\"ui\":%5Btrue,true,true,\"none\"%5D%7D%5D"
                 }],
                 "mappingType": 1,
                 "mappingTypes": [{


### PR DESCRIPTION
What
----

Our monitoring dashboard has a count of the currently firing alerts from Alert
Manager. It is configured to be a link to Prometheus, where one can see which
alerts are firing.

However, getting access to Prometheus is annoying, because it uses basic auth,
and to get those credentials we have to go to Credhub.

Instead, this commit changes the link to point to the same data, but presented
by Grafana. The user will already be logged in to Grafana, so it won't be
annoying.

How to review
-------------

Check the link works

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
