### PR TITLE
Increase the number of API instances in London

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -4,7 +4,7 @@ nats_instances: 3
 diego_api_instances: 3
 cell_instances: 138
 router_instances: 15
-api_instances: 12
+api_instances: 15
 doppler_instances: 69
 log_api_instances: 36
 scheduler_instances: 10


### PR DESCRIPTION
What
----

Tenants are (still) reporting CC instance scheduling failures (https://govuk.zendesk.com/agent/tickets/4873890).
API machines have 2 VCPUs and we see load exceeding 2 on some of the instances. 
After bumping schedulers and workers to limited success (queues shorter but still issues seen), checking whether the API machines are now the bottleneck.

How to review
-------------

- Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
