### PR TITLE
cflinuxfs3: 0.275.0 -> 0.278.0

### DIFF
--- a/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
+++ b/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
@@ -3,6 +3,6 @@
   path: /releases/name=cflinuxfs3
   value:
     name: "cflinuxfs3"
-    version: "0.275.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.275.0"
-    sha1: "c79ce67f8885a79fb6cfad6bbb8c7eab7fa0efee"
+    version: "0.278.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.278.0"
+    sha1: "e73d1797d5f854531b73c04d3a046d470c9e38dd"


### PR DESCRIPTION
What
----
https://www.pivotaltracker.com/story/show/181594743

Bump cflinuxfs3 from 0.275.0 to 0.278.0, addressing multiple CVEs

https://github.com/cloudfoundry/cflinuxfs3/compare/0.275.0...0.278.0



How to review
-------------

Either deploy to a dev env yourself or look at `dev01` right now.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
