### PR TITLE
isoseg: Respect the vm_tyme from data file

### DIFF
--- a/manifests/cf-manifest/scripts/generate-isolation-segment-ops-file.rb
+++ b/manifests/cf-manifest/scripts/generate-isolation-segment-ops-file.rb
@@ -32,6 +32,8 @@ isolation_segment["name"] = name
 
 isolation_segment["instances"] = seg_def["number_of_cells"]
 
+vm_type = seg_def["vm_type"] || "cell"
+
 unless seg_def["isolation_segment_size"].nil?
   vm_type = isolation_segment["vm_type"]
 
@@ -48,8 +50,6 @@ unless seg_def["isolation_segment_size"].nil?
     raise "Unknown isolation_segment_size #{seg_def['isolation_segment_size']}"
   end
 
-  isolation_segment["vm_type"] = vm_type
-
   isolation_segment
     .fetch("jobs")
     .find { |job| job["name"] == "rep" }[
@@ -58,6 +58,8 @@ unless seg_def["isolation_segment_size"].nil?
     "executor"][
     "memory_capacity_mb"] = memory_capacity
 end
+
+isolation_segment["vm_type"] = vm_type
 
 if seg_def["restricted_egress"]
   # When we restrict egress in an isolation segment, we presumably want to


### PR DESCRIPTION
What
----

At the moment, this value seems to be ignored, in favour of some custom
functionality in regards to `isolation_segment_size`.

This is rather unwanted and perhaps unfamiliar behaviour, but we're not
here to fix the way we run the show, only the thing at hand.

Adding vm_type variable before the block, will make sure it has been set
to something, before the custom logic kicks in and perhaps overrides it.

The assignment line has been moved out of the block, to run after, to
make sure both cases are handled in the same way...

Ruby foo bad - sorry future generations.

How to review
-------------

- Sanity check

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
