### PR TITLE
[#177001717] Adds `bosh-tfstate` input to the PSN terraform part of the pipeline

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1272,6 +1272,7 @@ jobs:
             trigger: true
           - get: psn-tfstate
           - get: vpc-tfstate
+          - get: bosh-tfstate
 
       - task: extract-terraform-variables
         tags: [colocated-with-web]


### PR DESCRIPTION
What
----
Adds `bosh-tfstate` input to the PSN terraform part of the pipeline in response to error:

```
missing inputs: bosh-tfstate
```

How to review
-------------
1. Code review by me

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
