### PR TITLE
BAU: Fix unbind_job make target

### DIFF
--- a/concourse/scripts/unbind_job.rb
+++ b/concourse/scripts/unbind_job.rb
@@ -10,7 +10,7 @@ def remove_passed(obj)
     if obj.key?("get") && obj["get"] == "paas-cf"
       obj.delete("passed")
     else
-      obj.each { |k, v| remove_passed(v) if %w[do aggregate in_parallel].include?(k) }
+      obj.each { |k, v| remove_passed(v) if %w[do aggregate in_parallel steps].include?(k) }
     end
   end
 end


### PR DESCRIPTION
What
----

`run_job` has been broken for a while.

We added `steps` under `in_parallel`, so it couldn't find the `get` step.

To fix this, when recursing, also scan any objects with the key `steps`.

How to review
-------------

Code Review
---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
