### PR TITLE
[#175819180] Address November CVEs through platform upgrade

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -368,13 +368,13 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-acceptance-tests
-      branch: cf13.19
+      branch: cf15.0
 
   - name: cf-smoke-tests-release
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-smoke-tests-release
-      tag_filter: "41.0.1"
+      tag_filter: "41.0.2"
       submodules:
       - "src/smoke_tests"
 
@@ -5198,7 +5198,7 @@ jobs:
                 API_ENDPOINT: ((api_endpoint))
                 CF_ADMIN: ((cf_admin))
                 CF_PASS: ((cf_pass))
-    
+
     on_success:
       try:
         task: ping-cronitor-continuous-smoke-tests-completed
@@ -5210,7 +5210,7 @@ jobs:
           DEPLOY_ENV: ((deploy_env))
           CCI_BUILD_NUMBER: $BUILD_NAME
           CRONITOR_PING_MESSAGE: "Continuous+smoke+tests+job+has+completed+successfully"
-          
+
     on_failure:
       try:
         task: ping-cronitor-continuous-smoke-tests-failed

--- a/concourse/pipelines/monitor-remote.yml
+++ b/concourse/pipelines/monitor-remote.yml
@@ -19,7 +19,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloudfoundry/cf-smoke-tests-release
-    tag_filter: "41.0.1"
+    tag_filter: "41.0.2"
     submodules:
       - "src/smoke_tests"
 

--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-xenial
-      version: "621.84"
+      version: "621.90"

--- a/manifests/cf-manifest/operations.d/030-bosh-dns.yml
+++ b/manifests/cf-manifest/operations.d/030-bosh-dns.yml
@@ -56,22 +56,29 @@
   value:
     name: dns_healthcheck_server_tls
     type: certificate
+    update_mode: converge
     options:
       ca: dns_healthcheck_tls_ca
       common_name: health.bosh-dns
       extended_key_usage:
       - server_auth
+      alternative_names:
+      - health.bosh-dns
 
 - type: replace
   path: /variables/-
   value:
     name: dns_healthcheck_client_tls
     type: certificate
+    update_mode: converge
     options:
       ca: dns_healthcheck_tls_ca
       common_name: health.bosh-dns
       extended_key_usage:
       - client_auth
+      alternative_names:
+      - health.bosh-dns
+
 
 - type: replace
   path: /variables/-
@@ -87,20 +94,25 @@
   value:
     name: dns_api_server_tls
     type: certificate
+    update_mode: converge
     options:
       ca: dns_api_tls_ca
       common_name: api.bosh-dns
       extended_key_usage:
       - server_auth
+      alternative_names:
+      - api.bosh-dns
 
 - type: replace
   path: /variables/-
   value:
     name: dns_api_client_tls
     type: certificate
+    update_mode: converge
     options:
       ca: dns_api_tls_ca
       common_name: api.bosh-dns
       extended_key_usage:
       - client_auth
-
+      alternative_names:
+      - api.bosh-dns

--- a/manifests/cf-manifest/operations.d/320-cc-release.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-release.yml
@@ -1,8 +1,0 @@
----
-- type: replace
-  path: /releases/name=capi
-  value:
-    name: "capi"
-    version: "1.98.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.98.0"
-    sha1: "e4b0b8a1ef10b71da5b09248150c3295197ee0b6"

--- a/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
+++ b/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
@@ -3,6 +3,6 @@
   path: /releases/name=uaa
   value:
     name: uaa
-    version: 0.1.24
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-0.1.24.tgz
-    sha1: beed5b2e1e92b82570627b355f7068326b808e2d
+    version: 0.1.25
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-0.1.25.tgz
+    sha1: 80e2c31c0d98cdf545208e600ca3597f55597546

--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -105,9 +105,12 @@
   value:
     name: loggregator_rds_metrics_collector
     type: certificate
+    update_mode: converge
     options:
       ca: loggregator_ca
       common_name: loggregator_rds_metrics_collector
       extended_key_usage:
         - client_auth
         - server_auth
+      alternative_names:
+        - loggregator_rds_metrics_collector

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe "release versions" do
 
     pinned_releases = {
       "uaa" => {
-        local: "0.1.24",
-        upstream: "74.24.0",
+        local: "0.1.25",
+        upstream: "74.28.0",
       },
     }
 

--- a/manifests/prometheus/alerts.d/bosh-duplicate-releases.yml
+++ b/manifests/prometheus/alerts.d/bosh-duplicate-releases.yml
@@ -9,7 +9,7 @@
       - alert: BoshDuplicateReleases_Warning
         expr: |
           count by (bosh_release_name) (
-            count by (bosh_release_name, bosh_release_version) (bosh_deployment_release_info{bosh_release_name!="bpm"})
+            count by (bosh_release_name, bosh_release_version) (bosh_deployment_release_info{bosh_release_name!="bpm", bosh_deployment!="app-autoscaler"})
           ) > 1
         labels:
           severity: warning


### PR DESCRIPTION
What
----

Addresses a collection of CVE's from November 2020 by upgrading the platform to `cf-deployment` v15.0.0. It also takes the opportunity to silence some alerts.

How to review
-------------
1. Code review
2. Run it down your dev env

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
