### PR TITLE
Extend the aws backing service ip range for sg

### DIFF
--- a/terraform/cloudfoundry/outputs.tf
+++ b/terraform/cloudfoundry/outputs.tf
@@ -74,7 +74,7 @@ output "aws_backing_service_ip_range_start" {
 }
 
 output "aws_backing_service_ip_range_stop" {
-  value = cidrhost(var.aws_backing_service_cidrs["zone8"], -1)
+  value = cidrhost(var.aws_backing_service_cidrs["zone11"], -1)
 }
 
 output "rds_broker_db_clients_security_group" {


### PR DESCRIPTION
What
----
We added more subnets in #2828 and #2829 to make more IPs available to RDS in eu-west-2c, but did miss that we have to  extend the ip range for the security groups as well in order to make them accessible.

How to review
-------------

- Code review
- Test in dev env

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
