### PR TITLE
app-autoscaler: unfork, bump to 3.7.7

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,5 +6,4 @@
 	url = https://github.com/bosh-prometheus/prometheus-boshrelease
 [submodule "app-autoscaler-release"]
 	path = manifests/app-autoscaler/upstream
-	url = https://github.com/alphagov/paas-app-autoscaler-release
-	shallow = true
+	url = https://github.com/cloudfoundry/app-autoscaler-release

--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -115,7 +115,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/alpine
-              tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+              tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
           inputs:
             - name: paas-cf
           params:
@@ -142,7 +142,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/bosh-cli-v2
-              tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+              tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
           run:
             path: sh
             args:
@@ -178,7 +178,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/awscli
-              tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+              tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
           run:
             path: ./paas-cf/concourse/scripts/rds_instances.sh
             args:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -697,20 +697,6 @@ resources:
       uri: https://github.com/alphagov/paas-yet-another-cloudwatch-exporter.git
       branch: gds_main
 
-  # we want to use an app-autoscaler-release version which has acceptance tests
-  # compatible with the CF CLI v7.
-  # This exists as a git branch but not an official release
-  # we can use the develop branch and specify the version in the get: step
-  # the underlying version of the bosh release is still specified via a git
-  # submodule in this repo
-  - name: app-autoscaler-release-git
-    type: git
-    version:
-      ref: ce0fb696423739ed7796e4c75c4ae31d82df5f41
-    source:
-      uri: https://github.com/cloudfoundry/app-autoscaler-release.git
-      branch: main
-
   - name: grafana-overview-annotation-id
     type: s3-iam
     source:
@@ -4852,10 +4838,6 @@ jobs:
             passed: *smoke-tests-resource-passed
           - get: cf-manifest
             passed: ['post-deploy']
-
-            # FIXME: when there is a release that supports CF CLI v7 we can use
-            # the submodule in this repo again
-          - get: app-autoscaler-release-git
 
       - do:
         - task: create-temp-user

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -11,72 +11,72 @@ meta:
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/alpine
-        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+        tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
     psql: &psql-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/psql
-        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+        tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
     node: &node-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/node
-        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+        tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
     node-chromium: &node-chromium-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/node-chromium
-        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+        tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
     awscli: &awscli-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+        tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+        tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
     cf-acceptance-tests: &cf-acceptance-tests-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+        tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
     cf-cli: &cf-cli-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-cli
-        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+        tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
     cf-uaac: &cf-uaac-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-uaac
-        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+        tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
     git-ssh: &git-ssh-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/git-ssh
-        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+        tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
     ruby-slim: &ruby-slim-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/ruby
-        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+        tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
     golang: &golang-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/golang
-        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+        tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
     terraform: &terraform-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+        tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
     curl-ssl: &curl-ssl-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/curl-ssl
-        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+        tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
 
   tasks:
@@ -272,7 +272,7 @@ resource_types:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/concourse-pool-resource
-    tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+    tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
 - name: s3-iam
   type: docker-image
@@ -816,7 +816,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+              tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
           inputs:
             - name: paas-cf
@@ -5120,7 +5120,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/spruce
-              tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+              tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
           inputs:
             - name: paas-cf
@@ -5343,7 +5343,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/spruce
-              tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+              tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
           inputs:
             - name: paas-admin-data
@@ -6475,7 +6475,7 @@ jobs:
           type: docker-image
           source:
             repository: ghcr.io/alphagov/paas/cf-uaac
-            tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+            tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
         inputs:
           - name: passwords

--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -41,7 +41,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/alpine
-              tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+              tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
           inputs:
             - name: paas-cf
             - name: deployment-timer
@@ -71,7 +71,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/awscli
-              tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+              tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
           run:
             path: ./paas-cf/concourse/scripts/rds_instances.sh
@@ -86,7 +86,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+              tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
           inputs:
             - name: paas-cf
@@ -119,7 +119,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+              tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
           inputs:
             - name: paas-cf

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -99,7 +99,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+              tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
           inputs:
             - name: paas-cf
@@ -171,7 +171,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/bosh-cli-v2
-              tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+              tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
           inputs:
             - name: bosh-vars-store
@@ -225,7 +225,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/ruby
-              tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+              tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
           inputs:
             - name: paas-cf
             - name: cf-tfstate
@@ -268,7 +268,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/terraform
-              tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+              tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
           inputs:
             - name: terraform-variables

--- a/concourse/pipelines/monitor-remote.yml
+++ b/concourse/pipelines/monitor-remote.yml
@@ -57,7 +57,7 @@ jobs:
         type: docker-image
         source:
           repository: ghcr.io/alphagov/paas/self-update-pipelines
-          tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+          tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
       inputs:
       - name: paas-cf

--- a/concourse/pipelines/test-certificate-rotation.yml
+++ b/concourse/pipelines/test-certificate-rotation.yml
@@ -5,25 +5,25 @@ meta:
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+        tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+        tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
     cf-acceptance-tests: &cf-acceptance-tests-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+        tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
     cf-cli: &cf-cli-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-cli
-        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+        tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
 
 resource_types:
@@ -40,7 +40,7 @@ resource_types:
     type: docker-image
     source:
       repository: ghcr.io/alphagov/paas/olhtbr-metadata-resource
-      tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+      tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
   - name: s3-iam
     type: docker-image

--- a/concourse/tasks/aiven-broker-acceptance-tests-run.yml
+++ b/concourse/tasks/aiven-broker-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+    tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/app-autoscaler-acceptance-tests-run.yml
+++ b/concourse/tasks/app-autoscaler-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+    tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/app-autoscaler-acceptance-tests-run.yml
+++ b/concourse/tasks/app-autoscaler-acceptance-tests-run.yml
@@ -10,9 +10,6 @@ inputs:
   - name: paas-cf
   - name: admin-creds
 
-  # FIXME: when there is a release that supports CF CLI v7 we can use
-  # the submodule in this repo again
-  - name: app-autoscaler-release-git
 outputs:
   - name: artifacts
 params:
@@ -57,7 +54,7 @@ run:
       fi
 
       echo "Running tests"
-      cd app-autoscaler-release-git
+      cd paas-cf/manifests/app-autoscaler/upstream
       source .envrc
       cd src/acceptance
       ./bin/test_default -p -nodes=8

--- a/concourse/tasks/check-az-is-enabled-in-manifest.yml
+++ b/concourse/tasks/check-az-is-enabled-in-manifest.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+    tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 params:
   DEPLOY_ENV:
   BOSH_ENVIRONMENT:

--- a/concourse/tasks/check-az-is-enabled-in-vpc.yml
+++ b/concourse/tasks/check-az-is-enabled-in-vpc.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+    tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 params:
   AWS_DEFAULT_REGION:
   EXPECTED_ACL_NAME:

--- a/concourse/tasks/configure-grafana.yml
+++ b/concourse/tasks/configure-grafana.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/ruby
-    tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+    tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 inputs:
   - name: paas-trusted-people
 run:

--- a/concourse/tasks/create_admin.yml
+++ b/concourse/tasks/create_admin.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-uaac
-    tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+    tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/cronitor-monitor-ping-action.yml
+++ b/concourse/tasks/cronitor-monitor-ping-action.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+    tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
 run:
   path: sh

--- a/concourse/tasks/curl-az-healthcheck.yml
+++ b/concourse/tasks/curl-az-healthcheck.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/curl-ssl
-    tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+    tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 params:
   AVAILABILITY_ZONE:
   ENABLE_AZ_HEALTHCHECK:

--- a/concourse/tasks/custom-acceptance-tests-run.yml
+++ b/concourse/tasks/custom-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+    tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/custom-broker-acceptance-tests-run.yml
+++ b/concourse/tasks/custom-broker-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+    tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/delete_admin.yml
+++ b/concourse/tasks/delete_admin.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
-    tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+    tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/forget-access-keys.yml
+++ b/concourse/tasks/forget-access-keys.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/terraform
-    tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+    tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/generate-git-keys.yml
+++ b/concourse/tasks/generate-git-keys.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+    tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
 
 run:

--- a/concourse/tasks/generate-test-config.yml
+++ b/concourse/tasks/generate-test-config.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+    tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/get-cf-cli-config.yml
+++ b/concourse/tasks/get-cf-cli-config.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/ruby
-    tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+    tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 inputs:
   - name: paas-cf
   - name: cf-manifest

--- a/concourse/tasks/remove-db.yml
+++ b/concourse/tasks/remove-db.yml
@@ -7,7 +7,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
-    tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+    tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
 run:
   path: sh

--- a/concourse/tasks/send-nagging-email-alert.yml
+++ b/concourse/tasks/send-nagging-email-alert.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+    tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 inputs:
   - name: paas-cf
 params:

--- a/concourse/tasks/smoke-tests-run.yml
+++ b/concourse/tasks/smoke-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+    tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/smoke-tests-run.yml
+++ b/concourse/tasks/smoke-tests-run.yml
@@ -17,6 +17,7 @@ run:
   args:
   - -c
   - |
+    export GO111MODULE="off"
     paas-cf/platform-tests/upstream/run_smoke_tests.sh
     TEST_EXIT_CODE=$?
     if [ "$EMAIL_ON_SMOKE_TEST_FAILURE" = "true" ]; then

--- a/concourse/tasks/tag-repo.yml
+++ b/concourse/tasks/tag-repo.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/git-ssh
-    tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+    tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
 
 inputs:

--- a/concourse/tasks/upload-test-artifacts.yml
+++ b/concourse/tasks/upload-test-artifacts.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+    tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/wait-for-api-availability-tests.yml
+++ b/concourse/tasks/wait-for-api-availability-tests.yml
@@ -11,7 +11,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+    tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
 run:
   path: sh

--- a/concourse/tasks/wait-for-app-availability-tests.yml
+++ b/concourse/tasks/wait-for-app-availability-tests.yml
@@ -13,7 +13,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
-    tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+    tag: 5adc49952d6b25505dc443ceff18975ad6d5165b
 
 run:
   path: sh

--- a/manifests/app-autoscaler/operations.d/001-release.yml
+++ b/manifests/app-autoscaler/operations.d/001-release.yml
@@ -4,6 +4,6 @@
   path: /releases/name=app-autoscaler?
   value:
     name: "app-autoscaler"
-    version: "3.3.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=3.3.0"
-    sha1: "f4a91ee476070a0a0bc26b5afe6fb313f04fe206"
+    version: "3.7.7"
+    url: "https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=3.7.7"
+    sha1: "27be1edb449dcea3c8bcac60a664970f11b34635"

--- a/manifests/app-autoscaler/operations.d/001-release.yml
+++ b/manifests/app-autoscaler/operations.d/001-release.yml
@@ -4,6 +4,6 @@
   path: /releases/name=app-autoscaler?
   value:
     name: "app-autoscaler"
-    version: "3.0.1"
-    url: "https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=3.0.1"
-    sha1: "4e0e9af071bb9de1b7f7db8a946e9cf67b902d4f"
+    version: "3.3.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=3.3.0"
+    sha1: "f4a91ee476070a0a0bc26b5afe6fb313f04fe206"

--- a/manifests/app-autoscaler/operations.d/002-links.yml
+++ b/manifests/app-autoscaler/operations.d/002-links.yml
@@ -5,9 +5,30 @@
   value: ((deploy_env))
 
 - type: replace
+  path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/domain=nats.service.cf.internal/targets/instance_group=nats/deployment
+  value: ((deploy_env))
+
+- type: replace
+  path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/domain=_.nats.service.cf.internal/targets/instance_group=nats/deployment
+  value: ((deploy_env))
+
+- type: replace
   path: /instance_groups/name=asapi/jobs/name=route_registrar/consumes/nats/deployment
   value: ((deploy_env))
 
 - type: replace
   path: /instance_groups/name=asapi/jobs/name=loggregator_agent/consumes/doppler/deployment
   value: ((deploy_env))
+
+- type: replace
+  path: /instance_groups/name=asactors/jobs/name=route_registrar/consumes/nats/deployment
+  value: ((deploy_env))
+
+- type: replace
+  path: /instance_groups/name=asmetrics/jobs/name=route_registrar/consumes/nats/deployment
+  value: ((deploy_env))
+
+- type: replace
+  path: /instance_groups/name=asnozzle/jobs/name=route_registrar/consumes/nats/deployment
+  value: ((deploy_env))
+  

--- a/manifests/app-autoscaler/operations.d/031-bosh-dns-aliases.yml
+++ b/manifests/app-autoscaler/operations.d/031-bosh-dns-aliases.yml
@@ -35,6 +35,14 @@
   value: cf
 
 - type: replace
+  path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/domain=nats.service.cf.internal/targets/0/network
+  value: cf
+
+- type: replace
+  path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/domain=_.nats.service.cf.internal/targets/0/network
+  value: cf
+
+- type: replace
   path: /variables/name=metricsserver_server/options/alternative_names
   value:
     - "metricsserver.service.cf.internal"

--- a/manifests/app-autoscaler/operations.d/035-internal-cert-update-mode-converge.yml
+++ b/manifests/app-autoscaler/operations.d/035-internal-cert-update-mode-converge.yml
@@ -1,0 +1,33 @@
+---
+- type: replace
+  path: /variables/name=scalingengine_server/update_mode?
+  value: converge
+
+- type: replace
+  path: /variables/name=eventgenerator_server/update_mode?
+  value: converge
+
+- type: replace
+  path: /variables/name=apiserver_server/update_mode?
+  value: converge
+
+- type: replace
+  path: /variables/name=apiserver_public_server/update_mode?
+  value: converge
+
+- type: replace
+  path: /variables/name=servicebroker_server/update_mode?
+  value: converge
+
+- type: replace
+  path: /variables/name=servicebroker_public_server/update_mode?
+  value: converge
+
+- type: replace
+  path: /variables/name=scheduler_server/update_mode?
+  value: converge
+
+- type: replace
+  path: /variables/name=postgres_server/update_mode?
+  value: converge
+


### PR DESCRIPTION
What
----

This is the autoscaler-upgrade-related parts of #2789 separated out to be merged ahead of schedule due to various log4j issues. 3.7.7 drops log4j altogether in favour of logback.

How to review
-------------

Look at `dev02` and be happy.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
