### PR TITLE
cdn-broker: 0.1.44 -> 0.1.45, reverting dependencies bump

### DIFF
--- a/manifests/cf-manifest/operations.d/720-cdn-broker.yml
+++ b/manifests/cf-manifest/operations.d/720-cdn-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: cdn-broker
-    version: 0.1.44
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.44.tgz
-    sha1: ec860070e8c2e1cce6a9a81ee1536f083b729c5f
+    version: 0.1.45
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.45.tgz
+    sha1: cdf58630fb6df6839adfe0c96fedd9caadaf9110
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-


### PR DESCRIPTION
What
----

The recent general dependencies bump appears to have prevented the cdn broker from authenticating with the CC. Revert it for now.

See https://github.com/alphagov/paas-cdn-broker-boshrelease/pull/47 and thereon https://github.com/alphagov/paas-cdn-broker/pull/53

How to review
-------------

Look at `dev02` (and ignore the unrelated grafana failure)

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
