### PR TITLE
[#175232600] Clarify just how "free" service plans are

### DIFF
--- a/config/service-brokers/aiven/config.json
+++ b/config/service-brokers/aiven/config.json
@@ -30,7 +30,7 @@
             "name": "tiny-6.x",
             "aiven_plan": "startup-4",
             "elasticsearch_version": "6",
-            "description": "NOT Highly Available, 1 dedicated VM, 1 CPU per VM, 4GB RAM per VM, 80GB disk space.",
+            "description": "NOT Highly Available, 1 dedicated VM, 1 CPU per VM, 4GB RAM per VM, 80GB disk space. Free for trial orgs. Costs for billable orgs.",
             "free": true,
             "metadata": {
               "displayName": "Tiny",
@@ -136,7 +136,7 @@
             "name": "tiny-7.x",
             "aiven_plan": "startup-4",
             "elasticsearch_version": "7",
-            "description": "NOT Highly Available, 1 dedicated VM, 1 CPU per VM, 4GB RAM per VM, 80GB disk space.",
+            "description": "NOT Highly Available, 1 dedicated VM, 1 CPU per VM, 4GB RAM per VM, 80GB disk space. Free for trial orgs. Costs for billable orgs.",
             "free": true,
             "metadata": {
               "displayName": "Tiny",
@@ -269,7 +269,7 @@
             "id": "f636ed93-3354-4173-b8bd-031f54866528",
             "name": "tiny-1.x",
             "aiven_plan": "startup-4",
-            "description": "NOT Highly Available, 1 dedicated VM, 2 CPU per VM, 4GB RAM per VM, 16GB disk space.",
+            "description": "NOT Highly Available, 1 dedicated VM, 2 CPU per VM, 4GB RAM per VM, 16GB disk space. Free for trial orgs. Costs for billable orgs.",
             "free": true,
             "metadata": {
               "displayName": "Tiny",

--- a/manifests/cf-manifest/operations.d/711-rds-broker-postgres95-plans.yml
+++ b/manifests/cf-manifest/operations.d/711-rds-broker-postgres95-plans.yml
@@ -120,7 +120,7 @@
   value:
     id: "5f2eec8a-0cad-4ab9-b81e-d6adade2fd42"
     name: "tiny-unencrypted-9.5"
-    description: "5GB Storage, NOT BACKED UP, Dedicated Instance, Max 50 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t2.micro."
+    description: "5GB Storage, NOT BACKED UP, Dedicated Instance, Max 50 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t2.micro. Free for trial orgs. Costs for billable orgs."
     free: true
     metadata:
       AdditionalMetadata:

--- a/manifests/cf-manifest/operations.d/712-rds-broker-mysql57-plans.yml
+++ b/manifests/cf-manifest/operations.d/712-rds-broker-mysql57-plans.yml
@@ -64,7 +64,7 @@
   value:
     id: 69977068-8ef5-4172-bfdb-e8cea3c14d01
     name: "tiny-unencrypted-5.7"
-    description: "5GB Storage, NOT BACKED UP, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.t2.micro."
+    description: "5GB Storage, NOT BACKED UP, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.t2.micro. Free for trial orgs. Costs for billable orgs."
     free: true
     metadata:
       AdditionalMetadata:

--- a/manifests/cf-manifest/operations.d/713-rds-broker-mysql57-plans-high-iops.yml
+++ b/manifests/cf-manifest/operations.d/713-rds-broker-mysql57-plans-high-iops.yml
@@ -41,7 +41,7 @@
   value:
     id: "6edc74d2-7eec-41bc-a0be-ae69c4e1cebb"
     name: "tiny-unencrypted-5.7-high-iops"
-    description: "25GB Storage, NOT BACKED UP, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.t3.micro."
+    description: "25GB Storage, NOT BACKED UP, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.t3.micro. Free for trial orgs. Costs for billable orgs."
     free: true
     metadata:
       AdditionalMetadata:

--- a/manifests/cf-manifest/operations.d/714-rds-broker-postgres10-high-iops-plans.yml
+++ b/manifests/cf-manifest/operations.d/714-rds-broker-postgres10-high-iops-plans.yml
@@ -103,7 +103,7 @@
   value:
     id: "c07ac6bb-8b26-4a08-b8db-9618d9f5f852"
     name: "tiny-unencrypted-10-high-iops"
-    description: "25GB Storage, NOT BACKED UP, Dedicated Instance, Max 50 Concurrent Connections. Postgres Version 10. DB Instance Class: db.t3.micro."
+    description: "25GB Storage, NOT BACKED UP, Dedicated Instance, Max 50 Concurrent Connections. Postgres Version 10. DB Instance Class: db.t3.micro. Free for trial orgs. Costs for billable orgs."
     free: true
     metadata:
       AdditionalMetadata:

--- a/manifests/cf-manifest/operations.d/715-rds-broker-postgres10-plans.yml
+++ b/manifests/cf-manifest/operations.d/715-rds-broker-postgres10-plans.yml
@@ -103,7 +103,7 @@
   value:
     id: "11f779fa-425c-4c86-9530-d0aebcb3c3e6"
     name: "tiny-unencrypted-10"
-    description: "5GB Storage, NOT BACKED UP, Dedicated Instance, Max 50 Concurrent Connections. Postgres Version 10. DB Instance Class: db.t2.micro."
+    description: "5GB Storage, NOT BACKED UP, Dedicated Instance, Max 50 Concurrent Connections. Postgres Version 10. DB Instance Class: db.t2.micro. Free for trial orgs. Costs for billable orgs."
     free: true
     metadata:
       AdditionalMetadata:

--- a/manifests/cf-manifest/operations.d/716-rds-broker-postgres11-plans.yml
+++ b/manifests/cf-manifest/operations.d/716-rds-broker-postgres11-plans.yml
@@ -103,7 +103,7 @@
   value:
     id: "9adbd87b-1ce8-4f9b-8562-b57041988fbe"
     name: "tiny-unencrypted-11"
-    description: "5GB Storage, NOT BACKED UP, Dedicated Instance, Max 50 Concurrent Connections. Postgres Version 11. DB Instance Class: db.t3.micro."
+    description: "5GB Storage, NOT BACKED UP, Dedicated Instance, Max 50 Concurrent Connections. Postgres Version 11. DB Instance Class: db.t3.micro. Free for trial orgs. Costs for billable orgs."
     free: true
     metadata:
       AdditionalMetadata:

--- a/manifests/cf-manifest/operations.d/717-rds-broker-postgres11-high-iops-plans.yml
+++ b/manifests/cf-manifest/operations.d/717-rds-broker-postgres11-high-iops-plans.yml
@@ -103,7 +103,7 @@
   value:
     id: "380ab966-d810-48e8-bc30-e008b51191cb"
     name: "tiny-unencrypted-11-high-iops"
-    description: "25GB Storage, NOT BACKED UP, Dedicated Instance, Max 50 Concurrent Connections. Postgres Version 11. DB Instance Class: db.t3.micro."
+    description: "25GB Storage, NOT BACKED UP, Dedicated Instance, Max 50 Concurrent Connections. Postgres Version 11. DB Instance Class: db.t3.micro. Free for trial orgs. Costs for billable orgs."
     free: true
     metadata:
       AdditionalMetadata:

--- a/manifests/cf-manifest/operations.d/718-rds-broker-mysql80-plans.yml
+++ b/manifests/cf-manifest/operations.d/718-rds-broker-mysql80-plans.yml
@@ -41,7 +41,7 @@
   value:
     id: 821e5039-2dde-433c-95ec-db998fdad7fd
     name: "tiny-unencrypted-8.0"
-    description: "5GB Storage, NOT BACKED UP, Dedicated Instance. MySQL Version 8.0. DB Instance Class: db.t3.micro."
+    description: "5GB Storage, NOT BACKED UP, Dedicated Instance. MySQL Version 8.0. DB Instance Class: db.t3.micro.  Free for trial orgs. Costs for billable orgs."
     free: true
     metadata:
       AdditionalMetadata:

--- a/manifests/cf-manifest/operations.d/719-rds-broker-mysql80-plans-high-iops.yml
+++ b/manifests/cf-manifest/operations.d/719-rds-broker-mysql80-plans-high-iops.yml
@@ -41,7 +41,7 @@
   value:
     id: "ccaaa0db-ca47-41ec-a2f6-3230544987f5"
     name: "tiny-unencrypted-8.0-high-iops"
-    description: "25GB Storage, NOT BACKED UP, Dedicated Instance. MySQL Version 8.0. DB Instance Class: db.t3.micro."
+    description: "25GB Storage, NOT BACKED UP, Dedicated Instance. MySQL Version 8.0. DB Instance Class: db.t3.micro. Free for trial orgs. Costs for billable orgs."
     free: true
     metadata:
       AdditionalMetadata:

--- a/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
+++ b/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
@@ -133,7 +133,7 @@
                     # 3.2
                     - id: c84d1bef-9500-4ce9-88b2-c0bd421bbf8a
                       name: tiny-3.2
-                      description: 568MB RAM, single node, no failover, daily backups (for instances created after 21/1/2019)
+                      description: "568MB RAM, single node, no failover, daily backups (for instances created after 21/1/2019). Free for trial orgs. Costs for billable orgs."
                       free: true
                       metadata:
                         displayName: Tiny
@@ -191,7 +191,7 @@
                     # 4.x
                     - id: b78c9d07-a031-495f-937c-28613905431c
                       name: tiny-4.x
-                      description: 568MB RAM, single node, no failover, daily backups (for instances created after 21/1/2019)
+                      description: "568MB RAM, single node, no failover, daily backups (for instances created after 21/1/2019). Free for trial orgs. Costs for billable orgs."
                       free: true
                       metadata:
                         displayName: Tiny
@@ -277,7 +277,7 @@
                     # 5.x
                     - id: 1f2cccd7-d9a9-4b9a-b517-73b381848b73
                       name: tiny-5.x
-                      description: 568MB RAM, single node, no failover, daily backups (for instances created after 21/1/2019)
+                      description: "568MB RAM, single node, no failover, daily backups (for instances created after 21/1/2019). Free for trial orgs. Costs for billable orgs."
                       free: true
                       metadata:
                         displayName: Tiny

--- a/manifests/cf-manifest/operations.d/750-s3-broker.yml
+++ b/manifests/cf-manifest/operations.d/750-s3-broker.yml
@@ -72,7 +72,7 @@
                   plans:
                     - id: 24efab31-8cbd-47c0-8513-a9345f3c512b
                       name: default
-                      description: A single S3 bucket
+                      description: "A single S3 bucket. Free for trial orgs. Costs for billable orgs."
                       free: true
                       metadata:
                         displayName: Default

--- a/manifests/cf-manifest/operations.d/760-sqs-broker.yml
+++ b/manifests/cf-manifest/operations.d/760-sqs-broker.yml
@@ -73,7 +73,7 @@
                   plans:
                     - id: 8ff216b8-afed-4833-a265-cd1f2feb919d
                       name: standard
-                      description: A standard SQS queue
+                      description: "A standard SQS queue. Free for trial orgs. Costs for billable orgs."
                       free: true
                       metadata:
                         displayName: Standard
@@ -82,7 +82,7 @@
 
                     - id: ac129e8a-6423-4792-aa0c-3a192408b3da
                       name: fifo
-                      description: A FIFO (first-in-first-out) SQS queue
+                      description: "A FIFO (first-in-first-out) SQS queue. Free for trial orgs. Costs for billable orgs."
                       free: true
                       metadata:
                         displayName: FIFO


### PR DESCRIPTION
What
----

Service plans have a boolean property `free` which tells CloudFoundry if the
plan is available to trial orgs. Unfortunately, `cf marketplace -e SERVICE`
says "free" whenever that property is true. That's a bit misleading for
billable orgs, who DO have to pay for it.

We don't have influence over the format of the `cf marketplace` command, so
instead of correcting it be more nuanced, we introduce a clarifying statement
in the description of the "free" plans.

How to review
-------------

1. Check you agree with the message.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
