### PR TITLE
Add AZ monitoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,6 +199,7 @@ dev: ## Set Environment to DEV
 	$(eval export ENABLE_DESTROY=true)
 	$(eval export ENABLE_AUTODELETE=true)
 	$(eval export ENABLE_TEST_PIPELINES=true)
+	$(eval export ENABLE_AZ_HEALTHCHECK ?= false)
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
 	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipelineapps.digital)
 	$(eval export APPS_HOSTED_ZONE_NAME=dev.cloudpipelineapps.digital)
@@ -225,6 +226,7 @@ dev: ## Set Environment to DEV
 dev01: dev
 	$(eval export DEPLOY_ENV=dev01)
 	$(eval export ENABLE_AUTODELETE=false)
+	$(eval export ENABLE_AZ_HEALTHCHECK ?= false)
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
 	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipelineapps.digital)
 	@true
@@ -233,6 +235,7 @@ dev01: dev
 dev02: dev
 	$(eval export DEPLOY_ENV=dev02)
 	$(eval export ENABLE_AUTODELETE=false)
+	$(eval export ENABLE_AZ_HEALTHCHECK ?= false)
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
 	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipelineapps.digital)
 	@true
@@ -243,6 +246,7 @@ stg-lon: ## Set Environment to stg-lon
 	$(eval export MAKEFILE_ENV_TARGET=stg-lon)
 	$(eval export PERSISTENT_ENVIRONMENT=true)
 	$(eval export ENABLE_AUTO_DEPLOY=true)
+	$(eval export ENABLE_AZ_HEALTHCHECK=true)
 	$(eval export OUTPUT_TAG_PREFIX=prod-)
 	$(eval export SYSTEM_DNS_ZONE_NAME=london.staging.cloudpipeline.digital)
 	$(eval export APPS_DNS_ZONE_NAME=london.staging.cloudpipelineapps.digital)
@@ -268,6 +272,7 @@ prod: ## Set Environment to Production
 	$(eval export MAKEFILE_ENV_TARGET=prod)
 	$(eval export PERSISTENT_ENVIRONMENT=true)
 	$(eval export ENABLE_AUTO_DEPLOY=true)
+	$(eval export ENABLE_AZ_HEALTHCHECK=true)
 	$(eval export INPUT_TAG_PREFIX=prod-)
 	$(eval export SYSTEM_DNS_ZONE_NAME=cloud.service.gov.uk)
 	$(eval export APPS_DNS_ZONE_NAME=cloudapps.digital)
@@ -293,6 +298,7 @@ prod-lon: ## Set Environment to prod-lon
 	$(eval export MAKEFILE_ENV_TARGET=prod-lon)
 	$(eval export PERSISTENT_ENVIRONMENT=true)
 	$(eval export ENABLE_AUTO_DEPLOY=true)
+	$(eval export ENABLE_AZ_HEALTHCHECK=true)
 	$(eval export INPUT_TAG_PREFIX=prod-)
 	$(eval export SYSTEM_DNS_ZONE_NAME=london.cloud.service.gov.uk)
 	$(eval export APPS_DNS_ZONE_NAME=london.cloudapps.digital)

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -139,6 +139,7 @@ groups:
       - api-availability-tests
       - cf-terraform
       - psn-terraform
+      - az-healthcheck-terraform
       - vpc-peering-terraform
       - generate-cf-config
       - cf-deploy
@@ -241,6 +242,10 @@ groups:
       - az-a-is-enabled-in-vpc
       - az-b-is-enabled-in-vpc
       - az-c-is-enabled-in-vpc
+      - az-healthcheck-terraform
+      - az-a-healthcheck
+      - az-b-healthcheck
+      - az-c-healthcheck
   - name: credentials
     jobs:
       - set-smoke-test-creds
@@ -440,6 +445,26 @@ resources:
             "resources": []
         }
 
+  - name: az-healthcheck-tfstate
+    type: s3-iam
+    source:
+      bucket: ((state_bucket))
+      versioned_file: azhc.tfstate
+      region_name: ((aws_region))
+      initial_version: "-"
+      initial_content_text: |
+        {
+            "version": 4,
+            "terraform_version": "0.12.29",
+            "serial": 0,
+            "outputs": {
+              "healthcheck_address_a": { "value": "", "type": "string" },
+              "healthcheck_address_b": { "value": "", "type": "string" },
+              "healthcheck_address_c": { "value": "", "type": "string" }
+            },
+            "resources": []
+        }
+
   - name: cf-manifest
     type: s3-iam
     source:
@@ -558,6 +583,11 @@ resources:
     type: time
     source:
       interval: 30m
+
+  - name: az-healthcheck-timer
+    type: time
+    source:
+      interval: 10m
 
   - name: billing-smoke-tests-timer
     type: time
@@ -790,6 +820,7 @@ jobs:
             BRANCH: ((branch_name))
             MAKEFILE_ENV_TARGET: ((makefile_env_target))
             AWS_DEFAULT_REGION: ((aws_region))
+            ENABLE_AZ_HEALTHCHECK: ((enable_az_healthcheck))
             SELF_UPDATE_PIPELINE: ((self_update_pipeline))
             PIPELINES_TO_UPDATE: ((pipeline_name))
             ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
@@ -1527,6 +1558,62 @@ jobs:
             file: updated-tfstate/vpc-peering.tfstate
       - *end-grafana-job-annotation
 
+  - name: az-healthcheck-terraform
+    serial_groups: [cf-deploy]
+    serial: true
+    plan:
+      - in_parallel:
+        - *add-grafana-job-annotation
+        - <<: *get-paas-cf
+          passed: ['pre-deploy']
+        - get: pipeline-trigger
+          passed: ['pre-deploy']
+          trigger: true
+        - get: az-healthcheck-tfstate
+
+      - task: terraform-apply-az-healthcheck
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *terraform-image-resource
+          inputs:
+            - name: paas-cf
+            - name: az-healthcheck-tfstate
+          outputs:
+            - name: updated-tfstate
+          params:
+            TF_VAR_region: ((aws_region))
+            AWS_DEFAULT_REGION: ((aws_region))
+            ENABLE_AZ_HEALTHCHECK: ((enable_az_healthcheck))
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                cp az-healthcheck-tfstate/azhc.tfstate updated-tfstate/azhc.tfstate
+
+                if [ "${ENABLE_AZ_HEALTHCHECK:-}" != "true" ]; then
+                  echo "Availabilty Zone Healthchecks have been disabled."
+                  exit 0
+                fi
+
+                terraform init paas-cf/terraform/az-monitoring
+
+                sh paas-cf/terraform/./update-terraform-providers.sh updated-tfstate/azhc.tfstate
+
+                terraform apply \
+                  -auto-approve=true \
+                  -state=updated-tfstate/azhc.tfstate \
+                  paas-cf/terraform/az-monitoring
+
+        ensure:
+          put: az-healthcheck-tfstate
+          params:
+            file: updated-tfstate/azhc.tfstate
+
+      - *end-grafana-job-annotation
+
   - name: disable-az-a-vpc
     old_name: disable-az-a
     serial_groups: [operator]
@@ -2249,6 +2336,168 @@ jobs:
         ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
         MESSAGE_TYPE: az-disabled-vpc
         CONTEXT: c
+
+  - name: az-a-healthcheck
+    serial: true
+    plan:
+      - in_parallel:
+          - get: az-healthcheck-timer
+            trigger: ((enable_az_healthcheck))
+          - <<: *get-paas-cf
+            passed: ['az-healthcheck-terraform']
+          - get: az-healthcheck-tfstate
+            passed: ['az-healthcheck-terraform']
+
+      - task: extract-terraform-variables
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *terraform-image-resource
+          inputs:
+            - name: paas-cf
+            - name: az-healthcheck-tfstate
+          outputs:
+            - name: terraform-variables
+          params:
+            AVAILABILITY_ZONE: ((aws_region))a
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                terraform output \
+                  -state=az-healthcheck-tfstate/azhc.tfstate \
+                  -raw \
+                  healthcheck_address_a > "terraform-variables/${AVAILABILITY_ZONE}"
+
+      - task: curl-az-healthcheck-a
+        tags: [colocated-with-web]
+        file: paas-cf/concourse/tasks/curl-az-healthcheck.yml
+        params:
+          AVAILABILITY_ZONE: ((aws_region))a
+          ENABLE_AZ_HEALTHCHECK: ((enable_az_healthcheck))
+
+    on_failure:
+      task: send-nagging-email-alert
+      tags: [colocated-with-web]
+      file: paas-cf/concourse/tasks/send-nagging-email-alert.yml
+      params:
+        AWS_DEFAULT_REGION: ((aws_region))
+        DEPLOY_ENV: ((deploy_env))
+        SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+        ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
+        ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
+        MESSAGE_TYPE: az-healthcheck
+        CONTEXT: ((aws_region))a
+
+  - name: az-b-healthcheck
+    serial: true
+    plan:
+      - in_parallel:
+          - get: az-healthcheck-timer
+            trigger: ((enable_az_healthcheck))
+          - <<: *get-paas-cf
+            passed: ['az-healthcheck-terraform']
+          - get: az-healthcheck-tfstate
+            passed: ['az-healthcheck-terraform']
+
+      - task: extract-terraform-variables
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *terraform-image-resource
+          inputs:
+            - name: paas-cf
+            - name: az-healthcheck-tfstate
+          outputs:
+            - name: terraform-variables
+          params:
+            AVAILABILITY_ZONE: ((aws_region))b
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                terraform output \
+                  -state=az-healthcheck-tfstate/azhc.tfstate \
+                  -raw \
+                  healthcheck_address_b > "terraform-variables/${AVAILABILITY_ZONE}"
+
+      - task: curl-az-healthcheck-b
+        tags: [colocated-with-web]
+        file: paas-cf/concourse/tasks/curl-az-healthcheck.yml
+        params:
+          AVAILABILITY_ZONE: ((aws_region))b
+          ENABLE_AZ_HEALTHCHECK: ((enable_az_healthcheck))
+
+    on_failure:
+      task: send-nagging-email-alert
+      tags: [colocated-with-web]
+      file: paas-cf/concourse/tasks/send-nagging-email-alert.yml
+      params:
+        AWS_DEFAULT_REGION: ((aws_region))
+        DEPLOY_ENV: ((deploy_env))
+        SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+        ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
+        ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
+        MESSAGE_TYPE: az-healthcheck
+        CONTEXT: ((aws_region))b
+
+  - name: az-c-healthcheck
+    serial: true
+    plan:
+      - in_parallel:
+          - get: az-healthcheck-timer
+            trigger: ((enable_az_healthcheck))
+          - <<: *get-paas-cf
+            passed: ['az-healthcheck-terraform']
+          - get: az-healthcheck-tfstate
+            passed: ['az-healthcheck-terraform']
+
+      - task: extract-terraform-variables
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *terraform-image-resource
+          inputs:
+            - name: paas-cf
+            - name: az-healthcheck-tfstate
+          outputs:
+            - name: terraform-variables
+          params:
+            AVAILABILITY_ZONE: ((aws_region))c
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                terraform output \
+                  -state=az-healthcheck-tfstate/azhc.tfstate \
+                  -raw \
+                  healthcheck_address_c > "terraform-variables/${AVAILABILITY_ZONE}"
+
+      - task: curl-az-healthcheck-c
+        tags: [colocated-with-web]
+        file: paas-cf/concourse/tasks/curl-az-healthcheck.yml
+        params:
+          AVAILABILITY_ZONE: ((aws_region))c
+          ENABLE_AZ_HEALTHCHECK: ((enable_az_healthcheck))
+
+    on_failure:
+      task: send-nagging-email-alert
+      tags: [colocated-with-web]
+      file: paas-cf/concourse/tasks/send-nagging-email-alert.yml
+      params:
+        AWS_DEFAULT_REGION: ((aws_region))
+        DEPLOY_ENV: ((deploy_env))
+        SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+        ALERT_EMAIL_ADDRESS: ((ALERT_EMAIL_ADDRESS))
+        ENABLE_ALERT_NOTIFICATIONS: ((ENABLE_ALERT_NOTIFICATIONS))
+        MESSAGE_TYPE: az-healthcheck
+        CONTEXT: ((aws_region))c
 
   - name: generate-cf-config
     serial_groups: [cf-deploy]

--- a/concourse/scripts/nagging_email.sh
+++ b/concourse/scripts/nagging_email.sh
@@ -66,6 +66,24 @@ EOF
   }
 }
 EOF
+  elif [ "${MESSAGE_TYPE}" = 'az-healthcheck' ]; then
+    cat <<EOF > message.json
+{
+  "Subject": {
+    "Data": "AZ ${CONTEXT} is no longer reachable in ${DEPLOY_ENV}'s VPC"
+  },
+  "Body": {
+    "Html": {
+      "Data": "<b>${DEPLOY_ENV}</b>'s VPC appears to be missing an AZ \
+      <b>${CONTEXT}</b>. If it's indeed Amazon's issue, we may need to consider disabling \
+      an AZ with boash. See \
+      <a href='https://deployer.${SYSTEM_DNS_ZONE_NAME}/teams/main/pipelines/create-cloudfoundry?group=health'>Concourse</a> \
+      for details<br/>Alternatively, something else caused this check to fail, which is also \
+      something that should be investigated."
+    }
+  }
+}
+EOF
   fi
 }
 

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -113,6 +113,7 @@ skip_autodelete_await: "${SKIP_AUTODELETE_AWAIT:-false}"
 ca_rotation_expiry_days: "${CA_ROTATION_EXPIRY_DAYS}"
 enable_paas_admin_continuous_deploy: ${ENABLE_PAAS_ADMIN_CONTINUOUS_DEPLOY:-true}
 disabled_azs: ${DISABLED_AZS:-}
+enable_az_healthcheck: ${ENABLE_AZ_HEALTHCHECK:-}
 EOF
   echo -e "pipeline_lock_git_private_key: |\\n  ${git_id_rsa//$'\n'/$'\n'  }"
 }

--- a/concourse/tasks/curl-az-healthcheck.yml
+++ b/concourse/tasks/curl-az-healthcheck.yml
@@ -1,0 +1,34 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: ghcr.io/alphagov/paas/curl-ssl
+    tag: a1262c2a552b9d3db7db2993c0494bde1f5ad5c2
+params:
+  AVAILABILITY_ZONE:
+  ENABLE_AZ_HEALTHCHECK:
+inputs:
+  - name: terraform-variables
+  - name: paas-cf
+run:
+  path: ash
+  args:
+    - -e
+    - -c
+    - |
+      echo "Checking the ability to perform tests on ${AVAILABILITY_ZONE}..."
+
+      if [ "${ENABLE_AZ_HEALTHCHECK:-}" = "false" ]; then
+        echo "Availabilty Zone Healthchecks have been disabled."
+        exit 0
+      fi
+
+      echo "Loading up the terraform outputs..."
+      HEALTHCHECK_IP=$(cat "terraform-variables/${AVAILABILITY_ZONE}")
+      export HEALTHCHECK_IP
+
+      # shellcheck disable=SC2154
+      echo "Getting a response from the healthcheck in ${AVAILABILITY_ZONE} at ${HEALTHCHECK_IP}..."
+      curl "http://${HEALTHCHECK_IP}:3000"
+      

--- a/terraform/az-monitoring/main.tf
+++ b/terraform/az-monitoring/main.tf
@@ -1,0 +1,69 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_ami" "amazon_linux_2" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-ebs"]
+  }
+}
+
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "az-healthcheck"
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+}
+
+resource "aws_route_table" "main" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+}
+
+module "healthcheck_a" {
+  source = "./module"
+
+  ami                = data.aws_ami.amazon_linux_2.id
+  cidr               = "10.0.1.0/24"
+  region             = var.region
+  aws_route_table_id = aws_route_table.main.id
+  vpc_id             = aws_vpc.main.id
+  zone               = "a"
+}
+
+module "healthcheck_b" {
+  source = "./module"
+
+  ami                = data.aws_ami.amazon_linux_2.id
+  cidr               = "10.0.2.0/24"
+  region             = var.region
+  aws_route_table_id = aws_route_table.main.id
+  vpc_id             = aws_vpc.main.id
+  zone               = "b"
+}
+
+module "healthcheck_c" {
+  source = "./module"
+
+  ami                = data.aws_ami.amazon_linux_2.id
+  cidr               = "10.0.3.0/24"
+  region             = var.region
+  aws_route_table_id = aws_route_table.main.id
+  vpc_id             = aws_vpc.main.id
+  zone               = "c"
+}

--- a/terraform/az-monitoring/module/main.tf
+++ b/terraform/az-monitoring/module/main.tf
@@ -1,0 +1,79 @@
+resource "aws_subnet" "main" {
+  availability_zone = "${var.region}${var.zone}"
+  cidr_block        = var.cidr
+  vpc_id            = var.vpc_id
+
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "az-healthcheck/${var.zone}"
+  }
+}
+
+resource "aws_route_table_association" "main" {
+  subnet_id      = aws_subnet.main.id
+  route_table_id = var.aws_route_table_id
+}
+
+resource "aws_security_group" "access_sg" {
+  name        = "az-healthcheck/${var.zone}"
+  description = "Security group for AZ Healthchecks allowing access"
+  vpc_id      = aws_subnet.main.vpc_id
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port        = 3000
+    to_port          = 3000
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  tags = {
+    Name = "az-healthcheck/${var.zone}"
+  }
+}
+
+resource "aws_instance" "healthcheck" {
+  ami           = var.ami
+  instance_type = var.instance_type
+  subnet_id     = aws_subnet.main.id
+
+  availability_zone = "${var.region}${var.zone}"
+  vpc_security_group_ids = [
+    aws_security_group.access_sg.id,
+  ]
+
+  user_data = <<-EOF
+    #!/bin/bash
+    set -ex
+    sudo yum update -y
+    sudo amazon-linux-extras install docker -y
+    sudo service docker start
+    sudo usermod -a -G docker ec2-user
+    su - ec2-user
+    docker run -d -p 3000:3000 ghcr.io/alphagov/paas/simple-healthcheck
+  EOF
+
+  tags = {
+    Name = "az-healthcheck/${var.zone}"
+  }
+
+  monitoring              = true
+  disable_api_termination = false
+  ebs_optimized           = true
+}

--- a/terraform/az-monitoring/module/outputs.tf
+++ b/terraform/az-monitoring/module/outputs.tf
@@ -1,0 +1,3 @@
+output "ip" {
+  value = aws_instance.healthcheck.public_ip
+}

--- a/terraform/az-monitoring/module/variables.tf
+++ b/terraform/az-monitoring/module/variables.tf
@@ -1,0 +1,28 @@
+variable "ami" {
+  description = "The AMI ID to be rolled out onto the VMs"
+}
+
+variable "cidr" {
+  description = "The CIDR block for the subnet to be created in"
+}
+
+variable "instance_type" {
+  default     = "t3.nano"
+  description = "The instance type and sizing used for the VMs"
+}
+
+variable "region" {
+  description = "AWS region"
+}
+
+variable "vpc_id" {
+  description = "ID of VPC created in main 'vpc' terraform"
+}
+
+variable "zone" {
+  description = "The regions availability zone to spin up infrastructure in (ie: a, b, c)"
+}
+
+variable "aws_route_table_id" {
+  description = "Route Table ID for association with subnets"
+}

--- a/terraform/az-monitoring/outputs.tf
+++ b/terraform/az-monitoring/outputs.tf
@@ -1,0 +1,11 @@
+output "healthcheck_address_a" {
+    value = module.healthcheck_a.ip
+}
+
+output "healthcheck_address_b" {
+    value = module.healthcheck_b.ip
+}
+
+output "healthcheck_address_c" {
+    value = module.healthcheck_c.ip
+}

--- a/terraform/az-monitoring/variables.tf
+++ b/terraform/az-monitoring/variables.tf
@@ -1,0 +1,3 @@
+variable "region" {
+  description = "AWS region"
+}

--- a/terraform/az-monitoring/versions.tf
+++ b/terraform/az-monitoring/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~>2.0"
+    }
+  }
+  required_version = ">= 0.14"
+}

--- a/tools/simple-healthcheck/.gitignore
+++ b/tools/simple-healthcheck/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/tools/simple-healthcheck/Dockerfile
+++ b/tools/simple-healthcheck/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:alpine
+
+WORKDIR /app
+
+COPY index.js index.js
+COPY package.json package.json
+
+RUN npm install
+
+ENV PORT 3000
+
+ENTRYPOINT [ "npm", "run", "start" ]

--- a/tools/simple-healthcheck/index.js
+++ b/tools/simple-healthcheck/index.js
@@ -1,0 +1,11 @@
+const Koa = require('koa');
+const app = new Koa();
+
+app.use(async ctx => {
+    ctx.body = {
+        status: 'OK',
+        timestamp: new Date() / 1000,
+    };
+});
+
+app.listen(process.env.PORT || 3000);

--- a/tools/simple-healthcheck/package.json
+++ b/tools/simple-healthcheck/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "simple-healthcheck",
+  "version": "1.0.0",
+  "description": "Very simple dynamic API to determine if the server is running.",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "koa": "^2.13.1"
+  }
+}


### PR DESCRIPTION
What
----

We'd like to be simply running a small application on different set of
services, with very minimal response time and data. We'd like to assure
the response is not cachable - or rather that we can determine if it
hasn't been.

We will be running 3 VMs across all AZ running out healthcheck
application, which then later will be pingable by our monitoring system.

How to review
-------------

- Code review
- Run the pipelines with `DISABLE_AZ_HEALTHCHECK=false`
- Monitor checks

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
