### PR TITLE
Update UAA release and remove test for signup link on paas-admin login page

### DIFF
--- a/manifests/cf-manifest/operations.d/330-uaa.yml
+++ b/manifests/cf-manifest/operations.d/330-uaa.yml
@@ -337,9 +337,9 @@
   path: /releases/-
   value:
     name: uaa-customized
-    version: 0.1.33
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-customized-0.1.33.tgz
-    sha1: 552b582d506aa84f17be1254264bf76fe24ae7af
+    version: 0.1.34
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-customized-0.1.34.tgz
+    sha1: 30bf7b191db7d04dc052c7a045f26456554da226
 
 - type: replace
   path: /instance_groups/name=uaa/jobs/-

--- a/manifests/cf-manifest/operations.d/330-uaa.yml
+++ b/manifests/cf-manifest/operations.d/330-uaa.yml
@@ -52,7 +52,6 @@
   value:
     homeRedirect: https://admin.((system_domain))/
     passwd: https://admin.((system_domain))/password/request-reset
-    signup: https://admin.london.cloud.service.gov.uk/support/sign-up
 
 - type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/login/self_service_links_enabled?

--- a/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
@@ -145,7 +145,6 @@ RSpec.describe "base properties" do
       subject(:links) { login.fetch("links") }
 
       it { is_expected.to include("passwd" => "https://admin.#{terraform_fixture_value(:cf_root_domain)}/password/request-reset") }
-      it { is_expected.to include("signup" => "https://admin.london.cloud.service.gov.uk/support/sign-up") }
       it { is_expected.to include("homeRedirect" => "https://admin.#{terraform_fixture_value(:cf_root_domain)}/") }
     end
   end


### PR DESCRIPTION
What
----

Bump UAA release version and remove test that checks for the existence of sign-up link on the admin login page as we're [removing](https://github.com/alphagov/paas-uaa-customized-boshrelease/pull/30) it 

How to review
-------------

tests still pass
check tarball version and sha against https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/uaa-customized-release/jobs/build-final-release/builds/3

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
