### PR TITLE
[Support] Revert our UAA release to 74.31.0

### DIFF
--- a/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
+++ b/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
@@ -3,6 +3,6 @@
   path: /releases/name=uaa
   value:
     name: uaa
-    version: 0.1.29
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-0.1.29.tgz
-    sha1: 2c30891341cd1ae5f630cfa596346940a2217fde
+    version: 0.1.28
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-0.1.28.tgz
+    sha1: c1f955c9ba35f21ae03670cb29b82286044a1171

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "release versions" do
 
     pinned_releases = {
       "uaa" => {
-        local: "0.1.29",
+        local: "0.1.28",
         upstream: "75.0.0",
       },
     }


### PR DESCRIPTION
What
----

Reverts our recent UAA bump due to an issue with the invite link. 

How to review
-------------

Code review (already deployed to dev02)

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
