### PR TITLE
Upgrade terraform

### DIFF
--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -1,7 +1,7 @@
 on: pull_request
 
 env:
-  TF_VERSION: "1.2.8"
+  TF_VERSION: "1.3.3"
   BOSH_CLI_VERSION: "2.0.48"
   PROMETHEUS_VERSION: "2.33.3"
   DEPLOY_ENV: "github"

--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -115,7 +115,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/alpine
-              tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+              tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
           inputs:
             - name: paas-cf
           params:
@@ -142,7 +142,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/bosh-cli-v2
-              tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+              tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
           run:
             path: sh
             args:
@@ -178,7 +178,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/awscli
-              tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+              tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
           run:
             path: ./paas-cf/concourse/scripts/rds_instances.sh
             args:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -11,72 +11,72 @@ meta:
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/alpine
-        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+        tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
     psql: &psql-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/psql
-        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+        tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
     node: &node-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/node
-        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+        tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
     node-chromium: &node-chromium-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/node-chromium
-        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+        tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
     awscli: &awscli-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+        tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+        tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
     cf-acceptance-tests: &cf-acceptance-tests-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+        tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
     cf-cli: &cf-cli-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-cli
-        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+        tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
     cf-uaac: &cf-uaac-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-uaac
-        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+        tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
     git-ssh: &git-ssh-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/git-ssh
-        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+        tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
     ruby-slim: &ruby-slim-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/ruby
-        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+        tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
     golang: &golang-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/golang
-        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+        tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
     terraform: &terraform-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+        tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
     curl-ssl: &curl-ssl-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/curl-ssl
-        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+        tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
 
 
   tasks:
@@ -268,7 +268,7 @@ resource_types:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/concourse-pool-resource
-    tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+    tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
 
 - name: s3-iam
   type: docker-image
@@ -799,7 +799,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+              tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
 
           inputs:
             - name: paas-cf
@@ -5145,7 +5145,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/spruce
-              tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+              tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
 
           inputs:
             - name: paas-cf
@@ -6186,7 +6186,7 @@ jobs:
           type: docker-image
           source:
             repository: ghcr.io/alphagov/paas/cf-uaac
-            tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+            tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
 
         inputs:
           - name: passwords

--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -41,7 +41,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/alpine
-              tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+              tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
           inputs:
             - name: paas-cf
             - name: deployment-timer
@@ -71,7 +71,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/awscli
-              tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+              tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
 
           run:
             path: ./paas-cf/concourse/scripts/rds_instances.sh
@@ -86,7 +86,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+              tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
 
           inputs:
             - name: paas-cf
@@ -119,7 +119,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+              tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
 
           inputs:
             - name: paas-cf

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -99,7 +99,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+              tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
 
           inputs:
             - name: paas-cf
@@ -171,7 +171,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/bosh-cli-v2
-              tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+              tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
 
           inputs:
             - name: bosh-vars-store
@@ -225,7 +225,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/ruby
-              tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+              tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
           inputs:
             - name: paas-cf
             - name: cf-tfstate
@@ -268,7 +268,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/terraform
-              tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+              tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
 
           inputs:
             - name: terraform-variables

--- a/concourse/pipelines/monitor-remote.yml
+++ b/concourse/pipelines/monitor-remote.yml
@@ -57,7 +57,7 @@ jobs:
         type: docker-image
         source:
           repository: ghcr.io/alphagov/paas/self-update-pipelines
-          tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+          tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
 
       inputs:
       - name: paas-cf

--- a/concourse/pipelines/test-certificate-rotation.yml
+++ b/concourse/pipelines/test-certificate-rotation.yml
@@ -5,25 +5,25 @@ meta:
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+        tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
 
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+        tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
 
     cf-acceptance-tests: &cf-acceptance-tests-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+        tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
 
     cf-cli: &cf-cli-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/cf-cli
-        tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+        tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
 
 
 resource_types:
@@ -40,7 +40,7 @@ resource_types:
     type: docker-image
     source:
       repository: ghcr.io/alphagov/paas/olhtbr-metadata-resource
-      tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+      tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
 
   - name: s3-iam
     type: docker-image

--- a/concourse/tasks/aiven-broker-acceptance-tests-run.yml
+++ b/concourse/tasks/aiven-broker-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
+    tag: 364e267f048a07d8b41f25369a99ab0991a1fecc
 
 inputs:
   - name: paas-cf

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -2,42 +2,42 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "4.25.0"
-  constraints = "~> 4.25.0"
+  version     = "4.36.1"
+  constraints = "~> 4.36.1"
   hashes = [
-    "h1:0dYkCnmIGkx+TlvUy21GpK7/8cCfN/fiZjHV+AAt3Xw=",
-    "zh:51fddc33f289108f60c2de78537f758ae913b2614187abfc3f560f9dd277bc1a",
-    "zh:5a2bfa0725a8941f12e775eb9c44582ec237a664321a740d8283e9b56452f2ad",
-    "zh:6ca73a9f11c2a9ff8f55433c00a12c1b69c22131251cb0698d32c682229b1233",
+    "h1:bVdhic55ukDoSukFwOOqX2q/gZ5efe4aBTMGivEuY4o=",
+    "zh:19b16047b4f15e9b8538a2b925f1e860463984eed7d9bd78e870f3e884e827a7",
+    "zh:3c0db06a9a14b05a77f3fe1fc029a5fb153f4966964790ca8e71ecc3427d83f5",
+    "zh:3c7407a8229005e07bc274cbae6e3a464c441a88810bfc6eceb2414678fd08ae",
+    "zh:3d96fa82c037fafbd3e7f4edc1de32afb029416650f6e392c39182fc74a9e03a",
+    "zh:8f4f540c5f63d847c4b802ca84d148bb6275a3b0723deb09bf933a4800bc7209",
+    "zh:9802cb77472d6bcf24c196ce2ca6d02fac9db91558536325fec85f955b71a8a4",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:aeafec22947a7be418adc3c6d1eddb719ed02b5e41b6e2cc9cbdca991e2140b8",
-    "zh:b043563789e32f6935bf51c3b4344482487c03cb084673f6181ce3443f956a3d",
-    "zh:b0693f4295d35ae6ce3656ee2294fd69eb732f601ba7d6eb28b7fded4471c3d2",
-    "zh:bccb9ec142aa11350a52142b71fd8f0332d36a94332207f45bd93ceb7297b922",
-    "zh:c353fd5060cf6d86e4505d0ade84a37f91d4d8774b17eaa1290a191d9da43729",
-    "zh:d07848da6940b2882b884fc24144741f7ce0442865c9833df26751c48429e11f",
-    "zh:d4feeb5c394ec9528d1633e2e2c133632d8d099f6c99654e2bbd2aa112b6a08e",
-    "zh:fb0a75edb943847354c759a665edb93fd7945b892be7d0511c6708785abf090c",
+    "zh:a263352433878c89832c2e38f4fd56cf96ae9969c13b5c710d5ba043cbd95743",
+    "zh:aca7954a5f458ceb14bf0c04c961c4e1e9706bf3b854a1e90a97d0b20f0fe6d3",
+    "zh:d78f400332e87a97cce2e080db9d01beb01f38f5402514a6705d6b8167e7730d",
+    "zh:e14bdc49be1d8b7d2543d5c58078c84b76051085e8e6715a895dcfe6034b6098",
+    "zh:f2e400b88c8de170bb5027922226da1e9a6614c03f2a6756c15c3b930c2f460c",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/random" {
-  version     = "3.4.2"
-  constraints = "~> 3.4.2"
+  version     = "3.4.3"
+  constraints = "~> 3.4.3"
   hashes = [
-    "h1:PIIfeOjmPoQRHfMM7MDr7qY3mQqD4F+38Dmq8pjvUUs=",
-    "zh:1e61d226778aefd01c0e139c0ad709b61e9ae4b33d72301b922bd3d000b76eee",
-    "zh:3c3295c3d2e9c3f9d60d557ee8faf2a30bd15f59f2c38ed13f50a3220dd027d0",
-    "zh:6661b4953b875857c3ac99fb1006daf314acebf2d1748045d208ebc8cbc647cd",
-    "zh:6e1823a349ceea5e4e0c684561473f57c46f73d7c197c39904d031ce6654bfb8",
+    "h1:tL3katm68lX+4lAncjQA9AXL4GR/VM+RPwqYf4D2X8Q=",
+    "zh:41c53ba47085d8261590990f8633c8906696fa0a3c4b384ff6a7ecbf84339752",
+    "zh:59d98081c4475f2ad77d881c4412c5129c56214892f490adf11c7e7a5a47de9b",
+    "zh:686ad1ee40b812b9e016317e7f34c0d63ef837e084dea4a1f578f64a6314ad53",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:8f8e6fd15e5228f1935c63d79bf3074f645ddba1350756acfc968b2a05bf85ee",
-    "zh:939a78da13a7932bd5429f0c77debe907bf9d6c6a26af50fd4d9f32ee16ea5a6",
-    "zh:995a592acbcde12f0d34ff5c3b74ec7054743315684b72b927bdc0d33e0e7c4d",
-    "zh:a9f8b88fe365ed9996d3386b415cabb445cf9d6e4b0e0b73f58af3aa31f1fa3d",
-    "zh:dda7c698cf92170665ca3ac1ccdc2177c0bec4807e69075422ae9d5c5308adbd",
-    "zh:eff42af6313499db0b3177a82851e0f2d2706e81cab11372d7d3673c41b15b9c",
-    "zh:fcd6826d4398147314620401a5908dd35c6f2ebac7e7d3a7d77078dbc7c5a0e6",
+    "zh:84103eae7251384c0d995f5a257c72b0096605048f757b749b7b62107a5dccb3",
+    "zh:8ee974b110adb78c7cd18aae82b2729e5124d8f115d484215fd5199451053de5",
+    "zh:9dd4561e3c847e45de603f17fa0c01ae14cae8c4b7b4e6423c9ef3904b308dda",
+    "zh:bb07bb3c2c0296beba0beec629ebc6474c70732387477a65966483b5efabdbc6",
+    "zh:e891339e96c9e5a888727b45b2e1bb3fcbdfe0fd7c5b4396e4695459b38c8cb1",
+    "zh:ea4739860c24dfeaac6c100b2a2e357106a89d18751f7693f3c31ecf6a996f8d",
+    "zh:f0c76ac303fd0ab59146c39bc121c5d7d86f878e9a69294e29444d4c653786f8",
+    "zh:f143a9a5af42b38fed328a161279906759ff39ac428ebcfe55606e05e1518b93",
   ]
 }
 
@@ -45,7 +45,6 @@ provider "registry.terraform.io/russellcardullo/pingdom" {
   version     = "1.1.2"
   constraints = "1.1.2"
   hashes = [
-    "h1:IjLMjsdkGxxWJCfyU2FWsgFNnhm0yMQ/ONUdiYzukSo=",
     "h1:gUFO1vrZTbE1MWgZzWOnQouXJifBR8eGaOytIkIG+Lg=",
     "zh:409cc0dff3f5039ff865ef7ba1e726329820da5e408fc1a5dbc56db26a909e70",
     "zh:50577b31da2fea32abf6ae29cdeddbb9d05a5c5acad7840a04d3476a19fc0a97",

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~>4.25.0"
+      version = "~>4.36.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "~>3.4.2"
+      version = "~>3.4.3"
     }
     pingdom = {
       source  = "russellcardullo/pingdom"

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -13,5 +13,5 @@ terraform {
       version = "1.1.2"
     }
   }
-  required_version = ">= 1.2.8"
+  required_version = ">= 1.3.3"
 }


### PR DESCRIPTION
What
----

- Upgrade terraform version to 1.3.3
- Upgrade providers. ~~Pingdom now uses api-token~~

How to review
-------------

- Check that the [pipeline](https://deployer.dev03.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/pipeline-lock/builds/19) is green and happy 
- ~~Does pingdom still work?~~


---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
