### PR TITLE
180444788 - Unfork UAA

### DIFF
--- a/manifests/cf-manifest/operations.d/330-uaa.yml
+++ b/manifests/cf-manifest/operations.d/330-uaa.yml
@@ -321,9 +321,9 @@
   path: /releases/-
   value:
     name: uaa-customized
-    version: 0.1.31
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-customized-0.1.31.tgz
-    sha1: 20edd103fd2d9709038c4f46172ce2ea30172f30
+    version: 0.1.33
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-customized-0.1.33.tgz
+    sha1: 552b582d506aa84f17be1254264bf76fe24ae7af
 
 - type: replace
   path: /instance_groups/name=uaa/jobs/-

--- a/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
+++ b/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
@@ -3,6 +3,6 @@
   path: /releases/name=uaa
   value:
     name: uaa
-    version: 0.1.35
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-0.1.35.tgz
-    sha1: 1d0cbd3bf11252fda305763518c7b29addb4af36
+    version: 75.19.0
+    url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.19.0
+    sha1: 7a1fe64957930074d1591d66d72aac9c3aed2dbe

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -27,12 +27,7 @@ RSpec.describe "release versions" do
       Gem::Version.new(v.gsub(/^v/, "").gsub(/^([0-9]+)$/, '0.0.\1'))
     end
 
-    pinned_releases = {
-      "uaa" => {
-        local: "0.1.35",
-        upstream: "75.19.0",
-      },
-    }
+    pinned_releases = {}
 
     manifest_releases = manifest_without_vars_store.fetch("releases").map { |release|
       [release["name"], release["version"]]


### PR DESCRIPTION
Description:
- Points to upstream CloudFoundry UAA 75.1.0
- Points to release 0.1.33 of the UAA customization bosh release

Point the UAA to CloudFoundry version to test what breaks in our customized UAA PaaS configuration

How to review
-------------

See Pivotal story for fuller discussion on how to review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
