### PR TITLE
paas-uaa: 0.1.34 -> 0.1.35

### DIFF
--- a/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
+++ b/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
@@ -3,6 +3,6 @@
   path: /releases/name=uaa
   value:
     name: uaa
-    version: 0.1.34
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-0.1.34.tgz
-    sha1: ecf17dbf8cec48be0efc010ba39f37449f2f1ff1
+    version: 0.1.35
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-0.1.35.tgz
+    sha1: 1d0cbd3bf11252fda305763518c7b29addb4af36

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "release versions" do
 
     pinned_releases = {
       "uaa" => {
-        local: "0.1.34",
+        local: "0.1.35",
         upstream: "75.15.0",
       },
     }


### PR DESCRIPTION
What
----
https://www.pivotaltracker.com/story/show/181770492

Addresses CVE-2022-22965 though a Spring bump.

How to review
-------------

Either deploy to a dev env and test inviting a new user manually, or look at `dev01` where (I think) it's still running this.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
