### PR TITLE
enable sqs for gds-techarchs orgs

### DIFF
--- a/config/service-brokers/sqs/prod-config.json
+++ b/config/service-brokers/sqs/prod-config.json
@@ -1,5 +1,6 @@
 {
   "allowed_orgs": [
-    "gds-tech-ops"
+    "gds-tech-ops",
+    "gds-techarchs"
   ]
 }

--- a/config/service-brokers/sqs/prod-lon-config.json
+++ b/config/service-brokers/sqs/prod-lon-config.json
@@ -1,8 +1,9 @@
 {
   "allowed_orgs": [
       "dof-dss",
-      "gds-tech-ops",
       "gds-document-checking-service",
+      "gds-tech-ops",
+      "gds-techarchs",
       "nicts-probate"
   ]
 }


### PR DESCRIPTION
What
----

Add `gds-techarchs` org to list of orgs that are using the sqs broker

@whi-tw has manually enabled sqs for these orgs however for consistency I am updating the sqs config

How to review
-------------

- validate json
- test the pipeline
- validate that the orgs are enabled to use sqs 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
