### PR TITLE
Scale down diego-cells in Ireland to 27

### DIFF
--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -2,7 +2,7 @@
 uaa_instances: 3
 nats_instances: 3
 diego_api_instances: 3
-cell_instances: 36
+cell_instances: 27
 router_instances: 72
 api_instances: 9
 doppler_instances: 54


### PR DESCRIPTION
What
----

Scale down diego-cells in Ireland to 27, as we have not seen the required cell amount to exceed 27 in the past year.

How to review
-------------

- Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
