### PR TITLE
Reduce the Notify DMS allocated storage size to be within limits

### DIFF
--- a/terraform/prod.dms.json
+++ b/terraform/prod.dms.json
@@ -1,8 +1,8 @@
     [
         {
             "name": "govuk-notify-test-migration",
-            "source_secret_name": "dms/notify-test/source",
-            "target_secret_name": "dms/notify-test/destination",
+            "source_secret_name": "dms-secrets/notify-test/source",
+            "target_secret_name": "dms-secrets/notify-test/destination",
             "instance": {
                 "allocated_storage": "6144",
                 "allow_major_version_upgrade": false,

--- a/terraform/prod.dms.json
+++ b/terraform/prod.dms.json
@@ -4,7 +4,7 @@
             "source_secret_name": "dms/notify-test/source",
             "target_secret_name": "dms/notify-test/destination",
             "instance": {
-                "allocated_storage": "1258291",
+                "allocated_storage": "6144",
                 "allow_major_version_upgrade": false,
                 "apply_immediately": true,
                 "auto_minor_version_upgrade": true,

--- a/terraform/spec/dms_spec.rb
+++ b/terraform/spec/dms_spec.rb
@@ -9,6 +9,12 @@ describe "dms" do
 
         expect(names).to all(match(/^[\-A-Za-z0-9._\/]+$/))
       end
+
+        it "must have a storage size between 5 and 6144" do
+            cfg = JSON.read_file(f, aliases: true)
+            allocated_storages = cfg.map { |e| e["instance"]["allocated_storage"].to_int }
+            expect(allocated_storages).to all(be_between(5, 6144))
+        end
     end
   end
 end

--- a/terraform/spec/dms_spec.rb
+++ b/terraform/spec/dms_spec.rb
@@ -10,11 +10,25 @@ describe "dms" do
         expect(names).to all(match(/^[\-A-Za-z0-9._\/]+$/))
       end
 
-        it "must have a storage size between 5 and 6144" do
-            cfg = JSON.read_file(f, aliases: true)
-            allocated_storages = cfg.map { |e| e["instance"]["allocated_storage"].to_int }
-            expect(allocated_storages).to all(be_between(5, 6144))
-        end
+      it "must have a storage size between 5 and 6144" do
+        cfg = JSON.read_file(f, aliases: true)
+        allocated_storages = cfg.map { |e| e["instance"]["allocated_storage"].to_int }
+        expect(allocated_storages).to all(be_between(5, 6144))
+      end
+
+      it "must have a source secret beginning with dms-secrets" do
+        cfg = JSON.read_file(f, aliases: true)
+        source_secrets = cfg.map { |e| e["source_secret_name"] }
+
+        expect(source_secrets).to all(match(/^dms-secrets.*$/))
+      end
+
+      it "must have a target secret beginning with dms-secrets" do
+        cfg = JSON.read_file(f, aliases: true)
+        target_secrets = cfg.map { |e| e["target_secret_name"] }
+
+        expect(target_secrets).to all(match(/^dms-secrets.*$/))
+      end
     end
   end
 end


### PR DESCRIPTION
What
----

The ~1.2TB allocated storage was far too high. The max is 6144mb.

How to review
-------------

Tests pass?

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
