### PR TITLE
Distinguish cell memory metrics by `bosh_job_name`

### DIFF
--- a/manifests/prometheus/alerts.d/diego_cell_rep_memory_capacity.yml
+++ b/manifests/prometheus/alerts.d/diego_cell_rep_memory_capacity.yml
@@ -8,8 +8,8 @@
       - record: rep_memory_capacity_pct:avg5m
         expr: >
           100 *
-          sum(avg_over_time(firehose_value_metric_rep_capacity_remaining_memory{environment="((metrics_environment))"}[5m])) by (environment) /
-          sum(avg_over_time(firehose_value_metric_rep_capacity_total_memory{environment="((metrics_environment))"}[5m])) by (environment)
+          sum(avg_over_time(firehose_value_metric_rep_capacity_remaining_memory{environment="((metrics_environment))"}[5m])) by (environment, bosh_job_name) /
+          sum(avg_over_time(firehose_value_metric_rep_capacity_total_memory{environment="((metrics_environment))"}[5m])) by (environment, bosh_job_name)
       - alert: DiegoCellRepMemoryCapacity
         expr:  rep_memory_capacity_pct:avg5m < 35
         for: 2h

--- a/manifests/prometheus/dashboards.d/user-impact.json
+++ b/manifests/prometheus/dashboards.d/user-impact.json
@@ -502,7 +502,7 @@
                 "stack": false,
                 "steppedLine": false,
                 "targets": [{
-                        "expr": "count(firehose_value_metric_rep_capacity_total_memory)",
+                        "expr": "count(firehose_value_metric_rep_capacity_total_memory{bosh_job_name=\"diego-cell\"})",
                         "format": "time_series",
                         "instant": false,
                         "intervalFactor": 1,
@@ -512,7 +512,7 @@
                     },
                     {
                         "refId": "B",
-                        "expr": "ceil(count(firehose_value_metric_rep_capacity_total_memory) * on () (100 - rep_memory_capacity_pct:avg5m) / (100 - 33))",
+                        "expr": "ceil(count(firehose_value_metric_rep_capacity_total_memory{bosh_job_name=\"diego-cell\"}) * on () (100 - rep_memory_capacity_pct:avg5m{bosh_job_name=\"diego-cell\"}) / (100 - 33))",
                         "intervalFactor": 1,
                         "format": "time_series",
                         "legendFormat": "Required"


### PR DESCRIPTION
What
----
Since we introduced isolation segments, we've had more than 1 set of cells per environment. Unfortunately, our metrics didn't distinguish between them fully, leading to counts and charts that weren't quite true.

This PR includes the `bosh_job_name` label in the memory metrics, and updates the cell count chart in the user impact dashboard to only show figures for the default cells.

N.B. see commit message for the reasoning behind the change to the chart

How to review
-------------

1. Run it down a pipeline (deployed to mine)
2. Make sure [the cell count chart in the user impact dashboard](https://grafana-1.andyhunt.dev.cloudpipeline.digital/d/paas-user-impact/user-impact-andyhunt?orgId=1&refresh=5s) isn't broken (you might need to zoom the chart in a bit, because it hasn't been deployed for long)

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
