### PR TITLE
terraform: add dedicated provider alias for ses smtp

### DIFF
--- a/terraform/cloudfoundry/smtp.tf
+++ b/terraform/cloudfoundry/smtp.tf
@@ -1,15 +1,28 @@
+# we send emails via SES in *one* region and the IAM user must be
+# created in that region for the ses_smtp_password_v4 to be generated
+# correctly
+provider "aws" {
+  alias  = "ses-region"
+  region = "eu-west-1"
+}
+
 resource "aws_iam_user" "ses_smtp" {
+  provider = aws.ses-region
+
   name = "ses-smtp-${var.env}"
 
   force_destroy = true
 }
 
 resource "aws_iam_user_group_membership" "ses_smtp" {
+  provider = aws.ses-region
+
   user   = aws_iam_user.ses_smtp.name
   groups = ["email-senders"]
 }
 
 resource "aws_iam_access_key" "ses_smtp" {
+  provider = aws.ses-region
+
   user = aws_iam_user.ses_smtp.name
 }
-


### PR DESCRIPTION
What
----

An IAM access key's `ses_smtp_password_v4` appears to be generated using the region of the iam resource's provider, which is not necessarily the region we're going to use it in. This causes auth failures when alertmanager in eu-west-2 tries to send emails via our SES in eu-west-1.

How to review
-------------

Have tested this in the `schmie` dev env (being eu-west-2), and it successfully stops the smtp auth failure messages which have also been seen in `prod-lon`. Haven't managed to get any actual emails through yet, but dev isn't really set up for that.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
