### PR TITLE
csls-splunk broker: enable access from gds-security in prod

### DIFF
--- a/config/service-brokers/csls-splunk/prod-config.json
+++ b/config/service-brokers/csls-splunk/prod-config.json
@@ -1,6 +1,7 @@
 {
   "allowed_orgs": [
     "digitalmarketplace",
+    "gds-security",
     "gds-tech-ops",
     "govuk_development",
     "govuk-corona-backend-consumers",


### PR DESCRIPTION
What
----

Given `gds-security` org access to the csls splunk broker. Looks like they must have had it in the past, but no longer do. This should make it permanent.

How to review
-------------

Look at it. I don't think deploying to a dev instance will have any effect.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
