### PR TITLE
Scale router, scheduler, cc_workers in Ireland

### DIFF
--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -3,12 +3,12 @@ uaa_instances: 3
 nats_instances: 3
 diego_api_instances: 3
 cell_instances: 36
-router_instances: 24
+router_instances: 72
 api_instances: 9
 doppler_instances: 54
 log_api_instances: 27
-scheduler_instances: 6
-cc_worker_instances: 6
+scheduler_instances: 12
+cc_worker_instances: 12
 cc_hourly_rate_limit: 60000
 cc_staging_timeout_in_seconds: 2700
 cc_maximum_health_check_timeout_in_seconds: 300


### PR DESCRIPTION
What
----
GOV.UK Notify are load testing for high anticipated traffic. We have seen the router instances under pressure as well as an increase in CC queued items possibly related to Notify's use of the autoscaler.

How to review
-------------

- CI
- Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
