### PR TITLE
diego cells: increase ephemeral disk size

### DIFF
--- a/manifests/cloud-config/paas-cf-cloud-config.yml
+++ b/manifests/cloud-config/paas-cf-cloud-config.yml
@@ -212,7 +212,7 @@ vm_types:
   cloud_properties:
     instance_type: ((cell_instance_type))
     ephemeral_disk:
-      size: 204800
+      size: 307200
       type: gp3
     security_groups:
     - ((terraform_outputs_rds_broker_db_clients_security_group))
@@ -223,7 +223,7 @@ vm_types:
   cloud_properties:
     instance_type: ((high_cpu_cell_instance_type))
     ephemeral_disk:
-      size: 204800
+      size: 307200
       type: gp3
     security_groups:
       - ((terraform_outputs_rds_broker_db_clients_security_group))
@@ -234,7 +234,7 @@ vm_types:
   cloud_properties:
     instance_type: ((small_cell_instance_type))
     ephemeral_disk:
-      size: 102400
+      size: 153600
       type: gp3
     security_groups:
     - ((terraform_outputs_rds_broker_db_clients_security_group))


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180312173

What
----

Increased the size of the ephemeral disks attached to the diego cells, to give them more headroom and prevent them alerting us so frequently.

I've chosen to multiply the current sizes by 1.5x. Perhaps we could go further, but to me this seems like a good conservative place to start.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
