### PR TITLE
Add 6 extra routers in Ireland to support Notify load tests

### DIFF
--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -3,7 +3,7 @@ uaa_instances: 3
 nats_instances: 3
 diego_api_instances: 3
 cell_instances: 45
-router_instances: 18
+router_instances: 24
 api_instances: 6
 doppler_instances: 39
 log_api_instances: 6


### PR DESCRIPTION
What
----
Notify are load testing at almost 2000 req/s, and causing all of the routers to sit at 70%+ CPU usage. Adding 6 more should take the pressure off a bit.

How to review
-------------
Check I did my maths right, and that it's a multiple of 3.

Tell me if you disagree with the approach.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
