### PR TITLE
[#178053268] Pin the CloudFoundry database to Postgres 11.12

### DIFF
--- a/terraform/cloudfoundry/cf_rds.tf
+++ b/terraform/cloudfoundry/cf_rds.tf
@@ -39,7 +39,7 @@ resource "aws_db_instance" "cf" {
   identifier           = "${var.env}-cf"
   allocated_storage    = 100
   engine               = "postgres"
-  engine_version       = "11.1"
+  engine_version       = "11.12"
   instance_class       = var.cf_db_instance_type
   username             = "dbadmin"
   password             = var.secrets_cf_db_master_password


### PR DESCRIPTION
What
----

We need to upgrade from Postgres 11.1 because of a vulnerability. At the time of writing, 11.12 is the highest minor version we can target.

```
$ aws rds describe-db-engine-versions --engine postgres --engine-version 11.1 | \
  jq '.DBEngineVersions[].ValidUpgradeTarget[] | select(.EngineVersion | startswith("11.")) | .EngineVersion'
"11.2"
"11.4"
"11.5"
"11.6"
"11.7"
"11.8"
"11.9"
"11.10"
"11.11"
"11.12"
```

How to review
-------------
This is difficult to test. In dev, all we can do is apply the upgrade to the database manually and immediately, then roll this PR out afterward, to check Terraform doesn't do anything unexpected.

We could, optionally, test the theory that Terraform will schedule the upgrade for the next maintenance window by rolling out the PR in a dev env without performing the upgrade first. This is what we'll be doing in prod.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
