### PR TITLE
logit lostash filters: interpret various more accurate timestamp fields

### DIFF
--- a/config/logit/30_various_timestamps.conf
+++ b/config/logit/30_various_timestamps.conf
@@ -1,0 +1,118 @@
+# Use more accurate timestamp fields, instead of the timestamp of when logit received the log
+
+date {
+  match => [ "[aiven_service_discovery][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[auctioneer][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[bbs][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[cc_deployment_updater][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[cc_uploader][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[cdn_broker][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[cdn_cron][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[cloud_controller_clock][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[cloud_controller_ng][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[cloud_controller_worker][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[elasticache_broker][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[eventgenerator][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[file_server][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[garden][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[golangapiserver][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[locket][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[metricsforwarder][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[policy_server][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[rds_broker][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[rds_metric_collector][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[rep][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[route_emitter][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[route_registrar][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[s3_broker][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[scalingengine][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[sqs_broker][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[ssh_proxy][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[tps][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}
+date {
+  match => [ "[vxlan_policy_agent][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+  target => "@timestamp"
+}

--- a/config/logit/output/generated_logit_filters.conf
+++ b/config/logit/output/generated_logit_filters.conf
@@ -1195,4 +1195,122 @@ filter {
       add_field => { "[@source][deployment]" => "%{[app][data][deployment]}" }
     }
   }
+# Use more accurate timestamp fields, instead of the timestamp of when logit received the log
+
+  date {
+    match => [ "[aiven_service_discovery][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[auctioneer][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[bbs][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[cc_deployment_updater][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[cc_uploader][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[cdn_broker][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[cdn_cron][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[cloud_controller_clock][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[cloud_controller_ng][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[cloud_controller_worker][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[elasticache_broker][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[eventgenerator][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[file_server][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[garden][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[golangapiserver][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[locket][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[metricsforwarder][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[policy_server][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[rds_broker][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[rds_metric_collector][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[rep][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[route_emitter][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[route_registrar][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[s3_broker][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[scalingengine][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[sqs_broker][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[ssh_proxy][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[tps][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
+  date {
+    match => [ "[vxlan_policy_agent][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]
+    target => "@timestamp"
+  }
 }

--- a/scripts/generate_logit_filters.sh
+++ b/scripts/generate_logit_filters.sh
@@ -53,6 +53,7 @@ echo "filter {" > /output/generated_logit_filters.conf
     sed 's/^/  /' < /tmp/logsearch-for-cloudfoundry/src/logsearch-config/target/logstash-filters-default.conf
     sed 's/^/  /' < /mnt/config/logit/20_custom_cf_filters.conf
     sed 's/^/  /' < /mnt/config/logit/21_paas_billing_filters.conf
+    sed 's/^/  /' < /mnt/config/logit/30_various_timestamps.conf
     echo "}"
 } >> /output/generated_logit_filters.conf
 


### PR DESCRIPTION
What
----

From a trawl of a month's worth of logs, these appear to be the fields already present that contain earlier, more accurate, host-generated timestamps. Some are ISO timestamps, some are unix epoch floats.

The ISO timestamps seem to be interpreted at some point after the logstash filters (?) (though not set to be the `@timestamp` value). The unix epoch values are ingested as strings, so not sortable.

How to review
-------------

Think we need to run `make logit-filters` and use the result to populate one of our logit stacks logstash configurations and testing it out.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
