### PR TITLE
uaa: bump to paas-uaa 0.1.34

### DIFF
--- a/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
+++ b/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
@@ -3,6 +3,6 @@
   path: /releases/name=uaa
   value:
     name: uaa
-    version: 0.1.33
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-0.1.33.tgz
-    sha1: 4e5f820bfa1793a07c60b78fd1e6b2d62dab5cec
+    version: 0.1.34
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-0.1.34.tgz
+    sha1: ecf17dbf8cec48be0efc010ba39f37449f2f1ff1

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "release versions" do
 
     pinned_releases = {
       "uaa" => {
-        local: "0.1.33",
+        local: "0.1.34",
         upstream: "75.8.0",
       },
     }


### PR DESCRIPTION
with fix for CVE-2021-45105 and CVE-2021-45046

What
----

Includes log4j 2.17.0 with fix for CVE-2021-45105 and CVE-2021-45046

How to review
-------------

:eyes: 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
