### PR TITLE
Split ips in x-forwarded-for

### DIFF
--- a/config/logit/20_custom_cf_filters.conf
+++ b/config/logit/20_custom_cf_filters.conf
@@ -110,3 +110,19 @@ mutate {
     "[gorouter][bytesreceived]" => "integer"
   }
 }
+
+# Process x_forwarded_for in gorouter logs in same way as done for RTR logs above
+if [gorouter][header][x_forwarded_for] {
+  # Set [gorouter][header][x_forwarded_for]
+  mutate {
+    gsub => ["[gorouter][header][x_forwarded_for]","[\s\"]",""] # remove quotes and whitespace
+    split => ["[gorouter][header][x_forwarded_for]", ","] # format is client, proxy1, proxy2 ...
+  }
+
+  # Set [gorouter][remote_addr]
+  # NOTE this value could potentially be spoofed - correct x-forwarded-for
+  # handling in logstash is very tricky
+  mutate {
+    add_field => ["[gorouter][remote_addr]", "%{[gorouter][header][x_forwarded_for][0]}"]
+  }
+}

--- a/config/logit/output/generated_logit_filters.conf
+++ b/config/logit/output/generated_logit_filters.conf
@@ -1187,6 +1187,24 @@ filter {
       "[gorouter][bytesreceived]" => "integer"
     }
   }
+
+
+  # Process x_forwarded_for in gorouter logs in same way as done for RTR logs above
+  if [gorouter][header][x_forwarded_for] {
+    # Set [gorouter][header][x_forwarded_for]
+    mutate {
+      gsub => ["[gorouter][header][x_forwarded_for]","[\s\"]",""] # remove quotes and whitespace
+      split => ["[gorouter][header][x_forwarded_for]", ","] # format is client, proxy1, proxy2 ...
+    }
+
+    # Set [gorouter][remote_addr]
+    # NOTE this value could potentially be spoofed - correct x-forwarded-for
+    # handling in logstash is very tricky
+    mutate {
+      add_field => ["[gorouter][remote_addr]", "%{[gorouter][header][x_forwarded_for][0]}"]
+    }
+  }
+
   # `paas-billing` provides the value of DEPLOY_ENV through an
   # `app.data.deployment` field. We want to set `@source.deployment` so
   # that it can be queried like the rest of the platform.
@@ -1195,7 +1213,7 @@ filter {
       add_field => { "[@source][deployment]" => "%{[app][data][deployment]}" }
     }
   }
-# Use more accurate timestamp fields, instead of the timestamp of when logit received the log
+  # Use more accurate timestamp fields, instead of the timestamp of when logit received the log
 
   date {
     match => [ "[aiven_service_discovery][timestamp]", "dd/MMMM/yyyy:HH:mm:ss Z", "dd/MMM/yyyy:HH:mm:ss Z", "ISO8601", "UNIX" ]


### PR DESCRIPTION
What
----

X-forwarded-for field in kibana is a string of comma separated ips. We want to be able to easily filter by ip. This PR converts the field into an array of ips

How to review
-------------

- Code review
- [Check that you can filter this field by individual ips ](https://kibana.logit.io/s/c7358874-2b30-44a6-8271-554ad3996e50/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(gorouter.header.x_forwarded_for),filters:!(('$state':(store:appState),exists:(field:gorouter.header.x_forwarded_for),meta:(alias:!n,disabled:!f,index:'logstash-*',key:gorouter.header.x_forwarded_for,negate:!f,type:exists,value:exists))),index:'logstash-*',interval:auto,query:(match_all:()),sort:!('@timestamp',desc)))

After merging
-------------
Copy `config/logit/output/generated_logit_filters.conf` and paste in Logit --> configure logstash pipelines, replacing the one in the editor. Test configuration --> apply
Do this for prod and staging

This will restart Kibana, so let people know!


---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
