### PR TITLE
concourse: create-cloudfoundry has env specific bg

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1,4 +1,7 @@
 ---
+display:
+  background_image: ((background_image_url))
+
 meta:
   resources:
     get-paas-cf: &get-paas-cf

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -70,7 +70,7 @@ fi
 case $DEPLOY_ENV in
 prod-lon)
   # Flag of Greater London
-  BACKGROUND_IMAGE_URL="https://upload.wikimedia.org/wikipedia/commons/2/25/Flag_of_Greater_London.svg"
+  BACKGROUND_IMAGE_URL="https://upload.wikimedia.org/wikipedia/commons/thumb/c/c7/Flag_of_the_City_of_London.svg/2880px-Flag_of_the_City_of_London.svg.png"
   ;;
 prod)
   # Flag of the City of Dublin

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -67,6 +67,25 @@ elif [ "${DEPLOY_ENV}" = "stg-lon" ]; then
   deploy_env_tag_prefix="v[0-9]*" # this matches all tags created by release ci
 fi
 
+case $DEPLOY_ENV in
+prod-lon)
+  # Flag of Greater London
+  BACKGROUND_IMAGE_URL="https://upload.wikimedia.org/wikipedia/commons/2/25/Flag_of_Greater_London.svg"
+  ;;
+prod)
+  # Flag of the City of Dublin
+  BACKGROUND_IMAGE_URL="https://upload.wikimedia.org/wikipedia/commons/thumb/8/8f/IRL_Dublin_flag.svg/1500px-IRL_Dublin_flag.svg.png"
+  ;;
+stg-lon)
+  # The Minack Theatre in Cornwall
+  BACKGROUND_IMAGE_URL="https://upload.wikimedia.org/wikipedia/commons/1/16/Minack_Theatre.jpg"
+  ;;
+*)
+  # A large inflatable duck
+  BACKGROUND_IMAGE_URL="https://si.wsj.net/public/resources/images/BN-EX226_duck_G_20141008024653.jpg"
+  ;;
+esac
+
 generate_vars_file() {
   cat <<EOF
 ---
@@ -109,6 +128,7 @@ monitored_deploy_env: ${MONITORED_DEPLOY_ENV:-}
 deploy_env_tag_prefix: "${deploy_env_tag_prefix}"
 skip_autodelete_await: "${SKIP_AUTODELETE_AWAIT:-false}"
 ca_rotation_expiry_days: "${CA_ROTATION_EXPIRY_DAYS}"
+background_image_url: ${BACKGROUND_IMAGE_URL}
 EOF
   echo -e "pipeline_lock_git_private_key: |\\n  ${git_id_rsa//$'\n'/$'\n'  }"
 }

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -69,15 +69,15 @@ fi
 
 case $DEPLOY_ENV in
 prod-lon)
-  # Flag of Greater London
-  BACKGROUND_IMAGE_URL="https://upload.wikimedia.org/wikipedia/commons/thumb/c/c7/Flag_of_the_City_of_London.svg/2880px-Flag_of_the_City_of_London.svg.png"
+  # London red phone boxes
+  BACKGROUND_IMAGE_URL="https://secretldn.com/wp-content/uploads/2017/02/london-classic-iconic-red-phoneboxes.jpg"
   ;;
 prod)
-  # Flag of the City of Dublin
-  BACKGROUND_IMAGE_URL="https://upload.wikimedia.org/wikipedia/commons/thumb/8/8f/IRL_Dublin_flag.svg/1500px-IRL_Dublin_flag.svg.png"
+  # Irish clover
+  BACKGROUND_IMAGE_URL="https://www.irishcentral.com/uploads/article/20853/cropped_st_patricks_day_shamrocks___getty.jpg?t=1583226320"
   ;;
 stg-lon)
-  # The Minack Theatre in Cornwall
+  # The Minack Theatre stage in Cornwall
   BACKGROUND_IMAGE_URL="https://upload.wikimedia.org/wikipedia/commons/1/16/Minack_Theatre.jpg"
   ;;
 *)


### PR DESCRIPTION
What
----

We need a signed commit to unblock the pipeline, may as well be the one which merges this PR

We also need more ducks, theatres, and regional flags in our lives.

Furthermore, it is nice to visually distinguish identical pipelines environmentally

How to review
-------------

Read the bash

View the pictures

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
