### PR TITLE
Fix billing plan valid_to for prom and unknown

### DIFF
--- a/config/billing/output/eu-west-1.json
+++ b/config/billing/output/eu-west-1.json
@@ -38,7 +38,7 @@
 		{
 			"name": "unknown-plan",
 			"valid_from": "1970-01-01",
-			"valid_to": "2019-02-28",
+			"valid_to": "9999-12-31",
 			"plan_guid": "d5091c33-2f9d-4b15-82dc-4ad69717fc03",
 			"components": [
 				{
@@ -54,7 +54,7 @@
 		{
 			"name": "prometheus",
 			"valid_from": "2017-01-01",
-			"valid_to": "2019-02-28",
+			"valid_to": "9999-12-31",
 			"plan_guid": "cc65268f-98e9-40ef-aa8c-8e595204064d",
 			"components": [
 				{
@@ -70,7 +70,7 @@
 		{
 			"name": "prometheus",
 			"valid_from": "2017-01-01",
-			"valid_to": "2019-02-28",
+			"valid_to": "9999-12-31",
 			"plan_guid": "7ab58e11-3959-49b4-9218-807e3e78f9af",
 			"components": [
 				{
@@ -86,7 +86,7 @@
 		{
 			"name": "prometheus",
 			"valid_from": "2017-01-01",
-			"valid_to": "2019-02-28",
+			"valid_to": "9999-12-31",
 			"plan_guid": "01889e73-78b3-41d9-b29e-71d6ccfc8821",
 			"components": [
 				{
@@ -102,7 +102,7 @@
 		{
 			"name": "prometheus",
 			"valid_from": "2017-01-01",
-			"valid_to": "2019-02-28",
+			"valid_to": "9999-12-31",
 			"plan_guid": "b5998c91-d379-4df7-b329-11450f8459f1",
 			"components": [
 				{

--- a/config/billing/output/eu-west-2.json
+++ b/config/billing/output/eu-west-2.json
@@ -38,7 +38,7 @@
 		{
 			"name": "unknown-plan",
 			"valid_from": "1970-01-01",
-			"valid_to": "2019-02-28",
+			"valid_to": "9999-12-31",
 			"plan_guid": "d5091c33-2f9d-4b15-82dc-4ad69717fc03",
 			"components": [
 				{
@@ -54,7 +54,7 @@
 		{
 			"name": "prometheus",
 			"valid_from": "2017-01-01",
-			"valid_to": "2019-02-28",
+			"valid_to": "9999-12-31",
 			"plan_guid": "cc65268f-98e9-40ef-aa8c-8e595204064d",
 			"components": [
 				{
@@ -70,7 +70,7 @@
 		{
 			"name": "prometheus",
 			"valid_from": "2017-01-01",
-			"valid_to": "2019-02-28",
+			"valid_to": "9999-12-31",
 			"plan_guid": "7ab58e11-3959-49b4-9218-807e3e78f9af",
 			"components": [
 				{
@@ -86,7 +86,7 @@
 		{
 			"name": "prometheus",
 			"valid_from": "2017-01-01",
-			"valid_to": "2019-02-28",
+			"valid_to": "9999-12-31",
 			"plan_guid": "01889e73-78b3-41d9-b29e-71d6ccfc8821",
 			"components": [
 				{
@@ -102,7 +102,7 @@
 		{
 			"name": "prometheus",
 			"valid_from": "2017-01-01",
-			"valid_to": "2019-02-28",
+			"valid_to": "9999-12-31",
 			"plan_guid": "b5998c91-d379-4df7-b329-11450f8459f1",
 			"components": [
 				{


### PR DESCRIPTION
What
----
Fix billing plan valid_to for prometheus and unknown plans.
When corrected in the templates earlier, I forgot to run the generate output script.

How to review
-------------

- Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
