### PR TITLE
Make PostgreSQL 13 plans new-billing compatible

### DIFF
--- a/config/billing/config-parts/postgres_13_high_iops_pricing_plans.json.erb
+++ b/config/billing/config-parts/postgres_13_high_iops_pricing_plans.json.erb
@@ -1,6 +1,7 @@
 {
   "name": "postgres tiny-unencrypted-13 high-iops",
   "valid_from": "2021-08-01",
+  "valid_to": "9999-12-31",
   "plan_guid": "6dbfcf62-98a8-4e6e-a820-b56737e6f2d5",
   "storage_in_mb": 25600,
   "memory_in_mb": 0,
@@ -8,12 +9,16 @@
     {
       "name": "instance",
       "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_t3_micro") %>",
+      "formula_new": "ceil($time_in_seconds/3600) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_pg_t3_micro") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     },
     {
       "name": "storage",
       "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_storage") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     }
@@ -22,6 +27,7 @@
 {
   "name": "postgres small-13 high-iops",
   "valid_from": "2021-08-01",
+  "valid_to": "9999-12-31",
   "plan_guid": "201c2579-6887-4933-a19c-4c4f270e599a",
   "storage_in_mb": 102400,
   "memory_in_mb": 0,
@@ -29,12 +35,16 @@
     {
       "name": "instance",
       "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_t3_small") %>",
+      "formula_new": "ceil($time_in_seconds/3600) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_pg_t3_small") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     },
     {
       "name": "storage",
       "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_storage") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     }
@@ -43,6 +53,7 @@
 {
   "name": "postgres small-ha-13 high-iops",
   "valid_from": "2021-08-01",
+  "valid_to": "9999-12-31",
   "plan_guid": "dc3acad6-3f0a-4624-a6bf-af36e71a5fd5",
   "storage_in_mb": 102400,
   "memory_in_mb": 0,
@@ -50,12 +61,16 @@
     {
       "name": "instance",
       "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_t3_small_ha") %>",
+      "formula_new": "ceil($time_in_seconds/3600) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_pg_t3_small_ha") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     },
     {
       "name": "storage",
       "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage_ha") %>",
+      "formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_storage_ha") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     }
@@ -64,6 +79,7 @@
 {
   "name": "postgres medium-13 high-iops",
   "valid_from": "2021-08-01",
+  "valid_to": "9999-12-31",
   "plan_guid": "d4ec545a-3b44-4b7c-88f7-a5be1ba081bb",
   "storage_in_mb": 512000,
   "memory_in_mb": 0,
@@ -71,12 +87,16 @@
     {
       "name": "instance",
       "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_m5_large") %>",
+      "formula_new": "ceil($time_in_seconds/3600) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_pg_m5_large") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     },
     {
       "name": "storage",
       "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_storage") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     }
@@ -85,6 +105,7 @@
 {
   "name": "postgres medium-ha-13 high-iops",
   "valid_from": "2021-08-01",
+  "valid_to": "9999-12-31",
   "plan_guid": "599d4f3b-c4e6-42ff-950d-b4b2c36f333d",
   "storage_in_mb": 512000,
   "memory_in_mb": 0,
@@ -92,12 +113,16 @@
     {
       "name": "instance",
       "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_m5_large_ha") %>",
+      "formula_new": "ceil($time_in_seconds/3600) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_pg_m5_large_ha") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     },
     {
       "name": "storage",
       "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage_ha") %>",
+      "formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_storage_ha") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     }
@@ -106,6 +131,7 @@
 {
   "name": "postgres large-13 high-iops",
   "valid_from": "2021-08-01",
+  "valid_to": "9999-12-31",
   "plan_guid": "c127fb33-3c71-4a66-8108-a648756c4d0e",
   "storage_in_mb": 2621440,
   "memory_in_mb": 0,
@@ -113,12 +139,16 @@
     {
       "name": "instance",
       "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_m5_2xlarge") %>",
+      "formula_new": "ceil($time_in_seconds/3600) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_pg_m5_2xlarge") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     },
     {
       "name": "storage",
       "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_storage") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     }
@@ -127,6 +157,7 @@
 {
   "name": "postgres large-ha-13 high-iops",
   "valid_from": "2021-08-01",
+  "valid_to": "9999-12-31",
   "plan_guid": "83eb4c8e-78ee-49b5-9346-bddd08db3634",
   "storage_in_mb": 2621440,
   "memory_in_mb": 0,
@@ -134,12 +165,16 @@
     {
       "name": "instance",
       "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_m5_2xlarge_ha") %>",
+      "formula_new": "ceil($time_in_seconds/3600) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_pg_m5_2xlarge_ha") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     },
     {
       "name": "storage",
       "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage_ha") %>",
+      "formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_storage_ha") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     }
@@ -148,6 +183,7 @@
 {
   "name": "postgres xlarge-13 high-iops",
   "valid_from": "2021-08-01",
+  "valid_to": "9999-12-31",
   "plan_guid": "af1e4881-50f4-4d95-b34d-e8a43821ffe6",
   "storage_in_mb": 10485760,
   "memory_in_mb": 0,
@@ -155,12 +191,16 @@
     {
       "name": "instance",
       "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_m5_4xlarge") %>",
+      "formula_new": "ceil($time_in_seconds/3600) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_pg_m5_4xlarge") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     },
     {
       "name": "storage",
       "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_storage") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     }
@@ -169,6 +209,7 @@
 {
   "name": "postgres xlarge-ha-13 high-iops",
   "valid_from": "2021-08-01",
+  "valid_to": "9999-12-31",
   "plan_guid": "54e08489-46af-474d-936f-9c30f5cc4f48",
   "storage_in_mb": 10485760,
   "memory_in_mb": 0,
@@ -176,12 +217,16 @@
     {
       "name": "instance",
       "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_m5_4xlarge_ha") %>",
+      "formula_new": "ceil($time_in_seconds/3600) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_pg_m5_4xlarge_ha") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     },
     {
       "name": "storage",
       "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage_ha") %>",
+      "formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_storage_ha") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     }

--- a/config/billing/config-parts/postgres_13_pricing_plans.json.erb
+++ b/config/billing/config-parts/postgres_13_pricing_plans.json.erb
@@ -1,6 +1,7 @@
 {
   "name": "postgres tiny-unencrypted-13",
   "valid_from": "2021-08-01",
+  "valid_to": "9999-12-31",
   "plan_guid": "101f57ab-3c67-40ff-b0e9-8189bf1127fd",
   "storage_in_mb": 5120,
   "memory_in_mb": 0,
@@ -8,12 +9,16 @@
     {
       "name": "instance",
       "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_t3_micro") %>",
+      "formula_new": "ceil($time_in_seconds/3600) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_pg_t3_micro") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     },
     {
       "name": "storage",
       "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_storage") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     }
@@ -22,6 +27,7 @@
 {
   "name": "postgres small-13",
   "valid_from": "2021-08-01",
+  "valid_to": "9999-12-31",
   "plan_guid": "818aa859-7294-4a07-80da-87fbd719b1d5",
   "storage_in_mb": 102400,
   "memory_in_mb": 0,
@@ -29,12 +35,16 @@
     {
       "name": "instance",
       "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_t3_small") %>",
+      "formula_new": "ceil($time_in_seconds/3600) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_pg_t3_small") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     },
     {
       "name": "storage",
       "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_storage") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     }
@@ -43,6 +53,7 @@
 {
   "name": "postgres small-ha-13",
   "valid_from": "2021-08-01",
+  "valid_to": "9999-12-31",
   "plan_guid": "9c5d4479-2337-4c70-95a9-5e01b46d2644",
   "storage_in_mb": 102400,
   "memory_in_mb": 0,
@@ -50,12 +61,16 @@
     {
       "name": "instance",
       "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_t3_small_ha") %>",
+      "formula_new": "ceil($time_in_seconds/3600) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_pg_t3_small_ha") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     },
     {
       "name": "storage",
       "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage_ha") %>",
+      "formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_storage_ha") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     }
@@ -64,6 +79,7 @@
 {
   "name": "postgres medium-13",
   "valid_from": "2021-08-01",
+  "valid_to": "9999-12-31",
   "plan_guid": "0fd6ade0-c29c-4726-83c3-683502890e69",
   "storage_in_mb": 102400,
   "memory_in_mb": 0,
@@ -71,12 +87,16 @@
     {
       "name": "instance",
       "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_m5_large") %>",
+      "formula_new": "ceil($time_in_seconds/3600) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_pg_m5_large") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     },
     {
       "name": "storage",
       "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_storage") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     }
@@ -85,6 +105,7 @@
 {
   "name": "postgres medium-ha-13",
   "valid_from": "2021-08-01",
+  "valid_to": "9999-12-31",
   "plan_guid": "2cfd1d3c-1974-4ff4-b967-1caf5c6be484",
   "storage_in_mb": 102400,
   "memory_in_mb": 0,
@@ -92,12 +113,16 @@
     {
       "name": "instance",
       "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_m5_large_ha") %>",
+      "formula_new": "ceil($time_in_seconds/3600) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_pg_m5_large_ha") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     },
     {
       "name": "storage",
       "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage_ha") %>",
+      "formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_storage_ha") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     }
@@ -106,6 +131,7 @@
 {
   "name": "postgres large-13",
   "valid_from": "2021-08-01",
+  "valid_to": "9999-12-31",
   "plan_guid": "9b7aa58e-0818-4ab2-bbfb-1b0fdabab65c",
   "storage_in_mb": 577536,
   "memory_in_mb": 0,
@@ -113,12 +139,16 @@
     {
       "name": "instance",
       "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_m5_2xlarge") %>",
+      "formula_new": "ceil($time_in_seconds/3600) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_pg_m5_2xlarge") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     },
     {
       "name": "storage",
       "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_storage") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     }
@@ -127,6 +157,7 @@
 {
   "name": "postgres large-ha-13",
   "valid_from": "2021-08-01",
+  "valid_to": "9999-12-31",
   "plan_guid": "b5c5f6a2-4fe8-444b-b981-26cbaafbdade",
   "storage_in_mb": 577536,
   "memory_in_mb": 0,
@@ -134,12 +165,16 @@
     {
       "name": "instance",
       "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_m5_2xlarge_ha") %>",
+      "formula_new": "ceil($time_in_seconds/3600) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_pg_m5_2xlarge_ha") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     },
     {
       "name": "storage",
       "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage_ha") %>",
+      "formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_storage_ha") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     }
@@ -148,6 +183,7 @@
 {
   "name": "postgres xlarge-13",
   "valid_from": "2021-08-01",
+  "valid_to": "9999-12-31",
   "plan_guid": "5bb79c8f-467b-4f2f-a754-140f3df1bd59",
   "storage_in_mb": 2097152,
   "memory_in_mb": 0,
@@ -155,12 +191,16 @@
     {
       "name": "instance",
       "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_m5_4xlarge") %>",
+      "formula_new": "ceil($time_in_seconds/3600) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_pg_m5_4xlarge") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     },
     {
       "name": "storage",
       "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_storage") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     }
@@ -169,6 +209,7 @@
 {
   "name": "postgres xlarge-ha-13",
   "valid_from": "2021-08-01",
+  "valid_to": "9999-12-31",
   "plan_guid": "b6cf21d9-8955-44eb-8bb4-f5c9f2e04123",
   "storage_in_mb": 2097152,
   "memory_in_mb": 0,
@@ -176,12 +217,16 @@
     {
       "name": "instance",
       "formula": "ceil($time_in_seconds/3600) * <%= price("rds_pg_m5_4xlarge_ha") %>",
+      "formula_new": "ceil($time_in_seconds/3600) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_pg_m5_4xlarge_ha") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     },
     {
       "name": "storage",
       "formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("rds_storage_ha") %>",
+      "formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * <%= price("external_price") %>",
+      "external_price": <%= price("rds_storage_ha") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
     }

--- a/config/billing/output/eu-west-1.json
+++ b/config/billing/output/eu-west-1.json
@@ -2264,6 +2264,7 @@
 		{
 			"name": "postgres tiny-unencrypted-13",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "101f57ab-3c67-40ff-b0e9-8189bf1127fd",
 			"storage_in_mb": 5120,
 			"memory_in_mb": 0,
@@ -2271,12 +2272,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 0.02",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 0.02,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.127",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.127,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2285,6 +2290,7 @@
 		{
 			"name": "postgres small-13",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "818aa859-7294-4a07-80da-87fbd719b1d5",
 			"storage_in_mb": 102400,
 			"memory_in_mb": 0,
@@ -2292,12 +2298,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 0.039",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 0.039,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.127",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.127,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2306,6 +2316,7 @@
 		{
 			"name": "postgres small-ha-13",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "9c5d4479-2337-4c70-95a9-5e01b46d2644",
 			"storage_in_mb": 102400,
 			"memory_in_mb": 0,
@@ -2313,12 +2324,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 0.078",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 0.078,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.253",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.253,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2327,6 +2342,7 @@
 		{
 			"name": "postgres medium-13",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "0fd6ade0-c29c-4726-83c3-683502890e69",
 			"storage_in_mb": 102400,
 			"memory_in_mb": 0,
@@ -2334,12 +2350,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 0.197",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 0.197,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.127",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.127,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2348,6 +2368,7 @@
 		{
 			"name": "postgres medium-ha-13",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "2cfd1d3c-1974-4ff4-b967-1caf5c6be484",
 			"storage_in_mb": 102400,
 			"memory_in_mb": 0,
@@ -2355,12 +2376,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 0.394",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 0.394,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.253",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.253,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2369,6 +2394,7 @@
 		{
 			"name": "postgres large-13",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "9b7aa58e-0818-4ab2-bbfb-1b0fdabab65c",
 			"storage_in_mb": 577536,
 			"memory_in_mb": 0,
@@ -2376,12 +2402,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 0.788",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 0.788,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.127",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.127,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2390,6 +2420,7 @@
 		{
 			"name": "postgres large-ha-13",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "b5c5f6a2-4fe8-444b-b981-26cbaafbdade",
 			"storage_in_mb": 577536,
 			"memory_in_mb": 0,
@@ -2397,12 +2428,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 1.576",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 1.576,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.253",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.253,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2411,6 +2446,7 @@
 		{
 			"name": "postgres xlarge-13",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "5bb79c8f-467b-4f2f-a754-140f3df1bd59",
 			"storage_in_mb": 2097152,
 			"memory_in_mb": 0,
@@ -2418,12 +2454,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 1.576",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 1.576,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.127",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.127,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2432,6 +2472,7 @@
 		{
 			"name": "postgres xlarge-ha-13",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "b6cf21d9-8955-44eb-8bb4-f5c9f2e04123",
 			"storage_in_mb": 2097152,
 			"memory_in_mb": 0,
@@ -2439,12 +2480,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 3.152",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 3.152,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.253",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.253,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2453,6 +2498,7 @@
 		{
 			"name": "postgres tiny-unencrypted-13 high-iops",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "6dbfcf62-98a8-4e6e-a820-b56737e6f2d5",
 			"storage_in_mb": 25600,
 			"memory_in_mb": 0,
@@ -2460,12 +2506,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 0.02",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 0.02,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.127",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.127,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2474,6 +2524,7 @@
 		{
 			"name": "postgres small-13 high-iops",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "201c2579-6887-4933-a19c-4c4f270e599a",
 			"storage_in_mb": 102400,
 			"memory_in_mb": 0,
@@ -2481,12 +2532,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 0.039",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 0.039,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.127",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.127,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2495,6 +2550,7 @@
 		{
 			"name": "postgres small-ha-13 high-iops",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "dc3acad6-3f0a-4624-a6bf-af36e71a5fd5",
 			"storage_in_mb": 102400,
 			"memory_in_mb": 0,
@@ -2502,12 +2558,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 0.078",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 0.078,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.253",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.253,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2516,6 +2576,7 @@
 		{
 			"name": "postgres medium-13 high-iops",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "d4ec545a-3b44-4b7c-88f7-a5be1ba081bb",
 			"storage_in_mb": 512000,
 			"memory_in_mb": 0,
@@ -2523,12 +2584,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 0.197",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 0.197,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.127",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.127,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2537,6 +2602,7 @@
 		{
 			"name": "postgres medium-ha-13 high-iops",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "599d4f3b-c4e6-42ff-950d-b4b2c36f333d",
 			"storage_in_mb": 512000,
 			"memory_in_mb": 0,
@@ -2544,12 +2610,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 0.394",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 0.394,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.253",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.253,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2558,6 +2628,7 @@
 		{
 			"name": "postgres large-13 high-iops",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "c127fb33-3c71-4a66-8108-a648756c4d0e",
 			"storage_in_mb": 2621440,
 			"memory_in_mb": 0,
@@ -2565,12 +2636,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 0.788",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 0.788,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.127",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.127,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2579,6 +2654,7 @@
 		{
 			"name": "postgres large-ha-13 high-iops",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "83eb4c8e-78ee-49b5-9346-bddd08db3634",
 			"storage_in_mb": 2621440,
 			"memory_in_mb": 0,
@@ -2586,12 +2662,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 1.576",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 1.576,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.253",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.253,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2600,6 +2680,7 @@
 		{
 			"name": "postgres xlarge-13 high-iops",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "af1e4881-50f4-4d95-b34d-e8a43821ffe6",
 			"storage_in_mb": 10485760,
 			"memory_in_mb": 0,
@@ -2607,12 +2688,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 1.576",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 1.576,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.127",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.127,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2621,6 +2706,7 @@
 		{
 			"name": "postgres xlarge-ha-13 high-iops",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "54e08489-46af-474d-936f-9c30f5cc4f48",
 			"storage_in_mb": 10485760,
 			"memory_in_mb": 0,
@@ -2628,12 +2714,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 3.152",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 3.152,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.253",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.253,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}

--- a/config/billing/output/eu-west-2.json
+++ b/config/billing/output/eu-west-2.json
@@ -2264,6 +2264,7 @@
 		{
 			"name": "postgres tiny-unencrypted-13",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "101f57ab-3c67-40ff-b0e9-8189bf1127fd",
 			"storage_in_mb": 5120,
 			"memory_in_mb": 0,
@@ -2271,12 +2272,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 0.021",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 0.021,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.133",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.133,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2285,6 +2290,7 @@
 		{
 			"name": "postgres small-13",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "818aa859-7294-4a07-80da-87fbd719b1d5",
 			"storage_in_mb": 102400,
 			"memory_in_mb": 0,
@@ -2292,12 +2298,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 0.041",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 0.041,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.133",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.133,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2306,6 +2316,7 @@
 		{
 			"name": "postgres small-ha-13",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "9c5d4479-2337-4c70-95a9-5e01b46d2644",
 			"storage_in_mb": 102400,
 			"memory_in_mb": 0,
@@ -2313,12 +2324,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 0.082",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 0.082,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.266",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.266,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2327,6 +2342,7 @@
 		{
 			"name": "postgres medium-13",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "0fd6ade0-c29c-4726-83c3-683502890e69",
 			"storage_in_mb": 102400,
 			"memory_in_mb": 0,
@@ -2334,12 +2350,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 0.206",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 0.206,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.133",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.133,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2348,6 +2368,7 @@
 		{
 			"name": "postgres medium-ha-13",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "2cfd1d3c-1974-4ff4-b967-1caf5c6be484",
 			"storage_in_mb": 102400,
 			"memory_in_mb": 0,
@@ -2355,12 +2376,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 0.412",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 0.412,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.266",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.266,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2369,6 +2394,7 @@
 		{
 			"name": "postgres large-13",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "9b7aa58e-0818-4ab2-bbfb-1b0fdabab65c",
 			"storage_in_mb": 577536,
 			"memory_in_mb": 0,
@@ -2376,12 +2402,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 0.824",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 0.824,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.133",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.133,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2390,6 +2420,7 @@
 		{
 			"name": "postgres large-ha-13",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "b5c5f6a2-4fe8-444b-b981-26cbaafbdade",
 			"storage_in_mb": 577536,
 			"memory_in_mb": 0,
@@ -2397,12 +2428,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 1.648",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 1.648,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.266",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.266,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2411,6 +2446,7 @@
 		{
 			"name": "postgres xlarge-13",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "5bb79c8f-467b-4f2f-a754-140f3df1bd59",
 			"storage_in_mb": 2097152,
 			"memory_in_mb": 0,
@@ -2418,12 +2454,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 1.648",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 1.648,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.133",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.133,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2432,6 +2472,7 @@
 		{
 			"name": "postgres xlarge-ha-13",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "b6cf21d9-8955-44eb-8bb4-f5c9f2e04123",
 			"storage_in_mb": 2097152,
 			"memory_in_mb": 0,
@@ -2439,12 +2480,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 3.296",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 3.296,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.266",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.266,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2453,6 +2498,7 @@
 		{
 			"name": "postgres tiny-unencrypted-13 high-iops",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "6dbfcf62-98a8-4e6e-a820-b56737e6f2d5",
 			"storage_in_mb": 25600,
 			"memory_in_mb": 0,
@@ -2460,12 +2506,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 0.021",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 0.021,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.133",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.133,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2474,6 +2524,7 @@
 		{
 			"name": "postgres small-13 high-iops",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "201c2579-6887-4933-a19c-4c4f270e599a",
 			"storage_in_mb": 102400,
 			"memory_in_mb": 0,
@@ -2481,12 +2532,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 0.041",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 0.041,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.133",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.133,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2495,6 +2550,7 @@
 		{
 			"name": "postgres small-ha-13 high-iops",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "dc3acad6-3f0a-4624-a6bf-af36e71a5fd5",
 			"storage_in_mb": 102400,
 			"memory_in_mb": 0,
@@ -2502,12 +2558,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 0.082",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 0.082,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.266",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.266,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2516,6 +2576,7 @@
 		{
 			"name": "postgres medium-13 high-iops",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "d4ec545a-3b44-4b7c-88f7-a5be1ba081bb",
 			"storage_in_mb": 512000,
 			"memory_in_mb": 0,
@@ -2523,12 +2584,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 0.206",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 0.206,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.133",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.133,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2537,6 +2602,7 @@
 		{
 			"name": "postgres medium-ha-13 high-iops",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "599d4f3b-c4e6-42ff-950d-b4b2c36f333d",
 			"storage_in_mb": 512000,
 			"memory_in_mb": 0,
@@ -2544,12 +2610,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 0.412",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 0.412,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.266",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.266,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2558,6 +2628,7 @@
 		{
 			"name": "postgres large-13 high-iops",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "c127fb33-3c71-4a66-8108-a648756c4d0e",
 			"storage_in_mb": 2621440,
 			"memory_in_mb": 0,
@@ -2565,12 +2636,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 0.824",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 0.824,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.133",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.133,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2579,6 +2654,7 @@
 		{
 			"name": "postgres large-ha-13 high-iops",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "83eb4c8e-78ee-49b5-9346-bddd08db3634",
 			"storage_in_mb": 2621440,
 			"memory_in_mb": 0,
@@ -2586,12 +2662,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 1.648",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 1.648,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.266",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.266,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2600,6 +2680,7 @@
 		{
 			"name": "postgres xlarge-13 high-iops",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "af1e4881-50f4-4d95-b34d-e8a43821ffe6",
 			"storage_in_mb": 10485760,
 			"memory_in_mb": 0,
@@ -2607,12 +2688,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 1.648",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 1.648,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.133",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.133,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -2621,6 +2706,7 @@
 		{
 			"name": "postgres xlarge-ha-13 high-iops",
 			"valid_from": "2021-08-01",
+			"valid_to": "9999-12-31",
 			"plan_guid": "54e08489-46af-474d-936f-9c30f5cc4f48",
 			"storage_in_mb": 10485760,
 			"memory_in_mb": 0,
@@ -2628,12 +2714,16 @@
 				{
 					"name": "instance",
 					"formula": "ceil($time_in_seconds/3600) * 3.296",
+					"formula_new": "ceil($time_in_seconds/3600) * external_price",
+					"external_price": 3.296,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				},
 				{
 					"name": "storage",
 					"formula": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 0.266",
+					"formula_new": "($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * external_price",
+					"external_price": 0.266,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}


### PR DESCRIPTION
What
----

New billing requires the fields `valid_to`, `formula_new` and `external_price` to be present in the paas-cf billing config.

How to review
-------------

- Code review
- Deploy to a dev env, restart the `paas-billing-collector` app in the `new-billing` space and check that the app starts successfully.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
