### PR TITLE
Make instance count changes

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -5,8 +5,8 @@ diego_api_instances: 3
 cell_instances: 105
 router_instances: 15
 api_instances: 12
-doppler_instances: 51
-log_api_instances: 18
+doppler_instances: 54
+log_api_instances: 27
 scheduler_instances: 4
 cc_worker_instances: 4
 cc_hourly_rate_limit: 20000

--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -7,8 +7,8 @@ router_instances: 15
 api_instances: 12
 doppler_instances: 54
 log_api_instances: 27
-scheduler_instances: 4
-cc_worker_instances: 4
+scheduler_instances: 6
+cc_worker_instances: 6
 cc_hourly_rate_limit: 20000
 cc_staging_timeout_in_seconds: 2700
 paas_region_name: london

--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -5,8 +5,8 @@ diego_api_instances: 3
 cell_instances: 36
 router_instances: 24
 api_instances: 6
-doppler_instances: 18
-log_api_instances: 18
+doppler_instances: 21
+log_api_instances: 12
 scheduler_instances: 4
 cc_worker_instances: 4
 cc_hourly_rate_limit: 60000

--- a/manifests/cf-manifest/spec/manifest/env_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/env_spec.rb
@@ -1,3 +1,7 @@
+def round_up(value, increment)
+  increment * ((value + increment - 1) / increment)
+end
+
 RSpec.describe "Environment specific configuration" do
   let(:default_manifest) { manifest_without_vars_store }
   let(:prod_manifest) { manifest_for_env("prod") }
@@ -41,14 +45,17 @@ RSpec.describe "Environment specific configuration" do
       end
 
       describe "doppler" do
-        it "instance count should be at least 1:2 with cell count" do
-          doppler_instance_count = env_manifest.fetch("instance_groups.doppler").dig("instances").to_f
+        it "instance count should be at least half of the cell count" do
+          doppler_ig = env_manifest.fetch("instance_groups.doppler")
           cell_instance_count = env_manifest.fetch("instance_groups.diego-cell").dig("instances").to_f
+          doppler_instance_count = doppler_ig.dig("instances").to_f
+          doppler_az_count = doppler_ig.fetch("azs").size
 
-          ratio = cell_instance_count / doppler_instance_count
+          half = cell_instance_count / 2
+          half_with_headroom = round_up(half, doppler_az_count) + doppler_az_count
 
-          expect(ratio).to be >= 2.0, "doppler instance count #{doppler_instance_count} is wrong. Rule of thumb is 1:2 with cells. Current ratio is #{doppler_instance_count}:#{cell_instance_count} (#{ratio})."
-          expect(ratio).to be < 2.5, "doppler instance count #{doppler_instance_count} is too high. Rule of thumb is 1:2 with cells. Current ratio is #{doppler_instance_count}:#{cell_instance_count} (#{ratio})."
+          expect(doppler_instance_count).to be >= half, "doppler instance count #{doppler_instance_count} is wrong. Rule of thumb is there should be at least half the count of cells in dopplers. Currently set to #{doppler_instance_count}, expecting at least #{half}."
+          expect(doppler_instance_count).to be <= half_with_headroom, "doppler instance count #{doppler_instance_count} is too high. There is no need to allow more headroom than a single set of three. Currently set to #{doppler_instance_count}, expecting at least #{half_with_headroom}."
         end
 
         it "instances are evenly distibutable across the AZs" do
@@ -56,6 +63,28 @@ RSpec.describe "Environment specific configuration" do
           az_count = doppler_ig.fetch("azs").size
           expect(doppler_ig.fetch("instances") % az_count).to eq(0),
             "doppler instance count is not divisible by the AZ count"
+        end
+      end
+
+      describe "log-api" do
+        it "instance count should be at least half of the doppler count" do
+          log_api_ig = env_manifest.fetch("instance_groups.log-api")
+          doppler_instance_count = env_manifest.fetch("instance_groups.doppler").dig("instances").to_f
+          log_api_instances_count = log_api_ig.dig("instances").to_f
+          log_api_az_count = log_api_ig.fetch("azs").size
+
+          half = doppler_instance_count / 2
+          half_with_headroom = round_up(half, log_api_az_count) + log_api_az_count
+
+          expect(log_api_instances_count).to be >= half, "log-api instance count #{log_api_instances_count} is wrong. Rule of thumb is there should be at least half the count of dopplers in log-api. Currently set to #{log_api_instances_count}, expecting at least #{half}."
+          expect(log_api_instances_count).to be <= half_with_headroom, "log-api instance count #{log_api_instances_count} is too high. There is no need to allow more headroom than a single set of three. Currently set to #{log_api_instances_count}, expecting at least #{half_with_headroom}."
+        end
+
+        it "instances are evenly distibutable across the AZs" do
+          log_api_ig = env_manifest.fetch("instance_groups.log-api")
+          az_count = log_api_ig.fetch("azs").size
+          expect(log_api_ig.fetch("instances") % az_count).to eq(0),
+            "log-api instance count is not divisible by the AZ count"
         end
       end
     end


### PR DESCRIPTION
What
----

> Traffic Controller resources are usually scaled in line with Doppler
> resources. The recommended formula for determining the number of Traffic
> Controller instances is:

> Number of Traffic Controller instances = Number of Doppler instances / 2

As we do not work in single instances, we increase things in pairs of threes.

We're also refining the tests for number of dopplers... As we seem to be
just on the edge and to incorporate the following:

> Doppler resources can require scaling to accommodate your overall log
> and metric volume. The recommended formula for estimating the number of
> Doppler instances you need to achieve a loss rate of < 1% is:

> Number of Doppler instances = doppler.ingress / 16 000
> where doppler.ingress represents the per-second rate of change of the
> ingress metric from the doppler source, summed over all VMs in your
> deployment.

Now, this isn't as simple as our rule of thumb ratio 2:1 with cells. But
is fairly close...

After examining the logs, we're just on the edge after recent changes,
missing that one extra doppler...

Along with the refined tests, I'm increasing the counts.

In addition, We'd like to eliminate the flakyness of the tests, by throwing
more resource at the system, hopefully handling more actions, more
promptly.

This is a finger in the air change, that should be small enough but may
be informative to our investigation into flaky smoke tests.

How to review
-------------

- Sanity check

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
