### PR TITLE
Timeout on deleting admin users after 5 minutes

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -3135,6 +3135,7 @@ jobs:
           task: remove-temp-user
           tags: [colocated-with-web]
           file: paas-cf/concourse/tasks/delete_admin.yml
+          timeout: 5m
           params:
             API_ENDPOINT: ((api_endpoint))
             CF_ADMIN: ((cf_admin))
@@ -3199,6 +3200,7 @@ jobs:
             task: remove-temp-user
             tags: [colocated-with-web]
             file: paas-cf/concourse/tasks/delete_admin.yml
+            timeout: 5m
             params:
               DISABLE_ADMIN_USER_CREATION: ((disable_cf_acceptance_tests))
               API_ENDPOINT: ((api_endpoint))
@@ -3309,6 +3311,7 @@ jobs:
           task: remove-temp-user
           tags: [colocated-with-web]
           file: paas-cf/concourse/tasks/delete_admin.yml
+          timeout: 5m
           params:
             DISABLE_ADMIN_USER_CREATION: ((disable_custom_acceptance_tests))
             API_ENDPOINT: ((api_endpoint))
@@ -3369,6 +3372,7 @@ jobs:
           task: remove-temp-user
           tags: [colocated-with-web]
           file: paas-cf/concourse/tasks/delete_admin.yml
+          timeout: 5m
           params:
             DISABLE_ADMIN_USER_CREATION: ((disable_custom_acceptance_tests))
             API_ENDPOINT: ((api_endpoint))
@@ -3460,6 +3464,7 @@ jobs:
           task: remove-temp-user
           tags: [colocated-with-web]
           file: paas-cf/concourse/tasks/delete_admin.yml
+          timeout: 5m
           params:
             DISABLE_ADMIN_USER_CREATION: ((disable_custom_acceptance_tests))
             API_ENDPOINT: ((api_endpoint))
@@ -3858,6 +3863,7 @@ jobs:
           task: remove-temp-user
           tags: [colocated-with-web]
           file: paas-cf/concourse/tasks/delete_admin.yml
+          timeout: 5m
           params:
             API_ENDPOINT: ((api_endpoint))
             CF_ADMIN: ((cf_admin))
@@ -4434,6 +4440,7 @@ jobs:
           task: remove-temp-user
           tags: [colocated-with-web]
           file: paas-cf/concourse/tasks/delete_admin.yml
+          timeout: 5m
           params:
             DISABLE_ADMIN_USER_CREATION: ((disable_custom_acceptance_tests))
             API_ENDPOINT: ((api_endpoint))
@@ -5174,6 +5181,7 @@ jobs:
             - task: remove-temp-user
               tags: [colocated-with-web]
               file: paas-cf/concourse/tasks/delete_admin.yml
+              timeout: 5m
               params:
                 API_ENDPOINT: ((api_endpoint))
                 CF_ADMIN: ((cf_admin))
@@ -5237,6 +5245,7 @@ jobs:
             - task: remove-temp-user
               tags: [colocated-with-web]
               file: paas-cf/concourse/tasks/delete_admin.yml
+              timeout: 5m
               params:
                 API_ENDPOINT: ((api_endpoint))
                 CF_ADMIN: ((cf_admin))


### PR DESCRIPTION
What
----

Many of our automated tasks create temporary admin users. They are
temporary by two mechanisms:

1) the password is discarded as soon as the task finishes
2) the user is deleted before the task finishes

Recently we have seen at least one occasion where deleting the admin
user froze for more than 6 hours. `cf delete-user -f` seemed to just
freeze. Having looked at the source code I'm not sure why.

This commit makes deleting the admin user optional. It will time out after 5 minutes. The task should still fail, giving us some notice of the problem, but users will be left behind.

This is even more OK because we still remove the admin permissions from users that are left behind. When we do a deploy, the `sync-admin-users` step of the `post-deploy` job removes admin from any unexpected user that is more than an hour old [1].

[1] https://deployer.cloud.service.gov.uk/teams/main/pipelines/create-cloudfoundry/jobs/post-deploy/builds/286 is an example of this. It deleted a temporary admin left behind by https://deployer.cloud.service.gov.uk/teams/main/pipelines/create-cloudfoundry/jobs/continuous-billing-smoke-tests/builds/19015

How to review
-------------

- Read my excessively long explanation above
- Check this matches the docs https://concourse-ci.org/jobs.html#schema.step.timeout
- Think about it
- Thank you

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
