### PR TITLE
Pins aws version for psn

### DIFF
--- a/terraform/psn/versions.tf
+++ b/terraform/psn/versions.tf
@@ -1,0 +1,1 @@
+../versions.tf


### PR DESCRIPTION
What
----
Here's my naive attempt to fix psn trying to use a newer version of the aws provider. I'm assuming it should be like others in https://github.com/alphagov/paas-cf/commit/a6195f00fa571c2cdec95ea9a187a7493cdab108

How to review
-------------

I'm not sure how to test as it only seems to run in prod

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
