### PR TITLE
Fix terraform dependency order with certificate validation

### DIFF
--- a/terraform/cloudfoundry/lbs.tf
+++ b/terraform/cloudfoundry/lbs.tf
@@ -156,7 +156,7 @@ resource "aws_lb_listener" "cf_router_app_domain_https" {
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = var.default_load_balancer_security_policy
-  certificate_arn   = aws_acm_certificate.apps.arn
+  certificate_arn   = aws_acm_certificate_validation.apps.certificate_arn
 
   default_action {
     type             = "forward"
@@ -241,7 +241,7 @@ resource "aws_lb_listener" "cf_router_system_domain_https" {
 
 resource "aws_lb_listener_certificate" "cf_router_metrics_domain_https" {
   listener_arn    = aws_lb_listener.cf_router_system_domain_https.arn
-  certificate_arn = aws_acm_certificate.metrics.arn
+  certificate_arn = aws_acm_certificate_validation.metrics.certificate_arn
 }
 
 resource "aws_lb_target_group" "cf_router_system_domain_https" {


### PR DESCRIPTION
What
----

After recreating an environment we got the following error pipeline error:

```
│ Error: adding LB Listener Certificate: UnsupportedCertificate: The certificate 'arn:aws:acm:eu-west-1:595665891067:certificate/3a91fd44-c879-4410-9073-8e962ccd23c4' must have a fully-qualified domain name, a supported signature, and a supported key size.
│ 	status code: 400, request id: 125e048b-64ee-4e96-a97c-d9d3fe599391
│ 
│   with aws_lb_listener_certificate.cf_router_metrics_domain_https,
│   on lbs.tf line 242, in resource "aws_lb_listener_certificate" "cf_router_metrics_domain_https":
│  242: resource "aws_lb_listener_certificate" "cf_router_metrics_domain_https" {
```

[from this concourse job.](https://deployer.dev04.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/cf-terraform/builds/28)

First google search for this error reveals this is a misleading erroring and essentially means you are trying to use the cert before the validation has finished.

The order from the logs looks like the following:

```
19:57:49    aws_acm_certificate.metrics: Creating...
19:57:58    aws_acm_certificate.metrics: Creation complete after 8s [id=arn:aws:acm:eu-west-1:595665891067:certificate/3a91fd44-c879-4410-9073-8e962ccd23c4]
20:01:56.   aws_acm_certificate_validation.metrics: Creating...
20:01:56    aws_lb_listener_certificate.cf_router_metrics_domain_https: Creating...
20:02:30    aws_acm_certificate_validation.metrics: Creation complete after 33s [id=0001-01-01 00:00:00 +0000 UTC]
20:03:55    Error: adding LB Listener Certificate: UnsupportedCertificate: The certificate 'arn:aws:acm:eu-west-1:595665891067:certificate/3a91fd44-c879-4410-9073-8e962ccd23c4' must have a fully-qualified domain name, a supported signature, and a supported key size.
```

As you can see it tried to attach the certificate before the validation had succeed.

This change gets the certificate arn from the validation rather than the certificate to ensure the validation has passed before we try to use the certificate.

How to review
-------------

Tested in dev01

Look at the change.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
