### PR TITLE
Scale Notify staging isolation segment to 24 cells

### DIFF
--- a/manifests/cf-manifest/isolation-segments/prod/govuk-notify-staging.yml
+++ b/manifests/cf-manifest/isolation-segments/prod/govuk-notify-staging.yml
@@ -1,3 +1,3 @@
 ---
-number_of_cells: 12
+number_of_cells: 24
 isolation_segment_name: govuk-notify-staging

--- a/manifests/cf-manifest/spec/manifest/isolation_segment_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/isolation_segment_spec.rb
@@ -282,7 +282,7 @@ RSpec.describe "isolation_segments" do
         expect(segs.count).to be >= 1
         seg = segs.select { |s| s["name"] == "diego-cell-iso-seg-govuk-notify-staging" }.first
         expect(seg).not_to be_nil
-        expect(seg["instances"]).to eq(12)
+        expect(seg["instances"]).to be >= 1
         expect(seg["jobs"].find { |j| j["name"] == "coredns" }).to be_nil
       end
     end


### PR DESCRIPTION
What
----

We recently created an isolation segment for GOV.UK Notify. They are using it to conduct load testing against their staging environment without affecting the rest of the PaaS.

We chose 12 cells to start with. This was based on the maximum memory usage if their staging environment autoscaled all the way up. We already suspected they might run low on CPU resources. They have now run more load tests and we can see that the isolation segment's cells all went up to 100% CPU.

This commit doubles the isolation segment's size from 12 cells up to 24. This will provide twice as much CPU.

An alternative approach is to use an EC2 instance type that has more vCPU cores. We may still do that, and it is cheaper (at least if we ignore existing Reserved Instances.) For now though we want load testing results that broadly will apply to Notify's production environment, using the normal cells.

How to review
-------------

Code and justification review.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
