### PR TITLE
Pin Ginkgo CLI version to the one used in packages

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -5615,7 +5615,7 @@ jobs:
               - -e
               - -c
               - |
-                go install github.com/onsi/ginkgo/v2/ginkgo@latest
+                go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.4
 
                 cd paas-cf/tools/metrics
                 echo 'Waiting 2 minutes before running the acceptance tests'


### PR DESCRIPTION
What
----
Pin Ginkgo CLI version to the one used in packages. Using latest has caused acceptance tests to fail with a version mismatch.

How to review
-------------

- Double-check in a dev env that deploy-paas-metrics/acceptance-tests pass

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
