### PR TITLE
Prevent Redis plans from being updated

### DIFF
--- a/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
+++ b/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
@@ -120,7 +120,7 @@
                     - elasticache
                     - redis
                   bindable: true
-                  plan_updateable: true
+                  plan_updateable: false
                   plans:
                     # Deprecated
                     - id: 3a51701c-eef3-447c-882b-907ad2bcb7ab


### PR DESCRIPTION
What
----

The broker stops plans from being updated [1], but the broker says they're allowed. This results
in a `cf update-service -p` call leading to a Redis service instance in a `failed` state. Rather
than that, we should make it clear that the plans can't actually be updated.

[1] https://github.com/alphagov/paas-elasticache-broker/blob/master/broker/broker.go#L212


How to review
-------------

1. Run this down your env
2. Check it prevents you from updating the plan of a Redis service instance, without getting in to a failed state

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
