### PR TITLE
Fix missing authorized-grant-types

### DIFF
--- a/manifests/cf-manifest/data/100-tenant-uaa-client-config.yml
+++ b/manifests/cf-manifest/data/100-tenant-uaa-client-config.yml
@@ -22,6 +22,7 @@ stg-lon:
     secret_name: secrets_uaa_clients_terraform_provider_test_account_secret
     uaa_client:
       scope: cloud_controller.admin,uaa.admin,scim.read,scim.write
+      authorized-grant-types: refresh_token,authorization_code,password
       override: true
 
 prod: []


### PR DESCRIPTION
What
----

Fixing `Missing property: uaa.clients.terraform-provider-test-account.authorized-grant-types)`

How to review
-------------

Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
