### PR TITLE
Improve Markdown output for buildpack emails generator

### DIFF
--- a/tools/buildpacks/email.tmpl
+++ b/tools/buildpacks/email.tmpl
@@ -9,6 +9,7 @@ If you have any problems using the new versions in the buildpacks, or working to
 Regards,
 
 The GOV.UK PaaS team
+
 {{- if .HasAnyHighlights }}
 # Highlights
 {{- range $index := .Data }}
@@ -32,5 +33,6 @@ The GOV.UK PaaS team
 Release notes:
 {{ range $version := .ReleaseNoteVersions }}
 * https://github.com/cloudfoundry/{{ $buildpack.RepoName }}/releases/tag/{{ $version }}{{ end }}
+
 --------{{ if $index }}
 {{ end }}{{ end }}


### PR DESCRIPTION
What
----

The template for the buildpack email generator was outputting Markdown that
caused the release notes links to turned in to a header:

```
[link](url)
----
```

Instead of

```
[link](url)

---
```

How to review
-------------

Run the script and check the Markdown output looks OK when rendered.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
