### PR TITLE
[#177724957] elasticache broker: add plans for redis 6.x

### DIFF
--- a/config/billing/config-parts/redis_pricing_plans.json.erb
+++ b/config/billing/config-parts/redis_pricing_plans.json.erb
@@ -136,6 +136,64 @@
 	  "guid" => "f60443d9-3e9f-4c9b-8653-c83b6418292e",
 	  "ha" => true,
 	  "aws_price" => price("elasticache_m5_2xlarge")
+	},
+
+	# Redis 6.x
+	{
+	  "name" => "micro-6.x",
+	  "valid_from" => "2021-08-01",
+	  "guid" => "1497f021-8d4c-46e0-90b7-ecc4cf66d115",
+	  "ha" => false,
+	  "aws_price" => price("elasticache_t3_micro")
+	},
+	{
+	  "name" => "micro-ha-6.x",
+	  "valid_from" => "2021-08-01",
+	  "guid" => "3eb66000-bd2b-467b-bf2f-8bbb1b39944f",
+	  "ha" => true,
+	  "aws_price" => price("elasticache_t3_micro")
+    },
+	{
+	  "name" => "tiny-6.x",
+	  "valid_from" => "2021-08-01",
+	  "guid" => "5cebcc74-0ef5-4df8-8a89-e147a4833fe1",
+	  "ha" => false,
+	  "aws_price" => price("elasticache_t2_small")
+	},
+	{
+	  "name" => "tiny-ha-6.x",
+	  "valid_from" => "2021-08-01",
+	  "guid" => "b1e02f1c-6929-4d37-86dc-d9db72ee371d",
+	  "ha" => true,
+	  "aws_price" => price("elasticache_t2_small")
+	},
+	{
+	  "name" => "small-ha-6.x",
+	  "valid_from" => "2021-08-01",
+	  "guid" => "5c67ef39-46fc-4e07-b66e-167e817371f5",
+	  "ha" => true,
+		"aws_price" => price("elasticache_t2_medium")
+	},
+	{
+	  "name" => "medium-ha-6.x",
+	  "valid_from" => "2021-08-01",
+	  "guid" => "490883f3-fb6c-4ad6-8106-466eb65e5872",
+	  "ha" => true,
+    "aws_price" => price("elasticache_m5_large")
+	},
+    {
+	  "name" => "large-ha-6.x",
+	  "valid_from" => "2021-08-01",
+	  "guid" => "f348cad2-8006-4cd4-af71-11fb8d152c6b",
+	  "ha" => true,
+	  "aws_price" => price("elasticache_m5_xlarge")
+	},
+    {
+	  "name" => "xlarge-ha-6.x",
+	  "valid_from" => "2021-08-01",
+	  "guid" => "aeebc36b-dda6-4e4a-9417-1bd9c4862ad7",
+	  "ha" => true,
+	  "aws_price" => price("elasticache_m5_2xlarge")
 	}
 
 ] %>

--- a/config/billing/output/eu-west-1.json
+++ b/config/billing/output/eu-west-1.json
@@ -3017,6 +3017,118 @@
 			]
 		},
 		{
+			"name": "redis micro-6.x",
+			"valid_from": "2021-08-01",
+			"plan_guid": "1497f021-8d4c-46e0-90b7-ecc4cf66d115",
+			"number_of_nodes": 1,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.018",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis micro-ha-6.x",
+			"valid_from": "2021-08-01",
+			"plan_guid": "3eb66000-bd2b-467b-bf2f-8bbb1b39944f",
+			"number_of_nodes": 2,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.018",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis tiny-6.x",
+			"valid_from": "2021-08-01",
+			"plan_guid": "5cebcc74-0ef5-4df8-8a89-e147a4833fe1",
+			"number_of_nodes": 1,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.036",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis tiny-ha-6.x",
+			"valid_from": "2021-08-01",
+			"plan_guid": "b1e02f1c-6929-4d37-86dc-d9db72ee371d",
+			"number_of_nodes": 2,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.036",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis small-ha-6.x",
+			"valid_from": "2021-08-01",
+			"plan_guid": "5c67ef39-46fc-4e07-b66e-167e817371f5",
+			"number_of_nodes": 2,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.073",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis medium-ha-6.x",
+			"valid_from": "2021-08-01",
+			"plan_guid": "490883f3-fb6c-4ad6-8106-466eb65e5872",
+			"number_of_nodes": 2,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.172",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis large-ha-6.x",
+			"valid_from": "2021-08-01",
+			"plan_guid": "f348cad2-8006-4cd4-af71-11fb8d152c6b",
+			"number_of_nodes": 2,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.343",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis xlarge-ha-6.x",
+			"valid_from": "2021-08-01",
+			"plan_guid": "aeebc36b-dda6-4e4a-9417-1bd9c4862ad7",
+			"number_of_nodes": 2,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.686",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
 			"name": "cloudfront cdn-route",
 			"valid_from": "2017-01-01",
 			"plan_guid": "fc055c72-1075-44c9-9aee-bddd52e1b053",

--- a/config/billing/output/eu-west-2.json
+++ b/config/billing/output/eu-west-2.json
@@ -3017,6 +3017,118 @@
 			]
 		},
 		{
+			"name": "redis micro-6.x",
+			"valid_from": "2021-08-01",
+			"plan_guid": "1497f021-8d4c-46e0-90b7-ecc4cf66d115",
+			"number_of_nodes": 1,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.019",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis micro-ha-6.x",
+			"valid_from": "2021-08-01",
+			"plan_guid": "3eb66000-bd2b-467b-bf2f-8bbb1b39944f",
+			"number_of_nodes": 2,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.019",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis tiny-6.x",
+			"valid_from": "2021-08-01",
+			"plan_guid": "5cebcc74-0ef5-4df8-8a89-e147a4833fe1",
+			"number_of_nodes": 1,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.038",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis tiny-ha-6.x",
+			"valid_from": "2021-08-01",
+			"plan_guid": "b1e02f1c-6929-4d37-86dc-d9db72ee371d",
+			"number_of_nodes": 2,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.038",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis small-ha-6.x",
+			"valid_from": "2021-08-01",
+			"plan_guid": "5c67ef39-46fc-4e07-b66e-167e817371f5",
+			"number_of_nodes": 2,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.077",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis medium-ha-6.x",
+			"valid_from": "2021-08-01",
+			"plan_guid": "490883f3-fb6c-4ad6-8106-466eb65e5872",
+			"number_of_nodes": 2,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.18",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis large-ha-6.x",
+			"valid_from": "2021-08-01",
+			"plan_guid": "f348cad2-8006-4cd4-af71-11fb8d152c6b",
+			"number_of_nodes": 2,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.36",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "redis xlarge-ha-6.x",
+			"valid_from": "2021-08-01",
+			"plan_guid": "aeebc36b-dda6-4e4a-9417-1bd9c4862ad7",
+			"number_of_nodes": 2,
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.721",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
 			"name": "cloudfront cdn-route",
 			"valid_from": "2017-01-01",
 			"plan_guid": "fc055c72-1075-44c9-9aee-bddd52e1b053",

--- a/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
+++ b/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
@@ -8,7 +8,7 @@
       parameters:
         cluster-enabled: 'no'
         maxmemory-policy: volatile-lru
-        reserved-memory: '0'
+        reserved-memory-percent: '0'
 
     non_ha_plan: &elasticache_non_ha_plan
       replicas_per_node_group: 0
@@ -50,6 +50,11 @@
       engine: redis
       engine_version: 5.0.6
       cache_parameter_group_family: redis5.0
+
+    redis_6_x: &elasticache_redis_6_x
+      engine: redis
+      engine_version: 6.x
+      cache_parameter_group_family: redis6.x
 
 - type: replace
   path: /releases/-
@@ -391,6 +396,120 @@
                             unit: GB
                           version: '5'
 
+                    # 6.x
+                    - id: 1497f021-8d4c-46e0-90b7-ecc4cf66d115
+                      name: micro-6.x
+                      description: "568MB RAM, single node, no failover, daily backups. Free for trial orgs. Costs for billable orgs."
+                      free: true
+                      metadata:
+                        displayName: Tiny
+                        AdditionalMetadata:
+                          backups: true
+                          encrypted: true
+                          highlyAvailable: false
+                          memory:
+                            amount: 568
+                            unit: MB
+                          version: '6'
+                    - id: 3eb66000-bd2b-467b-bf2f-8bbb1b39944f
+                      name: micro-ha-6.x
+                      description: "568MB RAM, highly-available, daily backups."
+                      free: false
+                      metadata:
+                        displayName: Tiny
+                        AdditionalMetadata:
+                          backups: true
+                          encrypted: true
+                          highlyAvailable: true
+                          memory:
+                            amount: 568
+                            unit: MB
+                          version: '6'
+                    - id: 5cebcc74-0ef5-4df8-8a89-e147a4833fe1
+                      name: tiny-6.x
+                      description: "1.5GB RAM, single node, no failover, daily backups (for instances created after 21/1/2019). Free for trial orgs. Costs for billable orgs."
+                      free: true
+                      metadata:
+                        displayName: Tiny
+                        AdditionalMetadata:
+                          backups: true
+                          encrypted: true
+                          highlyAvailable: false
+                          memory:
+                            amount: 1.5
+                            unit: GB
+                          version: '6'
+                    - id: b1e02f1c-6929-4d37-86dc-d9db72ee371d
+                      name: tiny-ha-6.x
+                      description: 1.5GB RAM, highly-available, daily backups
+                      free: false
+                      metadata:
+                        displayName: Tiny
+                        AdditionalMetadata:
+                          backups: true
+                          encrypted: true
+                          highlyAvailable: true
+                          memory:
+                            amount: 1.5
+                            unit: GB
+                          version: '6'
+                    - id: 5c67ef39-46fc-4e07-b66e-167e817371f5
+                      name: small-ha-6.x
+                      description: 3GB RAM, highly-available, daily backups
+                      free: false
+                      metadata:
+                        displayName: Small
+                        AdditionalMetadata:
+                          backups: true
+                          encrypted: true
+                          highlyAvailable: true
+                          memory:
+                            amount: 3
+                            unit: GB
+                          version: '6'
+                    - id: 490883f3-fb6c-4ad6-8106-466eb65e5872
+                      name: medium-ha-6.x
+                      description: 6.37GB RAM, highly-available, daily backups
+                      free: false
+                      metadata:
+                        displayName: Medium
+                        AdditionalMetadata:
+                          backups: true
+                          encrypted: true
+                          highlyAvailable: true
+                          memory:
+                            amount: 6.37
+                            unit: GB
+                          version: '6'
+                    - id: f348cad2-8006-4cd4-af71-11fb8d152c6b
+                      name: large-ha-6.x
+                      description: 12.93GB RAM, highly-available, daily backups
+                      free: false
+                      metadata:
+                        displayName: Large
+                        AdditionalMetadata:
+                          backups: true
+                          encrypted: true
+                          highlyAvailable: true
+                          memory:
+                            amount: 12.93
+                            unit: GB
+                          version: '6'
+                    - id: aeebc36b-dda6-4e4a-9417-1bd9c4862ad7
+                      name: xlarge-ha-6.x
+                      description: 26.04GB RAM, highly-available, daily backups
+                      free: false
+                      metadata:
+                        displayName: XLarge
+                        AdditionalMetadata:
+                          backups: true
+                          encrypted: true
+                          highlyAvailable: true
+                          memory:
+                            amount: 26.04
+                            unit: GB
+                          version: '6'
+
             plan_configs:
               3a51701c-eef3-447c-882b-907ad2bcb7ab: #tiny-clustered-3.2
                 <<: *elasticache_cache_cluster_config # yamllint disable-line
@@ -506,6 +625,54 @@
               f60443d9-3e9f-4c9b-8653-c83b6418292e: #xlarge-ha-5.x
                 <<: *elasticache_cache_cluster_config # yamllint disable-line
                 <<: *elasticache_redis_5_x # yamllint disable-line
+                <<: *elasticache_ha_plan # yamllint disable-line
+                <<: *elasticache_xlarge_plan # yamllint disable-line
+
+              1497f021-8d4c-46e0-90b7-ecc4cf66d115: #micro-6.x
+                <<: *elasticache_cache_cluster_config # yamllint disable-line
+                <<: *elasticache_redis_6_x # yamllint disable-line
+                <<: *elasticache_non_ha_plan # yamllint disable-line
+                <<: *elasticache_micro_plan # yamllint disable-line
+
+              3eb66000-bd2b-467b-bf2f-8bbb1b39944f: #micro-ha-6.x
+                <<: *elasticache_cache_cluster_config # yamllint disable-line
+                <<: *elasticache_redis_6_x # yamllint disable-line
+                <<: *elasticache_ha_plan # yamllint disable-line
+                <<: *elasticache_micro_plan # yamllint disable-line
+
+              5cebcc74-0ef5-4df8-8a89-e147a4833fe1: #tiny-6.x
+                <<: *elasticache_cache_cluster_config # yamllint disable-line
+                <<: *elasticache_redis_6_x # yamllint disable-line
+                <<: *elasticache_non_ha_plan # yamllint disable-line
+                <<: *elasticache_tiny_plan # yamllint disable-line
+
+              b1e02f1c-6929-4d37-86dc-d9db72ee371d: #tiny-ha-6.x
+                <<: *elasticache_cache_cluster_config # yamllint disable-line
+                <<: *elasticache_redis_6_x # yamllint disable-line
+                <<: *elasticache_ha_plan # yamllint disable-line
+                <<: *elasticache_tiny_plan # yamllint disable-line
+
+              5c67ef39-46fc-4e07-b66e-167e817371f5: #small-ha-6.x
+                <<: *elasticache_cache_cluster_config # yamllint disable-line
+                <<: *elasticache_redis_6_x # yamllint disable-line
+                <<: *elasticache_ha_plan # yamllint disable-line
+                <<: *elasticache_small_plan # yamllint disable-line
+
+              490883f3-fb6c-4ad6-8106-466eb65e5872: #medium-ha-6.x
+                <<: *elasticache_cache_cluster_config # yamllint disable-line
+                <<: *elasticache_redis_6_x # yamllint disable-line
+                <<: *elasticache_ha_plan # yamllint disable-line
+                <<: *elasticache_medium_plan # yamllint disable-line
+
+              f348cad2-8006-4cd4-af71-11fb8d152c6b: #large-ha-6.x
+                <<: *elasticache_cache_cluster_config # yamllint disable-line
+                <<: *elasticache_redis_6_x # yamllint disable-line
+                <<: *elasticache_ha_plan # yamllint disable-line
+                <<: *elasticache_large_plan # yamllint disable-line
+
+              aeebc36b-dda6-4e4a-9417-1bd9c4862ad7: #xlarge-ha-6.x
+                <<: *elasticache_cache_cluster_config # yamllint disable-line
+                <<: *elasticache_redis_6_x # yamllint disable-line
                 <<: *elasticache_ha_plan # yamllint disable-line
                 <<: *elasticache_xlarge_plan # yamllint disable-line
 

--- a/platform-tests/broker-acceptance/redis_service_test.go
+++ b/platform-tests/broker-acceptance/redis_service_test.go
@@ -19,6 +19,7 @@ var _ = Describe("Redis backing service", func() {
 			"tiny-3.2",
 			"tiny-4.x",
 			"tiny-5.x",
+			"tiny-6.x",
 		}
 
 		knownPlanNames = []string{
@@ -41,6 +42,14 @@ var _ = Describe("Redis backing service", func() {
 			"medium-ha-5.x",
 			"large-ha-5.x",
 			"xlarge-ha-5.x",
+			"micro-6.x",
+			"micro-ha-6.x",
+			"tiny-6.x",
+			"tiny-ha-6.x",
+			"small-ha-6.x",
+			"medium-ha-6.x",
+			"large-ha-6.x",
+			"xlarge-ha-6.x",
 		}
 	)
 


### PR DESCRIPTION
What
----

Config mostly cloned from 5.x plans except we no longer have any control over minor redis versions.

Here I have also switched the common parameter `reserved-memory` to `reserved-memory-percent`, which seems to be the newer more broadly supported form of the parameter, because it seems like `redis6.x` has quietly dropped support for `reserved-memory`. Still, since this is universally set to 0, surely 0% of X = 0, right?

Thoughts welcome.

How to review
-------------

Deploy. Try to provision a redis 6.x instance.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
