### PR TITLE
Remove 9 cells from Ireland

### DIFF
--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -2,7 +2,7 @@
 uaa_instances: 3
 nats_instances: 3
 diego_api_instances: 3
-cell_instances: 33
+cell_instances: 24
 router_instances: 24
 api_instances: 6
 doppler_instances: 39


### PR DESCRIPTION
What
----

This is a follow up to 4fa6ddb27747f55a479fe2c6f3397853b0b91191, and reduces
the number of cells in the default cell segment in Ireland. Notify are no
longer using them, so we need fewer.

How to review
-------------
1. See if you agree

![image](https://user-images.githubusercontent.com/1747386/103543871-21db9900-4e97-11eb-9040-6bdccb631c7b.png)


---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
