### PR TITLE
[#176655014] Silence CF app alerts by pointing them in to a black hole

### DIFF
--- a/manifests/prometheus/operations.d/311-silence-cf-app-alerts.yml
+++ b/manifests/prometheus/operations.d/311-silence-cf-app-alerts.yml
@@ -1,0 +1,18 @@
+---
+- type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers?/-
+  value:
+    name: silence
+
+- type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/route/routes/-
+  value:
+    receiver: silence
+    group_by:
+      - alertname
+    routes:
+      - match:
+          alertname: CFAppCrashed
+      - match:
+          alertname: CFAppUnhealthy
+


### PR DESCRIPTION
What
----

The Prometheus Bosh release gives us a package of CloudFoundry
alerts. Many of these we care about, but two in particular are
very noisy and don't provide us any useful information:

  - CFAppCrashed
  - CFAppUnhealthy

The Bosh release doesn't feature configuration options for
which alerts to enable/disable, or to configure their alert
level.

Instead of making a PR to the upstream, which will take a long
time to get merged and released, we can reduce our alert noise
quickly by directing those alerts in to a black hole in
Alertmanager.

How to review
-------------
1. [See that it deployed OK in my env](https://deployer.andyhunt.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/prometheus-deploy/builds/91)
2. See if you agree [with the configuration](https://prometheus.io/docs/alerting/latest/configuration/). Particularly that an empty receiver config should result in no action being taken.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
