### PR TITLE
Remove `cabinet-office-people-finder` from CSLS orgs

### DIFF
--- a/config/service-brokers/csls-splunk/prod-lon-config.json
+++ b/config/service-brokers/csls-splunk/prod-lon-config.json
@@ -1,7 +1,6 @@
 {
   "allowed_orgs": [
     "cabinet-office-papt",
-    "cabinet-office-people-finder",
     "cabinet-office-tu-facility-time",
     "ccs-conclave-cii",
     "ccs-digital-services-team",


### PR DESCRIPTION
What
----

The cabinet-office-people-finder` org has been deleted, however the
broker is still trying to enable the CSLS broker for this non existent
org. It was removed vi https://govuk.zendesk.com/agent/tickets/4397156

How to review
-------------

Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
