### PR TITLE
Use Postgres 12 for the healthcheck-db in post-deploy job.

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2925,13 +2925,50 @@ jobs:
                 cd paas-cf/platform-tests/example-apps/healthcheck
 
                 if  [ "${DISABLE_HEALTHCHECK_DB:-}" != "true" ] ; then
+                  max_iterations=20
+                  timeout_per_iteration_in_seconds=30
+
+                  # if healthcheck-db already exist and it's postgres 9.5
+                  # we need to delete the database before creating it with postgres 12 plan
+                  if cf service healthcheck-db | grep -q 'plan: .*tiny-unencrypted-9.5'; then
+                    cf unbind-service healthcheck healthcheck-db || true
+                    cf delete-service -f healthcheck-db
+                    loop_iterations=1
+                    while cf service healthcheck-db | grep -q 'status: .*delete in progress'; do
+                      if  [ $loop_iterations -gt $max_iterations ] ; then
+                        echo "Timeout of $((max_iterations*timeout_per_iteration_in_seconds)) seconds reached, exiting..."
+                        break
+                      fi
+                      echo "Waiting for the current healthcheck-db service instance deletion to complete..."
+                      sleep $timeout_per_iteration_in_seconds
+                      loop_iterations=$((loop_iterations+1))
+                    done
+                    if [ $loop_iterations -gt $max_iterations ] ; then
+                      echo "Failed to delete healthcheck-db, exiting..."
+                      cd "${BUILD_ROOT}"
+                      echo "no" > deployed-healthcheck/healthcheck-deployed
+                      exit 1
+                    fi
+                  fi
 
                   if ! cf service healthcheck-db > /dev/null; then
-                    cf create-service postgres tiny-unencrypted-9.5 healthcheck-db
+                    cf create-service postgres tiny-unencrypted-12 healthcheck-db
+                    loop_iterations=1
                     while ! cf service healthcheck-db | grep -q 'create succeeded'; do
+                      if  [ $loop_iterations -gt $max_iterations ] ; then
+                        echo "Timeout of $((max_iterations*timeout_per_iteration_in_seconds)) seconds reached, exiting..."
+                        break
+                      fi
                       echo "Waiting for creation of service to complete..."
-                      sleep 30
+                      sleep $timeout_per_iteration_in_seconds
+                      loop_iterations=$((loop_iterations+1))
                     done
+                    if [ $loop_iterations -gt $max_iterations ] ; then
+                      echo "Failed to create healthcheck-db, exiting..."
+                      cd "${BUILD_ROOT}"
+                      echo "no" > deployed-healthcheck/healthcheck-deployed
+                      exit 1
+                    fi
                   fi
 
                   ruby -ryaml -e '


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/175936044)

What
----
Due to EOL of  Postgres 9.5, we have to use Postgres 12 for our healthcheck-db.

How to review
-------------

1. Code review
2. Deploy it to your DEV env, don't forget to switch the DISABLE_HEALTHCHECK_DB environment variable to `false` in the [Makefile](https://github.com/alphagov/paas-cf/commit/3c1c71b01e251515294914d2d3c5144779ff0670)

Who can review
----
Not @barsutka 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
