### PR TITLE
182773204 enable multi az

### DIFF
--- a/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
+++ b/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
@@ -61,9 +61,9 @@
   path: /releases/-
   value:
     name: elasticache-broker
-    version: 0.1.18
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/elasticache-broker-0.1.18.tgz
-    sha1: d46ace6ed0f8019a57867989e47ee1239b07308e
+    version: 0.1.19
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/elasticache-broker-0.1.19.tgz
+    sha1: 416a17a858a90c2859ba69d59094e050c6d25d58
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-

--- a/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
+++ b/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
@@ -17,6 +17,7 @@
     ha_plan: &elasticache_ha_plan
       replicas_per_node_group: 1
       automatic_failover_enabled: true
+      multi_az_enabled: true
 
     micro_plan: &elasticache_micro_plan
       instance_type: cache.t3.micro


### PR DESCRIPTION
What
----

- Uses the latest release of the elasticache-broker-release.
- Sets multiAZ to "enabled" by default for highly available plans

How to review
-------------

Check that the tag in the release corresponds to the one created in https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/elasticache-broker-release/jobs/build-final-release/builds/3

This has been tested in a dev environment already

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
