### PR TITLE
[#183047939] Bump elasticache service broker

### DIFF
--- a/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
+++ b/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
@@ -61,9 +61,9 @@
   path: /releases/-
   value:
     name: elasticache-broker
-    version: 0.1.19
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/elasticache-broker-0.1.19.tgz
-    sha1: 416a17a858a90c2859ba69d59094e050c6d25d58
+    version: 0.1.20
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/elasticache-broker-0.1.20.tgz
+    sha1: 1649e485c7543a1f02cc8c8b7c67324549c1f8c0
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-
@@ -127,6 +127,7 @@
                     - redis
                   bindable: true
                   plan_updateable: false
+                  instances_retrievable: true
                   plans:
                     # Deprecated
                     - id: 3a51701c-eef3-447c-882b-907ad2bcb7ab


### PR DESCRIPTION
What
----

Bump the elasticache service broker to allow accessing maintenance and backup windows.

How to review
-------------

* Check the bosh release is the version  created after merging of alphagov/paas-elasticache-broker-boshrelease#18


Currently deployed to `dev03`.

in org/space `tnw / tw-test` I have deployed two redis instances. One with a `preferred_maintentance_window` set at provision-time and one without. Please ensure that:

* the instance metadata can be retrieved with the `cf service xxx --params`
* the maintenance window can be updated via `cf update-service xxx -c '{"preferred_maintenance_window":"mon:00:03-mon:01:42"}'`

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
