### PR TITLE
cdn-broker: 0.1.50 -> 0.1.51

### DIFF
--- a/manifests/cf-manifest/operations.d/720-cdn-broker.yml
+++ b/manifests/cf-manifest/operations.d/720-cdn-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: cdn-broker
-    version: 0.1.50
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.50.tgz
-    sha1: 73080a987154c726b9531723559d620e02f0142a
+    version: 0.1.51
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.51.tgz
+    sha1: 02bd2523d4b03d90f641c4d2ee277cf80ad74e27
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-


### PR DESCRIPTION
What
----

https://www.pivotaltracker.com/story/show/183923174

This includes some tooling changes that shouldn't be relevant to the boshrelease, along with the additions of the cloudfront distribution id in GetInstance responses.

How to review
-------------

:eyes:  This previously went out to dev04 where it worked fine: https://deployer.dev04.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/custom-broker-acceptance-tests/builds/14

(Ignore https://deployer.dev04.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/custom-broker-acceptance-tests/builds/15 where I tried to add a positive test for this feature and realized it would never work without a lot more work on the integration tests...)


---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
