### PR TITLE
Test that we have roughly the right number of Doppler instances

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -5,7 +5,7 @@ diego_api_instances: 3
 cell_instances: 105
 router_instances: 15
 api_instances: 12
-doppler_instances: 60
+doppler_instances: 51
 log_api_instances: 18
 scheduler_instances: 4
 cc_worker_instances: 4

--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -5,7 +5,7 @@ diego_api_instances: 3
 cell_instances: 36
 router_instances: 24
 api_instances: 6
-doppler_instances: 39
+doppler_instances: 18
 log_api_instances: 18
 scheduler_instances: 4
 cc_worker_instances: 4

--- a/manifests/cf-manifest/spec/manifest/env_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/env_spec.rb
@@ -31,11 +31,32 @@ RSpec.describe "Environment specific configuration" do
     context "for the #{env} environment" do
       let(:env_manifest) { manifest_for_env(env) }
 
-      it "has an equal number of cells per AZ" do
-        cell_ig = env_manifest.fetch("instance_groups.diego-cell")
-        az_count = cell_ig.fetch("azs").size
-        expect(cell_ig.fetch("instances") % az_count).to eq(0),
-          "cell instance count is not divisible by the AZ count"
+      describe "cells" do
+        it "are evenly distributable across the AZs" do
+          cell_ig = env_manifest.fetch("instance_groups.diego-cell")
+          az_count = cell_ig.fetch("azs").size
+          expect(cell_ig.fetch("instances") % az_count).to eq(0),
+            "cell instance count is not divisible by the AZ count"
+        end
+      end
+
+      describe "doppler" do
+        it "instance count should be at least 1:2 with cell count" do
+          doppler_instance_count = env_manifest.fetch("instance_groups.doppler").dig("instances").to_f
+          cell_instance_count = env_manifest.fetch("instance_groups.diego-cell").dig("instances").to_f
+
+          ratio = cell_instance_count / doppler_instance_count
+
+          expect(ratio).to be >= 2.0, "doppler instance count #{doppler_instance_count} is wrong. Rule of thumb is 1:2 with cells. Current ratio is #{doppler_instance_count}:#{cell_instance_count} (#{ratio})."
+          expect(ratio).to be < 2.5, "doppler instance count #{doppler_instance_count} is too high. Rule of thumb is 1:2 with cells. Current ratio is #{doppler_instance_count}:#{cell_instance_count} (#{ratio})."
+        end
+
+        it "instances are evenly distibutable across the AZs" do
+          doppler_ig = env_manifest.fetch("instance_groups.doppler")
+          az_count = doppler_ig.fetch("azs").size
+          expect(doppler_ig.fetch("instances") % az_count).to eq(0),
+            "doppler instance count is not divisible by the AZ count"
+        end
       end
     end
   end


### PR DESCRIPTION
What
----

We believe that we should have roughly 1 Doppler instance for every Diego Cell.
In the past, we haven't adjusted doppler counts when adjusting cell counts.
This test should force us to do that when it's appropriate.

How to review
-------------

Do you agree? Does the test look good?

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
