### PR TITLE
custom broker acceptance tests: test cf service --params for rds broker

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -115,7 +115,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/alpine
-              tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+              tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
           inputs:
             - name: paas-cf
           params:
@@ -142,7 +142,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/bosh-cli-v2
-              tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+              tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
           run:
             path: sh
             args:
@@ -178,7 +178,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/awscli
-              tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+              tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
           run:
             path: ./paas-cf/concourse/scripts/rds_instances.sh
             args:

--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -41,7 +41,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/alpine
-              tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+              tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
           inputs:
             - name: paas-cf
             - name: deployment-timer
@@ -71,7 +71,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/awscli
-              tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+              tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
           run:
             path: ./paas-cf/concourse/scripts/rds_instances.sh
@@ -86,7 +86,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+              tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
           inputs:
             - name: paas-cf
@@ -119,7 +119,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+              tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
           inputs:
             - name: paas-cf

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -99,7 +99,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+              tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
           inputs:
             - name: paas-cf
@@ -171,7 +171,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/bosh-cli-v2
-              tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+              tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
           inputs:
             - name: bosh-vars-store
@@ -225,7 +225,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/ruby
-              tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+              tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
           inputs:
             - name: paas-cf
             - name: cf-tfstate
@@ -268,7 +268,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/terraform
-              tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+              tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
           inputs:
             - name: terraform-variables

--- a/concourse/pipelines/monitor-remote.yml
+++ b/concourse/pipelines/monitor-remote.yml
@@ -57,7 +57,7 @@ jobs:
         type: docker-image
         source:
           repository: ghcr.io/alphagov/paas/self-update-pipelines
-          tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+          tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
       inputs:
       - name: paas-cf

--- a/concourse/pipelines/test-certificate-rotation.yml
+++ b/concourse/pipelines/test-certificate-rotation.yml
@@ -5,25 +5,25 @@ meta:
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
     cf-acceptance-tests: &cf-acceptance-tests-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-        tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
     cf-cli: &cf-cli-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-cli
-        tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
 
 resource_types:
@@ -40,7 +40,7 @@ resource_types:
     type: docker-image
     source:
       repository: ghcr.io/alphagov/paas/olhtbr-metadata-resource
-      tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+      tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
   - name: s3-iam
     type: docker-image

--- a/concourse/tasks/aiven-broker-acceptance-tests-run.yml
+++ b/concourse/tasks/aiven-broker-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+    tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/app-autoscaler-acceptance-tests-run.yml
+++ b/concourse/tasks/app-autoscaler-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+    tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/check-az-is-enabled-in-manifest.yml
+++ b/concourse/tasks/check-az-is-enabled-in-manifest.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+    tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 params:
   DEPLOY_ENV:
   BOSH_ENVIRONMENT:

--- a/concourse/tasks/check-az-is-enabled-in-vpc.yml
+++ b/concourse/tasks/check-az-is-enabled-in-vpc.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+    tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 params:
   AWS_DEFAULT_REGION:
   EXPECTED_ACL_NAME:

--- a/concourse/tasks/check-billing-comparison-with-cf.yml
+++ b/concourse/tasks/check-billing-comparison-with-cf.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+    tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 inputs:
   - name: paas-billing
 params:

--- a/concourse/tasks/configure-grafana.yml
+++ b/concourse/tasks/configure-grafana.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/ruby
-    tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+    tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 inputs:
   - name: paas-trusted-people
 run:

--- a/concourse/tasks/create_admin.yml
+++ b/concourse/tasks/create_admin.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-uaac
-    tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+    tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/cronitor-monitor-ping-action.yml
+++ b/concourse/tasks/cronitor-monitor-ping-action.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+    tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
 run:
   path: sh

--- a/concourse/tasks/curl-az-healthcheck.yml
+++ b/concourse/tasks/curl-az-healthcheck.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/curl-ssl
-    tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+    tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 params:
   AVAILABILITY_ZONE:
   ENABLE_AZ_HEALTHCHECK:

--- a/concourse/tasks/custom-acceptance-tests-run.yml
+++ b/concourse/tasks/custom-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+    tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/custom-broker-acceptance-tests-run.yml
+++ b/concourse/tasks/custom-broker-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+    tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/delete_admin.yml
+++ b/concourse/tasks/delete_admin.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
-    tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+    tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/forget-access-keys.yml
+++ b/concourse/tasks/forget-access-keys.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/terraform
-    tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+    tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/generate-git-keys.yml
+++ b/concourse/tasks/generate-git-keys.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+    tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
 
 run:

--- a/concourse/tasks/generate-test-config.yml
+++ b/concourse/tasks/generate-test-config.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+    tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/get-cf-cli-config.yml
+++ b/concourse/tasks/get-cf-cli-config.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/ruby
-    tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+    tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 inputs:
   - name: paas-cf
   - name: cf-manifest

--- a/concourse/tasks/remove-db.yml
+++ b/concourse/tasks/remove-db.yml
@@ -7,7 +7,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
-    tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+    tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
 run:
   path: sh

--- a/concourse/tasks/send-nagging-email-alert.yml
+++ b/concourse/tasks/send-nagging-email-alert.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+    tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 inputs:
   - name: paas-cf
 params:

--- a/concourse/tasks/smoke-tests-run.yml
+++ b/concourse/tasks/smoke-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+    tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/tag-repo.yml
+++ b/concourse/tasks/tag-repo.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/git-ssh
-    tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+    tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
 
 inputs:

--- a/concourse/tasks/upload-test-artifacts.yml
+++ b/concourse/tasks/upload-test-artifacts.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+    tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
 inputs:
   - name: paas-cf

--- a/concourse/tasks/wait-for-api-availability-tests.yml
+++ b/concourse/tasks/wait-for-api-availability-tests.yml
@@ -11,7 +11,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+    tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
 run:
   path: sh

--- a/concourse/tasks/wait-for-app-availability-tests.yml
+++ b/concourse/tasks/wait-for-app-availability-tests.yml
@@ -13,7 +13,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
-    tag: 637488d94d9391c3a3439b8d63f084fa28ff9668
+    tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
 
 run:
   path: sh

--- a/platform-tests/broker-acceptance/mysql_service_test.go
+++ b/platform-tests/broker-acceptance/mysql_service_test.go
@@ -78,6 +78,10 @@ var _ = Describe("MySQL backing service", func() {
 
 			fmt.Fprintf(GinkgoWriter, "Created database instance: %s\n", dbInstanceName)
 
+			cf_service_params := cf.Cf("service", dbInstanceName, "--params").Wait(testConfig.DefaultTimeoutDuration())
+			Expect(cf_service_params).To(Exit(0))
+			Expect(cf_service_params.Out.Contents()).To(ContainSubstring("skip_final_snapshot"))
+
 			Expect(cf.Cf(
 				"push", appName,
 				"--no-start",

--- a/platform-tests/broker-acceptance/postgres_service_test.go
+++ b/platform-tests/broker-acceptance/postgres_service_test.go
@@ -127,6 +127,10 @@ var _ = Describe("Postgres backing service", func() {
 
 			fmt.Fprintf(GinkgoWriter, "Created database instance: %s\n", dbInstanceName)
 
+			cf_service_params := cf.Cf("service", dbInstanceName, "--params").Wait(testConfig.DefaultTimeoutDuration())
+			Expect(cf_service_params).To(Exit(0))
+			Expect(cf_service_params.Out.Contents()).To(ContainSubstring("skip_final_snapshot"))
+
 			Expect(cf.Cf(
 				"push", appName,
 				"--no-start",


### PR DESCRIPTION
What
----

- Adds tests for `cf service --params` for rds broker 
- Updates docker images that were missed in [cf-deployment PR](https://github.com/alphagov/paas-cf/pull/2991)

How to review
-------------
- Code review
- Check that the tests succeed (I've [deployed to dev03](https://deployer.dev03.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/custom-broker-acceptance-tests/builds/17#L6357384e:42))

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
