### PR TITLE
Logit config: Handle as DEBUG (i.e., drop) spammy type=SYSCALL logs

### DIFF
--- a/config/logit/20_custom_cf_filters.conf
+++ b/config/logit/20_custom_cf_filters.conf
@@ -1,3 +1,11 @@
+if [@level] == "INFO" and [@message] =~ /type=SYSCALL msg=audit.* syscall=(159|54) success=yes/ {
+  # These are so high volume, and as Linux audit syscall logs they're basically debug anyway. Keep other types of audit logs as they may be useful and lower volume.
+  # 54 is setsockopt, 159 is adjtimex. Reference available at https://filippo.io/linux-syscall-table/
+  mutate {
+    replace => { "@level" => "DEBUG" }
+  }
+}
+
 # Drop debug logs
 if [@level] == "DEBUG" {
     drop { }

--- a/config/logit/output/generated_logit_filters.conf
+++ b/config/logit/output/generated_logit_filters.conf
@@ -1050,6 +1050,14 @@ filter {
     remove_field => [ "@version", "host", "port", "_logstash_input" ]
   }
 
+  if [@level] == "INFO" and [@message] =~ /type=SYSCALL msg=audit.* syscall=(159|54) success=yes/ {
+    # These are so high volume, and as Linux audit syscall logs they're basically debug anyway. Keep other types of audit logs as they may be useful and lower volume.
+    # 54 is setsockopt, 159 is adjtimex. Reference available at https://filippo.io/linux-syscall-table/
+    mutate {
+      replace => { "@level" => "DEBUG" }
+    }
+  }
+
   # Drop debug logs
   if [@level] == "DEBUG" {
       drop { }


### PR DESCRIPTION
What
----

Handle as DEBUG (i.e., drop) spammy type=SYSCALL logs. We send way too many GBs of logs to Logit and these look like they can be safely dropped.

How to review
-------------

* Code review
* Try it out on PaaS Dev.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
