### PR TITLE
Upgrade cf-deployment from v15.0.0 to v15.4.0 to address USNs

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -376,7 +376,7 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-acceptance-tests
-      branch: cf15.0
+      branch: cf15.4
 
   - name: cf-smoke-tests-release
     type: git

--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-xenial
-      version: "621.94"
+      version: "621.95"

--- a/manifests/cf-manifest/operations.d/320-cc-release.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-release.yml
@@ -3,6 +3,6 @@
   path: /releases/name=capi
   value:
     name: "capi"
-    version: "1.102.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.102.0"
-    sha1: "23b2b8e04dc809c62e885ec0397585f3a70171a8"
+    version: "1.103.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.103.0"
+    sha1: "0cadac56ab9fb287d2c6e848da476b1ccb3422c6"

--- a/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
+++ b/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
@@ -2,7 +2,7 @@
 - type: replace
   path: /releases/name=uaa
   value:
-    name: uaa
-    version: 0.1.25
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-0.1.25.tgz
-    sha1: 80e2c31c0d98cdf545208e600ca3597f55597546
+   name: uaa
+   version: 0.1.27
+   url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-0.1.27.tgz
+   sha1: 933c75ec38f50800dbf1650a7832f760d7db87ee

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe "release versions" do
 
     pinned_releases = {
       "uaa" => {
-        local: "0.1.25",
-        upstream: "74.28.0",
+        local: "0.1.27",
+        upstream: "74.29.0",
       },
     }
 


### PR DESCRIPTION
What
----
Upgrades `cf-deplyoment` from `v15.0.0` to `v15.4.0` to address the following USNs

- usn-4660-1
- usn-4635-1
- usn-4662-1
- usn-4665-1
- usn-4668-1
- usn-4667-1

Left to do
-----------
* [x] Rebase our UAA fork, and bump the version.

How to review
-------------
1. Code review
2. Check the versions bumped to here match those in the pivotal story
3. Check it runs down a pipeline OK

Who can review
--------------
Anyone

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
