### PR TITLE
Bump GitHub Actions Go version to 1.17

### DIFF
--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -6,7 +6,7 @@ env:
   PROMETHEUS_VERSION: "2.6.1"
   DEPLOY_ENV: "github"
   SHELLCHECK_VERSION: "0.7.1"
-  GO_VERSION: "1.15"
+  GO_VERSION: "1.17"
   RUBY_VERSION: "2.7"
 
 jobs:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/alphagov/paas-cf
+
+go 1.17


### PR DESCRIPTION
What
----

Our CI is currently failing as Gomega now requires Go >= 1.16.
Bumping to Go 1.17 which is the current release.
Also adding in a minimal `go.mod` as is required by Go >= 1.16.

Currently open PRs failing CI will require a rebase once this is merged.

How to review
-------------

- Code review
- Make sure CI tests are passing

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
