### PR TITLE
[#175872094] Scale Traffic Controller Instances

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -6,7 +6,7 @@ cell_instances: 84
 router_instances: 15
 api_instances: 12
 doppler_instances: 39
-log_api_instances: 6
+log_api_instances: 18
 scheduler_instances: 4
 cc_worker_instances: 4
 cc_hourly_rate_limit: 20000

--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -6,7 +6,7 @@ cell_instances: 36
 router_instances: 24
 api_instances: 6
 doppler_instances: 39
-log_api_instances: 6
+log_api_instances: 18
 scheduler_instances: 4
 cc_worker_instances: 4
 cc_hourly_rate_limit: 60000


### PR DESCRIPTION
What
----

Scaling as it's recommended to [have as many traffic controller instances](https://docs.cloudfoundry.org/loggregator/log-ops-guide.html#-traffic-controller) as doppler instances.

How to review
-------------

Code review 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
