### PR TITLE
Ensure we are alerted when our periodic tests do not run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ showenv: ## Display environment information
 	@scripts/showenv.sh
 
 .PHONY: upload-all-secrets
-upload-all-secrets: upload-google-oauth-secrets upload-microsoft-oauth-secrets upload-splunk-secrets upload-mailchimp-secrets upload-notify-secrets upload-aiven-secrets upload-logit-secrets upload-pagerduty-secrets upload-cyber-secrets upload-paas-trusted-people upload-zendesk-secrets
+upload-all-secrets: upload-google-oauth-secrets upload-microsoft-oauth-secrets upload-splunk-secrets upload-mailchimp-secrets upload-cronitor-secrets upload-notify-secrets upload-aiven-secrets upload-logit-secrets upload-pagerduty-secrets upload-cyber-secrets upload-paas-trusted-people upload-zendesk-secrets
 
 .PHONY: upload-google-oauth-secrets
 upload-google-oauth-secrets: check-env ## Decrypt and upload Google Admin Console credentials to Credhub
@@ -348,6 +348,12 @@ upload-mailchimp-secrets: check-env ## Decrypt and upload MailChimp Credentials 
 	$(if $(wildcard ${PAAS_PASSWORD_STORE_DIR}),,$(error Password store ${PAAS_PASSWORD_STORE_DIR} (PAAS_PASSWORD_STORE_DIR) does not exist))
 	$(eval export PASSWORD_STORE_DIR=${PAAS_PASSWORD_STORE_DIR})
 	@scripts/upload-secrets/upload-mailchimp-secrets.rb
+
+.PHONY: upload-cronitor-secrets
+upload-cronitor-secrets: check-env ## Decrypt and upload Cronitor secrets to Credhub
+	$(if $(wildcard ${PAAS_PASSWORD_STORE_DIR}),,$(error Password store ${PAAS_PASSWORD_STORE_DIR} (PAAS_PASSWORD_STORE_DIR) does not exist))
+	$(eval export PASSWORD_STORE_DIR=${PAAS_PASSWORD_STORE_DIR})
+	@scripts/upload-secrets/upload-cronitor-secrets.rb
 
 .PHONY: upload-notify-secrets
 upload-notify-secrets: check-env ## Decrypt and upload Notify Credentials to Credhub

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -5118,6 +5118,17 @@ jobs:
         - get: cf-manifest
           passed: ['post-deploy']
 
+      - try:
+          task: ping-cronitor-smoke-test-start
+          tags: [colocated-with-web]
+          file: paas-cf/concourse/tasks/cronitor-monitor-ping-action.yml
+          params:
+            CRONITOR_SMOKE_TEST_MONITOR_CODE: ((cronitor_smoke_test_monitor_code))
+            CRONITOR_MONITOR_PING_ENDPOINT: "run"
+            DEPLOY_ENV: ((deploy_env))
+            CCI_BUILD_NUMBER: $BUILD_NAME
+            CRONITOR_PING_MESSAGE: "Continuous+smoke+tests+job+has+started"
+
       - task: assert-should-run
         tags: [colocated-with-web]
         config:
@@ -5169,6 +5180,7 @@ jobs:
             SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
             ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
             EMAIL_ON_SMOKE_TEST_FAILURE: ((ENABLE_ALERT_NOTIFICATIONS))
+
           ensure:
             task: upload-test-artifacts
             tags: [colocated-with-web]
@@ -5186,6 +5198,54 @@ jobs:
                 API_ENDPOINT: ((api_endpoint))
                 CF_ADMIN: ((cf_admin))
                 CF_PASS: ((cf_pass))
+    
+    on_success:
+      try:
+        task: ping-cronitor-continuous-smoke-tests-completed
+        tags: [colocated-with-web]
+        file: paas-cf/concourse/tasks/cronitor-monitor-ping-action.yml
+        params:
+          CRONITOR_SMOKE_TEST_MONITOR_CODE: ((cronitor_smoke_test_monitor_code))
+          CRONITOR_MONITOR_PING_ENDPOINT: "complete"
+          DEPLOY_ENV: ((deploy_env))
+          CCI_BUILD_NUMBER: $BUILD_NAME
+          CRONITOR_PING_MESSAGE: "Continuous+smoke+tests+job+has+completed+successfully"
+          
+    on_failure:
+      try:
+        task: ping-cronitor-continuous-smoke-tests-failed
+        tags: [colocated-with-web]
+        file: paas-cf/concourse/tasks/cronitor-monitor-ping-action.yml
+        params:
+          CRONITOR_SMOKE_TEST_MONITOR_CODE: ((cronitor_smoke_test_monitor_code))
+          CRONITOR_MONITOR_PING_ENDPOINT: "fail"
+          DEPLOY_ENV: ((deploy_env))
+          CCI_BUILD_NUMBER: $BUILD_NAME
+          CRONITOR_PING_MESSAGE: "Continuous+smoke+tests+job+has+failed"
+
+    on_abort:
+      try:
+        task: ping-cronitor-continuous-smoke-tests-aborted
+        tags: [colocated-with-web]
+        file: paas-cf/concourse/tasks/cronitor-monitor-ping-action.yml
+        params:
+          CRONITOR_SMOKE_TEST_MONITOR_CODE: ((cronitor_smoke_test_monitor_code))
+          CRONITOR_MONITOR_PING_ENDPOINT: "fail"
+          DEPLOY_ENV: ((deploy_env))
+          CCI_BUILD_NUMBER: $BUILD_NAME
+          CRONITOR_PING_MESSAGE: "Continuous+smoke+tests+job+was+aborted"
+
+    on_error:
+      try:
+        task: ping-cronitor-continuous-smoke-tests-errored
+        tags: [colocated-with-web]
+        file: paas-cf/concourse/tasks/cronitor-monitor-ping-action.yml
+        params:
+          CRONITOR_SMOKE_TEST_MONITOR_CODE: ((cronitor_smoke_test_monitor_code))
+          CRONITOR_MONITOR_PING_ENDPOINT: "fail"
+          DEPLOY_ENV: ((deploy_env))
+          CCI_BUILD_NUMBER: $BUILD_NAME
+          CRONITOR_PING_MESSAGE: "Continuous+smoke+tests+job+finished+with+errors"
 
   - name: continuous-billing-smoke-tests
     serial_groups: [smoke-tests]

--- a/concourse/tasks/cronitor-monitor-ping-action.yml
+++ b/concourse/tasks/cronitor-monitor-ping-action.yml
@@ -1,0 +1,16 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: ghcr.io/alphagov/paas/cf-acceptance-tests
+    tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
+
+run:
+  path: sh
+  args:
+  - -e
+  - -c
+  - |
+    curl -m 10 "https://cronitor.link/${CRONITOR_SMOKE_TEST_MONITOR_CODE}/${CRONITOR_MONITOR_PING_ENDPOINT}?host=${DEPLOY_ENV}&series=${CCI_BUILD_NUMBER}&message=${CRONITOR_PING_MESSAGE}" || true
+

--- a/scripts/upload-secrets/upload-cronitor-secrets.rb
+++ b/scripts/upload-secrets/upload-cronitor-secrets.rb
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+script_path = File.absolute_path(__FILE__).sub!(Dir.pwd + "/", "")
+File.open(File.expand_path("~/.paas-script-usage"), "a") { |f| f.puts script_path }
+
+require_relative "upload_secrets.rb"
+
+deploy_env = ENV.fetch("DEPLOY_ENV")
+
+credhub_namespaces = [
+  "/concourse/main/create-cloudfoundry",
+  "/#{deploy_env}/#{deploy_env}",
+]
+
+cronitor_smoke_test_monitor_code = ENV["CRONITOR_SMOKE_TEST_MONITOR_CODE"] || get_secret("cronitor/#{ENV['MAKEFILE_ENV_TARGET']}/smoke_test_monitor_code", "__NO_CRONITOR_SMOKE_TEST_MONITOR_CODE__")
+
+upload_secrets(
+  credhub_namespaces,
+  "cronitor_smoke_test_monitor_code" => cronitor_smoke_test_monitor_code,
+)


### PR DESCRIPTION

What
----
[Story](https://www.pivotaltracker.com/story/show/175540593)

We want to be alerted when our smoke-tests are failing in production or more importantly are not running at all.
To achieve that, we are using cronitor to monitor our continuous smoke tests job.

How to review
-------------
you will have to have a Cronitor account or access to GDS Cronitor account.
1. Code review
2. Upload cronitor secrets to be sure that your dev environment is pointing to a valid Cronitor account and valid Monitor.
3. Deploy to your dev environment
4. Continuous smoke tests job should now ping Cronitor monitor at the start and finish of the job, in addition it will report failure, abort and error of the job.
5. Login to the Cronitor account (the one that you are testing against) and see that you are getting pings from smoke tests job in the activity tab of the monitor that was created for tracking smoke tests job.

Who can review
---
NOT @barsutka 
NOT @paroxp 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
