### PR TITLE
Increase cloud controller workers to 12 in prod-lon

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -8,7 +8,7 @@ api_instances: 15
 doppler_instances: 72
 log_api_instances: 36
 scheduler_instances: 10
-cc_worker_instances: 10
+cc_worker_instances: 12
 cc_hourly_rate_limit: 60000
 cc_staging_timeout_in_seconds: 2700
 cc_maximum_health_check_timeout_in_seconds: 300


### PR DESCRIPTION


What
----

We are still seeing problems with automated deployments using terraform. The API queue is increasing.

The database does not show any particular problems, so to try and speed up the processing of the queue I am increasing the number of workers.



How to review
-------------

Make sure the number change makes sense.
---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
