### PR TITLE
bosh update policy: use 25% `max_in_flight` for diego-cell instances

### DIFF
--- a/manifests/cf-manifest/operations.d/010-bosh-set-update-options.yml
+++ b/manifests/cf-manifest/operations.d/010-bosh-set-update-options.yml
@@ -8,6 +8,11 @@
   path: /update/max_in_flight
   value: 30%
 
+# tenant apps might not be as well behaved as cf components
+- type: replace
+  path: /instance_groups/name=diego-cell/update/max_in_flight
+  value: 25%
+
 - type: replace
   path: /update/canary_watch_time
   value: 30000-420000


### PR DESCRIPTION
What
----

Some tenant apps may not be as robust as cf components and as such may not cope well with sudden shocks of many app instances being moved around and/or temporarily having a reduced number of instances running.

How to review
-------------

:eyes: 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
