### PR TITLE
prod: scale down to 24 cell_instances

### DIFF
--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -2,7 +2,7 @@
 uaa_instances: 3
 nats_instances: 3
 diego_api_instances: 3
-cell_instances: 36
+cell_instances: 24
 router_instances: 72
 api_instances: 9
 doppler_instances: 54


### PR DESCRIPTION
What
----

We seem to be levelling around 20 cells' usage in `prod` - 36 cells is a waste. Haven't changed any of the rest of the infra to match due to the presence of Notify.

But I do note we have over twice as many router instances in `prod` as we do in `prod-lon` and only half the cells.

How to review
-------------

:eyes: 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
