### PR TITLE
Increase alert thresholds for AWS service limits

### DIFF
--- a/manifests/prometheus/env-specific/prod-lon.yml
+++ b/manifests/prometheus/env-specific/prod-lon.yml
@@ -2,7 +2,8 @@
 
 # AWS Limits not accesible via API
 aws_limits_elasticache_cache_parameter_groups: 400
-aws_limits_elasticache_nodes: 500
-aws_limits_s3_buckets: 250
+aws_limits_elasticache_nodes: 700
+# Change limit for prod as well - S3 is global
+aws_limits_s3_buckets: 300
 aws_limits_rds_instances: 750
 prometheus_disk_size: 200GB

--- a/manifests/prometheus/env-specific/prod.yml
+++ b/manifests/prometheus/env-specific/prod.yml
@@ -3,6 +3,7 @@
 # AWS Limits not accesible via API
 aws_limits_elasticache_cache_parameter_groups: 400
 aws_limits_elasticache_nodes: 400
-aws_limits_s3_buckets: 250
+# Change limit for prod-lon as well - S3 is global
+aws_limits_s3_buckets: 300
 aws_limits_rds_instances: 550
 prometheus_disk_size: 200GB


### PR DESCRIPTION
What
----

- Elasticache (Redis) node and S3 bucket usage has recently surpassed 80 percent of our service limits triggering alerts in prod-lon.
- We have been granted service limit increases to 700 Redis nodes and 300 buckets now.

How to review
-------------

Check the new limits

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
