### PR TITLE
Add medium and large influxdb plans

### DIFF
--- a/config/billing/config-parts/influxdb_pricing_plans.json.erb
+++ b/config/billing/config-parts/influxdb_pricing_plans.json.erb
@@ -25,6 +25,32 @@
 	]
 },
 {
+	"name": "influxdb medium-1.x",
+	"valid_from": "2021-07-01",
+	"plan_guid": "e30f5f31-a6bb-46f1-a40c-6f704c3089a8",
+	"components": [
+		{
+			"name": "instance",
+			"formula": "ceil($time_in_seconds/3600) * <%= price("aiven_influxdb_startup_14") %>",
+			"currency_code": "USD",
+			"vat_code": "Standard"
+		}
+	]
+},
+{
+	"name": "influxdb large-1.x",
+	"valid_from": "2021-07-01",
+	"plan_guid": "90464f28-2d09-4f2f-8645-10ae0ccaa0a9",
+	"components": [
+		{
+			"name": "instance",
+			"formula": "ceil($time_in_seconds/3600) * <%= price("aiven_influxdb_startup_28") %>",
+			"currency_code": "USD",
+			"vat_code": "Standard"
+		}
+	]
+},
+{
 	"name": "influxdb xxl-1.x",
 	"valid_from": "2021-04-01",
 	"plan_guid": "cc1ec730-918a-45cd-ae7c-fd1ec6414750",

--- a/config/billing/output/eu-west-1.json
+++ b/config/billing/output/eu-west-1.json
@@ -3099,6 +3099,32 @@
 			]
 		},
 		{
+			"name": "influxdb medium-1.x",
+			"valid_from": "2021-07-01",
+			"plan_guid": "e30f5f31-a6bb-46f1-a40c-6f704c3089a8",
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.473",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "influxdb large-1.x",
+			"valid_from": "2021-07-01",
+			"plan_guid": "90464f28-2d09-4f2f-8645-10ae0ccaa0a9",
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.801",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
 			"name": "influxdb xxl-1.x",
 			"valid_from": "2021-04-01",
 			"plan_guid": "cc1ec730-918a-45cd-ae7c-fd1ec6414750",

--- a/config/billing/output/eu-west-2.json
+++ b/config/billing/output/eu-west-2.json
@@ -3099,6 +3099,32 @@
 			]
 		},
 		{
+			"name": "influxdb medium-1.x",
+			"valid_from": "2021-07-01",
+			"plan_guid": "e30f5f31-a6bb-46f1-a40c-6f704c3089a8",
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.473",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "influxdb large-1.x",
+			"valid_from": "2021-07-01",
+			"plan_guid": "90464f28-2d09-4f2f-8645-10ae0ccaa0a9",
+			"components": [
+				{
+					"name": "instance",
+					"formula": "ceil($time_in_seconds/3600) * 0.801",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
 			"name": "influxdb xxl-1.x",
 			"valid_from": "2021-04-01",
 			"plan_guid": "cc1ec730-918a-45cd-ae7c-fd1ec6414750",

--- a/config/billing/pricing_data.yml
+++ b/config/billing/pricing_data.yml
@@ -13,6 +13,8 @@ defaults: &defaults
   aiven_elasticsearch_business_32: "4.384"
   aiven_influxdb_startup_4: "0.130"
   aiven_influxdb_startup_8: "0.295"
+  aiven_influxdb_startup_14: "0.473"
+  aiven_influxdb_startup_28: "0.801"
   aiven_influxdb_startup_112: "2.808"
 
 eu-west-1:

--- a/config/service-brokers/aiven/config.json
+++ b/config/service-brokers/aiven/config.json
@@ -311,6 +311,46 @@
             }
           },
           {
+            "id": "e30f5f31-a6bb-46f1-a40c-6f704c3089a8",
+            "name": "medium-1.x",
+            "aiven_plan": "startup-14",
+            "description": "NOT Highly Available, 1 dedicated VM, 2 CPU per VM, 15GB RAM per VM, 140GB disk space.",
+            "free": false,
+            "metadata": {
+              "displayName": "Medium",
+              "AdditionalMetadata": {
+                "backups": true,
+                "encrypted": true,
+                "highlyAvailable": false,
+                "nodes": 1,
+                "cpu": 2,
+                "memory": {"amount": 15, "unit": "GB"},
+                "storage": {"amount": 140, "unit": "GB"},
+                "version": "1"
+              }
+            }
+          },
+          {
+            "id": "90464f28-2d09-4f2f-8645-10ae0ccaa0a9",
+            "name": "large-1.x",
+            "aiven_plan": "startup-28",
+            "description": "NOT Highly Available, 1 dedicated VM, 4 CPU per VM, 31GB RAM per VM, 280GB disk space.",
+            "free": false,
+            "metadata": {
+              "displayName": "Large",
+              "AdditionalMetadata": {
+                "backups": true,
+                "encrypted": true,
+                "highlyAvailable": false,
+                "nodes": 1,
+                "cpu": 4,
+                "memory": {"amount": 31, "unit": "GB"},
+                "storage": {"amount": 280, "unit": "GB"},
+                "version": "1"
+              }
+            }
+          },
+          {
             "id": "cc1ec730-918a-45cd-ae7c-fd1ec6414750",
             "name": "xxl-1.x",
             "aiven_plan": "startup-112",


### PR DESCRIPTION

What
----

A tenant requires more than 50 GB storage. I have added the next two
larger plans up to facilitate an upgrade.
We add in a medium and large plan with 15G RAM / 140G storage and 31G RAM and 280G storage respectively

How to review
-------------

- Code review
- Deploy in dev and check Influx can be provisioned with new plan

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
