### PR TITLE
[#182177000] Enable overlapping blocks in Prometheus' timeseries database

### DIFF
--- a/manifests/prometheus/operations.d/002-enable-overlapping-tsdb-blocks.yml
+++ b/manifests/prometheus/operations.d/002-enable-overlapping-tsdb-blocks.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties?/prometheus/storage/tsdb/allow_overlapping_blocks?
+  value: true


### PR DESCRIPTION
What
----

We are going to be introducing some new recording rules to improve query performance, for which we will need to backfill the metric data. In order to do that, Prometheus' timeseries database needs to be allowed to have overlapping blocks of time, so that it can slot in the new metric data during compaction.

This PR ought to be reverted once the new recording rules have been added, and the metric data backfilled.

How to review
-------------
1. Read [the blog post from which we cribbed this information](https://jessicagreben.medium.com/prometheus-fill-in-data-for-new-recording-rules-30a14ccb8467)
2. Check that I've set [the correct property in the job spec](https://github.com/bosh-prometheus/prometheus-boshrelease/blob/master/jobs/prometheus2/templates/bin/prometheus_ctl)

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
