### PR TITLE
BAU - Add Notify staging space to isolation segment

### DIFF
--- a/manifests/cf-manifest/isolation-segments/prod/govuk-notify-staging.yml
+++ b/manifests/cf-manifest/isolation-segments/prod/govuk-notify-staging.yml
@@ -1,0 +1,4 @@
+---
+number_of_cells: 24
+isolation_segment_name: govuk-notify-staging
+vm_type: high_cpu_cell


### PR DESCRIPTION
Description:
- As per Zendesk ticket Notify would like to move their staging space into an isolation segment for load testing


---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
