### PR TITLE
Update Aiven cost alert value

### DIFF
--- a/manifests/prometheus/alerts.d/aiven-cost.yml
+++ b/manifests/prometheus/alerts.d/aiven-cost.yml
@@ -7,7 +7,7 @@
     name: AivenEstimatedCostHigh
     rules:
       - alert: AivenEstimatedCostHigh
-        expr: delta(paas_aiven_estimated_cost_pounds[24h]) * 30 > 28500
+        expr: delta(paas_aiven_estimated_cost_pounds[24h]) * 30 > 35000
         labels:
           severity: critical
         annotations:


### PR DESCRIPTION
What
----

Adjust the Aiven spending alert to the current spending limit.

Why
----

Our Aiven spending has increased and is currently triggering this alert.
We are able to raise the alerting limit as our spending is still within the limit of the agreed budget.

How to review
-------------

Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
