### PR TITLE
Add terraform provider UAA client

### DIFF
--- a/manifests/cf-manifest/data/100-tenant-uaa-client-config.yml
+++ b/manifests/cf-manifest/data/100-tenant-uaa-client-config.yml
@@ -17,7 +17,12 @@
 #     - https://APP_NAME.((app_domain))/callback/URL
 #     - https://CUSTOM_DOMA.in/callback/URL
 
-stg-lon: []
+stg-lon: 
+  - name: terraform-provider-test-account
+    secret_name: secrets_uaa_clients_terraform_provider_test_account_secret
+    uaa_client:
+      scope: cloud_controller.admin,uaa.admin,scim.read,scim.write
+      override: true
 
 prod: []
 


### PR DESCRIPTION
What
----

In order to run the tests against terraform there is a need for a custom
UAA client. in order to not have any conflict with Prod this has been
placed in staging.

How to review
-------------

Code review

Check there is a cred set via `credhub get -n /stg-lon/stg-lon/secrets_uaa_clients_terraform_provider_test_account_secret`

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
