### PR TITLE
isoseg: scale prod-lon isoseg from 0 to 2

### DIFF
--- a/manifests/cf-manifest/isolation-segments/prod-lon/egress-restricted-1.yml
+++ b/manifests/cf-manifest/isolation-segments/prod-lon/egress-restricted-1.yml
@@ -1,5 +1,5 @@
 ---
-number_of_cells: 0
+number_of_cells: 2
 isolation_segment_name: egress-restricted-1
 isolation_segment_size: small
 restricted_egress: true

--- a/manifests/cf-manifest/spec/manifest/isolation_segment_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/isolation_segment_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe "isolation_segments" do
     let(:instance_groups) { manifest.fetch("instance_groups") }
     let(:segs) { instance_groups.select { |i| i["name"] =~ /diego-cell-iso/ } }
 
-    %w[prod prod-lon stg-lon].each do |env|
+    %w[prod stg-lon].each do |env|
       describe env do
         let(:manifest) { manifest_for_env(env) }
 
@@ -266,6 +266,17 @@ RSpec.describe "isolation_segments" do
           expect(seg["instances"]).to eq(0)
           expect(seg["jobs"].find { |j| j["name"] == "coredns" }).not_to be_nil
         end
+      end
+    end
+
+    describe "prod-lon" do
+      let(:manifest) { manifest_for_env("prod-lon") }
+
+      it "contains an non-empty egress restricted isolation segment" do
+        expect(segs.count).to eq(1)
+        seg = segs.first
+        expect(seg["instances"]).to eq(2)
+        expect(seg["jobs"].find { |j| j["name"] == "coredns" }).not_to be_nil
       end
     end
   end


### PR DESCRIPTION
What
----

Egress restricted isolation segment for DCS to test in

Scaled to two, so draining during deployments can happen without stopping apps manually
_(which would have to happen if there was only 1 cell)_

How to review
-------------

Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
