### PR TITLE
[Support] Remove vpc-peering-terraform job dependency

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1438,10 +1438,10 @@ jobs:
       - *add-grafana-job-annotation
       - in_parallel:
           - get: pipeline-trigger
-            passed: ['cf-terraform', 'vpc-peering-terraform']
+            passed: ['cf-terraform']
             trigger: true
           - <<: *get-paas-cf
-            passed: ['cf-terraform', 'vpc-peering-terraform']
+            passed: ['cf-terraform']
           - get: vpc-tfstate
           - get: psn-tfstate
             passed: ['psn-terraform']


### PR DESCRIPTION
What
----

Updates generate-cf-config job so it isn't dependent on the vpc-peering-terraform job

How to review
-------------

Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
