### PR TITLE
Add notify production isolation segment

### DIFF
--- a/manifests/cf-manifest/isolation-segments/prod/govuk-notify-production.yml
+++ b/manifests/cf-manifest/isolation-segments/prod/govuk-notify-production.yml
@@ -1,0 +1,4 @@
+---
+number_of_cells: 24
+isolation_segment_name: govuk-notify-production
+vm_type: high_cpu_cell


### PR DESCRIPTION
Mimics the segment given to their staging environment after load tests
on the staging segment have seen a significant impact in terms of
performance.

The plan is hopefully to only keep these around for a few months and pay
the cost of that whilst we bring things under control and can look at
reducing our CPU usage in a more long term manner.

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
