### PR TITLE
Move AWS leaked key check into separate group

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -490,7 +490,7 @@ resources:
   - name: leaked-aws-key-check-timer
     type: time
     source:
-      interval: 5m
+      interval: 20m
 
   - name: check-certificates-timer
     type: time
@@ -5737,7 +5737,7 @@ jobs:
                 CF_PASS: ((cf_pass))
 
   - name: continuous-leaked-aws-key-check
-    serial_groups: [smoke-tests]
+    serial_groups: [security-checks]
     build_logs_to_retain: 10000
     plan:
       - in_parallel:


### PR DESCRIPTION
What
----

This is done as sharing a serial execution group with the leaked key check prevented smoke-tests, etc. being run in prod (only one running job per serial group is allowed).
The leaked key detection job is just a simple bash script, so it is safe to execute in parallel to smoke-tests.

We also saw the checks taking more time in prod (17 mins) as compared to dev (4 mins), so increasing the leaked key timer interval to 20 mins.

How to review
-------------

- Apply changes to pipeline in dev environment
- Check the jobs `continuous-leaked-aws-key-check` AND (`continuous-smoke-tests` OR `continuous-billing-smoke-tests`) can run in parallel.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
