### PR TITLE
prod-lon: reduce number of dopplers to 54

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -5,7 +5,7 @@ diego_api_instances: 3
 cell_instances: 141
 router_instances: 30
 api_instances: 15
-doppler_instances: 72
+doppler_instances: 54
 log_cache_instances: 36
 log_api_instances: 36
 scheduler_instances: 10

--- a/manifests/cf-manifest/spec/manifest/instance_type_counts_in_envs_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/instance_type_counts_in_envs_spec.rb
@@ -26,38 +26,10 @@ RSpec.describe "Instance counts in different environments" do
 
       describe "doppler" do
         it_behaves_like("evenly distributable", "doppler")
-
-        it "instance count should be at least half of the cell count" do
-          doppler_ig = env_manifest.fetch("instance_groups.doppler")
-          cell_instance_count = env_manifest.fetch("instance_groups.diego-cell").dig("instances").to_f
-          doppler_instance_count = doppler_ig.dig("instances").to_f
-          # Comment out check for overreaching instance count for now:
-          # This check does not consider cells in isolation segments
-          # doppler_az_count = doppler_ig.fetch("azs").size
-
-          half = cell_instance_count / 2
-          # half_with_headroom = round_up(half, doppler_az_count) + doppler_az_count
-
-          expect(doppler_instance_count).to be >= half, "doppler instance count #{doppler_instance_count} is wrong. Rule of thumb is there should be at least half the count of cells in dopplers. Currently set to #{doppler_instance_count}, expecting at least #{half}."
-          # expect(doppler_instance_count).to be <= half_with_headroom, "doppler instance count #{doppler_instance_count} is too high. There is no need to allow more headroom than a single set of #{doppler_az_count}. Currently set to #{doppler_instance_count}, expecting at least #{half_with_headroom}."
-        end
       end
 
       describe "log-api" do
         it_behaves_like("evenly distributable", "log-api")
-
-        it "instance count should be at least half of the doppler count" do
-          log_api_ig = env_manifest.fetch("instance_groups.log-api")
-          doppler_instance_count = env_manifest.fetch("instance_groups.doppler").dig("instances").to_f
-          log_api_instances_count = log_api_ig.dig("instances").to_f
-          log_api_az_count = log_api_ig.fetch("azs").size
-
-          half = doppler_instance_count / 2
-          half_with_headroom = round_up(half, log_api_az_count) + log_api_az_count
-
-          expect(log_api_instances_count).to be >= half, "log-api instance count #{log_api_instances_count} is wrong. Rule of thumb is there should be at least half the count of dopplers in log-api. Currently set to #{log_api_instances_count}, expecting at least #{half}."
-          expect(log_api_instances_count).to be <= half_with_headroom, "log-api instance count #{log_api_instances_count} is too high. There is no need to allow more headroom than a single set of three. Currently set to #{log_api_instances_count}, expecting at least #{half_with_headroom}."
-        end
       end
 
       describe "cc-worker" do


### PR DESCRIPTION
What
----

Part of https://www.pivotaltracker.com/story/show/182790768

This requires disabling the old spec constraints we had on numbers of loggregator-related nodes. These are no longer valid heuristics given recent changes in cf-deployment.

A lot of a doppler's workload has been moved to log-cache instances, so we should be able to reduce the number of dopplers.

How to review
-------------

:eyes: & :brain: 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
