### PR TITLE
Adds a useful script for cleaning up unused test orgs

### DIFF
--- a/scripts/cleanup_leftover_test_orgs.sh
+++ b/scripts/cleanup_leftover_test_orgs.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -e -u -o pipefail
+
+# shellcheck disable=SC2089
+ORGS='{"orgs":[]}'
+NEXT_PAGE_NUM=1
+while true; do
+  ORG_RESPONSE=$(cf curl "/v3/organizations?per_page=5000&page=${NEXT_PAGE_NUM}")
+  ORGS=$(
+    echo "$ORGS" | \
+      jq -rc --argjson new "$(echo "${ORG_RESPONSE}" | jq -rc '.resources')" \
+        '{"orgs": (.orgs + $new)}'
+  )
+
+  NEXT_PAGE_URL="$(echo "${ORG_RESPONSE}" | jq -rc '.pagination.next')"
+  if [ "$NEXT_PAGE_URL" == "null" ]; then
+    break
+  fi
+
+  NEXT_PAGE_NUM=$((NEXT_PAGE_NUM + 1))
+done
+
+for ORG in $(echo "${ORGS}" | jq -rc '.orgs[]'); do
+  ORG_NAME=$(echo "${ORG}" | jq -rc '.name')
+
+  if [[ "${ORG_NAME}" =~ ^ACC-|AIVENBACC-|ASATS-|BACC-|CATS-|SMOKE-.*$ ]]; then
+    echo ""
+    echo "---"
+    echo "${ORG_NAME} created at $(echo "${ORG}" | jq -rc '.created_at'). Delete? "
+
+    # shellcheck disable=SC2034
+    select yn in "Yes" "No";
+    do
+      case $REPLY in
+        1 )
+          cf delete-org -f "${ORG_NAME}"
+          break
+          ;;
+        2 ) echo "Not deleting ${ORG_NAME}"; break ;;
+        * ) echo "Invalid option. Select 1 or 2" ;;
+      esac
+    done
+  else
+    echo "Skipping ${ORG_NAME} because it's not a test org"
+  fi
+done
+
+echo "All done!"

--- a/scripts/cleanup_leftover_test_orgs.sh
+++ b/scripts/cleanup_leftover_test_orgs.sh
@@ -2,16 +2,44 @@
 
 set -e -u -o pipefail
 
-# shellcheck disable=SC2089
-ORGS='{"orgs":[]}'
+ORG_DEL_ERR_FILENAME="./org_deletion_failed.txt"
 NEXT_PAGE_NUM=1
 while true; do
-  ORG_RESPONSE=$(cf curl "/v3/organizations?per_page=5000&page=${NEXT_PAGE_NUM}")
-  ORGS=$(
-    echo "$ORGS" | \
-      jq -rc --argjson new "$(echo "${ORG_RESPONSE}" | jq -rc '.resources')" \
-        '{"orgs": (.orgs + $new)}'
-  )
+  ORG_RESPONSE=$(cf curl "/v3/organizations?per_page=200&page=${NEXT_PAGE_NUM}")
+  ORGS=$(echo "${ORG_RESPONSE}" | jq -c '.resources[] | [.name,.created_at]')
+
+  # Intentionally not quoting ${ORGS} below as it breaks itemization.
+  for ORG in ${ORGS}; do
+    ORG_NAME=$(echo "${ORG}" | jq -rc '.[0]')
+    ORG_CREATED_AT=$(echo "${ORG}" | jq -rc '.[1]')
+
+    if [[ "${ORG_NAME}" =~ ^ACC-|AIVENBACC-|ASATS-|BACC-|CATS-|SMOKE-.*$ ]]; then
+      echo ""
+      echo "---"
+      echo "${ORG_NAME} created at ${ORG_CREATED_AT}. Delete? "
+
+      # shellcheck disable=SC2034
+      select yn in "Yes" "No";
+      do
+        case $REPLY in
+          1 )
+            cf delete-org -f "${ORG_NAME}" || true
+
+            if cf org "${ORG_NAME}" > /dev/null
+            then
+              echo "${ORG_NAME}" >> "${ORG_DEL_ERR_FILENAME}"
+            fi
+
+            break
+            ;;
+          2 ) echo "Not deleting ${ORG_NAME}"; break ;;
+          * ) echo "Invalid option. Select 1 or 2" ;;
+        esac
+      done
+    else
+      echo "Skipping ${ORG_NAME} because it's not a test org"
+    fi
+  done
 
   NEXT_PAGE_URL="$(echo "${ORG_RESPONSE}" | jq -rc '.pagination.next')"
   if [ "$NEXT_PAGE_URL" == "null" ]; then
@@ -21,29 +49,9 @@ while true; do
   NEXT_PAGE_NUM=$((NEXT_PAGE_NUM + 1))
 done
 
-for ORG in $(echo "${ORGS}" | jq -rc '.orgs[]'); do
-  ORG_NAME=$(echo "${ORG}" | jq -rc '.name')
-
-  if [[ "${ORG_NAME}" =~ ^ACC-|AIVENBACC-|ASATS-|BACC-|CATS-|SMOKE-.*$ ]]; then
-    echo ""
-    echo "---"
-    echo "${ORG_NAME} created at $(echo "${ORG}" | jq -rc '.created_at'). Delete? "
-
-    # shellcheck disable=SC2034
-    select yn in "Yes" "No";
-    do
-      case $REPLY in
-        1 )
-          cf delete-org -f "${ORG_NAME}"
-          break
-          ;;
-        2 ) echo "Not deleting ${ORG_NAME}"; break ;;
-        * ) echo "Invalid option. Select 1 or 2" ;;
-      esac
-    done
-  else
-    echo "Skipping ${ORG_NAME} because it's not a test org"
-  fi
-done
+if test -e "${ORG_DEL_ERR_FILENAME}"
+then
+  echo "Deletion failed for orgs listed in ${ORG_DEL_ERR_FILENAME}."
+fi
 
 echo "All done!"


### PR DESCRIPTION
What
----

Our continuous smoke tests, acceptance tests and the like
create organizations in CF, and provision backing services.
Sometimes the tests fail and the resources don't get cleaned
up. This script tidies up.

How to review
-------------
1. Code review
2. Try it out in `dev02`

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
