### PR TITLE
added check-billing-logit-ssl-drain-service-app-bindings.sh to replac…

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -5423,7 +5423,7 @@ jobs:
                 cf cancel-deployment paas-billing-collector || true
                 cf push --strategy=rolling paas-billing-collector -f manifest-collector.yml
 
-                while ! cf service billing-logit-ssl-drain | grep -c 'create succeeded' | grep 2 > /dev/null; do
+                while ! ../paas-cf/concourse/scripts/check-billing-logit-ssl-drain-service-app-bindings.sh; do
                   echo "Waiting for binding of billing-logit-ssl-drain service to billing apps to complete..."
                   sleep 10
                 done

--- a/concourse/scripts/check-billing-logit-ssl-drain-service-app-bindings.sh
+++ b/concourse/scripts/check-billing-logit-ssl-drain-service-app-bindings.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# This script checks that bindings exist between the service billing-logit-ssl-drain and the billing apps. This is to ensure that the billing apps have been deployed successfully.
+
+set -e -u -o pipefail
+
+APP1_NAME='paas-billing-api'
+APP2_NAME='paas-billing-collector'
+
+APP1_GUID=$(cf curl "/v3/apps?names=${APP1_NAME}" | jq -r '.resources[].guid')
+APP2_GUID=$(cf curl "/v3/apps?names=${APP2_NAME}" | jq -r '.resources[].guid')
+
+SERVICE_INSTANCE_GUID=$(cf curl /v3/service_instances | jq -r '.resources[]|select(.name=="billing-logit-ssl-drain").guid')
+
+SERVICE_CREDENTIAL_BINDINGS=$(cf curl "/v3/service_credential_bindings?service_instance_guids=${SERVICE_INSTANCE_GUID}")
+
+SERVICE_CREDENTIAL_BINDINGS_COUNT=$(jq -r '.resources|length' <<< "${SERVICE_CREDENTIAL_BINDINGS}")
+if [[ "${SERVICE_CREDENTIAL_BINDINGS_COUNT}" != "2" ]]; then
+  echo "ERROR: expecting 2 service credential bindings. got: ${SERVICE_CREDENTIAL_BINDINGS_COUNT}"
+  exit 1
+fi
+
+BIND1_GUID=$(jq -r '.resources[0].relationships.app.data.guid' <<< "${SERVICE_CREDENTIAL_BINDINGS}")
+BIND1_STATE=$(jq -r '.resources[0].last_operation.state' <<< "${SERVICE_CREDENTIAL_BINDINGS}")
+BIND1_TYPE=$(jq -r '.resources[0].last_operation.type' <<< "${SERVICE_CREDENTIAL_BINDINGS}")
+BIND2_GUID=$(jq -r '.resources[1].relationships.app.data.guid' <<< "${SERVICE_CREDENTIAL_BINDINGS}")
+BIND2_STATE=$(jq -r '.resources[1].last_operation.state' <<< "${SERVICE_CREDENTIAL_BINDINGS}")
+BIND2_TYPE=$(jq -r '.resources[1].last_operation.type' <<< "${SERVICE_CREDENTIAL_BINDINGS}")
+
+if ! [[ "${BIND1_GUID}" = "${APP1_GUID}" && "${BIND2_GUID}" = "${APP2_GUID}" || "${BIND1_GUID}" = "${APP2_GUID}" && "${BIND2_GUID}" = "${APP1_GUID}" ]]; then
+  echo "ERROR: could not match app GUIDS to service binds"
+  exit 1
+fi
+
+if ! [[ "${BIND1_STATE}" = "succeeded" && "${BIND1_TYPE}" = "create" && "${BIND2_STATE}" = "succeeded" && "${BIND2_TYPE}" = "create" ]]; then
+  echo "ERROR: one or more bad bind states/types"
+  exit 1
+fi
+
+echo "Checked binding of billing-logit-ssl-drain service to billing apps..."


### PR DESCRIPTION
##What

I identified the issue detailed in the build log below, during the building of a new environment...

https://deployer.dev04.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/deploy-paas-billing/builds/1#L63593f2b:218

Since the upgrade of cli7 to cli8, the output has changed, which was breaking the existing check for "create succeeded" in certain circumstances.

The fix was to replace the existing check which counted the number of instances of "create succeeded", with a series of cf curls with return JSON, and then query that JSON for the expected values.

This test was previously sometimes passing, probably because a single app binding (before the 2nd was started) would have produced the expected count of 2.

##How to review

Deploy an environment using this code change, and check that the output matches the below...

https://deployer.dev04.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/deploy-paas-billing/builds/8#L63599b9c:204

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
