### PR TITLE
garden: Set cleanup threshold to prevent full disk

### DIFF
--- a/manifests/cf-manifest/operations.d/350-diego-cell.yml
+++ b/manifests/cf-manifest/operations.d/350-diego-cell.yml
@@ -38,6 +38,10 @@
   path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/destroy_containers_on_start
 
 - type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/grootfs?/reserved_space_for_other_jobs_in_mb?
+  value: 22549
+
+- type: replace
   path: /instance_groups/name=diego-cell/jobs/name=rep/properties/diego?/executor/memory_capacity_mb
   value: ((cell_memory_capacity_mb))
 


### PR DESCRIPTION
What
----

- At the moment, grootfs cache clean-up is not configured to kick in until a disk fills up.
- This leads to the team receiving BOSHJobEphemeralDiskPredictWillFill warnings and BOSHJobEphemeralDiskFull alerts.
- We set the grootfs.reserved_space_for_other_jobs_in_mb to 21 GiB in order to prevent these alerts from occurring during normal operation.

How to review
-------------

- Code review
- CI
- Check deployment to dev env

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
