### PR TITLE
Enlarge Firehose VMs to avoid exhausted CPU credits

### DIFF
--- a/manifests/prometheus/operations.d/221-monitor-cf.yml
+++ b/manifests/prometheus/operations.d/221-monitor-cf.yml
@@ -5,7 +5,7 @@
 
 - type: replace
   path: /instance_groups/name=firehose/vm_type
-  value: medium
+  value: large
 
 - type: replace
   path: /instance_groups/name=firehose/jobs/name=firehose_exporter/properties/firehose_exporter/doppler/idle_timeout?

--- a/manifests/prometheus/spec/operations/monitor_cf_spec.rb
+++ b/manifests/prometheus/spec/operations/monitor_cf_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "Monitor CF" do
   it "adds the firehose instance_group" do
     firehose = manifest_with_defaults.get("instance_groups.firehose")
     expect(firehose).not_to be_nil
-    expect(firehose["vm_type"]).to eq("medium")
+    expect(firehose["vm_type"]).to eq("large")
     expect(firehose["networks"]).to eq([{ "name" => "cf" }])
   end
 


### PR DESCRIPTION
What
----

We have "Firehose" VMs that run the [Firehose Exporter](https://github.com/bosh-prometheus/firehose_exporter).

Until now our Firehose VMs have used the t3.medium instance type. But in London they have been experiencing exhausted CPU credits for months now. CPU usage is not very high but they use just a bit more CPU than they have CPU credits. Moving them to m5.large will resolve this by giving them consistent amounts of CPU.

Here's a Firehose in London:

<img width="604" alt="Screenshot 2021-03-17 at 11 18 31" src="https://user-images.githubusercontent.com/163111/111459431-9130fd00-8712-11eb-8f09-931a89306d0c.png">

Here's a Firehose in Ireland:

<img width="603" alt="Screenshot 2021-03-17 at 11 18 23" src="https://user-images.githubusercontent.com/163111/111459450-9726de00-8712-11eb-8c61-e4b6aaf382b0.png">

You can see that the CPU credit usage isn't all that much higher in London, but it's enough to exhaust them. I think it's better to just move all Firehose VMs rather than just doing some.

How to review
-------------

Code review should be good enough. I'm pretty confident the `path` is correct based on https://github.com/alphagov/paas-cf/blob/b8763f4bd04cb5151d1a8ce822378f6536ede39a/manifests/prometheus/operations.d/400-set-instance-count.yml#L32

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
