### PR TITLE
Alert us when we've <=50 S3 buckets left in the quota

### DIFF
--- a/manifests/prometheus/alerts.d/s3_bucket_count.yml
+++ b/manifests/prometheus/alerts.d/s3_bucket_count.yml
@@ -7,7 +7,7 @@
     name: S3BucketCountCloseToLimit
     rules:
       - alert: S3BucketCountCloseToLimit
-        expr: paas_aws_s3_buckets_count > ((aws_limits_s3_buckets)) * .8
+        expr: paas_aws_s3_buckets_count >= (((aws_limits_s3_buckets))-50)
         for: 1h
         labels:
           severity: warning


### PR DESCRIPTION
What
----

Previously we were alerting when were over 80% of our quota. This made sense
when the limit was smaller. We're at 400 now, which means we're getting
alerted when we're at 320/400. That's too early, and the S3 bucket count growth
rate doesn't indicate we need to act soon; we've gained ~40 buckets (10%) in
the 30 days between 3rd May and 2nd June 2021.

If we continue alerting on 20% remaining, the alerts will continue to get
earlier and earlier and we get more and more blind to them.#

We should instead alert ourselves when there are 50 remaining. Our growth rate
suggests that gives us more than enough time to act.

How to review
-------------
Do you agree?

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
