### PR TITLE
[Support] Update VPC peering terraform

### DIFF
--- a/terraform/cloudfoundry/vpc_peering.tf
+++ b/terraform/cloudfoundry/vpc_peering.tf
@@ -1,28 +1,27 @@
 resource "aws_vpc_peering_connection" "vpc_peer" {
-  count         = length(var.peer_vpc_ids)
-  peer_owner_id = element(var.peer_account_ids, count.index)
-  peer_vpc_id   = element(var.peer_vpc_ids, count.index)
+  for_each      = toset(var.peer_vpc_ids)
+  peer_owner_id = element(var.peer_account_ids, index(var.peer_vpc_ids, each.value))
+  peer_vpc_id   = element(var.peer_vpc_ids, index(var.peer_vpc_ids, each.value))
   vpc_id        = var.vpc_id
 }
 
 resource "aws_route" "vpc_peer_route_0" {
-  count                     = length(var.peer_vpc_ids)
+  for_each                  = toset(var.peer_vpc_ids)
   route_table_id            = aws_route_table.internet[0].id
-  destination_cidr_block    = element(var.peer_cidrs, count.index)
-  vpc_peering_connection_id = element(aws_vpc_peering_connection.vpc_peer.*.id, count.index)
+  destination_cidr_block    = element(var.peer_cidrs, index(var.peer_vpc_ids, each.value))
+  vpc_peering_connection_id = element([for peer in aws_vpc_peering_connection.vpc_peer : peer.id], index(var.peer_vpc_ids, each.value))
 }
 
 resource "aws_route" "vpc_peer_route_1" {
-  count                     = length(var.peer_vpc_ids)
+  for_each                  = toset(var.peer_vpc_ids)
   route_table_id            = aws_route_table.internet[1].id
-  destination_cidr_block    = element(var.peer_cidrs, count.index)
-  vpc_peering_connection_id = element(aws_vpc_peering_connection.vpc_peer.*.id, count.index)
+  destination_cidr_block    = element(var.peer_cidrs, index(var.peer_vpc_ids, each.value))
+  vpc_peering_connection_id = element([for peer in aws_vpc_peering_connection.vpc_peer : peer.id], index(var.peer_vpc_ids, each.value))
 }
 
 resource "aws_route" "vpc_peer_route_2" {
-  count                     = length(var.peer_vpc_ids)
+  for_each                  = toset(var.peer_vpc_ids)
   route_table_id            = aws_route_table.internet[2].id
-  destination_cidr_block    = element(var.peer_cidrs, count.index)
-  vpc_peering_connection_id = element(aws_vpc_peering_connection.vpc_peer.*.id, count.index)
+  destination_cidr_block    = element(var.peer_cidrs, index(var.peer_vpc_ids, each.value))
+  vpc_peering_connection_id = element([for peer in aws_vpc_peering_connection.vpc_peer : peer.id], index(var.peer_vpc_ids, each.value))
 }
-


### PR DESCRIPTION
What
----

Adding a new vpc peering entry results in terraform recreating existing
connections because it uses the count parameter. This updates the resources
to use the for_each parameter so this doesn't happen.

How to review
-------------

- Code review
- Delete test VPC peering connections in the dev account
- Create devenv.vpc_peering.json and add a test vpc
- Deploy to your dev env
- Update devenv.vpc_peering.json with a new vpc and redeploy
- Confirm previous peer is still connected

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
