### PR TITLE
[Support] Add a gauge to keep track of the number of CloudFront Distributions

### DIFF
--- a/manifests/prometheus/alerts.d/cloudfront_instances_quota.yml
+++ b/manifests/prometheus/alerts.d/cloudfront_instances_quota.yml
@@ -1,0 +1,17 @@
+# Source: paas-metrics
+---
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: CloudfrontDistributionCountCloseToLimit
+    rules:
+      - alert: CloudfrontDistributionCountCloseToLimit
+        expr: paas_cloudfront_distributions_count > ((aws_limits_cloudfront_distributions)) / 100 * 80
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "Number of Cloudfront Distributions is close to the limit"
+          description: "We are using {{ $value | printf \"%.0f\" }} of ((aws_limits_cloudfront_distributions)) Cloudfront Distributions. We might have to contact AWS support to raise the limit."
+          url: https://console.aws.amazon.com/support/home#/case/create?issueType=service-limit-increase&limitType=service-code-cloudfront-distributions

--- a/manifests/prometheus/env-specific/default.yml
+++ b/manifests/prometheus/env-specific/default.yml
@@ -6,3 +6,4 @@ aws_limits_elasticache_nodes: 100
 aws_limits_s3_buckets: 150
 aws_limits_rds_instances: 40
 prometheus_disk_size: 100GB
+aws_limits_cloudfront_distributions: 200

--- a/manifests/prometheus/env-specific/prod-lon.yml
+++ b/manifests/prometheus/env-specific/prod-lon.yml
@@ -7,3 +7,5 @@ aws_limits_elasticache_nodes: 700
 aws_limits_s3_buckets: 400
 aws_limits_rds_instances: 750
 prometheus_disk_size: 200GB
+# Change limit for prod as well - Cloudfront is global
+aws_limits_cloudfront_distributions: 400

--- a/manifests/prometheus/env-specific/prod.yml
+++ b/manifests/prometheus/env-specific/prod.yml
@@ -7,3 +7,5 @@ aws_limits_elasticache_nodes: 400
 aws_limits_s3_buckets: 400
 aws_limits_rds_instances: 550
 prometheus_disk_size: 200GB
+# Change limit for prod-lon as well - Cloudfront is global
+aws_limits_cloudfront_distributions: 400

--- a/tools/metrics/README.md
+++ b/tools/metrics/README.md
@@ -21,6 +21,7 @@ The following metrics are currently collected:
 |`aws.cloudfront.bytes_uploaded` | Counter | Total number of bytes uploaded to a CloudFront distribution | `distribution_id` |
 |`aws.cloudfront.requests` | Counter | Total number of requests made to a CloudFront distribution | `distribution_id` |
 |`aws.cloudfront.totalerrorrate` | Gauge | The total rate of 4xx and 5xx errors in a CloudFront distribution | `distribution_id` |
+|`aws.cloudfront.distributions.count` | Gauge | The number of cloudfront distributions in this environment | |
 |`aws.s3.buckets.count` | Gauge | The total number of buckets in the AWS account | |
 |`cdn.tls.certificates.expiry` | Gauge | Number of days until a CloudFront cert expires | `hostname` |
 |`cdn.tls.certificates.validity` | Gauge | Number of days CloudFront cert is valid for | `hostname` |

--- a/tools/metrics/gauges_cloudfront_instances.go
+++ b/tools/metrics/gauges_cloudfront_instances.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"time"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/alphagov/paas-cf/tools/metrics/pkg/cloudfront"
+	m "github.com/alphagov/paas-cf/tools/metrics/pkg/metrics"
+	awscloudfront "github.com/aws/aws-sdk-go/service/cloudfront"
+)
+
+func CloudfrontDistributionInstancesGauge(
+	logger lager.Logger,
+	cloudfront *cloudfront.CloudFrontService,
+	interval time.Duration,
+) m.MetricReadCloser {
+	return m.NewMetricPoller(interval, func(w m.MetricWriter) error {
+		lsess := logger.Session("cloudfront-distribution-instances-gauge")
+		count, err := countCloudfrontDistributionInstance(cloudfront)
+		if err != nil {
+			lsess.Error("count-distribution-instances", err)
+			return err
+		}
+		if err != nil {
+			lsess.Error("count-distribution-instances", err)
+			return err
+		}
+		metrics := []m.Metric{
+			{
+				Kind:  "gauge",
+				Name:  "aws.cloudfront.distributions.count",
+				Value: float64(count),
+				Unit:  "count",
+			},
+		}
+
+		return w.WriteMetrics(metrics)
+	})
+}
+
+func countCloudfrontDistributionInstance(service *cloudfront.CloudFrontService) (int64, error) {
+	listDistributionsOutput, err := service.Client.ListDistributions(
+		&awscloudfront.ListDistributionsInput{})
+
+	if err != nil {
+		return 0, err
+	}
+
+	return *listDistributionsOutput.DistributionList.Quantity, nil
+}

--- a/tools/metrics/gauges_cloudfront_instances_test.go
+++ b/tools/metrics/gauges_cloudfront_instances_test.go
@@ -1,0 +1,84 @@
+package main_test
+
+import (
+	"fmt"
+	"time"
+
+	"code.cloudfoundry.org/lager"
+	. "github.com/alphagov/paas-cf/tools/metrics"
+	"github.com/alphagov/paas-cf/tools/metrics/pkg/cloudfront"
+	"github.com/aws/aws-sdk-go/aws"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	cloudfrontfakes "github.com/alphagov/paas-cf/tools/metrics/pkg/cloudfront/fakes"
+	m "github.com/alphagov/paas-cf/tools/metrics/pkg/metrics"
+	awscloudfront "github.com/aws/aws-sdk-go/service/cloudfront"
+)
+
+var _ = Describe("Cloudfront Distribution Instances Gauge", func() {
+	var (
+		cloudfrontSvc *cloudfront.CloudFrontService
+		cloudfrontAPI *cloudfrontfakes.FakeCloudFrontAPI
+		logger        lager.Logger
+
+		cloudfrontDistributionSummary []*awscloudfront.DistributionSummary
+		listDistributionsStub         = func(
+			input *awscloudfront.ListDistributionsInput,
+		) (*awscloudfront.ListDistributionsOutput, error) {
+			list := awscloudfront.DistributionList{
+				Quantity: aws.Int64(int64(len(cloudfrontDistributionSummary))),
+				Items:    cloudfrontDistributionSummary,
+			}
+			resp := awscloudfront.ListDistributionsOutput{
+				DistributionList: &list,
+			}
+			return &resp, nil
+		}
+	)
+
+	BeforeEach(func() {
+		cloudfrontAPI = &cloudfrontfakes.FakeCloudFrontAPI{}
+		cloudfrontSvc = &cloudfront.CloudFrontService{Client: cloudfrontAPI}
+
+		cloudfrontAPI.ListDistributionsStub = listDistributionsStub
+
+		logger = lager.NewLogger("cloudfront-distributions-gauge-test")
+		logger.RegisterSink(lager.NewWriterSink(GinkgoWriter, lager.DEBUG))
+	})
+
+	It("exposes a metric which counts the number of AWS Cloudfront Distributions", func() {
+		cloudfrontDistributionSummary = []*awscloudfront.DistributionSummary{
+			{Id: aws.String("cfd1")},
+			{Id: aws.String("cfd2")},
+			{Id: aws.String("cfd3")},
+		}
+
+		gauge := CloudfrontDistributionInstancesGauge(logger, cloudfrontSvc, 1*time.Second)
+
+		var metric m.Metric
+		Eventually(func() string {
+			var err error
+			metric, err = gauge.ReadMetric()
+			Expect(err).NotTo(HaveOccurred())
+			return metric.Name
+		}, 3*time.Second).Should(Equal("aws.cloudfront.distributions.count"))
+
+		Expect(metric.Value).To(Equal(float64(3)))
+
+	})
+
+	It("returns an error if describing AWS Cloudfront Distributions fails", func() {
+		cloudfrontAPI.ListDistributionsStub = func(
+			_ *awscloudfront.ListDistributionsInput,
+		) (*awscloudfront.ListDistributionsOutput, error) {
+			return nil, fmt.Errorf("error on purpose")
+		}
+
+		gauge := CloudfrontDistributionInstancesGauge(logger, cloudfrontSvc, 1*time.Second)
+		Eventually(func() error {
+			_, err := gauge.ReadMetric()
+			return err
+		}, 3*time.Second).ShouldNot(BeNil())
+	})
+})

--- a/tools/metrics/main.go
+++ b/tools/metrics/main.go
@@ -30,9 +30,9 @@ import (
 	"github.com/alphagov/paas-cf/tools/metrics/pkg/cloudwatch"
 	"github.com/alphagov/paas-cf/tools/metrics/pkg/debug"
 	"github.com/alphagov/paas-cf/tools/metrics/pkg/elasticache"
-	"github.com/alphagov/paas-cf/tools/metrics/pkg/rds"
 	m "github.com/alphagov/paas-cf/tools/metrics/pkg/metrics"
 	promrep "github.com/alphagov/paas-cf/tools/metrics/pkg/prometheus_reporter"
+	"github.com/alphagov/paas-cf/tools/metrics/pkg/rds"
 	"github.com/alphagov/paas-cf/tools/metrics/pkg/s3"
 	"github.com/alphagov/paas-cf/tools/metrics/pkg/tlscheck"
 )
@@ -184,6 +184,7 @@ func Main() error {
 		RDSDBInstancesGauge(logger, rdsService, 15*time.Minute),
 		AWSHealthEventsGauge(logger, awsRegion, healthService, 15*time.Minute),
 		ShieldOngoingAttacksGauge(logger, shieldService, 5*time.Minute),
+		CloudfrontDistributionInstancesGauge(logger, cfs, 15*time.Minute),
 	}
 	for _, addr := range strings.Split(os.Getenv("TLS_DOMAINS"), ",") {
 		gauges = append(gauges, TLSValidityGauge(logger, tlsChecker, strings.TrimSpace(addr), 15*time.Minute))


### PR DESCRIPTION
What
----

Add a gauge and alert for the number of Cloudfront Distributions in the account.

How to review
-------------

* Code Review
* Run tests
* Run down pipeline to check
---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
