### PR TITLE
log-cache instances: halve number in prod and prod-lon

### DIFF
--- a/manifests/cf-manifest/env-specific/default.yml
+++ b/manifests/cf-manifest/env-specific/default.yml
@@ -6,6 +6,7 @@ cell_instances: 3
 router_instances: 2
 api_instances: 2
 doppler_instances: 6
+log_cache_instances: 2
 log_api_instances: 2
 scheduler_instances: 2
 cc_worker_instances: 2

--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -6,6 +6,7 @@ cell_instances: 144
 router_instances: 30
 api_instances: 15
 doppler_instances: 72
+log_cache_instances: 36
 log_api_instances: 36
 scheduler_instances: 10
 cc_worker_instances: 12

--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -6,6 +6,7 @@ cell_instances: 36
 router_instances: 72
 api_instances: 9
 doppler_instances: 54
+log_cache_instances: 27
 log_api_instances: 27
 scheduler_instances: 12
 cc_worker_instances: 12

--- a/manifests/cf-manifest/env-specific/stg-lon.yml
+++ b/manifests/cf-manifest/env-specific/stg-lon.yml
@@ -6,6 +6,7 @@ cell_instances: 6
 router_instances: 3
 api_instances: 2
 doppler_instances: 3
+log_cache_instances: 3
 log_api_instances: 3
 scheduler_instances: 3
 cc_worker_instances: 2

--- a/manifests/cf-manifest/operations.d/365-log-cache.yml
+++ b/manifests/cf-manifest/operations.d/365-log-cache.yml
@@ -6,4 +6,4 @@
 
 - type: replace
   path: /instance_groups/name=log-cache/instances
-  value: ((doppler_instances))
+  value: ((log_cache_instances))

--- a/manifests/cf-manifest/spec/manifest/env_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/env_spec.rb
@@ -20,10 +20,17 @@ RSpec.describe "Environment specific configuration" do
     expect(default_api_instances).to be < prod_api_instances
   end
 
-  it "allows a higher number of instances of Doppler instances in production" do
+  it "allows a higher number of instances of Doppler in production" do
     default_doppler_instances = get_instance_group_instances(default_manifest, "doppler")
     prod_doppler_instances = get_instance_group_instances(prod_manifest, "doppler")
 
     expect(default_doppler_instances).to be < prod_doppler_instances
+  end
+
+  it "allows a higher number of instances of log cache in production" do
+    default_log_cache_instances = get_instance_group_instances(default_manifest, "log-cache")
+    prod_log_cache_instances = get_instance_group_instances(prod_manifest, "log-cache")
+
+    expect(default_log_cache_instances).to be < prod_log_cache_instances
   end
 end


### PR DESCRIPTION
What
----

https://www.pivotaltracker.com/story/show/181832139

We deployed cf-deployment 19 with surplus `log_cache` instances to avoid the possibility of underprovisioning with doing a complex release. Wisdom from cf slack suggests that we should be able to halve the number of log_cache instances now, and our metrics seem to support this.

How to review
-------------

This really only makes changes to production so I'm not sure it's sensibly possible.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
