### PR TITLE
[#179606510] Add an OAuth client for the API for use by PaaS admin local development

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2731,6 +2731,7 @@ jobs:
               SLIM_DEV_DEPLOYMENT: ((slim_dev_deployment))
               DISABLED_AZS: ((disabled_azs))
               VCAP_PASSWORD: ((vcap-password))
+              MAKEFILE_ENV_TARGET: ((makefile_env_target))
             run:
               path: sh
               args:

--- a/manifests/cf-manifest/operations/local-dev-paas-admin-oauth-client.yml
+++ b/manifests/cf-manifest/operations/local-dev-paas-admin-oauth-client.yml
@@ -1,0 +1,10 @@
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/paas-admin-local?
+  value:
+    override: true
+    authorized-grant-types: authorization_code,client_credentials,refresh_token
+    autoapprove: true
+    secret: "local-dev"
+    scope: cloud_controller.read,cloud_controller.admin_read_only,cloud_controller.global_auditor,cloud_controller.write,scim.me,openid,profile,uaa.user,cloud_controller.admincloud_controller.read,cloud_controller.admin_read_only,cloud_controller.global_auditor,cloud_controller.write,scim.me,openid,profile,uaa.user,cloud_controller.admin
+    authorities: scim.userids,scim.invite,scim.read,scim.write,oauth.login
+    redirect-uri: "http://localhost:3000/auth/login/callback"

--- a/manifests/cf-manifest/scripts/generate-manifest.sh
+++ b/manifests/cf-manifest/scripts/generate-manifest.sh
@@ -21,7 +21,7 @@ if [ "${SLIM_DEV_DEPLOYMENT-}" = "true" ]; then
   opsfile_args="$opsfile_args -o ${CF_MANIFEST_DIR}/operations/speed-up-deployment-dev.yml"
 fi
 
-if [ "${MAKEFILE_ENV_TARGET-}" = "dev" ]; then
+if [ "${MAKEFILE_ENV_TARGET-}" = "dev" ] && [ "${DEPLOY_ENV-}" != "prod" ] && [ "${DEPLOY_ENV-}" != "prod-lon" ] && [ "${DEPLOY_ENV-}" != "stg-lon" ]; then
   echo "Adding static OAuth credentials for PaaS admin local development." 1>&2
   echo "The callback URL for this client is localhost." 1>&2
   echo "This should only be available in development environments." 1>&2

--- a/manifests/cf-manifest/scripts/generate-manifest.sh
+++ b/manifests/cf-manifest/scripts/generate-manifest.sh
@@ -21,6 +21,14 @@ if [ "${SLIM_DEV_DEPLOYMENT-}" = "true" ]; then
   opsfile_args="$opsfile_args -o ${CF_MANIFEST_DIR}/operations/speed-up-deployment-dev.yml"
 fi
 
+if [ "${MAKEFILE_ENV_TARGET-}" = "dev" ]; then
+  echo "Adding static OAuth credentials for PaaS admin local development." 1>&2
+  echo "The callback URL for this client is localhost." 1>&2
+  echo "This should only be available in development environments." 1>&2
+  echo "If you're seeing this outside a development environment, stop the deployment and find out why." 1>&2
+  opsfile_args="$opsfile_args -o ${CF_MANIFEST_DIR}/operations/local-dev-paas-admin-oauth-client.yml"
+fi
+
 # We are going to generate a manifest, as if we did not have any isolation
 # segments.
 #


### PR DESCRIPTION
What
----

We want to be able to point our local PaaS admin instances at a CloudFoundry
development environment, so that we don't have to push to CF all the time when
working on it.

WARNING: The OAuth client is configured insecurely. It has
1. static credentials
2. a callback URL of "localhost:3000".
3. full admin access.

This is not something that should be present outside of development
environments. A warning has been added to the generate manifest script.

This is related to the [the `paas-admin` PR for the quality of life enhancement](https://github.com/alphagov/paas-admin/pull/2357)

How to review
-------------
It has been deployed to `dev03` and demonstrated to work, so code review only.

This should have no impact on staging or prod.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
