### PR TITLE
Clarifies the type of operator intervention needed

### DIFF
--- a/concourse/scripts/check-certificates.rb
+++ b/concourse/scripts/check-certificates.rb
@@ -68,7 +68,10 @@ end
 unless expiring_certificate_names.empty?
   separator
 
-  puts "The following certificates are expiring and require operator intervention:"
+  puts <<~HELP
+  There are certificates that require intervention. It is likely that you need to re-trigger the whole pipeline to roll the cells.
+  The following certificates are expiring and require operator intervention:"
+  HELP
 
   expiring_certificate_names.each do |cert|
     puts cert.red


### PR DESCRIPTION
What
----
When this messaged appeared, I triggered the `rotate-certs` job thinking that was the "operator intervention needed"

This was a mistake! Instead, I should've triggered the whole pipeline. This PR clarifies the type of operator intervention needed.

How to review
-------------

Check that it makes sense

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
