### PR TITLE
sqs: synchronous service binding support

### DIFF
--- a/manifests/cf-manifest/operations.d/760-sqs-broker.yml
+++ b/manifests/cf-manifest/operations.d/760-sqs-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: sqs-broker
-    version: 0.1.8
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/sqs-broker-0.1.8.tgz
-    sha1: 55c741e1c968238cf4c2f03df80e7bfde8f46a75
+    version: 0.0.1602175755
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/sqs-broker-0.0.1602175755.tgz
+    sha1: 83c1dcae33e73c753a31f910f2bbfadc6bba88c4
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-


### PR DESCRIPTION
What
----

Bump sqs service broker to bring in support for synchronous bindings to service instances. (see https://github.com/alphagov/paas-sqs-broker/pull/18).

CloudController does not support creating service-keys via async bindings, and we want to be able to use them. 

How to review
-------------

Branch is deployed to `DEPLOY_ENV=autom8` for your convince.

Try creating an sqs service and an associated service-key

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
