### PR TITLE
[#177001717] Specify subnet ids for AZ 1 and 2 (a, b) for the PSN VPC peering

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1329,7 +1329,7 @@ jobs:
                   exit 0
                 fi
                 # shellcheck disable=SC2154
-                export TF_VAR_subnet_ids="[\"${TF_VAR_subnet0_id}\", \"${TF_VAR_subnet1_id}\", \"${TF_VAR_subnet2_id}\"]"
+                export TF_VAR_subnet_ids="[\"${TF_VAR_subnet0_id}\", \"${TF_VAR_subnet1_id}\"]"
                 # shellcheck disable=SC2154
                 export TF_VAR_security_group_name="${TF_VAR_default_security_group}"
 


### PR DESCRIPTION
What
----
The PSN VPN endpoint only supports availability zones A and B (i.e. eu-west-2a,
eu-west-2b). Our Terraform outputs export all 3 AZs, so we can safely remove
the 3rd one as an input.

How to review
-------------

1. Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
