### PR TITLE
app-autoscaler-cpu-usage test app: add `app-autoscaler-cpu-usage-multiproc`

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -3537,6 +3537,10 @@ jobs:
                 cf push --strategy=rolling app-autoscaler-cpu-usage
                 cf aasp app-autoscaler-cpu-usage policy.json
 
+                cf cancel-deployment app-autoscaler-cpu-usage-multiproc || true
+                cf push --strategy=rolling app-autoscaler-cpu-usage-multiproc
+                cf aasp app-autoscaler-cpu-usage-multiproc policy.json
+
       - *end-grafana-job-annotation
 
   - name: post-deploy

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -3533,9 +3533,9 @@ jobs:
                   cf create-service autoscaler autoscaler-free-plan scale-app-autoscaler-cpu-usage
                 fi
 
-                cf cancel-deployment app-autoscaler-cpu-usage || true
-                cf push --strategy=rolling app-autoscaler-cpu-usage
-                cf aasp app-autoscaler-cpu-usage policy.json
+                cf cancel-deployment app-autoscaler-cpu-usage-singleproc || true
+                cf push --strategy=rolling app-autoscaler-cpu-usage-singleproc
+                cf aasp app-autoscaler-cpu-usage-singleproc policy.json
 
                 cf cancel-deployment app-autoscaler-cpu-usage-multiproc || true
                 cf push --strategy=rolling app-autoscaler-cpu-usage-multiproc

--- a/manifests/prometheus/alerts.d/app-autoscaler-is-not-scaling.yml
+++ b/manifests/prometheus/alerts.d/app-autoscaler-is-not-scaling.yml
@@ -3,13 +3,27 @@
 - type: replace
   path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
   value:
-    name: AppAutoscalingIsNotScaling
+    name: AppAutoscalingIsNotScalingSingleProc
     rules:
-      - alert: AppAutoscalingIsNotScaling
-        expr: changes(cf_application_instances{organization_name="admin", space_name="healthchecks", application_name="app-autoscaler-cpu-usage"}[1h]) < 1
+      - alert: AppAutoscalingIsNotScalingSingleProc
+        expr: changes(cf_application_instances{organization_name="admin", space_name="healthchecks", application_name="app-autoscaler-cpu-usage-singleproc"}[1h]) < 1
         for: 30m
         labels:
           severity: critical
         annotations:
-          summary: "App autoscaler is not scaling our healthcheck app"
+          summary: "App autoscaler is not scaling our single-process healthcheck app"
+          description: "The app autoscaler cpu scaling healthcheck app has scaled {{ $value | printf \"%.0f\" }} times over the last 30 minutes, it should have autoscaled more"
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: AppAutoscalingIsNotScalingMultiProc
+    rules:
+      - alert: AppAutoscalingIsNotScalingMultiProc
+        expr: changes(cf_application_instances{organization_name="admin", space_name="healthchecks", application_name="app-autoscaler-cpu-usage-multiproc"}[1h]) < 1
+        for: 30m
+        labels:
+          severity: critical
+        annotations:
+          summary: "App autoscaler is not scaling our multi-process healthcheck app"
           description: "The app autoscaler cpu scaling healthcheck app has scaled {{ $value | printf \"%.0f\" }} times over the last 30 minutes, it should have autoscaled more"

--- a/manifests/prometheus/spec/alerts/app-autoscaler-cpu.test.yml
+++ b/manifests/prometheus/spec/alerts/app-autoscaler-cpu.test.yml
@@ -8,25 +8,50 @@ evaluation_interval: 1m
 tests:
   - interval: 20m
     input_series:
-      - series: 'cf_application_instances{organization_name="admin", space_name="healthchecks", application_name="app-autoscaler-cpu-usage"}'
+      - series: 'cf_application_instances{organization_name="admin", space_name="healthchecks", application_name="app-autoscaler-cpu-usage-singleproc"}'
         values: 1 1 1 1 1 2 3 4 5
 
     alert_rule_test:
       # Does not fire without enough data
       - eval_time: 0m
-        alertname: AppAutoscalingIsNotScaling
+        alertname: AppAutoscalingIsNotScalingSingleProc
       # Does not fire until consistently not scaling
       - eval_time: 90m
-        alertname: AppAutoscalingIsNotScaling
+        alertname: AppAutoscalingIsNotScalingSingleProc
         exp_alerts:
           - exp_labels:
               severity: critical
               organization_name: admin
               space_name: healthchecks
-              application_name: app-autoscaler-cpu-usage
+              application_name: app-autoscaler-cpu-usage-singleproc
             exp_annotations:
-              summary: "App autoscaler is not scaling our healthcheck app"
+              summary: "App autoscaler is not scaling our single-process healthcheck app"
               description: "The app autoscaler cpu scaling healthcheck app has scaled 0 times over the last 30 minutes, it should have autoscaled more"
       # Does not fire after scaling
       - eval_time: 120m
-        alertname: AppAutoscalingIsNotScaling
+        alertname: AppAutoscalingIsNotScalingSingleProc
+
+  - interval: 20m
+    input_series:
+      - series: 'cf_application_instances{organization_name="admin", space_name="healthchecks", application_name="app-autoscaler-cpu-usage-multiproc"}'
+        values: 1 1 1 1 1 2 3 4 5
+
+    alert_rule_test:
+      # Does not fire without enough data
+      - eval_time: 0m
+        alertname: AppAutoscalingIsNotScalingMultiProc
+      # Does not fire until consistently not scaling
+      - eval_time: 90m
+        alertname: AppAutoscalingIsNotScalingMultiProc
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              organization_name: admin
+              space_name: healthchecks
+              application_name: app-autoscaler-cpu-usage-multiproc
+            exp_annotations:
+              summary: "App autoscaler is not scaling our multi-process healthcheck app"
+              description: "The app autoscaler cpu scaling healthcheck app has scaled 0 times over the last 30 minutes, it should have autoscaled more"
+      # Does not fire after scaling
+      - eval_time: 120m
+        alertname: AppAutoscalingIsNotScalingMultiProc

--- a/platform-tests/example-apps/app-autoscaler-cpu-usage/manifest.yml
+++ b/platform-tests/example-apps/app-autoscaler-cpu-usage/manifest.yml
@@ -2,8 +2,8 @@
 applications:
   - name: app-autoscaler-cpu-usage
 
-    memory: 128M
-    disk_quota: 256M
+    memory: 64M
+    disk_quota: 128M
 
     services: [scale-app-autoscaler-cpu-usage]
     buildpacks: [go_buildpack]
@@ -19,3 +19,30 @@ applications:
       GOPACKAGENAME: github.com/alphagov/paas-cf/platform-tests/example-apps/app-autoscaler-cpu-usage
 
       DURATION: 11m
+
+  - name: app-autoscaler-cpu-usage-multiproc
+
+    services: [scale-app-autoscaler-cpu-usage]
+    buildpacks: [go_buildpack]
+    stack: cflinuxfs3
+
+    no-route: true
+
+    env:
+      GOVERSION: go1.18
+      GOPACKAGENAME: github.com/alphagov/paas-cf/platform-tests/example-apps/app-autoscaler-cpu-usage
+
+      DURATION: 13m
+
+    processes:
+      - type: web
+        health-check-type: process
+        command: "./bin/app-autoscaler-cpu-usage"
+        memory: 64M
+        disk_quota: 128M
+      - type: no-op
+        instances: 1
+        health-check-type: process
+        command: "cat"
+        memory: 32M
+        disk_quota: 128M

--- a/platform-tests/example-apps/app-autoscaler-cpu-usage/manifest.yml
+++ b/platform-tests/example-apps/app-autoscaler-cpu-usage/manifest.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-  - name: app-autoscaler-cpu-usage
+  - name: app-autoscaler-cpu-usage-singleproc
 
     memory: 64M
     disk_quota: 128M


### PR DESCRIPTION
What
----
https://www.pivotaltracker.com/story/show/183165018

Here we add a multi-process continuously autoscaling test app to catch issue affecting only such apps. We leave in place (but rename) the single-process one and ensure there is an alert for each.

Also reduce the memory & disk allocation for each app, as each actually uses <16M, this is still generous.

How to review
-------------
How I did it:
 - deploy to a dev env
 - see both new apps running in grafana, scaling up and down
 - look at env's alertmanager, see no relevant alert
 - detach one of the apps' scaling policies, e.g. `cf dasp app-autoscaler-cpu-usage-multiproc`
 - do something else for a couple of hours
 - check alertmanager for a relevant alert

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
