### PR TITLE
Allow to pass a default into get_secrets

### DIFF
--- a/scripts/upload-secrets/upload-mailchimp-secrets.rb
+++ b/scripts/upload-secrets/upload-mailchimp-secrets.rb
@@ -13,7 +13,7 @@ credhub_namespaces = [
   "/#{deploy_env}/#{deploy_env}",
 ]
 
-mailchimp_api_key = ENV["MAILCHIMP_API_KEY"] || get_secret("mailchimp/#{ENV['MAKEFILE_ENV_TARGET']}/api_key") || "__NO_MAILCHIMP_API_KEY__"
+mailchimp_api_key = ENV["MAILCHIMP_API_KEY"] || get_secret("mailchimp/#{ENV['MAKEFILE_ENV_TARGET']}/api_key", "__NO_MAILCHIMP_API_KEY__")
 
 upload_secrets(
   credhub_namespaces,

--- a/scripts/upload-secrets/upload_secrets.rb
+++ b/scripts/upload-secrets/upload_secrets.rb
@@ -8,10 +8,13 @@ require "English"
 require "yaml"
 require "tempfile"
 
-def get_secret(path)
+def get_secret(path, default = nil)
   out = `pass "#{path}"`
-  abort out unless $CHILD_STATUS.success?
-  out
+
+  return out if $CHILD_STATUS.success?
+  return default.to_s unless default.nil?
+
+  abort out
 end
 
 def upload_secrets(credhub_namespaces, secrets)


### PR DESCRIPTION
What
----
Add an optional argument to the `get_secrets` function in order to pass a default (dummy) value to be used if the lookup in `paas-credentials` fails. Also set a dummy Mailchimp API key via this new route.

Why 
----
Some secrets, such as the Mailchimp API key, are only required in prod, but we still need to set a dummy value in staging and dev environments as it is expected to be non-nil during deployment/execution.

How to review
-------------
- Code review
- Check out the branch, run `CREDHUB (DEPLOY_ENV) $ make dev upload-all-secrets` and make sure it works as expected

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
