### PR TITLE
[180113784] Address CVEs (Bump cf deployment to 16.25)

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -527,7 +527,7 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-acceptance-tests
-      branch: cf16.24
+      branch: cf16.25
 
   - name: cf-smoke-tests-release
     type: git

--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-bionic
-      version: "1.34"
+      version: "1.36"

--- a/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
+++ b/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
@@ -3,6 +3,6 @@
   path: /releases/name=cflinuxfs3
   value:
     name: "cflinuxfs3"
-    version: "0.259.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.259.0"
-    sha1: "29d52117dd85990317e4ba06664956b579f15b20"
+    version: "0.263.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.263.0"
+    sha1: "d4af72c9f3996a02b46037d91e7adb7b0fded7f5"

--- a/manifests/cf-manifest/operations.d/320-cc-release.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-release.yml
@@ -3,6 +3,6 @@
   path: /releases/name=capi
   value:
     name: "capi"
-    version: "1.118.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.118.0"
-    sha1: "8fb688afcf570d36fb2eda241bbe03e61f3233e9"
+    version: "1.119.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.119.0"
+    sha1: "f57b95580fa2f555ee7be7f17a4be4db6a1fea34"

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "release versions" do
     pinned_releases = {
       "uaa" => {
         local: "0.1.28",
-        upstream: "75.7.0",
+        upstream: "75.8.0",
       },
     }
 


### PR DESCRIPTION
What
----
- Bump cf-deployment to 16.25, excluding buildpacks
- Bump cflinuxfs3 to 0.263.0 (cf-deployments requires or higher 0.262.0. 0.263.0 addresses other CVEs)
- Bump capi to 1.119.0, in line with cf-deployment 16.25
- Bump cf-acceptance-tests to 16.25
- Bump ubuntu-bionic stemcells to 1.36

How to review
-------------

- Code review commit by commit
- Deploy to dev env 
- Check against acceptance criteria in [the story](https://www.pivotaltracker.com/story/show/180113784)
---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
