### PR TITLE
Allow the continuous deployment of PaaS admin to be disabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,7 @@ dev: ## Set Environment to DEV
 	$(eval export ENABLE_MORNING_DEPLOYMENT=true)
 	$(eval export SLIM_DEV_DEPLOYMENT ?= true)
 	$(eval export CA_ROTATION_EXPIRY_DAYS ?= 360)
+	$(eval export ENABLE_PAAS_ADMIN_CONTINUOUS_DEPLOY ?= true)
 	@true
 
 .PHONY: dev01
@@ -256,6 +257,7 @@ stg-lon: ## Set Environment to stg-lon
 	$(eval export AWS_DEFAULT_REGION=eu-west-2)
 	$(eval export AWS_REGION=eu-west-2)
 	$(eval export CA_ROTATION_EXPIRY_DAYS=335)
+	$(eval export ENABLE_PAAS_ADMIN_CONTINUOUS_DEPLOY ?= true)
 	@true
 
 .PHONY: prod
@@ -279,6 +281,7 @@ prod: ## Set Environment to Production
 	$(eval export AWS_DEFAULT_REGION=eu-west-1)
 	$(eval export AWS_REGION=eu-west-1)
 	$(eval export CA_ROTATION_EXPIRY_DAYS=30)
+	$(eval export ENABLE_PAAS_ADMIN_CONTINUOUS_DEPLOY ?= true)
 	@true
 
 .PHONY: prod-lon
@@ -302,6 +305,7 @@ prod-lon: ## Set Environment to prod-lon
 	$(eval export AWS_DEFAULT_REGION=eu-west-2)
 	$(eval export AWS_REGION=eu-west-2)
 	$(eval export CA_ROTATION_EXPIRY_DAYS=30)
+	$(eval export ENABLE_PAAS_ADMIN_CONTINUOUS_DEPLOY ?= true)
 	@true
 
 .PHONY: bosh-cli

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -3954,7 +3954,7 @@ jobs:
     plan:
       - *add-grafana-job-annotation
       - get: paas-admin
-        trigger: true
+        trigger: ((enable_paas_admin_continuous_deploy))
 
       - in_parallel:
         - <<: *get-paas-cf

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -111,6 +111,7 @@ monitored_deploy_env: ${MONITORED_DEPLOY_ENV:-}
 deploy_env_tag_prefix: "${deploy_env_tag_prefix}"
 skip_autodelete_await: "${SKIP_AUTODELETE_AWAIT:-false}"
 ca_rotation_expiry_days: "${CA_ROTATION_EXPIRY_DAYS}"
+enable_paas_admin_continuous_deploy: ${ENABLE_PAAS_ADMIN_CONTINUOUS_DEPLOY:-true}
 EOF
   echo -e "pipeline_lock_git_private_key: |\\n  ${git_id_rsa//$'\n'/$'\n'  }"
 }


### PR DESCRIPTION
What
----

PaaS admin is usually re-deployed every time a new release is detected. In some environments, we don't want this to happen, because it wrecks developer productivity, or overwrites a deliberate change that is being tested.

Running the below will now disable the continuous deployment in an environment

  make ENV pipelines ENABLE_PAAS_ADMIN_CONTINUOUS_DEPLOY=false

How to review
-------------

See if you agree with the changes

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
