### PR TITLE
Bump UAA to release 0.1.31

### DIFF
--- a/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
+++ b/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
@@ -3,6 +3,7 @@
   path: /releases/name=uaa
   value:
     name: uaa
-    version: 0.1.28
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-0.1.28.tgz
-    sha1: c1f955c9ba35f21ae03670cb29b82286044a1171
+    version: 0.1.31
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-0.1.31.tgz
+    sha1: 2674f4e7786a7253bd4cc6c0cff10cb9c69d9e9c
+

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "release versions" do
 
     pinned_releases = {
       "uaa" => {
-        local: "0.1.28",
+        local: "0.1.31",
         upstream: "75.8.0",
       },
     }


### PR DESCRIPTION
What
----

Release 0.1.31 includes a mitigation for CVE-2021-44228


How to review
-------------
I saw it go out ok in `dev02`

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
