### PR TITLE
Increase number of doppler instances

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -5,7 +5,7 @@ diego_api_instances: 3
 cell_instances: 105
 router_instances: 15
 api_instances: 12
-doppler_instances: 39
+doppler_instances: 60
 log_api_instances: 18
 scheduler_instances: 4
 cc_worker_instances: 4


### PR DESCRIPTION
What
----

We're starting to see dropped messages from the system. The rule of
thumb is that we keep the ratio of cells to dopplers around 2:1.

This increase should suffice for a short while.

Ireland does not grow, and we didn't see issues thus far. If anything,
it is generously provisioned.

How to review
-------------

- Sanity check

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
