### PR TITLE
check-certificates: improve error message for soon-expiring certs

### DIFF
--- a/concourse/scripts/check-certificates.rb
+++ b/concourse/scripts/check-certificates.rb
@@ -68,11 +68,17 @@ end
 unless expiring_certificate_names.empty?
   separator
 
-  puts "The following certificates are expiring and require operator intervention:"
+  puts "The following certificates are expiring very soon:"
 
   expiring_certificate_names.each do |cert|
     puts cert.red
   end
+
+  puts <<~HELP
+    The deployment pipeline must be re-run from the beginning to complete the certificate rotation process before these have a chance to expire.
+
+    You may need to do this multiple times before this message goes away.
+  HELP
 end
 
 unless invalid_certificate_names.empty?


### PR DESCRIPTION
What
----
Change the error message displayed by the `check-certificates`(`-after-rotation`) job when certificates are expiring very soon.

The previous error message was vague and might lead the operator to retry just the rotate-certs job, which it turns out would be a bad thing to do.

How to review
-------------

:eyes: 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
