### PR TITLE
cf-deployment: v20.2.0 -> v21.3.0

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -528,7 +528,7 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-acceptance-tests
-      branch: cf20.2
+      branch: cf21.3
 
   - name: cf-smoke-tests-release
     type: git

--- a/manifests/cf-manifest/operations.d/009-disable-dynamic-asgs-UPSTREAM.yml
+++ b/manifests/cf-manifest/operations.d/009-disable-dynamic-asgs-UPSTREAM.yml
@@ -1,1 +1,0 @@
-../../cf-deployment/operations/disable-dynamic-asgs.yml

--- a/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
+++ b/manifests/cf-manifest/operations.d/339-uaa-set-uaa-boshrelease.yml
@@ -1,8 +1,0 @@
----
-- type: replace
-  path: /releases/name=uaa
-  value:
-    name: uaa
-    version: 75.19.0
-    url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.19.0
-    sha1: 7a1fe64957930074d1591d66d72aac9c3aed2dbe

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "release versions" do
     # - attempted login using an unknown/unrelated Google account
     #
     # these are tricky to automate due to their reliance on SSO and/or email.
-    tested_uaa_version = "75.19.0"
+    tested_uaa_version = "75.20.0"
     manifest_releases = get_manifest_releases
 
     expect(manifest_releases).to have_key("uaa"), "expected release for uaa to be found in manifest"

--- a/platform-tests/acceptance/tls_version_test.go
+++ b/platform-tests/acceptance/tls_version_test.go
@@ -20,6 +20,7 @@ func AssertTLSErrorOnClassicLB(err error) {
 	Expect(err).To(HaveOccurred())
 	Expect(err).To(SatisfyAny(
 		MatchError("tls: no supported versions satisfy MinVersion and MaxVersion"),
+		MatchError("tls: protocol version not supported"),
 		MatchError("EOF"),
 	))
 }
@@ -33,6 +34,7 @@ func AssertTLSErrorOnALB(err error) {
 		// but will return an error, which crypto/tls can
 		// translate in to the below, when connecting with SSL.
 		ContainSubstring("tls: no supported versions satisfy MinVersion and MaxVersion"),
+		ContainSubstring("tls: protocol version not supported"),
 	))
 }
 

--- a/platform-tests/upstream/run_acceptance_tests.sh
+++ b/platform-tests/upstream/run_acceptance_tests.sh
@@ -15,7 +15,6 @@ SLOW_SPEC_THRESHOLD=120
 SKIP_REGEX="${SKIP_REGEX:+${SKIP_REGEX}|}routing.API"
 SKIP_REGEX="${SKIP_REGEX}|Adding a wildcard route to a domain"
 SKIP_REGEX="${SKIP_REGEX}|when app has multiple ports mapped"
-SKIP_REGEX="${SKIP_REGEX}|Dynamic ASGs"
 SKIP_REGEX="${SKIP_REGEX// /\\s}" # Replace ' ' with \s
 
 export CONFIG


### PR DESCRIPTION
What
----

https://www.pivotaltracker.com/story/show/182344728

Bump cf-deployment to v21.3.0.

More details in individual commit messages, but this also switches to dynamic ASGs and re-enables the acceptance test for them.

Deploying this on a clean non-slim deployment succeeds with only the `api-availability-tests` failing at 99.82%. However, all the failures return a sensible and reasonable error message so I feel ok about it (see https://deployer.dev03.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/api-availability-tests/builds/88)

Manual UAA tests pass.

How to review
-------------

Deploy to a clean, non-slim dev env.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
