### PR TITLE
fix prometheus manifest generation, bump disk sizes

### DIFF
--- a/manifests/cf-manifest/spec/integration/integration_spec.rb
+++ b/manifests/cf-manifest/spec/integration/integration_spec.rb
@@ -1,176 +1,180 @@
 require "ipaddr"
 
 RSpec.describe "generic manifest validations" do
-  let(:manifest) { manifest_with_defaults }
+  %w[prod prod-lon stg-lon].each do |env|
+    context "for the #{env} environment" do
+      let(:manifest) { manifest_for_env(env) }
 
-  specify "it must have a name" do
-    expect(manifest["name"]).not_to be_nil
-    expect(manifest["name"]).to match(/\S+/)
-  end
-
-  it "sets stemcell versions as strings" do
-    manifest.fetch("stemcells").each do |stemcell|
-      expect(stemcell.fetch("version")).to be_a(String)
-    end
-  end
-
-  describe "there are no leftover variable substitutions" do
-    def no_values_contain(enumerable_or_str, str)
-      case enumerable_or_str
-      when Hash
-        enumerable_or_str.each do |_, v|
-          no_values_contain v, str
-        end
-      when Array
-        enumerable_or_str.each do |v|
-          no_values_contain v, str
-        end
-      when String
-        expect(enumerable_or_str).not_to include(str)
+      specify "it must have a name" do
+        expect(manifest["name"]).not_to be_nil
+        expect(manifest["name"]).to match(/\S+/)
       end
-    end
 
-    # BOSH interpolate leaves entries like `key: (( "value" ))` alone. This led
-    # to URLs of "(( \"value\" ))" being passed to nozzle during one
-    # cf upgrade. We have some entries that legitimately have )) in,
-    # but it seems unlikely we will have ones with a legitimate )).
-    specify "where '((' is present in output values" do
-      no_values_contain manifest, "(("
-    end
-  end
-
-  describe "name uniqueness" do
-    %w[
-      instance_groups
-      releases
-    ].each do |resource_type|
-      specify "all #{resource_type} have a unique name" do
-        all_resource_names = manifest.fetch(resource_type).map { |r| r["name"] }
-
-        duplicated_names = all_resource_names.select { |n| all_resource_names.count(n) > 1 }.uniq
-        expect(duplicated_names).to be_empty,
-          "found duplicate names (#{duplicated_names.join(',')}) for #{resource_type}"
-      end
-    end
-  end
-
-  describe "IP address uniqueness" do
-    specify "all jobs should use a unique IP address" do
-      all_ips = manifest["instance_groups"].map { |job|
-        job["networks"].map { |net| net["static_ips"] }
-      }.flatten.compact
-
-      duplicated_ips = all_ips.select { |ip| all_ips.count(ip) > 1 }.uniq
-      expect(duplicated_ips).to be_empty,
-        "found duplicate IP (#{duplicated_ips.join(',')})"
-    end
-  end
-
-  describe "jobs cross-references" do
-    specify "all jobs reference vm_types that exist" do
-      vm_type_names = cloud_config_with_defaults["vm_types"].map { |r| r["name"] }
-      manifest["instance_groups"].each do |job|
-        expect(vm_type_names).to include(job["vm_type"]),
-          "vm_type #{job['vm_type']} not found for job #{job['name']}"
-      end
-    end
-
-    specify "all jobs reference vm_extensions that exist" do
-      vm_extension_names = cloud_config_with_defaults.fetch("vm_extensions", []).map { |r| r["name"] }
-      manifest["instance_groups"].each do |job|
-        job.fetch("vm_extensions", []).each do |extension|
-          expect(vm_extension_names).to include(extension),
-            "vm_extension '#{extension}' not found for job #{job['name']}"
+      it "sets stemcell versions as strings" do
+        manifest.fetch("stemcells").each do |stemcell|
+          expect(stemcell.fetch("version")).to be_a(String)
         end
       end
-    end
 
-    specify "all jobs reference stemcells that exist" do
-      stemcell_names = manifest["stemcells"].map { |r| r["alias"] }
-      manifest["instance_groups"].each do |job|
-        expect(job.key?("stemcell")).to be(true),
-          "No stemcell defined for job #{job['name']}. You must add a stemcell to this job."
-        expect(stemcell_names).to include(job["stemcell"]),
-          "stemcell #{job['stemcell']} not found for job #{job['name']}. This value should correspond to `stemcells.*.alias`."
-      end
-    end
+      describe "there are no leftover variable substitutions" do
+        def no_values_contain(enumerable_or_str, str)
+          case enumerable_or_str
+          when Hash
+            enumerable_or_str.each do |_, v|
+              no_values_contain v, str
+            end
+          when Array
+            enumerable_or_str.each do |v|
+              no_values_contain v, str
+            end
+          when String
+            expect(enumerable_or_str).not_to include(str)
+          end
+        end
 
-    specify "all jobs reference availability zones that exist" do
-      azs_names = cloud_config_with_defaults["azs"].map { |r| r["name"] }
-      manifest["instance_groups"].each do |job|
-        expect(job.key?("azs")).to be(true),
-          "No azs key defined for job #{job['name']}. You must add some availability zones."
-        job["azs"].each do |az|
-          expect(azs_names).to include(az),
-            "AZ #{az} not found for job #{job['name']}. Check this az exists in the Cloud Config."
+        # BOSH interpolate leaves entries like `key: (( "value" ))` alone. This led
+        # to URLs of "(( \"value\" ))" being passed to nozzle during one
+        # cf upgrade. We have some entries that legitimately have )) in,
+        # but it seems unlikely we will have ones with a legitimate )).
+        specify "where '((' is present in output values" do
+          no_values_contain manifest, "(("
         end
       end
-    end
 
-    specify "all vm jobs reference releases that exist" do
-      release_names = manifest["releases"].map { |r| r["name"] }
+      describe "name uniqueness" do
+        %w[
+          instance_groups
+          releases
+        ].each do |resource_type|
+          specify "all #{resource_type} have a unique name" do
+            all_resource_names = manifest.fetch(resource_type).map { |r| r["name"] }
 
-      manifest["instance_groups"].each do |instance_group|
-        instance_group["jobs"].each do |job|
-          expect(release_names).to include(job["release"]),
-            "release #{job['release']} not found for job #{job['name']} in instance_group #{instance_group['name']}"
-        end
-      end
-    end
-
-    describe "networks" do
-      let(:networks_by_name) do
-        cloud_config_with_defaults["networks"].each_with_object({}) { |net, result| result[net["name"]] = net }
-      end
-      let(:network_names) { networks_by_name.keys }
-
-      specify "all jobs reference networks that exist" do
-        manifest["instance_groups"].each do |job|
-          job["networks"].each do |network|
-            expect(network_names).to include(network["name"]),
-              "network #{network['name']} not found for job #{job['name']}"
+            duplicated_names = all_resource_names.select { |n| all_resource_names.count(n) > 1 }.uniq
+            expect(duplicated_names).to be_empty,
+              "found duplicate names (#{duplicated_names.join(',')}) for #{resource_type}"
           end
         end
       end
 
-      specify "all jobs' static IPs are within the corresponding network's static ranges" do
-        network_static_ranges = networks_by_name.each_with_object({}) do |(name, network), results|
-          results[name] = []
-          network.fetch("subnets").each do |subnet|
-            subnet.fetch("static", []).each do |static|
-              if static =~ /\s*-\s*/
-                first, last = static.split(/\s*-\s*/, 2)
-                results[name] << Range.new(IPAddr.new(first), IPAddr.new(last))
-              else
-                results[name] << IPAddr.new(static)
+      describe "IP address uniqueness" do
+        specify "all jobs should use a unique IP address" do
+          all_ips = manifest["instance_groups"].map { |job|
+            job["networks"].map { |net| net["static_ips"] }
+          }.flatten.compact
+
+          duplicated_ips = all_ips.select { |ip| all_ips.count(ip) > 1 }.uniq
+          expect(duplicated_ips).to be_empty,
+            "found duplicate IP (#{duplicated_ips.join(',')})"
+        end
+      end
+
+      describe "jobs cross-references" do
+        specify "all jobs reference vm_types that exist" do
+          vm_type_names = cloud_config_with_defaults["vm_types"].map { |r| r["name"] }
+          manifest["instance_groups"].each do |job|
+            expect(vm_type_names).to include(job["vm_type"]),
+              "vm_type #{job['vm_type']} not found for job #{job['name']}"
+          end
+        end
+
+        specify "all jobs reference vm_extensions that exist" do
+          vm_extension_names = cloud_config_with_defaults.fetch("vm_extensions", []).map { |r| r["name"] }
+          manifest["instance_groups"].each do |job|
+            job.fetch("vm_extensions", []).each do |extension|
+              expect(vm_extension_names).to include(extension),
+                "vm_extension '#{extension}' not found for job #{job['name']}"
+            end
+          end
+        end
+
+        specify "all jobs reference stemcells that exist" do
+          stemcell_names = manifest["stemcells"].map { |r| r["alias"] }
+          manifest["instance_groups"].each do |job|
+            expect(job.key?("stemcell")).to be(true),
+              "No stemcell defined for job #{job['name']}. You must add a stemcell to this job."
+            expect(stemcell_names).to include(job["stemcell"]),
+              "stemcell #{job['stemcell']} not found for job #{job['name']}. This value should correspond to `stemcells.*.alias`."
+          end
+        end
+
+        specify "all jobs reference availability zones that exist" do
+          azs_names = cloud_config_with_defaults["azs"].map { |r| r["name"] }
+          manifest["instance_groups"].each do |job|
+            expect(job.key?("azs")).to be(true),
+              "No azs key defined for job #{job['name']}. You must add some availability zones."
+            job["azs"].each do |az|
+              expect(azs_names).to include(az),
+                "AZ #{az} not found for job #{job['name']}. Check this az exists in the Cloud Config."
+            end
+          end
+        end
+
+        specify "all vm jobs reference releases that exist" do
+          release_names = manifest["releases"].map { |r| r["name"] }
+
+          manifest["instance_groups"].each do |instance_group|
+            instance_group["jobs"].each do |job|
+              expect(release_names).to include(job["release"]),
+                "release #{job['release']} not found for job #{job['name']} in instance_group #{instance_group['name']}"
+            end
+          end
+        end
+
+        describe "networks" do
+          let(:networks_by_name) do
+            cloud_config_with_defaults["networks"].each_with_object({}) { |net, result| result[net["name"]] = net }
+          end
+          let(:network_names) { networks_by_name.keys }
+
+          specify "all jobs reference networks that exist" do
+            manifest["instance_groups"].each do |job|
+              job["networks"].each do |network|
+                expect(network_names).to include(network["name"]),
+                  "network #{network['name']} not found for job #{job['name']}"
+              end
+            end
+          end
+
+          specify "all jobs' static IPs are within the corresponding network's static ranges" do
+            network_static_ranges = networks_by_name.each_with_object({}) do |(name, network), results|
+              results[name] = []
+              network.fetch("subnets").each do |subnet|
+                subnet.fetch("static", []).each do |static|
+                  if static =~ /\s*-\s*/
+                    first, last = static.split(/\s*-\s*/, 2)
+                    results[name] << Range.new(IPAddr.new(first), IPAddr.new(last))
+                  else
+                    results[name] << IPAddr.new(static)
+                  end
+                end
+              end
+            end
+
+            manifest["instance_groups"].each do |job|
+              job["networks"].each do |job_network|
+                next unless job_network["static_ips"]
+
+                static_ranges = network_static_ranges.fetch(job_network["name"])
+                job_network["static_ips"].each do |ip|
+                  expect(
+                    static_ranges.any? { |r| r.is_a?(Range) ? r.include?(ip) : r == ip },
+                  ).to be_truthy, "IP #{ip} not in static range for network #{job_network['name']} in job #{job['name']}"
+                end
               end
             end
           end
         end
 
-        manifest["instance_groups"].each do |job|
-          job["networks"].each do |job_network|
-            next unless job_network["static_ips"]
+        specify "all jobs reference disk_types that exist" do
+          disk_type_names = cloud_config_with_defaults.fetch("disk_types", {}).map { |p| p["name"] }
 
-            static_ranges = network_static_ranges.fetch(job_network["name"])
-            job_network["static_ips"].each do |ip|
-              expect(
-                static_ranges.any? { |r| r.is_a?(Range) ? r.include?(ip) : r == ip },
-              ).to be_truthy, "IP #{ip} not in static range for network #{job_network['name']} in job #{job['name']}"
-            end
+          manifest["instance_groups"].each do |job|
+            next unless job["persistent_disk_type"]
+
+            expect(disk_type_names).to include(job["persistent_disk_type"]),
+              "disk_type #{job['persistent_disk_type']} not found for job #{job['name']}"
           end
         end
-      end
-    end
-
-    specify "all jobs reference disk_types that exist" do
-      disk_type_names = cloud_config_with_defaults.fetch("disk_types", {}).map { |p| p["name"] }
-
-      manifest["instance_groups"].each do |job|
-        next unless job["persistent_disk_type"]
-
-        expect(disk_type_names).to include(job["persistent_disk_type"]),
-          "disk_type #{job['persistent_disk_type']} not found for job #{job['name']}"
       end
     end
   end

--- a/manifests/cloud-config/paas-cf-cloud-config.yml
+++ b/manifests/cloud-config/paas-cf-cloud-config.yml
@@ -35,6 +35,10 @@ disk_types:
   disk_size: 768000
   cloud_properties:
     type: gp3
+- name: 1TB
+  disk_size: 1024000
+  cloud_properties:
+    type: gp3
 
 networks:
 - name: cf

--- a/manifests/prometheus/env-specific/prod-lon.yml
+++ b/manifests/prometheus/env-specific/prod-lon.yml
@@ -5,7 +5,7 @@ aws_limits_elasticache_cache_parameter_groups: 800
 aws_limits_elasticache_nodes: 1000
 # Change limit for prod as well - S3 is global
 aws_limits_s3_buckets: 750
-prometheus_disk_size: 750GB
+prometheus_disk_size: 1TB
 # Change limit for prod as well - Cloudfront is global
 aws_limits_cloudfront_distributions: 400
 

--- a/manifests/prometheus/env-specific/prod-lon.yml
+++ b/manifests/prometheus/env-specific/prod-lon.yml
@@ -5,7 +5,7 @@ aws_limits_elasticache_cache_parameter_groups: 800
 aws_limits_elasticache_nodes: 1000
 # Change limit for prod as well - S3 is global
 aws_limits_s3_buckets: 750
-prometheus_disk_size: 250GB
+prometheus_disk_size: 750GB
 # Change limit for prod as well - Cloudfront is global
 aws_limits_cloudfront_distributions: 400
 

--- a/manifests/prometheus/env-specific/prod.yml
+++ b/manifests/prometheus/env-specific/prod.yml
@@ -5,7 +5,7 @@ aws_limits_elasticache_cache_parameter_groups: 400
 aws_limits_elasticache_nodes: 400
 # Change limit for prod-lon as well - S3 is global
 aws_limits_s3_buckets: 750
-prometheus_disk_size: 500GB
+prometheus_disk_size: 750GB
 # Change limit for prod-lon as well - Cloudfront is global
 aws_limits_cloudfront_distributions: 400
 

--- a/manifests/prometheus/env-specific/prod.yml
+++ b/manifests/prometheus/env-specific/prod.yml
@@ -5,7 +5,7 @@ aws_limits_elasticache_cache_parameter_groups: 400
 aws_limits_elasticache_nodes: 400
 # Change limit for prod-lon as well - S3 is global
 aws_limits_s3_buckets: 750
-prometheus_disk_size: 250GB
+prometheus_disk_size: 500GB
 # Change limit for prod-lon as well - Cloudfront is global
 aws_limits_cloudfront_distributions: 400
 

--- a/manifests/prometheus/env-specific/stg-lon.yml
+++ b/manifests/prometheus/env-specific/stg-lon.yml
@@ -4,6 +4,6 @@
 aws_limits_elasticache_cache_parameter_groups: 20
 aws_limits_elasticache_nodes: 100
 aws_limits_s3_buckets: 100
-prometheus_disk_size: 100GB
+prometheus_disk_size: 500GB
 aws_limits_cloudfront_distributions: 200
 

--- a/manifests/prometheus/scripts/generate-manifest.sh
+++ b/manifests/prometheus/scripts/generate-manifest.sh
@@ -54,8 +54,8 @@ EOF
 bosh interpolate \
   --vars-file="${variables_file}" \
   --vars-file="${WORKDIR}/terraform-outputs/cf.yml" \
-  --vars-file="${PAAS_CF_DIR}/manifests/prometheus/env-specific/${ENV_SPECIFIC_BOSH_VARS_FILE}" \
   --vars-file="${PAAS_CF_DIR}/manifests/cf-manifest/env-specific/${ENV_SPECIFIC_BOSH_VARS_FILE}" \
+  --vars-file="${PAAS_CF_DIR}/manifests/prometheus/env-specific/${ENV_SPECIFIC_BOSH_VARS_FILE}" \
   ${opsfile_args} \
   ${alerts_opsfile_args} \
   "${PROM_BOSHRELEASE_DIR}/manifests/prometheus.yml"

--- a/manifests/prometheus/spec/manifest_validation_spec.rb
+++ b/manifests/prometheus/spec/manifest_validation_spec.rb
@@ -1,120 +1,124 @@
 require "ipaddr"
 
 RSpec.describe "generic manifest validations" do
-  let(:manifest) { manifest_with_defaults }
-  let(:cloud_config) { cloud_config_with_defaults }
+  %w[prod prod-lon stg-lon].each do |env|
+    context "for the #{env} environment" do
+      let(:manifest) { manifest_for_env(env) }
+      let(:cloud_config) { cloud_config_with_defaults }
 
-  specify "it must have a name" do
-    expect(manifest["name"]).to match(/\S+/)
-  end
-
-  it "sets stemcell versions as strings" do
-    manifest.fetch("stemcells").each do |stemcell|
-      expect(stemcell.fetch("version")).to be_a(String)
-    end
-  end
-
-  describe "name uniqueness" do
-    %w[
-      instance_groups
-      releases
-    ].each do |resource_type|
-      specify "all #{resource_type} have a unique name" do
-        all_resource_names = manifest.fetch(resource_type).map { |r| r["name"] }
-
-        duplicated_names = all_resource_names.select { |n| all_resource_names.count(n) > 1 }.uniq
-        expect(duplicated_names).to be_empty,
-          "found duplicate names (#{duplicated_names.join(',')}) for #{resource_type}"
+      specify "it must have a name" do
+        expect(manifest["name"]).to match(/\S+/)
       end
-    end
-  end
 
-  specify "all instance_groups have a bosh password set" do
-    missing = []
-    manifest.fetch("instance_groups").each do |ig|
-      pw = ig.dig("env", "bosh", "password")
-      missing << ig["name"] if pw.nil? || pw.empty?
-    end
-    expect(missing).to be_empty,
-      "Expected instance_groups #{missing.inspect} to have env.bosh.password set"
-  end
-
-  describe "jobs cross-references" do
-    specify "all jobs reference vm_types that exist" do
-      vm_type_names = cloud_config["vm_types"].map { |r| r["name"] }
-      manifest["instance_groups"].each do |job|
-        expect(vm_type_names).to include(job["vm_type"]),
-          "vm_type #{job['vm_type']} not found for job #{job['name']}"
-      end
-    end
-
-    specify "all jobs reference vm_extensions that exist" do
-      vm_extension_names = cloud_config.fetch("vm_extensions", []).map { |r| r["name"] }
-      manifest["instance_groups"].each do |job|
-        job.fetch("vm_extensions", []).each do |extension|
-          expect(vm_extension_names).to include(extension),
-            "vm_extension '#{extension}' not found for job #{job['name']}"
+      it "sets stemcell versions as strings" do
+        manifest.fetch("stemcells").each do |stemcell|
+          expect(stemcell.fetch("version")).to be_a(String)
         end
       end
-    end
 
-    specify "all jobs reference stemcells that exist" do
-      stemcell_names = manifest["stemcells"].map { |r| r["alias"] }
-      manifest["instance_groups"].each do |job|
-        expect(job.key?("stemcell")).to be(true),
-          "No stemcell defined for job #{job['name']}. You must add a stemcell to this job."
-        expect(stemcell_names).to include(job["stemcell"]),
-          "stemcell #{job['stemcell']} not found for job #{job['name']}. This value should correspond to `stemcells.*.alias`."
-      end
-    end
+      describe "name uniqueness" do
+        %w[
+          instance_groups
+          releases
+        ].each do |resource_type|
+          specify "all #{resource_type} have a unique name" do
+            all_resource_names = manifest.fetch(resource_type).map { |r| r["name"] }
 
-    specify "all jobs reference availability zones that exist" do
-      azs_names = cloud_config["azs"].map { |r| r["name"] }
-      manifest["instance_groups"].each do |job|
-        expect(job.key?("azs")).to be(true),
-          "No azs key defined for job #{job['name']}. You must add some availability zones."
-        job["azs"].each do |az|
-          expect(azs_names).to include(az),
-            "AZ #{az} not found for job #{job['name']}. Check this az exists in the Cloud Config."
-        end
-      end
-    end
-
-    specify "all vm jobs reference releases that exist" do
-      release_names = manifest["releases"].map { |r| r["name"] }
-
-      manifest["instance_groups"].each do |instance_group|
-        instance_group["jobs"].each do |job|
-          expect(release_names).to include(job["release"]),
-            "release #{job['release']} not found for job #{job['name']} in instance_group #{instance_group['name']}"
-        end
-      end
-    end
-
-    describe "networks" do
-      let(:networks_by_name) do
-        cloud_config["networks"].each_with_object({}) { |net, result| result[net["name"]] = net }
-      end
-      let(:network_names) { networks_by_name.keys }
-
-      specify "all jobs reference networks that exist" do
-        manifest["instance_groups"].each do |job|
-          job["networks"].each do |network|
-            expect(network_names).to include(network["name"]),
-              "network #{network['name']} not found for job #{job['name']}"
+            duplicated_names = all_resource_names.select { |n| all_resource_names.count(n) > 1 }.uniq
+            expect(duplicated_names).to be_empty,
+              "found duplicate names (#{duplicated_names.join(',')}) for #{resource_type}"
           end
         end
       end
-    end
 
-    specify "all jobs reference disk_types that exist" do
-      disk_type_names = cloud_config.fetch("disk_types", {}).map { |p| p["name"] }
+      specify "all instance_groups have a bosh password set" do
+        missing = []
+        manifest.fetch("instance_groups").each do |ig|
+          pw = ig.dig("env", "bosh", "password")
+          missing << ig["name"] if pw.nil? || pw.empty?
+        end
+        expect(missing).to be_empty,
+          "Expected instance_groups #{missing.inspect} to have env.bosh.password set"
+      end
 
-      manifest["instance_groups"].each do |job|
-        next unless job["persistent_disk_type"]
+      describe "jobs cross-references" do
+        specify "all jobs reference vm_types that exist" do
+          vm_type_names = cloud_config["vm_types"].map { |r| r["name"] }
+          manifest["instance_groups"].each do |job|
+            expect(vm_type_names).to include(job["vm_type"]),
+              "vm_type #{job['vm_type']} not found for job #{job['name']}"
+          end
+        end
 
-        expect(disk_type_names).to include(job["persistent_disk_type"]),
-          "disk_type #{job['persistent_disk_type']} not found for job #{job['name']}"
+        specify "all jobs reference vm_extensions that exist" do
+          vm_extension_names = cloud_config.fetch("vm_extensions", []).map { |r| r["name"] }
+          manifest["instance_groups"].each do |job|
+            job.fetch("vm_extensions", []).each do |extension|
+              expect(vm_extension_names).to include(extension),
+                "vm_extension '#{extension}' not found for job #{job['name']}"
+            end
+          end
+        end
+
+        specify "all jobs reference stemcells that exist" do
+          stemcell_names = manifest["stemcells"].map { |r| r["alias"] }
+          manifest["instance_groups"].each do |job|
+            expect(job.key?("stemcell")).to be(true),
+              "No stemcell defined for job #{job['name']}. You must add a stemcell to this job."
+            expect(stemcell_names).to include(job["stemcell"]),
+              "stemcell #{job['stemcell']} not found for job #{job['name']}. This value should correspond to `stemcells.*.alias`."
+          end
+        end
+
+        specify "all jobs reference availability zones that exist" do
+          azs_names = cloud_config["azs"].map { |r| r["name"] }
+          manifest["instance_groups"].each do |job|
+            expect(job.key?("azs")).to be(true),
+              "No azs key defined for job #{job['name']}. You must add some availability zones."
+            job["azs"].each do |az|
+              expect(azs_names).to include(az),
+                "AZ #{az} not found for job #{job['name']}. Check this az exists in the Cloud Config."
+            end
+          end
+        end
+
+        specify "all vm jobs reference releases that exist" do
+          release_names = manifest["releases"].map { |r| r["name"] }
+
+          manifest["instance_groups"].each do |instance_group|
+            instance_group["jobs"].each do |job|
+              expect(release_names).to include(job["release"]),
+                "release #{job['release']} not found for job #{job['name']} in instance_group #{instance_group['name']}"
+            end
+          end
+        end
+
+        describe "networks" do
+          let(:networks_by_name) do
+            cloud_config["networks"].each_with_object({}) { |net, result| result[net["name"]] = net }
+          end
+          let(:network_names) { networks_by_name.keys }
+
+          specify "all jobs reference networks that exist" do
+            manifest["instance_groups"].each do |job|
+              job["networks"].each do |network|
+                expect(network_names).to include(network["name"]),
+                  "network #{network['name']} not found for job #{job['name']}"
+              end
+            end
+          end
+        end
+
+        specify "all jobs reference disk_types that exist" do
+          disk_type_names = cloud_config.fetch("disk_types", {}).map { |p| p["name"] }
+
+          manifest["instance_groups"].each do |job|
+            next unless job["persistent_disk_type"]
+
+            expect(disk_type_names).to include(job["persistent_disk_type"]),
+              "disk_type #{job['persistent_disk_type']} not found for job #{job['name']}"
+          end
+        end
       end
     end
   end

--- a/manifests/prometheus/spec/support/manifest_helpers.rb
+++ b/manifests/prometheus/spec/support/manifest_helpers.rb
@@ -7,9 +7,13 @@ module ManifestHelpers
     include Singleton
   end
 
+  def manifest_for_env(deploy_env)
+    Cache.instance["manifest_for_env_#{deploy_env}"] ||=
+      render_manifest(deploy_env)
+  end
+
   def manifest_with_defaults
-    Cache.instance[:manifest_with_defaults] ||=
-      render_manifest_with_defaults
+    manifest_for_env("default")
   end
 
 private
@@ -26,7 +30,6 @@ private
     env["APPS_DNS_ZONE_NAME"] = "apps.example.com"
     env["DEPLOY_ENV"] = "test"
     env["BOSH_URL"] = "https://bosh.example.com:25555"
-    env["ENV_SPECIFIC_BOSH_VARS_FILE"] = "default.yml"
     env["GRAFANA_AUTH_GOOGLE_CLIENT_ID"] = "google-client-id"
     env["GRAFANA_AUTH_GOOGLE_CLIENT_SECRET"] = "google-client-secret"
     env["UAA_CLIENTS_CF_EXPORTER_SECRET"] = "uaa_clients_cf_exporter_secret"
@@ -37,7 +40,7 @@ private
     env
   end
 
-  def render_manifest_with_defaults
+  def render_manifest(deploy_env)
     workdir = Dir.mktmpdir("workdir")
 
     vars_store = Tempfile.new(["vars-store", ".yml"])
@@ -52,6 +55,7 @@ private
     env["PAAS_CF_DIR"] = root.to_s
     env["WORKDIR"] = workdir
     env["VARS_STORE"] = vars_store.path
+    env["ENV_SPECIFIC_BOSH_VARS_FILE"] = "#{deploy_env}.yml"
 
     output, error, status = Open3.capture3(env, "#{root}/manifests/prometheus/scripts/generate-manifest.sh")
     expect(status).to be_success, "generate-manifest.sh exited #{status.exitstatus}, stderr:\n#{error}"


### PR DESCRIPTION
What
----

https://www.pivotaltracker.com/story/show/182769592

Firstly this changes the "generic manifest tests" (called "integration" for the cf manifest) to run once for each env, because some important values e.g. disk types are affected by the env config and we want to make sure they're all valid.

Secondly this changes the way the `prometheus` deployment's manifest is generated. Previously we were prioritizing env-specific variables from the top-level/"cf" deployment over those specified in the prometheus deployment's env-specific vars. This meant that the `prometheus_disk_size` settings we had set there were never actually being used. Instead the "external" prometheus' was using the setting intended for just the "internal" prometheus.

Set the external prometheus `prometheus_disk_size` values to match their previous _actual_ value, and bump each up a tier in storage size to solve the original problem purportedly addressed in #2931

How to review
-------------

:eyes: 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
