### PR TITLE
concourse: do not require passed for overview id

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -98,7 +98,6 @@ meta:
       try:
         do:
           - get: grafana-overview-annotation-id
-            passed: [pipeline-lock]
 
           - put: grafana-overview-annotation
             tags: [colocated-with-web]


### PR DESCRIPTION
What
----

This passed constraint is within a try block and this is causing scheduling issues for the job before tag-release, as such the pipeline is being locked forever

Removing this passed constraint will stop this from occurring, and functionally grafana-overview-annotation-id is protected from multiple writes by the pipeline locking process

How to review
-------------

Be @philandstuff 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
