### PR TITLE
Don't upgrade auto-scaler's stemcells to bionic

### DIFF
--- a/manifests/app-autoscaler/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/app-autoscaler/operations.d/020-bosh-set-stemcells.yml
@@ -1,1 +1,3 @@
-../../cf-manifest/operations.d/020-bosh-set-stemcells.yml
+# THIS USED TO BE A SIMLINK!
+#
+# manifests/app-autoscaler/operations.d/020-bosh-set-stemcells.yml -> ../../cf-manifest/operations.d/020-bosh-set-stemcells.yml


### PR DESCRIPTION
What
----

We have found that the bionic upgrade is damaging the autoscaler in a
way, where the metricserver is being unresponsive, meaning the scaling
cannot be happening due to 500 errors from unreachable BOSH DNS
internal connection.

Reverting it back in the hope of it bringing back the autoscaler -
feature used by our tenants and hoping the upstream will perform more
tests.

How to review
-------------

- Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
