### PR TITLE
[#178621826] Fixup nagging alerts

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2016,24 +2016,14 @@ jobs:
           passed: ['pipeline-lock']
       - task: check-az-a-is-enabled-in-manifest
         tags: [colocated-with-web]
-        config:
-          platform: linux
-          image_resource: *gov-paas-bosh-cli-v2-image-resource
-          params:
-            DEPLOY_ENV: ((deploy_env))
-            BOSH_ENVIRONMENT: ((bosh_fqdn))
-            BOSH_CA_CERT: ((bosh-ca-cert))
-            BOSH_DEPLOYMENT: ((deploy_env))
-            BOSH_CLIENT_SECRET: ((bosh-client-secret))
-          run:
-            path: sh
-            args:
-              - -e
-              - -c
-              - |
-                echo 'instance_groups with z1 enabled:'
-                BOSH_CLIENT='admin' bosh -d "${DEPLOY_ENV}" manifest \
-                  | yq eval -e '.instance_groups[] | select(.azs[] | select(. == "z1")) | .name' -
+        file: paas-cf/concourse/tasks/check-az-is-enabled-in-manifest.yml
+        params:
+          DEPLOY_ENV: ((deploy_env))
+          BOSH_ENVIRONMENT: ((bosh_fqdn))
+          BOSH_CA_CERT: ((bosh-ca-cert))
+          BOSH_DEPLOYMENT: ((deploy_env))
+          BOSH_CLIENT_SECRET: ((bosh-client-secret))
+          BOSH_AZ: z1
     on_failure:
       task: send-nagging-email-alert
       tags: [colocated-with-web]
@@ -2057,24 +2047,14 @@ jobs:
           passed: ['pipeline-lock']
       - task: check-az-b-is-enabled-in-manifest
         tags: [colocated-with-web]
-        config:
-          platform: linux
-          image_resource: *gov-paas-bosh-cli-v2-image-resource
-          params:
-            DEPLOY_ENV: ((deploy_env))
-            BOSH_ENVIRONMENT: ((bosh_fqdn))
-            BOSH_CA_CERT: ((bosh-ca-cert))
-            BOSH_DEPLOYMENT: ((deploy_env))
-            BOSH_CLIENT_SECRET: ((bosh-client-secret))
-          run:
-            path: sh
-            args:
-              - -e
-              - -c
-              - |
-                echo 'instance_groups with z2 enabled:'
-                BOSH_CLIENT='admin' bosh -d "${DEPLOY_ENV}" manifest \
-                  | yq eval -e '.instance_groups[] | select(.azs[] | select(. == "z2")) | .name' -
+        file: paas-cf/concourse/tasks/check-az-is-enabled-in-manifest.yml
+        params:
+          DEPLOY_ENV: ((deploy_env))
+          BOSH_ENVIRONMENT: ((bosh_fqdn))
+          BOSH_CA_CERT: ((bosh-ca-cert))
+          BOSH_DEPLOYMENT: ((deploy_env))
+          BOSH_CLIENT_SECRET: ((bosh-client-secret))
+          BOSH_AZ: z2
     on_failure:
       task: send-nagging-email-alert
       tags: [colocated-with-web]
@@ -2098,24 +2078,14 @@ jobs:
           passed: ['pipeline-lock']
       - task: check-az-c-is-enabled-in-manifest
         tags: [colocated-with-web]
-        config:
-          platform: linux
-          image_resource: *gov-paas-bosh-cli-v2-image-resource
-          params:
-            DEPLOY_ENV: ((deploy_env))
-            BOSH_ENVIRONMENT: ((bosh_fqdn))
-            BOSH_CA_CERT: ((bosh-ca-cert))
-            BOSH_DEPLOYMENT: ((deploy_env))
-            BOSH_CLIENT_SECRET: ((bosh-client-secret))
-          run:
-            path: sh
-            args:
-              - -e
-              - -c
-              - |
-                echo 'instance_groups with z3 enabled:'
-                BOSH_CLIENT='admin' bosh -d "${DEPLOY_ENV}" manifest \
-                  | yq eval -e '.instance_groups[] | select(.azs[] | select(. == "z3")) | .name' -
+        file: paas-cf/concourse/tasks/check-az-is-enabled-in-manifest.yml
+        params:
+          DEPLOY_ENV: ((deploy_env))
+          BOSH_ENVIRONMENT: ((bosh_fqdn))
+          BOSH_CA_CERT: ((bosh-ca-cert))
+          BOSH_DEPLOYMENT: ((deploy_env))
+          BOSH_CLIENT_SECRET: ((bosh-client-secret))
+          BOSH_AZ: z3
     on_failure:
       task: send-nagging-email-alert
       tags: [colocated-with-web]

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2237,6 +2237,7 @@ jobs:
           image_resource: *awscli-image-resource
           params:
             AWS_DEFAULT_REGION: ((aws_region))
+            EXPECTED_ACL_NAME: disable_az_((aws_region))a
           inputs:
             - name: terraform-variables
             - name: paas-cf
@@ -2248,11 +2249,11 @@ jobs:
               - |
                 . terraform-variables/vpc.tfvars.sh
 
-                echo "Checking for network ACL disabling AZ..."
+                echo "Checking for network ACL named ${EXPECTED_ACL_NAME}..."
                 # shellcheck disable=SC2154
                 aws ec2 describe-network-acls \
                   --filters "Name=vpc-id,Values=${TF_VAR_vpc_id}" > network-acls.json
-                if jq -e '.NetworkAcls[] | select(.Tags[] | select(.Key == "Name" and .Value == "disable_az_((aws_region))a"))' < network-acls.json > /dev/null ; then
+                if jq -e '.NetworkAcls[] | select(.Tags[] | select(.Key == "Name" and .Value == env.EXPECTED_ACL_NAME))' < network-acls.json > /dev/null ; then
                   echo "Found, therefore AZ disabled. Failing."
                   false
                 else
@@ -2325,6 +2326,7 @@ jobs:
           image_resource: *awscli-image-resource
           params:
             AWS_DEFAULT_REGION: ((aws_region))
+            EXPECTED_ACL_NAME: disable_az_((aws_region))b
           inputs:
             - name: terraform-variables
             - name: paas-cf
@@ -2336,11 +2338,11 @@ jobs:
               - |
                 . terraform-variables/vpc.tfvars.sh
 
-                echo "Checking for network ACL disabling AZ..."
+                echo "Checking for network ACL named ${EXPECTED_ACL_NAME}..."
                 # shellcheck disable=SC2154
                 aws ec2 describe-network-acls \
                   --filters "Name=vpc-id,Values=${TF_VAR_vpc_id}" > network-acls.json
-                if jq -e '.NetworkAcls[] | select(.Tags[] | select(.Key == "Name" and .Value == "disable_az_((aws_region))b"))' < network-acls.json > /dev/null ; then
+                if jq -e '.NetworkAcls[] | select(.Tags[] | select(.Key == "Name" and .Value == env.EXPECTED_ACL_NAME))' < network-acls.json > /dev/null ; then
                   echo "Found, therefore AZ disabled. Failing."
                   false
                 else
@@ -2413,6 +2415,7 @@ jobs:
           image_resource: *awscli-image-resource
           params:
             AWS_DEFAULT_REGION: ((aws_region))
+            EXPECTED_ACL_NAME: disable_az_((aws_region))c
           inputs:
             - name: terraform-variables
             - name: paas-cf
@@ -2424,11 +2427,11 @@ jobs:
               - |
                 . terraform-variables/vpc.tfvars.sh
 
-                echo "Checking for network ACL disabling AZ..."
+                echo "Checking for network ACL named ${EXPECTED_ACL_NAME}..."
                 # shellcheck disable=SC2154
                 aws ec2 describe-network-acls \
                   --filters "Name=vpc-id,Values=${TF_VAR_vpc_id}" > network-acls.json
-                if jq -e '.NetworkAcls[] | select(.Tags[] | select(.Key == "Name" and .Value == "disable_az_((aws_region))c"))' < network-acls.json > /dev/null ; then
+                if jq -e '.NetworkAcls[] | select(.Tags[] | select(.Key == "Name" and .Value == env.EXPECTED_ACL_NAME))' < network-acls.json > /dev/null ; then
                   echo "Found, therefore AZ disabled. Failing."
                   false
                 else

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2232,33 +2232,10 @@ jobs:
 
       - task: check-az-a-is-enabled-in-vpc
         tags: [colocated-with-web]
-        config:
-          platform: linux
-          image_resource: *awscli-image-resource
-          params:
-            AWS_DEFAULT_REGION: ((aws_region))
-            EXPECTED_ACL_NAME: disable_az_((aws_region))a
-          inputs:
-            - name: terraform-variables
-            - name: paas-cf
-          run:
-            path: ash
-            args:
-              - -e
-              - -c
-              - |
-                . terraform-variables/vpc.tfvars.sh
-
-                echo "Checking for network ACL named ${EXPECTED_ACL_NAME}..."
-                # shellcheck disable=SC2154
-                aws ec2 describe-network-acls \
-                  --filters "Name=vpc-id,Values=${TF_VAR_vpc_id}" > network-acls.json
-                if jq -e '.NetworkAcls[] | select(.Tags[] | select(.Key == "Name" and .Value == env.EXPECTED_ACL_NAME))' < network-acls.json > /dev/null ; then
-                  echo "Found, therefore AZ disabled. Failing."
-                  false
-                else
-                  echo "Not found"
-                fi
+        file: paas-cf/concourse/tasks/check-az-is-enabled-in-vpc.yml
+        params:
+          AWS_DEFAULT_REGION: ((aws_region))
+          EXPECTED_ACL_NAME: disable_az_((aws_region))a
     on_failure:
       task: send-email-alert
       tags: [colocated-with-web]
@@ -2321,33 +2298,11 @@ jobs:
 
       - task: check-az-b-is-enabled-in-vpc
         tags: [colocated-with-web]
-        config:
-          platform: linux
-          image_resource: *awscli-image-resource
-          params:
-            AWS_DEFAULT_REGION: ((aws_region))
-            EXPECTED_ACL_NAME: disable_az_((aws_region))b
-          inputs:
-            - name: terraform-variables
-            - name: paas-cf
-          run:
-            path: ash
-            args:
-              - -e
-              - -c
-              - |
-                . terraform-variables/vpc.tfvars.sh
+        file: paas-cf/concourse/tasks/check-az-is-enabled-in-vpc.yml
+        params:
+          AWS_DEFAULT_REGION: ((aws_region))
+          EXPECTED_ACL_NAME: disable_az_((aws_region))b
 
-                echo "Checking for network ACL named ${EXPECTED_ACL_NAME}..."
-                # shellcheck disable=SC2154
-                aws ec2 describe-network-acls \
-                  --filters "Name=vpc-id,Values=${TF_VAR_vpc_id}" > network-acls.json
-                if jq -e '.NetworkAcls[] | select(.Tags[] | select(.Key == "Name" and .Value == env.EXPECTED_ACL_NAME))' < network-acls.json > /dev/null ; then
-                  echo "Found, therefore AZ disabled. Failing."
-                  false
-                else
-                  echo "Not found"
-                fi
     on_failure:
       task: send-email-alert
       tags: [colocated-with-web]
@@ -2410,33 +2365,11 @@ jobs:
 
       - task: check-az-c-is-enabled-in-vpc
         tags: [colocated-with-web]
-        config:
-          platform: linux
-          image_resource: *awscli-image-resource
-          params:
-            AWS_DEFAULT_REGION: ((aws_region))
-            EXPECTED_ACL_NAME: disable_az_((aws_region))c
-          inputs:
-            - name: terraform-variables
-            - name: paas-cf
-          run:
-            path: ash
-            args:
-              - -e
-              - -c
-              - |
-                . terraform-variables/vpc.tfvars.sh
+        file: paas-cf/concourse/tasks/check-az-is-enabled-in-vpc.yml
+        params:
+          AWS_DEFAULT_REGION: ((aws_region))
+          EXPECTED_ACL_NAME: disable_az_((aws_region))c
 
-                echo "Checking for network ACL named ${EXPECTED_ACL_NAME}..."
-                # shellcheck disable=SC2154
-                aws ec2 describe-network-acls \
-                  --filters "Name=vpc-id,Values=${TF_VAR_vpc_id}" > network-acls.json
-                if jq -e '.NetworkAcls[] | select(.Tags[] | select(.Key == "Name" and .Value == env.EXPECTED_ACL_NAME))' < network-acls.json > /dev/null ; then
-                  echo "Found, therefore AZ disabled. Failing."
-                  false
-                else
-                  echo "Not found"
-                fi
     on_failure:
       task: send-email-alert
       tags: [colocated-with-web]

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1972,8 +1972,11 @@ jobs:
   - name: resurrector-is-enabled
     serial: true
     plan:
-      - get: resurrector-is-enabled-timer
-        trigger: true
+      - in_parallel:
+        - get: resurrector-is-enabled-timer
+          trigger: true
+        - <<: *get-paas-cf
+          passed: ['pipeline-lock']
       - task: check-resurrector
         tags: [colocated-with-web]
         config:
@@ -1997,6 +2000,8 @@ jobs:
       config:
         platform: linux
         image_resource: *awscli-image-resource
+        inputs:
+          - name: paas-cf
         params:
           AWS_DEFAULT_REGION: ((aws_region))
           DEPLOY_ENV: ((deploy_env))
@@ -2022,8 +2027,11 @@ jobs:
   - name: az-a-is-enabled-in-manifest
     serial: true
     plan:
-      - get: az-is-enabled-in-manifest-timer
-        trigger: true
+      - in_parallel:
+        - get: az-is-enabled-in-manifest-timer
+          trigger: true
+        - <<: *get-paas-cf
+          passed: ['pipeline-lock']
       - task: check-az-a-is-enabled-in-manifest
         tags: [colocated-with-web]
         config:
@@ -2050,6 +2058,8 @@ jobs:
       config:
         platform: linux
         image_resource: *awscli-image-resource
+        inputs:
+          - name: paas-cf
         params:
           AWS_DEFAULT_REGION: ((aws_region))
           DEPLOY_ENV: ((deploy_env))
@@ -2076,8 +2086,11 @@ jobs:
   - name: az-b-is-enabled-in-manifest
     serial: true
     plan:
-      - get: az-is-enabled-in-manifest-timer
-        trigger: true
+      - in_parallel:
+        - get: az-is-enabled-in-manifest-timer
+          trigger: true
+        - <<: *get-paas-cf
+          passed: ['pipeline-lock']
       - task: check-az-b-is-enabled-in-manifest
         tags: [colocated-with-web]
         config:
@@ -2104,6 +2117,8 @@ jobs:
       config:
         platform: linux
         image_resource: *awscli-image-resource
+        inputs:
+          - name: paas-cf
         params:
           AWS_DEFAULT_REGION: ((aws_region))
           DEPLOY_ENV: ((deploy_env))
@@ -2130,8 +2145,11 @@ jobs:
   - name: az-c-is-enabled-in-manifest
     serial: true
     plan:
-      - get: az-is-enabled-in-manifest-timer
-        trigger: true
+      - in_parallel:
+        - get: az-is-enabled-in-manifest-timer
+          trigger: true
+        - <<: *get-paas-cf
+          passed: ['pipeline-lock']
       - task: check-az-c-is-enabled-in-manifest
         tags: [colocated-with-web]
         config:
@@ -2158,6 +2176,8 @@ jobs:
       config:
         platform: linux
         image_resource: *awscli-image-resource
+        inputs:
+          - name: paas-cf
         params:
           AWS_DEFAULT_REGION: ((aws_region))
           DEPLOY_ENV: ((deploy_env))
@@ -2188,6 +2208,7 @@ jobs:
           - get: az-is-enabled-in-vpc-timer
             trigger: true
           - <<: *get-paas-cf
+            passed: ['pipeline-lock']
           - get: vpc-tfstate
 
       - task: extract-terraform-variables
@@ -2243,6 +2264,8 @@ jobs:
       config:
         platform: linux
         image_resource: *awscli-image-resource
+        inputs:
+          - name: paas-cf
         params:
           AWS_DEFAULT_REGION: ((aws_region))
           DEPLOY_ENV: ((deploy_env))
@@ -2273,6 +2296,7 @@ jobs:
           - get: az-is-enabled-in-vpc-timer
             trigger: true
           - <<: *get-paas-cf
+            passed: ['pipeline-lock']
           - get: vpc-tfstate
 
       - task: extract-terraform-variables
@@ -2328,6 +2352,8 @@ jobs:
       config:
         platform: linux
         image_resource: *awscli-image-resource
+        inputs:
+          - name: paas-cf
         params:
           AWS_DEFAULT_REGION: ((aws_region))
           DEPLOY_ENV: ((deploy_env))
@@ -2358,6 +2384,7 @@ jobs:
           - get: az-is-enabled-in-vpc-timer
             trigger: true
           - <<: *get-paas-cf
+            passed: ['pipeline-lock']
           - get: vpc-tfstate
 
       - task: extract-terraform-variables
@@ -2413,6 +2440,8 @@ jobs:
       config:
         platform: linux
         image_resource: *awscli-image-resource
+        inputs:
+          - name: paas-cf
         params:
           AWS_DEFAULT_REGION: ((aws_region))
           DEPLOY_ENV: ((deploy_env))

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1995,34 +1995,16 @@ jobs:
               - |
                 BOSH_CLIENT='admin' bosh curl /resurrection | jq -e '.resurrection'
     on_failure:
-      task: send-email-alert
+      task: send-nagging-email-alert
       tags: [colocated-with-web]
-      config:
-        platform: linux
-        image_resource: *awscli-image-resource
-        inputs:
-          - name: paas-cf
-        params:
-          AWS_DEFAULT_REGION: ((aws_region))
-          DEPLOY_ENV: ((deploy_env))
-          SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
-          ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
-          ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
-        run:
-          path: ash
-          args:
-            - -e
-            - -c
-            - |
-              if [ "$ENABLE_ALERT_NOTIFICATIONS" = "true" ]; then
-                paas-cf/concourse/scripts/nagging_email.sh \
-                  "${DEPLOY_ENV}" \
-                  "${SYSTEM_DNS_ZONE_NAME}" \
-                  "${ALERT_EMAIL_ADDRESS}" \
-                  "resurrector-disabled"
-              else
-                echo "email alerts disabled"
-              fi
+      file: paas-cf/concourse/tasks/send-nagging-email-alert.yml
+      params:
+        AWS_DEFAULT_REGION: ((aws_region))
+        DEPLOY_ENV: ((deploy_env))
+        SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+        ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
+        ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
+        MESSAGE_TYPE: resurrector-disabled
 
   - name: az-a-is-enabled-in-manifest
     serial: true
@@ -2053,35 +2035,17 @@ jobs:
                 BOSH_CLIENT='admin' bosh -d "${DEPLOY_ENV}" manifest \
                   | yq eval -e '.instance_groups[] | select(.azs[] | select(. == "z1")) | .name' -
     on_failure:
-      task: send-email-alert
+      task: send-nagging-email-alert
       tags: [colocated-with-web]
-      config:
-        platform: linux
-        image_resource: *awscli-image-resource
-        inputs:
-          - name: paas-cf
-        params:
-          AWS_DEFAULT_REGION: ((aws_region))
-          DEPLOY_ENV: ((deploy_env))
-          SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
-          ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
-          ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
-        run:
-          path: ash
-          args:
-            - -e
-            - -c
-            - |
-              if [ "$ENABLE_ALERT_NOTIFICATIONS" = "true" ]; then
-                paas-cf/concourse/scripts/nagging_email.sh \
-                  "${DEPLOY_ENV}" \
-                  "${SYSTEM_DNS_ZONE_NAME}" \
-                  "${ALERT_EMAIL_ADDRESS}" \
-                  "az-disabled-in-manifest" \
-                  "z1"
-              else
-                echo "email alerts disabled"
-              fi
+      file: paas-cf/concourse/tasks/send-nagging-email-alert.yml
+      params:
+        AWS_DEFAULT_REGION: ((aws_region))
+        DEPLOY_ENV: ((deploy_env))
+        SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+        ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
+        ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
+        MESSAGE_TYPE: az-disabled-manifest
+        CONTEXT: z1
 
   - name: az-b-is-enabled-in-manifest
     serial: true
@@ -2112,35 +2076,17 @@ jobs:
                 BOSH_CLIENT='admin' bosh -d "${DEPLOY_ENV}" manifest \
                   | yq eval -e '.instance_groups[] | select(.azs[] | select(. == "z2")) | .name' -
     on_failure:
-      task: send-email-alert
+      task: send-nagging-email-alert
       tags: [colocated-with-web]
-      config:
-        platform: linux
-        image_resource: *awscli-image-resource
-        inputs:
-          - name: paas-cf
-        params:
-          AWS_DEFAULT_REGION: ((aws_region))
-          DEPLOY_ENV: ((deploy_env))
-          SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
-          ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
-          ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
-        run:
-          path: ash
-          args:
-            - -e
-            - -c
-            - |
-              if [ "$ENABLE_ALERT_NOTIFICATIONS" = "true" ]; then
-                paas-cf/concourse/scripts/nagging_email.sh \
-                  "${DEPLOY_ENV}" \
-                  "${SYSTEM_DNS_ZONE_NAME}" \
-                  "${ALERT_EMAIL_ADDRESS}" \
-                  "az-disabled-in-manifest" \
-                  "z2"
-              else
-                echo "email alerts disabled"
-              fi
+      file: paas-cf/concourse/tasks/send-nagging-email-alert.yml
+      params:
+        AWS_DEFAULT_REGION: ((aws_region))
+        DEPLOY_ENV: ((deploy_env))
+        SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+        ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
+        ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
+        MESSAGE_TYPE: az-disabled-manifest
+        CONTEXT: z2
 
   - name: az-c-is-enabled-in-manifest
     serial: true
@@ -2171,35 +2117,17 @@ jobs:
                 BOSH_CLIENT='admin' bosh -d "${DEPLOY_ENV}" manifest \
                   | yq eval -e '.instance_groups[] | select(.azs[] | select(. == "z3")) | .name' -
     on_failure:
-      task: send-email-alert
+      task: send-nagging-email-alert
       tags: [colocated-with-web]
-      config:
-        platform: linux
-        image_resource: *awscli-image-resource
-        inputs:
-          - name: paas-cf
-        params:
-          AWS_DEFAULT_REGION: ((aws_region))
-          DEPLOY_ENV: ((deploy_env))
-          SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
-          ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
-          ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
-        run:
-          path: ash
-          args:
-            - -e
-            - -c
-            - |
-              if [ "$ENABLE_ALERT_NOTIFICATIONS" = "true" ]; then
-                paas-cf/concourse/scripts/nagging_email.sh \
-                  "${DEPLOY_ENV}" \
-                  "${SYSTEM_DNS_ZONE_NAME}" \
-                  "${ALERT_EMAIL_ADDRESS}" \
-                  "az-disabled-in-manifest" \
-                  "z3"
-              else
-                echo "email alerts disabled"
-              fi
+      file: paas-cf/concourse/tasks/send-nagging-email-alert.yml
+      params:
+        AWS_DEFAULT_REGION: ((aws_region))
+        DEPLOY_ENV: ((deploy_env))
+        SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+        ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
+        ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
+        MESSAGE_TYPE: az-disabled-manifest
+        CONTEXT: z3
 
   - name: az-a-is-enabled-in-vpc
     serial: true
@@ -2237,35 +2165,17 @@ jobs:
           AWS_DEFAULT_REGION: ((aws_region))
           EXPECTED_ACL_NAME: disable_az_((aws_region))a
     on_failure:
-      task: send-email-alert
+      task: send-nagging-email-alert
       tags: [colocated-with-web]
-      config:
-        platform: linux
-        image_resource: *awscli-image-resource
-        inputs:
-          - name: paas-cf
-        params:
-          AWS_DEFAULT_REGION: ((aws_region))
-          DEPLOY_ENV: ((deploy_env))
-          SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
-          ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
-          ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
-        run:
-          path: ash
-          args:
-            - -e
-            - -c
-            - |
-              if [ "$ENABLE_ALERT_NOTIFICATIONS" = "true" ]; then
-                paas-cf/concourse/scripts/nagging_email.sh \
-                  "${DEPLOY_ENV}" \
-                  "${SYSTEM_DNS_ZONE_NAME}" \
-                  "${ALERT_EMAIL_ADDRESS}" \
-                  "az-disabled-vpc" \
-                  "a"
-              else
-                echo "email alerts disabled"
-              fi
+      file: paas-cf/concourse/tasks/send-nagging-email-alert.yml
+      params:
+        AWS_DEFAULT_REGION: ((aws_region))
+        DEPLOY_ENV: ((deploy_env))
+        SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+        ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
+        ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
+        MESSAGE_TYPE: az-disabled-vpc
+        CONTEXT: a
 
   - name: az-b-is-enabled-in-vpc
     serial: true
@@ -2304,35 +2214,17 @@ jobs:
           EXPECTED_ACL_NAME: disable_az_((aws_region))b
 
     on_failure:
-      task: send-email-alert
+      task: send-nagging-email-alert
       tags: [colocated-with-web]
-      config:
-        platform: linux
-        image_resource: *awscli-image-resource
-        inputs:
-          - name: paas-cf
-        params:
-          AWS_DEFAULT_REGION: ((aws_region))
-          DEPLOY_ENV: ((deploy_env))
-          SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
-          ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
-          ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
-        run:
-          path: ash
-          args:
-            - -e
-            - -c
-            - |
-              if [ "$ENABLE_ALERT_NOTIFICATIONS" = "true" ]; then
-                paas-cf/concourse/scripts/nagging_email.sh \
-                  "${DEPLOY_ENV}" \
-                  "${SYSTEM_DNS_ZONE_NAME}" \
-                  "${ALERT_EMAIL_ADDRESS}" \
-                  "az-disabled-vpc" \
-                  "b"
-              else
-                echo "email alerts disabled"
-              fi
+      file: paas-cf/concourse/tasks/send-nagging-email-alert.yml
+      params:
+        AWS_DEFAULT_REGION: ((aws_region))
+        DEPLOY_ENV: ((deploy_env))
+        SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+        ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
+        ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
+        MESSAGE_TYPE: az-disabled-vpc
+        CONTEXT: b
 
   - name: az-c-is-enabled-in-vpc
     serial: true
@@ -2371,35 +2263,17 @@ jobs:
           EXPECTED_ACL_NAME: disable_az_((aws_region))c
 
     on_failure:
-      task: send-email-alert
+      task: send-nagging-email-alert
       tags: [colocated-with-web]
-      config:
-        platform: linux
-        image_resource: *awscli-image-resource
-        inputs:
-          - name: paas-cf
-        params:
-          AWS_DEFAULT_REGION: ((aws_region))
-          DEPLOY_ENV: ((deploy_env))
-          SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
-          ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
-          ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
-        run:
-          path: ash
-          args:
-            - -e
-            - -c
-            - |
-              if [ "$ENABLE_ALERT_NOTIFICATIONS" = "true" ]; then
-                paas-cf/concourse/scripts/nagging_email.sh \
-                  "${DEPLOY_ENV}" \
-                  "${SYSTEM_DNS_ZONE_NAME}" \
-                  "${ALERT_EMAIL_ADDRESS}" \
-                  "az-disabled-vpc" \
-                  "c"
-              else
-                echo "email alerts disabled"
-              fi
+      file: paas-cf/concourse/tasks/send-nagging-email-alert.yml
+      params:
+        AWS_DEFAULT_REGION: ((aws_region))
+        DEPLOY_ENV: ((deploy_env))
+        SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+        ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
+        ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
+        MESSAGE_TYPE: az-disabled-vpc
+        CONTEXT: c
 
   - name: generate-cf-config
     serial_groups: [cf-deploy]

--- a/concourse/tasks/check-az-is-enabled-in-manifest.yml
+++ b/concourse/tasks/check-az-is-enabled-in-manifest.yml
@@ -1,0 +1,24 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: ghcr.io/alphagov/paas/bosh-cli-v2
+    tag: 8453e9c989abefdaad40895c25df7d18a82d6522
+params:
+  DEPLOY_ENV:
+  BOSH_ENVIRONMENT:
+  BOSH_CA_CERT:
+  BOSH_DEPLOYMENT:
+  BOSH_CLIENT_SECRET:
+  BOSH_AZ:
+run:
+  path: sh
+  args:
+    - -e
+    - -c
+    - |
+      echo "instance_groups with ${BOSH_AZ} enabled:"
+      BOSH_CLIENT='admin' bosh -d "${DEPLOY_ENV}" manifest \
+        | yq eval -j \
+        | jq -e '.instance_groups[] | select(.azs[] | select(. == env.BOSH_AZ)) | .name' -

--- a/concourse/tasks/check-az-is-enabled-in-vpc.yml
+++ b/concourse/tasks/check-az-is-enabled-in-vpc.yml
@@ -1,0 +1,32 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: ghcr.io/alphagov/paas/awscli
+    tag: 8453e9c989abefdaad40895c25df7d18a82d6522
+params:
+  AWS_DEFAULT_REGION:
+  EXPECTED_ACL_NAME:
+inputs:
+  - name: terraform-variables
+  - name: paas-cf
+run:
+  path: ash
+  args:
+    - -e
+    - -c
+    - |
+      . terraform-variables/vpc.tfvars.sh
+
+      # shellcheck disable=SC2154
+      echo "Checking for network ACL named ${EXPECTED_ACL_NAME}..."
+      # shellcheck disable=SC2154
+      aws ec2 describe-network-acls \
+        --filters "Name=vpc-id,Values=${TF_VAR_vpc_id}" > network-acls.json
+      if jq -e '.NetworkAcls[] | select(.Tags[] | select(.Key == "Name" and .Value == env.EXPECTED_ACL_NAME))' < network-acls.json > /dev/null ; then
+        echo "Found, therefore AZ disabled. Failing."
+        false
+      else
+        echo "Not found"
+      fi

--- a/concourse/tasks/send-nagging-email-alert.yml
+++ b/concourse/tasks/send-nagging-email-alert.yml
@@ -1,0 +1,33 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: ghcr.io/alphagov/paas/awscli
+    tag: 8453e9c989abefdaad40895c25df7d18a82d6522
+inputs:
+  - name: paas-cf
+params:
+  AWS_DEFAULT_REGION:
+  DEPLOY_ENV:
+  SYSTEM_DNS_ZONE_NAME:
+  ALERT_EMAIL_ADDRESS:
+  ENABLE_ALERT_NOTIFICATIONS:
+  MESSAGE_TYPE:
+  CONTEXT:
+run:
+  path: ash
+  args:
+    - -e
+    - -c
+    - |
+      if [ "$ENABLE_ALERT_NOTIFICATIONS" = "true" ]; then
+        paas-cf/concourse/scripts/nagging_email.sh \
+          "${DEPLOY_ENV}" \
+          "${SYSTEM_DNS_ZONE_NAME}" \
+          "${ALERT_EMAIL_ADDRESS}" \
+          "${MESSAGE_TYPE}" \
+          "${CONTEXT}"
+      else
+        echo "email alerts disabled"
+      fi


### PR DESCRIPTION
What
----

This is mostly a fixup to #2694's lack of foresight, not providing `paas-cf` as an input to the email-sending tasks. I made the provided `paas-cf`s use a `passed` of `pipeline-lock`, so that it would only try to use tasks & scripts matching the currently set pipeline.

As I was fixing it I was embarrassed and annoyed by the amount of repetition required and how verbose my previous solution was, so I did some refactoring here, pulling three of the steps out into separate tasks.

How to review
-------------

Same as #2694, though TBH we're unlikely to be able to test it properly (the emails) until it hits staging.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
