### PR TITLE
Decrease notify cells

### DIFF
--- a/manifests/cf-manifest/isolation-segments/prod/govuk-notify-production.yml
+++ b/manifests/cf-manifest/isolation-segments/prod/govuk-notify-production.yml
@@ -1,4 +1,4 @@
 ---
-number_of_cells: 36
+number_of_cells: 24
 isolation_segment_name: govuk-notify-production
 vm_type: high_cpu_cell


### PR DESCRIPTION
What
----
The govuk-notify-production is being underutilised so they can be scaled down

How to review (also questions)
-------------
- any reasons why this shouldn't be done? I've double checked memory and cpu usage
- do they need to do anything before this change is applied?
- do we need to scale back instances? https://github.com/alphagov/paas-cf/pull/2803/commits/bdf63a684d49b172953db4dbfa87ca8eb312ebc8


---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
