### PR TITLE
Increase cc.packages.max_package_size to 2G

### DIFF
--- a/manifests/cf-manifest/env-specific/default.yml
+++ b/manifests/cf-manifest/env-specific/default.yml
@@ -11,6 +11,7 @@ scheduler_instances: 2
 cc_worker_instances: 2
 cc_hourly_rate_limit: 15000
 cc_staging_timeout_in_seconds: 900
+cc_max_package_size: 1073741824
 cc_maximum_health_check_timeout_in_seconds: 300
 paas_region_name: dev
 

--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -11,6 +11,7 @@ scheduler_instances: 8
 cc_worker_instances: 8
 cc_hourly_rate_limit: 60000
 cc_staging_timeout_in_seconds: 2700
+cc_max_package_size: 2147483648
 cc_maximum_health_check_timeout_in_seconds: 300
 paas_region_name: london
 

--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -11,6 +11,7 @@ scheduler_instances: 4
 cc_worker_instances: 4
 cc_hourly_rate_limit: 60000
 cc_staging_timeout_in_seconds: 2700
+cc_max_package_size: 2147483648
 cc_maximum_health_check_timeout_in_seconds: 300
 paas_region_name: ireland
 

--- a/manifests/cf-manifest/env-specific/stg-lon.yml
+++ b/manifests/cf-manifest/env-specific/stg-lon.yml
@@ -11,6 +11,7 @@ scheduler_instances: 3
 cc_worker_instances: 2
 cc_hourly_rate_limit: 100000
 cc_staging_timeout_in_seconds: 1800
+cc_max_package_size: 2147483648
 cc_maximum_health_check_timeout_in_seconds: 300
 paas_region_name: staging
 

--- a/manifests/cf-manifest/operations.d/320-cc-objectstore-config.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-objectstore-config.yml
@@ -30,6 +30,16 @@
   value: ((environment))-cf-packages
 
 - type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/packages/max_package_size?
+  value: ((cc_max_package_size))
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/packages/max_package_size?
+  value: ((cc_max_package_size))
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages/max_package_size?
+  value: ((cc_max_package_size))
+
+- type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/resource_pool/resource_directory_key?
   value: ((environment))-cf-resources
 - type: replace


### PR DESCRIPTION
What
----

We have been contacted by a tenant whose staging is failing on uploading a > 1.5G sized build artifact cache file. The default maximum value is 1G. We are increasing to 2G to unblock the tenant.

pair: @whpearson @schmie

How to review
-------------

- Code review
- Check in dev environment

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
