### PR TITLE
[#178302212] create-cloudfoundry pipeline: add `DISABLED_AZS` variable 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,9 @@ Layout/HeredocIndentation:
 Layout/HashAlignment:
   Enabled: false
 
+Naming/FileName:
+  Exclude:
+    - 'manifests/cf-manifest/scripts/*'
 Naming/HeredocDelimiterNaming:
   Enabled: false
 

--- a/Makefile
+++ b/Makefile
@@ -218,6 +218,7 @@ dev: ## Set Environment to DEV
 	$(eval export SLIM_DEV_DEPLOYMENT ?= true)
 	$(eval export CA_ROTATION_EXPIRY_DAYS ?= 360)
 	$(eval export ENABLE_PAAS_ADMIN_CONTINUOUS_DEPLOY ?= true)
+	$(eval export DISABLED_AZS)
 	@true
 
 .PHONY: dev01
@@ -258,6 +259,7 @@ stg-lon: ## Set Environment to stg-lon
 	$(eval export AWS_REGION=eu-west-2)
 	$(eval export CA_ROTATION_EXPIRY_DAYS=335)
 	$(eval export ENABLE_PAAS_ADMIN_CONTINUOUS_DEPLOY ?= true)
+	$(eval export DISABLED_AZS)
 	@true
 
 .PHONY: prod
@@ -282,6 +284,7 @@ prod: ## Set Environment to Production
 	$(eval export AWS_REGION=eu-west-1)
 	$(eval export CA_ROTATION_EXPIRY_DAYS=30)
 	$(eval export ENABLE_PAAS_ADMIN_CONTINUOUS_DEPLOY ?= true)
+	$(eval export DISABLED_AZS)
 	@true
 
 .PHONY: prod-lon
@@ -306,6 +309,7 @@ prod-lon: ## Set Environment to prod-lon
 	$(eval export AWS_REGION=eu-west-2)
 	$(eval export CA_ROTATION_EXPIRY_DAYS=30)
 	$(eval export ENABLE_PAAS_ADMIN_CONTINUOUS_DEPLOY ?= true)
+	$(eval export DISABLED_AZS)
 	@true
 
 .PHONY: bosh-cli

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -206,12 +206,12 @@ groups:
       - healthcheck-check-state
       - healthcheck-disable
       - cleanup-deleted-cf-users
-      - disable-az-a
-      - enable-az-a
-      - disable-az-b
-      - enable-az-b
-      - disable-az-c
-      - enable-az-c
+      - disable-az-a-vpc
+      - enable-az-a-vpc
+      - disable-az-b-vpc
+      - enable-az-b-vpc
+      - disable-az-c-vpc
+      - enable-az-c-vpc
   - name: tests
     jobs:
       - app-availability-tests
@@ -1500,7 +1500,8 @@ jobs:
             file: updated-tfstate/vpc-peering.tfstate
       - *end-grafana-job-annotation
 
-  - name: disable-az-a
+  - name: disable-az-a-vpc
+    old_name: disable-az-a
     serial_groups: [operator]
     serial: true
     plan:
@@ -1546,7 +1547,7 @@ jobs:
               - |
                 BOSH_CLIENT='admin' bosh update-resurrection off
 
-      - task: disable-az
+      - task: disable-az-vpc
         tags: [colocated-with-web]
         config:
           platform: linux
@@ -1584,13 +1585,14 @@ jobs:
           params:
             file: updated-tfstate/az-management-a.tfstate
 
-  - name: enable-az-a
+  - name: enable-az-a-vpc
+    old_name: enable-az-a
     serial_groups: [operator]
     serial: true
     plan:
       - in_parallel:
           - <<: *get-paas-cf
-            passed: [disable-az-a]
+            passed: [disable-az-a-vpc]
           - get: az-management-a-tfstate
           - get: vpc-tfstate
 
@@ -1613,7 +1615,7 @@ jobs:
                 ruby paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
                 < vpc-tfstate/vpc.tfstate > terraform-variables/vpc.tfvars.sh
 
-      - task: enable-az
+      - task: enable-az-vpc
         tags: [colocated-with-web]
         config:
           platform: linux
@@ -1648,7 +1650,8 @@ jobs:
           params:
             file: updated-tfstate/az-management-a.tfstate
 
-  - name: disable-az-b
+  - name: disable-az-b-vpc
+    old_name: disable-az-b
     serial_groups: [operator]
     serial: true
     plan:
@@ -1694,7 +1697,7 @@ jobs:
               - |
                 BOSH_CLIENT='admin' bosh update-resurrection off
 
-      - task: disable-az
+      - task: disable-az-vpc
         tags: [colocated-with-web]
         config:
           platform: linux
@@ -1730,13 +1733,14 @@ jobs:
           params:
             file: updated-tfstate/az-management-b.tfstate
 
-  - name: enable-az-b
+  - name: enable-az-b-vpc
+    old_name: enable-az-b
     serial_groups: [operator]
     serial: true
     plan:
       - in_parallel:
           - <<: *get-paas-cf
-            passed: [disable-az-b]
+            passed: [disable-az-b-vpc]
           - get: az-management-b-tfstate
           - get: vpc-tfstate
 
@@ -1759,7 +1763,7 @@ jobs:
                 ruby paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
                 < vpc-tfstate/vpc.tfstate > terraform-variables/vpc.tfvars.sh
 
-      - task: enable-az
+      - task: enable-az-vpc
         tags: [colocated-with-web]
         config:
           platform: linux
@@ -1795,7 +1799,8 @@ jobs:
           params:
             file: updated-tfstate/az-management-b.tfstate
 
-  - name: disable-az-c
+  - name: disable-az-c-vpc
+    old_name: disable-az-c
     serial_groups: [operator]
     serial: true
     plan:
@@ -1841,7 +1846,7 @@ jobs:
               - |
                 BOSH_CLIENT='admin' bosh update-resurrection off
 
-      - task: disable-az
+      - task: disable-az-vpc
         tags: [colocated-with-web]
         config:
           platform: linux
@@ -1877,13 +1882,14 @@ jobs:
           params:
             file: updated-tfstate/az-management-c.tfstate
 
-  - name: enable-az-c
+  - name: enable-az-c-vpc
+    old_name: enable-az-c
     serial_groups: [operator]
     serial: true
     plan:
       - in_parallel:
           - <<: *get-paas-cf
-            passed: [disable-az-c]
+            passed: [disable-az-c-vpc]
           - get: az-management-c-tfstate
           - get: vpc-tfstate
 
@@ -1906,7 +1912,7 @@ jobs:
                 ruby paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
                 < vpc-tfstate/vpc.tfstate > terraform-variables/vpc.tfvars.sh
 
-      - task: enable-az
+      - task: enable-az-vpc
         tags: [colocated-with-web]
         config:
           platform: linux

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -771,6 +771,7 @@ jobs:
             NEW_ACCOUNT_EMAIL_ADDRESS: ((NEW_ACCOUNT_EMAIL_ADDRESS))
             SLIM_DEV_DEPLOYMENT: ((slim_dev_deployment))
             CONCOURSE_WEB_PASSWORD: ((concourse_web_password))
+            DISABLED_AZS: ((disabled_azs))
           run:
             path: ./paas-cf/concourse/scripts/self-update-pipeline.sh
 
@@ -2171,6 +2172,7 @@ jobs:
               ENV_SPECIFIC_BOSH_VARS_FILE: paas-cf/manifests/cf-manifest/env-specific/((env_specific_bosh_vars_file))
               ENV_SPECIFIC_ISOLATION_SEGMENTS_DIR: paas-cf/manifests/cf-manifest/isolation-segments/((env_specific_isolation_segments_dir))
               SLIM_DEV_DEPLOYMENT: ((slim_dev_deployment))
+              DISABLED_AZS: ((disabled_azs))
               VCAP_PASSWORD: ((vcap-password))
             run:
               path: sh

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1567,9 +1567,6 @@ jobs:
               - -e
               - -c
               - |
-                echo "RUNNING THIS ACTION FOR AZ-A, WILL MEAN THIS CONCOURSE IS BEING USELESS!"
-                echo "You will need to run the 'revert' action by hand, to get it back to working state."
-
                 . terraform-variables/vpc.tfvars.sh
 
                 cp az-management-a-tfstate/az-management-a.tfstate updated-tfstate/az-management-a.tfstate

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1527,6 +1527,24 @@ jobs:
                 ruby paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
                 < vpc-tfstate/vpc.tfstate > terraform-variables/vpc.tfvars.sh
 
+      - task: disable-bosh-resurrector
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *gov-paas-bosh-cli-v2-image-resource
+          params:
+            BOSH_ENVIRONMENT: ((bosh_fqdn))
+            BOSH_CA_CERT: ((bosh-ca-cert))
+            BOSH_DEPLOYMENT: ((deploy_env))
+            BOSH_CLIENT_SECRET: ((bosh-client-secret))
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                BOSH_CLIENT='admin' bosh update-resurrection off
+
       - task: disable-az
         tags: [colocated-with-web]
         config:
@@ -1657,6 +1675,24 @@ jobs:
                 ruby paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
                 < vpc-tfstate/vpc.tfstate > terraform-variables/vpc.tfvars.sh
 
+      - task: disable-bosh-resurrector
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *gov-paas-bosh-cli-v2-image-resource
+          params:
+            BOSH_ENVIRONMENT: ((bosh_fqdn))
+            BOSH_CA_CERT: ((bosh-ca-cert))
+            BOSH_DEPLOYMENT: ((deploy_env))
+            BOSH_CLIENT_SECRET: ((bosh-client-secret))
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                BOSH_CLIENT='admin' bosh update-resurrection off
+
       - task: disable-az
         tags: [colocated-with-web]
         config:
@@ -1785,6 +1821,24 @@ jobs:
               - |
                 ruby paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
                 < vpc-tfstate/vpc.tfstate > terraform-variables/vpc.tfvars.sh
+
+      - task: disable-bosh-resurrector
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *gov-paas-bosh-cli-v2-image-resource
+          params:
+            BOSH_ENVIRONMENT: ((bosh_fqdn))
+            BOSH_CA_CERT: ((bosh-ca-cert))
+            BOSH_DEPLOYMENT: ((deploy_env))
+            BOSH_CLIENT_SECRET: ((bosh-client-secret))
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                BOSH_CLIENT='admin' bosh update-resurrection off
 
       - task: disable-az
         tags: [colocated-with-web]

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -112,6 +112,7 @@ deploy_env_tag_prefix: "${deploy_env_tag_prefix}"
 skip_autodelete_await: "${SKIP_AUTODELETE_AWAIT:-false}"
 ca_rotation_expiry_days: "${CA_ROTATION_EXPIRY_DAYS}"
 enable_paas_admin_continuous_deploy: ${ENABLE_PAAS_ADMIN_CONTINUOUS_DEPLOY:-true}
+disabled_azs: ${DISABLED_AZS:-}
 EOF
   echo -e "pipeline_lock_git_private_key: |\\n  ${git_id_rsa//$'\n'/$'\n'  }"
 }

--- a/manifests/cf-manifest/scripts/generate-disable-azs-ops-file.rb
+++ b/manifests/cf-manifest/scripts/generate-disable-azs-ops-file.rb
@@ -1,0 +1,15 @@
+require "yaml"
+
+manifest = YAML.safe_load(STDIN.read)
+
+zones = ARGV
+puts YAML.dump(
+  manifest.dig("instance_groups")
+   .map do |g|
+     {
+       "type" => "replace",
+       "path" => "/instance_groups/name=#{g['name']}/azs",
+       "value" => (g["azs"] - zones),
+     }
+   end,
+)

--- a/manifests/cf-manifest/scripts/generate-manifest.sh
+++ b/manifests/cf-manifest/scripts/generate-manifest.sh
@@ -7,6 +7,7 @@ CF_MANIFEST_DIR=${PAAS_CF_DIR}/manifests/cf-manifest
 CF_DEPLOYMENT_DIR=${PAAS_CF_DIR}/manifests/cf-deployment
 SHARED_MANIFEST_DIR=${PAAS_CF_DIR}/manifests/shared
 WORKDIR=${WORKDIR:-.}
+DISABLED_AZS=${DISABLED_AZS:-}
 
 opsfile_args=""
 
@@ -65,6 +66,18 @@ for isolation_segment_definition in "${ENV_SPECIFIC_ISOLATION_SEGMENTS_DIR}"/*.y
       ) - <<< "${manifest_with_isolation_segments}"
   )"
 done
+
+if [ -n "${DISABLED_AZS}" ]; then
+  for AZ in ${DISABLED_AZS}; do
+  manifest_with_isolation_segments="$(
+    bosh interpolate \
+    --ops-file <(
+      ruby "${CF_MANIFEST_DIR}/scripts/generate-disable-azs-ops-file.rb" "$AZ" \
+      <<< "${manifest_with_isolation_segments}"
+    ) - <<< "${manifest_with_isolation_segments}"
+  )"
+  done
+fi
 
 # Now we have a manifest with isolation segments, ready for BOSH
 echo "$manifest_with_isolation_segments"


### PR DESCRIPTION
What
----

This variable takes a space separated list of names of AZs that should be omitted from cf's `instance_groups`. AZ names are expected to be as understood by bosh, e.g. `z2`.

Shutting down an AZ at this level should cause bosh to reallocate the desired number of resources across the AZs that are still up, rather than just tolerating operation at a lower capacity which is what would happen using the VPC-level disabling mechanism. Normal state is expected to be unset/empty string.

Related things _also_ done as part of this PR:

 - Renamed the existing `disable-az-*` jobs to `disable-az-*-vpc` to make clear what the difference is between this and the new mechanism. Renaming done with an `old_name` so history etc should be retained.
 - Prevented the `disable-az-*-vpc` jobs from disabling the VPC's `infra` subnet, as it turns out resources without redundancy could be on this subnet. In our case it was concourse's RDS db, which of course made concourse non-operational.
 - Disable the bosh resurrector as part of the `disable-az-*-vpc` jobs to prevent it fruitlessly attempting to fix the instances in the disabled AZ and continually occupying locks in doing so. Open question here about what we should do about re-enabling the resurrector. Should the `enable-az-*-vpc` jobs turn it back on? Or would it be better to just have some gentle alerting going all the time that the resurrector's off to remind people to re-enable it once the incident's over?


How to review
-------------

 - Firstly bring up an environment with `SLIM_DEV_DEPLOYMENT=false` so that you have all AZs up.
 - Trigger the `disable-az-c-vpc` job from the pipeline's `operator` page.
 - Set the pipeline's `DISABLED_AZS` to `z3` & re-trigger the deployment.
 - Watch the deployment go out, moving resources to the remaining AZs. Eventually the desired number of resources should be reached.
 - Trigger the `enable-az-c-vpc` job from the pipeline's `operator` page.
 - Set the pipeline's `DISABLED_AZS` back to an empty string & re-deploy.

If you're feeling particularly adventurous you could try disabling multiple AZs.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
