### PR TITLE
set_security_groups_from_manifest: don't scrape cf output, use cf curl

### DIFF
--- a/concourse/scripts/set_security_groups_from_manifest.rb
+++ b/concourse/scripts/set_security_groups_from_manifest.rb
@@ -47,17 +47,10 @@ private
   end
 
   def fetch_security_groups
-    groups = []
+    response = `cf curl /v3/security_groups?per_page=1000`
+    abort "security_groups request failed" unless $CHILD_STATUS.success?
 
-    security_groups = `cf security-groups`
-    abort security_groups unless $CHILD_STATUS.success?
-
-    security_groups.each_line do |line|
-      if line =~ /\A#\d+\s+(\S+)\s*/
-        groups << Regexp.last_match(1)
-      end
-    end
-    groups
+    JSON.parse(response)["resources"].map { |sg| sg["name"] }
   end
 
   def cf(*args)

--- a/concourse/scripts/spec/security_groups_setter_spec.rb
+++ b/concourse/scripts/spec/security_groups_setter_spec.rb
@@ -28,9 +28,10 @@ RSpec.describe SecurityGroupsSetter do
   end
 
   before do
-    allow(sg_setter).to receive(:`).with("cf security-groups") do
+    allow(sg_setter).to receive(:`).with("cf curl /v3/security_groups?per_page=1000") do
       system("exit 0") # setup $?
-      ""
+      # heavily abbreviated response
+      '{"resources": []}'
     end
   end
 
@@ -43,14 +44,10 @@ RSpec.describe SecurityGroupsSetter do
 
     context "with no extant security groups" do
       before do
-        allow(sg_setter).to receive(:`).with("cf security-groups") do
+        allow(sg_setter).to receive(:`).with("cf curl /v3/security_groups?per_page=1000") do
           system("exit 0") # setup $?
-          <<-EOT
-Getting security groups as admin
-OK
-
-     Name                   Organization   Space
-          EOT
+          # heavily abbreviated response
+          '{"resources": []}'
         end
       end
 
@@ -77,16 +74,17 @@ OK
       end
 
       before do
-        allow(sg_setter).to receive(:`).with("cf security-groups") do
+        allow(sg_setter).to receive(:`).with("cf curl /v3/security_groups?per_page=1000") do
           system("exit 0") # setup $?
+          # heavily abbreviated response
           <<-EOT
-Getting security groups as admin
-OK
-
-     Name                   Organization   Space
-#0   public_networks
-#1   dns
-#2   rds_broker_instances
+{
+  "resources": [
+    {"name": "public_networks"},
+    {"name": "dns"},
+    {"name": "rds_broker_instances"}
+  ]
+}
           EOT
         end
         security_group_definitions << { "name" => "dns", "rules" => dns_rules }


### PR DESCRIPTION
What
----

It looks like cf's output has changed enough to make the regex not work correctly anymore, so use json from `cf curl` instead.

We could probably take some further steps to ensure this has gone through ok, e.g. try to read back the configuration after an attempted update, but we want to get this out.

How to review
-------------

Look at `dev01`.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
