### PR TITLE
Deprecate elasticsearch 6.x plans in the aiven broker.

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -5224,6 +5224,15 @@ jobs:
 
                 cf enable-service-access elasticsearch -b aiven-broker
 
+                # Disable deprecated plans
+                cat <<EOF | xargs -n1 cf disable-service-access elasticsearch -p
+                tiny-6.x
+                small-ha-6.x
+                medium-ha-6.x
+                large-ha-6.x
+                xlarge-ha-6.x
+                EOF
+
                 cf enable-service-access influxdb -b aiven-broker
 
       - do:

--- a/config/service-brokers/aiven/config.json
+++ b/config/service-brokers/aiven/config.json
@@ -32,6 +32,7 @@
             "elasticsearch_version": "6",
             "description": "NOT Highly Available, 1 dedicated VM, 1 CPU per VM, 4GB RAM per VM, 80GB disk space. Free for trial orgs. Costs for billable orgs.",
             "free": true,
+            "active": false,
             "metadata": {
               "displayName": "Tiny",
               "AdditionalMetadata": {
@@ -53,6 +54,7 @@
             "elasticsearch_version": "6",
             "description": "3 dedicated VMs, 1 CPU per VM, 4GB RAM per VM, 240GB disk space.",
             "free": false,
+            "active": false,
             "metadata": {
               "displayName": "Small",
               "AdditionalMetadata": {
@@ -74,6 +76,7 @@
             "elasticsearch_version": "6",
             "description": "3 dedicated VMs, 2 CPU per VM, 8GB RAM per VM, 525GB disk space.",
             "free": false,
+            "active": false,
             "metadata": {
               "displayName": "Medium",
               "AdditionalMetadata": {
@@ -95,6 +98,7 @@
             "elasticsearch_version": "6",
             "description": "3 dedicated VMs, 2 CPU per VM, 15GB RAM per VM, 1050GB disk space.",
             "free": false,
+            "active": false,
             "metadata": {
               "displayName": "Large",
               "AdditionalMetadata": {
@@ -116,6 +120,7 @@
             "elasticsearch_version": "6",
             "description": "3 dedicated VMs, 4 CPU per VM, 31GB RAM per VM, 2100GB disk space.",
             "free": false,
+            "active": false,
             "metadata": {
               "displayName": "XLarge",
               "AdditionalMetadata": {

--- a/platform-tests/aiven-broker-acceptance/elasticsearch_service_test.go
+++ b/platform-tests/aiven-broker-acceptance/elasticsearch_service_test.go
@@ -36,7 +36,6 @@ var _ = Describe("Elasticsearch backing service", func() {
 
 	It("has the expected plans available", func() {
 		expectedPlans := []string{
-			"tiny-6.x", "small-ha-6.x", "medium-ha-6.x", "large-ha-6.x", "xlarge-ha-6.x",
 			"tiny-7.x", "small-ha-7.x", "medium-ha-7.x", "large-ha-7.x", "xlarge-ha-7.x",
 		}
 


### PR DESCRIPTION
What
----

Deprecate ElasticSearch 6.x plans in the Aiven broker.

Doing this using Maxim and Miki's commit from last year, it should now work.

How to review
-------------

Code review.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
