### PR TITLE
Target Postgres 12 major version only for CDN database

### DIFF
--- a/terraform/cloudfoundry/cdn_broker.tf
+++ b/terraform/cloudfoundry/cdn_broker.tf
@@ -110,7 +110,7 @@ resource "aws_db_instance" "cdn" {
   identifier           = "${var.env}-cdn"
   allocated_storage    = 10
   engine               = "postgres"
-  engine_version       = "12.3"
+  engine_version       = "12"
   instance_class       = "db.t2.small"
   name                 = "cdn"
   username             = "dbadmin"


### PR DESCRIPTION
What
----
Targeting a specific version of Postgres for the CDN database makes some
upgrade paths impossible. By targeting only the major version, AWS RDS can pick
an appropriate upgrade target in the event one is needed (e.g. for dev envs
going from an earlier version).

This should have no impact on instances already of Postgres 12.


How to review
-------------
1. Code review
2. Deploy it to an env that already has a Postgres 12 CDN broker database

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
