### PR TITLE
Increase London cell count to 117

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -5,7 +5,7 @@ diego_api_instances: 3
 cell_instances: 117
 router_instances: 15
 api_instances: 12
-doppler_instances: 57
+doppler_instances: 60
 log_api_instances: 30
 scheduler_instances: 6
 cc_worker_instances: 6

--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -2,7 +2,7 @@
 uaa_instances: 3
 nats_instances: 3
 diego_api_instances: 3
-cell_instances: 111
+cell_instances: 117
 router_instances: 15
 api_instances: 12
 doppler_instances: 57


### PR DESCRIPTION
What
----

We had a tenant notifying us of slow/timing out deployments in London and the current cell utilisation is close to the required cell count mark. Adding in 2x3 extra cells as recently we hit a maximum of 115 required.
Also increasing Doppler instance count to 60 as needs to be >= 50 percent Diego-cells and divisible by 3 (58.5 -> 60)

How to review
-------------

- Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
