### PR TITLE
az-management: exclude backing services when disabling subnets

### DIFF
--- a/terraform/az-management/README.md
+++ b/terraform/az-management/README.md
@@ -1,7 +1,7 @@
 # AZ Management
 
-If there is ever an occurance of AWS losing a single AZ, we'd like to have a
-way of disabling that AZ programatically, to ensure our CF and BOSH stop any
+If there is ever an occurrence of AWS losing a single AZ, we'd like to have a
+way of disabling that AZ programmatically, to ensure our CF and BOSH stop any
 traffic and scheduling onto the damaged AZ.
 
 ## How to run
@@ -18,6 +18,6 @@ The following will re-enable an AZ:
 terraform destroy
 ```
 
-This is only intended to be run through Concourse job. However it may be
+This is only intended to be run through Concourse job. However, it may be
 necessary to run by hand, if we happen to lose an AZ that the Concourse is
 running on.


### PR DESCRIPTION
What
----

https://www.pivotaltracker.com/story/show/182772579

This covers RDS & Elasticache instances - these won't automatically handle endpoints being unreachable, so disconnecting their subnets would just result in any non-HA (or HA-but-not-failed-over) service instances being cut off from their apps.

This was @cadmiumcat 's work mostly, I just tested it & fixed a syntax change.

How to review
-------------

Well, I'll describe how I tested it, you can decide to what extent you want to do similar:

- Deploy this to a dev env.
- Create a non-ha database in cf
- Look at the AWS console to see which AZ it was placed in. If it gets put in the same AZ as your rds broker (or elasticache broker if you've chosen an elasticache db), try again. Slim dev envs only have one of each broker and if you disable its AZ you won't be able to bind to it while the AZ is disabled.
- Check you can `cf conduit` to your db.
- Disable the AZ that your db resides in using the `disable-az-?-vpc` concourse job.
- Check you can still `cf conduit` to your db.
- Might be useful to do a `bosh vms` at this point to check the disablement _is actually_ disabling ec2 instances. If the AZ you disabled is c/`z3` it's possible your slim bosh env doesn't have any instances in it, so would be good to do another check afterwards with an AZ that does so you can ensure this.
- Re-enable az with `enable-az-?-vpc` job.
- Check everything's back to normal.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
