### PR TITLE
autoscaler: add SANs to internal certificates

### DIFF
--- a/manifests/app-autoscaler/operations.d/035-internal-cert-SANs.yml
+++ b/manifests/app-autoscaler/operations.d/035-internal-cert-SANs.yml
@@ -1,0 +1,65 @@
+---
+- type: replace
+  path: /variables/name=scalingengine_server/options/alternative_names
+  value:
+    - scalingengine.service.cf.internal
+- type: replace
+  path: /variables/name=scalingengine_server/update_mode
+  value: converge
+
+- type: replace
+  path: /variables/name=eventgenerator_server/options/alternative_names
+  value:
+    - eventgenerator.service.cf.internal
+- type: replace
+  path: /variables/name=eventgenerator_server/update_mode
+  value: converge
+
+- type: replace
+  path: /variables/name=apiserver_server/options/alternative_names
+  value:
+    - apiserver.service.cf.internal
+- type: replace
+  path: /variables/name=apiserver_server/update_mode
+  value: converge
+
+- type: replace
+  path: /variables/name=apiserver_public_server/options/alternative_names
+  value:
+    - autoscaler.((system_domain))
+- type: replace
+  path: /variables/name=apiserver_public_server/update_mode
+  value: converge
+
+- type: replace
+  path: /variables/name=servicebroker_server/options/alternative_names
+  value:
+    - servicebroker.service.cf.internal
+- type: replace
+  path: /variables/name=servicebroker_server/update_mode
+  value: converge
+
+- type: replace
+  path: /variables/name=servicebroker_public_server/options/alternative_names
+  value:
+    - autoscalerservicebroker.((system_domain))
+- type: replace
+  path: /variables/name=servicebroker_public_server/update_mode
+  value: converge
+
+- type: replace
+  path: /variables/name=scheduler_server/options/alternative_names
+  value:
+    - autoscalerscheduler.service.cf.internal
+- type: replace
+  path: /variables/name=scheduler_server/update_mode
+  value: converge
+
+- type: replace
+  path: /variables/name=postgres_server/options/alternative_names
+  value:
+    - autoscalerpostgres.service.cf.internal
+- type: replace
+  path: /variables/name=postgres_server/update_mode
+  value: converge
+


### PR DESCRIPTION
What
----

This is an opsfile-ification of https://github.com/cloudfoundry/app-autoscaler-release/commit/b63457ccff66f37e7fc40335d6ed5cdef65b4760#diff-2555bd0e06456d1923ec77e940061868c6c5eff404d94f60d482f7428b0daac7

This is to smooth the transition to a new autoscaler release which requires SANs in its internal certificates. Can remove following that release.

How to review
-------------

Roll out to a pristine dev environment and check that the certificates in question get regenerated.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
