### PR TITLE
cdn-broker: 0.1.48 -> 0.1.49, add acceptance tests for ownership of parent domain

### DIFF
--- a/manifests/cf-manifest/operations.d/720-cdn-broker.yml
+++ b/manifests/cf-manifest/operations.d/720-cdn-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: cdn-broker
-    version: 0.1.48
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.48.tgz
-    sha1: ee6b435b00869191c4ac189ab222fe3ac253d1a2
+    version: 0.1.49
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.49.tgz
+    sha1: 00a7c9788953038592dc3fddf1fc1e4898e1f742
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-


### PR DESCRIPTION
What
----

Bump cdn-broker to include https://github.com/alphagov/paas-cdn-broker/pull/59, add an acceptance test for this functionality.

How to review
-------------

Deploy to a dev env, :eyes: at results of new test?

Or look at https://deployer.dev01.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/custom-broker-acceptance-tests/builds/143

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
