### PR TITLE
router: set route_services_timeout to 900s

### DIFF
--- a/manifests/cf-manifest/operations.d/310-router.yml
+++ b/manifests/cf-manifest/operations.d/310-router.yml
@@ -14,6 +14,11 @@
   value: 8443
 
 - type: replace
+  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/route_services_timeout?
+  # match value set on AWS load balancer
+  value: 900
+
+- type: replace
   path: /instance_groups/name=router/jobs/name=gorouter/properties/router/status/user
   value: router_user
 


### PR DESCRIPTION
What
----

Current default of 60s causes problems for some users: https://govuk.zendesk.com/agent/tickets/5118907

Now begins the debate of what value to set it to. I chose 900s (15m) as it matches the timeout we set on our AWS load balancers - with the idea that any query we would expect them to handle should be possible to handle with a route service.

How to review
-------------

Describe the steps required to test the changes.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
