### PR TITLE
[#183920956] cf upgrade to cf24.6 and stemcell change to jammy

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -544,13 +544,13 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-acceptance-tests
-      branch: cf21.11
+      branch: cf24.6
 
   - name: cf-smoke-tests-release
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-smoke-tests-release
-      tag_filter: "42.0.19"
+      tag_filter: "42.0.37"
       submodules:
       - "src/smoke_tests"
 

--- a/concourse/pipelines/monitor-remote.yml
+++ b/concourse/pipelines/monitor-remote.yml
@@ -28,7 +28,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloudfoundry/cf-smoke-tests-release
-    tag_filter: "42.0.19"
+    tag_filter: "42.0.37"
     submodules:
       - "src/smoke_tests"
 

--- a/manifests/app-autoscaler/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/app-autoscaler/operations.d/020-bosh-set-stemcells.yml
@@ -3,5 +3,5 @@
   path: /stemcells
   value:
     - alias: default
-      os: ubuntu-bionic
-      version: "1.107"
+      os: ubuntu-jammy
+      version: "1.75"

--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -3,5 +3,5 @@
   path: /stemcells
   value:
     - alias: default
-      os: ubuntu-bionic
-      version: "1.107"
+      os: ubuntu-jammy
+      version: "1.75"

--- a/manifests/cf-manifest/operations.d/021-bionic-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/021-bionic-set-stemcells.yml
@@ -2,34 +2,34 @@
 - type: replace
   path: /addons/name=loggregator_agent/include/stemcell
   value:
-    - os: ubuntu-bionic
+    - os: ubuntu-jammy
 
 - type: replace
   path: /addons/name=forwarder_agent/include/stemcell
   value:
-    - os: ubuntu-bionic
+    - os: ubuntu-jammy
 
 - type: replace
   path: /addons/name=loggr-syslog-agent/include/stemcell
   value:
-    - os: ubuntu-bionic
+    - os: ubuntu-jammy
 
 - type: replace
   path: /addons/name=prom_scraper/include/stemcell
   value:
-    - os: ubuntu-bionic
+    - os: ubuntu-jammy
 
 - type: replace
   path: /addons/name=metrics-discovery-registrar/include/stemcell
   value:
-    - os: ubuntu-bionic
+    - os: ubuntu-jammy
 
 - type: replace
   path: /addons/name=metrics-agent/include/stemcell
   value:
-    - os: ubuntu-bionic
+    - os: ubuntu-jammy
 
 - type: replace
   path: /addons/name=bpm/include/stemcell
   value:
-    - os: ubuntu-bionic
+    - os: ubuntu-jammy

--- a/manifests/cf-manifest/operations.d/200-awslogs.yml
+++ b/manifests/cf-manifest/operations.d/200-awslogs.yml
@@ -3,6 +3,6 @@
   path: /releases/-
   value:
     name: awslogs
-    version: 0.1.6
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/awslogs-0.1.6.tgz
-    sha1: db6d8cf0b5da5c9ecabb6be08df0ad5442b4a401
+    version: 0.1.8
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/awslogs-0.1.8.tgz
+    sha1: f2a5fc665b8d6581c302bc90aaa49a7ccd72efb9

--- a/manifests/cf-manifest/operations.d/210-cf-disable-routing-api.yml
+++ b/manifests/cf-manifest/operations.d/210-cf-disable-routing-api.yml
@@ -16,3 +16,12 @@
   path: /variables/name=routing_api_tls
 - type: remove
   path: /variables/name=routing_api_tls_client
+- type: replace
+  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/ca_certs
+  value:
+    - ((diego_instance_identity_ca.ca))
+    - ((cc_tls.ca))
+    - ((uaa_ssl.ca))
+    - ((network_policy_server_external.ca))
+- type: remove
+  path: /instance_groups/name=api/jobs/name=route_registrar/properties/route_registrar/routes/name=routing-api

--- a/manifests/cf-manifest/operations.d/320-cc-release.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-release.yml
@@ -3,6 +3,6 @@
   path: /releases/name=capi
   value:
     name: "capi"
-    version: "1.139.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.139.0"
-    sha1: "bf904f6f360508a66ffd67d1f66c061be3e2ee8f"
+    version: "1.143.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.143.0"
+    sha1: "ee1208d40968bb125601038fcf83b2ef12214d30"

--- a/manifests/cf-manifest/operations.d/320-cc-ship-logs-for-auditing.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-ship-logs-for-auditing.yml
@@ -2,10 +2,10 @@
 - type: replace
   path: /instance_groups/name=api/jobs?/-
   value:
-    name: awslogs-bionic
+    name: awslogs-jammy
     release: awslogs
     properties:
-      awslogs-bionic:
+      awslogs-jammy:
         region: ((terraform_outputs_region))
         awslogs_files_config:
           - name: /var/vcap/sys/log/cloud_controller_ng/security_events.log

--- a/manifests/cf-manifest/operations.d/330-uaa-ship-logs-for-auditing.yml
+++ b/manifests/cf-manifest/operations.d/330-uaa-ship-logs-for-auditing.yml
@@ -2,10 +2,10 @@
 - type: replace
   path: /instance_groups/name=uaa/jobs?/-
   value:
-    name: awslogs-bionic
+    name: awslogs-jammy
     release: awslogs
     properties:
-      awslogs-bionic:
+      awslogs-jammy:
         region: ((terraform_outputs_region))
         awslogs_files_config:
           - name: /var/vcap/sys/log/uaa/uaa_events.log

--- a/manifests/cf-manifest/operations.d/330-uaa.yml
+++ b/manifests/cf-manifest/operations.d/330-uaa.yml
@@ -189,7 +189,7 @@
   value: https://login.((system_domain))
 
 - type: remove
-  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/cc-service-dashboards/scope
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/cc-service-dashboards/scopes
 
 - type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/cc_routing/override?
@@ -204,8 +204,23 @@
   value: 72000
 
 - type: replace
-  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/cf/scope
-  value: network.admin,network.write,cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write,scim.invite,doppler.firehose,uaa.user,routing.router_groups.read,routing.router_groups.write,cloud_controller.admin_read_only,cloud_controller.global_auditor
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/cf/scopes
+  value:
+    - network.admin
+    - network.write
+    - cloud_controller.read
+    - cloud_controller.write
+    - openid,password.write
+    - cloud_controller.admin
+    - scim.read
+    - scim.write
+    - scim.invite
+    - doppler.firehose
+    - uaa.user
+    - routing.router_groups.read
+    - routing.router_groups.write
+    - cloud_controller.admin_read_only
+    - cloud_controller.global_auditor
 
 - type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/cloud_controller_username_lookup/override?
@@ -224,8 +239,12 @@
   value: https://login.((system_domain))/login
 
 - type: replace
-  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/ssh-proxy/scope
-  value: openid,cloud_controller.read,cloud_controller.write,cloud_controller.admin
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/ssh-proxy/scopes
+  value:
+    - openid
+    - cloud_controller.read
+    - cloud_controller.write
+    - cloud_controller.admin
 
 - type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/tcp_emitter/override?

--- a/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
@@ -35,10 +35,10 @@ RSpec.describe "base properties" do
       end
     end
 
-    it "default stemcell os is ubuntu-bionic series" do
+    it "default stemcell os is ubuntu-jammy series" do
       default = stemcells.find { |s| s["alias"] == "default" }
 
-      expect(default["os"]).to eq("ubuntu-bionic")
+      expect(default["os"]).to eq("ubuntu-jammy")
     end
 
     it "stemcell version is not older than the one in cf-deployment **iff they're the same major version**" do

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "release versions" do
     # - attempted login using an unknown/unrelated Google account
     #
     # these are tricky to automate due to their reliance on SSO and/or email.
-    tested_uaa_version = "76.0.0"
+    tested_uaa_version = "76.5.0"
     manifest_releases = get_manifest_releases
 
     expect(manifest_releases).to have_key("uaa"), "expected release for uaa to be found in manifest"
@@ -118,7 +118,7 @@ RSpec.describe "release versions" do
     expect(monitor_remote_smoke_tests_resource_version).to eq(cf_smoke_tests_resource_version)
   end
 
-  pinned_cf_acceptance_tests_version = "21.11"
+  pinned_cf_acceptance_tests_version = "24.6"
   specify "cf-acceptance-tests version should be the same as the CF manifest version" do
     cf_manifest_version = cf_deployment_manifest
       .fetch("manifest_version")


### PR DESCRIPTION
What
----

Upgrade cloud foundry version to cf24.6.
Upgrade to jammy stemcell. 

Why
----

We need to keep up-to-date with cloud foundry releases. Bionic is running out of support in April.

How to review
-------------

Tested in dev04.
Full rebuild also done.
uaa manual testing done.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
