### PR TITLE
Tmp fix: git-resource for letsencrypt issue

### DIFF
--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -1,4 +1,14 @@
 ---
+resource_types:
+  # FIX ME: The server certificate verification fails when using the concourse
+  # version of the resource_type `git`. As a temporary fix we have docker image
+  # of the resource. This resource_type can be deleted when the issue is resolved
+  - name: git
+    type: docker-image
+    source:
+      repository: ghcr.io/alphagov/paas/git-resource
+      tag: 1f84d4a76b4a2491283e0107ae7ed4bc83c84d1b
+
 resources:
   - name: paas-cf
     type: git


### PR DESCRIPTION
The deployment-kick-off pipeline was missed in an [earlier bug-fix #2749](https://github.com/alphagov/paas-cf/pull/2749).

What
----

Add in a git-resource container image resource type to work around letsencrypt issue (change of root CA not present in current config).

How to review
-------------

Manually update pipeline, .e.g `make dev pipelines BRANCH=git-resource-tmp-fix-kick-off-pipeline` and see `deployment-kick-off` run without issue.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
