### PR TITLE
Triple cloud controller rate limit in Ireland

### DIFF
--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -9,7 +9,7 @@ doppler_instances: 39
 log_api_instances: 6
 scheduler_instances: 4
 cc_worker_instances: 4
-cc_hourly_rate_limit: 20000
+cc_hourly_rate_limit: 60000
 cc_staging_timeout_in_seconds: 2700
 paas_region_name: ireland
 


### PR DESCRIPTION
What
----
There is a bug in the currently deployed version of Cloud Controller (1.102.0)
which is causing CF CLI v6 to misbehave and send polling requests as fast as it
possibly can. That's resulting in Notify getting rate limited when trying to
deploy.

We don't have a fix for the bug at the moment, and the rate limit is blocking
Notify's deploys. This commit triples the limit in Ireland to allow them to get
stuff out while we look for a fix.

How to review
-------------
1. See if you agree with the problem and the solution

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
