### PR TITLE
Raise maximum disk space an app can request to 8gb

### DIFF
--- a/manifests/cf-manifest/operations.d/320-cc-increase-max-app-disk.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-increase-max-app-disk.yml
@@ -1,15 +1,15 @@
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/maximum_app_disk_in_mb?
-  value: 6144
+  value: 8192
 
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/maximum_app_disk_in_mb?
-  value: 6144
+  value: 8192
 
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/maximum_app_disk_in_mb?
-  value: 6144
+  value: 8192
 
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/cc/maximum_app_disk_in_mb?
-  value: 6144
+  value: 8192


### PR DESCRIPTION
What
----

One of our users requires extra disk space to be able to temporarily store and scan file uploads. This increases it to 8gb

How to review
-------------

Deploy to dev environment, check that you can scale an app to use more than 6gb of disk space, e.g. `cf scale paas-admin -k 8GB`

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
