### PR TITLE
[#178621826] create-cloudfoundry pipeline: add AZ-status-related indicator/alert jobs

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -106,7 +106,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/alpine
-              tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+              tag: 8453e9c989abefdaad40895c25df7d18a82d6522
           inputs:
             - name: paas-cf
           params:
@@ -133,7 +133,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/bosh-cli-v2
-              tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+              tag: 8453e9c989abefdaad40895c25df7d18a82d6522
           run:
             path: sh
             args:
@@ -169,7 +169,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/awscli
-              tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+              tag: 8453e9c989abefdaad40895c25df7d18a82d6522
           run:
             path: ./paas-cf/concourse/scripts/rds_instances.sh
             args:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -11,67 +11,67 @@ meta:
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/alpine
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 8453e9c989abefdaad40895c25df7d18a82d6522
     psql: &psql-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/psql
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 8453e9c989abefdaad40895c25df7d18a82d6522
     node: &node-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/node
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 8453e9c989abefdaad40895c25df7d18a82d6522
     awscli: &awscli-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 8453e9c989abefdaad40895c25df7d18a82d6522
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 8453e9c989abefdaad40895c25df7d18a82d6522
     cf-acceptance-tests: &cf-acceptance-tests-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 8453e9c989abefdaad40895c25df7d18a82d6522
     cf-cli: &cf-cli-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-cli
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 8453e9c989abefdaad40895c25df7d18a82d6522
     cf-uaac: &cf-uaac-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-uaac
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 8453e9c989abefdaad40895c25df7d18a82d6522
     git-ssh: &git-ssh-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/git-ssh
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 8453e9c989abefdaad40895c25df7d18a82d6522
     ruby-slim: &ruby-slim-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/ruby
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 8453e9c989abefdaad40895c25df7d18a82d6522
     golang: &golang-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/golang
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 8453e9c989abefdaad40895c25df7d18a82d6522
     terraform: &terraform-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 8453e9c989abefdaad40895c25df7d18a82d6522
     curl-ssl: &curl-ssl-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/curl-ssl
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
 
   tasks:
@@ -243,7 +243,7 @@ resource_types:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/concourse-pool-resource
-    tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+    tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
 - name: s3-iam
   type: docker-image
@@ -754,7 +754,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+              tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
           inputs:
             - name: paas-cf
@@ -4536,7 +4536,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/spruce
-              tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+              tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
           inputs:
             - name: paas-cf
@@ -4758,7 +4758,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/spruce
-              tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+              tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
           inputs:
             - name: paas-admin-data
@@ -5681,7 +5681,7 @@ jobs:
           type: docker-image
           source:
             repository: ghcr.io/alphagov/paas/cf-uaac
-            tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+            tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
         inputs:
           - name: passwords

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -233,6 +233,9 @@ groups:
       - az-a-is-enabled-in-manifest
       - az-b-is-enabled-in-manifest
       - az-c-is-enabled-in-manifest
+      - az-a-is-enabled-in-vpc
+      - az-b-is-enabled-in-vpc
+      - az-c-is-enabled-in-vpc
   - name: credentials
     jobs:
       - set-smoke-test-creds
@@ -542,6 +545,11 @@ resources:
       interval: 30m
 
   - name: az-is-enabled-in-manifest-timer
+    type: time
+    source:
+      interval: 30m
+
+  - name: az-is-enabled-in-vpc-timer
     type: time
     source:
       interval: 30m
@@ -2169,6 +2177,261 @@ jobs:
                   "${ALERT_EMAIL_ADDRESS}" \
                   "az-disabled-in-manifest" \
                   "z3"
+              else
+                echo "email alerts disabled"
+              fi
+
+  - name: az-a-is-enabled-in-vpc
+    serial: true
+    plan:
+      - in_parallel:
+          - get: az-is-enabled-in-vpc-timer
+            trigger: true
+          - <<: *get-paas-cf
+          - get: vpc-tfstate
+
+      - task: extract-terraform-variables
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *ruby-slim-image-resource
+          inputs:
+            - name: paas-cf
+            - name: vpc-tfstate
+          outputs:
+            - name: terraform-variables
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                ruby paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
+                < vpc-tfstate/vpc.tfstate > terraform-variables/vpc.tfvars.sh
+
+      - task: check-az-a-is-enabled-in-vpc
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *awscli-image-resource
+          params:
+            AWS_DEFAULT_REGION: ((aws_region))
+          inputs:
+            - name: terraform-variables
+            - name: paas-cf
+          run:
+            path: ash
+            args:
+              - -e
+              - -c
+              - |
+                . terraform-variables/vpc.tfvars.sh
+
+                echo "Checking for network ACL disabling AZ..."
+                # shellcheck disable=SC2154
+                aws ec2 describe-network-acls \
+                  --filters "Name=vpc-id,Values=${TF_VAR_vpc_id}" > network-acls.json
+                if jq -e '.NetworkAcls[] | select(.Tags[] | select(.Key == "Name" and .Value == "disable_az_((aws_region))a"))' < network-acls.json > /dev/null ; then
+                  echo "Found, therefore AZ disabled. Failing."
+                  false
+                else
+                  echo "Not found"
+                fi
+    on_failure:
+      task: send-email-alert
+      tags: [colocated-with-web]
+      config:
+        platform: linux
+        image_resource: *awscli-image-resource
+        params:
+          AWS_DEFAULT_REGION: ((aws_region))
+          DEPLOY_ENV: ((deploy_env))
+          SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+          ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
+          ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
+        run:
+          path: ash
+          args:
+            - -e
+            - -c
+            - |
+              if [ "$ENABLE_ALERT_NOTIFICATIONS" = "true" ]; then
+                paas-cf/concourse/scripts/nagging_email.sh \
+                  "${DEPLOY_ENV}" \
+                  "${SYSTEM_DNS_ZONE_NAME}" \
+                  "${ALERT_EMAIL_ADDRESS}" \
+                  "az-disabled-vpc" \
+                  "a"
+              else
+                echo "email alerts disabled"
+              fi
+
+  - name: az-b-is-enabled-in-vpc
+    serial: true
+    plan:
+      - in_parallel:
+          - get: az-is-enabled-in-vpc-timer
+            trigger: true
+          - <<: *get-paas-cf
+          - get: vpc-tfstate
+
+      - task: extract-terraform-variables
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *ruby-slim-image-resource
+          inputs:
+            - name: paas-cf
+            - name: vpc-tfstate
+          outputs:
+            - name: terraform-variables
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                ruby paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
+                < vpc-tfstate/vpc.tfstate > terraform-variables/vpc.tfvars.sh
+
+      - task: check-az-b-is-enabled-in-vpc
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *awscli-image-resource
+          params:
+            AWS_DEFAULT_REGION: ((aws_region))
+          inputs:
+            - name: terraform-variables
+            - name: paas-cf
+          run:
+            path: ash
+            args:
+              - -e
+              - -c
+              - |
+                . terraform-variables/vpc.tfvars.sh
+
+                echo "Checking for network ACL disabling AZ..."
+                # shellcheck disable=SC2154
+                aws ec2 describe-network-acls \
+                  --filters "Name=vpc-id,Values=${TF_VAR_vpc_id}" > network-acls.json
+                if jq -e '.NetworkAcls[] | select(.Tags[] | select(.Key == "Name" and .Value == "disable_az_((aws_region))b"))' < network-acls.json > /dev/null ; then
+                  echo "Found, therefore AZ disabled. Failing."
+                  false
+                else
+                  echo "Not found"
+                fi
+    on_failure:
+      task: send-email-alert
+      tags: [colocated-with-web]
+      config:
+        platform: linux
+        image_resource: *awscli-image-resource
+        params:
+          AWS_DEFAULT_REGION: ((aws_region))
+          DEPLOY_ENV: ((deploy_env))
+          SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+          ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
+          ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
+        run:
+          path: ash
+          args:
+            - -e
+            - -c
+            - |
+              if [ "$ENABLE_ALERT_NOTIFICATIONS" = "true" ]; then
+                paas-cf/concourse/scripts/nagging_email.sh \
+                  "${DEPLOY_ENV}" \
+                  "${SYSTEM_DNS_ZONE_NAME}" \
+                  "${ALERT_EMAIL_ADDRESS}" \
+                  "az-disabled-vpc" \
+                  "b"
+              else
+                echo "email alerts disabled"
+              fi
+
+  - name: az-c-is-enabled-in-vpc
+    serial: true
+    plan:
+      - in_parallel:
+          - get: az-is-enabled-in-vpc-timer
+            trigger: true
+          - <<: *get-paas-cf
+          - get: vpc-tfstate
+
+      - task: extract-terraform-variables
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *ruby-slim-image-resource
+          inputs:
+            - name: paas-cf
+            - name: vpc-tfstate
+          outputs:
+            - name: terraform-variables
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                ruby paas-cf/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
+                < vpc-tfstate/vpc.tfstate > terraform-variables/vpc.tfvars.sh
+
+      - task: check-az-c-is-enabled-in-vpc
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *awscli-image-resource
+          params:
+            AWS_DEFAULT_REGION: ((aws_region))
+          inputs:
+            - name: terraform-variables
+            - name: paas-cf
+          run:
+            path: ash
+            args:
+              - -e
+              - -c
+              - |
+                . terraform-variables/vpc.tfvars.sh
+
+                echo "Checking for network ACL disabling AZ..."
+                # shellcheck disable=SC2154
+                aws ec2 describe-network-acls \
+                  --filters "Name=vpc-id,Values=${TF_VAR_vpc_id}" > network-acls.json
+                if jq -e '.NetworkAcls[] | select(.Tags[] | select(.Key == "Name" and .Value == "disable_az_((aws_region))c"))' < network-acls.json > /dev/null ; then
+                  echo "Found, therefore AZ disabled. Failing."
+                  false
+                else
+                  echo "Not found"
+                fi
+    on_failure:
+      task: send-email-alert
+      tags: [colocated-with-web]
+      config:
+        platform: linux
+        image_resource: *awscli-image-resource
+        params:
+          AWS_DEFAULT_REGION: ((aws_region))
+          DEPLOY_ENV: ((deploy_env))
+          SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+          ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
+          ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
+        run:
+          path: ash
+          args:
+            - -e
+            - -c
+            - |
+              if [ "$ENABLE_ALERT_NOTIFICATIONS" = "true" ]; then
+                paas-cf/concourse/scripts/nagging_email.sh \
+                  "${DEPLOY_ENV}" \
+                  "${SYSTEM_DNS_ZONE_NAME}" \
+                  "${ALERT_EMAIL_ADDRESS}" \
+                  "az-disabled-vpc" \
+                  "c"
               else
                 echo "email alerts disabled"
               fi

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -229,6 +229,7 @@ groups:
       - continuous-billing-smoke-tests
       - continuous-leaked-aws-key-check
       - check-certificates
+      - resurrector-is-enabled
   - name: credentials
     jobs:
       - set-smoke-test-creds
@@ -531,6 +532,11 @@ resources:
     type: time
     source:
       interval: 5m
+
+  - name: resurrector-is-enabled-timer
+    type: time
+    source:
+      interval: 30m
 
   - name: billing-smoke-tests-timer
     type: time
@@ -1944,6 +1950,58 @@ jobs:
           put: az-management-c-tfstate
           params:
             file: updated-tfstate/az-management-c.tfstate
+
+  # ideally this would be a monitoring-driven alert but this is not exposed as a metric
+  # and might be too private for our semi-public grafana anyway
+  - name: resurrector-is-enabled
+    serial: true
+    plan:
+      - get: resurrector-is-enabled-timer
+        trigger: true
+      - task: check-resurrector
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *gov-paas-bosh-cli-v2-image-resource
+          params:
+            BOSH_ENVIRONMENT: ((bosh_fqdn))
+            BOSH_CA_CERT: ((bosh-ca-cert))
+            BOSH_DEPLOYMENT: ((deploy_env))
+            BOSH_CLIENT_SECRET: ((bosh-client-secret))
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                BOSH_CLIENT='admin' bosh curl /resurrection | jq -e '.resurrection'
+    on_failure:
+      task: send-email-alert
+      tags: [colocated-with-web]
+      config:
+        platform: linux
+        image_resource: *awscli-image-resource
+        params:
+          AWS_DEFAULT_REGION: ((aws_region))
+          DEPLOY_ENV: ((deploy_env))
+          SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+          ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
+          ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
+        run:
+          path: ash
+          args:
+            - -e
+            - -c
+            - |
+              if [ "$ENABLE_ALERT_NOTIFICATIONS" = "true" ]; then
+                paas-cf/concourse/scripts/nagging_email.sh \
+                  "${DEPLOY_ENV}" \
+                  "${SYSTEM_DNS_ZONE_NAME}" \
+                  "${ALERT_EMAIL_ADDRESS}" \
+                  "resurrector-disabled"
+              else
+                echo "email alerts disabled"
+              fi
 
   - name: generate-cf-config
     serial_groups: [cf-deploy]

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -230,6 +230,9 @@ groups:
       - continuous-leaked-aws-key-check
       - check-certificates
       - resurrector-is-enabled
+      - az-a-is-enabled-in-manifest
+      - az-b-is-enabled-in-manifest
+      - az-c-is-enabled-in-manifest
   - name: credentials
     jobs:
       - set-smoke-test-creds
@@ -534,6 +537,11 @@ resources:
       interval: 5m
 
   - name: resurrector-is-enabled-timer
+    type: time
+    source:
+      interval: 30m
+
+  - name: az-is-enabled-in-manifest-timer
     type: time
     source:
       interval: 30m
@@ -1999,6 +2007,168 @@ jobs:
                   "${SYSTEM_DNS_ZONE_NAME}" \
                   "${ALERT_EMAIL_ADDRESS}" \
                   "resurrector-disabled"
+              else
+                echo "email alerts disabled"
+              fi
+
+  - name: az-a-is-enabled-in-manifest
+    serial: true
+    plan:
+      - get: az-is-enabled-in-manifest-timer
+        trigger: true
+      - task: check-az-a-is-enabled-in-manifest
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *gov-paas-bosh-cli-v2-image-resource
+          params:
+            DEPLOY_ENV: ((deploy_env))
+            BOSH_ENVIRONMENT: ((bosh_fqdn))
+            BOSH_CA_CERT: ((bosh-ca-cert))
+            BOSH_DEPLOYMENT: ((deploy_env))
+            BOSH_CLIENT_SECRET: ((bosh-client-secret))
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                echo 'instance_groups with z1 enabled:'
+                BOSH_CLIENT='admin' bosh -d "${DEPLOY_ENV}" manifest \
+                  | yq eval -e '.instance_groups[] | select(.azs[] | select(. == "z1")) | .name' -
+    on_failure:
+      task: send-email-alert
+      tags: [colocated-with-web]
+      config:
+        platform: linux
+        image_resource: *awscli-image-resource
+        params:
+          AWS_DEFAULT_REGION: ((aws_region))
+          DEPLOY_ENV: ((deploy_env))
+          SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+          ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
+          ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
+        run:
+          path: ash
+          args:
+            - -e
+            - -c
+            - |
+              if [ "$ENABLE_ALERT_NOTIFICATIONS" = "true" ]; then
+                paas-cf/concourse/scripts/nagging_email.sh \
+                  "${DEPLOY_ENV}" \
+                  "${SYSTEM_DNS_ZONE_NAME}" \
+                  "${ALERT_EMAIL_ADDRESS}" \
+                  "az-disabled-in-manifest" \
+                  "z1"
+              else
+                echo "email alerts disabled"
+              fi
+
+  - name: az-b-is-enabled-in-manifest
+    serial: true
+    plan:
+      - get: az-is-enabled-in-manifest-timer
+        trigger: true
+      - task: check-az-b-is-enabled-in-manifest
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *gov-paas-bosh-cli-v2-image-resource
+          params:
+            DEPLOY_ENV: ((deploy_env))
+            BOSH_ENVIRONMENT: ((bosh_fqdn))
+            BOSH_CA_CERT: ((bosh-ca-cert))
+            BOSH_DEPLOYMENT: ((deploy_env))
+            BOSH_CLIENT_SECRET: ((bosh-client-secret))
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                echo 'instance_groups with z2 enabled:'
+                BOSH_CLIENT='admin' bosh -d "${DEPLOY_ENV}" manifest \
+                  | yq eval -e '.instance_groups[] | select(.azs[] | select(. == "z2")) | .name' -
+    on_failure:
+      task: send-email-alert
+      tags: [colocated-with-web]
+      config:
+        platform: linux
+        image_resource: *awscli-image-resource
+        params:
+          AWS_DEFAULT_REGION: ((aws_region))
+          DEPLOY_ENV: ((deploy_env))
+          SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+          ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
+          ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
+        run:
+          path: ash
+          args:
+            - -e
+            - -c
+            - |
+              if [ "$ENABLE_ALERT_NOTIFICATIONS" = "true" ]; then
+                paas-cf/concourse/scripts/nagging_email.sh \
+                  "${DEPLOY_ENV}" \
+                  "${SYSTEM_DNS_ZONE_NAME}" \
+                  "${ALERT_EMAIL_ADDRESS}" \
+                  "az-disabled-in-manifest" \
+                  "z2"
+              else
+                echo "email alerts disabled"
+              fi
+
+  - name: az-c-is-enabled-in-manifest
+    serial: true
+    plan:
+      - get: az-is-enabled-in-manifest-timer
+        trigger: true
+      - task: check-az-c-is-enabled-in-manifest
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *gov-paas-bosh-cli-v2-image-resource
+          params:
+            DEPLOY_ENV: ((deploy_env))
+            BOSH_ENVIRONMENT: ((bosh_fqdn))
+            BOSH_CA_CERT: ((bosh-ca-cert))
+            BOSH_DEPLOYMENT: ((deploy_env))
+            BOSH_CLIENT_SECRET: ((bosh-client-secret))
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                echo 'instance_groups with z3 enabled:'
+                BOSH_CLIENT='admin' bosh -d "${DEPLOY_ENV}" manifest \
+                  | yq eval -e '.instance_groups[] | select(.azs[] | select(. == "z3")) | .name' -
+    on_failure:
+      task: send-email-alert
+      tags: [colocated-with-web]
+      config:
+        platform: linux
+        image_resource: *awscli-image-resource
+        params:
+          AWS_DEFAULT_REGION: ((aws_region))
+          DEPLOY_ENV: ((deploy_env))
+          SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+          ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
+          ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
+        run:
+          path: ash
+          args:
+            - -e
+            - -c
+            - |
+              if [ "$ENABLE_ALERT_NOTIFICATIONS" = "true" ]; then
+                paas-cf/concourse/scripts/nagging_email.sh \
+                  "${DEPLOY_ENV}" \
+                  "${SYSTEM_DNS_ZONE_NAME}" \
+                  "${ALERT_EMAIL_ADDRESS}" \
+                  "az-disabled-in-manifest" \
+                  "z3"
               else
                 echo "email alerts disabled"
               fi

--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -31,7 +31,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/alpine
-              tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+              tag: 8453e9c989abefdaad40895c25df7d18a82d6522
           inputs:
             - name: paas-cf
             - name: deployment-timer
@@ -61,7 +61,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/awscli
-              tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+              tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
           run:
             path: ./paas-cf/concourse/scripts/rds_instances.sh
@@ -76,7 +76,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+              tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
           inputs:
             - name: paas-cf
@@ -109,7 +109,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+              tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
           inputs:
             - name: paas-cf

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -90,7 +90,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+              tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
           inputs:
             - name: paas-cf
@@ -162,7 +162,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/bosh-cli-v2
-              tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+              tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
           inputs:
             - name: bosh-vars-store
@@ -216,7 +216,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/ruby
-              tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+              tag: 8453e9c989abefdaad40895c25df7d18a82d6522
           inputs:
             - name: paas-cf
             - name: cf-tfstate
@@ -259,7 +259,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/terraform
-              tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+              tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
           inputs:
             - name: terraform-variables

--- a/concourse/pipelines/monitor-remote.yml
+++ b/concourse/pipelines/monitor-remote.yml
@@ -48,7 +48,7 @@ jobs:
         type: docker-image
         source:
           repository: ghcr.io/alphagov/paas/self-update-pipelines
-          tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+          tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
       inputs:
       - name: paas-cf

--- a/concourse/pipelines/test-certificate-rotation.yml
+++ b/concourse/pipelines/test-certificate-rotation.yml
@@ -5,25 +5,25 @@ meta:
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
     cf-acceptance-tests: &cf-acceptance-tests-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
     cf-cli: &cf-cli-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-cli
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
 
 resource_types:
@@ -31,7 +31,7 @@ resource_types:
     type: docker-image
     source:
       repository: ghcr.io/alphagov/paas/olhtbr-metadata-resource
-      tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+      tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
   - name: s3-iam
     type: docker-image

--- a/concourse/scripts/nagging_email.sh
+++ b/concourse/scripts/nagging_email.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+set -eu
+
+DEPLOY_ENV=$1
+SYSTEM_DNS_ZONE_NAME=$2
+ALERT_EMAIL_ADDRESS=$3
+MESSAGE_TYPE=$4
+
+TO="${ALERT_EMAIL_ADDRESS}"
+FROM="${ALERT_EMAIL_ADDRESS}"
+
+write_message_json() {
+  if [ "${MESSAGE_TYPE}" = 'resurrector-disabled' ]; then
+    cat <<EOF > message.json
+{
+  "Subject": {
+    "Data": "Resurrector is disabled in ${DEPLOY_ENV}"
+  },
+  "Body": {
+    "Html": {
+      "Data": "Bosh's resurrector is currently disabled in <b>${DEPLOY_ENV}</b>. Presumably \
+      this is deliberate, but you probably want to re-enable it as soon as you deem sensible, \
+      to avoid having to go and recreate dead instances manually. See \
+      <a href='https://deployer.${SYSTEM_DNS_ZONE_NAME}/teams/main/pipelines/create-cloudfoundry?group=health'>Concourse</a> \
+      for details<br/>Alternatively, something else caused this check to fail, which is also \
+      something that should be investigated."
+    }
+  }
+}
+EOF
+  fi
+}
+
+write_message_json
+
+aws ses send-email --region eu-west-1 --to "${TO}" --message file://message.json --from "${FROM}"

--- a/concourse/scripts/nagging_email.sh
+++ b/concourse/scripts/nagging_email.sh
@@ -6,6 +6,7 @@ DEPLOY_ENV=$1
 SYSTEM_DNS_ZONE_NAME=$2
 ALERT_EMAIL_ADDRESS=$3
 MESSAGE_TYPE=$4
+CONTEXT=$5
 
 TO="${ALERT_EMAIL_ADDRESS}"
 FROM="${ALERT_EMAIL_ADDRESS}"
@@ -22,6 +23,24 @@ write_message_json() {
       "Data": "Bosh's resurrector is currently disabled in <b>${DEPLOY_ENV}</b>. Presumably \
       this is deliberate, but you probably want to re-enable it as soon as you deem sensible, \
       to avoid having to go and recreate dead instances manually. See \
+      <a href='https://deployer.${SYSTEM_DNS_ZONE_NAME}/teams/main/pipelines/create-cloudfoundry?group=health'>Concourse</a> \
+      for details<br/>Alternatively, something else caused this check to fail, which is also \
+      something that should be investigated."
+    }
+  }
+}
+EOF
+  elif [ "${MESSAGE_TYPE}" = 'az-disabled-manifest' ]; then
+    cat <<EOF > message.json
+{
+  "Subject": {
+    "Data": "AZ ${CONTEXT} is disabled in ${DEPLOY_ENV}'s manifest"
+  },
+  "Body": {
+    "Html": {
+      "Data": "No instance_groups in <b>${DEPLOY_ENV}</b> are configured to use \
+      <b>${CONTEXT}</b>. Presumably the AZ has been disabled and this is deliberate, \
+      but you probably want to re-enable it as soon as you deem sensible. See \
       <a href='https://deployer.${SYSTEM_DNS_ZONE_NAME}/teams/main/pipelines/create-cloudfoundry?group=health'>Concourse</a> \
       for details<br/>Alternatively, something else caused this check to fail, which is also \
       something that should be investigated."

--- a/concourse/scripts/nagging_email.sh
+++ b/concourse/scripts/nagging_email.sh
@@ -48,6 +48,24 @@ EOF
   }
 }
 EOF
+  elif [ "${MESSAGE_TYPE}" = 'az-disabled-vpc' ]; then
+    cat <<EOF > message.json
+{
+  "Subject": {
+    "Data": "AZ ${CONTEXT} is disabled in ${DEPLOY_ENV}'s VPC"
+  },
+  "Body": {
+    "Html": {
+      "Data": "<b>${DEPLOY_ENV}</b>'s VPC appears to have a network ACL disabling AZ \
+      <b>${CONTEXT}</b>. Presumably this is deliberate, but you probably want to re-enable \
+      it as soon as you deem sensible. See \
+      <a href='https://deployer.${SYSTEM_DNS_ZONE_NAME}/teams/main/pipelines/create-cloudfoundry?group=health'>Concourse</a> \
+      for details<br/>Alternatively, something else caused this check to fail, which is also \
+      something that should be investigated."
+    }
+  }
+}
+EOF
   fi
 }
 

--- a/concourse/tasks/aiven-broker-acceptance-tests-run.yml
+++ b/concourse/tasks/aiven-broker-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+    tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/app-autoscaler-acceptance-tests-run.yml
+++ b/concourse/tasks/app-autoscaler-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+    tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/configure-grafana.yml
+++ b/concourse/tasks/configure-grafana.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/ruby
-    tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+    tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 inputs:
   - name: paas-trusted-people
 run:

--- a/concourse/tasks/create_admin.yml
+++ b/concourse/tasks/create_admin.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-uaac
-    tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+    tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/cronitor-monitor-ping-action.yml
+++ b/concourse/tasks/cronitor-monitor-ping-action.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+    tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
 run:
   path: sh

--- a/concourse/tasks/custom-acceptance-tests-run.yml
+++ b/concourse/tasks/custom-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+    tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/custom-broker-acceptance-tests-run.yml
+++ b/concourse/tasks/custom-broker-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+    tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/delete_admin.yml
+++ b/concourse/tasks/delete_admin.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
-    tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+    tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/forget-access-keys.yml
+++ b/concourse/tasks/forget-access-keys.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/terraform
-    tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+    tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/generate-git-keys.yml
+++ b/concourse/tasks/generate-git-keys.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+    tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
 
 run:

--- a/concourse/tasks/generate-test-config.yml
+++ b/concourse/tasks/generate-test-config.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+    tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/get-cf-cli-config.yml
+++ b/concourse/tasks/get-cf-cli-config.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/ruby
-    tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+    tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 inputs:
   - name: paas-cf
   - name: cf-manifest

--- a/concourse/tasks/remove-db.yml
+++ b/concourse/tasks/remove-db.yml
@@ -7,7 +7,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
-    tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+    tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
 run:
   path: sh

--- a/concourse/tasks/smoke-tests-run.yml
+++ b/concourse/tasks/smoke-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+    tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/tag-repo.yml
+++ b/concourse/tasks/tag-repo.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/git-ssh
-    tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+    tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
 
 inputs:

--- a/concourse/tasks/upload-test-artifacts.yml
+++ b/concourse/tasks/upload-test-artifacts.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+    tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/wait-for-api-availability-tests.yml
+++ b/concourse/tasks/wait-for-api-availability-tests.yml
@@ -11,7 +11,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+    tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
 run:
   path: sh

--- a/concourse/tasks/wait-for-app-availability-tests.yml
+++ b/concourse/tasks/wait-for-app-availability-tests.yml
@@ -13,7 +13,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
-    tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+    tag: 8453e9c989abefdaad40895c25df7d18a82d6522
 
 run:
   path: sh


### PR DESCRIPTION
~This is a draft because it sits on top of #2683, and needs that to be merged first.~

What
----

Now that we have switches with which we can "easily" disable troublesome AZs, it would be good to have some visibility of the effective state of these switches and also some alerts to remind us to restore the AZs once we think the incident is over. One of the switches now has the additional side effect of disabling the resurrector - but doesn't automatically re-enable it when flipped back, so making the state of the resurrector visible and also raising reminder alerts would be useful too.

This PR creates a periodic job for each bit of state, using a naming pattern `-is-enabled-`. The jobs are set to "fail" when the relevant bit is _not_ enabled, allowing the job to be used effectively as a red/green indicator light in the pipeline. **If** `((ENABLE_ALERT_NOTIFICATIONS))` is set, then a failure will also fire off an alert email (much like a smoke test failure). Together this means that the feature is useful for both prod and non-prod environments.

For each bit of state checked, I've tried to avoid just-looking-at-the-flag and instead make the mechanism reflect the truer state of the actual system.

For `resurrector-is-enabled`, this is mostly straightforward because we can poke a (completely undocumented) part of the Director API to see its current state.

For `az-*-is-enabled-in-manifest` this parses the current manifest (according to `bosh`) and considers an AZ to have been "disabled" if no `instance_groups` list it in their `azs`.

For `az-*-is-enabled-in-vpc` this is a little trickier. The only _true_ way of checking this would be to poke aws for the list of active network ACLs in the relevant VPC and actually _understand_ which ones may be blocking everything, but I ain't gonna do that. I settled in the end with looking for an ACL following the expected naming scheme in use by the terraform. It's one step better than parsing the `az-management` tfstate and probing for the existence of the ACL id listed there, and it's two steps better than just parsing the tfstate and presuming it reflects reality. Neither of which would be able to cope with an ACL that had been orphaned from its statefile somehow.

After a bit of thought it felt like the right place for these jobs was the "health" group, making it look a lil something like this:

<img width="455" alt="Screenshot 2021-07-01 at 11 34 51" src="https://user-images.githubusercontent.com/807447/124110785-7df73280-da60-11eb-9953-1a1966c0b92e.png">


How to review
-------------

Deploy the branch to a dev env. Disable a VPC. Within half an hour both the respective `az-*-is-enabled-in-vpc` and `resurrector-is-enabled` should go red (within half an hour, though it's suggested you trigger the jobs manually).

Deploy with `DISABLED_AZS` set and watch `az-*-is-enabled-in-manifest` go red.

They should all go green again once you've restored the settings. You'll possibly want to enable alerts sent to somewhere harmless too.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
