### PR TITLE
Address CVE-2021-22115 by bumping capi to 0.106.0

### DIFF
--- a/manifests/cf-manifest/operations.d/320-cc-release.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-release.yml
@@ -3,6 +3,6 @@
   path: /releases/name=capi
   value:
     name: "capi"
-    version: "1.104.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.104.0"
-    sha1: "eae1171ff4c53bfb59f4b4d396d007ebc661cb59"
+    version: "1.106.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.106.0"
+    sha1: "5eca119d80771fedb1127a295472201b243e0793"


### PR DESCRIPTION
What
----

Address CVE-2021-22115 by bumping capi to 0.106.0

How to review
-------------
- Check release details against https://bosh.io/releases/github.com/cloudfoundry/capi-release?version=1.106.0
- Run down your dev environment pipeline

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
