### PR TITLE
alerts: improve expression for certificate check failure alerts

### DIFF
--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -3,7 +3,7 @@ on: pull_request
 env:
   TF_VERSION: "1.0.8"
   BOSH_CLI_VERSION: "2.0.48"
-  PROMETHEUS_VERSION: "2.6.1"
+  PROMETHEUS_VERSION: "2.22.2"
   DEPLOY_ENV: "github"
   SHELLCHECK_VERSION: "0.7.1"
   GO_VERSION: "1.17"
@@ -55,6 +55,7 @@ jobs:
         run: |
           wget -q -O prometheus.tgz "https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.linux-amd64.tar.gz"
           sudo tar xzf "prometheus.tgz" -C /usr/local/bin --wildcards --wildcards-match-slash --strip-components=1 '*promtool'
+          promtool --version
 
       - name: "Install Go ${{env.GO_VERSION}}"
         uses: actions/setup-go@v2

--- a/manifests/prometheus/alerts.d/concourse-check-certificates-errors.yml
+++ b/manifests/prometheus/alerts.d/concourse-check-certificates-errors.yml
@@ -7,7 +7,8 @@
     name: ConcourseCheckCertificatesErrors
     rules:
       - record: "concourse_check_certificates_errors"
-        expr: sum(concourse_builds_finished{exported_job="check-certificates",pipeline="create-cloudfoundry",status="errored"} or (absent(concourse_builds_finished{exported_job="check-certificates",pipeline="create-cloudfoundry",status="errored"})-1))
+        # in english: "only fill in gaps in the concourse_builds_finished counter with 0 if there haven't been any values for 12h, otherwise fill in with the maximum value from the last 12h"
+        expr: sum(concourse_builds_finished{exported_job="check-certificates",pipeline="create-cloudfoundry",status="errored"} or absent_over_time(concourse_builds_finished{exported_job="check-certificates",pipeline="create-cloudfoundry",status="errored"}[12h])-1 or max_over_time(concourse_builds_finished{exported_job="check-certificates",pipeline="create-cloudfoundry",status="errored"}[12h]))
 
       - alert: ConcourseCheckCertificatesErrors
         expr: increase(concourse_check_certificates_errors[3d]) >= 2

--- a/manifests/prometheus/alerts.d/concourse-check-certificates-failures.yml
+++ b/manifests/prometheus/alerts.d/concourse-check-certificates-failures.yml
@@ -7,7 +7,8 @@
     name: ConcourseCheckCertificatesFailures
     rules:
       - record: "concourse_check_certificates_failures"
-        expr: sum(concourse_builds_finished{exported_job="check-certificates",pipeline="create-cloudfoundry",status="failed"} or (absent(concourse_builds_finished{exported_job="check-certificates",pipeline="create-cloudfoundry",status="failed"})-1))
+        # in english: "only fill in gaps in the concourse_builds_finished counter with 0 if there haven't been any values for 12h, otherwise fill in with the maximum value from the last 12h"
+        expr: sum(concourse_builds_finished{exported_job="check-certificates",pipeline="create-cloudfoundry",status="failed"} or absent_over_time(concourse_builds_finished{exported_job="check-certificates",pipeline="create-cloudfoundry",status="failed"}[12h])-1 or max_over_time(concourse_builds_finished{exported_job="check-certificates",pipeline="create-cloudfoundry",status="failed"}[12h]))
 
       - alert: ConcourseCheckCertificatesFailures
         expr: increase(concourse_check_certificates_failures[1h]) >= 1

--- a/manifests/prometheus/spec/alerts/app-autoscaler-cpu.test.yml
+++ b/manifests/prometheus/spec/alerts/app-autoscaler-cpu.test.yml
@@ -1,7 +1,7 @@
 ---
 rule_files:
   # See alerts_validation_spec.rb for details of how stdin gets set:
-  - spec/alerts/fixtures/rules.yml
+  - fixtures/rules.yml
 
 evaluation_interval: 1m
 

--- a/manifests/prometheus/spec/alerts/bosh-high-cpu-utilisation.test.yml
+++ b/manifests/prometheus/spec/alerts/bosh-high-cpu-utilisation.test.yml
@@ -1,7 +1,7 @@
 ---
 rule_files:
   # See alerts_validation_spec.rb for details of how stdin gets set:
-  - spec/alerts/fixtures/rules.yml
+  - fixtures/rules.yml
 
 evaluation_interval: 1m
 

--- a/manifests/prometheus/spec/alerts/cloud-controller-unregistry.test.yml
+++ b/manifests/prometheus/spec/alerts/cloud-controller-unregistry.test.yml
@@ -1,7 +1,7 @@
 ---
 rule_files:
   # See alerts_validation_spec.rb for details of how stdin gets set:
-  - spec/alerts/fixtures/rules.yml
+  - fixtures/rules.yml
 
 evaluation_interval: 1m
 

--- a/manifests/prometheus/spec/alerts/cloudfront_tls_certificates_expiry.test.yml
+++ b/manifests/prometheus/spec/alerts/cloudfront_tls_certificates_expiry.test.yml
@@ -1,7 +1,7 @@
 ---
 rule_files:
   # See alerts_validation_spec.rb for details of how stdin gets set:
-  - spec/alerts/fixtures/rules.yml
+  - fixtures/rules.yml
 
 evaluation_interval: 1m
 

--- a/manifests/prometheus/spec/alerts/concourse-smoketests-errors.test.yml
+++ b/manifests/prometheus/spec/alerts/concourse-smoketests-errors.test.yml
@@ -1,7 +1,7 @@
 ---
 rule_files:
   # See alerts_validation_spec.rb for details of how stdin gets set:
-  - spec/alerts/fixtures/rules.yml
+  - fixtures/rules.yml
 
 evaluation_interval: 1m
 

--- a/manifests/prometheus/spec/alerts/concourse-smoketests-failures.test.yml
+++ b/manifests/prometheus/spec/alerts/concourse-smoketests-failures.test.yml
@@ -1,7 +1,7 @@
 ---
 rule_files:
   # See alerts_validation_spec.rb for details of how stdin gets set:
-  - spec/alerts/fixtures/rules.yml
+  - fixtures/rules.yml
 
 evaluation_interval: 1m
 

--- a/manifests/prometheus/spec/alerts/diego_cell_available_memory.test.yml
+++ b/manifests/prometheus/spec/alerts/diego_cell_available_memory.test.yml
@@ -1,7 +1,7 @@
 ---
 rule_files:
   # See alerts_validation_spec.rb for details of how stdin gets set:
-  - spec/alerts/fixtures/rules.yml
+  - fixtures/rules.yml
 
 evaluation_interval: 1m
 

--- a/manifests/prometheus/spec/alerts/diego_cell_rep_container_capacity.test.yml
+++ b/manifests/prometheus/spec/alerts/diego_cell_rep_container_capacity.test.yml
@@ -1,7 +1,7 @@
 ---
 rule_files:
   # See alerts_validation_spec.rb for details of how stdin gets set:
-  - spec/alerts/fixtures/rules.yml
+  - fixtures/rules.yml
 
 evaluation_interval: 1m
 

--- a/manifests/prometheus/spec/alerts/diego_cell_rep_memory_capacity.test..yml
+++ b/manifests/prometheus/spec/alerts/diego_cell_rep_memory_capacity.test..yml
@@ -1,7 +1,7 @@
 ---
 rule_files:
   # See alerts_validation_spec.rb for details of how stdin gets set:
-  - spec/alerts/fixtures/rules.yml
+  - fixtures/rules.yml
 
 evaluation_interval: 1m
 

--- a/manifests/prometheus/spec/alerts/doppler-dropped-envelopes.test.yml
+++ b/manifests/prometheus/spec/alerts/doppler-dropped-envelopes.test.yml
@@ -1,7 +1,7 @@
 ---
 rule_files:
   # See alerts_validation_spec.rb for details of how stdin gets set:
-  - spec/alerts/fixtures/rules.yml
+  - fixtures/rules.yml
 
 evaluation_interval: 1m
 

--- a/manifests/prometheus/spec/alerts/gorouter-latency.test.yml
+++ b/manifests/prometheus/spec/alerts/gorouter-latency.test.yml
@@ -1,7 +1,7 @@
 ---
 rule_files:
   # See alerts_validation_spec.rb for details of how stdin gets set:
-  - spec/alerts/fixtures/rules.yml
+  - fixtures/rules.yml
 
 evaluation_interval: 1m
 

--- a/manifests/prometheus/spec/alerts/router_total_routes.test.yml
+++ b/manifests/prometheus/spec/alerts/router_total_routes.test.yml
@@ -1,7 +1,7 @@
 ---
 rule_files:
   # See alerts_validation_spec.rb for details of how stdin gets set:
-  - spec/alerts/fixtures/rules.yml
+  - fixtures/rules.yml
 
 evaluation_interval: 1m
 

--- a/manifests/prometheus/spec/alerts/uaa-5xx-errors.test.yml
+++ b/manifests/prometheus/spec/alerts/uaa-5xx-errors.test.yml
@@ -1,7 +1,7 @@
 ---
 rule_files:
   # See alerts_validation_spec.rb for details of how stdin gets set:
-  - spec/alerts/fixtures/rules.yml
+  - fixtures/rules.yml
 
 evaluation_interval: 1m
 


### PR DESCRIPTION
What
----
I started writing up a ticket for this (https://www.pivotaltracker.com/story/show/182035914) but decided to just do it as I'd already done most of the work anyway.

Previous expression would substitute all missing values with 0, which would get picked up as resets by `increase()`, meaning a spotty value would get counted many times. Instead only use 0 when we haven't seen any values in the last 12h otherwise use `max_over_time` from the last 12h.

Ideally we'd use `last_over_time`, but that's only available from prometheus 2.26 onwards, which we don't quite have yet.


How to review
-------------
Deploy to a dev env, see perhaps see if alertmanager alerts appear following repeated failures? Could take multiple days. Could otherwise just suck it and see.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
