### PR TITLE
181073179 - Add enable private domain creation step to create Cloud Foundry pipeline

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -4123,6 +4123,28 @@ jobs:
 
                 cf enable-feature-flag service_instance_sharing
 
+      - task: enable-private-domain-creation-feature-flag
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          inputs:
+            - name: paas-cf
+          params:
+            API_ENDPOINT: ((api_endpoint))
+            CF_ADMIN: ((cf_admin))
+            CF_PASS: ((cf_pass))
+          image_resource: *cf-cli-image-resource
+          run:
+            path: sh
+            args:
+              - -e
+              - -u
+              - -c
+              - |
+                cf api "${API_ENDPOINT}"
+                cf auth "${CF_ADMIN}" "${CF_PASS}"
+
+                cf enable-feature-flag private_domain_creation
 
       - task: ensure-internal-apps-domain-created
         tags: [colocated-with-web]


### PR DESCRIPTION
Description:
- Acceptance tests for the CDN broker require the private_domain_creation feature flag to be enabled
- Prod and the other environments already have this enabled so this will ensure it is turned on when
Cloud Foundry is deployed


🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
