### PR TITLE
cf: scale london gorouters from 6 to 15

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -3,7 +3,7 @@ uaa_instances: 3
 nats_instances: 3
 diego_api_instances: 3
 cell_instances: 63
-router_instances: 6
+router_instances: 9
 api_instances: 12
 doppler_instances: 33
 log_api_instances: 6

--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -3,7 +3,7 @@ uaa_instances: 3
 nats_instances: 3
 diego_api_instances: 3
 cell_instances: 63
-router_instances: 9
+router_instances: 15
 api_instances: 12
 doppler_instances: 33
 log_api_instances: 6


### PR DESCRIPTION
What
----

CPU pegged during tenant load test (GDS VPS) which caused 5xxs across
the whole platform: we need more gorouters during high load

![gorouter process cpu usage](https://user-images.githubusercontent.com/1482692/96288303-1a64cc00-0fdb-11eb-8b08-4a956d7c91b6.png)

My interpretation of this chart is that something (it may not necessarily be CPU) is constrained during high periods of load, I believe that horizontally scaling will alleviate this problem

BOSH processes additionally have CPU limits

How to review
-------------

Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
