### PR TITLE
Improve error message when not on the VPN

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -33,10 +33,18 @@ success() {
 
 check_aws_account_used() {
   required_account="${1}"
-  account_alias=$(aws iam list-account-aliases | grep gov-paas | tr -d '" ')
+  account_alias=$(aws iam list-account-aliases)
+  aws_exit_status=$?
+  if [ $aws_exit_status -ne 0 ]; then
+    echo
+    echo "Error talking to the AWS API. Check that you're using the VPN."
+    exit 1
+  fi
 
-  if [[ "${account_alias}" != "gov-paas-${required_account}" ]]; then
-    echo "Required AWS account is ${required_account}, but your aws-cli is using keys for ${account_alias}"
+  account_alias_name=$(echo "${account_alias}" | grep gov-paas | tr -d '" ')
+  if [[ "${account_alias_name}" != "gov-paas-${required_account}" ]]; then
+    echo
+    echo "Required AWS account is ${required_account}, but your aws-cli is using keys for ${account_alias_name}"
     exit 1
   fi
 }


### PR DESCRIPTION
What
----

Until now, running commands such as `make dev pipelines` when not on the VPN resulted in an awful and incorrect error:

```
An error occurred (AccessDenied) when calling the ListAccountAliases operation: User: arn:aws:sts::_____:assumed-role/____________/______ is not authorized to perform: iam:ListAccountAliases on resource: * with an explicit deny
Required AWS account is dev, but your aws-cli is using keys for
Makefile:16: recipe for target 'check-env' failed
make: *** [check-env] Error 1
```

This commit adds a check that detects when the AWS API call fails, and warns about that. It also suggests users check they are on the VPN:

```
An error occurred (AccessDenied) when calling the ListAccountAliases operation: User: arn:aws:sts::_____:assumed-   is not authorized to perform: iam:ListAccountAliases on resource: *  with an explicit deny

Error talking to the AWS API. Check that you're using the VPN.
make: *** [check-env] Error 1
```

This should stop users (including me!) getting hopelessly confused. I also slightly improved the original error message, which happens when using the wrong credentials (rare since we introduced `aws-vault` and the GDS CLI.)

How to review
-------------

* Code review
* I've tested the various error cases of this; feel free to check yourself if you like
* There isn't an equivalent problem in `paas-bootstrap` as far as I can tell

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
