### PR TITLE
#183452476 Update cf-deployment to 21.11.0

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -11,72 +11,72 @@ meta:
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/alpine
-        tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
     psql: &psql-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/psql
-        tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
     node: &node-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/node
-        tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
     node-chromium: &node-chromium-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/node-chromium
-        tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
     awscli: &awscli-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
     cf-acceptance-tests: &cf-acceptance-tests-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-        tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
     cf-cli: &cf-cli-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-cli
-        tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
     cf-uaac: &cf-uaac-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-uaac
-        tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
     git-ssh: &git-ssh-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/git-ssh
-        tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
     ruby-slim: &ruby-slim-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/ruby
-        tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
     golang: &golang-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/golang
-        tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
     terraform: &terraform-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
     curl-ssl: &curl-ssl-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/curl-ssl
-        tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
 
   tasks:
@@ -268,7 +268,7 @@ resource_types:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/concourse-pool-resource
-    tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+    tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
 - name: s3-iam
   type: docker-image
@@ -799,7 +799,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+              tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
           inputs:
             - name: paas-cf
@@ -5145,7 +5145,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/spruce
-              tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+              tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
           inputs:
             - name: paas-cf
@@ -6186,7 +6186,7 @@ jobs:
           type: docker-image
           source:
             repository: ghcr.io/alphagov/paas/cf-uaac
-            tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+            tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
         inputs:
           - name: passwords

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -523,13 +523,13 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-acceptance-tests
-      branch: cf21.7
+      branch: cf21.11
 
   - name: cf-smoke-tests-release
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-smoke-tests-release
-      tag_filter: "42.0.10"
+      tag_filter: "42.0.19"
       submodules:
       - "src/smoke_tests"
 

--- a/concourse/pipelines/monitor-remote.yml
+++ b/concourse/pipelines/monitor-remote.yml
@@ -28,7 +28,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloudfoundry/cf-smoke-tests-release
-    tag_filter: "42.0.10"
+    tag_filter: "42.0.19"
     submodules:
       - "src/smoke_tests"
 

--- a/manifests/app-autoscaler/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/app-autoscaler/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-bionic
-      version: "1.97"
+      version: "1.107"

--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-bionic
-      version: "1.97"
+      version: "1.107"

--- a/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
+++ b/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
@@ -3,6 +3,6 @@
   path: /releases/name=cflinuxfs3
   value:
     name: "cflinuxfs3"
-    version: "0.318.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.318.0"
-    sha1: "abaf2f80223f9b476f168c6a10761d6317f58f9c"
+    version: "0.326.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.326.0"
+    sha1: "5f690d12b34e86137c41966e4dc4825beaed2b1a"

--- a/manifests/cf-manifest/operations.d/320-cc-release.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-release.yml
@@ -3,6 +3,6 @@
   path: /releases/name=capi
   value:
     name: "capi"
-    version: "1.136.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.136.0"
-    sha1: "e4b0fff246099c44a2ffb4551c4d7c69e1863f04"
+    version: "1.139.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.139.0"
+    sha1: "bf904f6f360508a66ffd67d1f66c061be3e2ee8f"

--- a/manifests/cf-manifest/operations/scale-down-dev.yml
+++ b/manifests/cf-manifest/operations/scale-down-dev.yml
@@ -21,7 +21,7 @@
 
 - type: replace
   path: /instance_groups/name=diego-cell/instances
-  value: 2
+  value: 3
 
 - type: replace
   path: /instance_groups/name=router/instances
@@ -41,22 +41,6 @@
 
 - type: replace
   path: /instance_groups/name=log-api/instances
-  value: 2
-
-- type: replace
-  path: /instance_groups/name=doppler/instances
-  value: 2
-
-- type: replace
-  path: /instance_groups/name=router/instances
-  value: 2
-
-- type: replace
-  path: /instance_groups/name=diego-cell/instances
-  value: 2
-
-- type: replace
-  path: /instance_groups/name=api/instances
   value: 2
 
 # Ensure there is 1 of everything that is not availability tested

--- a/manifests/cf-manifest/spec/manifest/certificates_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/certificates_spec.rb
@@ -48,14 +48,6 @@ RSpec.describe "certificates" do
         common_name = c.dig("options", "common_name")
         alt_names = c.dig("options", "alternative_names") || []
 
-        if cert_name == "policy_server_asg_syncer_cc_client"
-          # This is a special case, see https://github.com/cloudfoundry/cf-deployment/pull/985
-
-          expect(alt_names.length).to eq(0),
-            "policy_server_asg_syncer_cc_client does not have an alternative_name set in cloudfoundry/cf-deployment. When this test starts failing, remove this if statement."
-          next
-        end
-
         expect(alt_names.length).to be > 0,
           "Certificate #{cert_name} (common_name '#{common_name}') must have at least one alternative_name"
       end

--- a/manifests/cf-manifest/spec/manifest/dev_scaling_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/dev_scaling_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "dev environment scaling" do
     # It scales back CF components to two instances
     expect(dev_manifest.fetch("instance_groups.api.instances")).to eq(2)
     expect(dev_manifest.fetch("instance_groups.doppler.instances")).to eq(2)
-    expect(dev_manifest.fetch("instance_groups.diego-cell.instances")).to eq(2)
+    expect(dev_manifest.fetch("instance_groups.diego-cell.instances")).to eq(3)
 
     # It scales back brokers to 1
     expect(dev_manifest.fetch("instance_groups.rds_broker.instances")).to eq(1)

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "release versions" do
     # - attempted login using an unknown/unrelated Google account
     #
     # these are tricky to automate due to their reliance on SSO and/or email.
-    tested_uaa_version = "75.22.0"
+    tested_uaa_version = "76.0.0"
     manifest_releases = get_manifest_releases
 
     expect(manifest_releases).to have_key("uaa"), "expected release for uaa to be found in manifest"
@@ -117,7 +117,7 @@ RSpec.describe "release versions" do
     expect(monitor_remote_smoke_tests_resource_version).to eq(cf_smoke_tests_resource_version)
   end
 
-  pinned_cf_acceptance_tests_version = "21.7"
+  pinned_cf_acceptance_tests_version = "21.11"
   specify "cf-acceptance-tests version should be the same as the CF manifest version" do
     cf_manifest_version = cf_deployment_manifest
       .fetch("manifest_version")


### PR DESCRIPTION
What
----

* Upgrade CF to `21.11.0`
* Use latest versions of docker tools (fixes for the new need for CF v3 api, so update CF CLI)
* Increase number of Diego cells in dev from 2 to 3 - this should kill off some test failures while developing in future

How to review
-------------

Check it's gone down a dev environment 'greenly' (see `dev01`)

Who can review
--------------

Mob review with @dark5un @corlettb @jackjoy-gds 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
