### PR TITLE
Bump elasticache broker

### DIFF
--- a/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
+++ b/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
@@ -61,9 +61,9 @@
   path: /releases/-
   value:
     name: elasticache-broker
-    version: 0.1.20
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/elasticache-broker-0.1.20.tgz
-    sha1: 1649e485c7543a1f02cc8c8b7c67324549c1f8c0
+    version: 0.1.21
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/elasticache-broker-0.1.21.tgz
+    sha1: 24f4a1fc8664a7bf42dd7dbe16b3051417c78ff6
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-


### PR DESCRIPTION
What
----

Bump elasticache broker: [Adds test_failover option to broker to allow a user to test the failover of their ha cluster](https://github.com/alphagov/paas-elasticache-broker/pull/33)

How to review
-------------
Already tested (I think). [Check it's the right version and sha?](https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/elasticache-broker-release/jobs/build-final-release/builds/6)

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
