### PR TITLE
[#174804724] Add a Grafana dashboard to track service usage by type

### DIFF
--- a/manifests/prometheus/dashboards.d/service-type-adoption.json
+++ b/manifests/prometheus/dashboards.d/service-type-adoption.json
@@ -1,0 +1,504 @@
+{
+  "dashboard": {
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "id": null,
+    "iteration": 1600956584994,
+    "links": [],
+    "panels": [
+      {
+        "content": "# Service type adoption dashboard\n\nUse the service type dropdown to choose which service(s) to see.\n\n## The visualisations\nEvery service type has the same 3 visualisations:\n\n1. 7 day change - the number of provisioned service instances compared to 7 days ago\n2. 30 day change -  the number of provisioned service instances compared to 30 days ago\n3. daily change - chart plotting the average, min, and max serivce instances per day over the last 7 days. \n\n",
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 143,
+        "links": [],
+        "mode": "markdown",
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Explainer",
+        "type": "text"
+      },
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 7
+        },
+        "id": 6,
+        "panels": [],
+        "repeat": "service_type",
+        "scopedVars": {
+          "service_type": {
+            "selected": true,
+            "text": "influxdb",
+            "value": "influxdb"
+          }
+        },
+        "title": "$service_type",
+        "type": "row"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": false,
+        "colors": [
+          "#299c46",
+          "rgba(237, 129, 40, 0.89)",
+          "#d44a3a"
+        ],
+        "format": "none",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 12,
+          "x": 0,
+          "y": 8
+        },
+        "id": 4,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "postfix": "",
+        "postfixFontSize": "50%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "scopedVars": {
+          "service_type": {
+            "selected": true,
+            "text": "influxdb",
+            "value": "influxdb"
+          }
+        },
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": false,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": false
+        },
+        "tableColumn": "",
+        "targets": [
+          {
+            "expr": "floor(sum(avg_over_time(paas_op_services_provisioned_count{type=\"${service_type}\"}[1d]))) - floor(sum(avg_over_time(paas_op_services_provisioned_count{type=\"${service_type}\"}[1d] offset 7d)))",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "refId": "A"
+          }
+        ],
+        "thresholds": "",
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "${service_type} 7 day change",
+        "type": "singlestat",
+        "valueFontSize": "80%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "current"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": false,
+        "colors": [
+          "#299c46",
+          "rgba(237, 129, 40, 0.89)",
+          "#d44a3a"
+        ],
+        "format": "none",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 8
+        },
+        "id": 86,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "postfix": "",
+        "postfixFontSize": "50%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "scopedVars": {
+          "service_type": {
+            "selected": true,
+            "text": "influxdb",
+            "value": "influxdb"
+          }
+        },
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": false,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": false
+        },
+        "tableColumn": "",
+        "targets": [
+          {
+            "expr": "sum(paas_op_services_provisioned_count{type=\"${service_type}\"})",
+            "format": "time_series",
+            "instant": false,
+            "intervalFactor": 1,
+            "refId": "A"
+          }
+        ],
+        "thresholds": "",
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Current # of ${service_type} service instances",
+        "type": "singlestat",
+        "valueFontSize": "80%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "current"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": false,
+        "colors": [
+          "#299c46",
+          "rgba(237, 129, 40, 0.89)",
+          "#d44a3a"
+        ],
+        "format": "none",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 12,
+          "x": 0,
+          "y": 12
+        },
+        "id": 40,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "postfix": "",
+        "postfixFontSize": "50%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "scopedVars": {
+          "service_type": {
+            "selected": true,
+            "text": "influxdb",
+            "value": "influxdb"
+          }
+        },
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": false,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": false
+        },
+        "tableColumn": "",
+        "targets": [
+          {
+            "expr": "floor(sum(avg_over_time(paas_op_services_provisioned_count{type=\"${service_type}\"}[1d]))) - floor(sum(avg_over_time(paas_op_services_provisioned_count{type=\"${service_type}\"}[1d] offset 30d)))",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "refId": "A"
+          }
+        ],
+        "thresholds": "",
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "${service_type} 30 day change",
+        "type": "singlestat",
+        "valueFontSize": "80%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "current"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "description": "The average number shows steady, ongoing usage.\n\nMinimums and maximums show activity within a day (e.g. people playing with a backing service, or using it in an ephemeral way)",
+        "fill": 1,
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 16
+        },
+        "id": 2,
+        "interval": "1d",
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "percentage": false,
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "scopedVars": {
+          "service_type": {
+            "selected": true,
+            "text": "influxdb",
+            "value": "influxdb"
+          }
+        },
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "label_replace(\n  sum(floor(avg_over_time(paas_op_services_provisioned_count{type=\"${service_type}\"}[1d]))),\n  \"type\",\n  \"${service_type}\",\n  \"\",\n  \"\"\n)",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "Average {{type}} service instances",
+            "refId": "A"
+          },
+          {
+            "expr": "label_replace(\n  sum(min_over_time(paas_op_services_provisioned_count{type=\"${service_type}\"}[1d])),\n  \"type\",\n  \"${service_type}\",\n  \"\",\n  \"\"\n)",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "Minimum {{type}} service instances",
+            "refId": "B"
+          },
+          {
+            "expr": "label_replace(\n  sum(max_over_time(paas_op_services_provisioned_count{type=\"${service_type}\"}[1d])),\n  \"type\",\n  \"${service_type}\",\n  \"\",\n  \"\"\n)",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "Maximum {{type}} service instances",
+            "refId": "C"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "daily change in ${service_type} service instances",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": "# service instances",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      }
+    ],
+    "refresh": false,
+    "schemaVersion": 18,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "allValue": null,
+          "current": {
+            "selected": false,
+            "text": "influxdb",
+            "value": "influxdb"
+          },
+          "datasource": "prometheus",
+          "definition": "label_values(paas_op_services_provisioned_count, type)",
+          "hide": 0,
+          "includeAll": true,
+          "label": "Service type",
+          "multi": true,
+          "name": "service_type",
+          "options": [],
+          "query": "label_values(paas_op_services_provisioned_count, type)",
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        }
+      ]
+    },
+    "time": {
+      "from": "now-7d",
+      "to": "now"
+    },
+    "timepicker": {
+      "hidden": true,
+      "nowDelay": "30d",
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "UTC",
+    "title": "Service type adoption - __DEPLOY_ENV__",
+    "uid": "paas-service-type-adoption"
+  },
+  "folderId": 0,
+  "overwrite": true
+}


### PR DESCRIPTION


What
----

Adds a Grafana dashboard to track service usage by type

The dashboard shows each of the following for each type of service on the
platform:
+ 7 day change
+ 30 day change
+ daily usage (min, max, average service instances)

How to review
-------------
Deploy this branch and check the dashboard exists in Grafana.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
