### PR TITLE
loggregator instances: switch doppler and log cache to more appropriate instance types

### DIFF
--- a/manifests/cf-manifest/operations.d/100-cf-update-vm-types.yml
+++ b/manifests/cf-manifest/operations.d/100-cf-update-vm-types.yml
@@ -10,13 +10,13 @@
   value: xlarge
 - type: replace
   path: /instance_groups/name=doppler/vm_type
-  value: large
+  value: high_cpu_large
 - type: replace
   path: /instance_groups/name=log-api/vm_type
   value: high_cpu_xlarge
 - type: replace
   path: /instance_groups/name=log-cache/vm_type
-  value: large
+  value: high_mem_large
 - type: replace
   path: /instance_groups/name=nats/vm_type
   value: medium

--- a/manifests/cloud-config/operations/use-spot-instances-in-dev.yml
+++ b/manifests/cloud-config/operations/use-spot-instances-in-dev.yml
@@ -39,6 +39,22 @@
   value: ((xlarge_vm_spot_bid_price))
 
 - type: replace
+  path: /vm_types/name=high_cpu_large/cloud_properties/spot_ondemand_fallback?
+  value: true
+
+- type: replace
+  path: /vm_types/name=high_cpu_large/cloud_properties/spot_bid_price?
+  value: ((high_cpu_large_vm_spot_bid_price))
+
+- type: replace
+  path: /vm_types/name=high_mem_large/cloud_properties/spot_ondemand_fallback?
+  value: true
+
+- type: replace
+  path: /vm_types/name=high_mem_large/cloud_properties/spot_bid_price?
+  value: ((high_mem_large_vm_spot_bid_price))
+
+- type: replace
   path: /vm_types/name=high_cpu_xlarge/cloud_properties/spot_ondemand_fallback?
   value: true
 

--- a/manifests/cloud-config/paas-cf-cloud-config.yml
+++ b/manifests/cloud-config/paas-cf-cloud-config.yml
@@ -191,6 +191,20 @@ vm_types:
       size: 10240
       type: gp3
 
+- name: high_cpu_large
+  cloud_properties:
+    instance_type: ((high_cpu_large_vm_instance_type))
+    ephemeral_disk:
+      size: 10240
+      type: gp3
+
+- name: high_mem_large
+  cloud_properties:
+    instance_type: ((high_mem_large_vm_instance_type))
+    ephemeral_disk:
+      size: 10240
+      type: gp3
+
 - name: high_cpu_xlarge
   cloud_properties:
     instance_type: ((high_cpu_xlarge_vm_instance_type))

--- a/manifests/variables.yml
+++ b/manifests/variables.yml
@@ -4,6 +4,10 @@
 # instances of some types.
 #
 
+#
+# Spot bid prices tend to be chosen as something around the 1y 100% upfront RI price
+#
+
 compilation_vm_instance_type: c5.large
 
 nano_vm_instance_type: t3.nano
@@ -20,6 +24,12 @@ large_vm_spot_bid_price: 0.05
 
 xlarge_vm_instance_type: m5.xlarge
 xlarge_vm_spot_bid_price: 0.1
+
+high_cpu_large_vm_instance_type: c5.large
+high_cpu_large_vm_spot_bid_price: 0.05
+
+high_mem_large_vm_instance_type: r5.large
+high_mem_large_vm_spot_bid_price: 0.08
 
 high_cpu_xlarge_vm_instance_type: c5.xlarge
 high_cpu_xlarge_vm_spot_bid_price: 0.1


### PR DESCRIPTION
What
----

https://www.pivotaltracker.com/story/show/182790768

Doppler doesn't use the memory we give it and log-cache could use more if we gave it. Following this we might be able to horizontally downscale log-cache a little further, particularly if we increased the percentage of memory it was allowed to use for logs.

Following some stress-testing on dev02, it was possible to push `c5.large` dopplers to receiving 8k messages/sec each without their memory usage going above 15%. This is well above what our current doppler load is, so I'm happy this halving of the dopplers' memory will have no ill effects.

As for the log-cache instances, that is effectively an _upgrade_, doubling their memory.

So all in all I'm quite confident in this change not having immediate ill effects.

How to review
-------------

Unfortunately I destroyed the prometheus instance that had all the performance test data you would have been able to look at :sweat: 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
