### PR TITLE
182427769-Fix-GOPATH-error

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -5576,7 +5576,6 @@ jobs:
                 cp "paas-cf/config/billing/output/${AWS_REGION}.json" ./src/github.com/alphagov/paas-billing/config.json
                 cp "paas-cf/config/billing/tests/${AWS_REGION}_billing_rds_charges.feature" ./src/github.com/alphagov/paas-billing/gherkin/features/
 
-                export GOPATH="${PWD}"
                 export BILLING_API_URL="https://billing.${SYSTEM_DNS_ZONE_NAME}"
                 go install github.com/cucumber/godog/cmd/godog@v0.12.5
                 cd src/github.com/alphagov/paas-billing


### PR DESCRIPTION
Description:
- GOPATH is already defined in the docker image so no need to define it here
- Fixes the error as "$PWD" is not in the PATH