### PR TITLE
Raise London API rate limit to 60,000

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -9,7 +9,7 @@ doppler_instances: 54
 log_api_instances: 27
 scheduler_instances: 6
 cc_worker_instances: 6
-cc_hourly_rate_limit: 20000
+cc_hourly_rate_limit: 60000
 cc_staging_timeout_in_seconds: 2700
 cc_maximum_health_check_timeout_in_seconds: 300
 paas_region_name: london


### PR DESCRIPTION
What
----

In commit 6f7a23e601f4 we raised the API rate limit in Ireland to 60k because
of a bug. In London, we're now experiencing a different bug that could be
alleviated by raising the API rate limit.

Specifically, we're seeing tenants getting rate limited when using
`paas-prometheus-exporter` to monitor large orgs.

How to review
-------------
Agree?

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
