### PR TITLE
Remove Notify's staging isolation segment

### DIFF
--- a/manifests/cf-manifest/isolation-segments/prod/govuk-notify-staging.yml
+++ b/manifests/cf-manifest/isolation-segments/prod/govuk-notify-staging.yml
@@ -1,4 +1,0 @@
----
-number_of_cells: 24
-isolation_segment_name: govuk-notify-staging
-vm_type: high_cpu_cell

--- a/manifests/cf-manifest/spec/manifest/isolation_segment_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/isolation_segment_spec.rb
@@ -278,9 +278,9 @@ RSpec.describe "isolation_segments" do
         expect(seg["jobs"].find { |j| j["name"] == "coredns" }).not_to be_nil
       end
 
-      it "contains an egress-unrestricted isolation segment for GOV.UK Notify staging" do
+      it "contains an egress-unrestricted isolation segment for GOV.UK Notify production" do
         expect(segs.count).to be >= 1
-        seg = segs.select { |s| s["name"] == "diego-cell-iso-seg-govuk-notify-staging" }.first
+        seg = segs.select { |s| s["name"] == "diego-cell-iso-seg-govuk-notify-production" }.first
         expect(seg).not_to be_nil
         expect(seg["instances"]).to be >= 1
         expect(seg["jobs"].find { |j| j["name"] == "coredns" }).to be_nil


### PR DESCRIPTION
What
----
They no longer need their isolation segment. We've already added the number of cells required for them in to the main segment.

How to review
-------------
1. Check I deleted the wrong file
2. Run `cf isolation-segments` to make sure they aren't still entitled to it

After deployment
------------------
1. We probably need to run `cf delete-isolation-segment` to get rid of it in CF, since I don't think the pipeline does it. The pipeline only removes the cells.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
