### PR TITLE
Buildpack email generation interactively prompts for highlights

### DIFF
--- a/scripts/create_buildpacks_email.sh
+++ b/scripts/create_buildpacks_email.sh
@@ -31,4 +31,7 @@ fi
 
 cd "${root_dir}/tools/buildpacks"
 
-go run email.go structs.go -old <(git show "$previous_commit:config/buildpacks.yml") -new <(git show "head:config/buildpacks.yml")
+EMAIL_OUT="email-$(date "+%Y-%m-%d").txt"
+go run email.go structs.go -old <(git show "$previous_commit:config/buildpacks.yml") -new <(git show "head:config/buildpacks.yml") -out "${EMAIL_OUT}"
+
+echo "Email content writen to: $(pwd)/${EMAIL_OUT}"

--- a/tools/buildpacks/.gitignore
+++ b/tools/buildpacks/.gitignore
@@ -1,0 +1,3 @@
+tmp*
+email-*.txt
+vendor

--- a/tools/buildpacks/email.tmpl
+++ b/tools/buildpacks/email.tmpl
@@ -9,6 +9,16 @@ If you have any problems using the new versions in the buildpacks, or working to
 Regards,
 
 The GOV.UK PaaS team
+{{- if .HasAnyHighlights }}
+# Highlights
+{{- range $index := .Data }}
+{{- if .HasHighlights }}
+{{ $buildpack := .Buildpack }}
+## {{ .Buildpack.Name }}: {{ .Buildpack.Version}}
+{{.Highlights}}
+{{- end }}
+{{- end }}
+{{- end }}
 
 # Planned Releases:
 {{ range $index := .Data }}

--- a/tools/buildpacks/go.mod
+++ b/tools/buildpacks/go.mod
@@ -3,6 +3,7 @@ module github.com/alphagov/paas-cf/tools/buildpacks
 require (
 	github.com/google/go-github/v24 v24.0.0
 	golang.org/x/oauth2 v0.0.0-20190115181402-5dab4167f31c
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
 	gopkg.in/yaml.v2 v2.2.2
 )
 

--- a/tools/buildpacks/go.sum
+++ b/tools/buildpacks/go.sum
@@ -15,8 +15,9 @@ golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190115181402-5dab4167f31c h1:pcBdqVcrlT+A3i+tWsOROFONQyey9tisIQHI4xqVGLg=
 golang.org/x/oauth2 v0.0.0-20190115181402-5dab4167f31c/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180824143301-4910a1d54f87/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=


### PR DESCRIPTION
What
----
When we send out an email to tenants about buildpack upgrades, we list all of the dependency version changes, along with links to all of the release notes. This is decent chunk of information, and it would be easy for tenants to not read through all of the release notes for all the buildpacks they use, and/or to miss something important.

To make life easier for them, we should read the release notes ourselves as operators, and summarise the important bits (e.g important versions being removed, shiny new versions being added, whole new buildpacks being introduced).

The buildpack email generation Go program now interactively prompts users to read the notes and edit a message about them (n.b. it respects the $EDITOR env var). Those messages are compiled in to the final email.

How to review
-------------

Do you agree with this approach?
Do you think we should tidy the codebase up a bit?

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
