### PR TITLE
[#180965549] Upgrades the TLS cipher suite we use on load balancers

### DIFF
--- a/terraform/cloudfoundry/broker_alb.tf
+++ b/terraform/cloudfoundry/broker_alb.tf
@@ -16,7 +16,7 @@ resource "aws_lb_listener" "cf_brokers" {
   load_balancer_arn = aws_lb.cf_brokers.arn
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = var.default_elb_security_policy
+  ssl_policy        = var.default_load_balancer_security_policy
   certificate_arn   = data.aws_acm_certificate.system.arn
 
   default_action {

--- a/terraform/cloudfoundry/cdn_broker.tf
+++ b/terraform/cloudfoundry/cdn_broker.tf
@@ -30,13 +30,13 @@ resource "aws_elb" "cdn_broker" {
 }
 
 resource "aws_lb_ssl_negotiation_policy" "cdn_broker" {
-  name          = "paas-${random_pet.elb_cipher.keepers.default_elb_security_policy}-${random_pet.elb_cipher.id}"
+  name          = "paas-${random_pet.elb_cipher.keepers.default_classic_load_balancer_security_policy}-${random_pet.elb_cipher.id}"
   load_balancer = aws_elb.cdn_broker.id
   lb_port       = 443
 
   attribute {
     name  = "Reference-Security-Policy"
-    value = random_pet.elb_cipher.keepers.default_elb_security_policy
+    value = random_pet.elb_cipher.keepers.default_classic_load_balancer_security_policy
   }
 }
 

--- a/terraform/cloudfoundry/elasticache_broker.tf
+++ b/terraform/cloudfoundry/elasticache_broker.tf
@@ -30,13 +30,13 @@ resource "aws_elb" "elasticache_broker" {
 }
 
 resource "aws_lb_ssl_negotiation_policy" "elasticache_broker" {
-  name          = "paas-${random_pet.elb_cipher.keepers.default_elb_security_policy}-${random_pet.elb_cipher.id}"
+  name          = "paas-${random_pet.elb_cipher.keepers.default_classic_load_balancer_security_policy}-${random_pet.elb_cipher.id}"
   load_balancer = aws_elb.elasticache_broker.id
   lb_port       = 443
 
   attribute {
     name  = "Reference-Security-Policy"
-    value = random_pet.elb_cipher.keepers.default_elb_security_policy
+    value = random_pet.elb_cipher.keepers.default_classic_load_balancer_security_policy
   }
 }
 

--- a/terraform/cloudfoundry/elbs.tf
+++ b/terraform/cloudfoundry/elbs.tf
@@ -2,7 +2,7 @@ resource "random_pet" "elb_cipher" {
   length = 1
 
   keepers = {
-    default_elb_security_policy = var.default_elb_security_policy
+    default_classic_load_balancer_security_policy = var.default_classic_load_balancer_security_policy
   }
 }
 

--- a/terraform/cloudfoundry/lbs.tf
+++ b/terraform/cloudfoundry/lbs.tf
@@ -36,7 +36,7 @@ resource "aws_lb_listener" "cf_loggregator" {
   load_balancer_arn = aws_lb.cf_loggregator.arn
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = var.default_elb_security_policy
+  ssl_policy        = var.default_load_balancer_security_policy
   certificate_arn   = data.aws_acm_certificate.system.arn
 
   default_action {
@@ -155,7 +155,7 @@ resource "aws_lb_listener" "cf_router_app_domain_https" {
   load_balancer_arn = aws_lb.cf_router_app_domain.arn
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = var.default_elb_security_policy
+  ssl_policy        = var.default_load_balancer_security_policy
   certificate_arn   = aws_acm_certificate.apps.arn
 
   default_action {
@@ -230,7 +230,7 @@ resource "aws_lb_listener" "cf_router_system_domain_https" {
   load_balancer_arn = aws_lb.cf_router_system_domain.arn
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = var.default_elb_security_policy
+  ssl_policy        = var.default_load_balancer_security_policy
   certificate_arn   = data.aws_acm_certificate.system.arn
 
   default_action {

--- a/terraform/cloudfoundry/prometheus.tf
+++ b/terraform/cloudfoundry/prometheus.tf
@@ -120,7 +120,7 @@ resource "aws_lb_listener" "prometheus" {
   load_balancer_arn = aws_lb.prometheus.arn
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = var.default_elb_security_policy
+  ssl_policy        = var.default_load_balancer_security_policy
   certificate_arn   = data.aws_acm_certificate.system.arn
 
   default_action {

--- a/terraform/cloudfoundry/rds_broker.tf
+++ b/terraform/cloudfoundry/rds_broker.tf
@@ -30,13 +30,13 @@ resource "aws_elb" "rds_broker" {
 }
 
 resource "aws_lb_ssl_negotiation_policy" "rds_broker" {
-  name          = "paas-${random_pet.elb_cipher.keepers.default_elb_security_policy}-${random_pet.elb_cipher.id}"
+  name          = "paas-${random_pet.elb_cipher.keepers.default_classic_load_balancer_security_policy}-${random_pet.elb_cipher.id}"
   load_balancer = aws_elb.rds_broker.id
   lb_port       = 443
 
   attribute {
     name  = "Reference-Security-Policy"
-    value = random_pet.elb_cipher.keepers.default_elb_security_policy
+    value = random_pet.elb_cipher.keepers.default_classic_load_balancer_security_policy
   }
 }
 

--- a/terraform/cloudfoundry/s3_broker.tf
+++ b/terraform/cloudfoundry/s3_broker.tf
@@ -30,13 +30,13 @@ resource "aws_elb" "s3_broker" {
 }
 
 resource "aws_lb_ssl_negotiation_policy" "s3_broker" {
-  name          = "paas-${random_pet.elb_cipher.keepers.default_elb_security_policy}-${random_pet.elb_cipher.id}"
+  name          = "paas-${random_pet.elb_cipher.keepers.default_classic_load_balancer_security_policy}-${random_pet.elb_cipher.id}"
   load_balancer = aws_elb.s3_broker.id
   lb_port       = 443
 
   attribute {
     name  = "Reference-Security-Policy"
-    value = random_pet.elb_cipher.keepers.default_elb_security_policy
+    value = random_pet.elb_cipher.keepers.default_classic_load_balancer_security_policy
   }
 }
 

--- a/terraform/cloudfoundry/sqs_broker.tf
+++ b/terraform/cloudfoundry/sqs_broker.tf
@@ -30,13 +30,13 @@ resource "aws_elb" "sqs_broker" {
 }
 
 resource "aws_lb_ssl_negotiation_policy" "sqs_broker" {
-  name          = "paas-${random_pet.elb_cipher.keepers.default_elb_security_policy}-${random_pet.elb_cipher.id}"
+  name          = "paas-${random_pet.elb_cipher.keepers.default_classic_load_balancer_security_policy}-${random_pet.elb_cipher.id}"
   load_balancer = aws_elb.sqs_broker.id
   lb_port       = 443
 
   attribute {
     name  = "Reference-Security-Policy"
-    value = random_pet.elb_cipher.keepers.default_elb_security_policy
+    value = random_pet.elb_cipher.keepers.default_classic_load_balancer_security_policy
   }
 }
 

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -36,9 +36,15 @@ variable "aws_account" {
   description = "the AWS account being deployed to"
 }
 
+# See https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#tls-security-policies
+variable "default_load_balancer_security_policy" {
+  description = "Which Security policy to use for ALBs and NLBs. This controls things like available SSL protocols/ciphers."
+  default     = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
+}
+
 # See https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-policy-table.html
-variable "default_elb_security_policy" {
-  description = "Which Security policy to use for ELBs. This controls things like available SSL protocols/ciphers."
+variable "default_classic_load_balancer_security_policy" {
+  description = "Which Security policy to use for classic load balancers. This controls things like available SSL protocols/ciphers."
   default     = "ELBSecurityPolicy-TLS-1-2-2017-01"
 }
 


### PR DESCRIPTION
What
----
Upgrades from to 'ELBSecurityPolicy-TLS-1-2-2017-01' to 'ELBSecurityPolicy-TLS-1-2-Ext-2018-06' for ALB/NLB and 'ELBSecurityPolicy-TLS-1-2-2017-01' for classic load balancers. As it stands today (2022-02-23), AWS does not have an ELB security policy which supports TLS 1.3 on Application Load Balancers. One is avaibale for Network Load Balancers, but in the interests of consistency we will only use it when ALBs have the same support.
    
The policy names for ALB/NLBs and classic load balancers have diverged in AWS, so we've had to diverge the two properties here too.

The presence of the 'SslPolicy' field on the 'ModifyListener' action of AWS' Elastic Load Balancing API [1] suggests that we will be able to modify the policy without downtime. Equally, the AWS Terraform provider documentation makes no mention of needing to destroy the listener before making the change.

[1] https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_ModifyListener.html

How to review
-------------

Did I miss anywhere?

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
