### PR TITLE
Pin cell counts chart to default cell segment only

### DIFF
--- a/manifests/prometheus/dashboards.d/user-impact.json
+++ b/manifests/prometheus/dashboards.d/user-impact.json
@@ -502,7 +502,7 @@
                 "stack": false,
                 "steppedLine": false,
                 "targets": [{
-                        "expr": "count(firehose_value_metric_rep_capacity_total_memory)",
+                        "expr": "count(firehose_value_metric_rep_capacity_total_memory{bosh_job_name=\"diego-cell\"})",
                         "format": "time_series",
                         "instant": false,
                         "intervalFactor": 1,
@@ -512,7 +512,7 @@
                     },
                     {
                         "refId": "B",
-                        "expr": "ceil(count(firehose_value_metric_rep_capacity_total_memory) * on () (100 - rep_memory_capacity_pct:avg5m) / (100 - 33))",
+                        "expr": "ceil(count(firehose_value_metric_rep_capacity_total_memory{bosh_job_name=\"diego-cell\"}) * on () (100 - rep_memory_capacity_pct:avg5m{bosh_job_name=\"diego-cell\"}) / (100 - 33))",
                         "intervalFactor": 1,
                         "format": "time_series",
                         "legendFormat": "Required"


### PR DESCRIPTION
What
----

Recently introduced and reverted a change that differentiated cell memory
metrics by isolation segment. Now that it's reverted, new metric values are no
longer differentiated, but old ones are. In order to have the cell counts chart
display properly, we need to explicitly look at the `diego-cell` segment.

How to review
-------------
1. Check I got the expression right
2. Compare it [a modified version in prod](https://grafana-1.cloud.service.gov.uk/d/HVQu5D-Mk/andy-user-impact-prod?orgId=1&refresh=5s)

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
