### PR TITLE
Increase the PaaS metrics acceptance test timeout to 30s

### DIFF
--- a/tools/metrics/acceptance/acceptance_suite_test.go
+++ b/tools/metrics/acceptance/acceptance_suite_test.go
@@ -85,7 +85,7 @@ func getMetricNames() ([]string, error) {
 }
 
 var _ = BeforeSuite(func() {
-	SetDefaultEventuallyTimeout(2 * time.Minute)          // Fail after 1m
+	SetDefaultEventuallyTimeout(10 * time.Minute)          // Fail after 10m
 	SetDefaultEventuallyPollingInterval(10 * time.Second) // Try every 10s
 
 	SetDefaultConsistentlyDuration(10 * time.Second)       // Test for 10s


### PR DESCRIPTION
What
----

PaaS metrics has a lot of metrics to generate, and in busy production
systems this can take a while. The default timeout was far too low, and was
causing regular test failures.


How to review
-------------

What do you think? Good idea?

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
