### PR TITLE
Fix creation of temporary table locking issues

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 1.19.0
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-1.19.0.tgz
-    sha1: e38babc545ea6e702bc78eed2d706ea8a808a534
+    version: 1.21.0
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-1.21.0.tgz
+    sha1: 500e4b5e5624db63b741fd9f951151e670d36ee7
 
 - type: replace
   path: /instance_groups/-


### PR DESCRIPTION

What
----
The creation of temporary tables was causing triggers to be run that
attempted to lock tables to add permissions. This is unnecessary for
temporary tables, as they are scoped to a user.

This updates the broker to make the triggers no longer run.


How to review
-------------

Have a look in dev03 (where it is deployed) and see that it creating a temporary table is no longer verbose.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
