### PR TITLE
Add rds manual db snapshot quota alert

### DIFF
--- a/manifests/prometheus/alerts.d/rds_db_manual_snapshot_quota.yml
+++ b/manifests/prometheus/alerts.d/rds_db_manual_snapshot_quota.yml
@@ -1,0 +1,17 @@
+# Source: paas-metrics
+---
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: RDSDBManualSnapshotCountCloseToQuota
+    rules:
+      - alert: RDSDBManualSnapshotCountCloseToQuota
+        expr: ((paas_aws_rds_manual_snapshot_count / paas_aws_rds_manual_snapshot_quota_count) * 100) > 80
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "Number of AWS RDS Manual Snapshots is close to the quota"
+          description: "We are using {{ $value | printf \"%.0f\" }}% of the RDS manual snapshot quota. We might have to increase the quota."
+          url: "https://console.aws.amazon.com/servicequotas/home?region=((aws_region))#!/services/rds/quotas/L-9B510759"

--- a/manifests/prometheus/alerts.d/rds_db_manual_snapshot_quota.yml
+++ b/manifests/prometheus/alerts.d/rds_db_manual_snapshot_quota.yml
@@ -13,5 +13,5 @@
           severity: warning
         annotations:
           summary: "Number of AWS RDS Manual Snapshots is close to the quota"
-          description: "We are using {{ $value | printf \"%.0f\" }}% of the RDS manual snapshot quota. We might have to increase the quota."
+          description: "We are using {{ $value | printf \"%.0f\" }}% of the RDS manual snapshot quota. We might have to request a quota increase from AWS. You can request an increase via Service Quotas on the AWS console"
           url: "https://console.aws.amazon.com/servicequotas/home?region=((aws_region))#!/services/rds/quotas/L-9B510759"

--- a/tools/metrics/acceptance/aws_test.go
+++ b/tools/metrics/acceptance/aws_test.go
@@ -42,6 +42,8 @@ var _ = Describe("AWS", func() {
 		Eventually(getMetricNames).Should(SatisfyAll(
 			ContainElement("paas_aws_rds_dbinstances_count"),
 			ContainElement("paas_aws_rds_dbinstances_quota_count"),
+			ContainElement("paas_aws_rds_manual_snapshot_count"),
+			ContainElement("paas_aws_rds_manual_snapshot_quota_count"),
 		))
 	})
 })

--- a/tools/metrics/gauges_rds_db_manual_snapshots.go
+++ b/tools/metrics/gauges_rds_db_manual_snapshots.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"code.cloudfoundry.org/lager"
+	m "github.com/alphagov/paas-cf/tools/metrics/pkg/metrics"
+	"github.com/alphagov/paas-cf/tools/metrics/pkg/rds"
+	"github.com/alphagov/paas-cf/tools/metrics/pkg/servicequotas"
+	"github.com/aws/aws-sdk-go/aws"
+	awsrds "github.com/aws/aws-sdk-go/service/rds"
+	awsservicequotas "github.com/aws/aws-sdk-go/service/servicequotas"
+)
+
+func RDSDBManualSnapshotsGauge(
+	logger lager.Logger,
+	rds *rds.RDSService,
+	serviceQuotas *servicequotas.ServiceQuotas,
+	interval time.Duration,
+) m.MetricReadCloser {
+	return m.NewMetricPoller(interval, func(w m.MetricWriter) error {
+		lsess := logger.Session("rds-db-manual-snapshots-gauge")
+		count, err := countRDSManualSnapshots(rds)
+		if err != nil {
+			lsess.Error("count-manual-snapshots", err)
+			return err
+		}
+		quota, err := getRDSManualSnapshotQuota(serviceQuotas)
+		if err != nil {
+			lsess.Error("get-db-quota", err)
+			return err
+		}
+		metrics := []m.Metric{
+			{
+				Kind:  "gauge",
+				Name:  "aws.rds.manual.snapshot.count",
+				Value: float64(count),
+				Unit:  "count",
+			},
+			{
+				Kind:  "gauge",
+				Name:  "aws.rds.manual.snapshot.quota.count",
+				Value: quota,
+				Unit:  "count",
+			},
+		}
+
+		return w.WriteMetrics(metrics)
+	})
+}
+
+func countRDSManualSnapshots(service *rds.RDSService) (int, error) {
+	snapshots, err := service.Client.DescribeDBSnapshots(
+		&awsrds.DescribeDBSnapshotsInput{
+			SnapshotType: aws.String("manual"),
+		})
+
+	if err != nil {
+		return 0, err
+	}
+
+	return len(snapshots.DBSnapshots), nil
+}
+
+func getRDSManualSnapshotQuota(service *servicequotas.ServiceQuotas) (float64, error) {
+	out, err := service.Client.GetServiceQuota(&awsservicequotas.GetServiceQuotaInput{
+		QuotaCode:   aws.String("L-9B510759"),
+		ServiceCode: aws.String("rds"),
+	})
+
+	if err != nil {
+		return float64(0), err
+	}
+
+	quota := out.Quota
+
+	if quota.ErrorReason != nil {
+		return float64(0), fmt.Errorf(*quota.ErrorReason.ErrorMessage)
+	}
+
+	return *quota.Value, nil
+}

--- a/tools/metrics/gauges_rds_db_manual_snapshots_test.go
+++ b/tools/metrics/gauges_rds_db_manual_snapshots_test.go
@@ -1,0 +1,137 @@
+package main_test
+
+import (
+	"fmt"
+	"time"
+
+	"code.cloudfoundry.org/lager"
+	. "github.com/alphagov/paas-cf/tools/metrics"
+	"github.com/alphagov/paas-cf/tools/metrics/pkg/rds"
+	"github.com/alphagov/paas-cf/tools/metrics/pkg/servicequotas"
+	"github.com/aws/aws-sdk-go/aws"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	m "github.com/alphagov/paas-cf/tools/metrics/pkg/metrics"
+	rdsfakes "github.com/alphagov/paas-cf/tools/metrics/pkg/rds/fakes"
+	servicequotasfakes "github.com/alphagov/paas-cf/tools/metrics/pkg/servicequotas/fakes"
+	awsrds "github.com/aws/aws-sdk-go/service/rds"
+	awsservicequotas "github.com/aws/aws-sdk-go/service/servicequotas"
+)
+
+var _ = Describe("RDS DB Manual Snapshot Gauge", func() {
+	var (
+		rdsSvc           *rds.RDSService
+		rdsAPI           *rdsfakes.FakeRDSAPI
+		servicequotasSvc *servicequotas.ServiceQuotas
+		servicequotasAPI *servicequotasfakes.FakeServiceQuotasAPI
+		logger           lager.Logger
+
+		rdsDatabaseSnapshots    []*awsrds.DBSnapshot
+		describeDBSnapshotsStub = func(
+			input *awsrds.DescribeDBSnapshotsInput,
+		) (*awsrds.DescribeDBSnapshotsOutput, error) {
+			return &awsrds.DescribeDBSnapshotsOutput{
+				DBSnapshots: rdsDatabaseSnapshots,
+			}, nil
+		}
+
+		quota               *float64
+		getServiceQuotaStub = func(
+			input *awsservicequotas.GetServiceQuotaInput,
+		) (*awsservicequotas.GetServiceQuotaOutput, error) {
+			return &awsservicequotas.GetServiceQuotaOutput{
+				Quota: &awsservicequotas.ServiceQuota{Value: quota},
+			}, nil
+		}
+	)
+
+	BeforeEach(func() {
+		rdsAPI = &rdsfakes.FakeRDSAPI{}
+		rdsSvc = &rds.RDSService{Client: rdsAPI}
+		servicequotasAPI = &servicequotasfakes.FakeServiceQuotasAPI{}
+		servicequotasSvc = &servicequotas.ServiceQuotas{Client: servicequotasAPI}
+
+		rdsAPI.DescribeDBSnapshotsStub = describeDBSnapshotsStub
+		servicequotasAPI.GetServiceQuotaStub = getServiceQuotaStub
+
+		logger = lager.NewLogger("rds-db-manual-snapshots-gauge-test")
+		logger.RegisterSink(lager.NewWriterSink(GinkgoWriter, lager.DEBUG))
+	})
+
+	It("exposes a metric which counts the number of db manual snapshots", func() {
+		rdsDatabaseSnapshots = []*awsrds.DBSnapshot{
+			{DBSnapshotIdentifier: aws.String("snapshot1")},
+			{DBSnapshotIdentifier: aws.String("snapshot2")},
+		}
+		quota = aws.Float64(float64(40))
+
+		gauge := RDSDBManualSnapshotsGauge(logger, rdsSvc, servicequotasSvc, 1*time.Second)
+
+		var metric m.Metric
+		Eventually(func() string {
+			var err error
+			metric, err = gauge.ReadMetric()
+			Expect(err).NotTo(HaveOccurred())
+			return metric.Name
+		}, 3*time.Second).Should(Equal("aws.rds.manual.snapshot.count"))
+
+		Expect(metric.Value).To(Equal(float64(2)))
+
+	})
+
+	It("exposes the current RDS DB manual snapshot quota as a metric", func() {
+		rdsDatabaseSnapshots = []*awsrds.DBSnapshot{
+			{DBSnapshotIdentifier: aws.String("snapshot1")},
+		}
+		quota = aws.Float64(float64(40))
+
+		gauge := RDSDBManualSnapshotsGauge(logger, rdsSvc, servicequotasSvc, 1*time.Second)
+
+		var metric m.Metric
+		Eventually(func() string {
+			var err error
+			metric, err = gauge.ReadMetric()
+			Expect(err).NotTo(HaveOccurred())
+			return metric.Name
+		}, 3*time.Second).Should(Equal("aws.rds.manual.snapshot.quota.count"))
+
+		Expect(metric.Value).To(Equal(float64(40)))
+
+	})
+
+	It("returns an error if describing RDS DB manual snapshot fails", func() {
+		rdsAPI.DescribeDBSnapshotsStub = func(
+			_ *awsrds.DescribeDBSnapshotsInput,
+		) (*awsrds.DescribeDBSnapshotsOutput, error) {
+			return nil, fmt.Errorf("error on purpose")
+		}
+		quota = aws.Float64(float64(40))
+
+		gauge := RDSDBManualSnapshotsGauge(logger, rdsSvc, servicequotasSvc, 1*time.Second)
+		Eventually(func() error {
+			_, err := gauge.ReadMetric()
+			return err
+		}, 3*time.Second).ShouldNot(BeNil())
+	})
+
+	It("returns an error if getting the RDS manual snapshot quota fails", func() {
+		rdsDatabaseSnapshots = []*awsrds.DBSnapshot{
+			{DBSnapshotIdentifier: aws.String("snapshot1")},
+		}
+
+		servicequotasAPI.GetServiceQuotaStub = func(
+			input *awsservicequotas.GetServiceQuotaInput,
+		) (*awsservicequotas.GetServiceQuotaOutput, error) {
+			return &awsservicequotas.GetServiceQuotaOutput{
+				Quota: &awsservicequotas.ServiceQuota{Value: aws.Float64(float64(0))},
+			}, fmt.Errorf("error on purpose")
+		}
+
+		gauge := RDSDBManualSnapshotsGauge(logger, rdsSvc, servicequotasSvc, 1*time.Second)
+		Eventually(func() error {
+			_, err := gauge.ReadMetric()
+			return err
+		}, 3*time.Second).ShouldNot(BeNil())
+	})
+})

--- a/tools/metrics/main.go
+++ b/tools/metrics/main.go
@@ -3,15 +3,16 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/alphagov/paas-cf/tools/metrics/pkg/health"
-	"github.com/alphagov/paas-cf/tools/metrics/pkg/logit"
-	"github.com/alphagov/paas-cf/tools/metrics/pkg/shield"
 	"log"
 	"net/http"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/alphagov/paas-cf/tools/metrics/pkg/health"
+	"github.com/alphagov/paas-cf/tools/metrics/pkg/logit"
+	"github.com/alphagov/paas-cf/tools/metrics/pkg/shield"
 
 	"github.com/aws/aws-sdk-go/aws"
 
@@ -184,6 +185,7 @@ func Main() error {
 		BillingCollectorPerformanceGauge(logger, 15*time.Minute, logitClient),
 		BillingApiPerformanceGauge(logger, 15*time.Minute, logitClient),
 		RDSDBInstancesGauge(logger, rdsService, serviceQuotas, 15*time.Minute),
+		RDSDBManualSnapshotsGauge(logger, rdsService, serviceQuotas, 15*time.Minute),
 		AWSHealthEventsGauge(logger, awsRegion, healthService, 15*time.Minute),
 		ShieldOngoingAttacksGauge(logger, shieldService, 5*time.Minute),
 		CloudfrontDistributionInstancesGauge(logger, cfs, 15*time.Minute),


### PR DESCRIPTION
What
----

Add manual db snapshot quota alert.

This change adds new metrics paas_aws_rds_manual_snapshot_count and paas_aws_rds_manual_snapshot_quota_count to the metrics-exporter and configures a prometheus alert.

This change is dependant on the following [change](https://github.com/alphagov/paas-aws-account-wide-terraform/pull/329).

How to review
-------------

Pipeline Jobs can be viewed [deploy-paas-metrics](https://deployer.dev04.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/deploy-paas-metrics/builds/8) and [prometheus-deploy](https://deployer.dev04.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/prometheus-deploy/builds/18)

Prometheus alert can be viewed [here](https://prometheus-1.dev04.dev.cloudpipeline.digital/alerts?search=snapshot), metrics [paas_aws_rds_manual_snapshot_count](https://prometheus-1.dev04.dev.cloudpipeline.digital/graph?g0.expr=paas_aws_rds_manual_snapshot_count&g0.tab=1&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1h) and [paas_aws_rds_manual_snapshot_quota_count](https://prometheus-1.dev04.dev.cloudpipeline.digital/graph?g0.expr=paas_aws_rds_manual_snapshot_quota_count&g0.tab=1&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1h)



---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
