### PR TITLE
Updating uaa release to fix log4j by updating to log4j 2.16

### DIFF
--- a/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
+++ b/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
@@ -3,7 +3,7 @@
   path: /releases/name=uaa
   value:
     name: uaa
-    version: 0.1.31
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-0.1.31.tgz
-    sha1: 2674f4e7786a7253bd4cc6c0cff10cb9c69d9e9c
+    version: 0.1.32
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-0.1.32.tgz
+    sha1: dd54aa23a2b91438a720acc5bf60ccf07d8702f5
 

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "release versions" do
 
     pinned_releases = {
       "uaa" => {
-        local: "0.1.31",
+        local: "0.1.32",
         upstream: "75.8.0",
       },
     }


### PR DESCRIPTION
What
----
Updating uaa release to fix log4j by updating to log4j 2.16

See  https://lists.apache.org/thread/83y7dx5xvn3h5290q1twn16tltolv88f
for details


How to review
-------------

Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
