### PR TITLE
[#182177000] Use xlarge instance type for platform Prometheus machines

### DIFF
--- a/manifests/prometheus/operations.d/100-update-vm-types.yml
+++ b/manifests/prometheus/operations.d/100-update-vm-types.yml
@@ -6,4 +6,4 @@
   value: nano
 - type: replace
   path: /instance_groups/name=prometheus2/vm_type
-  value: large
+  value: xlarge

--- a/manifests/prometheus/spec/operations/update_vm_types_spec.rb
+++ b/manifests/prometheus/spec/operations/update_vm_types_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "update-vm-types.yml" do
   {
     "alertmanager" => "nano",
     "grafana" => "nano",
-    "prometheus2" => "large",
+    "prometheus2" => "xlarge",
   }.each do |name, type|
     it "sets the vm_type for #{name} to #{type}" do
       expect(manifest_with_defaults.get("instance_groups.#{name}.vm_type")).to eq(type)


### PR DESCRIPTION
What
----

The previous instance type gave the machine 8gb RAM, which was proving not to be enough and caused Prometheus to dip in to its swap regularly. The `xlarge` instance type will give it 16gb RAM.

How to review
-------------

1. Check I used the right instance type name from the cloud config

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
