### PR TITLE
Pazmin platform prometheus

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -3974,7 +3974,7 @@ jobs:
           outputs:
             - name: paas-admin-data
           params:
-            PLATFORM_PROMETHEUS_ENDPOINT: "https://prometheus-1.((system_dns_zone_name))"
+            PLATFORM_PROMETHEUS_ENDPOINT: "https://prometheus-2.((system_dns_zone_name))"
             PLATFORM_PROMETHEUS_USERNAME: admin
             PLATFORM_PROMETHEUS_PASSWORD: ((platform_prometheus_password))
           run:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -424,7 +424,8 @@ resources:
   - name: performance-scraper-timer
     type: time
     source:
-      interval: 24h
+      start: 2AM
+      stop: 3AM
 
   - name: smoke-tests-timer
     type: time


### PR DESCRIPTION
What
----

We'd like the scraper to be reliable. It is possible, that during the
day, a lot of users are impacting prometheus' performance, sometimes
preventing us from gathering the metrics.

Running late at night, should allow the data to be collected
uninterrupted...

There are two prometheus instances, and due to how reliable we'd like
the scraper to be, we could attempt to use the prometheus that isn't
that frequently used.

How to review
-------------

- Sanity check

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
