### PR TITLE
Bump service limit alerts for ElastiCache

### DIFF
--- a/manifests/prometheus/env-specific/prod-lon.yml
+++ b/manifests/prometheus/env-specific/prod-lon.yml
@@ -1,8 +1,8 @@
 ---
 
 # AWS Limits not accesible via API
-aws_limits_elasticache_cache_parameter_groups: 700
-aws_limits_elasticache_nodes: 700
+aws_limits_elasticache_cache_parameter_groups: 800
+aws_limits_elasticache_nodes: 800
 # Change limit for prod as well - S3 is global
 aws_limits_s3_buckets: 400
 prometheus_disk_size: 200GB


### PR DESCRIPTION
What
----

As per AWS support request [8564758351](https://console.aws.amazon.com/support/home#/case/?displayId=8564758351&language=en) we have been granted increased service limits for ElastiCache node and parameter group count of 800.

How to review
-------------

- Check the support request
- Check for typos

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
