### PR TITLE
fix(pipeline): specify space and org to ensure single binding returned

### DIFF
--- a/concourse/scripts/check-billing-logit-ssl-drain-service-app-bindings.sh
+++ b/concourse/scripts/check-billing-logit-ssl-drain-service-app-bindings.sh
@@ -4,13 +4,21 @@
 
 set -e -u -o pipefail
 
+SERVICE_INSTANCE_NAME='billing-logit-ssl-drain'
+
 APP1_NAME='paas-billing-api'
 APP2_NAME='paas-billing-collector'
 
-APP1_GUID=$(cf curl "/v3/apps?names=${APP1_NAME}" | jq -r '.resources[].guid')
-APP2_GUID=$(cf curl "/v3/apps?names=${APP2_NAME}" | jq -r '.resources[].guid')
+SPACE_NAME='billing'
+ORG_NAME='admin'
 
-SERVICE_INSTANCE_GUID=$(cf curl /v3/service_instances | jq -r '.resources[]|select(.name=="billing-logit-ssl-drain").guid')
+SPACE_GUID=$(cf curl "/v3/spaces?names=${SPACE_NAME}" | jq -r '.resources[].guid')
+ORG_GUID=$(cf curl "/v3/organizations?names=${ORG_NAME}" | jq -r '.resources[].guid')
+
+APP1_GUID=$(cf curl "/v3/apps?names=${APP1_NAME}&space_guids=${SPACE_GUID}&organization_guids=${ORG_GUID}" | jq -r '.resources[].guid')
+APP2_GUID=$(cf curl "/v3/apps?names=${APP2_NAME}&space_guids=${SPACE_GUID}&organization_guids=${ORG_GUID}" | jq -r '.resources[].guid')
+
+SERVICE_INSTANCE_GUID=$(cf curl "/v3/service_instances?space_guids=${SPACE_GUID}&organization_guids=${ORG_GUID}" | jq -r ".resources[]|select(.name==\"${SERVICE_INSTANCE_NAME}\").guid")
 
 SERVICE_CREDENTIAL_BINDINGS=$(cf curl "/v3/service_credential_bindings?service_instance_guids=${SERVICE_INSTANCE_GUID}")
 


### PR DESCRIPTION
What
----

I found an issue with the recent change to service binding checks where the scripts fails if multiple bindings are returned by multiple biller apps being deployed in an env. The fix was to specify space and org to limit response to a single GUID.

How to review
-------------

Example of failure...

https://deployer.dev02.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/deploy-paas-billing/builds/213#L63586334:202

Example of success on this branch...

https://deployer.dev02.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/deploy-paas-billing/builds/215#L6363bf26:204

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
