### PR TITLE
[#177978094] Bump cf-deployment to 16.17

### DIFF
--- a/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
+++ b/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
@@ -3,6 +3,6 @@
   path: /releases/name=cflinuxfs3
   value:
     name: "cflinuxfs3"
-    version: "0.242.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.242.0"
-    sha1: "1b923a0eb4ee39e470b8e74f638e95944602e162"
+    version: "0.246.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.246.0"
+    sha1: "dca01593ce06cd52bcbb4916c8dbac297eb476e7"


### PR DESCRIPTION
What
----

Addresses issues with metrics-discovery-release which may have caused the high
log volume we're currently seeing from it.
See release note for 3.0.4 which is what the previous cf-deployment bump sent
us to: https://github.com/cloudfoundry/metrics-discovery-release/releases

[Story](https://www.pivotaltracker.com/story/show/177978094)

Updates:
cf-deployment: 16.17
 cflinuxfs3: 0.246

How to review
-------------

- Code review
- Test in development environment

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨