### PR TITLE
[#175819180][Play after PR#2528] Remove update mode from certificate

### DIFF
--- a/manifests/cf-manifest/operations.d/030-bosh-dns.yml
+++ b/manifests/cf-manifest/operations.d/030-bosh-dns.yml
@@ -56,7 +56,6 @@
   value:
     name: dns_healthcheck_server_tls
     type: certificate
-    update_mode: converge
     options:
       ca: dns_healthcheck_tls_ca
       common_name: health.bosh-dns
@@ -70,7 +69,6 @@
   value:
     name: dns_healthcheck_client_tls
     type: certificate
-    update_mode: converge
     options:
       ca: dns_healthcheck_tls_ca
       common_name: health.bosh-dns
@@ -94,7 +92,6 @@
   value:
     name: dns_api_server_tls
     type: certificate
-    update_mode: converge
     options:
       ca: dns_api_tls_ca
       common_name: api.bosh-dns
@@ -108,7 +105,6 @@
   value:
     name: dns_api_client_tls
     type: certificate
-    update_mode: converge
     options:
       ca: dns_api_tls_ca
       common_name: api.bosh-dns

--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -105,7 +105,6 @@
   value:
     name: loggregator_rds_metrics_collector
     type: certificate
-    update_mode: converge
     options:
       ca: loggregator_ca
       common_name: loggregator_rds_metrics_collector


### PR DESCRIPTION
What
----
Removes `update_mode: converge` from certificate type variables so that we don't have a foot cannon in that area. We added it to begin with so that we could force the update of certificates as a result of a change to their properties; in this case adding subject alternative names.

We don't want that behaviour to persist in future. We should opt in to it by adding the flag back.

How to review
-------------
1. Check it fully reverts the `update_mode: converge` additions from #2528
2. Deploy to your dev env after #2528 (or later) has been run down your env

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
