### PR TITLE
Remove cabinet-office-nsra's VPC peering

### DIFF
--- a/terraform/prod-lon.vpc_peering.json
+++ b/terraform/prod-lon.vpc_peering.json
@@ -52,11 +52,5 @@
         "account_id": "011755346992",
         "vpc_id": "vpc-0e82d077854b512f3",
         "subnet_cidr": "172.18.12.0/22"
-    },
-    {
-        "peer_name": "cabinet-office-nsra",
-        "account_id": "961408729235",
-        "vpc_id": "vpc-09e705b2d551cd9a8",
-        "subnet_cidr": "172.18.16.0/22"
     }
 ]


### PR DESCRIPTION
What
----

We already removed the cabinet-office-nsra organisation but forgot to remove the VPC peering.

How to review
-------------

Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
