### PR TITLE
[#177001717] Alter PSN Terraform to output multiple subnet group seeds

### DIFF
--- a/terraform/psn/data/security-group-seed.json.tpl
+++ b/terraform/psn/data/security-group-seed.json.tpl
@@ -1,6 +1,3 @@
-[
-  {
-    "peer_name": "psn",
-    "subnet_cidr": ${psn_cidrs}
-  }
-]
+${jsonencode(
+  [for i, cidr in psn_cidrs : { "peer_name": "psn_subnet_${i}", "subnet_cidr": "${cidr}" }]
+)}

--- a/terraform/psn/psn.tf
+++ b/terraform/psn/psn.tf
@@ -71,7 +71,7 @@ output "psn_security_group_seed_json" {
   value = templatefile(
     "${path.module}/data/security-group-seed.json.tpl",
     {
-      psn_cidrs = jsonencode(formatlist("%s/32", [for interface in data.aws_network_interface.psn_interface : interface.private_ip]))
+      psn_cidrs = [for interface in data.aws_network_interface.psn_interface : interface.private_ip]
     }
   )
 }


### PR DESCRIPTION
What
----

Cloud Foundry's Cloud Controller expects that security groups
will specify a destination as a single string. As a result, our
script for generating ops files for security groups bakes in
the assumption that its input will have a single string in the
corresponding part (the `subnet_cidr` parameter).

The PSN Terraform code was outputting an input for that script
which gave the `subnet_cidr` parameter as an array of strings,
because the PSN VPC connection has multiple IPs. This caused an
error when deploying to Cloud Foundry that we could only catch
in a production deploy.

To mitigate this, we mutate the output from the PSN Terraform
to output one seed per subnet. The script we have for
generating security groups is already capable of generating
multiple security groups. This is the safer approach, because
the VPC peering security groups generation script is more
widely used.

How to review
-------------
To review this, you need to generate an output from the template, and use it as input to the VPC peering script. See below.

1. Generate the Terraform output
    ``` bash
    cd paas-cf
    cd terraform/psn
    terraform init
    terraform console
    > templatefile("data/security-group-seed.json.tpl", { psn_cidrs = ["10.0.0.10/32", "10.1.2.3/32"] })
    # e.g.
    # [{"peer_name":"psn_subnet_0","subnet_cidr":"10.0.0.10/32"},{"peer_name":"psn_subnet_1","subnet_cidr":"10.1.2.3/32"}]
    ```
    Copy output from this. It includes "<<EOT" and "EOT", but you should ignore it. The `terraform output -raw` command that's used to get the output value _does not_ include it.
    
2. Write it to `paas-cf/output.json`
3. Look at the output of the VPC peering ops file generation script
    ```bash
    cd paas-cf
    ruby terraform/scripts/generate_vpc_peering_opsfile.rb output.json
    # e.g.
    # ---
    # - type: replace
    #   path: "/instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/security_group_definitions?/-"
    #   value:
    #     name: vpc_peer_psn_subnet_0
    #     rules:
    #     - protocol: all
    #       destination: 10.0.0.10/32
    # - type: replace
    #   path: "/instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/security_group_definitions?/-"
    #   value:
    #     name: vpc_peer_psn_subnet_1
    #     rules:
    #     - protocol: all
    #       destination: 10.1.2.3/32
---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
