### PR TITLE
create-cloudfoundry: ensure logit-syslog-drain exists before creating cloudwatch exporter

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -3198,6 +3198,9 @@ jobs:
               API_ENDPOINT: ((api_endpoint))
               CF_ADMIN: ((cf_admin))
               CF_PASS: ((cf_pass))
+
+              LOGIT_ADDRESS: ((logit_syslog_address))
+              LOGIT_PORT: ((logit_syslog_port))
             inputs:
               - name: paas-cf
               - name: config
@@ -3237,6 +3240,16 @@ jobs:
                         AWS_SECRET_ACCESS_KEY: "${YACE_AWS_SECRET_ACCESS_KEY}"
                       command: "src -listen-address=0.0.0.0:\$PORT"
                   EOF
+
+                  if ! cf service logit-syslog-drain > /dev/null; then
+                    cf create-user-provided-service \
+                      logit-syslog-drain \
+                      -l "syslog-tls://${LOGIT_ADDRESS}:${LOGIT_PORT}"
+                  else
+                    cf update-user-provided-service \
+                      logit-syslog-drain \
+                      -l "syslog-tls://${LOGIT_ADDRESS}:${LOGIT_PORT}"
+                  fi
 
                   cf cancel-deployment cloudwatch-exporter || true
                   cf push --strategy=rolling cloudwatch-exporter


### PR DESCRIPTION
What
----

The `deploy-cloudwatch-exporter` task of the `prometheus-deploy` job expects the `logit-syslog-drain` service to exist in the `admin` / `monitoring` space, making no effort to create it if it doesn't.

Looks like the place this is normally created is in `deploy-paas-metrics`, which comes _after_ it in the pipeline, which is not ideal. So copy the existing pattern to ensure it exists before attempting to deploy.

How to review
-------------

Technically you'd have to destroy a dev env and recreate it from scratch to see this in action. But you could just deploy to an existing dev env and check it doesn't break everything.

Who can review
------------
Not @risicle or @nimalank7 as we are both complicit.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
