### PR TITLE
Make Postgres 13 formulae consistent with new billing

### DIFF
--- a/config/billing/config-parts/postgres_13_high_iops_pricing_plans.json.erb
+++ b/config/billing/config-parts/postgres_13_high_iops_pricing_plans.json.erb
@@ -16,8 +16,8 @@
     },
     {
       "name": "storage",
-      "formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("rds_storage") %>",
-      "formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("external_price") %>",
+      "formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("external_price") %>",
       "external_price": <%= price("rds_storage") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
@@ -42,8 +42,8 @@
     },
     {
       "name": "storage",
-      "formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("rds_storage") %>",
-      "formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("external_price") %>",
+      "formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("external_price") %>",
       "external_price": <%= price("rds_storage") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
@@ -68,8 +68,8 @@
     },
     {
       "name": "storage",
-      "formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("rds_storage_ha") %>",
-      "formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("external_price") %>",
+      "formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("rds_storage_ha") %>",
+      "formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("external_price") %>",
       "external_price": <%= price("rds_storage_ha") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
@@ -94,8 +94,8 @@
     },
     {
       "name": "storage",
-      "formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("rds_storage") %>",
-      "formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("external_price") %>",
+      "formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("external_price") %>",
       "external_price": <%= price("rds_storage") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
@@ -120,8 +120,8 @@
     },
     {
       "name": "storage",
-      "formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("rds_storage_ha") %>",
-      "formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("external_price") %>",
+      "formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("rds_storage_ha") %>",
+      "formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("external_price") %>",
       "external_price": <%= price("rds_storage_ha") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
@@ -146,8 +146,8 @@
     },
     {
       "name": "storage",
-      "formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("rds_storage") %>",
-      "formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("external_price") %>",
+      "formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("external_price") %>",
       "external_price": <%= price("rds_storage") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
@@ -172,8 +172,8 @@
     },
     {
       "name": "storage",
-      "formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("rds_storage_ha") %>",
-      "formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("external_price") %>",
+      "formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("rds_storage_ha") %>",
+      "formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("external_price") %>",
       "external_price": <%= price("rds_storage_ha") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
@@ -198,8 +198,8 @@
     },
     {
       "name": "storage",
-      "formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("rds_storage") %>",
-      "formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("external_price") %>",
+      "formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("external_price") %>",
       "external_price": <%= price("rds_storage") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
@@ -224,8 +224,8 @@
     },
     {
       "name": "storage",
-      "formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("rds_storage_ha") %>",
-      "formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("external_price") %>",
+      "formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("rds_storage_ha") %>",
+      "formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("external_price") %>",
       "external_price": <%= price("rds_storage_ha") %>,
       "currency_code": "USD",
       "vat_code": "Standard"

--- a/config/billing/config-parts/postgres_13_pricing_plans.json.erb
+++ b/config/billing/config-parts/postgres_13_pricing_plans.json.erb
@@ -16,8 +16,8 @@
     },
     {
       "name": "storage",
-      "formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("rds_storage") %>",
-      "formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("external_price") %>",
+      "formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("external_price") %>",
       "external_price": <%= price("rds_storage") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
@@ -42,8 +42,8 @@
     },
     {
       "name": "storage",
-      "formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("rds_storage") %>",
-      "formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("external_price") %>",
+      "formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("external_price") %>",
       "external_price": <%= price("rds_storage") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
@@ -68,8 +68,8 @@
     },
     {
       "name": "storage",
-      "formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("rds_storage_ha") %>",
-      "formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("external_price") %>",
+      "formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("rds_storage_ha") %>",
+      "formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("external_price") %>",
       "external_price": <%= price("rds_storage_ha") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
@@ -94,8 +94,8 @@
     },
     {
       "name": "storage",
-      "formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("rds_storage") %>",
-      "formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("external_price") %>",
+      "formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("external_price") %>",
       "external_price": <%= price("rds_storage") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
@@ -120,8 +120,8 @@
     },
     {
       "name": "storage",
-      "formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("rds_storage_ha") %>",
-      "formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("external_price") %>",
+      "formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("rds_storage_ha") %>",
+      "formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("external_price") %>",
       "external_price": <%= price("rds_storage_ha") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
@@ -146,8 +146,8 @@
     },
     {
       "name": "storage",
-      "formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("rds_storage") %>",
-      "formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("external_price") %>",
+      "formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("external_price") %>",
       "external_price": <%= price("rds_storage") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
@@ -172,8 +172,8 @@
     },
     {
       "name": "storage",
-      "formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("rds_storage_ha") %>",
-      "formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("external_price") %>",
+      "formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("rds_storage_ha") %>",
+      "formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("external_price") %>",
       "external_price": <%= price("rds_storage_ha") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
@@ -198,8 +198,8 @@
     },
     {
       "name": "storage",
-      "formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("rds_storage") %>",
-      "formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("external_price") %>",
+      "formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("rds_storage") %>",
+      "formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("external_price") %>",
       "external_price": <%= price("rds_storage") %>,
       "currency_code": "USD",
       "vat_code": "Standard"
@@ -224,8 +224,8 @@
     },
     {
       "name": "storage",
-      "formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("rds_storage_ha") %>",
-      "formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * <%= price("external_price") %>",
+      "formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("rds_storage_ha") %>",
+      "formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * <%= price("external_price") %>",
       "external_price": <%= price("rds_storage_ha") %>,
       "currency_code": "USD",
       "vat_code": "Standard"

--- a/config/billing/output/eu-west-1.json
+++ b/config/billing/output/eu-west-1.json
@@ -2279,8 +2279,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.127",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.127",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.127,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2305,8 +2305,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.127",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.127",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.127,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2331,8 +2331,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.253",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.253",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.253,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2357,8 +2357,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.127",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.127",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.127,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2383,8 +2383,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.253",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.253",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.253,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2409,8 +2409,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.127",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.127",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.127,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2435,8 +2435,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.253",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.253",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.253,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2461,8 +2461,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.127",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.127",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.127,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2487,8 +2487,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.253",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.253",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.253,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2513,8 +2513,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.127",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.127",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.127,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2539,8 +2539,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.127",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.127",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.127,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2565,8 +2565,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.253",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.253",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.253,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2591,8 +2591,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.127",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.127",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.127,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2617,8 +2617,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.253",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.253",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.253,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2643,8 +2643,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.127",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.127",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.127,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2669,8 +2669,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.253",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.253",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.253,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2695,8 +2695,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.127",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.127",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.127,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2721,8 +2721,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.253",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.253",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.253,
 					"currency_code": "USD",
 					"vat_code": "Standard"

--- a/config/billing/output/eu-west-2.json
+++ b/config/billing/output/eu-west-2.json
@@ -2279,8 +2279,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.133",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.133",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.133,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2305,8 +2305,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.133",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.133",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.133,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2331,8 +2331,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.266",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.266",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.266,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2357,8 +2357,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.133",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.133",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.133,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2383,8 +2383,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.266",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.266",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.266,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2409,8 +2409,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.133",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.133",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.133,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2435,8 +2435,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.266",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.266",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.266,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2461,8 +2461,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.133",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.133",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.133,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2487,8 +2487,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.266",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.266",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.266,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2513,8 +2513,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.133",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.133",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.133,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2539,8 +2539,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.133",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.133",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.133,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2565,8 +2565,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.266",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.266",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.266,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2591,8 +2591,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.133",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.133",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.133,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2617,8 +2617,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.266",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.266",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.266,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2643,8 +2643,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.133",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.133",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.133,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2669,8 +2669,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.266",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.266",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.266,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2695,8 +2695,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.133",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.133",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.133,
 					"currency_code": "USD",
 					"vat_code": "Standard"
@@ -2721,8 +2721,8 @@
 				},
 				{
 					"name": "storage",
-					"formula": "($storage_in_mb/1024) * $time_in_seconds/2678401 * 0.266",
-					"formula_new": "($storage_in_mb/1024) * $time_in_seconds/2678401 * external_price",
+					"formula": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * 0.266",
+					"formula_new": "($storage_in_mb/1024) * ($time_in_seconds/2678401) * external_price",
 					"external_price": 0.266,
 					"currency_code": "USD",
 					"vat_code": "Standard"


### PR DESCRIPTION
What
----

New billing has a number of known formulae it expects. The formulae without
(), for postgres 13, is not currently in new billing.

This changes the formulae to make them be picked up happily by new
billing.

Paas-billing change is here

https://github.com/alphagov/paas-billing/commit/e673723e9ecb7bb5a6fdbfbdbca8161c2260eb5a


How to review
-------------

Code review - not @whpearson 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
