### PR TITLE
[#183090353] Reduce paas-admin instances to 3 in dev envs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,7 @@ dev: ## Set Environment to DEV
 	$(eval export SLIM_DEV_DEPLOYMENT ?= true)
 	$(eval export CA_ROTATION_EXPIRY_DAYS ?= 345)
 	$(eval export ENABLE_PAAS_ADMIN_CONTINUOUS_DEPLOY ?= true)
+	$(eval export PAAS_ADMIN_INSTANCE_COUNT ?= 3)
 	$(eval export DISABLED_AZS)
 	@true
 

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -5156,6 +5156,7 @@ jobs:
             NOTIFY_WELCOME_TEMPLATE_ID: 1859ce68-f133-4218-ac6e-a8ef32a41292
             AWS_REGION: ((aws_region))
             UAA_CLIENTS_PAAS_ADMIN_SECRET: ((uaa_clients_paas_admin_secret))
+            INSTANCE_COUNT: ((paas_admin_instance_count))
           run:
             path: sh
             args:
@@ -5167,7 +5168,7 @@ jobs:
                 - name: paas-admin
                   routes:
                   - route: "admin.${SYSTEM_DNS_ZONE_NAME}"
-                  instances: 6
+                  instances: ${INSTANCE_COUNT}
                   services:
                    - logit-syslog-drain
                   env:

--- a/concourse/scripts/pipelines-cloudfoundry.sh
+++ b/concourse/scripts/pipelines-cloudfoundry.sh
@@ -112,6 +112,7 @@ deploy_env_tag_prefix: "${deploy_env_tag_prefix}"
 skip_autodelete_await: "${SKIP_AUTODELETE_AWAIT:-false}"
 ca_rotation_expiry_days: "${CA_ROTATION_EXPIRY_DAYS}"
 enable_paas_admin_continuous_deploy: ${ENABLE_PAAS_ADMIN_CONTINUOUS_DEPLOY:-true}
+paas_admin_instance_count: ${PAAS_ADMIN_INSTANCE_COUNT:-6}
 disabled_azs: ${DISABLED_AZS:-}
 enable_az_healthcheck: ${ENABLE_AZ_HEALTHCHECK:-}
 EOF


### PR DESCRIPTION
What
----

Rather than deploying 6 instances to our resource-limited dev environments, instead deploy 3.

This does, incidentally, allow specifying the number of instances as an envar to `make XXX pipelines` (`$PAAS_ADMIN_INSTANCE_COUNT`)

How to review
-------------

* Code Review

## Test that 3 instances are created by default in dev environments

* Check out this branch
* `make dev## pipelines`
* `bin/fly -t dev## get-pipeline -p create-cloudfoundry | yq '.jobs.[] | select(.name == "deploy-paas-admin") | .plan.[] | select(.task == "render-manifest") | .config.params.INSTANCE_COUNT'`
    * This should return `3`
* `make dev## run_job JOB=deploy-paas-admin`
* Ensure 3 instances have indeed been created via cf-cli (`instances:      3/3`)

## Test that 6 instances are created by default in non-dev environments

> In this case, we are going to update the pipelines in `stg-lon` but just trust the output of `fly get-pipeline`

* Check out this branch
* `make stg-lon pipelines`
* `bin/fly -t stg-lon get-pipeline -p create-cloudfoundry | yq '.jobs.[] | select(.name == "deploy-paas-admin") | .plan.[] | select(.task == "render-manifest") | .config.params.INSTANCE_COUNT'`
    * This should return `6`
* Check out `origin/main`
* `make stg-lon pipelines` - this will reset the pipelines back to how they were


> If you don't fancy installing `yq`, i guess a simple `bin/fly -t $ENV get-pipeline -p create-cloudfoundry | grep -A10 'name: paas-admin-manifest$' | grep -E '^\s+INSTANCE_COUNT'` would suffice

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
