### PR TITLE
Increase alert threshold for AWS service limits

### DIFF
--- a/manifests/prometheus/env-specific/prod-lon.yml
+++ b/manifests/prometheus/env-specific/prod-lon.yml
@@ -1,9 +1,9 @@
 ---
 
 # AWS Limits not accesible via API
-aws_limits_elasticache_cache_parameter_groups: 400
+aws_limits_elasticache_cache_parameter_groups: 500
 aws_limits_elasticache_nodes: 700
 # Change limit for prod as well - S3 is global
-aws_limits_s3_buckets: 300
+aws_limits_s3_buckets: 400
 aws_limits_rds_instances: 750
 prometheus_disk_size: 200GB


### PR DESCRIPTION
We maintain alerts for reaching 80 percent use of our service limits.
Alerts for S3 and ElastiCache parameter groups have been triggered and an increase was requested from AWS.

What
----

Increased service limits alert threshold: 400 S3 Buckets, 500 Elasticache parm groups

How to review
-------------

Sanity check numbers / check for typos / CI


---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
