### PR TITLE
log-cache: set memory_limit_percent to 65

### DIFF
--- a/manifests/cf-manifest/operations.d/235-log-cache-tuning.yml
+++ b/manifests/cf-manifest/operations.d/235-log-cache-tuning.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=log-cache/jobs/name=log-cache/properties/memory_limit_percent?
+  value: 65


### PR DESCRIPTION
What
----
https://www.pivotaltracker.com/story/show/182790768
Now we have instances with more memory, we have ~60% of a log-cache's memory unused, so we can increase the proportion of an instance's memory the log cache is allowed to use. Initially this is a conservative increase from the default 50%.

This works in dev, though it's tricky to fill up a log-cache's memory usage in a sane amount of time to show it making a difference

How to review
-------------

:eyes: https://deployer.dev03.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/cf-deploy/builds/131

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
