### PR TITLE
Improve diego cell memory alerts

### DIFF
--- a/manifests/prometheus/alerts.d/diego_cell_mem_few_candidates.yml
+++ b/manifests/prometheus/alerts.d/diego_cell_mem_few_candidates.yml
@@ -1,0 +1,26 @@
+# Source: bosh-exporter
+---
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: DiegoCellMemoryFewCandidates
+    rules:
+      - alert: DiegoCellMemoryFewCandidates4G
+        expr: (count(firehose_value_metric_rep_capacity_remaining_memory{bosh_job_name="diego-cell"} > 4096) or vector(0)) < 3
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: Few candidate cells for a 4GiB app
+          description: Only {{ $value | printf "%.0f" }} cell(s) are advertising enough free memory to run a 4GiB app instance. Some tenant app(s) may be scaling out of control or we may have depleted cell capacity.
+          url: https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision
+
+      - alert: DiegoCellMemoryFewCandidates16G
+        expr: (count(firehose_value_metric_rep_capacity_remaining_memory{bosh_job_name="diego-cell"} > 16384) or vector(0)) < 3
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: Few candidate cells for a 16GiB app
+          description: Only {{ $value | printf "%.0f" }} cell(s) are advertising enough free memory to run a 16GiB app instance. Some tenant app(s) may be scaling out of control or we may have depleted cell capacity.
+          url: https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision

--- a/manifests/prometheus/alerts.d/diego_cell_mem_few_candidates.yml
+++ b/manifests/prometheus/alerts.d/diego_cell_mem_few_candidates.yml
@@ -33,7 +33,8 @@
           severity: warning
         annotations:
           summary: Few candidate cells for a 16GiB app
-          description: Only {{ $value | printf "%.0f" }} cell(s) are advertising enough free memory to run a 16GiB app instance. The threshold is 3 (1 per AZ).
+          description: |
+            Only {{ $value | printf "%.0f" }} cell(s) are advertising enough free memory to run a 16GiB app instance. The threshold is 3 (1 per AZ).
 
             The likely impact is some tenants are unable to schedule some apps, but failures may be sporadic.
 

--- a/manifests/prometheus/alerts.d/diego_cell_mem_few_candidates.yml
+++ b/manifests/prometheus/alerts.d/diego_cell_mem_few_candidates.yml
@@ -12,7 +12,18 @@
           severity: critical
         annotations:
           summary: Few candidate cells for a 4GiB app
-          description: Only {{ $value | printf "%.0f" }} cell(s) are advertising enough free memory to run a 4GiB app instance. Some tenant app(s) may be scaling out of control or we may have depleted cell capacity.
+          description: |
+            Only {{ $value | printf "%.0f" }} cell(s) are advertising enough free memory to run a 4GiB app instance. The threshold is 3 (1 per AZ).
+
+            The likely impact is some tenants are unable to schedule some apps, but failures may be sporadic.
+
+            It means we don't have enough capacity to run all tenant workloads. This is probably caused by natural growth, but it is also possible
+            that one or more tenant applications are scaling out beyond their intended limtis (e.g. because of a fault
+            in the tenant's autoscaling policy, or a tenant starting many tasks with `cf run-task`).
+
+            First check for something consuming a lot of excess resources, then scale the number of cells if you can't find anything. Scaling while
+            something is actively consuming more and more resources likely won't fix the problem.
+
           url: https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision
 
       - alert: DiegoCellMemoryFewCandidates16G
@@ -22,5 +33,14 @@
           severity: warning
         annotations:
           summary: Few candidate cells for a 16GiB app
-          description: Only {{ $value | printf "%.0f" }} cell(s) are advertising enough free memory to run a 16GiB app instance. Some tenant app(s) may be scaling out of control or we may have depleted cell capacity.
+          description: Only {{ $value | printf "%.0f" }} cell(s) are advertising enough free memory to run a 16GiB app instance. The threshold is 3 (1 per AZ).
+
+            The likely impact is some tenants are unable to schedule some apps, but failures may be sporadic.
+
+            It means we don't have enough capacity to run all tenant workloads. This is probably caused by natural growth, but it is also possible
+            that one or more tenant applications are scaling out beyond their intended limtis (e.g. because of a fault
+            in the tenant's autoscaling policy, or a tenant starting many tasks with `cf run-task`).
+
+            First check for something consuming a lot of excess resources, then scale the number of cells if you can't find anything. Scaling while
+            something is actively consuming more and more resources likely won't fix the problem.
           url: https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision

--- a/manifests/prometheus/alerts.d/diego_cell_rep_memory_capacity.yml
+++ b/manifests/prometheus/alerts.d/diego_cell_rep_memory_capacity.yml
@@ -3,7 +3,7 @@
 - type: replace
   path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
   value:
-    name: DiegoCellRepMemoryCapacity
+    name: DiegoCellRepsMemoryCapacity
     rules:
       # Average amount of free memory across all cells over the last 5 minutes
       - record: rep_memory_capacity_pct:avg5m
@@ -38,16 +38,21 @@
       - record: diego_cells_required
         expr: ceil(1.5 * diego_cell_capacity_used_pct:avg5m)
 
-      - alert: DiegoCellRepMemoryCapacity
+      - alert: DiegoCellRepsReachingTotalMemoryCapacity
         expr:  rep_memory_capacity_pct:avg5m < 35
         for: 2h
         labels:
           severity: warning
         annotations:
-          summary: Rep low free memory capacity
+          summary: Reps low free memory capacity
           bosh_job_name: "{{ $labels.bosh_job_name }}"
           description: >
-            Low free memory {{ $value | printf "%.0f" }}% for the advertised rep memory capacity
-            in the last 2 hours on average.
-            Review if we need to scale...
+            Rep is reporting that the average uncommitted memory across all cells has reached {{ $value | printf "%.0f"}}% over the last 5 minutes.
+
+            The threshold for this alert is under 35%
+
+            We aim to have at least 33% of memory available on average so that we can we can suffer the loss of an AZ by rescheduling the workloads
+            in the lost zone across the other two.
+
+            Review whether we need to scale up the number of cells.
           url: https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision

--- a/manifests/prometheus/spec/alerts/diego_cell_mem_few_candidates.test.yml
+++ b/manifests/prometheus/spec/alerts/diego_cell_mem_few_candidates.test.yml
@@ -1,0 +1,141 @@
+---
+rule_files:
+  # See alerts_validation_spec.rb for details of how stdin gets set:
+  - fixtures/rules.yml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 10m
+    input_series:
+      - series: 'firehose_value_metric_rep_capacity_remaining_memory{bosh_job_name="diego-cell", bosh_job_id="1"}'
+        values: 22e3 15e3 15e3 3e3  3e3  19e3 3e3  20e3 2e3  5e3
+      - series: 'firehose_value_metric_rep_capacity_remaining_memory{bosh_job_name="diego-cell", bosh_job_id="2"}'
+        values: 22e3 22e3 1e3  12e3 3e3  3e3  9e3  20e3 5e3  2e3
+      - series: 'firehose_value_metric_rep_capacity_remaining_memory{bosh_job_name="diego-cell", bosh_job_id="3"}'
+        values: 1e3  1e3  1e3  1e3  1e3  1e3  1e3  20e3 2e3  2e3
+      - series: 'firehose_value_metric_rep_capacity_remaining_memory{bosh_job_name="diego-cell", bosh_job_id="4"}'
+        values: 1e3  1e3  1e3  1e3  1e3  1e3  1e3  20e3 2e3  20e3
+      - series: 'firehose_value_metric_rep_capacity_remaining_memory{bosh_job_name="diego-cell", bosh_job_id="5"}'
+        values: 11e3 11e3 11e3 1e3  1e3  11e3 19e3 20e3 20e3 2e3
+      - series: 'firehose_value_metric_rep_capacity_remaining_memory{bosh_job_name="diego-cell", bosh_job_id="6"}'
+        values: 17e3 16e3 15e3 14e3 13e3 12e3 11e3 20e3 2e3  2e3
+
+    alert_rule_test:
+      - eval_time: 0
+        alertname: DiegoCellMemoryFewCandidates4G
+      - eval_time: 0
+        alertname: DiegoCellMemoryFewCandidates16G
+
+      - eval_time: 10m
+        alertname: DiegoCellMemoryFewCandidates4G
+        # hasn't met condition for long enough
+      - eval_time: 10m
+        alertname: DiegoCellMemoryFewCandidates16G
+
+      - eval_time: 20m
+        alertname: DiegoCellMemoryFewCandidates4G
+        # hasn't met condition for long enough
+      - eval_time: 20m
+        alertname: DiegoCellMemoryFewCandidates16G
+
+      - eval_time: 26m
+        alertname: DiegoCellMemoryFewCandidates4G
+      - eval_time: 26m
+        alertname: DiegoCellMemoryFewCandidates16G
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: Few candidate cells for a 16GiB app
+              description: Only 0 cell(s) are advertising enough free memory to run a 16GiB app instance. Some tenant app(s) may be scaling out of control or we may have depleted cell capacity.
+              url: https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision
+
+        # hasn't met condition for long enough
+      - eval_time: 30m
+        alertname: DiegoCellMemoryFewCandidates4G
+      - eval_time: 30m
+        alertname: DiegoCellMemoryFewCandidates16G
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: Few candidate cells for a 16GiB app
+              description: Only 0 cell(s) are advertising enough free memory to run a 16GiB app instance. Some tenant app(s) may be scaling out of control or we may have depleted cell capacity.
+              url: https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision
+
+      - eval_time: 40m
+        alertname: DiegoCellMemoryFewCandidates4G
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+            exp_annotations:
+              summary: Few candidate cells for a 4GiB app
+              description: Only 1 cell(s) are advertising enough free memory to run a 4GiB app instance. Some tenant app(s) may be scaling out of control or we may have depleted cell capacity.
+              url: https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision
+      - eval_time: 40m
+        alertname: DiegoCellMemoryFewCandidates16G
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: Few candidate cells for a 16GiB app
+              description: Only 0 cell(s) are advertising enough free memory to run a 16GiB app instance. Some tenant app(s) may be scaling out of control or we may have depleted cell capacity.
+              url: https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision
+
+      - eval_time: 50m
+        alertname: DiegoCellMemoryFewCandidates4G
+      - eval_time: 50m
+        alertname: DiegoCellMemoryFewCandidates16G
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: Few candidate cells for a 16GiB app
+              description: Only 1 cell(s) are advertising enough free memory to run a 16GiB app instance. Some tenant app(s) may be scaling out of control or we may have depleted cell capacity.
+              url: https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision
+
+      - eval_time: 70m
+        alertname: DiegoCellMemoryFewCandidates4G
+      - eval_time: 70m
+        alertname: DiegoCellMemoryFewCandidates16G
+
+        # hasn't met condition for long enough
+      - eval_time: 80m
+        alertname: DiegoCellMemoryFewCandidates4G
+        # hasn't met condition for long enough
+      - eval_time: 80m
+        alertname: DiegoCellMemoryFewCandidates16G
+
+        # alerts before DiegoCellMemoryFewCandidates16G because shorter `for`
+      - eval_time: 90m
+        alertname: DiegoCellMemoryFewCandidates4G
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+            exp_annotations:
+              summary: Few candidate cells for a 4GiB app
+              description: Only 2 cell(s) are advertising enough free memory to run a 4GiB app instance. Some tenant app(s) may be scaling out of control or we may have depleted cell capacity.
+              url: https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision
+        # hasn't met condition for long enough
+      - eval_time: 90m
+        alertname: DiegoCellMemoryFewCandidates16G
+
+      - eval_time: 96m
+        alertname: DiegoCellMemoryFewCandidates4G
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+            exp_annotations:
+              summary: Few candidate cells for a 4GiB app
+              description: Only 0 cell(s) are advertising enough free memory to run a 4GiB app instance. Some tenant app(s) may be scaling out of control or we may have depleted cell capacity.
+              url: https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision
+      - eval_time: 96m
+        alertname: DiegoCellMemoryFewCandidates16G
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: Few candidate cells for a 16GiB app
+              description: Only 0 cell(s) are advertising enough free memory to run a 16GiB app instance. Some tenant app(s) may be scaling out of control or we may have depleted cell capacity.
+              url: https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision

--- a/manifests/prometheus/spec/alerts/diego_cell_mem_few_candidates.test.yml
+++ b/manifests/prometheus/spec/alerts/diego_cell_mem_few_candidates.test.yml
@@ -48,7 +48,17 @@ tests:
               severity: warning
             exp_annotations:
               summary: Few candidate cells for a 16GiB app
-              description: Only 0 cell(s) are advertising enough free memory to run a 16GiB app instance. Some tenant app(s) may be scaling out of control or we may have depleted cell capacity.
+              description: |
+                Only 0 cell(s) are advertising enough free memory to run a 16GiB app instance. The threshold is 3 (1 per AZ).
+
+                The likely impact is some tenants are unable to schedule some apps, but failures may be sporadic.
+
+                It means we don't have enough capacity to run all tenant workloads. This is probably caused by natural growth, but it is also possible
+                that one or more tenant applications are scaling out beyond their intended limtis (e.g. because of a fault
+                in the tenant's autoscaling policy, or a tenant starting many tasks with `cf run-task`).
+
+                First check for something consuming a lot of excess resources, then scale the number of cells if you can't find anything. Scaling while
+                something is actively consuming more and more resources likely won't fix the problem.
               url: https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision
 
         # hasn't met condition for long enough
@@ -61,7 +71,17 @@ tests:
               severity: warning
             exp_annotations:
               summary: Few candidate cells for a 16GiB app
-              description: Only 0 cell(s) are advertising enough free memory to run a 16GiB app instance. Some tenant app(s) may be scaling out of control or we may have depleted cell capacity.
+              description: |
+                Only 0 cell(s) are advertising enough free memory to run a 16GiB app instance. The threshold is 3 (1 per AZ).
+
+                The likely impact is some tenants are unable to schedule some apps, but failures may be sporadic.
+
+                It means we don't have enough capacity to run all tenant workloads. This is probably caused by natural growth, but it is also possible
+                that one or more tenant applications are scaling out beyond their intended limtis (e.g. because of a fault
+                in the tenant's autoscaling policy, or a tenant starting many tasks with `cf run-task`).
+
+                First check for something consuming a lot of excess resources, then scale the number of cells if you can't find anything. Scaling while
+                something is actively consuming more and more resources likely won't fix the problem.
               url: https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision
 
       - eval_time: 40m
@@ -71,7 +91,17 @@ tests:
               severity: critical
             exp_annotations:
               summary: Few candidate cells for a 4GiB app
-              description: Only 1 cell(s) are advertising enough free memory to run a 4GiB app instance. Some tenant app(s) may be scaling out of control or we may have depleted cell capacity.
+              description: |
+                Only 1 cell(s) are advertising enough free memory to run a 4GiB app instance. The threshold is 3 (1 per AZ).
+
+                The likely impact is some tenants are unable to schedule some apps, but failures may be sporadic.
+
+                It means we don't have enough capacity to run all tenant workloads. This is probably caused by natural growth, but it is also possible
+                that one or more tenant applications are scaling out beyond their intended limtis (e.g. because of a fault
+                in the tenant's autoscaling policy, or a tenant starting many tasks with `cf run-task`).
+
+                First check for something consuming a lot of excess resources, then scale the number of cells if you can't find anything. Scaling while
+                something is actively consuming more and more resources likely won't fix the problem.
               url: https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision
       - eval_time: 40m
         alertname: DiegoCellMemoryFewCandidates16G
@@ -80,7 +110,17 @@ tests:
               severity: warning
             exp_annotations:
               summary: Few candidate cells for a 16GiB app
-              description: Only 0 cell(s) are advertising enough free memory to run a 16GiB app instance. Some tenant app(s) may be scaling out of control or we may have depleted cell capacity.
+              description: |
+                Only 0 cell(s) are advertising enough free memory to run a 16GiB app instance. The threshold is 3 (1 per AZ).
+
+                The likely impact is some tenants are unable to schedule some apps, but failures may be sporadic.
+
+                It means we don't have enough capacity to run all tenant workloads. This is probably caused by natural growth, but it is also possible
+                that one or more tenant applications are scaling out beyond their intended limtis (e.g. because of a fault
+                in the tenant's autoscaling policy, or a tenant starting many tasks with `cf run-task`).
+
+                First check for something consuming a lot of excess resources, then scale the number of cells if you can't find anything. Scaling while
+                something is actively consuming more and more resources likely won't fix the problem.
               url: https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision
 
       - eval_time: 50m
@@ -92,7 +132,17 @@ tests:
               severity: warning
             exp_annotations:
               summary: Few candidate cells for a 16GiB app
-              description: Only 1 cell(s) are advertising enough free memory to run a 16GiB app instance. Some tenant app(s) may be scaling out of control or we may have depleted cell capacity.
+              description: |
+                Only 1 cell(s) are advertising enough free memory to run a 16GiB app instance. The threshold is 3 (1 per AZ).
+
+                The likely impact is some tenants are unable to schedule some apps, but failures may be sporadic.
+
+                It means we don't have enough capacity to run all tenant workloads. This is probably caused by natural growth, but it is also possible
+                that one or more tenant applications are scaling out beyond their intended limtis (e.g. because of a fault
+                in the tenant's autoscaling policy, or a tenant starting many tasks with `cf run-task`).
+
+                First check for something consuming a lot of excess resources, then scale the number of cells if you can't find anything. Scaling while
+                something is actively consuming more and more resources likely won't fix the problem.
               url: https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision
 
       - eval_time: 70m
@@ -115,7 +165,17 @@ tests:
               severity: critical
             exp_annotations:
               summary: Few candidate cells for a 4GiB app
-              description: Only 2 cell(s) are advertising enough free memory to run a 4GiB app instance. Some tenant app(s) may be scaling out of control or we may have depleted cell capacity.
+              description: |
+                Only 2 cell(s) are advertising enough free memory to run a 4GiB app instance. The threshold is 3 (1 per AZ).
+
+                The likely impact is some tenants are unable to schedule some apps, but failures may be sporadic.
+
+                It means we don't have enough capacity to run all tenant workloads. This is probably caused by natural growth, but it is also possible
+                that one or more tenant applications are scaling out beyond their intended limtis (e.g. because of a fault
+                in the tenant's autoscaling policy, or a tenant starting many tasks with `cf run-task`).
+
+                First check for something consuming a lot of excess resources, then scale the number of cells if you can't find anything. Scaling while
+                something is actively consuming more and more resources likely won't fix the problem.
               url: https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision
         # hasn't met condition for long enough
       - eval_time: 90m
@@ -128,7 +188,17 @@ tests:
               severity: critical
             exp_annotations:
               summary: Few candidate cells for a 4GiB app
-              description: Only 0 cell(s) are advertising enough free memory to run a 4GiB app instance. Some tenant app(s) may be scaling out of control or we may have depleted cell capacity.
+              description: |
+                Only 0 cell(s) are advertising enough free memory to run a 4GiB app instance. The threshold is 3 (1 per AZ).
+
+                The likely impact is some tenants are unable to schedule some apps, but failures may be sporadic.
+
+                It means we don't have enough capacity to run all tenant workloads. This is probably caused by natural growth, but it is also possible
+                that one or more tenant applications are scaling out beyond their intended limtis (e.g. because of a fault
+                in the tenant's autoscaling policy, or a tenant starting many tasks with `cf run-task`).
+
+                First check for something consuming a lot of excess resources, then scale the number of cells if you can't find anything. Scaling while
+                something is actively consuming more and more resources likely won't fix the problem.
               url: https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision
       - eval_time: 96m
         alertname: DiegoCellMemoryFewCandidates16G
@@ -137,5 +207,15 @@ tests:
               severity: warning
             exp_annotations:
               summary: Few candidate cells for a 16GiB app
-              description: Only 0 cell(s) are advertising enough free memory to run a 16GiB app instance. Some tenant app(s) may be scaling out of control or we may have depleted cell capacity.
+              description: |
+                Only 0 cell(s) are advertising enough free memory to run a 16GiB app instance. The threshold is 3 (1 per AZ).
+
+                The likely impact is some tenants are unable to schedule some apps, but failures may be sporadic.
+
+                It means we don't have enough capacity to run all tenant workloads. This is probably caused by natural growth, but it is also possible
+                that one or more tenant applications are scaling out beyond their intended limtis (e.g. because of a fault
+                in the tenant's autoscaling policy, or a tenant starting many tasks with `cf run-task`).
+
+                First check for something consuming a lot of excess resources, then scale the number of cells if you can't find anything. Scaling while
+                something is actively consuming more and more resources likely won't fix the problem.
               url: https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision

--- a/manifests/prometheus/spec/alerts/diego_cell_rep_memory_capacity.test..yml
+++ b/manifests/prometheus/spec/alerts/diego_cell_rep_memory_capacity.test..yml
@@ -33,28 +33,26 @@ tests:
       # Does not fire when the percentage of free memory
       # is above the threshold
       - eval_time: 2h
-        alertname: DiegoCellRepMemoryCapacity
+        alertname: DiegoCellRepsReachingTotalMemoryCapacity
 
       # Does not fire when the percentage of free memory
       # has not been below the threshold for long enough
       - eval_time: 4h
-        alertname: DiegoCellRepMemoryCapacity
+        alertname: DiegoCellRepsReachingTotalMemoryCapacity
 
       # Fires when the percentage of free memory
       # has been below the threshold for 2 hours
       - eval_time: 5h
-        alertname: DiegoCellRepMemoryCapacity
+        alertname: DiegoCellRepsReachingTotalMemoryCapacity
         exp_alerts:
           - exp_labels:
               severity: warning
               environment: test
             exp_annotations:
-              summary: Rep low free memory capacity
+              summary: Reps low free memory capacity
               bosh_job_name: diego-cells
               description: >
-                Low free memory 75% for the advertised rep memory capacity
-                in the last 2 hours on average.
-                Review if we need to scale...
+                Low free memory 75% for the total advertised rep memory capacity in the last 2 hours on average - if we lost an AZ we may not be able to find space for all the app instances we're currently running. Review if we need to scale.
               url: https://team-manual.cloud.service.gov.uk/architecture_decision_records/ADR021-cell-capacity-assignment-2/#decision
 
     promql_expr_test:


### PR DESCRIPTION
What
----

https://www.pivotaltracker.com/story/show/183164959

This slightly improves the wording for the former `DiegoCellRepMemoryCapacity` alert, making it `DiegoCellRepsReachingTotalMemoryCapacity`.

This then also adds a gentle alert for there being fewer than 3 cells with enough memory for a 16GiB app instance (and therefore not enough for full HA), and a pagerduty alert for there being fewer than 3 cells with enough memory for a 4GiB app. I'd only expect these to be triggered in fairly extreme circumstances, probably when we're already running a depleted number of cells.

How to review
-------------

Currently running in `dev02`, Where you can see it being triggered from the low number of cells there generally are in slim deployments: https://alertmanager-1.dev02.dev.cloudpipeline.digital

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
