### PR TITLE
Fix some incorrect behaviour when run on Linux

### DIFF
--- a/scripts/cf_subshell_scoped_login.sh
+++ b/scripts/cf_subshell_scoped_login.sh
@@ -31,7 +31,7 @@ case $TARGET in
     ;;
 esac
 
-TMPDIR=${TMPDIR:-/tmp}
+TMPDIR=${TMPDIR:-/tmp/}
 CF_HOME=$(mktemp -d "${TMPDIR}cf_home.XXXXXX")
 cleanup() {
   echo "Cleaning up temporary CF_HOME..."
@@ -47,7 +47,8 @@ export CF_HOME
 export CF_SUBSHELL_TARGET=$TARGET
 
 cf api "${API_URL}"
-open "${PASSCODE_URL}" && cf login --sso
+OPEN=$(which open 2>/dev/null || echo -n xdg-open)
+$OPEN "${PASSCODE_URL}" && cf login --sso
 
 echo
 echo "You are now in a subshell with CF_HOME set to ${CF_HOME}"


### PR DESCRIPTION
What
----

Fixed some incorrect behaviour when run on linux

* TMPDIR was being set without a trailing slash, and mktemp could not
  create `/tmpcf_home.XXXXXX`
* `open` does not exist on linux. test if it's available, and if not,
  use `xdg-open` instead.


How to review
-------------

Use `scripts/cf_subshell_scoped_login.sh` on a mac to ensure it still functions correctly.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
