### PR TITLE
[#175778451] Create dedicated servers for GOV.UK Notify to do load testing against staging

### DIFF
--- a/manifests/cf-manifest/isolation-segments/prod/govuk-notify-staging.yml
+++ b/manifests/cf-manifest/isolation-segments/prod/govuk-notify-staging.yml
@@ -1,0 +1,3 @@
+---
+number_of_cells: 12
+isolation_segment_name: govuk-notify-staging

--- a/manifests/cf-manifest/spec/manifest/isolation_segment_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/isolation_segment_spec.rb
@@ -256,16 +256,34 @@ RSpec.describe "isolation_segments" do
     let(:instance_groups) { manifest.fetch("instance_groups") }
     let(:segs) { instance_groups.select { |i| i["name"] =~ /diego-cell-iso/ } }
 
-    %w[prod stg-lon].each do |env|
-      describe env do
-        let(:manifest) { manifest_for_env(env) }
+    describe "stg-lon" do
+      let(:manifest) { manifest_for_env("stg-lon") }
 
-        it "contains an empty egress restricted isolation segment" do
-          expect(segs.count).to eq(1)
-          seg = segs.first
-          expect(seg["instances"]).to eq(0)
-          expect(seg["jobs"].find { |j| j["name"] == "coredns" }).not_to be_nil
-        end
+      it "contains an empty egress restricted isolation segment" do
+        expect(segs.count).to eq(1)
+        seg = segs.first
+        expect(seg["instances"]).to eq(0)
+        expect(seg["jobs"].find { |j| j["name"] == "coredns" }).not_to be_nil
+      end
+    end
+
+    describe "prod" do
+      let(:manifest) { manifest_for_env("prod") }
+
+      it "contains an empty egress restricted isolation segment" do
+        expect(segs.count).to be >= 1
+        seg = segs.select { |s| s["name"] == "diego-cell-iso-seg-egress-restricted-1" }.first
+        expect(seg).not_to be_nil
+        expect(seg["instances"]).to eq(0)
+        expect(seg["jobs"].find { |j| j["name"] == "coredns" }).not_to be_nil
+      end
+
+      it "contains an egress-unrestricted isolation segment for GOV.UK Notify staging" do
+        expect(segs.count).to be >= 1
+        seg = segs.select { |s| s["name"] == "diego-cell-iso-seg-govuk-notify-staging" }.first
+        expect(seg).not_to be_nil
+        expect(seg["instances"]).to eq(12)
+        expect(seg["jobs"].find { |j| j["name"] == "coredns" }).to be_nil
       end
     end
 


### PR DESCRIPTION
What
----

GOV.UK Notify want to do load testing without interfering with their production workload. We've been having CPU capacity problems when they do it on the main PaaS Ireland cells.

This commit creates an Isolation Segment for them:

* Twelve cells, which is 1/4 the size of PaaS Ireland.
* To start with, the same `r5.xlarge` EC2 instance type as we use normally.
* These are just dedicated cells. We aren't doing any egress filtering or other security measures.

This commit doesn't assign their `staging` space to this Isolation Segment. I think it's fine for us to do that manually after deploy.

How to review
-------------

I think code review is fine.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
