### PR TITLE
Remove paas-admin-data deployment

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -148,7 +148,6 @@ groups:
       - post-deploy
       - deploy-paas-accounts
       - deploy-paas-admin
-      - deploy-paas-admin-data
       - deploy-paas-auditor
       - deploy-paas-billing
       - deploy-paas-metrics
@@ -192,7 +191,6 @@ groups:
     jobs:
       - deploy-paas-accounts
       - deploy-paas-admin
-      - deploy-paas-admin-data
       - deploy-paas-auditor
       - deploy-paas-billing
       - deploy-paas-metrics
@@ -567,12 +565,6 @@ resources:
       branch: main
       pool: ((pipeline_name))
       private_key: ((pipeline_lock_git_private_key))
-
-  - name: performance-scraper-timer
-    type: time
-    source:
-      start: 2AM
-      stop: 3AM
 
   - name: smoke-tests-timer
     type: time
@@ -5199,7 +5191,6 @@ jobs:
                     DOMAIN_NAME: "https://admin.${SYSTEM_DNS_ZONE_NAME}"
                     AWS_ACCESS_KEY_ID: ((paas_admin_aws_access_key_id))
                     AWS_SECRET_ACCESS_KEY: ((paas_admin_aws_secret_access_key))
-                    PLATFORM_METRICS_ENDPOINT: "http://paas-admin-data.apps.internal:8080"
                     PROMETHEUS_USERNAME: paas-admin
                     PROMETHEUS_PASSWORD: ((paas_admin_prometheus_password))
                     PROMETHEUS_ENDPOINT: "https://prometheus.${SYSTEM_DNS_ZONE_NAME}"
@@ -5311,118 +5302,6 @@ jobs:
           GIT_SSH_PRIVATE_KEY: ((paas-admin-git-keys.private_key))
           GIT_SSH_PUBLIC_KEY: ((paas-admin-git-keys.public_key))
           GIT_USER: gov-paas-((deploy_env))
-
-      - *end-grafana-job-annotation
-
-  - name: deploy-paas-admin-data
-    serial: true
-    plan:
-      - *add-grafana-job-annotation
-      - get: paas-admin
-      - get: performance-scraper-timer
-        trigger: true
-
-      - in_parallel:
-        - <<: *get-paas-cf
-          passed: ['post-deploy']
-
-        - get: cf-manifest
-          passed: ['post-deploy']
-
-      - task: build
-        tags: [colocated-with-web]
-        config:
-          platform: linux
-          image_resource: *node-image-resource
-          inputs:
-            - name: paas-admin
-          outputs:
-            - name: paas-admin-data
-          params:
-            DEPLOY_ENV: ((deploy_env))
-            PINGDOM_API_TOKEN: ((pingdom_api_token))
-            PLATFORM_PROMETHEUS_ENDPOINT: "https://prometheus-2.((system_dns_zone_name))"
-            PLATFORM_PROMETHEUS_USERNAME: admin
-            PLATFORM_PROMETHEUS_PASSWORD: ((platform_prometheus_password))
-          run:
-            path: sh
-            args:
-              - -e
-              - -u
-              - -c
-              - |
-                export PINGDOM_CHECK_ID="4685013"
-                if [ "${DEPLOY_ENV}" = "prod-lon" ]; then
-                  export PINGDOM_CHECK_ID="4685882"
-                elif [ "${DEPLOY_ENV}" = "prod" ]; then
-                  export PINGDOM_CHECK_ID="3364261"
-                fi
-
-                echo "Interacting with ${PLATFORM_PROMETHEUS_ENDPOINT} as ${PLATFORM_PROMETHEUS_USERNAME}..."
-                cd paas-admin
-                npm ci
-                npm run -s scrape:performance > ../paas-admin-data/metrics.json
-
-      - task: render-manifest
-        tags: [colocated-with-web]
-        config:
-          platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: ghcr.io/alphagov/paas/spruce
-              tag: 36ed580ea6b5062feb10b1c45395696d75941020
-
-          inputs:
-            - name: paas-admin-data
-          outputs:
-            - name: paas-admin-data
-          run:
-            path: sh
-            args:
-              - -e
-              - -c
-              - |
-                cat <<EOF > ./paas-admin-data/manifest.yml
-                applications:
-                - name: paas-admin-data
-                  memory: 64M
-                  buildpacks:
-                  - staticfile_buildpack
-                  routes:
-                  - route: "paas-admin-data.apps.internal"
-                  instances: 3
-                EOF
-
-      - task: deploy
-        tags: [colocated-with-web]
-        config:
-          platform: linux
-          image_resource: *cf-cli-image-resource
-          inputs:
-            - name: paas-admin-data
-          params:
-            SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
-            API_ENDPOINT: ((api_endpoint))
-            CF_ADMIN: ((cf_admin))
-            CF_PASS: ((cf_pass))
-            CF_CLIENT_SECRET: ((cf_client_secret))
-          run:
-            path: sh
-            args:
-              - -e
-              - -u
-              - -c
-              - |
-                cf api "${API_ENDPOINT}"
-                cf auth "${CF_ADMIN}" "${CF_PASS}"
-                cf target -o admin -s public
-
-                cd paas-admin-data
-
-                cf cancel-deployment paas-admin-data || true
-                cf push --strategy=rolling paas-admin-data
-                cf add-network-policy paas-admin paas-admin-data --protocol tcp --port 8080
 
       - *end-grafana-job-annotation
 


### PR DESCRIPTION
What
----

We're removing the /performance page from paas-admin, so this is no longer required

revert of  https://github.com/alphagov/paas-cf/pull/2589

How to review
-------------

- tests pass
- happy with the code removal

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
