### PR TITLE
Scale diego cells in London to 144

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -2,7 +2,7 @@
 uaa_instances: 3
 nats_instances: 3
 diego_api_instances: 3
-cell_instances: 141
+cell_instances: 144
 router_instances: 30
 api_instances: 15
 doppler_instances: 45


### PR DESCRIPTION

What
----

Scale diego cells in London to 144.
Memory pressure / desired cell count is creeping up to current value of 141.


How to review
-------------

Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
