### PR TITLE
cdn-broker: fix cf domain checking among other things

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -2976,6 +2976,7 @@ jobs:
                 UAA_CLIENTS_PAAS_ADMIN_SECRET=$(credhub get -q -n "${BOSH_NS}/uaa_clients_paas_admin_secret")
                 UAA_CLIENTS_PAAS_AUDITOR_SECRET=$(credhub get -q -n "${BOSH_NS}/secrets_uaa_clients_paas_auditor_secret")
                 UAA_CLIENTS_PAAS_PROMETHEUS_ENDPOINTS_SECRET=$(credhub get -q -n "${BOSH_NS}/secrets_uaa_clients_paas_prometheus_endpoints_secret")
+                UAA_CLIENTS_CDN_BROKER_SECRET=$(credhub get -q -n "${BOSH_NS}/secrets_uaa_clients_cdn_broker_secret")
                 SECRETS_TEST_USER_PASSWORD=$(credhub get -q -n "${BOSH_NS}/secrets_test_user_password")
                 CUSTOM_BROKER_ACCEPTANCE_PROMETHEUS_PASSWORD=$(credhub get -q -n "${BOSH_NS}/custom_broker_acceptance_prometheus_password")
 
@@ -3011,6 +3012,7 @@ jobs:
                 credhub set --name="${PIPELINE_NS}/uaa_clients_paas_admin_secret" --type password --password "${UAA_CLIENTS_PAAS_ADMIN_SECRET}"
                 credhub set --name="${PIPELINE_NS}/uaa_clients_paas_auditor_secret" --type password --password "${UAA_CLIENTS_PAAS_AUDITOR_SECRET}"
                 credhub set --name="${PIPELINE_NS}/uaa_clients_paas_prometheus_endpoints_secret" --type password --password "${UAA_CLIENTS_PAAS_PROMETHEUS_ENDPOINTS_SECRET}"
+                credhub set --name="${PIPELINE_NS}/uaa_clients_cdn_broker_secret" --type password --password "${UAA_CLIENTS_CDN_BROKER_SECRET}"
                 credhub set --name="${PIPELINE_NS}/secrets_test_user_password" --type password --password "${SECRETS_TEST_USER_PASSWORD}"
                 credhub set --name="${PIPELINE_NS}/platform_prometheus_password" --type password --password "${PLATFORM_PROMETHEUS_PASSWORD}"
 
@@ -6557,6 +6559,7 @@ jobs:
               credhub generate -n "${BOSH_NS}/secrets_uaa_clients_paas_billing_secret" -t password
               credhub generate -n "${BOSH_NS}/secrets_uaa_clients_paas_metrics_secret" -t password
               credhub generate -n "${BOSH_NS}/secrets_uaa_clients_paas_prometheus_endpoints_secret" -t password
+              credhub generate -n "${BOSH_NS}/secrets_uaa_clients_cdn_broker_secret" -t password
               credhub generate -n "${BOSH_NS}/uaa_clients_cf_exporter_secret" -t password
               credhub generate -n "${BOSH_NS}/uaa_clients_cf_smoke_tests_secret" -t password
               credhub generate -n "${BOSH_NS}/uaa_clients_firehose_exporter_secret" -t password

--- a/manifests/cf-manifest/operations.d/330-uaa.yml
+++ b/manifests/cf-manifest/operations.d/330-uaa.yml
@@ -157,6 +157,18 @@
     secret: ((secrets_uaa_clients_paas_prometheus_endpoints_secret))
 
 - type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/cdn-broker?
+  value:
+    access-token-validity: 1209600
+    authorities: oauth.login,cloud_controller.global_auditor,scim.read
+    authorized-grant-types: client_credentials,refresh_token,authorization_code
+    autoapprove: true
+    override: true
+    redirect-uri: https://cdn-broker.((system_domain))/oauth/callback
+    scope: cloud_controller.admin_read_only
+    secret: ((secrets_uaa_clients_cdn_broker_secret))
+
+- type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/user_invitation?
   value:
     authorities: oauth.login,scim.write,emails.write,scim.userids
@@ -311,6 +323,11 @@
   path: /variables/-
   value:
     name: secrets_uaa_clients_paas_prometheus_endpoints_secret
+    type: password
+- type: replace
+  path: /variables/-
+  value:
+    name: secrets_uaa_clients_cdn_broker_secret
     type: password
 
 - type: replace

--- a/manifests/cf-manifest/operations.d/720-cdn-broker.yml
+++ b/manifests/cf-manifest/operations.d/720-cdn-broker.yml
@@ -40,7 +40,7 @@
             aws_access_key_id: ""
             aws_secret_access_key: ""
             api_address: https://api.((terraform_outputs_cf_root_domain))
-            client_id: "cdn_broker"
+            client_id: "cdn-broker"
             client_secret: ((secrets_uaa_clients_cdn_broker_secret))
             default_origin: ((terraform_outputs_cf_apps_domain))
             aws_region: "((terraform_outputs_region))"
@@ -51,22 +51,7 @@
       - name: cf
 
 - type: replace
-  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/cdn_broker?
-  value:
-    authorities: uaa.none
-    authorized-grant-types: password
-    override: true
-    scope: cloud_controller.admin_read_only
-    secret: ((secrets_uaa_clients_cdn_broker_secret))
-
-- type: replace
   path: /variables/-
   value:
     name: secrets_cdn_broker_admin_password
-    type: password
-
-- type: replace
-  path: /variables/-
-  value:
-    name: secrets_uaa_clients_cdn_broker_secret
     type: password

--- a/manifests/cf-manifest/operations.d/720-cdn-broker.yml
+++ b/manifests/cf-manifest/operations.d/720-cdn-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: cdn-broker
-    version: 0.1.47
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.47.tgz
-    sha1: cfbb094c441764bd7ddf08e0b90d9097c40afcf7
+    version: 0.1.48
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.48.tgz
+    sha1: ee6b435b00869191c4ac189ab222fe3ac253d1a2
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-

--- a/platform-tests/broker-acceptance/cdn_broker_test.go
+++ b/platform-tests/broker-acceptance/cdn_broker_test.go
@@ -40,17 +40,67 @@ var _ = Describe("CDN broker", func() {
 
 			serviceInstanceName = generator.PrefixedRandomName(testConfig.GetNamePrefix(), "test-cdn")
 
+			// best effort tidyup - we don't really care if these pass or fail
+			defer pollForServiceDeletionCompletion(serviceInstanceName)
+			defer cf.Cf("delete-domain", domainName, "-f")
+			defer cf.Cf("delete-service", serviceInstanceName, "-f")
+
 			By("creating a CDN instance: "+serviceInstanceName, func() {
 				Expect(cf.Cf("create-domain", orgName, domainName).Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
 				Expect(cf.Cf("create-service", serviceName, serviceName, serviceInstanceName, "-c", domainNameList).Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
 				pollForCdnServiceCreationCompletion(serviceInstanceName)
 			})
 
-			defer By("deleting a standard CDN service", func() {
+			By("deleting a standard CDN service", func() {
 				Expect(cf.Cf("delete-service", serviceInstanceName, "-f").Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
 				Expect(cf.Cf("delete-domain", domainName, "-f").Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
 				pollForServiceDeletionCompletion(serviceInstanceName)
 			})
 		})
+
+		It("refuses to create a CDN for a domain without a cf create-domain", func() {
+			domainName := generator.PrefixedRandomName(testConfig.GetNamePrefix(), "cdn-broker") + ".net"
+			domainNameList := fmt.Sprintf(`{"domain": "%s"}`, domainName)
+
+			serviceInstanceName = generator.PrefixedRandomName(testConfig.GetNamePrefix(), "test-cdn")
+
+			// best effort tidyup - we don't really care if these pass or fail.
+			// currently this kind of failure doesn't actually stop the service
+			// being "created".
+			defer pollForServiceDeletionCompletion(serviceInstanceName)
+			defer cf.Cf("delete-service", serviceInstanceName, "-f")
+
+			By("attempting to create a CDN instance: "+serviceInstanceName, func() {
+				cf_create_service := cf.Cf("create-service", serviceName, serviceName, serviceInstanceName, "-c", domainNameList).Wait(testConfig.DefaultTimeoutDuration())
+				Expect(cf_create_service).To(Exit(1))
+				Expect(cf_create_service.Err.Contents()).To(ContainSubstring("cf create-domain"))
+			})
+		})
+
+		It("refuses to create a CDN for a domain with wrong ownership", func() {
+			domainName := generator.PrefixedRandomName(testConfig.GetNamePrefix(), "cdn-broker") + ".net"
+			domainNameList := fmt.Sprintf(`{"domain": "%s"}`, domainName)
+
+			serviceInstanceName = generator.PrefixedRandomName(testConfig.GetNamePrefix(), "test-cdn")
+
+			// best effort tidyup - we don't really care if these pass or fail.
+			// currently this kind of failure doesn't actually stop the service
+			// being "created".
+			defer pollForServiceDeletionCompletion(serviceInstanceName)
+			defer cf.Cf("delete-domain", domainName, "-f")
+			defer cf.Cf("delete-service", serviceInstanceName, "-f")
+
+			By("attempting to create a CDN instance: "+serviceInstanceName, func() {
+				Expect(cf.Cf("create-domain", altOrgName, domainName).Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
+				cf_create_service := cf.Cf("create-service", serviceName, serviceName, serviceInstanceName, "-c", domainNameList).Wait(testConfig.DefaultTimeoutDuration())
+				Expect(cf_create_service).To(Exit(1))
+				Expect(cf_create_service.Err.Contents()).To(ContainSubstring("different organization"))
+			})
+		})
+
+		// tests of update-service functionality would be wonderful but quite hard to implement as to get a service
+		// into a state where it will accept updates we would have to first validate the domain which would require
+		// the tests having permissions to update dns records on route53.
+
 	})
 })


### PR DESCRIPTION
What
----

https://www.pivotaltracker.com/story/show/181233950

Depends on https://github.com/alphagov/paas-cdn-broker/pull/56

See individual commit comments for details, but this firstly fixes the provisioning of the cdn-broker's uaa secret, _then_ bumps our cdn-broker to the result of https://github.com/alphagov/paas-cdn-broker/pull/56 (which should add domain ownership checking and better error handling), _then_ adds tests for cf domain existence and ownership to the custom-broker-acceptance-tests.

How to review
-------------

Deploy to a dev env. Ensure custom-broker-acceptance-tests pass. Maybe even run `rotate-cloudfoundry-credentials` and check a re-deploy succeeds and tests pass again.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
