### PR TITLE
Fix cloudfoundry destroy pipeline.

### DIFF
--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -163,6 +163,15 @@ jobs:
           DB_NAME: accounts-db
           BOUND_APPS: paas-accounts
 
+      - task: remove-auditor-db
+        tags: [colocated-with-web]
+        file: paas-cf/concourse/tasks/remove-db.yml
+        params:
+          ORG: admin
+          SPACE: billing
+          DB_NAME: auditor-db
+          BOUND_APPS: paas-auditor
+
       - task: delete-deployments
         tags: [colocated-with-web]
         config:

--- a/terraform/cloudfoundry/buckets.tf
+++ b/terraform/cloudfoundry/buckets.tf
@@ -1,5 +1,7 @@
 resource "aws_s3_bucket" "droplets-s3" {
   bucket = "${var.env}-cf-droplets"
+
+  force_destroy = var.bucket_force_destroy
 }
 
 resource "aws_s3_bucket_acl" "droplets-s3" {
@@ -43,6 +45,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "droplets-s3" {
 
 resource "aws_s3_bucket" "buildpacks-s3" {
   bucket = "${var.env}-cf-buildpacks"
+
+  force_destroy = var.bucket_force_destroy
 }
 
 resource "aws_s3_bucket_acl" "buildpacks-s3" {
@@ -86,6 +90,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "buildpacks-s3" {
 }
 resource "aws_s3_bucket" "packages-s3" {
   bucket = "${var.env}-cf-packages"
+
+  force_destroy = var.bucket_force_destroy
 }
 
 resource "aws_s3_bucket_acl" "packages-s3" {
@@ -128,6 +134,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "packages-s3" {
 }
 resource "aws_s3_bucket" "resources-s3" {
   bucket = "${var.env}-cf-resources"
+
+  force_destroy = var.bucket_force_destroy
 }
 
 resource "aws_s3_bucket_acl" "resources-s3" {

--- a/terraform/cloudfoundry/dev.tfvars
+++ b/terraform/cloudfoundry/dev.tfvars
@@ -12,3 +12,5 @@ cf_db_maintenance_window       = "Mon:07:00-Mon:08:00"
 cf_db_multi_az                 = "false"
 cf_db_skip_final_snapshot      = "true"
 system_dns_zone_id             = "Z1QGLFML8EG6G7"
+
+bucket_force_destroy           = true

--- a/terraform/cloudfoundry/prod.tfvars
+++ b/terraform/cloudfoundry/prod.tfvars
@@ -14,3 +14,5 @@ cf_db_maintenance_window        = "Thu:07:00-Thu:08:00"
 cf_db_multi_az                  = "true"
 cf_db_skip_final_snapshot       = "false"
 system_dns_zone_id              = "Z39UURGVWSYTHL"
+
+bucket_force_destroy            = false

--- a/terraform/cloudfoundry/staging.tfvars
+++ b/terraform/cloudfoundry/staging.tfvars
@@ -14,3 +14,5 @@ cf_db_maintenance_window        = "Wed:07:00-Wed:08:00"
 cf_db_multi_az                  = "true"
 cf_db_skip_final_snapshot       = "false"
 system_dns_zone_id              = "ZPFAUK62IO6DS"
+
+bucket_force_destroy            = false

--- a/terraform/cloudfoundry/variables.tf
+++ b/terraform/cloudfoundry/variables.tf
@@ -161,3 +161,8 @@ variable "system_dns_zone_id" {
 variable "system_dns_zone_name" {
   description = "Amazon Route53 DNS zone name for the provisioned environment."
 }
+
+variable "bucket_force_destroy" {
+  description = "Force destroy aws s3 buckets"
+  default = false
+}


### PR DESCRIPTION
What
----

Fixes the cloudfoundry destroy pipeline so that manual removals are not necessary.

- Set the force_destroy option in dev environments to the cloud foundry s3 buckets.
- Remove the auditor postgres db before the bosh destroy happens.


How to review
-------------

A successful log file of a full destroy can be seen [here](https://deployer.dev04.dev.cloudpipeline.digital/teams/main/pipelines/destroy-cloudfoundry/jobs/delete-deployment/builds/6#L635a75f6:1) and [here](https://deployer.dev04.dev.cloudpipeline.digital/teams/main/pipelines/destroy-cloudfoundry/jobs/terraform-destroy/builds/7#L635a76f2:1).
Ensure you are happy with the protection of non-dev buckets. 


---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
