### PR TITLE
dev environments: set CA_ROTATION_EXPIRY_DAYS to 345

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ dev: ## Set Environment to DEV
 	$(eval export PAAS_HIGH_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
 	$(eval export ENABLE_MORNING_DEPLOYMENT=true)
 	$(eval export SLIM_DEV_DEPLOYMENT ?= true)
-	$(eval export CA_ROTATION_EXPIRY_DAYS ?= 360)
+	$(eval export CA_ROTATION_EXPIRY_DAYS ?= 345)
 	$(eval export ENABLE_PAAS_ADMIN_CONTINUOUS_DEPLOY ?= true)
 	$(eval export DISABLED_AZS)
 	@true


### PR DESCRIPTION

What
----

Having these set to 360 (i.e. having a cert rotation happen every 5 days) is too disruptive to the development process and may even make dev testing _more_ unreliable, as we will frequently be testing with setups that roll more nodes on a deploy than production will.

How to review
-------------

:eyes: :brain: 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
