### PR TITLE
Upload stemcells during autoscaler deploy

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2742,6 +2742,47 @@ jobs:
           params:
             file: app-autoscaler-manifest-pre-vars/app-autoscaler-manifest-pre-vars.yml
 
+      - task: get-and-upload-stemcell
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *gov-paas-bosh-cli-v2-image-resource
+          inputs:
+            - name: paas-cf
+            - name: app-autoscaler-manifest
+          params:
+            BOSH_ENVIRONMENT: ((bosh_fqdn))
+            BOSH_CA_CERT: ((bosh-ca-cert))
+            BOSH_DEPLOYMENT: app-autoscaler
+            BOSH_CLIENT_SECRET: ((bosh-client-secret))
+            BOSH_EXPORTER_PASSWORD: ((bosh-exporter-password))
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
+
+                BOSH_CLIENT='admin'
+                export BOSH_CLIENT
+
+                stemcell_index=0
+                while true; do
+                  if ! $VAL_FROM_YAML "stemcells.${stemcell_index}" app-autoscaler-manifest/app-autoscaler-manifest.yml > /dev/null 2>&1; then
+                    break
+                  fi
+
+                  STEMCELL_VERSION=$($VAL_FROM_YAML "stemcells.${stemcell_index}.version" app-autoscaler-manifest/app-autoscaler-manifest.yml)
+                  STEMCELL_OS=$($VAL_FROM_YAML "stemcells.${stemcell_index}.os" app-autoscaler-manifest/app-autoscaler-manifest.yml)
+
+                  wget "https://bosh.io/d/stemcells/bosh-aws-xen-hvm-${STEMCELL_OS}-go_agent?v=${STEMCELL_VERSION}" -O stemcell.tgz
+
+                  bosh -n upload-stemcell stemcell.tgz
+
+                  stemcell_index=$((stemcell_index + 1))
+                done
+
       - task: app-autoscaler-deploy
         tags: [colocated-with-web]
         config:

--- a/manifests/app-autoscaler/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/app-autoscaler/operations.d/020-bosh-set-stemcells.yml
@@ -1,3 +1,7 @@
-# THIS USED TO BE A SIMLINK!
-#
-# manifests/app-autoscaler/operations.d/020-bosh-set-stemcells.yml -> ../../cf-manifest/operations.d/020-bosh-set-stemcells.yml
+---
+- type: replace
+  path: /stemcells
+  value:
+    - alias: default
+      os: ubuntu-xenial
+      version: "621.123"


### PR DESCRIPTION


What
----

As in [1] and [2], the CF app autoscaler isn't working with the Ubuntu Bionic stemcells right now, and needs to be deployed with the old Xenial stemcells instead.

This has been working in environments that existed prior to the Xenial->Bionic switch, because the Xenial stemcell image continued to exist in Bosh's storage. However, this isn't true for new environments, and thus they fail to deploy the autoscaler.

To remedy this, we take a copy of the stemcell uploading Concourse task, and pop it in the pipeline just before the autoscaler is deployed. We also replicate the ops file that sets the stemcell from `cf-manifest`. The two combine to download the correct stemcell image, and upload it to Bosh.

[1] https://github.com/cloudfoundry/app-autoscaler-release/pull/254
[2] https://github.com/cloudfoundry/app-autoscaler-release/issues/253

How to review
-------------
Run it down a _fresh_ environment and see if it deploys.

OR 

Delete the Xenial stemcell from storage in an existing dev env, and run it down.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
