### PR TITLE
Disable major version upgrades flag after postgres 13 - **Merge after 08/11/21**

### DIFF
--- a/terraform/cloudfoundry/cf_rds.tf
+++ b/terraform/cloudfoundry/cf_rds.tf
@@ -61,7 +61,7 @@ resource "aws_db_instance" "cf" {
   skip_final_snapshot       = var.cf_db_skip_final_snapshot
   vpc_security_group_ids    = [aws_security_group.cf_rds.id]
 
-  allow_major_version_upgrade = true
+  allow_major_version_upgrade = false
   auto_minor_version_upgrade  = false
   apply_immediately           = false
 


### PR DESCRIPTION
What
----

We dont want AWS to auto upgrade, major versions.

How to review
-------------

See if this applys to staging.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
