### PR TITLE
billing integration tests: move `APP_ROOT` to correct place in task

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -5348,8 +5348,6 @@ jobs:
                 cp "paas-cf/config/billing/output/${AWS_REGION}.json" ./src/github.com/alphagov/paas-billing/config.json
                 cp "paas-cf/config/billing/tests/${AWS_REGION}_billing_rds_charges.feature" ./src/github.com/alphagov/paas-billing/gherkin/features/
 
-                export APP_ROOT="$PWD"
-
                 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
                 echo "deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
 
@@ -5365,6 +5363,7 @@ jobs:
 
                 export TEST_DATABASE_URL="postgres://postgres:@localhost:5432/?sslmode=disable"
                 cd src/github.com/alphagov/paas-billing
+                export APP_ROOT="$PWD"
 
                 make integration
 


### PR DESCRIPTION

What
----

This ended up in the wrong place following all the moving about (_before_ we `cd` into the correct directory).

How to review
-------------

:eyes: 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
