### PR TITLE
[#181945547] Add prometheus watchdog

### DIFF
--- a/manifests/prometheus/alerts.d/watchdog.yml
+++ b/manifests/prometheus/alerts.d/watchdog.yml
@@ -1,0 +1,16 @@
+# Source: firehose-exporter
+---
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: AlertingWatchdog
+    rules:
+      - alert: AlertingWatchdog
+        expr: vector(1)
+        labels:
+          severity: none
+        annotations:
+          summary: "An alert that should always be firing to certify that Alertmanager is working properly"
+          description: This is an alert meant to ensure that the entire alerting pipeline is functional.
+
+          url: "https://team-manual.cloud.service.gov.uk/incident_management/responding_to_alerts/#alerting-watchdog"

--- a/manifests/prometheus/operations.d/310-alertmanager-routes.yml
+++ b/manifests/prometheus/operations.d/310-alertmanager-routes.yml
@@ -1,5 +1,4 @@
 ---
-
 - type: replace
   path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/route?
   value:
@@ -18,6 +17,12 @@
       - receiver: silence
         match:
           alertname: CFAppUnhealthy
+        continue: false
+      # Dead man's snitch alerts
+      - receiver: cronitor-alertingwatchdog
+        repeat_interval: 5m
+        match:
+          alertname: AlertingWatchdog
         continue: false
       # Loud alerts
       - receiver: warning-receiver
@@ -46,7 +51,15 @@
       - from: govpaas-alerting-((aws_account))@digital.cabinet-office.gov.uk
         to: govpaas-alerting-((aws_account))+warning@digital.cabinet-office.gov.uk
         headers:
-          Subject: "[((metrics_environment))] [warning] {{ .GroupLabels.SortedPairs.Values | join \" \" }}"
+          Subject: '[((metrics_environment))] [warning] {{ .GroupLabels.SortedPairs.Values | join " " }}'
+
+- type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers?/-
+  value:
+    name: cronitor-alertingwatchdog
+    webhook_configs:
+      - url: "https://cronitor.link/p/((cronitor_telemetry_api_key))/((cronitor_alertingwatchdog_heartbeat_code))"
+        send_resolved: false
 
 - type: replace
   path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers?/-
@@ -56,7 +69,7 @@
       - from: govpaas-alerting-((aws_account))@digital.cabinet-office.gov.uk
         to: govpaas-alerting-((aws_account))+critical@digital.cabinet-office.gov.uk
         headers:
-          Subject: "[((metrics_environment))] [critical] {{ .GroupLabels.SortedPairs.Values | join \" \" }}"
+          Subject: '[((metrics_environment))] [critical] {{ .GroupLabels.SortedPairs.Values | join " " }}'
 
 - type: replace
   path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers?/-
@@ -64,7 +77,7 @@
     name: pagerduty-24-7-receiver
     pagerduty_configs:
       - service_key: ((alertmanager_pagerduty_24_7_service_key))
-        description: "[((metrics_environment))] {{ .GroupLabels.SortedPairs.Values | join \" \" }}"
+        description: '[((metrics_environment))] {{ .GroupLabels.SortedPairs.Values | join " " }}'
 
 - type: replace
   path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers?/-
@@ -72,7 +85,7 @@
     name: pagerduty-in-hours-receiver
     pagerduty_configs:
       - service_key: ((alertmanager_pagerduty_in_hours_service_key))
-        description: "[((metrics_environment))] {{ .GroupLabels.SortedPairs.Values | join \" \" }}"
+        description: '[((metrics_environment))] {{ .GroupLabels.SortedPairs.Values | join " " }}'
 
 - type: replace
   path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers?/-

--- a/scripts/upload-secrets/upload-cronitor-secrets.rb
+++ b/scripts/upload-secrets/upload-cronitor-secrets.rb
@@ -12,12 +12,21 @@ credhub_namespaces = [
   "/concourse/main/create-cloudfoundry",
   "/#{deploy_env}/#{deploy_env}",
 ]
+prometheus_namespaces = ["/#{deploy_env}/prometheus"]
 
 cronitor_smoke_test_monitor_code = ENV["CRONITOR_SMOKE_TEST_MONITOR_CODE"] || get_secret("cronitor/#{ENV['MAKEFILE_ENV_TARGET']}/smoke_test_monitor_code", "__NO_CRONITOR_SMOKE_TEST_MONITOR_CODE__")
-cronitor_billing_smoke_test_monitor_code = ENV["CRONITOR_BILLING_SMOKE_TEST_MONITOR_CODE"] || get_secret("cronitor/#{ENV['MAKEFILE_ENV_TARGET']}/billing_smoke_test_monitor_code", "__NO_CRONITOR_SMOKE_TEST_MONITOR_CODE__")
-
+cronitor_billing_smoke_test_monitor_code = ENV["CRONITOR_BILLING_SMOKE_TEST_MONITOR_CODE"] || get_secret("cronitor/#{ENV['MAKEFILE_ENV_TARGET']}/billing_smoke_test_monitor_code", "__NO_CRONITOR_BILLING_SMOKE_TEST_MONITOR_CODE__")
 upload_secrets(
   credhub_namespaces,
   "cronitor_smoke_test_monitor_code" => cronitor_smoke_test_monitor_code,
   "cronitor_billing_smoke_test_monitor_code" => cronitor_billing_smoke_test_monitor_code,
+)
+
+cronitor_alertingwatchdog_heartbeat_code = ENV["CRONITOR_ALERTINGWATCHDOG_HEARTBEAT_CODE"] || get_secret("cronitor/#{ENV['DEPLOY_ENV']}/alertingwatchdog_heartbeat_code", "__NO_CRONITOR_ALERTINGWATCHDOG_HEARTBEAT_CODE__")
+telemetry_api_key = ENV["TELEMETRY_API_KEY"] || get_secret("cronitor/telemetry_api_key", "__NO_CRONITOR_TELEMETRY_API_KEY__")
+
+upload_secrets(
+  prometheus_namespaces,
+  "cronitor_alertingwatchdog_heartbeat_code" => cronitor_alertingwatchdog_heartbeat_code,
+  "cronitor_telemetry_api_key" => telemetry_api_key,
 )


### PR DESCRIPTION
What
----

Configure prometheus to call out to cronitor every 5 minutes, via a persistent alarm.

As this alarm is generated from Prometheus, it is essentially an e2e test of whether Prometheus is working.

How to review
-------------

* Run this down a dev pipeline (or just check that dev03 has it deployed)
* Check that the healthcheck in Cronitor is working (link in pivotal)

## Important pre-deploy

This will require the cronitor secrets to be rolled out first for each environment, otherwise the deploy will fail. See the other PR linked in Pivotal.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
