### PR TITLE
Remove alternate time slot from AWS redis update manager

### DIFF
--- a/tools/aws_redis_update_manager/aws_redis_update_manager
+++ b/tools/aws_redis_update_manager/aws_redis_update_manager
@@ -49,14 +49,6 @@ parser = OptionParser.new do |opts|
     options[:maintenance_window_time_range] = r
   end
 
-  opts.on("--alt-maintenance-window-date DATE", "Alternative maintenance window date") do |d|
-    options[:alt_maintenance_window_date] = d
-  end
-
-  opts.on("--alt-maintenance-window-time-range RANGE", "Alternative maintenance window time range") do |r|
-    options[:alt_maintenance_window_time_range] = r
-  end
-
   opts.on("--region REGION", 'Region: ["London", "Ireland"]') do |r|
     options[:region] = r
   end
@@ -90,8 +82,6 @@ when "email", "preview"
 
   abort "Please specify --maintenance-window-date" if options[:maintenance_window_date].nil?
   abort "Please specify --maintenance-window-time-range" if options[:maintenance_window_time_range].nil?
-  abort "Please specify --alt-maintenance-window-date" if options[:alt_maintenance_window_date].nil?
-  abort "Please specify --alt-maintenance-window-time-range" if options[:alt_maintenance_window_time_range].nil?
 
   abort "Please specify --region" if options[:region].nil?
 end
@@ -108,8 +98,6 @@ when "email"
     notify_api_key: options[:notify_api_key],
     maintenance_window_date: options[:maintenance_window_date],
     maintenance_window_time_range: options[:maintenance_window_time_range],
-    alt_maintenance_window_date: options[:alt_maintenance_window_date],
-    alt_maintenance_window_time_range: options[:alt_maintenance_window_time_range],
     region: options[:region],
   )
 when "preview"
@@ -120,8 +108,6 @@ when "preview"
     notify_api_key: options[:notify_api_key],
     maintenance_window_date: options[:maintenance_window_date],
     maintenance_window_time_range: options[:maintenance_window_time_range],
-    alt_maintenance_window_date: options[:alt_maintenance_window_date],
-    alt_maintenance_window_time_range: options[:alt_maintenance_window_time_range],
     region: options[:region],
   )
 when "print"

--- a/tools/aws_redis_update_manager/lib/aws_redis_update_manager.rb
+++ b/tools/aws_redis_update_manager/lib/aws_redis_update_manager.rb
@@ -74,8 +74,6 @@ class AwsRedisUpdateManager
     notify_api_key:,
     maintenance_window_date:,
     maintenance_window_time_range:,
-    alt_maintenance_window_date:,
-    alt_maintenance_window_time_range:,
     region:
   )
     example_service_instance = OpenStruct.new(
@@ -96,8 +94,6 @@ class AwsRedisUpdateManager
       service_instances: [example_service_instance],
       maintenance_window_date: maintenance_window_date,
       maintenance_window_time_range: maintenance_window_time_range,
-      alt_maintenance_window_date: alt_maintenance_window_date,
-      alt_maintenance_window_time_range: alt_maintenance_window_time_range,
       region: region,
     )
 
@@ -108,8 +104,6 @@ class AwsRedisUpdateManager
     notify_api_key:,
     maintenance_window_date:,
     maintenance_window_time_range:,
-    alt_maintenance_window_date:,
-    alt_maintenance_window_time_range:,
     region:
   )
     cf_org_finder = CloudFoundryOrgFinder.new
@@ -134,8 +128,6 @@ class AwsRedisUpdateManager
             service_instances: org_service_instances,
             maintenance_window_date: maintenance_window_date,
             maintenance_window_time_range: maintenance_window_time_range,
-            alt_maintenance_window_date: alt_maintenance_window_date,
-            alt_maintenance_window_time_range: alt_maintenance_window_time_range,
             region: region,
           )
 

--- a/tools/aws_redis_update_manager/lib/tenant_notifier.rb
+++ b/tools/aws_redis_update_manager/lib/tenant_notifier.rb
@@ -56,8 +56,6 @@ class TenantNotifier
 
   # If the timing of the update doesn’t work for you
 
-  We can offer you the alternative time slot of <%= alt_maintenance_window_date %> between <%= alt_maintenance_window_time_range %>.
-
   Please reply to this email to request this alternative slot.
 
   If you have any further questions, please contact GOV.UK PaaS support on gov-uk-paas-support@digital.cabinet-office.gov.uk.
@@ -72,7 +70,6 @@ class TenantNotifier
     org_name:,
     service_instances:,
     maintenance_window_date:, maintenance_window_time_range:,
-    alt_maintenance_window_date:, alt_maintenance_window_time_range:,
     region:
   )
     ERB.new(TEMPLATE).result_with_hash(
@@ -80,8 +77,6 @@ class TenantNotifier
       service_instances: service_instances,
       maintenance_window_date: maintenance_window_date,
       maintenance_window_time_range: maintenance_window_time_range,
-      alt_maintenance_window_date: alt_maintenance_window_date,
-      alt_maintenance_window_time_range: alt_maintenance_window_time_range,
       region: region,
     )
   end
@@ -91,7 +86,6 @@ class TenantNotifier
     org_name:,
     service_instances:,
     maintenance_window_date:, maintenance_window_time_range:,
-    alt_maintenance_window_date:, alt_maintenance_window_time_range:,
     region:
   )
     contents = generate_email_contents(
@@ -99,8 +93,6 @@ class TenantNotifier
       service_instances: service_instances,
       maintenance_window_date: maintenance_window_date,
       maintenance_window_time_range: maintenance_window_time_range,
-      alt_maintenance_window_date: alt_maintenance_window_date,
-      alt_maintenance_window_time_range: alt_maintenance_window_time_range,
       region: region,
     )
 

--- a/tools/aws_redis_update_manager/spec/tenant_notifier_spec.rb
+++ b/tools/aws_redis_update_manager/spec/tenant_notifier_spec.rb
@@ -25,9 +25,6 @@ RSpec.describe TenantNotifier do
   let(:maintenance_window_date) { "2038/01/19" }
   let(:maintenance_window_time_range) { "2000-2100" }
 
-  let(:alt_maintenance_window_date) { "2038/01/19" }
-  let(:alt_maintenance_window_time_range) { "2000-2100" }
-
   context "when generating an email" do
     let(:contents) do
       TenantNotifier.new(notify_api_key).generate_email_contents(
@@ -35,8 +32,6 @@ RSpec.describe TenantNotifier do
         service_instances: service_instances,
         maintenance_window_date: maintenance_window_date,
         maintenance_window_time_range: maintenance_window_time_range,
-        alt_maintenance_window_date: alt_maintenance_window_date,
-        alt_maintenance_window_time_range: alt_maintenance_window_time_range,
         region: "London",
       )
     end
@@ -63,12 +58,6 @@ RSpec.describe TenantNotifier do
       )
     end
 
-    it "includes the alternative maintenance window" do
-      expect(contents).to match(
-        "on #{alt_maintenance_window_date}, between #{alt_maintenance_window_time_range}",
-      )
-    end
-
     it "includes the region" do
       expect(contents).to match(
         "(London)",
@@ -85,8 +74,6 @@ RSpec.describe TenantNotifier do
         service_instances: service_instances,
         maintenance_window_date: maintenance_window_date,
         maintenance_window_time_range: maintenance_window_time_range,
-        alt_maintenance_window_date: alt_maintenance_window_date,
-        alt_maintenance_window_time_range: alt_maintenance_window_time_range,
         region: "London",
       )
     end
@@ -104,8 +91,6 @@ RSpec.describe TenantNotifier do
             service_instances: service_instances,
             maintenance_window_date: maintenance_window_date,
             maintenance_window_time_range: maintenance_window_time_range,
-            alt_maintenance_window_date: alt_maintenance_window_date,
-            alt_maintenance_window_time_range: alt_maintenance_window_time_range,
             region: "London",
           ),
         )),


### PR DESCRIPTION
What
----
Nobody made use of the alternate slot last time, so it seems unnecessary to
publish two. Instead, tenants can email us if the time doesn't suit them, and
we'll work it out.

How to review
-------------
1. Code review
2. Run it in your dev env, with `--action preview`

I've previewed the email in `prod-lon` and confirmed that preview works as intended.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
