### PR TITLE
manifest spec: reintroduce uaa version checks outlining necessary testing

### DIFF
--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -14,6 +14,17 @@ RSpec.describe "release versions" do
     end
   end
 
+  def normalise_version(version)
+    v = version
+    Gem::Version.new(v.gsub(/^v/, "").gsub(/^([0-9]+)$/, '0.0.\1'))
+  end
+
+  def get_manifest_releases
+    manifest_without_vars_store.fetch("releases").map { |release|
+      [release["name"], release["version"]]
+    }.to_h
+  end
+
   specify "release versions match their download URL version" do
     manifest_without_vars_store.fetch("releases").each do |release|
       expect(release.fetch("version")).to match_version_from_url(release.fetch("url")),
@@ -22,16 +33,8 @@ RSpec.describe "release versions" do
   end
 
   specify "manifest versions are not older than the ones in cf_deployment" do
-    def normalise_version(version)
-      v = version
-      Gem::Version.new(v.gsub(/^v/, "").gsub(/^([0-9]+)$/, '0.0.\1'))
-    end
-
     pinned_releases = {}
-
-    manifest_releases = manifest_without_vars_store.fetch("releases").map { |release|
-      [release["name"], release["version"]]
-    }.to_h
+    manifest_releases = get_manifest_releases
 
     cf_deployment_releases = cf_deployment_manifest.fetch("releases").map { |release|
       [release["name"], release["version"]]
@@ -50,14 +53,33 @@ RSpec.describe "release versions" do
     end
 
     pinned_releases.each do |name, pinned_versions|
-      expect(manifest_releases).to have_key(name), "expected pinned release #{name} for found in manifest"
-      expect(cf_deployment_releases).to have_key(name), "expected pinned release #{name} for found in cf-deployment"
+      expect(manifest_releases).to have_key(name), "expected pinned release for #{name} to be found in manifest"
+      expect(cf_deployment_releases).to have_key(name), "expected pinned release for #{name} to be found in cf-deployment"
       expect(normalise_version(manifest_releases[name])).to be(normalise_version(pinned_versions[:local])),
          "expected #{name} to be using our own built tarball #{pinned_versions[:local]} not #{manifest_releases[name]}"
 
       expect(normalise_version(cf_deployment_releases[name])).to be(normalise_version(pinned_versions[:upstream])),
         "expected #{name} upstream to be #{pinned_versions[:upstream]} not #{cf_deployment_releases[name]}. We might need to rebase our forked #{name} release and generate a new tarball, or use the upstream version."
     end
+  end
+
+  specify "UAA version has been manually tested against our customizations" do
+    # by bumping this version number you promise that the following have been
+    # manually tested:
+    #
+    # - login via SSO
+    # - login via username/password
+    # - failed login due to wrong password
+    # - forgotten password reset
+    # - user invitation/activation
+    # - attempted login using an unknown/unrelated Google account
+    #
+    # these are tricky to automate due to their reliance on SSO and/or email.
+    tested_uaa_version = "75.19.0"
+    manifest_releases = get_manifest_releases
+
+    expect(manifest_releases).to have_key("uaa"), "expected release for uaa to be found in manifest"
+    expect(normalise_version(manifest_releases["uaa"])).to be(normalise_version(tested_uaa_version)), "expected release for uaa to be a version which has been manually tested against our uaa customizations"
   end
 
   specify "cf-smoke-tests-release version is not older than in upstream" do


### PR DESCRIPTION
What
----

Now that we've unforked our uaa dependency we're potentially vulnerable to breakage on uaa updates in areas that aren't covered by automated testing.

This is possible because of the tight coupling of our uaa customization, problems with which prevented us from unforking for so long in the first place.

This is a precursor to the cf-deployment 21.x upgrade (https://www.pivotaltracker.com/story/show/182344728), which will be the first time in ages we've done a "routine" uaa upgrade.

How to review
-------------

Try overriding the version in the manifest, see if the error message is sensible?

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
