### PR TITLE
Add 3 additional subnets for aws backing services

### DIFF
--- a/terraform/cloudfoundry/variables.tf
+++ b/terraform/cloudfoundry/variables.tf
@@ -21,16 +21,19 @@ variable "apps_wildcard_weight" {
 variable "aws_backing_service_cidrs" {
   description = "CIDR for AWS backing service subnets indexed by AZ"
 
-  default = {
-    zone0 = "10.0.52.0/24"
-    zone1 = "10.0.53.0/24"
-    zone2 = "10.0.54.0/24"
-    zone3 = "10.0.55.0/24"
-    zone4 = "10.0.56.0/24"
-    zone5 = "10.0.57.0/24"
-    zone6 = "10.0.58.0/24"
-    zone7 = "10.0.59.0/24"
-    zone8 = "10.0.60.0/24"
+  default  = {
+    zone0  = "10.0.52.0/24"
+    zone1  = "10.0.53.0/24"
+    zone2  = "10.0.54.0/24"
+    zone3  = "10.0.55.0/24"
+    zone4  = "10.0.56.0/24"
+    zone5  = "10.0.57.0/24"
+    zone6  = "10.0.58.0/24"
+    zone7  = "10.0.59.0/24"
+    zone8  = "10.0.60.0/24"
+    zone9  = "10.0.61.0/24"
+    zone10 = "10.0.62.0/24"
+    zone11 = "10.0.63.0/24"
   }
 }
 

--- a/terraform/cloudfoundry/variables.tf
+++ b/terraform/cloudfoundry/variables.tf
@@ -21,7 +21,7 @@ variable "apps_wildcard_weight" {
 variable "aws_backing_service_cidrs" {
   description = "CIDR for AWS backing service subnets indexed by AZ"
 
-  default  = {
+  default = {
     zone0  = "10.0.52.0/24"
     zone1  = "10.0.53.0/24"
     zone2  = "10.0.54.0/24"


### PR DESCRIPTION
What
----

We have ran out of assignable IPs on all subnets in eu-west-2c and expecting this to be the cause for "incompatible-network" errors when deploying new RDS instances.
This is likely not a complete fix to that, but we will require the additional subnets.

How to review
-------------

- Code review: check consistency

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
