### PR TITLE
[#181744627] Wrap continuous billing smoke tests in cronitor monitoring

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -7011,6 +7011,17 @@ jobs:
         - get: cf-manifest
           passed: ['post-deploy']
 
+      - try:
+          task: ping-cronitor-billing-test-start
+          tags: [colocated-with-web]
+          file: paas-cf/concourse/tasks/cronitor-monitor-ping-action.yml
+          params:
+            CRONITOR_SMOKE_TEST_MONITOR_CODE: ((cronitor_billing_smoke_test_monitor_code))
+            CRONITOR_MONITOR_PING_ENDPOINT: "run"
+            DEPLOY_ENV: ((deploy_env))
+            CCI_BUILD_NUMBER: $BUILD_NAME
+            CRONITOR_PING_MESSAGE: "Continuous+billing+smoke+tests+job+has+started"
+
       - do:
         - task: create-temp-user
           tags: [colocated-with-web]
@@ -7060,6 +7071,54 @@ jobs:
                 API_ENDPOINT: ((api_endpoint))
                 CF_ADMIN: ((cf_admin))
                 CF_PASS: ((cf_pass))
+
+    on_success:
+      try:
+        task: ping-cronitor-continuous-billing-smoke-tests-completed
+        tags: [colocated-with-web]
+        file: paas-cf/concourse/tasks/cronitor-monitor-ping-action.yml
+        params:
+          CRONITOR_SMOKE_TEST_MONITOR_CODE: ((cronitor_billing_smoke_test_monitor_code))
+          CRONITOR_MONITOR_PING_ENDPOINT: "complete"
+          DEPLOY_ENV: ((deploy_env))
+          CCI_BUILD_NUMBER: $BUILD_NAME
+          CRONITOR_PING_MESSAGE: "Continuous+billing+smoke+tests+job+has+completed+successfully"
+
+    on_failure:
+      try:
+        task: ping-cronitor-continuous-billing-smoke-tests-failed
+        tags: [colocated-with-web]
+        file: paas-cf/concourse/tasks/cronitor-monitor-ping-action.yml
+        params:
+          CRONITOR_SMOKE_TEST_MONITOR_CODE: ((cronitor_billing_smoke_test_monitor_code))
+          CRONITOR_MONITOR_PING_ENDPOINT: "fail"
+          DEPLOY_ENV: ((deploy_env))
+          CCI_BUILD_NUMBER: $BUILD_NAME
+          CRONITOR_PING_MESSAGE: "Continuous+billing+smoke+tests+job+has+failed"
+
+    on_abort:
+      try:
+        task: ping-cronitor-continuous-billing-smoke-tests-aborted
+        tags: [colocated-with-web]
+        file: paas-cf/concourse/tasks/cronitor-monitor-ping-action.yml
+        params:
+          CRONITOR_SMOKE_TEST_MONITOR_CODE: ((cronitor_billing_smoke_test_monitor_code))
+          CRONITOR_MONITOR_PING_ENDPOINT: "fail"
+          DEPLOY_ENV: ((deploy_env))
+          CCI_BUILD_NUMBER: $BUILD_NAME
+          CRONITOR_PING_MESSAGE: "Continuous+billing+smoke+tests+job+was+aborted"
+
+    on_error:
+      try:
+        task: ping-cronitor-continuous-billing-smoke-tests-errored
+        tags: [colocated-with-web]
+        file: paas-cf/concourse/tasks/cronitor-monitor-ping-action.yml
+        params:
+          CRONITOR_SMOKE_TEST_MONITOR_CODE: ((cronitor_billing_smoke_test_monitor_code))
+          CRONITOR_MONITOR_PING_ENDPOINT: "fail"
+          DEPLOY_ENV: ((deploy_env))
+          CCI_BUILD_NUMBER: $BUILD_NAME
+          CRONITOR_PING_MESSAGE: "Continuous+billing+smoke+tests+job+finished+with+errors"
 
   - name: continuous-new-billing-smoke-tests
     serial_groups: [smoke-tests]

--- a/scripts/upload-secrets/upload-cronitor-secrets.rb
+++ b/scripts/upload-secrets/upload-cronitor-secrets.rb
@@ -14,8 +14,10 @@ credhub_namespaces = [
 ]
 
 cronitor_smoke_test_monitor_code = ENV["CRONITOR_SMOKE_TEST_MONITOR_CODE"] || get_secret("cronitor/#{ENV['MAKEFILE_ENV_TARGET']}/smoke_test_monitor_code", "__NO_CRONITOR_SMOKE_TEST_MONITOR_CODE__")
+cronitor_billing_smoke_test_monitor_code = ENV["CRONITOR_BILLING_SMOKE_TEST_MONITOR_CODE"] || get_secret("cronitor/#{ENV['MAKEFILE_ENV_TARGET']}/billing_smoke_test_monitor_code", "__NO_CRONITOR_SMOKE_TEST_MONITOR_CODE__")
 
 upload_secrets(
   credhub_namespaces,
   "cronitor_smoke_test_monitor_code" => cronitor_smoke_test_monitor_code,
+  "cronitor_billing_smoke_test_monitor_code" => cronitor_billing_smoke_test_monitor_code,
 )


### PR DESCRIPTION
What
----

We want to be alerted about billing smoke tests failing in the same way as our regular platform-level smoke tests. We haven't covered the `continuous-new-billing-smoke-tests` set because they are being cleaned up in other work.

Also adds in the new secret required for Cronitor integration.

How to review
-------------
1. Code review
2. Deploy it, make it fail, see the alert go off. (See the secrets PR on the story for the correct branch to get secrets from)

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
