### PR TITLE
instance types: switch dopplers back to "large"

### DIFF
--- a/manifests/cf-manifest/operations.d/100-cf-update-vm-types.yml
+++ b/manifests/cf-manifest/operations.d/100-cf-update-vm-types.yml
@@ -10,7 +10,7 @@
   value: xlarge
 - type: replace
   path: /instance_groups/name=doppler/vm_type
-  value: high_cpu_xlarge
+  value: large
 - type: replace
   path: /instance_groups/name=log-api/vm_type
   value: high_cpu_xlarge

--- a/manifests/variables.yml
+++ b/manifests/variables.yml
@@ -1,4 +1,9 @@
 ---
+#
+# Before you go changing instance types, remember we may have reserved
+# instances of some types.
+#
+
 compilation_vm_instance_type: c5.large
 
 nano_vm_instance_type: t3.nano


### PR DESCRIPTION
What
----

Dopplers turn out to be quite memory-bound, and aren't really using the extra cpu power granted to them by the high-cpu-xlarge upgrade (https://github.com/alphagov/paas-cf/pull/2814).

What's more we have reserved `m5.large` instances which we're now not using.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
