### PR TITLE
change notify isolation-segment instance type

### DIFF
--- a/manifests/cf-manifest/isolation-segments/prod/govuk-notify-staging.yml
+++ b/manifests/cf-manifest/isolation-segments/prod/govuk-notify-staging.yml
@@ -1,3 +1,4 @@
 ---
 number_of_cells: 24
 isolation_segment_name: govuk-notify-staging
+vm_type: high_cpu_cell

--- a/manifests/cloud-config/operations/use-spot-instances-in-dev.yml
+++ b/manifests/cloud-config/operations/use-spot-instances-in-dev.yml
@@ -63,6 +63,14 @@
   value: ((cell_vm_spot_bid_price))
 
 - type: replace
+  path: /vm_types/name=high_cpu_cell/cloud_properties/spot_ondemand_fallback?
+  value: true
+
+- type: replace
+  path: /vm_types/name=high_cpu_cell/cloud_properties/spot_bid_price?
+  value: ((high_cpu_cell_vm_spot_bid_price))
+
+- type: replace
   path: /vm_types/name=small_cell/cloud_properties/spot_ondemand_fallback?
   value: true
 

--- a/manifests/cloud-config/paas-cf-cloud-config.yml
+++ b/manifests/cloud-config/paas-cf-cloud-config.yml
@@ -212,6 +212,17 @@ vm_types:
     - ((terraform_outputs_elasticache_broker_clients_security_group))
     - ((terraform_outputs_default_security_group))
 
+- name: high_cpu_cell
+  cloud_properties:
+    instance_type: ((high_cpu_cell_instance_type))
+    ephemeral_disk:
+      size: 204800
+      type: gp2
+    security_groups:
+      - ((terraform_outputs_rds_broker_db_clients_security_group))
+      - ((terraform_outputs_elasticache_broker_clients_security_group))
+      - ((terraform_outputs_default_security_group))
+
 - name: small_cell
   cloud_properties:
     instance_type: ((small_cell_instance_type))

--- a/manifests/variables.yml
+++ b/manifests/variables.yml
@@ -19,6 +19,9 @@ xlarge_vm_spot_bid_price: 0.1
 cell_instance_type: r5.xlarge
 cell_vm_spot_bid_price: 0.15
 
+high_cpu_cell_instance_type: m5.2xlarge
+high_cpu_cell_vm_spot_bid_price: 0.15
+
 small_cell_instance_type: r5.large
 small_cell_vm_spot_bid_price: 0.06
 


### PR DESCRIPTION
What
----

Notify would like to test their app on instances with more CPU whilst keeping the memory the same

How to review
-------------

Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
