### PR TITLE
[#177474241] Prevent persistent dev envs being autodelete

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,18 @@ dev: ## Set Environment to DEV
 	$(eval export CA_ROTATION_EXPIRY_DAYS ?= 360)
 	@true
 
+.PHONY: dev01
+dev01: $(eval export DEPLOY_ENV=dev01)
+dev01: dev
+	$(eval export ENABLE_AUTODELETE=false)
+	@true
+
+.PHONY: dev02
+dev02: $(eval export DEPLOY_ENV=dev02)
+dev02: dev
+	$(eval export ENABLE_AUTODELETE=false)
+	@true
+
 .PHONY: stg-lon
 stg-lon: ## Set Environment to stg-lon
 	$(eval export AWS_ACCOUNT=staging)

--- a/Makefile
+++ b/Makefile
@@ -220,14 +220,14 @@ dev: ## Set Environment to DEV
 	@true
 
 .PHONY: dev01
-dev01: $(eval export DEPLOY_ENV=dev01)
 dev01: dev
+	$(eval export DEPLOY_ENV=dev01)
 	$(eval export ENABLE_AUTODELETE=false)
 	@true
 
 .PHONY: dev02
-dev02: $(eval export DEPLOY_ENV=dev02)
 dev02: dev
+	$(eval export DEPLOY_ENV=dev02)
 	$(eval export ENABLE_AUTODELETE=false)
 	@true
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,22 @@ in [Additional Notes](#check-and-release-pipeline-locking).
 NB: The CloudFoundry deployment (but not the supporting infrastructure) will [auto-delete
 overnight](#overnight-deletion-of-environments) by default.
 
+### Shared development environments
+In March 2021, we introduced two shared development environments: `dev01` and `dev02`. They are identical to other development
+environments, other than that they aren't torn down overnight. 
+
+To work with them, use their respective `dev01` and `dev02` Make targets; e.g.
+
+```
+make dev01 showenv
+make dev02 pipelines
+```
+
+They were introduced to try to reduce the burden of individuals  running their own environments, and having them be 
+very slow to start up in a morning. We opted for two shared environments over having every development environment not shut
+down overnight because it was cheaper in the long run.
+
+
 ### Destroy
 
 Run the `destroy-cloudfoundry` pipeline to delete the CloudFoundry deployment, and supporting infrastructure.


### PR DESCRIPTION
What
----
We've introduced two shared, persistent dev envs. We don't want them auto-deleting every night.

How to review
-------------
1. Code review. In particular, see commit messages for an explanation of the dark Make magic.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
