### PR TITLE
cf internal prometheus: bump to boshrelease 27.0.0

### DIFF
--- a/manifests/cf-manifest/operations.d/500-prometheus.yml
+++ b/manifests/cf-manifest/operations.d/500-prometheus.yml
@@ -2,9 +2,9 @@
   path: /releases/-
   value:
     name: "prometheus"
-    version: "26.5.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=26.5.0"
-    sha1: "9825f13da17da079df9b7dbfdacd16f993eb09cc"
+    version: "27.0.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=27.0.0"
+    sha1: "39f6c86220c75c27bfad39c902dcbe8448c48dfd"
 
 - type: replace
   path: /releases/-

--- a/manifests/runtime-config/operations.d/510-add-prometheus-blackbox-exporter.yml
+++ b/manifests/runtime-config/operations.d/510-add-prometheus-blackbox-exporter.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: "prometheus"
-    version: "26.5.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=26.5.0"
-    sha1: "9825f13da17da079df9b7dbfdacd16f993eb09cc"
+    version: "27.0.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=27.0.0"
+    sha1: "39f6c86220c75c27bfad39c902dcbe8448c48dfd"
 
 - type: replace
   path: /addons?/-


### PR DESCRIPTION
What
----

When we (I) bumped our separate prometheus to boshrelease 27.0.0 I missed that the other prometheii should be bumped in tandem, and now one of our alerts is nagging us that we have multiple versions of prometheus deployed.

How to review
-------------

Deploy to a dev env, or look at `dev03`?

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
