### PR TITLE
prometheus: upgrade firehose instance group to high_cpu_xlarge

### DIFF
--- a/manifests/prometheus/operations.d/221-monitor-cf.yml
+++ b/manifests/prometheus/operations.d/221-monitor-cf.yml
@@ -5,7 +5,7 @@
 
 - type: replace
   path: /instance_groups/name=firehose/vm_type
-  value: large
+  value: high_cpu_xlarge
 
 - type: replace
   path: /instance_groups/name=firehose/jobs/name=firehose_exporter/properties/firehose_exporter/doppler/idle_timeout?

--- a/manifests/prometheus/operations/change-vm-types-dev.yml
+++ b/manifests/prometheus/operations/change-vm-types-dev.yml
@@ -1,0 +1,7 @@
+---
+
+# dev Prometheus environments don't need upscaled instances
+
+- type: replace
+  path: /instance_groups/name=firehose/vm_type
+  value: large

--- a/manifests/prometheus/scripts/generate-manifest.sh
+++ b/manifests/prometheus/scripts/generate-manifest.sh
@@ -13,6 +13,7 @@ for i in "${PAAS_CF_DIR}"/manifests/prometheus/operations.d/*.yml; do
 done
 
 if [ "${SLIM_DEV_DEPLOYMENT-}" = "true" ]; then
+  opsfile_args+="-o ${PAAS_CF_DIR}/manifests/prometheus/operations/change-vm-types-dev.yml "
   opsfile_args+="-o ${PAAS_CF_DIR}/manifests/prometheus/operations/scale-down-dev.yml "
   opsfile_args+="-o ${PAAS_CF_DIR}/manifests/prometheus/operations/speed-up-deployment-dev.yml "
 fi

--- a/manifests/prometheus/spec/operations/monitor_cf_spec.rb
+++ b/manifests/prometheus/spec/operations/monitor_cf_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "Monitor CF" do
   it "adds the firehose instance_group" do
     firehose = manifest_with_defaults.get("instance_groups.firehose")
     expect(firehose).not_to be_nil
-    expect(firehose["vm_type"]).to eq("large")
+    expect(firehose["vm_type"]).to eq("high_cpu_xlarge")
     expect(firehose["networks"]).to eq([{ "name" => "cf" }])
   end
 


### PR DESCRIPTION
What
----

It looks like the first envelopes dopplers start dropping are destined for prometheus' firehose instances. Perhaps because these appear to be built without the anti-backpressure measures later implementations of loggregator components were. These firehose instances do appear to spike up to ~70% cpu utilization under heavy load, so we should probably upgrade them similarly to how we've upgraded other doppler clients.

How to review
-------------

Look at `dev03` and be happy.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
