### PR TITLE
app-autoscaler: bionic stemcell: 1.84 -> 1.90

### DIFF
--- a/manifests/app-autoscaler/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/app-autoscaler/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-bionic
-      version: "1.84"
+      version: "1.90"


### PR DESCRIPTION
What
----

Bumped autoscaler's stemcell to match the cf stemcells bumped in https://github.com/alphagov/paas-cf/pull/2920

How to review
-------------

:eyes: https://deployer.dev02.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/app-autoscaler-acceptance-tests/builds/137

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
