### PR TITLE
external prometheus: increase prometheus_disk_size to 250G in prod & prod-lon

### DIFF
--- a/manifests/prometheus/env-specific/prod-lon.yml
+++ b/manifests/prometheus/env-specific/prod-lon.yml
@@ -5,7 +5,7 @@ aws_limits_elasticache_cache_parameter_groups: 800
 aws_limits_elasticache_nodes: 1000
 # Change limit for prod as well - S3 is global
 aws_limits_s3_buckets: 750
-prometheus_disk_size: 200GB
+prometheus_disk_size: 250GB
 # Change limit for prod as well - Cloudfront is global
 aws_limits_cloudfront_distributions: 400
 

--- a/manifests/prometheus/env-specific/prod.yml
+++ b/manifests/prometheus/env-specific/prod.yml
@@ -5,7 +5,7 @@ aws_limits_elasticache_cache_parameter_groups: 400
 aws_limits_elasticache_nodes: 400
 # Change limit for prod-lon as well - S3 is global
 aws_limits_s3_buckets: 750
-prometheus_disk_size: 200GB
+prometheus_disk_size: 250GB
 # Change limit for prod-lon as well - Cloudfront is global
 aws_limits_cloudfront_distributions: 400
 


### PR DESCRIPTION
What
----
https://www.pivotaltracker.com/story/show/182769592

This is as opposed to setting a size-based retention policy, which would cause us to stop getting alerts when we're no longer able to retain our requested 450d of metrics.

Looking back in history the "450d" comes from a desire to have more than a year's worth of metrics available to us for analysis.

How to review
-------------

:eyes: 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
