### PR TITLE
[#180081291] stop removing envvar

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -6092,10 +6092,6 @@ jobs:
                     logit-syslog-drain \
                     -l "syslog-tls://${LOGIT_ADDRESS}:${LOGIT_PORT}"
                 fi
-                
-                ## TODO: remove me after deployed everywhere
-                # remove vestigial environment variable
-                cf unset-env aiven-broker "SERVICE_NAME_PREFIX" || true
 
                 ruby -ryaml -e "
                   env = {


### PR DESCRIPTION
What
----

- Revert "REMOVEME: remove vestigial envar"

This was just to ensure an old envvar was removed on the first deployment. It is now not needed, as it has been run once.

How to review
-------------

* Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
