### PR TITLE
cf-depoyment v19 precursor: add an initial simplified log-cache instance group

### DIFF
--- a/manifests/cf-manifest/operations.d/000-cf-deployment-19-preemptively-add-log-cache.yml
+++ b/manifests/cf-manifest/operations.d/000-cf-deployment-19-preemptively-add-log-cache.yml
@@ -1,0 +1,36 @@
+---
+# create an initial, simplified log-cache instance group, just to give
+# the dns alias something to point at
+#
+# to be modified further by later operations as per usual.
+
+- type: replace
+  path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/-
+  value:
+    domain: log-cache.service.cf.internal
+    targets:
+    - query: '*'
+      instance_group: log-cache
+      # use custom deployment_name and network_name (this would usually be done by
+      # an upstream opsfile that doesn't know about the log-cache alias yet)
+      deployment: ((deployment_name))
+      network: ((network_name))
+      domain: bosh
+
+- type: replace
+  path: /instance_groups/-
+  value:
+    name: log-cache
+    azs:
+    - z1
+    - z2
+    instances: 1
+    vm_type: small
+    stemcell: default
+    networks:
+    # use custom network_name (this would usually be done by an upstream opsfile
+    # that doesn't know about the log-cache instance_group yet)
+    - name: ((network_name))
+    # no jobs so we can avoid dragging in bits of the cf-deployment v19 manifest
+    # related to them
+    jobs: []

--- a/manifests/cf-manifest/operations.d/100-cf-update-vm-types.yml
+++ b/manifests/cf-manifest/operations.d/100-cf-update-vm-types.yml
@@ -15,6 +15,9 @@
   path: /instance_groups/name=log-api/vm_type
   value: high_cpu_xlarge
 - type: replace
+  path: /instance_groups/name=log-cache/vm_type
+  value: large
+- type: replace
   path: /instance_groups/name=nats/vm_type
   value: medium
 - type: replace

--- a/manifests/cf-manifest/operations.d/365-log-cache.yml
+++ b/manifests/cf-manifest/operations.d/365-log-cache.yml
@@ -1,0 +1,9 @@
+---
+
+- type: replace
+  path: /instance_groups/name=log-cache/azs/-
+  value: z3
+
+- type: replace
+  path: /instance_groups/name=log-cache/instances
+  value: ((doppler_instances))

--- a/manifests/cf-manifest/operations.d/800-set-vcap-password.yml
+++ b/manifests/cf-manifest/operations.d/800-set-vcap-password.yml
@@ -12,6 +12,9 @@
   path: /instance_groups/name=doppler/env?/bosh/password
   value: ((vcap_password))
 - type: replace
+  path: /instance_groups/name=log-cache/env?/bosh/password
+  value: ((vcap_password))
+- type: replace
   path: /instance_groups/name=log-api/env?/bosh/password
   value: ((vcap_password))
 - type: replace


### PR DESCRIPTION
What
----
https://www.pivotaltracker.com/story/show/181415115

This lays the ground for cf-deployment 19.0.0 to go out.

cf-deployment >=18 separates the `log-cache` from the `doppler` instances. It helps if all the cluster's instances are aware of the log-cache bosh dns alias before the full deployment goes out.

We're going for the same number of instances and vm types as the existing dopplers so we know we're not underprovisioning. Once we've observed production load using this we can decide what to downscale and how.

Doing the scaling & sizing in this initial deployment mostly so the tests don't whine at us about something they see as a misconfiguration.

How to review
-------------

Roll out to a (**non-slim**) dev env and watch for any downtime?

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
