### PR TITLE
Ignore account notification events in AWS health metrics

### DIFF
--- a/tools/metrics/pkg/health/service.go
+++ b/tools/metrics/pkg/health/service.go
@@ -27,6 +27,11 @@ func (hs HealthService) CountOpenEventsForServiceInRegion(service string, region
 			Regions: []*string {
 				aws.String(region),
 			},
+			EventTypeCategories: []*string {
+				aws.String(awshealth.EventTypeCategoryInvestigation),
+				aws.String(awshealth.EventTypeCategoryIssue),
+				aws.String(awshealth.EventTypeCategoryScheduledChange),
+			},
 		},
 		// We don't really expect there to be >100
 		// open events for a single service.


### PR DESCRIPTION
What
----
Account notification events appear to be for long running things like
deprecations or other AWS service changes. We don't really want these to be
appearing in our alerts, because they're going to be long running and noisy.

We care about short term, service impacting events.

How to review
-------------

1. See if you agree with the change in principal
2. Code review
3. [See if I haven't included an event category that I should have](https://docs.aws.amazon.com/health/latest/APIReference/API_EventFilter.html#AWSHealth-Type-EventFilter-eventTypeCategories)

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
