### PR TITLE
prod isolation-segments: remove govuk-notify-staging

### DIFF
--- a/manifests/cf-manifest/isolation-segments/prod/govuk-notify-staging.yml
+++ b/manifests/cf-manifest/isolation-segments/prod/govuk-notify-staging.yml
@@ -1,4 +1,0 @@
----
-number_of_cells: 36
-isolation_segment_name: govuk-notify-staging
-vm_type: high_cpu_cell


### PR DESCRIPTION
What
----

Deleted the `govuk-notify-staging` isolation segment from `prod` as per their request. Their load testing is complete for the time being.

Need to make sure they have migrated their space(s) away from this segment and restaged their apps before deploying this.

Not sure if we should also reduce the loggregator-related instance groups to match.


How to review
-------------

Not sure you can.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
