### PR TITLE
Reduce number of targets to one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,15 +220,19 @@ dev: ## Set Environment to DEV
 	@true
 
 .PHONY: dev01
-dev01: $(eval export DEPLOY_ENV=dev01)
 dev01: dev
+	$(eval export DEPLOY_ENV=dev01)
 	$(eval export ENABLE_AUTODELETE=false)
+	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
+	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipelineapps.digital)
 	@true
 
 .PHONY: dev02
-dev02: $(eval export DEPLOY_ENV=dev02)
 dev02: dev
+	$(eval export DEPLOY_ENV=dev02)
 	$(eval export ENABLE_AUTODELETE=false)
+	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
+	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipelineapps.digital)
 	@true
 
 .PHONY: stg-lon


### PR DESCRIPTION
What
----

We couldn't do this before, as some of the variables in `dev` target are
generated based on DEPLOY_ENV value.

We can override those to however, making it all seemless and making Make
happy with a single target at all times...

How to review
-------------

- Sanity check

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
