### PR TITLE
[Support] Specify elasticsearch broker with -b flag

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -4396,7 +4396,7 @@ jobs:
                 cf enable-service-access elasticsearch -b aiven-broker
 
                 # Disable deprecated plans
-                cat <<EOF | xargs -n1 cf disable-service-access elasticsearch -p
+                cat <<EOF | xargs -n1 cf disable-service-access elasticsearch -b aiven-broker -p
                 tiny-6.x
                 small-ha-6.x
                 medium-ha-6.x


### PR DESCRIPTION
What
----

Adds the -b flag when running cf disable-service-access elasticsearch due to a deploy failure.

How to review
-------------

Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
