### PR TITLE
log-cache: set `memory_limit_percent` to 70, adjust instance counts

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -5,9 +5,9 @@ diego_api_instances: 3
 cell_instances: 144
 router_instances: 30
 api_instances: 15
-doppler_instances: 45
-log_cache_instances: 27
-log_api_instances: 27
+doppler_instances: 39
+log_cache_instances: 24
+log_api_instances: 21
 scheduler_instances: 10
 cc_worker_instances: 12
 cc_hourly_rate_limit: 60000

--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -5,9 +5,9 @@ diego_api_instances: 3
 cell_instances: 24
 router_instances: 39
 api_instances: 9
-doppler_instances: 24
-log_cache_instances: 18
-log_api_instances: 15
+doppler_instances: 21
+log_cache_instances: 15
+log_api_instances: 12
 scheduler_instances: 12
 cc_worker_instances: 12
 cc_hourly_rate_limit: 60000

--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -3,7 +3,7 @@ uaa_instances: 3
 nats_instances: 3
 diego_api_instances: 3
 cell_instances: 24
-router_instances: 39
+router_instances: 33
 api_instances: 9
 doppler_instances: 21
 log_cache_instances: 15

--- a/manifests/cf-manifest/operations.d/235-log-cache-tuning.yml
+++ b/manifests/cf-manifest/operations.d/235-log-cache-tuning.yml
@@ -1,4 +1,4 @@
 ---
 - type: replace
   path: /instance_groups/name=log-cache/jobs/name=log-cache/properties/memory_limit_percent?
-  value: 65
+  value: 70


### PR DESCRIPTION
What
----

https://www.pivotaltracker.com/story/show/182790768

First we push the `memory_limit_percent` another 5%, which it looks like it can afford.

Then we adjust the instance counts based on what the metrics look like after the instance type switch.

How to review
-------------

:eyes: 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
