### PR TITLE
Correct the link for currently firing alerts in the user impact dashboard redux

### DIFF
--- a/manifests/prometheus/dashboards.d/user-impact-redux.json
+++ b/manifests/prometheus/dashboards.d/user-impact-redux.json
@@ -324,7 +324,7 @@
           {
             "targetBlank": true,
             "title": "Currently firing alerts",
-            "url": "https://grafana-1.andyhunt.dev.cloudpipeline.digital/explore?left=%5B\"now-24h\",\"now\",\"prometheus\",%7B\"expr\":\"ALERTS%7Balertstate%3D%5C\"firing%5C\",layer%3D%5C\"%5C\",alertname!~%5C\"%5ECFApp.*$%5C\"%7D\",\"format\":\"time_series\",\"instant\":true,\"intervalFactor\":1,\"legendFormat\":null,\"step\":null%7D,%7B\"ui\":%5Btrue,true,true,\"none\"%5D%7D%5D"
+            "url": "https://grafana-1.__SYSTEM_DNS_ZONE_NAME__/explore?left=%5B\"now-24h\",\"now\",\"prometheus\",%7B\"expr\":\"ALERTS%7Balertstate%3D%5C\"firing%5C\",layer%3D%5C\"%5C\",alertname!~%5C\"%5ECFApp.*$%5C\"%7D\",\"format\":\"time_series\",\"instant\":true,\"intervalFactor\":1,\"legendFormat\":null,\"step\":null%7D,%7B\"ui\":%5Btrue,true,true,\"none\"%5D%7D%5D"
           }
         ],
         "mappingType": 1,


### PR DESCRIPTION
What
----

The alerts count link went to my dev env by mistake. Updates it to use the correct domain.

How to review
-------------
Probably doesn't need review. It's not critical to anything, and it's a very small, unimportant change.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
