### PR TITLE
Add 3 cells to London

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -2,7 +2,7 @@
 uaa_instances: 3
 nats_instances: 3
 diego_api_instances: 3
-cell_instances: 81
+cell_instances: 84
 router_instances: 15
 api_instances: 12
 doppler_instances: 39


### PR DESCRIPTION
What
----

We've been seeing a lot of HTTP 502s coming out of GoRouter recently. We think that's caused by apps not responding in time.

We're seeing high CPU usage in around 1 in 8 of the cells (memory consumption remains fine). We think this could be the cause of apps not responding in time. Adding more cells provides more CPU cores to carry out the work of the apps.

In 7 days we'll check back on the rate of HTTP 502s to see if adding cells had a positive impact.

## CPU usage across all cells in the last 7 days
![image](https://user-images.githubusercontent.com/1747386/104332967-a017eb00-54e8-11eb-8087-0bdfe7f59787.png)

## Number of cells whose 1m average CPU usage is above 50% over the last 7 days
![image](https://user-images.githubusercontent.com/1747386/104333163-d6ee0100-54e8-11eb-8f65-c186ce5da1d3.png)

How to review
-------------
1. Do you agree with the rationale?
1. Do you agree with the number of cells being added?
---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
