### PR TITLE
Revert "bump sqs-broker again"

### DIFF
--- a/manifests/cf-manifest/operations.d/760-sqs-broker.yml
+++ b/manifests/cf-manifest/operations.d/760-sqs-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: sqs-broker
-    version: 0.1.10
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/sqs-broker-0.1.10.tgz
-    sha1: 7926e0be89082d2ce10e7ac985b7183c08003bcd
+    version: 0.1.9
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/sqs-broker-0.1.9.tgz
+    sha1: f661e49ce070c626b9c962ea90404a1ed0a9332d
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-


### PR DESCRIPTION
Reverts alphagov/paas-cf#2481

This seemed to break the platform tests with

```
• Failure [1.326 seconds]
SQS broker
/tmp/build/64614f0d/paas-cf/platform-tests/broker-acceptance/sqs_broker_test.go:16
creating an SQS queue
/tmp/build/64614f0d/paas-cf/platform-tests/broker-acceptance/sqs_broker_test.go:36
is accessible from the healthcheck app [It]
/tmp/build/64614f0d/paas-cf/platform-tests/broker-acceptance/sqs_broker_test.go:42
Expected
<int>: 1
to match exit code:
<int>: 0
```