### PR TITLE
PSN connection for DCS: Remove broken and unused concourse-tfstate reference

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1281,7 +1281,6 @@ jobs:
           inputs:
             - name: paas-cf
             - name: vpc-tfstate
-            - name: concourse-tfstate
           outputs:
             - name: terraform-variables
           run:


### PR DESCRIPTION
What
----

Remove the concourse-tfstate input, we don't `get` it and we also don't use it.

How to review
-------------

* Sanity check

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
