### PR TITLE
Increase ireland routers by 50%

### DIFF
--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -3,7 +3,7 @@ uaa_instances: 3
 nats_instances: 3
 diego_api_instances: 3
 cell_instances: 36
-router_instances: 12
+router_instances: 18
 api_instances: 6
 doppler_instances: 33
 log_api_instances: 6


### PR DESCRIPTION
What
----

A tenant in Ireland is doing some load testing and may be seeing a little noisy neighbouring. This commit increases our routers by 50% which should firmly prevent that happening.

We've already decided to actually benchmark our routing, so soon this should happen based on data rather than intuition.

How to review
-------------

* Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
