### PR TITLE
billing-experimental deployment: use db named billing-experimental-db

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -5631,10 +5631,10 @@ jobs:
 
                 cf target -o admin -s billing-experimental
 
-                if ! cf service billing-db > /dev/null; then
-                  cf create-service postgres "${BILLING_DB_PLAN}" billing-db
-                  while ! cf service billing-db | grep -iqE 'status:\s+create succeeded'; do
-                    echo "Waiting for creation of billing-db service to complete..."
+                if ! cf service billing-experimental-db > /dev/null; then
+                  cf create-service postgres "${BILLING_DB_PLAN}" billing-experimental-db
+                  while ! cf service billing-experimental-db | grep -iqE 'status:\s+create succeeded'; do
+                    echo "Waiting for creation of billing-experimental-db service to complete..."
                     sleep 30
                   done
                 fi
@@ -5667,7 +5667,7 @@ jobs:
                     app['env'] = {} unless app['env']
                     app['env'] = app['env'].merge(env)
                     app['services'] = [
-                      'billing-db',
+                      'billing-experimental-db',
                       'billing-logit-ssl-drain'
                     ]
                     app['routes'] = [
@@ -5682,7 +5682,7 @@ jobs:
                     app['env'] = {} unless app['env']
                     app['env'] = app['env'].merge(env)
                     app['services'] = [
-                      'billing-db',
+                      'billing-experimental-db',
                       'billing-logit-ssl-drain'
                     ]
                     app['health-check-http-endpoint'] = '/'


### PR DESCRIPTION
What
----

https://www.pivotaltracker.com/story/show/183803351

This allows us to use a db that is shared from the billing space without name collisions. The reason for using a space-shared database is to allow us to start with a clone of the real production `billing-db`, but clones can only easily be done into the same space. So we have to choose a db name that won't collide with one already in the production `billing` space.

Once this is deployed I should jump into staging and both prod envs and deleting the `billing-db` services they've already created in the `billing-experimental` space.


How to review
-------------

:eyes: 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
