### PR TITLE
Revert "log-cache: set memory_limit_percent to 70"

### DIFF
--- a/manifests/cf-manifest/operations.d/235-log-cache-tuning.yml
+++ b/manifests/cf-manifest/operations.d/235-log-cache-tuning.yml
@@ -1,4 +1,4 @@
 ---
 - type: replace
   path: /instance_groups/name=log-cache/jobs/name=log-cache/properties/memory_limit_percent?
-  value: 70
+  value: 65


### PR DESCRIPTION
What
----

On reflection, leaving log-caches with a little more headroom for when e.g. their siblings disappear is probably a good thing.

Yesterday's difficult rollout resulted in instances going into swap briefly.

How to review
-------------

:eyes: 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
