### PR TITLE
Map additional backing-service subnets to AZs

### DIFF
--- a/terraform/eu-west-1.tfvars
+++ b/terraform/eu-west-1.tfvars
@@ -3,15 +3,18 @@ region = "eu-west-1"
 zone_count = 3
 
 zones = {
-  zone0 = "eu-west-1a"
-  zone1 = "eu-west-1b"
-  zone2 = "eu-west-1c"
-  zone3 = "eu-west-1a"
-  zone4 = "eu-west-1b"
-  zone5 = "eu-west-1c"
-  zone6 = "eu-west-1a"
-  zone7 = "eu-west-1b"
-  zone8 = "eu-west-1c"
+  zone0  = "eu-west-1a"
+  zone1  = "eu-west-1b"
+  zone2  = "eu-west-1c"
+  zone3  = "eu-west-1a"
+  zone4  = "eu-west-1b"
+  zone5  = "eu-west-1c"
+  zone6  = "eu-west-1a"
+  zone7  = "eu-west-1b"
+  zone8  = "eu-west-1c"
+  zone9  = "eu-west-1a"
+  zone10 = "eu-west-1b"
+  zone11 = "eu-west-1c"
 }
 
 microbosh_ips = {

--- a/terraform/eu-west-2.tfvars
+++ b/terraform/eu-west-2.tfvars
@@ -3,15 +3,18 @@ region = "eu-west-2"
 zone_count = 3
 
 zones = {
-  zone0 = "eu-west-2a"
-  zone1 = "eu-west-2b"
-  zone2 = "eu-west-2c"
-  zone3 = "eu-west-2a"
-  zone4 = "eu-west-2b"
-  zone5 = "eu-west-2c"
-  zone6 = "eu-west-2a"
-  zone7 = "eu-west-2b"
-  zone8 = "eu-west-2c"
+  zone0  = "eu-west-2a"
+  zone1  = "eu-west-2b"
+  zone2  = "eu-west-2c"
+  zone3  = "eu-west-2a"
+  zone4  = "eu-west-2b"
+  zone5  = "eu-west-2c"
+  zone6  = "eu-west-2a"
+  zone7  = "eu-west-2b"
+  zone8  = "eu-west-2c"
+  zone9  = "eu-west-2a"
+  zone10 = "eu-west-2b"
+  zone11 = "eu-west-2c"
 }
 
 microbosh_ips = {


### PR DESCRIPTION
What
----

In #2828 we added additional subnets for the aws-backing-services to address a shortage of free IPs in eu-west-2c. As the CIDR blocks are not automatically mapped, this change is required as well

How to review
-------------

- Code review
- Optional testing in a dev env

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
