### PR TITLE
Remove ElasticSearch version 6 from our offering

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1648,7 +1648,6 @@ jobs:
                 UAA_ADMIN_CLIENT_SECRET=$(credhub get -q -n "${BOSH_NS}/uaa_admin_client_secret")
                 UAA_CLIENTS_PAAS_ADMIN_SECRET=$(credhub get -q -n "${BOSH_NS}/uaa_clients_paas_admin_secret")
                 UAA_CLIENTS_PAAS_AUDITOR_SECRET=$(credhub get -q -n "${BOSH_NS}/secrets_uaa_clients_paas_auditor_secret")
-                UAA_CLIENTS_PAAS_VAULT_PLUGIN_SECRET=$(credhub get -q -n "${BOSH_NS}/secrets_uaa_clients_paas_vault_plugin_secret")
                 UAA_CLIENTS_PAAS_PROMETHEUS_ENDPOINTS_SECRET=$(credhub get -q -n "${BOSH_NS}/secrets_uaa_clients_paas_prometheus_endpoints_secret")
                 SECRETS_TEST_USER_PASSWORD=$(credhub get -q -n "${BOSH_NS}/secrets_test_user_password")
                 CUSTOM_BROKER_ACCEPTANCE_PROMETHEUS_PASSWORD=$(credhub get -q -n "${BOSH_NS}/custom_broker_acceptance_prometheus_password")
@@ -4809,7 +4808,6 @@ jobs:
               credhub generate -n "${BOSH_NS}/secrets_uaa_clients_login_secret" -t password
               credhub generate -n "${BOSH_NS}/secrets_uaa_clients_notifications_secret" -t password
               credhub generate -n "${BOSH_NS}/secrets_uaa_clients_paas_auditor_secret" -t password
-              credhub generate -n "${BOSH_NS}/secrets_uaa_clients_paas_vault_plugin_secret" -t password
               credhub generate -n "${BOSH_NS}/secrets_uaa_clients_paas_billing_secret" -t password
               credhub generate -n "${BOSH_NS}/secrets_uaa_clients_paas_metrics_secret" -t password
               credhub generate -n "${BOSH_NS}/secrets_uaa_clients_paas_prometheus_endpoints_secret" -t password

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -4396,6 +4396,15 @@ jobs:
 
                 cf enable-service-access elasticsearch -b aiven-broker
 
+                # Disable deprecated plans
+                cat <<EOF | xargs -n1 cf disable-service-access elasticsearch -p
+                tiny-6.x
+                small-ha-6.x
+                medium-ha-6.x
+                large-ha-6.x
+                xlarge-ha-6.x
+                EOF
+
                 cf enable-service-access influxdb -b aiven-broker
 
       - do:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1648,6 +1648,7 @@ jobs:
                 UAA_ADMIN_CLIENT_SECRET=$(credhub get -q -n "${BOSH_NS}/uaa_admin_client_secret")
                 UAA_CLIENTS_PAAS_ADMIN_SECRET=$(credhub get -q -n "${BOSH_NS}/uaa_clients_paas_admin_secret")
                 UAA_CLIENTS_PAAS_AUDITOR_SECRET=$(credhub get -q -n "${BOSH_NS}/secrets_uaa_clients_paas_auditor_secret")
+                UAA_CLIENTS_PAAS_VAULT_PLUGIN_SECRET=$(credhub get -q -n "${BOSH_NS}/secrets_uaa_clients_paas_vault_plugin_secret")
                 UAA_CLIENTS_PAAS_PROMETHEUS_ENDPOINTS_SECRET=$(credhub get -q -n "${BOSH_NS}/secrets_uaa_clients_paas_prometheus_endpoints_secret")
                 SECRETS_TEST_USER_PASSWORD=$(credhub get -q -n "${BOSH_NS}/secrets_test_user_password")
                 CUSTOM_BROKER_ACCEPTANCE_PROMETHEUS_PASSWORD=$(credhub get -q -n "${BOSH_NS}/custom_broker_acceptance_prometheus_password")
@@ -4799,6 +4800,7 @@ jobs:
               credhub generate -n "${BOSH_NS}/secrets_uaa_clients_login_secret" -t password
               credhub generate -n "${BOSH_NS}/secrets_uaa_clients_notifications_secret" -t password
               credhub generate -n "${BOSH_NS}/secrets_uaa_clients_paas_auditor_secret" -t password
+              credhub generate -n "${BOSH_NS}/secrets_uaa_clients_paas_vault_plugin_secret" -t password
               credhub generate -n "${BOSH_NS}/secrets_uaa_clients_paas_billing_secret" -t password
               credhub generate -n "${BOSH_NS}/secrets_uaa_clients_paas_metrics_secret" -t password
               credhub generate -n "${BOSH_NS}/secrets_uaa_clients_paas_prometheus_endpoints_secret" -t password

--- a/config/service-brokers/aiven/config.json
+++ b/config/service-brokers/aiven/config.json
@@ -32,6 +32,7 @@
             "elasticsearch_version": "6",
             "description": "NOT Highly Available, 1 dedicated VM, 1 CPU per VM, 4GB RAM per VM, 80GB disk space. Free for trial orgs. Costs for billable orgs.",
             "free": true,
+            "active": false,
             "metadata": {
               "displayName": "Tiny",
               "AdditionalMetadata": {
@@ -53,6 +54,7 @@
             "elasticsearch_version": "6",
             "description": "3 dedicated VMs, 1 CPU per VM, 4GB RAM per VM, 240GB disk space.",
             "free": false,
+            "active": false,
             "metadata": {
               "displayName": "Small",
               "AdditionalMetadata": {
@@ -74,6 +76,7 @@
             "elasticsearch_version": "6",
             "description": "3 dedicated VMs, 2 CPU per VM, 8GB RAM per VM, 525GB disk space.",
             "free": false,
+            "active": false,
             "metadata": {
               "displayName": "Medium",
               "AdditionalMetadata": {
@@ -95,6 +98,7 @@
             "elasticsearch_version": "6",
             "description": "3 dedicated VMs, 2 CPU per VM, 15GB RAM per VM, 1050GB disk space.",
             "free": false,
+            "active": false,
             "metadata": {
               "displayName": "Large",
               "AdditionalMetadata": {
@@ -116,6 +120,7 @@
             "elasticsearch_version": "6",
             "description": "3 dedicated VMs, 4 CPU per VM, 31GB RAM per VM, 2100GB disk space.",
             "free": false,
+            "active": false,
             "metadata": {
               "displayName": "XLarge",
               "AdditionalMetadata": {

--- a/manifests/cf-manifest/operations.d/330-uaa.yml
+++ b/manifests/cf-manifest/operations.d/330-uaa.yml
@@ -134,18 +134,6 @@
     secret: ((secrets_uaa_clients_paas_auditor_secret))
 
 - type: replace
-  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/paas-vault-plugin?
-  value:
-    access-token-validity: 1209600
-    authorities: cloud_controller.admin_read_only,uaa.resource
-    authorized-grant-types: client_credentials,refresh_token,authorization_code
-    autoapprove: true
-    override: true
-    redirect-uri: https://vault-plugin.((system_domain))/oauth/callback
-    scope: openid,oauth.approvals,cloud_controller.admin_read_only,cloud_controller.read,cloud_controller.global_auditor,cloud_controller.admin
-    secret: ((secrets_uaa_clients_paas_vault_plugin_secret))
-
-- type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/paas-metrics?
   value:
     access-token-validity: 1209600
@@ -318,11 +306,6 @@
   path: /variables/-
   value:
     name: secrets_uaa_clients_paas_auditor_secret
-    type: password
-- type: replace
-  path: /variables/-
-  value:
-    name: secrets_uaa_clients_paas_vault_plugin_secret
     type: password
 - type: replace
   path: /variables/-

--- a/manifests/cf-manifest/operations.d/330-uaa.yml
+++ b/manifests/cf-manifest/operations.d/330-uaa.yml
@@ -134,6 +134,18 @@
     secret: ((secrets_uaa_clients_paas_auditor_secret))
 
 - type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/paas-vault-plugin?
+  value:
+    access-token-validity: 1209600
+    authorities: cloud_controller.admin_read_only,uaa.resource
+    authorized-grant-types: client_credentials,refresh_token,authorization_code
+    autoapprove: true
+    override: true
+    redirect-uri: https://vault-plugin.((system_domain))/oauth/callback
+    scope: openid,oauth.approvals,cloud_controller.admin_read_only,cloud_controller.read,cloud_controller.global_auditor,cloud_controller.admin
+    secret: ((secrets_uaa_clients_paas_vault_plugin_secret))
+
+- type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/paas-metrics?
   value:
     access-token-validity: 1209600
@@ -306,6 +318,11 @@
   path: /variables/-
   value:
     name: secrets_uaa_clients_paas_auditor_secret
+    type: password
+- type: replace
+  path: /variables/-
+  value:
+    name: secrets_uaa_clients_paas_vault_plugin_secret
     type: password
 - type: replace
   path: /variables/-

--- a/platform-tests/aiven-broker-acceptance/elasticsearch_service_test.go
+++ b/platform-tests/aiven-broker-acceptance/elasticsearch_service_test.go
@@ -36,7 +36,6 @@ var _ = Describe("Elasticsearch backing service", func() {
 
 	It("has the expected plans available", func() {
 		expectedPlans := []string{
-			"tiny-6.x", "small-ha-6.x", "medium-ha-6.x", "large-ha-6.x", "xlarge-ha-6.x",
 			"tiny-7.x", "small-ha-7.x", "medium-ha-7.x", "large-ha-7.x", "xlarge-ha-7.x",
 		}
 


### PR DESCRIPTION
What
----
[Story](https://www.pivotaltracker.com/story/show/175556676)

Elasticsearch version 6 is being deprecated by Aiven, more details are available [here](https://help.aiven.io/en/articles/4206285-upgrading-elasticsearch-versions-2-x-5-x), hence we have to remove support for version 6 from our broker.

How to review
-------------

1. Create few service instances of Elasticsearch version 6.x in your dev env.
2. Bind applications ([healthcheck](https://github.com/alphagov/paas-cf/tree/master/platform-tests/example-apps/healthcheck) will do) - to the service instances that you created in step 1 and make sure it works fine (e.g.: curl https://<app-route>/elasticsearch-test returns `{"success": true}`).
3. Deploy this PR/commit to your DEV environment.
4. run `cf m -e elasticsearch` to make sure that there are no 6.x plans available.
5. make sure that you can *not* create elasticsearch service instance based on 6.x plans, i.e. running `cf create-service elasticsearch tiny-6.x es-tiny-v6` should fail right away.
6. make sure that the applications bound to instances created in step 1 still work fine.
7. Upgrade service instance that you created in step No.1 to elasticsearch version 7 - make sure it succeed. More info about upgrading is available [here](https://docs.cloud.service.gov.uk/deploying_services/elasticsearch/#upgrade-elasticsearch-service-plan)
8. make sure that the applications bound to now the upgraded instances still work fine.

Who can review
---
Not @barsutka 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
