### PR TITLE
[#176226306] Stop using DockerHub images

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -105,8 +105,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: alpine
-              tag: 3.12
+              repository: ghcr.io/alphagov/paas/alpine
+              tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
           inputs:
             - name: paas-cf
           params:
@@ -133,7 +133,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/bosh-cli-v2
-              tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+              tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
           run:
             path: sh
             args:
@@ -169,7 +169,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/awscli
-              tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+              tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
           run:
             path: ./paas-cf/concourse/scripts/rds_instances.sh
             args:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -7,42 +7,51 @@ meta:
         submodule_recursive: 'false'  # git-resource issue 307
 
   containers:
+    alpine: &alpine-image-resource
+      type: docker-image
+      source:
+        repository: ghcr.io/alphagov/paas/alpine
+        tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
+    psql: &psql-image-resource
+      type: docker-image
+      source:
+        repository: ghcr.io/alphagov/paas/psql
+        tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
+    node: &node-image-resource
+      type: docker-image
+      source:
+        repository: ghcr.io/alphagov/paas/node
+        tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
     awscli: &awscli-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
         tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
-
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
         tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
-
     cf-acceptance-tests: &cf-acceptance-tests-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-acceptance-tests
         tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
-
     cf-cli: &cf-cli-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-cli
         tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
-
     cf-uaac: &cf-uaac-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-uaac
         tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
-
     git-ssh: &git-ssh-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/git-ssh
         tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
-
     ruby-slim: &ruby-slim-image-resource
       type: docker-image
       source:
@@ -58,7 +67,6 @@ meta:
       source:
         repository: ghcr.io/alphagov/paas/terraform
         tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
-
     curl-ssl: &curl-ssl-image-resource
       type: docker-image
       source:
@@ -599,11 +607,7 @@ jobs:
           task: lock-the-pipeline
           tags: [colocated-with-web]
           config:
-            image_resource:
-              type: docker-image
-              source:
-                repository: ghcr.io/alphagov/paas/alpine
-                tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
+            image_resource: *alpine-image-resource
             platform: linux
             params:
               DISABLE_PIPELINE_LOCKING: ((disable_pipeline_locking))
@@ -1209,12 +1213,7 @@ jobs:
         tags: [colocated-with-web]
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: ghcr.io/alphagov/paas/psql
-              tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
-
+          image_resource: *psql-image-resource
           inputs:
             - name: terraform-variables
             - name: paas-cf
@@ -3749,11 +3748,7 @@ jobs:
         tags: [colocated-with-web]
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: ghcr.io/alphagov/paas/node
-              tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
+          image_resource: *node-image-resource
           inputs:
             - name: paas-admin
           outputs:
@@ -3886,11 +3881,7 @@ jobs:
           tags: [colocated-with-web]
           config:
             platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: ghcr.io/alphagov/paas/node
-                tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
+            image_resource: *node-image-resource
             params:
               DISABLE_CUSTOM_ACCEPTANCE_TESTS: ((disable_custom_acceptance_tests))
               DEPLOY_ENV: ((deploy_env))
@@ -4707,11 +4698,7 @@ jobs:
           task: unlock-the-pipeline
           tags: [colocated-with-web]
           config:
-            image_resource:
-              type: docker-image
-              source:
-                repository: ghcr.io/alphagov/paas/alpine
-                tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
+            image_resource: *alpine-image-resource
             platform: linux
             params:
               DISABLE_PIPELINE_LOCKING: ((disable_pipeline_locking))
@@ -5196,11 +5183,7 @@ jobs:
         tags: [colocated-with-web]
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: ghcr.io/alphagov/paas/alpine
-              tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
+          image_resource: *alpine-image-resource
           inputs:
             - name: deployed-healthcheck
           params:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -11,59 +11,59 @@ meta:
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+        tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+        tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
     cf-acceptance-tests: &cf-acceptance-tests-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-        tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+        tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
     cf-cli: &cf-cli-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-cli
-        tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+        tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
     cf-uaac: &cf-uaac-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-uaac
-        tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+        tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
     git-ssh: &git-ssh-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/git-ssh
-        tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+        tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
     ruby-slim: &ruby-slim-image-resource
       type: docker-image
       source:
-        repository: ruby
-        tag: 2.7-slim
+        repository: ghcr.io/alphagov/paas/ruby
+        tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
     golang: &golang-image-resource
       type: docker-image
       source:
-        repository: golang
-        tag: '1.14'
+        repository: ghcr.io/alphagov/paas/golang
+        tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
     terraform: &terraform-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+        tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
     curl-ssl: &curl-ssl-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/curl-ssl
-        tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+        tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
 
   tasks:
@@ -221,8 +221,8 @@ resource_types:
 - name: pinned-pool
   type: docker-image
   source:
-    repository: concourse/pool-resource
-    tag: 1.1.1
+    repository: ghcr.io/alphagov/paas/concourse-pool-resource
+    tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
 - name: s3-iam
   type: docker-image
@@ -602,8 +602,8 @@ jobs:
             image_resource:
               type: docker-image
               source:
-                repository: alpine
-                tag: 3.12
+                repository: ghcr.io/alphagov/paas/alpine
+                tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
             platform: linux
             params:
               DISABLE_PIPELINE_LOCKING: ((disable_pipeline_locking))
@@ -632,7 +632,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+              tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
           inputs:
             - name: paas-cf
@@ -1213,7 +1213,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/psql
-              tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+              tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
           inputs:
             - name: terraform-variables
@@ -3752,8 +3752,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: node
-              tag: lts-alpine
+              repository: ghcr.io/alphagov/paas/node
+              tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
           inputs:
             - name: paas-admin
           outputs:
@@ -3779,7 +3779,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/spruce
-              tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+              tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
           inputs:
             - name: paas-cf
@@ -3889,8 +3889,8 @@ jobs:
             image_resource:
               type: docker-image
               source:
-                repository: node
-                tag: lts-alpine
+                repository: ghcr.io/alphagov/paas/node
+                tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
             params:
               DISABLE_CUSTOM_ACCEPTANCE_TESTS: ((disable_custom_acceptance_tests))
               DEPLOY_ENV: ((deploy_env))
@@ -4710,8 +4710,8 @@ jobs:
             image_resource:
               type: docker-image
               source:
-                repository: alpine
-                tag: 3.12
+                repository: ghcr.io/alphagov/paas/alpine
+                tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
             platform: linux
             params:
               DISABLE_PIPELINE_LOCKING: ((disable_pipeline_locking))
@@ -4810,7 +4810,7 @@ jobs:
           type: docker-image
           source:
             repository: ghcr.io/alphagov/paas/cf-uaac
-            tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+            tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
         inputs:
           - name: passwords
@@ -5199,8 +5199,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: alpine
-              tag: 3.12
+              repository: ghcr.io/alphagov/paas/alpine
+              tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
           inputs:
             - name: deployed-healthcheck
           params:

--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -30,8 +30,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: alpine
-              tag: 3.12
+              repository: ghcr.io/alphagov/paas/alpine
+              tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
           inputs:
             - name: paas-cf
             - name: deployment-timer
@@ -61,7 +61,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/awscli
-              tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+              tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
           run:
             path: ./paas-cf/concourse/scripts/rds_instances.sh
@@ -76,7 +76,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+              tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
           inputs:
             - name: paas-cf
@@ -109,7 +109,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+              tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
           inputs:
             - name: paas-cf

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -90,7 +90,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+              tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
           inputs:
             - name: paas-cf
@@ -162,7 +162,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/bosh-cli-v2
-              tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+              tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
           inputs:
             - name: bosh-vars-store
@@ -215,8 +215,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: ruby
-              tag: 2.7-slim
+              repository: ghcr.io/alphagov/paas/ruby
+              tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
           inputs:
             - name: paas-cf
             - name: cf-tfstate
@@ -259,7 +259,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/terraform
-              tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+              tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
           inputs:
             - name: terraform-variables

--- a/concourse/pipelines/monitor-remote.yml
+++ b/concourse/pipelines/monitor-remote.yml
@@ -48,7 +48,7 @@ jobs:
         type: docker-image
         source:
           repository: ghcr.io/alphagov/paas/self-update-pipelines
-          tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+          tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
       inputs:
       - name: paas-cf

--- a/concourse/pipelines/test-certificate-rotation.yml
+++ b/concourse/pipelines/test-certificate-rotation.yml
@@ -5,33 +5,33 @@ meta:
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+        tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+        tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
     cf-acceptance-tests: &cf-acceptance-tests-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-        tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+        tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
     cf-cli: &cf-cli-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-cli
-        tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+        tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
 
 resource_types:
   - name: metadata
     type: docker-image
     source:
-      repository: olhtbr/metadata-resource
-      tag: 2.0.1
+      repository: ghcr.io/alphagov/paas/olhtbr-metadata-resource
+      tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
   - name: s3-iam
     type: docker-image

--- a/concourse/spec/image_resource_spec.rb
+++ b/concourse/spec/image_resource_spec.rb
@@ -53,6 +53,16 @@ RSpec.describe "image resources" do
         end
     end
   end
+
+  describe "dockerhub docker images" do
+    # DockerHub images are those where there's no hostname at the start of the
+    # image name. Detecting that by the absence of a full stop.
+    dockerhub_images = image_tags_by_repo.select { |repo, _| repo.match?(%r{[^\.]+/}) }
+
+    describe "are not being used" do
+      expect(dockerhub_images).to be_empty
+    end
+  end
 end
 
 # rubocop:enable Security/YAMLLoad

--- a/concourse/spec/image_resource_spec.rb
+++ b/concourse/spec/image_resource_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "image resources" do
       .each do |repo, tags|
       context "repo #{repo}" do
         it "has only one tag" do
-          expect(tags.length).to eq(1)
+          expect(tags).to have_attributes(size: 1)
         end
 
         it "is a lowercase git hash" do
@@ -48,7 +48,7 @@ RSpec.describe "image resources" do
         .reject { |repo, _| repo.match?(/-resource$/) }
         .to_h.values .flatten .uniq.tap do |all_tags|
           it "onlies have one tag" do
-            expect(all_tags.length).to eq(1)
+            expect(all_tags).to have_attributes(size: 1)
           end
         end
     end
@@ -57,9 +57,10 @@ RSpec.describe "image resources" do
   describe "dockerhub docker images" do
     # DockerHub images are those where there's no hostname at the start of the
     # image name. Detecting that by the absence of a full stop.
-    dockerhub_images = image_tags_by_repo.select { |repo, _| repo.match?(%r{[^\.]+/}) }
+    # The regex is complicated by not all image names having a slash in.
+    dockerhub_images = image_tags_by_repo.select { |repo, _| repo.match?(%r{^[^\.]+(/.+)?$}) }
 
-    describe "are not being used" do
+    it "are not being used" do
       expect(dockerhub_images).to be_empty
     end
   end

--- a/concourse/tasks/aiven-broker-acceptance-tests-run.yml
+++ b/concourse/tasks/aiven-broker-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+    tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/app-autoscaler-acceptance-tests-run.yml
+++ b/concourse/tasks/app-autoscaler-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+    tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/configure-grafana.yml
+++ b/concourse/tasks/configure-grafana.yml
@@ -3,8 +3,8 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: ruby
-    tag: 2.7-slim
+    repository: ghcr.io/alphagov/paas/ruby
+    tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 inputs:
   - name: paas-trusted-people
 run:

--- a/concourse/tasks/create_admin.yml
+++ b/concourse/tasks/create_admin.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-uaac
-    tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+    tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/cronitor-monitor-ping-action.yml
+++ b/concourse/tasks/cronitor-monitor-ping-action.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+    tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
 run:
   path: sh

--- a/concourse/tasks/custom-acceptance-tests-run.yml
+++ b/concourse/tasks/custom-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+    tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/custom-broker-acceptance-tests-run.yml
+++ b/concourse/tasks/custom-broker-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+    tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/delete_admin.yml
+++ b/concourse/tasks/delete_admin.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
-    tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+    tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/forget-access-keys.yml
+++ b/concourse/tasks/forget-access-keys.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/terraform
-    tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+    tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/generate-git-keys.yml
+++ b/concourse/tasks/generate-git-keys.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+    tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
 
 run:

--- a/concourse/tasks/generate-test-config.yml
+++ b/concourse/tasks/generate-test-config.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+    tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/get-cf-cli-config.yml
+++ b/concourse/tasks/get-cf-cli-config.yml
@@ -3,8 +3,8 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: ruby
-    tag: 2.7-slim
+    repository: ghcr.io/alphagov/paas/ruby
+    tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 inputs:
   - name: paas-cf
   - name: cf-manifest

--- a/concourse/tasks/remove-db.yml
+++ b/concourse/tasks/remove-db.yml
@@ -7,7 +7,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
-    tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+    tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
 run:
   path: sh

--- a/concourse/tasks/smoke-tests-run.yml
+++ b/concourse/tasks/smoke-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+    tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/tag-repo.yml
+++ b/concourse/tasks/tag-repo.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/git-ssh
-    tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+    tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
 
 inputs:

--- a/concourse/tasks/upload-test-artifacts.yml
+++ b/concourse/tasks/upload-test-artifacts.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+    tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/wait-for-api-availability-tests.yml
+++ b/concourse/tasks/wait-for-api-availability-tests.yml
@@ -11,7 +11,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+    tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
 run:
   path: sh

--- a/concourse/tasks/wait-for-app-availability-tests.yml
+++ b/concourse/tasks/wait-for-app-availability-tests.yml
@@ -13,7 +13,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
-    tag: 54495aab0a18ba76a55d98ae19f904d3629feb77
+    tag: b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 
 run:
   path: sh


### PR DESCRIPTION
What
----

We want to stop using DockerHub images because the rate limiting could impact our ability to run CI/CD jobs. This adds a test which will stop us using DockerHub images. We plan to use GitHub Container Registry instead.

How to review
-------------

This is one of several PRs in `#176226306`. Review the others first.

⚠️  Before merging this PR, the Docker image tags need updating to what's built when the other PRs are merged.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
