### PR TITLE
Increase london cells to 138

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -2,11 +2,11 @@
 uaa_instances: 3
 nats_instances: 3
 diego_api_instances: 3
-cell_instances: 126
+cell_instances: 138
 router_instances: 15
 api_instances: 12
-doppler_instances: 63
-log_api_instances: 33
+doppler_instances: 69
+log_api_instances: 36
 scheduler_instances: 8
 cc_worker_instances: 8
 cc_hourly_rate_limit: 60000


### PR DESCRIPTION
What
----
    
We are alerted that currrent required capacity is 133.
Also increasing Doppler instances to 69 (>= 50% of cells and needs to be divisible by 3).
Also increasing log-api instances to 36 (>= 50% of Doppler instances and needs to be divisible by 3).

How to review
-------------

- Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
