### PR TITLE
Bump London Elasticache Parm Group service limit

### DIFF
--- a/manifests/prometheus/env-specific/prod-lon.yml
+++ b/manifests/prometheus/env-specific/prod-lon.yml
@@ -1,7 +1,7 @@
 ---
 
 # AWS Limits not accesible via API
-aws_limits_elasticache_cache_parameter_groups: 500
+aws_limits_elasticache_cache_parameter_groups: 700
 aws_limits_elasticache_nodes: 700
 # Change limit for prod as well - S3 is global
 aws_limits_s3_buckets: 400


### PR DESCRIPTION
What
----
We are alerted if using more than 80 percent of the current limit (500).
AWS raised the service limit to 700 for us.

How to review
-------------

- Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
