### PR TITLE
[#175917036] Shield SRT access bucket policy

### DIFF
--- a/terraform/cloudfoundry/policies/elb_access_log_bucket.json.tpl
+++ b/terraform/cloudfoundry/policies/elb_access_log_bucket.json.tpl
@@ -2,11 +2,28 @@
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "ELBWriteS3Logs",
       "Effect": "Allow",
       "Action": "s3:PutObject",
       "Resource": "arn:aws:s3:::${bucket_name}/*/AWSLogs/*",
       "Principal": {
         "AWS": "arn:aws:iam::${principal}:root"
+      }
+    },
+    {
+      "Sid": "AWSDDoSResponseTeamAccessS3Bucket",
+      "Effect": "Allow",
+      "Action": [
+                "s3:GetBucketLocation",
+                "s3:GetObject",
+                "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}",
+        "arn:aws:s3:::${bucket_name}/*"
+      ],
+      "Principal": {
+        "Service": "drt.shield.amazonaws.com"
       }
     }
   ]


### PR DESCRIPTION
What
----

Allow the SRT access role to access our access log buttons. ([access](https://en.wikipedia.org/wiki/Semantic_satiation))

How to review
-------------

Run down a dev env

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
