### PR TITLE
Grant Splunk broker access to gds-digital-identity-authentication

### DIFF
--- a/config/service-brokers/csls-splunk/prod-lon-config.json
+++ b/config/service-brokers/csls-splunk/prod-lon-config.json
@@ -8,6 +8,7 @@
     "ccs-document-upload",
     "ccs-pmp-idam",
     "ccs-report-management-info",
+    "gds-digital-identity-authentication",
     "gds-document-checking-service",
     "gds-shielded-vulnerable-people-service",
     "govuk-accounts",


### PR DESCRIPTION
What
----
Gives the `gds-digital-identity-authentication` org access to the Splunk broker

How to review
-------------
Did I get the org name right?

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
