### PR TITLE
Increase notify staging isolation segments

### DIFF
--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -4,9 +4,9 @@ nats_instances: 3
 diego_api_instances: 3
 cell_instances: 36
 router_instances: 24
-api_instances: 8
-doppler_instances: 48
-log_api_instances: 24
+api_instances: 9
+doppler_instances: 54
+log_api_instances: 27
 scheduler_instances: 6
 cc_worker_instances: 6
 cc_hourly_rate_limit: 60000

--- a/manifests/cf-manifest/isolation-segments/prod/govuk-notify-staging.yml
+++ b/manifests/cf-manifest/isolation-segments/prod/govuk-notify-staging.yml
@@ -1,4 +1,4 @@
 ---
-number_of_cells: 24
+number_of_cells: 36
 isolation_segment_name: govuk-notify-staging
 vm_type: high_cpu_cell


### PR DESCRIPTION
What
----

Notify asked us to increase the isolation segments to 36 for staging

Increasing other cells to roughly match

There were problems with doppler in the last load test, which is why
they are increased a bit more.

How to review
-------------

Make sure that the increases make sense.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
