### PR TITLE
[#178944646] billing: add sqs pricing plan

### DIFF
--- a/config/billing/config-parts/sqs_pricing_plans.json.erb
+++ b/config/billing/config-parts/sqs_pricing_plans.json.erb
@@ -1,0 +1,26 @@
+{
+	"name": "aws-sqs-queue standard",
+	"valid_from": "2021-09-01",
+	"plan_guid": "8ff216b8-afed-4833-a265-cd1f2feb919d",
+	"components": [
+		{
+			"name": "queue",
+			"formula": "ceil($time_in_seconds/3600) * <%= price("sqs_queue_default") %>",
+			"currency_code": "USD",
+			"vat_code": "Standard"
+		}
+	]
+},
+{
+	"name": "aws-sqs-queue fifo",
+	"valid_from": "2021-09-01",
+	"plan_guid": "ac129e8a-6423-4792-aa0c-3a192408b3da",
+	"components": [
+		{
+			"name": "queue",
+			"formula": "ceil($time_in_seconds/3600) * <%= price("sqs_queue_default") %>",
+			"currency_code": "USD",
+			"vat_code": "Standard"
+		}
+	]
+},

--- a/config/billing/config.json.erb
+++ b/config/billing/config.json.erb
@@ -20,6 +20,7 @@
 		<%= include("config-parts/elasticsearch_pricing_plans.json.erb") %>
 		<%= include("config-parts/influxdb_pricing_plans.json.erb") %>
 		<%= include("config-parts/s3_pricing_plans.json.erb") %>
+		<%= include("config-parts/sqs_pricing_plans.json.erb") %>
 		<%= include("config-parts/deprecated_pricing_plans.json.erb") %>
 	]
 }

--- a/config/billing/output/eu-west-1.json
+++ b/config/billing/output/eu-west-1.json
@@ -3151,6 +3151,32 @@
 			]
 		},
 		{
+			"name": "aws-sqs-queue standard",
+			"valid_from": "2021-09-01",
+			"plan_guid": "8ff216b8-afed-4833-a265-cd1f2feb919d",
+			"components": [
+				{
+					"name": "queue",
+					"formula": "ceil($time_in_seconds/3600) * 0.00685",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "aws-sqs-queue fifo",
+			"valid_from": "2021-09-01",
+			"plan_guid": "ac129e8a-6423-4792-aa0c-3a192408b3da",
+			"components": [
+				{
+					"name": "queue",
+					"formula": "ceil($time_in_seconds/3600) * 0.00685",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
 			"name": "mongodb tiny (compose)",
 			"valid_from": "2017-01-01",
 			"plan_guid": "fdfd4fc1-ce69-451c-a436-c2e2795b9abe",

--- a/config/billing/output/eu-west-2.json
+++ b/config/billing/output/eu-west-2.json
@@ -3151,6 +3151,32 @@
 			]
 		},
 		{
+			"name": "aws-sqs-queue standard",
+			"valid_from": "2021-09-01",
+			"plan_guid": "8ff216b8-afed-4833-a265-cd1f2feb919d",
+			"components": [
+				{
+					"name": "queue",
+					"formula": "ceil($time_in_seconds/3600) * 0.00685",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "aws-sqs-queue fifo",
+			"valid_from": "2021-09-01",
+			"plan_guid": "ac129e8a-6423-4792-aa0c-3a192408b3da",
+			"components": [
+				{
+					"name": "queue",
+					"formula": "ceil($time_in_seconds/3600) * 0.00685",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
 			"name": "mongodb tiny (compose)",
 			"valid_from": "2017-01-01",
 			"plan_guid": "fdfd4fc1-ce69-451c-a436-c2e2795b9abe",

--- a/config/billing/pricing_data.yml
+++ b/config/billing/pricing_data.yml
@@ -72,6 +72,7 @@ eu-west-1:
   elasticache_m5_xlarge: "0.343"
   elasticache_m5_2xlarge: "0.686"
   s3_bucket_default: "0.00685"
+  sqs_queue_default: "0.00685"
 
 eu-west-2:
   <<: *defaults
@@ -129,3 +130,4 @@ eu-west-2:
   elasticache_m5_xlarge: "0.36"
   elasticache_m5_2xlarge: "0.721"
   s3_bucket_default: "0.00685"
+  sqs_queue_default: "0.00685"


### PR DESCRIPTION
What
----

Added a pricing plan for sqs queues so we can charge for them so profit.

For the `component.name` I assumed these were relatively free-form and we don't quite have anything like this yet so i just put `queue`. Good enough?

As it is, I've set this to start collecting queue prices from the first of Aug, but if this isn't merged before then (likely), I'll probably bump it forwards to something post-rollout.

How to review
-------------

Well, *I* tested this by creating a billable organization on a dev paas with only SQS queues in a space, then kicking the billing collector until it woke up and did its job, counting the price of the sqs service:
 
<img width="1245" alt="Screenshot 2021-07-30 at 13 18 19" src="https://user-images.githubusercontent.com/807447/127653627-16e10947-e737-4990-8c70-54a314e453ed.png">

You could probably do similar quite easily. (But if you do so remember first to bump back the `valid_from` dates to something in the past) 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
