### PR TITLE
Revert cell memory metric changes

### DIFF
--- a/manifests/prometheus/alerts.d/diego_cell_rep_memory_capacity.yml
+++ b/manifests/prometheus/alerts.d/diego_cell_rep_memory_capacity.yml
@@ -8,8 +8,8 @@
       - record: rep_memory_capacity_pct:avg5m
         expr: >
           100 *
-          sum(avg_over_time(firehose_value_metric_rep_capacity_remaining_memory{environment="((metrics_environment))"}[5m])) by (environment, bosh_job_name) /
-          sum(avg_over_time(firehose_value_metric_rep_capacity_total_memory{environment="((metrics_environment))"}[5m])) by (environment, bosh_job_name)
+          sum(avg_over_time(firehose_value_metric_rep_capacity_remaining_memory{environment="((metrics_environment))"}[5m])) by (environment) /
+          sum(avg_over_time(firehose_value_metric_rep_capacity_total_memory{environment="((metrics_environment))"}[5m])) by (environment)
       - alert: DiegoCellRepMemoryCapacity
         expr:  rep_memory_capacity_pct:avg5m < 35
         for: 2h

--- a/manifests/prometheus/dashboards.d/user-impact.json
+++ b/manifests/prometheus/dashboards.d/user-impact.json
@@ -502,7 +502,7 @@
                 "stack": false,
                 "steppedLine": false,
                 "targets": [{
-                        "expr": "count(firehose_value_metric_rep_capacity_total_memory{bosh_job_name=\"diego-cell\"})",
+                        "expr": "count(firehose_value_metric_rep_capacity_total_memory)",
                         "format": "time_series",
                         "instant": false,
                         "intervalFactor": 1,
@@ -512,7 +512,7 @@
                     },
                     {
                         "refId": "B",
-                        "expr": "ceil(count(firehose_value_metric_rep_capacity_total_memory{bosh_job_name=\"diego-cell\"}) * on () (100 - rep_memory_capacity_pct:avg5m{bosh_job_name=\"diego-cell\"}) / (100 - 33))",
+                        "expr": "ceil(count(firehose_value_metric_rep_capacity_total_memory) * on () (100 - rep_memory_capacity_pct:avg5m) / (100 - 33))",
                         "intervalFactor": 1,
                         "format": "time_series",
                         "legendFormat": "Required"


### PR DESCRIPTION
What
----
Reverts the changes made in #2551 because they broke the chart in prod and prod-lon.

How to review
-------------

Check I reverted all of the commits in the original PR.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
