### PR TITLE
paas-rds-broker: bump to 1.26.0

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 1.24.0
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-1.24.0.tgz
-    sha1: 26f666148954bee58f97b78b7a5db76bf60440a9
+    version: 1.26.0
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-1.26.0.tgz
+    sha1: 69697ac04ea780f3d36c53d113667d03a947e677
 
 - type: replace
   path: /instance_groups/-


### PR DESCRIPTION
What
----

Bumped the rds broker to 1.26, including tag cache improvements.

https://www.pivotaltracker.com/story/show/181047681

How to review
-------------

Either deploy to a dev env or look at `dev03` right now, see the broker acceptance tests passing and be happy.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
