### PR TITLE
Replace deprecated characters in pipelines

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -42,7 +42,7 @@ resources:
       region_name: ((aws_region))
       versioned_file: bosh-vars-store.yml
 
-  - name: bosh-CA-crt
+  - name: bosh-ca-crt
     type: s3-iam
     source:
       bucket: ((state_bucket))
@@ -65,7 +65,7 @@ jobs:
       - get: bosh-vars-store
       - get: paas-cf
       - get: cf-manifest
-      - get: bosh-CA-crt
+      - get: bosh-ca-crt
 
       - task: get-cf-cli-config
         tags: [colocated-with-web]
@@ -123,10 +123,10 @@ jobs:
             - name: delete-timer
             - name: bosh-vars-store
             - name: paas-cf
-            - name: bosh-CA-crt
+            - name: bosh-ca-crt
           params:
             BOSH_ENVIRONMENT: ((bosh_fqdn))
-            BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
+            BOSH_CA_CERT: bosh-ca-crt/bosh-CA.crt
           outputs:
             - name: deployed-healthcheck
           image_resource:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2676,7 +2676,7 @@ jobs:
 
                 ./paas-cf/concourse/scripts/set_quotas_from_manifest.rb cf-manifest/cf-manifest.yml
 
-      - task: enable-diego_docker-feature-flag
+      - task: enable-diego-docker-feature-flag
         tags: [colocated-with-web]
         config:
           platform: linux
@@ -2699,7 +2699,7 @@ jobs:
 
                 cf enable-feature-flag diego_docker
 
-      - task: enable-service_instance_sharing-feature-flag
+      - task: enable-service-instance-sharing-feature-flag
         tags: [colocated-with-web]
         config:
           platform: linux

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -56,7 +56,7 @@ resources:
       region_name: ((aws_region))
       versioned_file: bosh-vars-store.yml
 
-  - name: bosh-CA-crt
+  - name: bosh-ca-crt
     type: s3-iam
     source:
       bucket: ((state_bucket))
@@ -121,7 +121,7 @@ jobs:
           - get: bosh-vars-store
           - get: paas-cf
           - get: cf-manifest
-          - get: bosh-CA-crt
+          - get: bosh-ca-crt
 
       - task: get-cf-cli-config
         tags: [colocated-with-web]
@@ -167,10 +167,10 @@ jobs:
           inputs:
             - name: bosh-vars-store
             - name: paas-cf
-            - name: bosh-CA-crt
+            - name: bosh-ca-crt
           params:
             BOSH_ENVIRONMENT: ((bosh_fqdn))
-            BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
+            BOSH_CA_CERT: bosh-ca-crt/bosh-CA.crt
           outputs:
             - name: deployed-healthcheck
           run:


### PR DESCRIPTION
What
----

Since our latest concourse upgrade we were seeing a lot of illegal character errors, this PR corrects those without changing the underlying cert files 

```
DEPRECATION WARNING:
  - resources.bosh-CA-crt: 'bosh-CA-crt' is not a valid identifier: illegal character 'C'
  - jobs.delete-deployment.plan.do[0].in_parallel.steps[4].get(bosh-CA-crt): 'bosh-CA-crt' is not a valid identifier: illegal character 'C'
identifier schema documentation: https://concourse-ci.org/config-basics.html#schema.identifier
```
```
DEPRECATION WARNING:
  - jobs.post-deploy.plan.do[3].in_parallel.steps[9].task(enable-diego_docker-feature-flag): 'enable-diego_docker-feature-flag' is not a valid identifier: illegal character '_'
  - jobs.post-deploy.plan.do[3].in_parallel.steps[10].task(enable-service_instance_sharing-feature-flag): 'enable-service_instance_sharing-feature-flag' is not a valid identifier: illegal character '_'

identifier schema documentation: https://concourse-ci.org/config-basics.html#schema.identifier
```


How to review
-------------

Code review and deploy to your dev env

Who can review
--------------

Anyone


🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
