### PR TITLE
prod: reduce number of dopplers to 24, log_api instances to 15

### DIFF
--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -5,9 +5,9 @@ diego_api_instances: 3
 cell_instances: 24
 router_instances: 39
 api_instances: 9
-doppler_instances: 30
+doppler_instances: 24
 log_cache_instances: 18
-log_api_instances: 18
+log_api_instances: 15
 scheduler_instances: 12
 cc_worker_instances: 12
 cc_hourly_rate_limit: 60000


### PR DESCRIPTION
What
----

Both dopplers and log_api instances not yet showing adverse effects of downscaling.

How to review
-------------

:eyes: 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
