### PR TITLE
Remove DB parameter group for postgres 11 - **Merge after 08/11/21**

### DIFF
--- a/terraform/cloudfoundry/cf_rds.tf
+++ b/terraform/cloudfoundry/cf_rds.tf
@@ -29,12 +29,6 @@ resource "aws_security_group" "cf_rds" {
   }
 }
 
-resource "aws_db_parameter_group" "cf_pg_11" {
-  name        = "${var.env}-pg11-cf"
-  family      = "postgres11"
-  description = "RDS Postgres 11 default parameter group"
-}
-
 resource "aws_db_parameter_group" "cf_pg_13" {
   name        = "${var.env}-pg13-cf"
   family      = "postgres13"


### PR DESCRIPTION
What
----

Remove the parameter group for pg11 as we have migrated to 13.

How to review
-------------

Tested in dev02, it should hit staging first so will see if it causes issues.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
