### PR TITLE
Fix setting max_allowed_packet for MySQL 5.7

### DIFF
--- a/terraform/cloudfoundry/rds_broker.tf
+++ b/terraform/cloudfoundry/rds_broker.tf
@@ -128,5 +128,14 @@ resource "aws_db_parameter_group" "rds_broker_mysql57" {
   name        = "rdsbroker-mysql57-${var.env}"
   family      = "mysql5.7"
   description = "RDS Broker MySQL 5.7 parameter group"
+
+  parameter {
+    apply_method = "pending-reboot"
+    name         = "max_allowed_packet"
+    // 256MB. setting this high for Drupal https://drupal-admin.com/blog/setup-mysql-drupal
+    // this is also set in the RDS Broker codebase
+    // ideally stop defining parameter groups here and let the broker codebase do it
+    value        = "268435456"
+  }
 }
 


### PR DESCRIPTION
What
----

A tenant using Drupal has had problems with the default value of `max_allowed_packet` in RDS. The default is 4MB and that seems to prevent using strings or blobs larger than that.

In https://github.com/alphagov/paas-rds-broker/pull/135 we increased `max_allowed_packet` to 256MB. That worked, but then broke again.

It turns out that MySQL 5.7 is also configured in Terraform. It's a bit tricky to try and remove it (needs some state editing.) For now I'm just going to set `max_allowed_packet` in Terraform as well.

How to review
-------------

Code review should suffice.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
