### PR TITLE
Increase lower limit for expiry days to be greater than zero

### DIFF
--- a/manifests/prometheus/alerts.d/cloudfront_tls_certificates_expiry.yml
+++ b/manifests/prometheus/alerts.d/cloudfront_tls_certificates_expiry.yml
@@ -8,7 +8,7 @@
     rules:
 
       - alert: CloudFrontTLSCertificateExpiresSoon
-        expr: "paas_cdn_tls_certificates_expiry_days <= 21 >= 0"
+        expr: "paas_cdn_tls_certificates_expiry_days <= 21 > 0"
         for: 5m
         annotations:
           summary: "A tenant/CloudFront TLS certificate is close to expiry"

--- a/manifests/prometheus/spec/alerts/cloudfront_tls_certificates_expiry.test.yml
+++ b/manifests/prometheus/spec/alerts/cloudfront_tls_certificates_expiry.test.yml
@@ -13,7 +13,7 @@ tests:
       - series: 'paas_cdn_tls_certificates_expiry_days{hostname="expiring"}'
         values: 10
       - series: 'paas_cdn_tls_certificates_expiry_days{hostname="expired"}'
-        values: -5
+        values: 0
 
     alert_rule_test:
       - alertname: CloudFrontTLSCertificateExpiresSoon


### PR DESCRIPTION

What
----

When certs expire, the days until expiring is zero
rather than a negative number. We should not get alerted
for certs that have 0 days left

How to review
-------------

code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
