### PR TITLE
Run BBS on a higher-CPU instance type

### DIFF
--- a/manifests/cf-manifest/operations.d/100-cf-update-vm-types.yml
+++ b/manifests/cf-manifest/operations.d/100-cf-update-vm-types.yml
@@ -7,7 +7,7 @@
   value: medium
 - type: replace
   path: /instance_groups/name=diego-api/vm_type
-  value: medium
+  value: large
 - type: replace
   path: /instance_groups/name=doppler/vm_type
   value: large


### PR DESCRIPTION
What
----

For some time the active `diego-api` VM in Ireland has been exhausting its CPU credits. This VM runs [BBS](https://docs.run.pivotal.io/concepts/diego/diego-architecture.html#components), a Cloud Foundry component which manages the cluster of app instances. This has predictably experienced higher load as tenants have been doing more autoscaling.

This PR changes the EC2 instance type used for the `diego-api` VM. It upgrades from a `t3.medium` instance type to an `m5.large` [Benchmarks show](https://www.drlinkcheck.com/blog/t3-vs-m5) that the `m5.large`'s constant CPU performance is roughly equal to the burst performance of the `t3.medium`. This means that it will have substantially more CPU available at all times.

Cost estimate is something like $120/month in each non-dev environment.

How to review
-------------

* Review my justification above
* If you want to look more into this, look at the CPU credit balance of our `diego-api` VMs. It seems that only one of the nodes is active at a time, and that active node in Ireland always exhausts its CPU credits. We've been getting alerts about that (see https://govuk.zendesk.com/agent/tickets/4295089)

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
