### PR TITLE
Change source of bosh admin password to concourse-var

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -35,13 +35,6 @@ resources:
       stop: 6:00 -0000
       interval: 2h
 
-  - name: bosh-vars-store
-    type: s3-iam
-    source:
-      bucket: ((state_bucket))
-      region_name: ((aws_region))
-      versioned_file: bosh-vars-store.yml
-
   - name: bosh-ca-crt
     type: s3-iam
     source:
@@ -62,7 +55,6 @@ jobs:
     plan:
       - get: delete-timer
         trigger: true
-      - get: bosh-vars-store
       - get: paas-cf
       - get: cf-manifest
       - get: bosh-ca-crt
@@ -121,12 +113,12 @@ jobs:
           platform: linux
           inputs:
             - name: delete-timer
-            - name: bosh-vars-store
             - name: paas-cf
             - name: bosh-ca-crt
           params:
             BOSH_ENVIRONMENT: ((bosh_fqdn))
             BOSH_CA_CERT: bosh-ca-crt/bosh-CA.crt
+            BOSH_CLIENT_SECRET: ((bosh-client-secret))
           outputs:
             - name: deployed-healthcheck
           image_resource:
@@ -140,11 +132,8 @@ jobs:
               - -e
               - -c
               - |
-                VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
                 BOSH_CLIENT='admin'
-                BOSH_CLIENT_SECRET=$($VAL_FROM_YAML admin_password bosh-vars-store/bosh-vars-store.yml)
                 export BOSH_CLIENT
-                export BOSH_CLIENT_SECRET
 
 
                 bosh -n delete-deployment --force --deployment "((deploy_env))"

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -49,13 +49,6 @@ resources:
       region_name: ((aws_region))
       key: ((pipeline_trigger_file))
 
-  - name: bosh-vars-store
-    type: s3-iam
-    source:
-      bucket: ((state_bucket))
-      region_name: ((aws_region))
-      versioned_file: bosh-vars-store.yml
-
   - name: bosh-ca-crt
     type: s3-iam
     source:
@@ -118,7 +111,6 @@ jobs:
           - get: pipeline-trigger
             passed: ['init']
             trigger: true
-          - get: bosh-vars-store
           - get: paas-cf
           - get: cf-manifest
           - get: bosh-ca-crt
@@ -165,11 +157,11 @@ jobs:
               tag: a1262c2a552b9d3db7db2993c0494bde1f5ad5c2
 
           inputs:
-            - name: bosh-vars-store
             - name: paas-cf
             - name: bosh-ca-crt
           params:
             BOSH_ENVIRONMENT: ((bosh_fqdn))
+            BOSH_CLIENT_SECRET: ((bosh-client-secret))
             BOSH_CA_CERT: bosh-ca-crt/bosh-CA.crt
           outputs:
             - name: deployed-healthcheck
@@ -179,11 +171,8 @@ jobs:
               - -e
               - -c
               - |
-                VAL_FROM_YAML=$(pwd)/paas-cf/concourse/scripts/val_from_yaml.rb
                 BOSH_CLIENT='admin'
-                BOSH_CLIENT_SECRET=$($VAL_FROM_YAML admin_password bosh-vars-store/bosh-vars-store.yml)
                 export BOSH_CLIENT
-                export BOSH_CLIENT_SECRET
 
                 bosh -n delete-deployment --force --deployment "((deploy_env))"
                 bosh -n delete-deployment --force --deployment prometheus


### PR DESCRIPTION

What
----
The deletion of my cloud foundry failed due to not being able to find
admin_password in the bosh-vars-store.

Rather than trying to figure out how to put it in the bosh-vars-store I
decided to remove the dependency on the bosh-vars-store and use the
concourse var as is used in create-cf,

https://github.com/alphagov/paas-cf/blob/main/concourse/pipelines/create-cloudfoundry.yml#L1568

How to review
-------------

Deploy the concourse jobs and test that they can delete cloudfoundry

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
