### PR TITLE
[#177263693] Use a 'large' type VM for platform Prometheus instances

### DIFF
--- a/manifests/prometheus/operations.d/100-update-vm-types.yml
+++ b/manifests/prometheus/operations.d/100-update-vm-types.yml
@@ -6,4 +6,4 @@
   value: nano
 - type: replace
   path: /instance_groups/name=prometheus2/vm_type
-  value: medium
+  value: large

--- a/manifests/prometheus/spec/operations/monitor_cf_spec.rb
+++ b/manifests/prometheus/spec/operations/monitor_cf_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Monitor CF" do
   it "adds the firehose instance_group" do
-    firehose = manifest_with_defaults.get("instance_groups.prometheus2")
+    firehose = manifest_with_defaults.get("instance_groups.firehose")
     expect(firehose).not_to be_nil
     expect(firehose["vm_type"]).to eq("medium")
     expect(firehose["networks"]).to eq([{ "name" => "cf" }])

--- a/manifests/prometheus/spec/operations/update_vm_types_spec.rb
+++ b/manifests/prometheus/spec/operations/update_vm_types_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "update-vm-types.yml" do
   {
     "alertmanager" => "nano",
     "grafana" => "nano",
-    "prometheus2" => "medium",
+    "prometheus2" => "large",
   }.each do |name, type|
     it "sets the vm_type for #{name} to #{type}" do
       expect(manifest_with_defaults.get("instance_groups.#{name}.vm_type")).to eq(type)


### PR DESCRIPTION
What
----
We're utilising Prometheus a bit more, and pushing it a bit harder. A larger VM type should help it stay available for us.

How to review
-------------

1. Deploy your env, leave it half an hour so there's some historic data
2. Deploy this branch
3. Check that the historic data is there after deploy

In my env the deploy happened at ~1530 and lasted 20 minutes.

![image](https://user-images.githubusercontent.com/1747386/110966941-bc4fd100-834d-11eb-8d8e-064ffc2766c3.png)


---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
