### PR TITLE
[#176574936] Remove `postgis` from default Postgres extensions

### DIFF
--- a/manifests/cf-manifest/operations.d/714-rds-broker-postgres10-high-iops-plans.yml
+++ b/manifests/cf-manifest/operations.d/714-rds-broker-postgres10-high-iops-plans.yml
@@ -17,7 +17,7 @@
       engine: "postgres"
       engine_version: "10"
       engine_family: "postgres10"
-      default_extensions: ["uuid-ossp", "postgis", "citext"]
+      default_extensions: ["uuid-ossp", "citext"]
       allowed_extensions: [
         "address_standardizer",
         "address_standardizer_data_us",

--- a/manifests/cf-manifest/operations.d/715-rds-broker-postgres10-plans.yml
+++ b/manifests/cf-manifest/operations.d/715-rds-broker-postgres10-plans.yml
@@ -17,7 +17,7 @@
       engine: "postgres"
       engine_version: "10"
       engine_family: "postgres10"
-      default_extensions: ["uuid-ossp", "postgis", "citext"]
+      default_extensions: ["uuid-ossp", "citext"]
       allowed_extensions: [
         "address_standardizer",
         "address_standardizer_data_us",

--- a/manifests/cf-manifest/operations.d/716-rds-broker-postgres11-plans.yml
+++ b/manifests/cf-manifest/operations.d/716-rds-broker-postgres11-plans.yml
@@ -17,7 +17,7 @@
       engine: "postgres"
       engine_version: "11"
       engine_family: "postgres11"
-      default_extensions: ["uuid-ossp", "postgis", "citext"]
+      default_extensions: ["uuid-ossp", "citext"]
       allowed_extensions: [
         "address_standardizer",
         "address_standardizer_data_us",

--- a/manifests/cf-manifest/operations.d/717-rds-broker-postgres11-high-iops-plans.yml
+++ b/manifests/cf-manifest/operations.d/717-rds-broker-postgres11-high-iops-plans.yml
@@ -17,7 +17,7 @@
       engine: "postgres"
       engine_version: "11"
       engine_family: "postgres11"
-      default_extensions: ["uuid-ossp", "postgis", "citext"]
+      default_extensions: ["uuid-ossp", "citext"]
       allowed_extensions: [
         "address_standardizer",
         "address_standardizer_data_us",

--- a/manifests/cf-manifest/operations.d/720-rds-broker-postgres12-plans.yml
+++ b/manifests/cf-manifest/operations.d/720-rds-broker-postgres12-plans.yml
@@ -17,7 +17,7 @@
       engine: "postgres"
       engine_version: "12"
       engine_family: "postgres12"
-      default_extensions: ["uuid-ossp", "postgis", "citext"]
+      default_extensions: ["uuid-ossp", "citext"]
       allowed_extensions: [
         "address_standardizer",
         "address_standardizer_data_us",

--- a/manifests/cf-manifest/operations.d/721-rds-broker-postgres12-high-iops-plans.yml
+++ b/manifests/cf-manifest/operations.d/721-rds-broker-postgres12-high-iops-plans.yml
@@ -17,7 +17,7 @@
       engine: "postgres"
       engine_version: "12"
       engine_family: "postgres12"
-      default_extensions: ["uuid-ossp", "postgis", "citext"]
+      default_extensions: ["uuid-ossp", "citext"]
       allowed_extensions: [
         "address_standardizer",
         "address_standardizer_data_us",


### PR DESCRIPTION
What
----

We believe that the `postgis` extension is causing problems when upgrading
Postgres major versions. We're making a change the RDS broker to force it to be
disabled when upgrading, but in order to do that the extension has to be
removed from the list of defaults.

How to review
-------------

1. Make sure I didn't miss anywhere
2. See if it [deployed OK in my environment](https://deployer.andyhunt.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry)
3. See if you can enable and disable the `postgis` extension on a Postgres database

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
