### PR TITLE
Scale London instance count to 96

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -2,7 +2,7 @@
 uaa_instances: 3
 nats_instances: 3
 diego_api_instances: 3
-cell_instances: 87
+cell_instances: 96
 router_instances: 15
 api_instances: 12
 doppler_instances: 39


### PR DESCRIPTION
What
----
According to our metrics, we are currently running fewer instances than required.

How to review
-------------
- Code review
- Optionally check https://grafana-1.london.cloud.service.gov.uk/d/paas-user-impact/user-impact-prod-lon?orgId=1&refresh=5s

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
