### PR TITLE
[#175917080] Email in-hours support when a DDoS is detected

### DIFF
--- a/terraform/cloudfoundry/lbs.tf
+++ b/terraform/cloudfoundry/lbs.tf
@@ -268,6 +268,65 @@ resource "aws_lb_target_group" "cf_router_system_domain_https" {
   }
 }
 
+data "aws_sns_topic" "email_in_hours_paas_support" {
+  name = "email-in-hours-paas-support"
+}
+
+resource "aws_cloudwatch_metric_alarm" "loggregator_lb_ddos_detected" {
+  alarm_name          = "${var.env}-loggregator-lb-ddos-detected"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "DDoSDetected"
+  namespace           = "AWS/DDOSProtection"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = 0
+  alarm_description   = "DDOS Detected against loggregator load balancer"
+  actions_enabled     = "true"
+  alarm_actions       = [data.aws_sns_topic.email_in_hours_paas_support.arn]
+
+  dimensions = {
+    ResourceArn = aws_lb.cf_loggregator.arn
+  }
+}
+
+
+resource "aws_cloudwatch_metric_alarm" "system_domain_lb_ddos_detected" {
+  alarm_name          = "${var.env}-system-domain-lb-ddos-detected"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "DDoSDetected"
+  namespace           = "AWS/DDOSProtection"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = 0
+  alarm_description   = "DDOS Detected against system domain load balancer"
+  actions_enabled     = "true"
+  alarm_actions       = [data.aws_sns_topic.email_in_hours_paas_support.arn]
+
+  dimensions = {
+    ResourceArn = aws_lb.cf_router_system_domain.arn
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "app_domain_lb_ddos_detected" {
+  alarm_name          = "${var.env}-app-domain-lb-ddos-detected"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "DDoSDetected"
+  namespace           = "AWS/DDOSProtection"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = 0
+  alarm_description   = "DDOS Detected against app domain load balancer"
+  actions_enabled     = "true"
+  alarm_actions       = [data.aws_sns_topic.email_in_hours_paas_support.arn]
+
+  dimensions = {
+    ResourceArn = aws_lb.cf_router_app_domain.arn
+  }
+}
+
 output "cf_router_system_domain_https_target_group_name" {
   value = aws_lb_target_group.cf_router_system_domain_https.name
 }


### PR DESCRIPTION
What
----

This commit creates CloudWatch alarms that will go off when AWS Shield Advanced detects a DDoS against our platform load balancers.

These CloudWatch alarms then notify an SNS topic being configured in our account-wide Terraform (https://github.com/alphagov/paas-aws-account-wide-terraform/pull/261.) That SNS topic then emails us so that we know about the potential problem.

How to review
-------------

This is deployed in my `miki` dev env. You can also deploy it in your own dev env.

How to release
---------------

Before merging this PR, https://github.com/alphagov/paas-aws-account-wide-terraform/pull/261 needs to be reviewed, merged and applied to all environments.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
