### PR TITLE
Change log-api, doppler vm_type to c5.xlarge

### DIFF
--- a/manifests/cf-manifest/operations.d/100-cf-update-vm-types.yml
+++ b/manifests/cf-manifest/operations.d/100-cf-update-vm-types.yml
@@ -10,10 +10,10 @@
   value: xlarge
 - type: replace
   path: /instance_groups/name=doppler/vm_type
-  value: large
+  value: high_cpu_xlarge
 - type: replace
   path: /instance_groups/name=log-api/vm_type
-  value: large
+  value: high_cpu_xlarge
 - type: replace
   path: /instance_groups/name=nats/vm_type
   value: medium

--- a/manifests/cloud-config/operations/use-spot-instances-in-dev.yml
+++ b/manifests/cloud-config/operations/use-spot-instances-in-dev.yml
@@ -39,6 +39,14 @@
   value: ((xlarge_vm_spot_bid_price))
 
 - type: replace
+  path: /vm_types/name=high_cpu_xlarge/cloud_properties/spot_ondemand_fallback?
+  value: true
+
+- type: replace
+  path: /vm_types/name=high_cpu_xlarge/cloud_properties/spot_bid_price?
+  value: ((high_cpu_xlarge_vm_spot_bid_price))
+
+- type: replace
   path: /vm_types/name=router/cloud_properties/spot_ondemand_fallback?
   value: true
 

--- a/manifests/cloud-config/paas-cf-cloud-config.yml
+++ b/manifests/cloud-config/paas-cf-cloud-config.yml
@@ -187,6 +187,13 @@ vm_types:
       size: 10240
       type: gp3
 
+- name: high_cpu_xlarge
+  cloud_properties:
+    instance_type: ((high_cpu_xlarge_vm_instance_type))
+    ephemeral_disk:
+      size: 10240
+      type: gp3
+
 - name: router
   cloud_properties:
     instance_type: ((router_instance_type))

--- a/manifests/variables.yml
+++ b/manifests/variables.yml
@@ -16,6 +16,9 @@ large_vm_spot_bid_price: 0.05
 xlarge_vm_instance_type: m5.xlarge
 xlarge_vm_spot_bid_price: 0.1
 
+high_cpu_xlarge_vm_instance_type: c5.xlarge
+high_cpu_xlarge_vm_spot_bid_price: 0.1
+
 cell_instance_type: r5.xlarge
 cell_vm_spot_bid_price: 0.15
 


### PR DESCRIPTION
What
----
During load tests of GOV.UK Notify, we have found the logging backend to be potentially CPU (thread performance) bound. We are introducing a new `high_cpu_xlarge_vm_instance_type`, `high_cpu_xlarge` and assign it to log-api and doppler instances.

How to review
-------------

- Code review
- Change is currently rolling out to `schmie` dev env (overrode dev downscale to check new instance type).

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
