### PR TITLE
Add support for postgres 12 plans to the RDS broker

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2454,6 +2454,32 @@ jobs:
                 xlarge-ha-11-high-iops
                 EOF
 
+                # Enable Postgres 12 plans
+                cat <<EOF | xargs -n1 cf enable-service-access postgres -b rds-broker -p
+                tiny-unencrypted-12
+                small-12
+                small-ha-12
+                medium-12
+                medium-ha-12
+                large-12
+                large-ha-12
+                xlarge-12
+                xlarge-ha-12
+                EOF
+
+                # Enable Postgres 12 High IOPS plans
+                cat <<EOF | xargs -n1 cf enable-service-access postgres -b rds-broker -p
+                tiny-unencrypted-12-high-iops
+                small-12-high-iops
+                small-ha-12-high-iops
+                medium-12-high-iops
+                medium-ha-12-high-iops
+                large-12-high-iops
+                large-ha-12-high-iops
+                xlarge-12-high-iops
+                xlarge-ha-12-high-iops
+                EOF
+
                 # Disable deprecated plans
                 cat <<EOF | xargs -n1 cf disable-service-access mysql -p
                 small-unencrypted-5.7
@@ -5198,7 +5224,7 @@ jobs:
                 API_ENDPOINT: ((api_endpoint))
                 CF_ADMIN: ((cf_admin))
                 CF_PASS: ((cf_pass))
-    
+
     on_success:
       try:
         task: ping-cronitor-continuous-smoke-tests-completed
@@ -5210,7 +5236,7 @@ jobs:
           DEPLOY_ENV: ((deploy_env))
           CCI_BUILD_NUMBER: $BUILD_NAME
           CRONITOR_PING_MESSAGE: "Continuous+smoke+tests+job+has+completed+successfully"
-          
+
     on_failure:
       try:
         task: ping-cronitor-continuous-smoke-tests-failed

--- a/config/billing/config-parts/postgres_12_high_iops_pricing_plans.json.erb
+++ b/config/billing/config-parts/postgres_12_high_iops_pricing_plans.json.erb
@@ -1,0 +1,189 @@
+{
+  "name": "postgres tiny-unencrypted-12 high-iops",
+  "valid_from": "2020-12-01",
+  "plan_guid": "f1fdbac4-4581-48cb-807c-63dc8a40bbfd",
+  "storage_in_mb": 25600,
+  "memory_in_mb": 0,
+  "components": [
+    {
+      "name": "instance",
+      "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_t3_micro") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    },
+    {
+      "name": "storage",
+      "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    }
+  ]
+},
+{
+  "name": "postgres small-12 high-iops",
+  "valid_from": "2020-12-01",
+  "plan_guid": "6fe540eb-e6a7-49bc-bfbe-cb097c9f358e",
+  "storage_in_mb": 102400,
+  "memory_in_mb": 0,
+  "components": [
+    {
+      "name": "instance",
+      "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_t3_small") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    },
+    {
+      "name": "storage",
+      "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    }
+  ]
+},
+{
+  "name": "postgres small-ha-12 high-iops",
+  "valid_from": "2020-12-01",
+  "plan_guid": "7b2e29e8-b187-4da5-921e-3581df1bc0a1",
+  "storage_in_mb": 102400,
+  "memory_in_mb": 0,
+  "components": [
+    {
+      "name": "instance",
+      "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_t3_small_ha") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    },
+    {
+      "name": "storage",
+      "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage_ha") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    }
+  ]
+},
+{
+  "name": "postgres medium-12 high-iops",
+  "valid_from": "2020-12-01",
+  "plan_guid": "09b58be1-d0d6-41a5-9297-5e29c2752a07",
+  "storage_in_mb": 512000,
+  "memory_in_mb": 0,
+  "components": [
+    {
+      "name": "instance",
+      "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_m5_large") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    },
+    {
+      "name": "storage",
+      "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    }
+  ]
+},
+{
+  "name": "postgres medium-ha-12 high-iops",
+  "valid_from": "2020-12-01",
+  "plan_guid": "95065f02-0c52-40fe-b12c-3b13a01c8748",
+  "storage_in_mb": 512000,
+  "memory_in_mb": 0,
+  "components": [
+    {
+      "name": "instance",
+      "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_m5_large_ha") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    },
+    {
+      "name": "storage",
+      "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage_ha") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    }
+  ]
+},
+{
+  "name": "postgres large-12 high-iops",
+  "valid_from": "2020-12-01",
+  "plan_guid": "b36503e9-3066-476e-9d7b-d00b2108f802",
+  "storage_in_mb": 2621440,
+  "memory_in_mb": 0,
+  "components": [
+    {
+      "name": "instance",
+      "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_m5_2xlarge") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    },
+    {
+      "name": "storage",
+      "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    }
+  ]
+},
+{
+  "name": "postgres large-ha-12 high-iops",
+  "valid_from": "2020-12-01",
+  "plan_guid": "78c39693-c13b-49d9-8ae2-6df910388846",
+  "storage_in_mb": 2621440,
+  "memory_in_mb": 0,
+  "components": [
+    {
+      "name": "instance",
+      "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_m5_2xlarge_ha") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    },
+    {
+      "name": "storage",
+      "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage_ha") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    }
+  ]
+},
+{
+  "name": "postgres xlarge-12 high-iops",
+  "valid_from": "2020-12-01",
+  "plan_guid": "fa8125ab-5398-4ed4-88a6-64719b6add48",
+  "storage_in_mb": 10485760,
+  "memory_in_mb": 0,
+  "components": [
+    {
+      "name": "instance",
+      "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_m5_4xlarge") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    },
+    {
+      "name": "storage",
+      "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    }
+  ]
+},
+{
+  "name": "postgres xlarge-ha-12 high-iops",
+  "valid_from": "2020-12-01",
+  "plan_guid": "386116e4-efa4-4472-ae1c-40e0ce3f5474",
+  "storage_in_mb": 10485760,
+  "memory_in_mb": 0,
+  "components": [
+    {
+      "name": "instance",
+      "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_m5_4xlarge_ha") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    },
+    {
+      "name": "storage",
+      "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage_ha") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    }
+  ]
+},

--- a/config/billing/config-parts/postgres_12_pricing_plans.json.erb
+++ b/config/billing/config-parts/postgres_12_pricing_plans.json.erb
@@ -1,0 +1,189 @@
+{
+  "name": "postgres tiny-unencrypted-12",
+  "valid_from": "2020-12-01",
+  "plan_guid": "8b8a7372-84ab-43de-8634-8a23dd3b23f6",
+  "storage_in_mb": 5120,
+  "memory_in_mb": 0,
+  "components": [
+    {
+      "name": "instance",
+      "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_t3_micro") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    },
+    {
+      "name": "storage",
+      "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    }
+  ]
+},
+{
+  "name": "postgres small-12",
+  "valid_from": "2020-12-01",
+  "plan_guid": "d89daa72-0219-4b40-81b9-8df14612ee74",
+  "storage_in_mb": 102400,
+  "memory_in_mb": 0,
+  "components": [
+    {
+      "name": "instance",
+      "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_t3_small") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    },
+    {
+      "name": "storage",
+      "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    }
+  ]
+},
+{
+  "name": "postgres small-ha-12",
+  "valid_from": "2020-12-01",
+  "plan_guid": "f38342c0-b119-438e-a450-2170f2fc789f",
+  "storage_in_mb": 102400,
+  "memory_in_mb": 0,
+  "components": [
+    {
+      "name": "instance",
+      "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_t3_small_ha") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    },
+    {
+      "name": "storage",
+      "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage_ha") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    }
+  ]
+},
+{
+  "name": "postgres medium-12",
+  "valid_from": "2020-12-01",
+  "plan_guid": "41e4c5eb-2cb0-4f7c-8864-60b1cdbf06d5",
+  "storage_in_mb": 102400,
+  "memory_in_mb": 0,
+  "components": [
+    {
+      "name": "instance",
+      "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_m5_large") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    },
+    {
+      "name": "storage",
+      "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    }
+  ]
+},
+{
+  "name": "postgres medium-ha-12",
+  "valid_from": "2020-12-01",
+  "plan_guid": "43c55e2c-8068-4e10-9e2f-893204e45b2d",
+  "storage_in_mb": 102400,
+  "memory_in_mb": 0,
+  "components": [
+    {
+      "name": "instance",
+      "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_m5_large_ha") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    },
+    {
+      "name": "storage",
+      "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage_ha") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    }
+  ]
+},
+{
+  "name": "postgres large-12",
+  "valid_from": "2020-12-01",
+  "plan_guid": "44f6cc4c-6172-4efa-badc-c0f9453f2b09",
+  "storage_in_mb": 524288,
+  "memory_in_mb": 0,
+  "components": [
+    {
+      "name": "instance",
+      "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_m5_2xlarge") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    },
+    {
+      "name": "storage",
+      "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    }
+  ]
+},
+{
+  "name": "postgres large-ha-12",
+  "valid_from": "2020-12-01",
+  "plan_guid": "5fbc649c-018a-4097-aa4f-d46358aadbe1",
+  "storage_in_mb": 524288,
+  "memory_in_mb": 0,
+  "components": [
+    {
+      "name": "instance",
+      "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_m5_2xlarge_ha") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    },
+    {
+      "name": "storage",
+      "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage_ha") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    }
+  ]
+},
+{
+  "name": "postgres xlarge-12",
+  "valid_from": "2020-12-01",
+  "plan_guid": "810e88e7-5e35-4b48-92a0-fe7b99fb41d2",
+  "storage_in_mb": 2097152,
+  "memory_in_mb": 0,
+  "components": [
+    {
+      "name": "instance",
+      "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_m5_4xlarge") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    },
+    {
+      "name": "storage",
+      "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    }
+  ]
+},
+{
+  "name": "postgres xlarge-ha-12",
+  "valid_from": "2020-12-01",
+  "plan_guid": "404e6784-343b-4957-b684-3206184a5e11",
+  "storage_in_mb": 2097152,
+  "memory_in_mb": 0,
+  "components": [
+    {
+      "name": "instance",
+      "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_m5_4xlarge_ha") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    },
+    {
+      "name": "storage",
+      "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage_ha") %>",
+      "currency_code": "USD",
+      "vat_code": "Standard"
+    }
+  ]
+},

--- a/config/billing/config.json.erb
+++ b/config/billing/config.json.erb
@@ -9,6 +9,8 @@
 		<%= include("config-parts/postgres_10_high_iops_pricing_plans.json.erb") %>
 		<%= include("config-parts/postgres_11_pricing_plans.json.erb") %>
 		<%= include("config-parts/postgres_11_high_iops_pricing_plans.json.erb") %>
+		<%= include("config-parts/postgres_12_pricing_plans.json.erb") %>
+		<%= include("config-parts/postgres_12_high_iops_pricing_plans.json.erb") %>
 		<%= include("config-parts/mysql_57_pricing_plans.json.erb") %>
 		<%= include("config-parts/mysql_57_high_iops_pricing_plans.json.erb") %>
 		<%= include("config-parts/mysql_80_pricing_plans.json.erb") %>

--- a/config/billing/output/eu-west-1.json
+++ b/config/billing/output/eu-west-1.json
@@ -1323,6 +1323,384 @@
 			]
 		},
 		{
+			"name": "postgres tiny-unencrypted-12",
+			"valid_from": "2020-12-01",
+			"plan_guid": "8b8a7372-84ab-43de-8634-8a23dd3b23f6",
+			"storage_in_mb": 5120,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.02",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.127",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres small-12",
+			"valid_from": "2020-12-01",
+			"plan_guid": "d89daa72-0219-4b40-81b9-8df14612ee74",
+			"storage_in_mb": 102400,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.039",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.127",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres small-ha-12",
+			"valid_from": "2020-12-01",
+			"plan_guid": "f38342c0-b119-438e-a450-2170f2fc789f",
+			"storage_in_mb": 102400,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.078",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.253",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres medium-12",
+			"valid_from": "2020-12-01",
+			"plan_guid": "41e4c5eb-2cb0-4f7c-8864-60b1cdbf06d5",
+			"storage_in_mb": 102400,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.197",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.127",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres medium-ha-12",
+			"valid_from": "2020-12-01",
+			"plan_guid": "43c55e2c-8068-4e10-9e2f-893204e45b2d",
+			"storage_in_mb": 102400,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.394",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.253",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres large-12",
+			"valid_from": "2020-12-01",
+			"plan_guid": "44f6cc4c-6172-4efa-badc-c0f9453f2b09",
+			"storage_in_mb": 524288,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.788",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.127",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres large-ha-12",
+			"valid_from": "2020-12-01",
+			"plan_guid": "5fbc649c-018a-4097-aa4f-d46358aadbe1",
+			"storage_in_mb": 524288,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 1.576",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.253",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres xlarge-12",
+			"valid_from": "2020-12-01",
+			"plan_guid": "810e88e7-5e35-4b48-92a0-fe7b99fb41d2",
+			"storage_in_mb": 2097152,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 1.576",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.127",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres xlarge-ha-12",
+			"valid_from": "2020-12-01",
+			"plan_guid": "404e6784-343b-4957-b684-3206184a5e11",
+			"storage_in_mb": 2097152,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 3.152",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.253",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres tiny-unencrypted-12 high-iops",
+			"valid_from": "2020-12-01",
+			"plan_guid": "f1fdbac4-4581-48cb-807c-63dc8a40bbfd",
+			"storage_in_mb": 25600,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.02",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.127",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres small-12 high-iops",
+			"valid_from": "2020-12-01",
+			"plan_guid": "6fe540eb-e6a7-49bc-bfbe-cb097c9f358e",
+			"storage_in_mb": 102400,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.039",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.127",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres small-ha-12 high-iops",
+			"valid_from": "2020-12-01",
+			"plan_guid": "7b2e29e8-b187-4da5-921e-3581df1bc0a1",
+			"storage_in_mb": 102400,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.078",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.253",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres medium-12 high-iops",
+			"valid_from": "2020-12-01",
+			"plan_guid": "09b58be1-d0d6-41a5-9297-5e29c2752a07",
+			"storage_in_mb": 512000,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.197",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.127",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres medium-ha-12 high-iops",
+			"valid_from": "2020-12-01",
+			"plan_guid": "95065f02-0c52-40fe-b12c-3b13a01c8748",
+			"storage_in_mb": 512000,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.394",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.253",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres large-12 high-iops",
+			"valid_from": "2020-12-01",
+			"plan_guid": "b36503e9-3066-476e-9d7b-d00b2108f802",
+			"storage_in_mb": 2621440,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.788",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.127",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres large-ha-12 high-iops",
+			"valid_from": "2020-12-01",
+			"plan_guid": "78c39693-c13b-49d9-8ae2-6df910388846",
+			"storage_in_mb": 2621440,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 1.576",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.253",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres xlarge-12 high-iops",
+			"valid_from": "2020-12-01",
+			"plan_guid": "fa8125ab-5398-4ed4-88a6-64719b6add48",
+			"storage_in_mb": 10485760,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 1.576",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.127",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres xlarge-ha-12 high-iops",
+			"valid_from": "2020-12-01",
+			"plan_guid": "386116e4-efa4-4472-ae1c-40e0ce3f5474",
+			"storage_in_mb": 10485760,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 3.152",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.253",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
 			"name": "mysql tiny-unencrypted-5.7",
 			"valid_from": "2017-01-01",
 			"plan_guid": "69977068-8ef5-4172-bfdb-e8cea3c14d01",

--- a/config/billing/output/eu-west-2.json
+++ b/config/billing/output/eu-west-2.json
@@ -1323,6 +1323,384 @@
 			]
 		},
 		{
+			"name": "postgres tiny-unencrypted-12",
+			"valid_from": "2020-12-01",
+			"plan_guid": "8b8a7372-84ab-43de-8634-8a23dd3b23f6",
+			"storage_in_mb": 5120,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.021",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.133",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres small-12",
+			"valid_from": "2020-12-01",
+			"plan_guid": "d89daa72-0219-4b40-81b9-8df14612ee74",
+			"storage_in_mb": 102400,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.041",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.133",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres small-ha-12",
+			"valid_from": "2020-12-01",
+			"plan_guid": "f38342c0-b119-438e-a450-2170f2fc789f",
+			"storage_in_mb": 102400,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.082",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.266",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres medium-12",
+			"valid_from": "2020-12-01",
+			"plan_guid": "41e4c5eb-2cb0-4f7c-8864-60b1cdbf06d5",
+			"storage_in_mb": 102400,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.206",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.133",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres medium-ha-12",
+			"valid_from": "2020-12-01",
+			"plan_guid": "43c55e2c-8068-4e10-9e2f-893204e45b2d",
+			"storage_in_mb": 102400,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.412",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.266",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres large-12",
+			"valid_from": "2020-12-01",
+			"plan_guid": "44f6cc4c-6172-4efa-badc-c0f9453f2b09",
+			"storage_in_mb": 524288,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.824",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.133",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres large-ha-12",
+			"valid_from": "2020-12-01",
+			"plan_guid": "5fbc649c-018a-4097-aa4f-d46358aadbe1",
+			"storage_in_mb": 524288,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 1.648",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.266",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres xlarge-12",
+			"valid_from": "2020-12-01",
+			"plan_guid": "810e88e7-5e35-4b48-92a0-fe7b99fb41d2",
+			"storage_in_mb": 2097152,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 1.648",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.133",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres xlarge-ha-12",
+			"valid_from": "2020-12-01",
+			"plan_guid": "404e6784-343b-4957-b684-3206184a5e11",
+			"storage_in_mb": 2097152,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 3.296",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.266",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres tiny-unencrypted-12 high-iops",
+			"valid_from": "2020-12-01",
+			"plan_guid": "f1fdbac4-4581-48cb-807c-63dc8a40bbfd",
+			"storage_in_mb": 25600,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.021",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.133",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres small-12 high-iops",
+			"valid_from": "2020-12-01",
+			"plan_guid": "6fe540eb-e6a7-49bc-bfbe-cb097c9f358e",
+			"storage_in_mb": 102400,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.041",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.133",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres small-ha-12 high-iops",
+			"valid_from": "2020-12-01",
+			"plan_guid": "7b2e29e8-b187-4da5-921e-3581df1bc0a1",
+			"storage_in_mb": 102400,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.082",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.266",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres medium-12 high-iops",
+			"valid_from": "2020-12-01",
+			"plan_guid": "09b58be1-d0d6-41a5-9297-5e29c2752a07",
+			"storage_in_mb": 512000,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.206",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.133",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres medium-ha-12 high-iops",
+			"valid_from": "2020-12-01",
+			"plan_guid": "95065f02-0c52-40fe-b12c-3b13a01c8748",
+			"storage_in_mb": 512000,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.412",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.266",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres large-12 high-iops",
+			"valid_from": "2020-12-01",
+			"plan_guid": "b36503e9-3066-476e-9d7b-d00b2108f802",
+			"storage_in_mb": 2621440,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.824",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.133",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres large-ha-12 high-iops",
+			"valid_from": "2020-12-01",
+			"plan_guid": "78c39693-c13b-49d9-8ae2-6df910388846",
+			"storage_in_mb": 2621440,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 1.648",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.266",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres xlarge-12 high-iops",
+			"valid_from": "2020-12-01",
+			"plan_guid": "fa8125ab-5398-4ed4-88a6-64719b6add48",
+			"storage_in_mb": 10485760,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 1.648",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.133",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "postgres xlarge-ha-12 high-iops",
+			"valid_from": "2020-12-01",
+			"plan_guid": "386116e4-efa4-4472-ae1c-40e0ce3f5474",
+			"storage_in_mb": 10485760,
+			"memory_in_mb": 0,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 3.296",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "storage",
+					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.266",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
 			"name": "mysql tiny-unencrypted-5.7",
 			"valid_from": "2017-01-01",
 			"plan_guid": "69977068-8ef5-4172-bfdb-e8cea3c14d01",

--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 0.1.72
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.72.tgz
-    sha1: e62443110ab94c599cb74fbba52731228ac2590b
+    version: 0.0.1606408827
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.0.1606408827.tgz
+    sha1: 1eba63f22be78a360020814180b3bd53e89a5f8f
 
 - type: replace
   path: /instance_groups/-

--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 0.0.1606408827
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.0.1606408827.tgz
-    sha1: 1eba63f22be78a360020814180b3bd53e89a5f8f
+    version: 0.1.73
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-0.1.73.tgz
+    sha1: 088048daeda8936b7f830fa40275dd3efd4bf0da
 
 - type: replace
   path: /instance_groups/-

--- a/manifests/cf-manifest/operations.d/720-rds-broker-postgres12-plans.yml
+++ b/manifests/cf-manifest/operations.d/720-rds-broker-postgres12-plans.yml
@@ -1,0 +1,352 @@
+---
+- type: replace
+  path: /meta?/rds_broker
+  value:
+    default_postgres_rds_properties: &default_postgres_rds_properties
+      storage_type: "gp2"
+      auto_minor_version_upgrade: true
+      multi_az: false
+      storage_encrypted: false
+      publicly_accessible: false
+      copy_tags_to_snapshot: true
+      skip_final_snapshot: false
+      backup_retention_period: 7
+      db_subnet_group_name: ((terraform_outputs_rds_broker_dbs_subnet_group))
+      vpc_security_group_ids:
+        - ((terraform_outputs_rds_broker_dbs_security_group_id))
+      engine: "postgres"
+      engine_version: "12"
+      engine_family: "postgres12"
+      default_extensions: ["uuid-ossp", "postgis", "citext"]
+      allowed_extensions: [
+        "address_standardizer",
+        "address_standardizer_data_us",
+        "bloom",
+        "btree_gin",
+        "btree_gist",
+        "citext",
+        "cube",
+        "dblink",
+        "dict_int",
+        "dict_xsyn",
+        "earthdistance",
+        "fuzzystrmatch",
+        "hstore",
+        "hstore_plperl",
+        "intagg",
+        "intarray",
+        "ip4r",
+        "isn",
+        "log_fdw",
+        "libprotobuf",
+        "ltree",
+        "orafce",
+        "pgaudit",
+        "pg_buffercache",
+        "pg_freespacemap",
+        "pg_hint_plan",
+        "pg_prewarm",
+        "pg_repack",
+        "pg_similarity",
+        "pg_stat_statements",
+        "pg_transport",
+        "pg_trgm",
+        "pg_visibility",
+        "pgcrypto",
+        "pageinspect",
+        "pglogical",
+        "pgrowlocks",
+        "pgrouting",
+        "pgstattuple",
+        "pgtap",
+        "plcoffee",
+        "plls",
+        "plperl",
+        "plpgsql",
+        "pltcl",
+        "plv8",
+        "postgis",
+        "postgis_tiger_geocoder",
+        "postgis_topology",
+        "postgres_fdw",
+        "postgresql-hll",
+        "prefix",
+        "sslinfo",
+        "tablefunc",
+        "test_parser",
+        "tsm_system_rows",
+        "tsm_system_time",
+        "unaccent",
+        "uuid-ossp"
+      ]
+
+    tiny_plan_rds_properties: &tiny_plan_rds_properties
+      db_instance_class: "db.t3.micro"
+      allocated_storage: 5
+      backup_retention_period: 0
+      skip_final_snapshot: true
+    small_plan_rds_properties: &small_plan_rds_properties
+      db_instance_class: "db.t3.small"
+      allocated_storage: 100
+    medium_plan_rds_properties: &medium_plan_rds_properties
+      db_instance_class: "db.m5.large"
+      allocated_storage: 100
+    large_plan_rds_properties: &large_plan_rds_properties
+      db_instance_class: "db.m5.2xlarge"
+      allocated_storage: 512
+    xlarge_plan_rds_properties: &xlarge_plan_rds_properties
+      db_instance_class: "db.m5.4xlarge"
+      allocated_storage: 2048
+
+- type: replace
+  path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog/services/name=postgres/plans?/-
+  value:
+    id: "8b8a7372-84ab-43de-8634-8a23dd3b23f6"
+    name: "tiny-unencrypted-12"
+    description: "5GB Storage, NOT BACKED UP, Dedicated Instance, Max 50 Concurrent Connections. Postgres Version 12. DB Instance Class: db.t3.micro. Free for trial orgs. Costs for billable orgs."
+    free: true
+    metadata:
+      AdditionalMetadata:
+        backups: false
+        concurrentConnections: 50
+        encrypted: false
+        highlyAvailable: false
+        instanceClass: db.t3.micro
+        storage:
+          amount: 5
+          unit: GB
+        version: '12'
+      displayName: Tiny
+      bullets:
+        - "Dedicated Postgres 12 server"
+        - "AWS RDS"
+    rds_properties:
+      <<: *default_postgres_rds_properties # yamllint disable-line
+      <<: *tiny_plan_rds_properties # yamllint disable-line
+
+- type: replace
+  path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog/services/name=postgres/plans?/-
+  value:
+    id: "d89daa72-0219-4b40-81b9-8df14612ee74"
+    name: "small-12"
+    description: "100GB Storage, Dedicated Instance, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 12. DB Instance Class: db.t3.small."
+    free: false
+    metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 200
+        encrypted: true
+        highlyAvailable: false
+        instanceClass: db.t3.small
+        storage:
+          amount: 100
+          unit: GB
+        version: '12'
+      displayName: Small
+      bullets:
+        - "Dedicated Postgres 12 server"
+        - "Storage Encrypted"
+        - "AWS RDS"
+    rds_properties:
+      <<: *default_postgres_rds_properties # yamllint disable-line
+      <<: *small_plan_rds_properties # yamllint disable-line
+      storage_encrypted: true
+
+- type: replace
+  path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog/services/name=postgres/plans?/-
+  value:
+    id: "f38342c0-b119-438e-a450-2170f2fc789f"
+    name: "small-ha-12"
+    description: "100GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 12. DB Instance Class: db.t3.small."
+    free: false
+    metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 200
+        encrypted: true
+        highlyAvailable: true
+        instanceClass: db.t3.small
+        storage:
+          amount: 100
+          unit: GB
+        version: '12'
+      displayName: Small highly-available
+      bullets:
+        - "Dedicated Postgres 12 server"
+        - "AWS RDS"
+    rds_properties:
+      <<: *default_postgres_rds_properties # yamllint disable-line
+      <<: *small_plan_rds_properties # yamllint disable-line
+      multi_az: true
+      storage_encrypted: true
+
+- type: replace
+  path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog/services/name=postgres/plans?/-
+  value:
+    id: "41e4c5eb-2cb0-4f7c-8864-60b1cdbf06d5"
+    name: "medium-12"
+    description: "100GB Storage, Dedicated Instance, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 12. DB Instance Class: db.m5.large."
+    free: false
+    metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 500
+        encrypted: true
+        highlyAvailable: false
+        instanceClass: db.m5.large
+        storage:
+          amount: 100
+          unit: GB
+        version: '12'
+      displayName: Medium
+      bullets:
+        - "Dedicated Postgres 12 server"
+        - "Storage Encrypted"
+        - "AWS RDS"
+    rds_properties:
+      <<: *default_postgres_rds_properties # yamllint disable-line
+      <<: *medium_plan_rds_properties # yamllint disable-line
+      storage_encrypted: true
+
+- type: replace
+  path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog/services/name=postgres/plans?/-
+  value:
+    id: "43c55e2c-8068-4e10-9e2f-893204e45b2d"
+    name: "medium-ha-12"
+    description: "100GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 12. DB Instance Class: db.m5.large."
+    free: false
+    metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 500
+        encrypted: true
+        highlyAvailable: true
+        instanceClass: db.m5.large
+        storage:
+          amount: 100
+          unit: GB
+        version: '12'
+      displayName: Medium highly-available
+      bullets:
+        - "Dedicated Postgres 12 server"
+        - "Storage Encrypted"
+        - "AWS RDS"
+    rds_properties:
+      <<: *default_postgres_rds_properties # yamllint disable-line
+      <<: *medium_plan_rds_properties # yamllint disable-line
+      multi_az: true
+      storage_encrypted: true
+
+- type: replace
+  path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog/services/name=postgres/plans?/-
+  value:
+    id: "44f6cc4c-6172-4efa-badc-c0f9453f2b09"
+    name: "large-12"
+    description: "512GB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 12. DB Instance Class: db.m5.2xlarge."
+    free: false
+    metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: false
+        instanceClass: db.m5.2xlarge
+        storage:
+          amount: 512
+          unit: GB
+        version: '12'
+      displayName: Large
+      bullets:
+        - "Dedicated Postgres 12 server"
+        - "Storage Encrypted"
+        - "AWS RDS"
+    rds_properties:
+      <<: *default_postgres_rds_properties # yamllint disable-line
+      <<: *large_plan_rds_properties # yamllint disable-line
+      storage_encrypted: true
+
+- type: replace
+  path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog/services/name=postgres/plans?/-
+  value:
+    id: "5fbc649c-018a-4097-aa4f-d46358aadbe1"
+    name: "large-ha-12"
+    description: "512GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 12. DB Instance Class: db.m5.2xlarge."
+    free: false
+    metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: true
+        instanceClass: db.m5.2xlarge
+        storage:
+          amount: 512
+          unit: GB
+        version: '12'
+      displayName: Large highly-available
+      bullets:
+        - "Dedicated Postgres 12 server"
+        - "Storage Encrypted"
+        - "AWS RDS"
+    rds_properties:
+      <<: *default_postgres_rds_properties # yamllint disable-line
+      <<: *large_plan_rds_properties # yamllint disable-line
+      multi_az: true
+      storage_encrypted: true
+
+- type: replace
+  path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog/services/name=postgres/plans?/-
+  value:
+    id: "810e88e7-5e35-4b48-92a0-fe7b99fb41d2"
+    name: "xlarge-12"
+    description: "2TB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 12. DB Instance Class: db.m5.4xlarge."
+    free: false
+    metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: false
+        instanceClass: db.m5.4xlarge
+        storage:
+          amount: 2
+          unit: TB
+        version: '12'
+      displayName: Extra Large
+      bullets:
+        - "Dedicated Postgres 12 server"
+        - "Storage Encrypted"
+        - "AWS RDS"
+    rds_properties:
+      <<: *default_postgres_rds_properties # yamllint disable-line
+      <<: *xlarge_plan_rds_properties # yamllint disable-line
+      storage_encrypted: true
+
+- type: replace
+  path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog/services/name=postgres/plans?/-
+  value:
+    id: "404e6784-343b-4957-b684-3206184a5e11"
+    name: "xlarge-ha-12"
+    description: "2TB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 12. DB Instance Class: db.m5.4xlarge."
+    free: false
+    metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: true
+        instanceClass: db.m5.4xlarge
+        storage:
+          amount: 2
+          unit: TB
+        version: '12'
+      displayName: Extra Large highly-available
+      bullets:
+        - "Dedicated Postgres 12 server"
+        - "Storage Encrypted"
+        - "AWS RDS"
+    rds_properties:
+      <<: *default_postgres_rds_properties # yamllint disable-line
+      <<: *xlarge_plan_rds_properties # yamllint disable-line
+      multi_az: true
+      storage_encrypted: true

--- a/manifests/cf-manifest/operations.d/721-rds-broker-postgres12-high-iops-plans.yml
+++ b/manifests/cf-manifest/operations.d/721-rds-broker-postgres12-high-iops-plans.yml
@@ -1,0 +1,361 @@
+---
+- type: replace
+  path: /meta?/rds_broker
+  value:
+    default_postgres_rds_properties: &default_postgres_rds_properties
+      storage_type: "gp2"
+      auto_minor_version_upgrade: true
+      multi_az: false
+      storage_encrypted: false
+      publicly_accessible: false
+      copy_tags_to_snapshot: true
+      skip_final_snapshot: false
+      backup_retention_period: 7
+      db_subnet_group_name: ((terraform_outputs_rds_broker_dbs_subnet_group))
+      vpc_security_group_ids:
+        - ((terraform_outputs_rds_broker_dbs_security_group_id))
+      engine: "postgres"
+      engine_version: "12"
+      engine_family: "postgres12"
+      default_extensions: ["uuid-ossp", "postgis", "citext"]
+      allowed_extensions: [
+        "address_standardizer",
+        "address_standardizer_data_us",
+        "bloom",
+        "btree_gin",
+        "btree_gist",
+        "citext",
+        "cube",
+        "dblink",
+        "dict_int",
+        "dict_xsyn",
+        "earthdistance",
+        "fuzzystrmatch",
+        "hstore",
+        "hstore_plperl",
+        "intagg",
+        "intarray",
+        "ip4r",
+        "isn",
+        "log_fdw",
+        "libprotobuf",
+        "ltree",
+        "orafce",
+        "pgaudit",
+        "pg_buffercache",
+        "pg_freespacemap",
+        "pg_hint_plan",
+        "pg_prewarm",
+        "pg_repack",
+        "pg_similarity",
+        "pg_stat_statements",
+        "pg_transport",
+        "pg_trgm",
+        "pg_visibility",
+        "pgcrypto",
+        "pageinspect",
+        "pglogical",
+        "pgrowlocks",
+        "pgrouting",
+        "pgstattuple",
+        "pgtap",
+        "plcoffee",
+        "plls",
+        "plperl",
+        "plpgsql",
+        "pltcl",
+        "plv8",
+        "postgis",
+        "postgis_tiger_geocoder",
+        "postgis_topology",
+        "postgres_fdw",
+        "postgresql-hll",
+        "prefix",
+        "sslinfo",
+        "tablefunc",
+        "test_parser",
+        "tsm_system_rows",
+        "tsm_system_time",
+        "unaccent",
+        "uuid-ossp"
+      ]
+
+    tiny_plan_rds_properties: &tiny_plan_rds_properties
+      db_instance_class: "db.t3.micro"
+      allocated_storage: 25
+      backup_retention_period: 0
+      skip_final_snapshot: true
+    small_plan_rds_properties: &small_plan_rds_properties
+      db_instance_class: "db.t3.small"
+      allocated_storage: 100
+    medium_plan_rds_properties: &medium_plan_rds_properties
+      db_instance_class: "db.m5.large"
+      allocated_storage: 500
+    large_plan_rds_properties: &large_plan_rds_properties
+      db_instance_class: "db.m5.2xlarge"
+      allocated_storage: 2560
+    xlarge_plan_rds_properties: &xlarge_plan_rds_properties
+      db_instance_class: "db.m5.4xlarge"
+      allocated_storage: 10240
+
+- type: replace
+  path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog/services/name=postgres/plans?/-
+  value:
+    id: "f1fdbac4-4581-48cb-807c-63dc8a40bbfd"
+    name: "tiny-unencrypted-12-high-iops"
+    description: "25GB Storage, NOT BACKED UP, Dedicated Instance, Max 50 Concurrent Connections. Postgres Version 12. DB Instance Class: db.t3.micro. Free for trial orgs. Costs for billable orgs."
+    free: true
+    metadata:
+      AdditionalMetadata:
+        backups: false
+        concurrentConnections: 50
+        encrypted: false
+        highlyAvailable: false
+        highIOPS: true
+        instanceClass: db.t3.micro
+        storage:
+          amount: 25
+          unit: GB
+        version: '12'
+      displayName: Tiny high-IOPS
+      bullets:
+        - "Dedicated Postgres 12 server"
+        - "AWS RDS"
+    rds_properties:
+      <<: *default_postgres_rds_properties # yamllint disable-line
+      <<: *tiny_plan_rds_properties # yamllint disable-line
+
+- type: replace
+  path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog/services/name=postgres/plans?/-
+  value:
+    id: "6fe540eb-e6a7-49bc-bfbe-cb097c9f358e"
+    name: "small-12-high-iops"
+    description: "100GB Storage, Dedicated Instance, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 12. DB Instance Class: db.t3.small."
+    free: false
+    metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 200
+        encrypted: true
+        highlyAvailable: false
+        highIOPS: true
+        instanceClass: db.t3.small
+        storage:
+          amount: 100
+          unit: GB
+        version: '12'
+      displayName: Small high-IOPS
+      bullets:
+        - "Dedicated Postgres 12 server"
+        - "Storage Encrypted"
+        - "AWS RDS"
+    rds_properties:
+      <<: *default_postgres_rds_properties # yamllint disable-line
+      <<: *small_plan_rds_properties # yamllint disable-line
+      storage_encrypted: true
+
+- type: replace
+  path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog/services/name=postgres/plans?/-
+  value:
+    id: "7b2e29e8-b187-4da5-921e-3581df1bc0a1"
+    name: "small-ha-12-high-iops"
+    description: "100GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 12. DB Instance Class: db.t3.small."
+    free: false
+    metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 200
+        encrypted: true
+        highlyAvailable: true
+        highIOPS: true
+        instanceClass: db.t3.small
+        storage:
+          amount: 100
+          unit: GB
+        version: '12'
+      displayName: Small highly-available high-IOPS
+      bullets:
+        - "Dedicated Postgres 12 server"
+        - "AWS RDS"
+    rds_properties:
+      <<: *default_postgres_rds_properties # yamllint disable-line
+      <<: *small_plan_rds_properties # yamllint disable-line
+      multi_az: true
+      storage_encrypted: true
+
+- type: replace
+  path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog/services/name=postgres/plans?/-
+  value:
+    id: "09b58be1-d0d6-41a5-9297-5e29c2752a07"
+    name: "medium-12-high-iops"
+    description: "500GB Storage, Dedicated Instance, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 12. DB Instance Class: db.m5.large."
+    free: false
+    metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 500
+        encrypted: true
+        highlyAvailable: false
+        highIOPS: true
+        instanceClass: db.m5.large
+        storage:
+          amount: 500
+          unit: GB
+        version: '12'
+      displayName: Medium high-IOPS
+      bullets:
+        - "Dedicated Postgres 12 server"
+        - "Storage Encrypted"
+        - "AWS RDS"
+    rds_properties:
+      <<: *default_postgres_rds_properties # yamllint disable-line
+      <<: *medium_plan_rds_properties # yamllint disable-line
+      storage_encrypted: true
+
+- type: replace
+  path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog/services/name=postgres/plans?/-
+  value:
+    id: "95065f02-0c52-40fe-b12c-3b13a01c8748"
+    name: "medium-ha-12-high-iops"
+    description: "500GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 12. DB Instance Class: db.m5.large."
+    free: false
+    metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 500
+        encrypted: true
+        highlyAvailable: true
+        highIOPS: true
+        instanceClass: db.m5.large
+        storage:
+          amount: 500
+          unit: GB
+        version: '12'
+      displayName: Medium highly-available high-IOPS
+      bullets:
+        - "Dedicated Postgres 12 server"
+        - "Storage Encrypted"
+        - "AWS RDS"
+    rds_properties:
+      <<: *default_postgres_rds_properties # yamllint disable-line
+      <<: *medium_plan_rds_properties # yamllint disable-line
+      multi_az: true
+      storage_encrypted: true
+
+- type: replace
+  path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog/services/name=postgres/plans?/-
+  value:
+    id: "b36503e9-3066-476e-9d7b-d00b2108f802"
+    name: "large-12-high-iops"
+    description: "2.5TB Storage Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 12. DB Instance Class: db.m5.2xlarge."
+    free: false
+    metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: false
+        highIOPS: true
+        instanceClass: db.m5.2xlarge
+        storage:
+          amount: 2.5
+          unit: TB
+        version: '12'
+      displayName: Large high-IOPS
+      bullets:
+        - "Dedicated Postgres 12 server"
+        - "Storage Encrypted"
+        - "AWS RDS"
+    rds_properties:
+      <<: *default_postgres_rds_properties # yamllint disable-line
+      <<: *large_plan_rds_properties # yamllint disable-line
+      storage_encrypted: true
+
+- type: replace
+  path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog/services/name=postgres/plans?/-
+  value:
+    id: "78c39693-c13b-49d9-8ae2-6df910388846"
+    name: "large-ha-12-high-iops"
+    description: "2.5TB Storage Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 12. DB Instance Class: db.m5.2xlarge."
+    free: false
+    metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: true
+        highIOPS: true
+        instanceClass: db.m5.2xlarge
+        storage:
+          amount: 2.5
+          unit: TB
+        version: '12'
+      displayName: Large highly-available high-IOPS
+      bullets:
+        - "Dedicated Postgres 12 server"
+        - "Storage Encrypted"
+        - "AWS RDS"
+    rds_properties:
+      <<: *default_postgres_rds_properties # yamllint disable-line
+      <<: *large_plan_rds_properties # yamllint disable-line
+      multi_az: true
+      storage_encrypted: true
+
+- type: replace
+  path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog/services/name=postgres/plans?/-
+  value:
+    id: "fa8125ab-5398-4ed4-88a6-64719b6add48"
+    name: "xlarge-12-high-iops"
+    description: "10TB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 12. DB Instance Class: db.m5.4xlarge."
+    free: false
+    metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: false
+        highIOPS: true
+        instanceClass: db.m5.4xlarge
+        storage:
+          amount: 10
+          unit: TB
+        version: '12'
+      displayName: Extra Large high-IOPS
+      bullets:
+        - "Dedicated Postgres 12 server"
+        - "Storage Encrypted"
+        - "AWS RDS"
+    rds_properties:
+      <<: *default_postgres_rds_properties # yamllint disable-line
+      <<: *xlarge_plan_rds_properties # yamllint disable-line
+      storage_encrypted: true
+
+- type: replace
+  path: /instance_groups/name=rds_broker/jobs/name=rds-broker/properties/rds-broker/catalog/services/name=postgres/plans?/-
+  value:
+    id: "386116e4-efa4-4472-ae1c-40e0ce3f5474"
+    name: "xlarge-ha-12-high-iops"
+    description: "10TB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 12. DB Instance Class: db.m5.4xlarge."
+    free: false
+    metadata:
+      AdditionalMetadata:
+        backups: true
+        concurrentConnections: 5000
+        encrypted: true
+        highlyAvailable: true
+        highIOPS: true
+        instanceClass: db.m5.4xlarge
+        storage:
+          amount: 10
+          unit: TB
+        version: '12'
+      displayName: Extra Large highly-available high-IOPS
+      bullets:
+        - "Dedicated Postgres 12 server"
+        - "Storage Encrypted"
+        - "AWS RDS"
+    rds_properties:
+      <<: *default_postgres_rds_properties # yamllint disable-line
+      <<: *xlarge_plan_rds_properties # yamllint disable-line
+      multi_az: true
+      storage_encrypted: true

--- a/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
@@ -272,6 +272,24 @@ RSpec.describe "RDS broker properties" do
           "large-ha-11-high-iops",
           "xlarge-11-high-iops",
           "xlarge-ha-11-high-iops",
+          "tiny-unencrypted-12",
+          "small-12",
+          "small-ha-12",
+          "medium-12",
+          "medium-ha-12",
+          "large-12",
+          "large-ha-12",
+          "xlarge-12",
+          "xlarge-ha-12",
+          "tiny-unencrypted-12-high-iops",
+          "small-12-high-iops",
+          "small-ha-12-high-iops",
+          "medium-12-high-iops",
+          "medium-ha-12-high-iops",
+          "large-12-high-iops",
+          "large-ha-12-high-iops",
+          "xlarge-12-high-iops",
+          "xlarge-ha-12-high-iops",
         )
       end
 
@@ -332,6 +350,16 @@ RSpec.describe "RDS broker properties" do
 
           it "uses postgres 11" do
             expect(rds_properties["engine_version"]).to eq("11")
+          end
+
+          include_examples "plans using t3 and m5 instances"
+        end
+
+        shared_examples "postgres 12 plans" do
+          let(:rds_properties) { plan.fetch("rds_properties") }
+
+          it "uses postgres 12" do
+            expect(rds_properties["engine_version"]).to eq("12")
           end
 
           include_examples "plans using t3 and m5 instances"
@@ -938,6 +966,214 @@ RSpec.describe "RDS broker properties" do
 
           it_behaves_like "all postgres plans"
           it_behaves_like "postgres 11 plans"
+          it_behaves_like "xlarge sized high iops plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "HA plans"
+          it_behaves_like "Encryption enabled plans"
+        end
+
+        # Postgres 12
+        describe "tiny-unencrypted-12" do
+          subject(:plan) { pg_plans.find { |p| p["name"] == "tiny-unencrypted-12" } }
+
+          it "is marked as free" do
+            expect(plan.fetch("free")).to eq(true)
+          end
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "postgres 12 plans"
+          it_behaves_like "tiny sized plans"
+          it_behaves_like "backup disabled plans"
+          it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption disabled plans"
+        end
+
+        describe "small-12" do
+          subject(:plan) { pg_plans.find { |p| p["name"] == "small-12" } }
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "postgres 12 plans"
+          it_behaves_like "small sized plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption enabled plans"
+        end
+
+        describe "small-ha-12" do
+          subject(:plan) { pg_plans.find { |p| p["name"] == "small-ha-12" } }
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "postgres 12 plans"
+          it_behaves_like "small sized plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "HA plans"
+          it_behaves_like "Encryption enabled plans"
+        end
+
+        describe "medium-12" do
+          subject(:plan) { pg_plans.find { |p| p["name"] == "medium-12" } }
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "postgres 12 plans"
+          it_behaves_like "medium sized plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption enabled plans"
+        end
+
+        describe "medium-ha-12" do
+          subject(:plan) { pg_plans.find { |p| p["name"] == "medium-ha-12" } }
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "postgres 12 plans"
+          it_behaves_like "medium sized plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "HA plans"
+          it_behaves_like "Encryption enabled plans"
+        end
+
+        describe "large-12" do
+          subject(:plan) { pg_plans.find { |p| p["name"] == "large-12" } }
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "postgres 12 plans"
+          it_behaves_like "large sized plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption enabled plans"
+        end
+
+        describe "large-ha-12" do
+          subject(:plan) { pg_plans.find { |p| p["name"] == "large-ha-12" } }
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "postgres 12 plans"
+          it_behaves_like "large sized plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "HA plans"
+          it_behaves_like "Encryption enabled plans"
+        end
+
+        describe "xlarge-12" do
+          subject(:plan) { pg_plans.find { |p| p["name"] == "xlarge-12" } }
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "postgres 12 plans"
+          it_behaves_like "xlarge sized plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption enabled plans"
+        end
+
+        describe "xlarge-ha-12" do
+          subject(:plan) { pg_plans.find { |p| p["name"] == "xlarge-ha-12" } }
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "postgres 12 plans"
+          it_behaves_like "xlarge sized plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "HA plans"
+          it_behaves_like "Encryption enabled plans"
+        end
+
+        # Postgres 12 High IOPS
+        describe "tiny-unencrypted-12-high-iops" do
+          subject(:plan) { pg_plans.find { |p| p["name"] == "tiny-unencrypted-12-high-iops" } }
+
+          it "is marked as free" do
+            expect(plan.fetch("free")).to eq(true)
+          end
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "postgres 12 plans"
+          it_behaves_like "tiny sized high iops plans"
+          it_behaves_like "backup disabled plans"
+          it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption disabled plans"
+        end
+
+        describe "small-12-high-iops" do
+          subject(:plan) { pg_plans.find { |p| p["name"] == "small-12-high-iops" } }
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "postgres 12 plans"
+          it_behaves_like "small sized high iops plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption enabled plans"
+        end
+
+        describe "small-ha-12-high-iops" do
+          subject(:plan) { pg_plans.find { |p| p["name"] == "small-ha-12-high-iops" } }
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "postgres 12 plans"
+          it_behaves_like "small sized high iops plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "HA plans"
+          it_behaves_like "Encryption enabled plans"
+        end
+
+        describe "medium-12-high-iops" do
+          subject(:plan) { pg_plans.find { |p| p["name"] == "medium-12-high-iops" } }
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "postgres 12 plans"
+          it_behaves_like "medium sized high iops plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption enabled plans"
+        end
+
+        describe "medium-ha-12-high-iops" do
+          subject(:plan) { pg_plans.find { |p| p["name"] == "medium-ha-12-high-iops" } }
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "postgres 12 plans"
+          it_behaves_like "medium sized high iops plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "HA plans"
+          it_behaves_like "Encryption enabled plans"
+        end
+
+        describe "large-12-high-iops" do
+          subject(:plan) { pg_plans.find { |p| p["name"] == "large-12-high-iops" } }
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "postgres 12 plans"
+          it_behaves_like "large sized high iops plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption enabled plans"
+        end
+
+        describe "large-ha-12-high-iops" do
+          subject(:plan) { pg_plans.find { |p| p["name"] == "large-ha-12-high-iops" } }
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "postgres 12 plans"
+          it_behaves_like "large sized high iops plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "HA plans"
+          it_behaves_like "Encryption enabled plans"
+        end
+
+        describe "xlarge-12-high-iops" do
+          subject(:plan) { pg_plans.find { |p| p["name"] == "xlarge-12-high-iops" } }
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "postgres 12 plans"
+          it_behaves_like "xlarge sized high iops plans"
+          it_behaves_like "backup enabled plans"
+          it_behaves_like "non-HA plans"
+          it_behaves_like "Encryption enabled plans"
+        end
+
+        describe "xlarge-ha-12-high-iops" do
+          subject(:plan) { pg_plans.find { |p| p["name"] == "xlarge-ha-12-high-iops" } }
+
+          it_behaves_like "all postgres plans"
+          it_behaves_like "postgres 12 plans"
           it_behaves_like "xlarge sized high iops plans"
           it_behaves_like "backup enabled plans"
           it_behaves_like "HA plans"

--- a/platform-tests/broker-acceptance/postgres_service_test.go
+++ b/platform-tests/broker-acceptance/postgres_service_test.go
@@ -17,7 +17,7 @@ import (
 var _ = Describe("Postgres backing service", func() {
 	const (
 		serviceName  = "postgres"
-		testPlanName = "tiny-unencrypted-11"
+		testPlanName = "tiny-unencrypted-12"
 	)
 
 	It("should have registered the postgres service", func() {
@@ -58,6 +58,15 @@ var _ = Describe("Postgres backing service", func() {
 			Expect(cfMarketplaceOutput).To(ContainSubstring("large-ha-10"))
 			Expect(cfMarketplaceOutput).To(ContainSubstring("xlarge-10"))
 			Expect(cfMarketplaceOutput).To(ContainSubstring("xlarge-ha-10"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("tiny-unencrypted-10-high-iops"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("small-10-high-iops"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("small-ha-10-high-iops"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("medium-10-high-iops"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("medium-ha-10-high-iops"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("large-10-high-iops"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("large-ha-10-high-iops"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("xlarge-10-high-iops"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("xlarge-ha-10-high-iops"))
 
 			Expect(cfMarketplaceOutput).To(ContainSubstring("tiny-unencrypted-11"))
 			Expect(cfMarketplaceOutput).To(ContainSubstring("small-11"))
@@ -68,6 +77,35 @@ var _ = Describe("Postgres backing service", func() {
 			Expect(cfMarketplaceOutput).To(ContainSubstring("large-ha-11"))
 			Expect(cfMarketplaceOutput).To(ContainSubstring("xlarge-11"))
 			Expect(cfMarketplaceOutput).To(ContainSubstring("xlarge-ha-11"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("tiny-unencrypted-11-high-iops"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("small-11-high-iops"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("small-ha-11-high-iops"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("medium-11-high-iops"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("medium-ha-11-high-iops"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("large-11-high-iops"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("large-ha-11-high-iops"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("xlarge-11-high-iops"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("xlarge-ha-11-high-iops"))
+
+			Expect(cfMarketplaceOutput).To(ContainSubstring("tiny-unencrypted-12"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("small-12"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("small-ha-12"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("medium-12"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("medium-ha-12"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("large-12"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("large-ha-12"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("xlarge-12"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("xlarge-ha-12"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("tiny-unencrypted-12-high-iops"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("small-12-high-iops"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("small-ha-12-high-iops"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("medium-12-high-iops"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("medium-ha-12-high-iops"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("large-12-high-iops"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("large-ha-12-high-iops"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("xlarge-12-high-iops"))
+			Expect(cfMarketplaceOutput).To(ContainSubstring("xlarge-ha-12-high-iops"))
+
 		})
 	})
 	Context("creating a database instance", func() {


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/175721576)

What
----
We want to add Postgres 12.X database engine to our RDS Broker offering.

rds-broker-boshrelease PR is [here](https://github.com/alphagov/paas-rds-broker-boshrelease/pull/98)

How to review
-------------
- Code review
- Deploy to your dev env
- Make sure that `post-deploy` and `custom-broker-acceptance-tests` jobs are `green`.
- Check that postgres 12 plans are visible when you are running `cf m -e postgres`
- [Optional] Create a service instance with one of the postgres 12 plans (`tiny-unencrypted-12` is the smallest one).
- [Optional] Check that the database was created correctly either via psql or via AWS Console.

Who can review
===
Not @barsutka 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
