### PR TITLE
create-cloudfoundry: make `app-autoscaler-acceptance-tests` mandatory to continue

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -5910,10 +5910,10 @@ jobs:
     plan:
       - in_parallel:
           - get: pipeline-trigger
-            passed: ['smoke-tests', 'acceptance-tests', 'custom-acceptance-tests', 'custom-broker-acceptance-tests', 'bosh-tests']
+            passed: ['smoke-tests', 'acceptance-tests', 'custom-acceptance-tests', 'custom-broker-acceptance-tests', 'bosh-tests', 'app-autoscaler-acceptance-tests']
             trigger: true
           - <<: *get-paas-cf
-            passed: ['smoke-tests', 'acceptance-tests', 'custom-acceptance-tests', 'custom-broker-acceptance-tests', 'bosh-tests']
+            passed: ['smoke-tests', 'acceptance-tests', 'custom-acceptance-tests', 'custom-broker-acceptance-tests', 'bosh-tests', 'app-autoscaler-acceptance-tests']
       - task: remove-transitional-flag-for-ca
         tags: [colocated-with-web]
         config:


### PR DESCRIPTION
What
----

https://www.pivotaltracker.com/story/show/183510169

These now appear to be reliable enough on staging and production that this shouldn't be a problem.

How to review
-------------

Either deploy to your own dev env and observe the pipeline running or just look at dev02, which may still be running this branch.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
