### PR TITLE
GP3 disks

### DIFF
--- a/manifests/cloud-config/paas-cf-cloud-config.yml
+++ b/manifests/cloud-config/paas-cf-cloud-config.yml
@@ -14,27 +14,27 @@ disk_types:
 - name: 5GB
   disk_size: 5120
   cloud_properties:
-    type: gp2
+    type: gp3
 - name: 10GB
   disk_size: 10240
   cloud_properties:
-    type: gp2
+    type: gp3
 - name: 100GB
   disk_size: 102400
   cloud_properties:
-    type: gp2
+    type: gp3
 - name: 200GB
   disk_size: 204800
   cloud_properties:
-    type: gp2
+    type: gp3
 - name: 500GB
   disk_size: 512000
   cloud_properties:
-    type: gp2
+    type: gp3
 - name: 750GB
   disk_size: 768000
   cloud_properties:
-    type: gp2
+    type: gp3
 
 networks:
 - name: cf
@@ -149,21 +149,21 @@ vm_types:
     instance_type: ((nano_vm_instance_type))
     ephemeral_disk:
       size: 10240
-      type: gp2
+      type: gp3
 
 - name: small
   cloud_properties:
     instance_type: ((small_vm_instance_type))
     ephemeral_disk:
       size: 10240
-      type: gp2
+      type: gp3
 
 - name: errand
   cloud_properties:
     instance_type: ((small_vm_instance_type))
     ephemeral_disk:
       size: 10240
-      type: gp2
+      type: gp3
     iam_instance_profile: bosh-errand
 
 - name: medium
@@ -171,42 +171,42 @@ vm_types:
     instance_type: ((medium_vm_instance_type))
     ephemeral_disk:
       size: 10240
-      type: gp2
+      type: gp3
 
 - name: large
   cloud_properties:
     instance_type: ((large_vm_instance_type))
     ephemeral_disk:
       size: 10240
-      type: gp2
+      type: gp3
 
 - name: xlarge
   cloud_properties:
     instance_type: ((xlarge_vm_instance_type))
     ephemeral_disk:
       size: 10240
-      type: gp2
+      type: gp3
 
 - name: router
   cloud_properties:
     instance_type: ((router_instance_type))
     ephemeral_disk:
       size: 10240
-      type: gp2
+      type: gp3
 
 - name: slim_router
   cloud_properties:
     instance_type: ((slim_router_instance_type))
     ephemeral_disk:
       size: 10240
-      type: gp2
+      type: gp3
 
 - name: cell
   cloud_properties:
     instance_type: ((cell_instance_type))
     ephemeral_disk:
       size: 204800
-      type: gp2
+      type: gp3
     security_groups:
     - ((terraform_outputs_rds_broker_db_clients_security_group))
     - ((terraform_outputs_elasticache_broker_clients_security_group))
@@ -217,7 +217,7 @@ vm_types:
     instance_type: ((high_cpu_cell_instance_type))
     ephemeral_disk:
       size: 204800
-      type: gp2
+      type: gp3
     security_groups:
       - ((terraform_outputs_rds_broker_db_clients_security_group))
       - ((terraform_outputs_elasticache_broker_clients_security_group))
@@ -228,7 +228,7 @@ vm_types:
     instance_type: ((small_cell_instance_type))
     ephemeral_disk:
       size: 102400
-      type: gp2
+      type: gp3
     security_groups:
     - ((terraform_outputs_rds_broker_db_clients_security_group))
     - ((terraform_outputs_elasticache_broker_clients_security_group))
@@ -239,7 +239,7 @@ vm_extensions:
   cloud_properties:
     ephemeral_disk:
       size: 65536
-      type: gp2
+      type: gp3
 
 - name: cf_cc_instance_profile
   cloud_properties:

--- a/manifests/cloud-config/spec/vm_types_spec.rb
+++ b/manifests/cloud-config/spec/vm_types_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe "vm_types" do
   describe "the cell pool" do
     let(:pool) { vm_types.find { |p| p["name"] == "cell" } }
 
-    it "has a gp2 ephemeral disk of at least 100G" do
+    it "has a gp3 ephemeral disk of at least 100G" do
       ephemeral_disk = pool["cloud_properties"]["ephemeral_disk"]
       expect(ephemeral_disk).to be_a_kind_of(Hash)
       expect(ephemeral_disk).to include("size", "type")
       expect(ephemeral_disk["size"].to_i).to be >= 102_400
-      expect(ephemeral_disk["type"]).to eq("gp2")
+      expect(ephemeral_disk["type"]).to eq("gp3")
     end
   end
 
@@ -28,7 +28,7 @@ RSpec.describe "vm_types" do
         expect(ephemeral_disk).to be_a_kind_of(Hash), "expected #{pool['name']} to have a ephemeral_disk definition"
         expect(ephemeral_disk).to include("size", "type")
         expect(ephemeral_disk["size"].to_i).to be >= 10_240
-        expect(ephemeral_disk["type"]).to eq("gp2")
+        expect(ephemeral_disk["type"]).to eq("gp3")
       end
     end
   end


### PR DESCRIPTION
What
----
Upgrades platform infrastructure to use [GP3 disks](https://aws.amazon.com/ebs/general-purpose/). They're an upgrade over GP2, and cost 20% less. 

Does not change the disk type of RDS instances, because [GP3 doesn't appear to be supported there yet](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html) (see `StorageType`).

How to review
-------------

1. Run it down your pipeline and make sure it's all OK
2. see that [it deployed fine in my env](https://deployer.andyhunt.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/cf-deploy/builds/122)

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
