### PR TITLE
`app-autoscaler-cpu-usage` example app: revamp for better reliability, simplicity

### DIFF
--- a/platform-tests/example-apps/app-autoscaler-cpu-usage/main.go
+++ b/platform-tests/example-apps/app-autoscaler-cpu-usage/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"log"
-	"math"
 	"os"
 	"time"
 )
@@ -19,24 +18,26 @@ func main() {
 	}
 
 	log.Printf(
-		"My plan is to chill for %ds then party hard for %ds seconds, then repeat",
-		int(duration.Seconds()), int(duration.Seconds()),
+		"My plan is to chill for %s then party hard for %s, then repeat",
+		duration, duration,
 	)
 
 	for {
-		now := time.Now()
-		secondOfHour := now.Second() + (60 * now.Minute()) // between 0 and 3600
+		// using a fixed "now" makes it easier to reason about behaviour
+		// and removes an amount of nondeterminism
+		uniformNow := time.Now()
+		party, timeRemaining := shouldWePartyAndForHowLong(uniformNow, duration)
 
-		if weShouldChill(secondOfHour, duration) {
-			chillForSomeTime(time.Now().Sub(time.Now().Truncate(duration)))
+		if party {
+			partyHardForSomeTime(timeRemaining)
 		} else {
-			partyHardForSomeTime(time.Now().Sub(time.Now().Truncate(duration)))
+			chillForSomeTime(timeRemaining)
 		}
 	}
 }
 
 func chillForSomeTime(duration time.Duration) {
-	until := time.Now().Truncate(time.Minute).Add(duration)
+	until := time.Now().Truncate(time.Millisecond).Add(duration)
 
 	log.Printf("Going to chill until %s", until)
 
@@ -44,7 +45,7 @@ func chillForSomeTime(duration time.Duration) {
 }
 
 func partyHardForSomeTime(duration time.Duration) {
-	until := time.Now().Truncate(time.Minute).Add(duration)
+	until := time.Now().Truncate(time.Millisecond).Add(duration)
 	done := make(chan struct{})
 
 	log.Printf("Going to party hard until %s", until)
@@ -63,14 +64,18 @@ func partyHardForSomeTime(duration time.Duration) {
 	done <- struct{}{}
 }
 
-func weShouldChill(secondOfHour int, duration time.Duration) bool {
-	// y = sin(t * pi) is a wave with a period of 2
-	// where t is the current second of the hour
-	// y is positive between 0 and 1 and negative between 1 and 2
+func shouldWePartyAndForHowLong(tNow time.Time, period time.Duration) (bool, time.Duration) {
+	// this has to be calculated based on absolute time so that different
+	// instances are in sync with each other, meaning we can't use
+	// go's monotonic clock arithmetic, so in theory this isn't totally
+	// clock-slew-safe, but i can live with that.
 
-	// if sin(t * pi / seconds) is >= 0 then we should chill, else party hard
-	// this ensures that all instances of the app chill and in phase
+	// whether we should party is just whether the time tNow divided by the
+	// period is odd
+	shouldWe := (tNow.UnixMilli() / int64(period.Milliseconds())) % 2 != 0
 
-	durationSeconds := duration.Seconds()
-	return math.Sin(math.Pi*float64(secondOfHour)/durationSeconds) >= 0
+	// the time remaining is the period minus the remainder of that division
+	timeRemaining := period - time.Duration(float64(tNow.UnixMilli() % int64(period.Milliseconds())) * float64(time.Millisecond))
+
+	return shouldWe, timeRemaining
 }


### PR DESCRIPTION
What
----

This is an app that is deployed with our autoscaler to continuously exercise it by spinning for a period of time and then sleeping for a period of time. But the way it's written it's a little flaky and quirky. If we're going to set up an alert to ensure this is always behaving correctly (as appears to have been the original intention), it would be nice to be able to eliminate any of these strangenesses. The goal here is to, as much as possible, have all instances of this app perform their spinning at the same time (two instances "out of phase" will result in an approximately constant average cpu usage, which won't result in the desired scale-up-scale-down behaviour). Using this technique, that is much more reliable.

Before:
<img width="820" alt="Before" src="https://user-images.githubusercontent.com/807447/187483305-f5a2b1f0-d1ac-4567-8943-c7a5316c3af3.png">

After (ignore gap while prometheus was being redeployed):
<img width="820" alt="After" src="https://user-images.githubusercontent.com/807447/187483389-a9a68623-591c-4ecd-91c4-a4730a0a0f2a.png">


How to review
-------------

Deploy to a dev env, look at the pretty plot in grafana?

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
