### PR TITLE
181929453 - Remove unnecessary GOPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ test:
 .PHONY: scripts_spec
 scripts_spec:
 	cd scripts &&\
-		go get -d -t . &&\
+		go get -t . &&\
 		go test
 
 .PHONY: tools_spec
@@ -47,7 +47,7 @@ concourse_spec:
 	cd concourse &&\
 		bundle exec rspec
 	cd concourse/scripts &&\
-		go get -d -t . &&\
+		go get -t . &&\
 		go test
 	cd concourse/scripts &&\
 		bundle exec rspec
@@ -98,7 +98,7 @@ terraform_spec:
 	cd terraform &&\
 		terraform init
 	cd terraform/scripts &&\
-		go get -d -t . &&\
+		go get -t . &&\
 		go test
 	-wget "https://github.com/tmccombs/hcl2json/releases/download/v0.3.2/hcl2json_$$(go env GOOS)_$$(go env GOARCH)" \
 		-q \

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -6879,7 +6879,6 @@ jobs:
 
                   cf target -o admin -s billing
 
-                  export GOPATH="${PWD}"
                   export BILLING_API_URL="https://billing.${SYSTEM_DNS_ZONE_NAME}"
                   cd src/github.com/alphagov/paas-billing
                   make smoke

--- a/platform-tests/upstream/run_acceptance_tests.sh
+++ b/platform-tests/upstream/run_acceptance_tests.sh
@@ -23,9 +23,6 @@ CONFIG="$(pwd)/test-config/config.json"
 echo "Sleeping for ${SLEEPTIME} seconds..."
 for i in $(seq $SLEEPTIME 1); do echo -ne "$i"'\r'; sleep 1; done; echo
 
-GOPATH="${GOPATH}:$(pwd)"
-export GOPATH
-
 echo "Starting acceptance tests"
 cd src/github.com/cloudfoundry/cf-acceptance-tests
 ./bin/test \


### PR DESCRIPTION
Description:
- GOPATH is already set in the base docker images and doesn't need to be set again to PWD
- Go 1.18 always has -d enabled so it is redundant to include it here

What
----

Describe what you have changed and why.

How to review
-------------

Describe the steps required to test the changes.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
