### PR TITLE
Release new version of the rds broker (1.38.0)

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 1.36.0
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-1.36.0.tgz
-    sha1: 94295c97ca325f08efd77c8e69af7d48ef86008a
+    version: 1.38.0
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-1.38.0.tgz
+    sha1: d3693b19385a53bf07864bbb6f33f7088c9d6023
 
 - type: replace
   path: /instance_groups/-


### PR DESCRIPTION
What
----

The new version of the rds broker includes a fix for this [issue](https://www.pivotaltracker.com/story/show/183378729).

How to review
-------------

This branch has been deployed to dev-04. See [link](https://deployer.dev04.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/pipeline-lock/builds/15)

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
