### PR TITLE
Carry on sending emails even if one fails

### DIFF
--- a/tools/aws_redis_update_manager/lib/tenant_notifier.rb
+++ b/tools/aws_redis_update_manager/lib/tenant_notifier.rb
@@ -56,7 +56,7 @@ class TenantNotifier
 
   # If the timing of the update doesn’t work for you
 
-  Please reply to this email to request this alternative slot.
+  Please reply to this email to request an alternative slot.
 
   If you have any further questions, please contact GOV.UK PaaS support on gov-uk-paas-support@digital.cabinet-office.gov.uk.
 


### PR DESCRIPTION

What
----
We don't want the script to fail when it trips over one email address.
Instead, continue and generate a list of failed attempts at the end.

How to review
-------------
Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
