### PR TITLE
Fix link to Concourse create-cloudfoundry health group in smoke test failures

### DIFF
--- a/concourse/scripts/smoke_tests_email.sh
+++ b/concourse/scripts/smoke_tests_email.sh
@@ -30,7 +30,7 @@ write_message_json() {
   "Body": {
     "Html": {
       "Data": "The smoke tests have failed in environment <b>${DEPLOY_ENV}</b>. See \
-      <a href='https://deployer.${SYSTEM_DNS_ZONE_NAME}/teams/main/pipelines/create-cloudfoundry?groups=health'>Concourse</a> \
+      <a href='https://deployer.${SYSTEM_DNS_ZONE_NAME}/teams/main/pipelines/create-cloudfoundry?group=health'>Concourse</a> \
       for details<br/>"
     }
   }


### PR DESCRIPTION
What
----

When a smoke test fails, we get an email like this:
`The smoke tests have failed in environment prod-lon. See Concourse for details`
With `Concourse` being a link to e.g. https://deployer.london.cloud.service.gov.uk/teams/main/pipelines/create-cloudfoundry?groups=health
But that URL doesn't work, it should be https://deployer.london.cloud.service.gov.uk/teams/main/pipelines/create-cloudfoundry?group=health

How to review
-------------

Check the old link doesn't work and the new one does.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
