### PR TITLE
[Support] Remove gds-shielded-vulnerable-people-service

### DIFF
--- a/config/service-brokers/csls-splunk/prod-lon-config.json
+++ b/config/service-brokers/csls-splunk/prod-lon-config.json
@@ -10,7 +10,6 @@
     "ccs-report-management-info",
     "gds-digital-identity-authentication",
     "gds-document-checking-service",
-    "gds-shielded-vulnerable-people-service",
     "govuk-accounts",
     "x-co-authentication"
   ]


### PR DESCRIPTION
What
----

Removes csls-splunk broker access for gds-shielded-vulnerable-people-service as the org has been deleted.

How to review
-------------

Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
