### PR TITLE
Bump xenial stemcell version to mitigate usn-4749-1 and bump cflinuxfs3

### DIFF
--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-xenial
-      version: "621.101"
+      version: "621.108"


### PR DESCRIPTION
What
----

Bum xenial stemcell to 621.108 to mitigate [USN-4749-1](https://www.cloudfoundry.org/blog/usn-4749-1/)

How to review
-------------

Run down pipeline

Who can review
--------------

Not Me

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
