### PR TITLE
Remove orgs from the allowed csls-splunk list

### DIFF
--- a/config/service-brokers/csls-splunk/prod-config.json
+++ b/config/service-brokers/csls-splunk/prod-config.json
@@ -4,7 +4,6 @@
     "gds-security",
     "gds-tech-ops",
     "govuk_development",
-    "govuk-corona-backend-consumers",
     "govuk-notify",
     "govuk-pay"
   ]

--- a/config/service-brokers/csls-splunk/prod-lon-config.json
+++ b/config/service-brokers/csls-splunk/prod-lon-config.json
@@ -1,7 +1,6 @@
 {
   "allowed_orgs": [
     "cabinet-office-papt",
-    "cabinet-office-tu-facility-time",
     "ccs-conclave-cii",
     "ccs-conclave-sssos",
     "ccs-digital-services-team",
@@ -10,7 +9,6 @@
     "ccs-report-management-info",
     "gds-digital-identity-authentication",
     "gds-document-checking-service",
-    "govuk-accounts",
     "x-co-authentication"
   ]
 }


### PR DESCRIPTION
What
----

We have removed these orgs, so we no longer need them in the list

How to review
-------------

Check that the correct orgs are being removed
 
---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
