### PR TITLE
Increase london cells to 144

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -2,10 +2,10 @@
 uaa_instances: 3
 nats_instances: 3
 diego_api_instances: 3
-cell_instances: 138
+cell_instances: 144
 router_instances: 15
 api_instances: 15
-doppler_instances: 69
+doppler_instances: 72
 log_api_instances: 36
 scheduler_instances: 10
 cc_worker_instances: 10


### PR DESCRIPTION

What
----

We are getting close to the cell limit of 138, to get some head room
increase it to 144
.
Also increasing Doppler instances to 72 (>= 50% of cells and needs to be divisible by 3).
Keep log-api instances at 36 (>= 50% of Doppler instances and needs to be divisible by 3).

How to review
-------------

Check it looks sensible

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
