### PR TITLE
Increase diego-cell count to 123 in London

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -2,11 +2,11 @@
 uaa_instances: 3
 nats_instances: 3
 diego_api_instances: 3
-cell_instances: 117
+cell_instances: 123
 router_instances: 15
 api_instances: 12
-doppler_instances: 60
-log_api_instances: 30
+doppler_instances: 63
+log_api_instances: 33
 scheduler_instances: 8
 cc_worker_instances: 8
 cc_hourly_rate_limit: 60000


### PR DESCRIPTION
What
----

We are alerted that currrent required capacity is 119 and last weeks peak capacity requirement was 121. 
Also increasing Doppler instances to 63 (>= 50% of cells and needs to be divisible by 3).
Also increasing log-api instances to 33 (>= 50% of Dopplers and needs to be divisible by 3).

How to review
-------------

- Code review
- CI

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
