### PR TITLE
[FIX] Make `current-branch` make target actually function correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,9 +229,6 @@ dev%: dev
 	$(eval export ENABLE_AZ_HEALTHCHECK ?= false)
 	@true
 
-tnw-test: dev07
-	@env
-
 .PHONY: stg-lon
 stg-lon: ## Set Environment to stg-lon
 	$(eval export AWS_ACCOUNT=staging)
@@ -320,7 +317,7 @@ ssh_bosh: ## SSH to the bosh server
 
 .PHONY: current-branch
 current-branch: ## Deploy current checked out branch
-	$(eval export BRANCH=$(git rev-parse --abbrev-ref HEAD))
+	$(eval export BRANCH=$(shell sh -c "git rev-parse --abbrev-ref HEAD"))
 	@true
 
 .PHONY: pipelines


### PR DESCRIPTION
This is a fixup of a mess I made in #2780. Apparently my export of BRANCH didn't actually do anything? `make` is weird sometimes.

What
----

* Fix `current-branch` make target so it actually functions correctly.

```Makefile
.PHONY: current-branch
current-branch: ## Deploy current checked out branch
	$(eval export BRANCH=$(shell sh -c "git rev-parse --abbrev-ref HEAD"))
	@true

.PHONY: tnw-test
tnw-test:
	/bin/sh -c "echo $${BRANCH}"
```
```shell
❯ make current-branch tnw-test
/bin/sh -c "echo ${BRANCH}"
development_make_target_improvements
```


How to review
-------------

* Code review.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
