### PR TITLE
[#176655014] Restore "silence" alertmanager receiver that was lost in earlier commit

### DIFF
--- a/manifests/prometheus/operations.d/310-alertmanager-routes.yml
+++ b/manifests/prometheus/operations.d/310-alertmanager-routes.yml
@@ -73,3 +73,8 @@
     pagerduty_configs:
       - service_key: ((alertmanager_pagerduty_in_hours_service_key))
         description: "[((metrics_environment))] {{ .GroupLabels.SortedPairs.Values | join \" \" }}"
+
+- type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers?/-
+  value:
+    name: silence


### PR DESCRIPTION
What
----
Commit 7c04e6d2f7d595693b521dfcee7d694d33f6b915 reworked a configuration to
prepend instead of append, and in removing an ops file we forgot to bring
across a related element.

How to review
-------------

1. Check I restored the silence receiver that removed in the above commit

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
