### PR TITLE
182427769 - Remove deprecated Ginkgo V1 functionality

### DIFF
--- a/platform-tests/broker-acceptance/s3_broker_test.go
+++ b/platform-tests/broker-acceptance/s3_broker_test.go
@@ -152,7 +152,7 @@ var _ = Describe("S3 broker", func() {
 			})
 		})
 
-		It("do not run in to race conditions", func(done Done) {
+		It("do not run in to race conditions", func() {
 			By("binding the two apps simultaneously, we should see no errors", func() {
 				bindAppOneChan := make(chan int)
 				bindAppTwoChan := make(chan int)
@@ -178,8 +178,6 @@ var _ = Describe("S3 broker", func() {
 				Eventually(<-unbindAppOneChan, 60*time.Second).Should(Equal(0))
 				Eventually(<-unbindAppTwoChan, 60*time.Second).Should(Equal(0))
 			})
-
-			close(done)
 		}) // Override default timeout of 1 second for async to be one minute
 	})
 })


### PR DESCRIPTION
Description:
- Ginkgo has deprecated using done for asynchronous tests
- Functionality has been replaced by asynchronous matchers in the test

What
----

Describe what you have changed and why.

How to review
-------------

Check against https://deployer.dev02.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/custom-broker-acceptance-tests/builds/140

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
