### PR TITLE
Correct path to TF state file in AZ healthcheck output extraction

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2381,7 +2381,7 @@ jobs:
               - -c
               - |
                 terraform output \
-                  -state=../../../az-healthcheck-tfstate/azhc.tfstate \
+                  -state=az-healthcheck-tfstate/azhc.tfstate \
                   -raw \
                   healthcheck_address_a > "terraform-variables/${AVAILABILITY_ZONE}"
 
@@ -2435,7 +2435,7 @@ jobs:
               - -c
               - |
                 terraform output \
-                  -state=../../../az-healthcheck-tfstate/azhc.tfstate \
+                  -state=az-healthcheck-tfstate/azhc.tfstate \
                   -raw \
                   healthcheck_address_b > "terraform-variables/${AVAILABILITY_ZONE}"
 
@@ -2489,7 +2489,7 @@ jobs:
               - -c
               - |
                 terraform output \
-                  -state=../../../az-healthcheck-tfstate/azhc.tfstate \
+                  -state=az-healthcheck-tfstate/azhc.tfstate \
                   -raw \
                   healthcheck_address_c > "terraform-variables/${AVAILABILITY_ZONE}"
 


### PR DESCRIPTION
What
----

The path to the state file was wrong, which caused an error message to be
silently written to the output file, which was subsequently ingested in a later
task. The value it ingested was of no use to it, and caused an error, which
manifest itself as a failed healthcheck.

How to review
-------------
We mobbed it on a call and saw it worked

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
