### PR TITLE
Bugfix: Replaces deprecated terraform command

### DIFF
--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -296,11 +296,12 @@ jobs:
                 cp cf-tfstate/cf.tfstate updated-cf-tfstate/cf.tfstate
                 cd paas-cf/terraform/cloudfoundry || exit
                 terraform init
-                terraform destroy -force -var env="((deploy_env))" \
+                terraform destroy \
+                  -auto-approve -var env="((deploy_env))" \
                   -var-file="../../../paas-cf/terraform/((aws_account)).tfvars" \
                   -var-file="../../../paas-cf/terraform/cloudfoundry/((aws_account)).tfvars" \
                   -var-file="../../../paas-cf/terraform/((aws_region)).tfvars" \
-                  -state=../../../updated-cf-tfstate/cf.tfstate paas-cf/terraform/cloudfoundry
+                  -state=../../../updated-cf-tfstate/cf.tfstate
         ensure:
           put: cf-tfstate
           params:


### PR DESCRIPTION

What
----
The [upgraded terraform](https://github.com/alphagov/paas-cf/pull/2750) has changed a couple of things and now this script is broken. To fix it:
- `-force` has been replaced by `-auto-approve` as the former is no longer recognised
- ~~use `-chdir` to change the directory from which the command is executed https://www.terraform.io/docs/cli/commands/#switching-working-directory-with-chdir~~

How to review
-------------
Run the `destroy-cloudfroundry` pipeline in a dev environment and check that terraform doesn't complain about running this command

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
