### PR TITLE
Add 12 cells to Ireland

### DIFF
--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -2,7 +2,7 @@
 uaa_instances: 3
 nats_instances: 3
 diego_api_instances: 3
-cell_instances: 24
+cell_instances: 36
 router_instances: 24
 api_instances: 6
 doppler_instances: 39


### PR DESCRIPTION
What
----

Notify are ditching their staging isolation segment for the time being. We need to restore the 
number of cells their staging environment was occupying before, so there's room for their 
apps to come back. We don't need to restore the full 24 from the isolation segment, because
they won't be running load tests agains staging and thus won't need the extra capacity.

How to review
-------------
1. Do you agree with the number?

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
