### PR TITLE
Switch billing-collector to use a http endpoint for probes

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -5412,6 +5412,10 @@ jobs:
                       'billing-db',
                       'billing-logit-ssl-drain'
                     ]
+                    app['health-check-http-endpoint'] = '/'
+                    app['routes'] = [
+                      { 'route' => 'billing-collector.${SYSTEM_DNS_ZONE_NAME}' }
+                    ]
                   }
                   File.write('manifest-collector.yml', collector.to_yaml)
                 "


### PR DESCRIPTION
What
----

This change switches billing-collector from a process check to a http call. This change is linked to a change in [paas-billing](https://github.com/alphagov/paas-billing/pull/160).

How to review
-------------

You should be familiar with the change in paas-billing.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
