### PR TITLE
cf: scale london to 63 cells

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -2,7 +2,7 @@
 uaa_instances: 3
 nats_instances: 3
 diego_api_instances: 3
-cell_instances: 60
+cell_instances: 63
 router_instances: 6
 api_instances: 12
 doppler_instances: 33


### PR DESCRIPTION
What
----

There was a brief period where our calculations deemed 64 necessary
![chart of cells required over time](https://user-images.githubusercontent.com/1482692/96098221-c4ecca00-0ec9-11eb-9c47-857dd631df65.png)


We are also onboarding new tenants (eg DCS for testing) in London

Increase to 63 from 60 (multiples of 3)

How to review
-------------

Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
