### PR TITLE
Mitigate 'app app' pricing plan being created

### DIFF
--- a/config/billing/config.json.erb
+++ b/config/billing/config.json.erb
@@ -1,5 +1,5 @@
 {
-	"ignore_missing_plans": true,
+	"ignore_missing_plans": false,
 	"currency_rates": <%= include("config-parts/currency_rates.json.erb") %>,
 	"vat_rates": <%= include("config-parts/vat_rates.json.erb") %>,
 	"pricing_plans": [


### PR DESCRIPTION

What
----

We are having a problem with our calculator in ireland

We narrowed this down to a pricing plan called 'app app' that is being
created, by generateMissingPlans in paas-billing. For some reason it
thinks there is not the correct pricing plan and is generating one.

This turns off all pricing plan generation. Which may cause issues as
the collector needs to have pricing plan for each event it has. An
alternate mitigation will be suggested.


How to review
-------------

Deploy to a dev environment.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
