### PR TITLE
[181943509] Set autoscaler bionic stemcell to 1.76

### DIFF
--- a/manifests/app-autoscaler/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/app-autoscaler/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-bionic
-      version: "1.61"
+      version: "1.76"


### PR DESCRIPTION
What
----

Set autoscaler bionic stemcell to 1.76  as part of CVE mitigation.

How to review
-------------

- Code review
- Test in dev env

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
