### PR TITLE
[WIP] [#175684079] Use high CPU cells in Ireland

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,6 +254,7 @@ prod: ## Set Environment to Production
 	$(eval export ENV_SPECIFIC_ISOLATION_SEGMENTS_DIR=prod)
 	$(eval export DISABLE_CF_ACCEPTANCE_TESTS=true)
 	$(eval export DEPLOY_ENV=prod)
+	$(eval export HIGH_CPU_CELLS ?= true)
 	$(eval export PAAS_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
 	$(eval export PAAS_HIGH_PASSWORD_STORE_DIR?=${HOME}/.paas-pass-high)
 	$(eval export AWS_DEFAULT_REGION=eu-west-1)

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -648,6 +648,7 @@ jobs:
             SKIP_AWS_CREDENTIAL_VALIDATION: true
             NEW_ACCOUNT_EMAIL_ADDRESS: ((NEW_ACCOUNT_EMAIL_ADDRESS))
             SLIM_DEV_DEPLOYMENT: ((slim_dev_deployment))
+            HIGH_CPU_CELLS: ((high_cpu_cells))
             CONCOURSE_WEB_PASSWORD: ((concourse_web_password))
           run:
             path: ./paas-cf/concourse/scripts/self-update-pipeline.sh
@@ -1413,6 +1414,7 @@ jobs:
               ENV_SPECIFIC_BOSH_VARS_FILE: paas-cf/manifests/cf-manifest/env-specific/((env_specific_bosh_vars_file))
               ENV_SPECIFIC_ISOLATION_SEGMENTS_DIR: paas-cf/manifests/cf-manifest/isolation-segments/((env_specific_isolation_segments_dir))
               SLIM_DEV_DEPLOYMENT: ((slim_dev_deployment))
+              HIGH_CPU_CELLS: ((high_cpu_cells))
               VCAP_PASSWORD: ((vcap-password))
             run:
               path: sh

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -104,6 +104,7 @@ disable_pipeline_locking: ${DISABLE_PIPELINE_LOCKING:-}
 auto_deploy: $([ "${ENABLE_AUTO_DEPLOY:-}" ] && echo "true" || echo "false")
 persistent_environment: ${PERSISTENT_ENVIRONMENT}
 slim_dev_deployment: ${SLIM_DEV_DEPLOYMENT:-}
+high_cpu_cells: ${HIGH_CPU_CELLS:-}
 monitored_state_bucket: ${MONITORED_STATE_BUCKET:-}
 monitored_aws_region: ${MONITORED_AWS_REGION:-}
 monitored_deploy_env: ${MONITORED_DEPLOY_ENV:-}

--- a/manifests/cf-manifest/operations/use-high-cpu-cells.yml
+++ b/manifests/cf-manifest/operations/use-high-cpu-cells.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=diego-cell/vm_type
+  value: high_cpu_cell

--- a/manifests/cf-manifest/scripts/generate-manifest.sh
+++ b/manifests/cf-manifest/scripts/generate-manifest.sh
@@ -20,6 +20,10 @@ if [ "${SLIM_DEV_DEPLOYMENT-}" = "true" ]; then
   opsfile_args="$opsfile_args -o ${CF_MANIFEST_DIR}/operations/speed-up-deployment-dev.yml"
 fi
 
+if [ "${HIGH_CPU_CELLS-}" = "true" ]; then
+  opsfile_args="$opsfile_args -o ${CF_MANIFEST_DIR}/operations/use-high-cpu-cells.yml"
+fi
+
 # We are going to generate a manifest, as if we did not have any isolation
 # segments.
 #

--- a/manifests/cloud-config/operations/use-spot-instances-in-dev.yml
+++ b/manifests/cloud-config/operations/use-spot-instances-in-dev.yml
@@ -63,6 +63,14 @@
   value: ((cell_vm_spot_bid_price))
 
 - type: replace
+  path: /vm_types/name=high_cpu_cell/cloud_properties/spot_ondemand_fallback?
+  value: true
+
+- type: replace
+  path: /vm_types/name=high_cpu_cell/cloud_properties/spot_bid_price?
+  value: ((high_cpu_cell_vm_spot_bid_price))
+
+- type: replace
   path: /vm_types/name=small_cell/cloud_properties/spot_ondemand_fallback?
   value: true
 

--- a/manifests/cloud-config/paas-cf-cloud-config.yml
+++ b/manifests/cloud-config/paas-cf-cloud-config.yml
@@ -212,6 +212,17 @@ vm_types:
     - ((terraform_outputs_elasticache_broker_clients_security_group))
     - ((terraform_outputs_default_security_group))
 
+- name: high_cpu_cell
+  cloud_properties:
+    instance_type: ((high_cpu_cell_instance_type))
+    ephemeral_disk:
+      size: 204800
+      type: gp2
+    security_groups:
+    - ((terraform_outputs_rds_broker_db_clients_security_group))
+    - ((terraform_outputs_elasticache_broker_clients_security_group))
+    - ((terraform_outputs_default_security_group))
+
 - name: small_cell
   cloud_properties:
     instance_type: ((small_cell_instance_type))

--- a/manifests/variables.yml
+++ b/manifests/variables.yml
@@ -19,6 +19,9 @@ xlarge_vm_spot_bid_price: 0.1
 cell_instance_type: r5.xlarge
 cell_vm_spot_bid_price: 0.15
 
+high_cpu_cell_instance_type: m5.2xlarge
+high_cpu_cell_vm_spot_bid_price: 0.30
+
 small_cell_instance_type: r5.large
 small_cell_vm_spot_bid_price: 0.06
 


### PR DESCRIPTION
What
----

Until now we have used `r5.xlarge` instances in all environments. These offer 32GB of RAM and 4 vCPU cores.

This PR switches the EC2 instance type used for Diego Cells in Ireland. We will now use `m5.2xlarge` instances there. These are very similar to `r5.xlarge` with the key difference that they offer 8 vCPU cores. Therefore Ireland's cells will have double the CPU processing power.

This is done by adding a new `HIGH_CPU_CELLS` flag to the pipeline. If set to `true` your environment will use `m5.2xlarge`. It's configured to only be `true` in Ireland.

Why
----

GOV.UK Notify are using a great deal of our platform's CPU. They have reached the point where any further CPU usage starts to impact on other tenants. While they work on reducing their CPU usage, we are giving the platform more CPU. This allows them to carry on doing important work.

How to review
-------------



---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
