### PR TITLE
CDN DB: upgrade version

### DIFF
--- a/terraform/cloudfoundry/cdn_broker.tf
+++ b/terraform/cloudfoundry/cdn_broker.tf
@@ -100,17 +100,26 @@ resource "aws_db_parameter_group" "cdn_pg_9_5" {
   description = "CDN Postgres 9.5 parameter group"
 }
 
+resource "aws_db_parameter_group" "cdn_pg_12" {
+  name        = "${var.env}-pg12-cdn"
+  family      = "postgres12"
+  description = "CDN Postgres 12 parameter group"
+}
+
 resource "aws_db_instance" "cdn" {
   identifier           = "${var.env}-cdn"
   allocated_storage    = 10
   engine               = "postgres"
-  engine_version       = "9.5"
+  engine_version       = "12.3"
   instance_class       = "db.t2.small"
   name                 = "cdn"
   username             = "dbadmin"
   password             = var.secrets_cdn_db_master_password
   db_subnet_group_name = aws_db_subnet_group.cdn_rds.name
-  parameter_group_name = aws_db_parameter_group.cdn_pg_9_5.id
+  parameter_group_name = aws_db_parameter_group.cdn_pg_12.id
+
+  allow_major_version_upgrade = true
+  apply_immediately           = true
 
   storage_type               = "gp2"
   backup_window              = "02:00-03:00"


### PR DESCRIPTION
What
----

Postgres 9 is running out of life soon. We're upgrading to the latest available version.

How to review
-------------

I'd really like someone else test this as well as me doing this on Lee's environment...

When I've run this, it was set to be upgrading to version `10.13` then to `12.3`. In accordance with [compatibility table](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html) it is possible to upgrade straight to `12.3` thus another test may be good...

* Have your environment running first
* Have a `cdn-route` service in use (I have created subdomain on my personal domain, pointed to `cdn-route` mapped to `healthcheck` app)
* Run pipeline from this branch
* Monitor `cdn-route` service domain
* Expect green pipeline and uninterrupted service

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
