### PR TITLE
Correct Notify DMS test name

### DIFF
--- a/terraform/prod.dms.json
+++ b/terraform/prod.dms.json
@@ -1,6 +1,6 @@
     [
         {
-            "name": "GOV.UK Notify test migration",
+            "name": "govuk-notify-test-migration",
             "source_secret_name": "dms/notify-test/source",
             "target_secret_name": "dms/notify-test/destination",
             "instance": {

--- a/terraform/spec/dms_spec.rb
+++ b/terraform/spec/dms_spec.rb
@@ -1,0 +1,14 @@
+require "json"
+
+describe "dms" do
+  Dir.glob("../*.dms.json") do |f|
+    describe f do
+      it "names must contain only valid characters" do
+        cfg = JSON.read_file(f, aliases: true)
+        names = cfg.map { |e| e["name"] }
+
+        expect(names).to all(match(/^[\-A-Za-z0-9._\/]+$/))
+      end
+    end
+  end
+end


### PR DESCRIPTION
What
----

In #3062 I introduced a DMS configuration whose name contained spaces. Spaces are not valid in the name.

I've now fixed the name and added a little test to prevent it happening again

How to review
-------------

1. Tests pass, indicating name is OK

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
