### PR TITLE
make logit-filters: switch to using debian-based jruby docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -488,7 +488,7 @@ logit-filters:
 		-v $(CURDIR)/config/logit/output:/output:rw \
 		-w /mnt \
 		--platform linux/amd64 \
-		jruby:9.2-alpine ./scripts/generate_logit_filters.sh $(LOGSEARCH_BOSHRELEASE_TAG) $(LOGSEARCH_FOR_CLOUDFOUNDRY_TAG)
+		jruby:9.2 ./scripts/generate_logit_filters.sh $(LOGSEARCH_BOSHRELEASE_TAG) $(LOGSEARCH_FOR_CLOUDFOUNDRY_TAG)
 	@echo "updated $(CURDIR)/config/logit/output/generated_logit_filters.conf"
 
 .PHONY: logit-alerts

--- a/scripts/generate_logit_filters.sh
+++ b/scripts/generate_logit_filters.sh
@@ -24,7 +24,7 @@ fi
 
 set -u
 
-apk update && apk add git
+apt update && apt install git -y
 
 cd /tmp
 git clone https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry.git


### PR DESCRIPTION
What
----

The alpine based images are no longer maintained (https://github.com/jruby/docker-jruby/issues/56) and don't exist for aarch64. while the regular debian-based 9.2 aarch64 images aren't on dockerhub either, it's possible to *build* them from the `Dockerfile` on an aarch64 mac.

How to review
-------------

Check if `make logit-filters` works for you. On an aarch64 mac you may need to build an image from the Dockerfile @ https://github.com/jruby/docker-jruby/tree/master/9.2/jre8

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
