### PR TITLE
Give the GITHUB_TOKEN permission to create PRs

### DIFF
--- a/.github/workflows/generate_buildpack_bump_pr.yml
+++ b/.github/workflows/generate_buildpack_bump_pr.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 env:
   GO_VERSION: "1.18"
@@ -42,8 +43,6 @@ jobs:
           echo "NEW_BRANCH_NAME=$NEW_BRANCH_NAME" >> $GITHUB_ENV
 
       - name: Create PR
-        env:
-          GITHUB_TOKEN: ${{ secrets.GOVUK_PAAS_UNPRIVILEGED_BOT_PAT }}
         run: |
           gh pr create \
             --base main \


### PR DESCRIPTION
What
----

Github allows you to elevate the provided GITHUB_TOKEN's permissions, so it can create a PR.

Rather than having an unprivileged bot token, elevate the token's permissions to allow this via the workflow.

(@AP-Hunt told me that there were issues with this that needed a workaround, and it's just come up again on https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/226)

How to review
-------------

Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
