### PR TITLE
[#182852599] Address CVE 2022-2068

### DIFF
--- a/manifests/app-autoscaler/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/app-autoscaler/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-bionic
-      version: "1.90"
+      version: "1.91"

--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-bionic
-      version: "1.90"
+      version: "1.91"

--- a/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
+++ b/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
@@ -3,6 +3,6 @@
   path: /releases/name=cflinuxfs3
   value:
     name: "cflinuxfs3"
-    version: "0.307.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.307.0"
-    sha1: "618528fdec5d90539937c745c02a6a4db3171dc2"
+    version: "0.312.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.312.0"
+    sha1: "0617c7ff3a421b34f48923d99e8052019ee81313"


### PR DESCRIPTION
What
----

- Upgrade bionic-stemcell to 1.91
- Upgrade cflinuxfs3 to 0.312

The cflinuxfs3 upgrade is not technically required by CVE, but looks to contain useful fixes.

How to review
-------------

- Code review - any typos
- Deploy to dev environment (edit: [deployed Jul 29th](https://deployer.dev01.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/cf-deploy/builds/232.1) to `dev01`). 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
