### PR TITLE
Up the cc max health check timeout to 300s

### DIFF
--- a/manifests/cf-manifest/env-specific/default.yml
+++ b/manifests/cf-manifest/env-specific/default.yml
@@ -11,6 +11,7 @@ scheduler_instances: 2
 cc_worker_instances: 2
 cc_hourly_rate_limit: 15000
 cc_staging_timeout_in_seconds: 900
+cc_maximum_health_check_timeout_in_seconds: 300
 paas_region_name: dev
 
 prometheus_disk_size: 100GB

--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -11,6 +11,7 @@ scheduler_instances: 6
 cc_worker_instances: 6
 cc_hourly_rate_limit: 20000
 cc_staging_timeout_in_seconds: 2700
+cc_maximum_health_check_timeout_in_seconds: 300
 paas_region_name: london
 
 prometheus_disk_size: 750GB

--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -11,6 +11,7 @@ scheduler_instances: 4
 cc_worker_instances: 4
 cc_hourly_rate_limit: 60000
 cc_staging_timeout_in_seconds: 2700
+cc_maximum_health_check_timeout_in_seconds: 300
 paas_region_name: ireland
 
 prometheus_disk_size: 500GB

--- a/manifests/cf-manifest/env-specific/stg-lon.yml
+++ b/manifests/cf-manifest/env-specific/stg-lon.yml
@@ -11,6 +11,7 @@ scheduler_instances: 3
 cc_worker_instances: 2
 cc_hourly_rate_limit: 100000
 cc_staging_timeout_in_seconds: 1800
+cc_maximum_health_check_timeout_in_seconds: 300
 paas_region_name: staging
 
 prometheus_disk_size: 500GB

--- a/manifests/cf-manifest/operations.d/320-cc-set-healthcheck-timeout.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-set-healthcheck-timeout.yml
@@ -1,0 +1,11 @@
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/maximum_health_check_timeout?
+  value: ((cc_maximum_health_check_timeout_in_seconds))
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/maximum_health_check_timeout?
+  value: ((cc_maximum_health_check_timeout_in_seconds))
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/maximum_health_check_timeout?
+  value: ((cc_maximum_health_check_timeout_in_seconds))


### PR DESCRIPTION
What
----

Up the cc max health check timeout to 300s

We have a tenant struggling with health check timeouts when deploying a large Python app ([Link to ticket](https://govuk.zendesk.com/agent/tickets/4613945)).

How to review
-------------

Deploy to dev environment and `cf push` an app with `applications.timeout: 300` in the manifest.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
