### PR TITLE
Bump S3 service limit in Ireland as well

### DIFF
--- a/manifests/prometheus/env-specific/prod.yml
+++ b/manifests/prometheus/env-specific/prod.yml
@@ -4,6 +4,6 @@
 aws_limits_elasticache_cache_parameter_groups: 400
 aws_limits_elasticache_nodes: 400
 # Change limit for prod-lon as well - S3 is global
-aws_limits_s3_buckets: 300
+aws_limits_s3_buckets: 400
 aws_limits_rds_instances: 550
 prometheus_disk_size: 200GB


### PR DESCRIPTION
What
----

The S3 service limit threshold for alerts needs to be configured for
both London and Ireland dashboard, this was overlooked last time.

How to review
-------------

Check the value

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
