### PR TITLE
Fix valid_to for Prometheus and unknown plans

### DIFF
--- a/config/billing/config-parts/platform_pricing_plans.json.erb
+++ b/config/billing/config-parts/platform_pricing_plans.json.erb
@@ -1,7 +1,7 @@
 {
 	"name": "unknown-plan",
 	"valid_from": "1970-01-01",
-	"valid_to": "2019-02-28",
+	"valid_to": "9999-12-31",
 	"plan_guid": "d5091c33-2f9d-4b15-82dc-4ad69717fc03",
 	"components": [
 		{
@@ -17,7 +17,7 @@
 {
 	"name": "prometheus",
 	"valid_from": "2017-01-01",
-	"valid_to": "2019-02-28",
+	"valid_to": "9999-12-31",
 	"plan_guid": "cc65268f-98e9-40ef-aa8c-8e595204064d",
 	"components": [
 		{
@@ -33,7 +33,7 @@
 {
 	"name": "prometheus",
 	"valid_from": "2017-01-01",
-	"valid_to": "2019-02-28",
+	"valid_to": "9999-12-31",
 	"plan_guid": "7ab58e11-3959-49b4-9218-807e3e78f9af",
 	"components": [
 		{
@@ -49,7 +49,7 @@
 {
 	"name": "prometheus",
 	"valid_from": "2017-01-01",
-	"valid_to": "2019-02-28",
+	"valid_to": "9999-12-31",
 	"plan_guid": "01889e73-78b3-41d9-b29e-71d6ccfc8821",
 	"components": [
 		{
@@ -65,7 +65,7 @@
 {
 	"name": "prometheus",
 	"valid_from": "2017-01-01",
-	"valid_to": "2019-02-28",
+	"valid_to": "9999-12-31",
 	"plan_guid": "b5998c91-d379-4df7-b329-11450f8459f1",
 	"components": [
 		{


### PR DESCRIPTION
What
----

Accidentally updated valid_to across the platforms billing template -
unknown plan and Prometheus plans became unvalid after 2019-02-28 for
new billing.

How to review
-------------

- Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
