### PR TITLE
Allow new org so that they can use splunk

### DIFF
--- a/config/service-brokers/csls-splunk/prod-lon-config.json
+++ b/config/service-brokers/csls-splunk/prod-lon-config.json
@@ -3,6 +3,7 @@
     "cabinet-office-papt",
     "ccs-conclave-cii",
     "ccs-conclave-sssos",
+    "ccs-conclave-evidence-locker",
     "ccs-digital-services-team",
     "ccs-document-upload",
     "ccs-pmp-idam",


### PR DESCRIPTION
What
----

We've had a request to enable splunk for this org. We need to add it to the allow list too

How to review
-------------

Name of the org matches `cs-conclave-evidence-locker`?

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
