### PR TITLE
[#175872448] Show isolation segments in cell capacity chart

### DIFF
--- a/manifests/prometheus/alerts.d/diego_cell_rep_memory_capacity.yml
+++ b/manifests/prometheus/alerts.d/diego_cell_rep_memory_capacity.yml
@@ -5,11 +5,39 @@
   value:
     name: DiegoCellRepMemoryCapacity
     rules:
+      # Average amount of free memory across all cells over the last 5 minutes
       - record: rep_memory_capacity_pct:avg5m
         expr: >
           100 *
-          sum(avg_over_time(firehose_value_metric_rep_capacity_remaining_memory{environment="((metrics_environment))"}[5m])) by (environment) /
-          sum(avg_over_time(firehose_value_metric_rep_capacity_total_memory{environment="((metrics_environment))"}[5m])) by (environment)
+          sum(avg_over_time(firehose_value_metric_rep_capacity_remaining_memory{environment="((metrics_environment))"}[5m])) by (environment, bosh_job_name) /
+          sum(avg_over_time(firehose_value_metric_rep_capacity_total_memory{environment="((metrics_environment))"}[5m])) by (environment, bosh_job_name)
+
+      # Average amount of memory being used across all cells over the last minutes
+      - record: rep_memory_used_pct:avg5m
+        expr: 100 - rep_memory_capacity_pct:avg5m
+
+      # The number of diego cells that have been deployed
+      - record: diego_cells_deployed
+        expr: count(firehose_value_metric_rep_capacity_total_memory) by (environment, bosh_job_name)
+
+      # The percentage of the deployed cells being utilised.
+      # Multiply average memory usage (in the interval 0..1)
+      # by cell count to find how many cells worth of resources
+      # we're using
+      - record: diego_cell_capacity_used_pct:avg5m
+        expr: diego_cells_deployed * (rep_memory_used_pct:avg5m/100)
+
+      # As per ADR021 [1], we want to be roughly 30% over provisioned.
+      # We can calculate the amount we need to meet that requirement
+      # by multiplying the number of cells we're utilising by 1.5,
+      # and raising it to the next whole number. Doing so treats the
+      # amount of cells we're using right now as two thirds of the total,
+      # ergo we're one third over-provisioned.
+      #
+      # [1] https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision
+      - record: diego_cells_required
+        expr: ceil(1.5 * diego_cell_capacity_used_pct:avg5m)
+
       - alert: DiegoCellRepMemoryCapacity
         expr:  rep_memory_capacity_pct:avg5m < 35
         for: 2h
@@ -17,6 +45,7 @@
           severity: warning
         annotations:
           summary: Rep low free memory capacity
+          bosh_job_name: "{{ $labels.bosh_job_name }}"
           description: >
             Low free memory {{ $value | printf "%.0f" }}% for the advertised rep memory capacity
             in the last 2 hours on average.

--- a/manifests/prometheus/dashboards.d/user-impact-redux.json
+++ b/manifests/prometheus/dashboards.d/user-impact-redux.json
@@ -1,0 +1,1333 @@
+{
+  "dashboard": {
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "limit": 100,
+          "name": "Annotations & Alerts",
+          "showIn": 0,
+          "type": "dashboard"
+        },
+        {
+          "datasource": "-- Grafana --",
+          "enable": false,
+          "hide": false,
+          "iconColor": "rgba(255, 96, 96, 1)",
+          "limit": 100,
+          "name": "Deployment - Detailed",
+          "showIn": 0,
+          "tags": [
+            "deployment",
+            "concourse"
+          ],
+          "type": "tags"
+        },
+        {
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": false,
+          "iconColor": "#37872D",
+          "limit": 100,
+          "name": "Deployment - Overview",
+          "showIn": 0,
+          "tags": [
+            "deployment-overview",
+            "concourse"
+          ],
+          "type": "tags"
+        }
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "iteration": 1610711495327,
+    "links": [],
+    "panels": [
+      {
+        "datasource": null,
+        "description": "$isoseg",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {},
+            "decimals": 0,
+            "mappings": [
+              {
+                "from": "66",
+                "id": 0,
+                "text": " Add more cells",
+                "to": "100",
+                "type": 2
+              },
+              {
+                "from": "60",
+                "id": 1,
+                "text": "Add more soon",
+                "to": "66",
+                "type": 2,
+                "value": "6"
+              },
+              {
+                "from": "50",
+                "id": 2,
+                "text": "Good",
+                "to": "60",
+                "type": 2
+              },
+              {
+                "from": "40",
+                "id": 3,
+                "text": "Usage reducing",
+                "to": "50",
+                "type": 2
+              },
+              {
+                "from": "0",
+                "id": 4,
+                "text": "Reduce cells",
+                "to": "40",
+                "type": 2
+              },
+              {
+                "from": "101",
+                "id": 5,
+                "text": "Over capacity",
+                "to": "1000000",
+                "type": 2
+              }
+            ],
+            "max": 100,
+            "min": 0,
+            "noValue": "Error",
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "yellow",
+                  "value": 40
+                },
+                {
+                  "color": "green",
+                  "value": 50
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 60
+                },
+                {
+                  "color": "red",
+                  "value": 66
+                }
+              ]
+            },
+            "unit": "percent"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 3,
+          "x": 0,
+          "y": 0
+        },
+        "id": 16,
+        "options": {
+          "colorMode": "background",
+          "graphMode": "none",
+          "justifyMode": "center",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "7.1.5",
+        "repeat": "isoseg",
+        "repeatDirection": "v",
+        "scopedVars": {
+          "isoseg": {
+            "selected": true,
+            "text": "diego-cell",
+            "value": "diego-cell"
+          }
+        },
+        "targets": [
+          {
+            "expr": "(diego_cells_required{bosh_job_name=\"$isoseg\"} / diego_cells_deployed{bosh_job_name=\"$isoseg\"})*100",
+            "instant": true,
+            "interval": "",
+            "legendFormat": "Cell utilisation",
+            "refId": "A"
+          }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "$isoseg cell utilisation",
+        "type": "stat"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "description": "Number of cells deployed vs number of cells required over the last 30 days.  Used to see trends in cell usage.",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 7,
+          "w": 9,
+          "x": 3,
+          "y": 0
+        },
+        "hiddenSeries": false,
+        "id": 19,
+        "legend": {
+          "alignAsTable": false,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "rightSide": false,
+          "show": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "percentage": false,
+        "pluginVersion": "7.1.5",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "repeat": "isoseg",
+        "repeatDirection": "v",
+        "scopedVars": {
+          "isoseg": {
+            "selected": true,
+            "text": "diego-cell",
+            "value": "diego-cell"
+          }
+        },
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "diego_cells_deployed{bosh_job_name=\"$isoseg\"}",
+            "interval": "",
+            "legendFormat": "Deployed",
+            "refId": "A"
+          },
+          {
+            "expr": "diego_cells_required{bosh_job_name=\"$isoseg\"}",
+            "interval": "",
+            "legendFormat": "Required",
+            "refId": "B"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "$isoseg cell count (30 days)",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": "Num cells",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": true,
+        "colorValue": false,
+        "colors": [
+          "#299c46",
+          "rgba(237, 129, 40, 0.89)",
+          "#d44a3a"
+        ],
+        "datasource": "prometheus",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "format": "none",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 4,
+          "x": 12,
+          "y": 0
+        },
+        "id": 5,
+        "interval": null,
+        "links": [
+          {
+            "targetBlank": true,
+            "title": "Currently firing alerts",
+            "url": "https://grafana-1.andyhunt.dev.cloudpipeline.digital/explore?left=%5B\"now-24h\",\"now\",\"prometheus\",%7B\"expr\":\"ALERTS%7Balertstate%3D%5C\"firing%5C\",layer%3D%5C\"%5C\",alertname!~%5C\"%5ECFApp.*$%5C\"%7D\",\"format\":\"time_series\",\"instant\":true,\"intervalFactor\":1,\"legendFormat\":null,\"step\":null%7D,%7B\"ui\":%5Btrue,true,true,\"none\"%5D%7D%5D"
+          }
+        ],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "postfix": "",
+        "postfixFontSize": "50%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": false,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": false
+        },
+        "tableColumn": "",
+        "targets": [
+          {
+            "expr": "(count(ALERTS{alertstate=\"firing\",layer=\"\",alertname!~\"^CFApp.*$\"}) - (avg(alertmanager_alerts{state=\"suppressed\"}) or vector(0))) or vector(0)",
+            "format": "time_series",
+            "instant": true,
+            "intervalFactor": 1,
+            "refId": "A"
+          }
+        ],
+        "thresholds": "1,1",
+        "title": "Platform Alerts",
+        "type": "singlestat",
+        "valueFontSize": "200%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "current"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": true,
+        "colorValue": false,
+        "colors": [
+          "#299c46",
+          "#1f1f1f",
+          "#1f1f1f"
+        ],
+        "datasource": "prometheus",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "format": "none",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 4,
+          "x": 16,
+          "y": 0
+        },
+        "id": 14,
+        "interval": null,
+        "links": [
+          {
+            "targetBlank": true,
+            "title": "https://prometheus-1.andyhunt.dev.cloudpipeline.digital/alerts",
+            "url": "https://prometheus-1.andyhunt.dev.cloudpipeline.digital/alerts"
+          }
+        ],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "postfix": "",
+        "postfixFontSize": "50%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": false,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": false
+        },
+        "tableColumn": "",
+        "targets": [
+          {
+            "expr": "count(ALERTS{alertstate=\"firing\",layer=~\"^.+$\"}) or vector(0)",
+            "format": "time_series",
+            "instant": true,
+            "intervalFactor": 1,
+            "refId": "A"
+          }
+        ],
+        "thresholds": "1,1",
+        "title": "Other Alerts",
+        "type": "singlestat",
+        "valueFontSize": "200%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "current"
+      },
+      {
+        "datasource": "prometheus",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {},
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 15
+                },
+                {
+                  "color": "red",
+                  "value": 20
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 4,
+          "x": 20,
+          "y": 0
+        },
+        "id": 13,
+        "links": [],
+        "options": {
+          "colorMode": "background",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "mean"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "7.1.5",
+        "targets": [
+          {
+            "expr": "avg(avg_over_time(firehose_value_metric_cc_job_queue_length_total[5m]))",
+            "format": "time_series",
+            "interval": "",
+            "intervalFactor": 1,
+            "legendFormat": "CC Job Queue Length",
+            "refId": "A"
+          }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Average CloudController Job Queue",
+        "type": "stat"
+      },
+      {
+        "datasource": null,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {},
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 12,
+          "x": 12,
+          "y": 4
+        },
+        "id": 23,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "center",
+          "orientation": "vertical",
+          "reduceOptions": {
+            "calcs": [
+              "last"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "value_and_name"
+        },
+        "pluginVersion": "7.1.5",
+        "targets": [
+          {
+            "expr": "avg(firehose_value_metric_bbs_lr_ps_running)",
+            "instant": false,
+            "interval": "",
+            "legendFormat": "Running",
+            "refId": "A"
+          },
+          {
+            "expr": "avg(firehose_value_metric_bbs_lr_ps_desired)",
+            "instant": false,
+            "interval": "",
+            "legendFormat": "Desired",
+            "refId": "B"
+          }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Application instances",
+        "type": "stat"
+      },
+      {
+        "datasource": null,
+        "description": "$isoseg",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {},
+            "decimals": 0,
+            "mappings": [
+              {
+                "from": "66",
+                "id": 0,
+                "text": " Add more cells",
+                "to": "100",
+                "type": 2
+              },
+              {
+                "from": "60",
+                "id": 1,
+                "text": "Add more soon",
+                "to": "66",
+                "type": 2,
+                "value": "6"
+              },
+              {
+                "from": "50",
+                "id": 2,
+                "text": "Good",
+                "to": "60",
+                "type": 2
+              },
+              {
+                "from": "40",
+                "id": 3,
+                "text": "Usage reducing",
+                "to": "50",
+                "type": 2
+              },
+              {
+                "from": "0",
+                "id": 4,
+                "text": "Reduce cells",
+                "to": "40",
+                "type": 2
+              },
+              {
+                "from": "101",
+                "id": 5,
+                "text": "Over capacity",
+                "to": "1000000",
+                "type": 2
+              }
+            ],
+            "max": 100,
+            "min": 0,
+            "noValue": "Error",
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "yellow",
+                  "value": 40
+                },
+                {
+                  "color": "green",
+                  "value": 50
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 60
+                },
+                {
+                  "color": "red",
+                  "value": 66
+                }
+              ]
+            },
+            "unit": "percent"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 3,
+          "x": 0,
+          "y": 7
+        },
+        "id": 39,
+        "options": {
+          "colorMode": "background",
+          "graphMode": "none",
+          "justifyMode": "center",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "7.1.5",
+        "repeat": null,
+        "repeatDirection": "v",
+        "repeatIteration": 1610711495327,
+        "repeatPanelId": 16,
+        "scopedVars": {
+          "isoseg": {
+            "selected": true,
+            "text": "diego-cell-iso-seg-not-egress-restricted-1",
+            "value": "diego-cell-iso-seg-not-egress-restricted-1"
+          }
+        },
+        "targets": [
+          {
+            "expr": "(diego_cells_required{bosh_job_name=\"$isoseg\"} / diego_cells_deployed{bosh_job_name=\"$isoseg\"})*100",
+            "instant": true,
+            "interval": "",
+            "legendFormat": "Cell utilisation",
+            "refId": "A"
+          }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "$isoseg cell utilisation",
+        "type": "stat"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "description": "Number of cells deployed vs number of cells required over the last 30 days.  Used to see trends in cell usage.",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 7,
+          "w": 9,
+          "x": 3,
+          "y": 7
+        },
+        "hiddenSeries": false,
+        "id": 40,
+        "legend": {
+          "alignAsTable": false,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "rightSide": false,
+          "show": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "percentage": false,
+        "pluginVersion": "7.1.5",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "repeat": null,
+        "repeatDirection": "v",
+        "repeatIteration": 1610711495327,
+        "repeatPanelId": 19,
+        "scopedVars": {
+          "isoseg": {
+            "selected": true,
+            "text": "diego-cell-iso-seg-not-egress-restricted-1",
+            "value": "diego-cell-iso-seg-not-egress-restricted-1"
+          }
+        },
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "diego_cells_deployed{bosh_job_name=\"$isoseg\"}",
+            "interval": "",
+            "legendFormat": "Deployed",
+            "refId": "A"
+          },
+          {
+            "expr": "diego_cells_required{bosh_job_name=\"$isoseg\"}",
+            "interval": "",
+            "legendFormat": "Required",
+            "refId": "B"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "$isoseg cell count (30 days)",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": "Num cells",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "datasource": null,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 2,
+          "w": 12,
+          "x": 12,
+          "y": 8
+        },
+        "id": 37,
+        "options": {
+          "content": "<center><h1>API</h1></center>",
+          "mode": "html"
+        },
+        "pluginVersion": "7.1.0",
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "",
+        "type": "text"
+      },
+      {
+        "datasource": "prometheus",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {},
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "reqps"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 6,
+          "w": 7,
+          "x": 12,
+          "y": 10
+        },
+        "id": 3,
+        "links": [],
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "mean"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "7.1.5",
+        "targets": [
+          {
+            "expr": "sum(rate(firehose_value_metric_cc_http_status_2_xx[2m]))",
+            "format": "time_series",
+            "interval": "",
+            "intervalFactor": 1,
+            "legendFormat": "2xx Responses",
+            "refId": "A"
+          }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "API requests/sec",
+        "type": "stat"
+      },
+      {
+        "datasource": null,
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {},
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 5
+                },
+                {
+                  "color": "red",
+                  "value": 20
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 5,
+          "x": 19,
+          "y": 10
+        },
+        "id": 27,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "mean"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "7.1.5",
+        "targets": [
+          {
+            "expr": "sum(rate(firehose_value_metric_cc_http_status_4_xx[2m]))",
+            "interval": "",
+            "legendFormat": "4xx responses",
+            "refId": "A"
+          }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "API 4xx response rate over 2m",
+        "type": "stat"
+      },
+      {
+        "datasource": null,
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {},
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 1
+                },
+                {
+                  "color": "red",
+                  "value": 5
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 5,
+          "x": 19,
+          "y": 13
+        },
+        "id": 28,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "mean"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "7.1.5",
+        "targets": [
+          {
+            "expr": "sum(rate(firehose_value_metric_cc_http_status_5_xx[2m]))",
+            "interval": "",
+            "legendFormat": "4xx responses",
+            "refId": "A"
+          }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "API 5xx response rate over 2m",
+        "type": "stat"
+      },
+      {
+        "datasource": null,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 2,
+          "w": 12,
+          "x": 12,
+          "y": 16
+        },
+        "id": 38,
+        "options": {
+          "content": "<center><h1>Gorouter</h1></center>",
+          "mode": "html"
+        },
+        "pluginVersion": "7.1.0",
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "",
+        "type": "text"
+      },
+      {
+        "datasource": null,
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {},
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 5
+                },
+                {
+                  "color": "red",
+                  "value": 20
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 5,
+          "x": 12,
+          "y": 18
+        },
+        "id": 34,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "mean"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "7.1.5",
+        "targets": [
+          {
+            "expr": "sum(rate(firehose_counter_event_gorouter_responses_4_xx_total[2m]))",
+            "interval": "",
+            "legendFormat": "4xx responses",
+            "refId": "A"
+          }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Gorouter 4xx response rate over 2m",
+        "type": "stat"
+      },
+      {
+        "datasource": "prometheus",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {},
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "reqps"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 6,
+          "w": 7,
+          "x": 17,
+          "y": 18
+        },
+        "id": 31,
+        "links": [],
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "mean"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "7.1.5",
+        "targets": [
+          {
+            "expr": "sum(rate(firehose_counter_event_gorouter_responses_total[2m]))",
+            "format": "time_series",
+            "interval": "",
+            "intervalFactor": 1,
+            "legendFormat": "2xx Responses",
+            "refId": "A"
+          }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Gorouter requests/sec",
+        "type": "stat"
+      },
+      {
+        "datasource": null,
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {},
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 5
+                },
+                {
+                  "color": "red",
+                  "value": 20
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 5,
+          "x": 12,
+          "y": 21
+        },
+        "id": 35,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "mean"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "7.1.5",
+        "targets": [
+          {
+            "expr": "sum(rate(firehose_counter_event_gorouter_responses_5_xx_total[2m]))",
+            "interval": "",
+            "legendFormat": "4xx responses",
+            "refId": "A"
+          }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Gorouter 5xx response rate over 2m",
+        "type": "stat"
+      }
+    ],
+    "refresh": "",
+    "schemaVersion": 26,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "allValue": "All",
+          "current": {
+            "selected": true,
+            "tags": [],
+            "text": [
+              "diego-cell",
+              "diego-cell-iso-seg-not-egress-restricted-1"
+            ],
+            "value": [
+              "diego-cell",
+              "diego-cell-iso-seg-not-egress-restricted-1"
+            ]
+          },
+          "datasource": "prometheus",
+          "definition": "label_values(diego_cells_deployed, bosh_job_name)",
+          "hide": 0,
+          "includeAll": false,
+          "label": "Isolation Segment",
+          "multi": true,
+          "name": "isoseg",
+          "options": [],
+          "query": "label_values(diego_cells_deployed, bosh_job_name)",
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        }
+      ]
+    },
+    "time": {
+      "from": "now-24h",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "UTC",
+    "title": "User Impact Redux - __DEPLOY_ENV__",
+    "uid": "user-impact-redux",
+    "id": null
+  },
+  "folderId": 0,
+  "overwrite": true
+}

--- a/manifests/prometheus/spec/alerts/diego_cell_rep_memory_capacity.test..yml
+++ b/manifests/prometheus/spec/alerts/diego_cell_rep_memory_capacity.test..yml
@@ -8,16 +8,25 @@ evaluation_interval: 1m
 tests:
   - interval: 5m
     input_series:
-      - series: 'firehose_value_metric_rep_capacity_remaining_memory{environment="test", bosh_job_id="1"}'
+      # Cells whose available memory craters
+      # after the first two hours
+      - series: 'firehose_value_metric_rep_capacity_remaining_memory{environment="test", bosh_job_id="1", bosh_job_name="diego-cells"}'
         values: '80000-10x24 30000-10x36'
 
-      - series: 'firehose_value_metric_rep_capacity_total_memory{environment="test", bosh_job_id="1"}'
+      - series: 'firehose_value_metric_rep_capacity_total_memory{environment="test", bosh_job_id="1", bosh_job_name="diego-cells"}'
         values: '100000-0x60'
 
-      - series: 'firehose_value_metric_rep_capacity_remaining_memory{environment="test", bosh_job_id="2"}'
+      - series: 'firehose_value_metric_rep_capacity_remaining_memory{environment="test", bosh_job_id="2", bosh_job_name="diego-cells"}'
         values: '70000-10x60 20000-10x36'
 
-      - series: 'firehose_value_metric_rep_capacity_total_memory{environment="test", bosh_job_id="2"}'
+      - series: 'firehose_value_metric_rep_capacity_total_memory{environment="test", bosh_job_id="2", bosh_job_name="diego-cells"}'
+        values: '100000-0x60'
+
+      # Isolation segment whose memory stays stable throughout
+      - series: 'firehose_value_metric_rep_capacity_remaining_memory{environment="test", bosh_job_id="1", bosh_job_name="diego-cells-iso-seg"}'
+        values: '90000-0x60'
+
+      - series: 'firehose_value_metric_rep_capacity_total_memory{environment="test", bosh_job_id="1", bosh_job_name="diego-cells-iso-seg"}'
         values: '100000-0x60'
 
     alert_rule_test:
@@ -41,8 +50,37 @@ tests:
               environment: test
             exp_annotations:
               summary: Rep low free memory capacity
+              bosh_job_name: diego-cells
               description: >
                 Low free memory 75% for the advertised rep memory capacity
                 in the last 2 hours on average.
                 Review if we need to scale...
               url: https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision
+
+    promql_expr_test:
+      - expr: rep_memory_capacity_pct:avg5m
+        eval_time: 0m
+        exp_samples:
+          - labels: 'rep_memory_capacity_pct:avg5m{environment="test", bosh_job_name="diego-cells"}'
+            value: 75
+          - labels: 'rep_memory_capacity_pct:avg5m{environment="test", bosh_job_name="diego-cells-iso-seg"}'
+            value: 90
+
+  - interval: 5m
+    input_series:
+      # Each series has a fixed amount of memory for 1 hour
+      # Two diego-cells series, and one diego-cells-iso-seg series.
+      - series: 'firehose_value_metric_rep_capacity_total_memory{environment="test", bosh_job_name="diego-cells", bosh_job_index="1"}'
+        values: 100+0x12
+      - series: 'firehose_value_metric_rep_capacity_total_memory{environment="test", bosh_job_name="diego-cells", bosh_job_index="2"}'
+        values: 100+0x12
+      - series: 'firehose_value_metric_rep_capacity_total_memory{environment="test", bosh_job_name="diego-cells-iso-seg", bosh_job_index="1"}'
+        values: 100+0x12
+    promql_expr_test:
+      - expr: diego_cells_deployed
+        eval_time: 5m
+        exp_samples:
+          - labels: 'diego_cells_deployed{bosh_job_name="diego-cells", environment="test"}'
+            value: 2
+          - labels: 'diego_cells_deployed{bosh_job_name="diego-cells-iso-seg", environment="test"}'
+            value: 1


### PR DESCRIPTION
What
----

Rework cell capacity metrics and alerts

We recently introduced isolation segments in to our production environments.
Isolation segments are collections of diego cells that are reserved for the
exclusive used of the Cloud Foundry orgs that are granted access to them. Aside
from this and their instance type, they exhibit identical characteristics.

For a long time we’ve a chart on our monitoring dashboard that shows us the
number of cells we have deployed, versus the number of cells we think we need
to meet our cell capacity goals, as per ADR021 [1]. With the introduction of
isolation segments, this chart has been misreporting the number of deployed
cells (and thus the required number), because the metrics haven’t distinguished
between different groups of cells.

On top of that, the metrics used to calculate the used capacity and required
capacity was confusing and complicated.

This commit re-works those metrics, to make them easier to maintain, and to
have them differentiate between the cell groups. It adds 4 new metrics:

`rep_memory_used_pct:avg5m` the average amount of memory used in a 5m window
over all cells in a group. This is the inverse of `rep_memory_capacity_pct:avg5m`

`diego_cells_deployed` the number of cells currently deployed in each group

`diego_cell_capacity_used_pct:avg5m` what percentage of the deployed cells’
capacity is being used. This is calculated by multiplying the average memory
usage percentage by the number of cells. For example, if you have 10 cells
deployed, with an average memory utilisation of 35%, then you have 10 * 35% =
3.5 cells utilised.

`diego_cells_required` the number of cells required to meet our capacity
goals as per [1]. This is calculated at 1.5 times the number of cells being
utilised. Our goal is to have 1/3rd spare capacity at all times, so to work out
how many cells we need, we must treat the number of utilised cells as 2/3rd of
our capacity. Multiplying by 1.5 achieves that.

The commit also adds some useful tests of expressions, and ensures the cell
memory capacity alarm alerts us as to which group of cells is running under
capacity.

[1] https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/

How to review
-------------

Check my working
Code review
Deploy to your env and make sure it doesn't break anything unexpected

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
