### PR TITLE
[#184303348] Open cloud foundry security groups to secret manager endpoint subnet

### DIFF
--- a/manifests/cf-manifest/operations.d/770-secret-manager-endpoint.yml
+++ b/manifests/cf-manifest/operations.d/770-secret-manager-endpoint.yml
@@ -1,0 +1,22 @@
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/security_group_definitions/-
+  value:
+    name: secret_manager_endpoint
+    rules:
+      - protocol: tcp
+        destination: 10.0.79.0-10.0.79.15
+        ports: '443'
+      - protocol: tcp
+        destination: 10.0.79.16-10.0.79.31
+        ports: '443'
+      - protocol: tcp
+        destination: 10.0.79.32-10.0.79.47
+        ports: '443'
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/default_running_security_groups/-
+  value: secret_manager_endpoint
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/default_staging_security_groups/-
+  value: secret_manager_endpoint

--- a/terraform/spec/dms_spec.rb
+++ b/terraform/spec/dms_spec.rb
@@ -1,4 +1,7 @@
 require "json"
+require "ipaddr"
+require "yaml"
+require "open3"
 
 describe "dms" do
   Dir.glob("../*.dms.json") do |f|
@@ -29,6 +32,22 @@ describe "dms" do
 
         expect(target_secrets).to all(match(/^dms-secrets.*$/))
       end
+    end
+  end
+
+  describe "CIDR verification" do
+    let(:variables_file) { File.read("dms/variables.tf") }
+    let(:yaml_file) { YAML.load_file("../manifests/cf-manifest/operations.d/770-secret-manager-endpoint.yml") }
+    let(:tf_json) { JSON.parse(Open3.capture2("hcl2json dms/variables.tf")[0]) }
+    let(:variables) { tf_json["variable"]["aws_vpc_endpoint_cidrs_per_zone"] }
+    let(:cidrs) { variables[0]["default"].values }
+    let(:ranges) { cidrs.map { |cidr| IPAddr.new(cidr).to_range.to_s.gsub("..", "-") } }
+    let(:yaml_ranges) do
+      yaml_file.find { |i| i["path"] == "/instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/security_group_definitions/-" }["value"]["rules"].map { |r| r["destination"] }
+    end
+
+    it "verifies that the CIDRs in variables.tf match the ranges in 770-secret-manager-endpoint.yml" do
+      expect(ranges).to match_array(yaml_ranges)
     end
   end
 end


### PR DESCRIPTION
What
----

This pull request aims to open up the Cloud Foundry security groups to the AWS Secret Manager endpoint subnet, which was added by the tf-dms module. Instead of linking the output of tf-dms like other security group ranges, the subnets have been hardcoded to prevent dependencies within Concourse jobs. Additionally, a test case has been added to ensure that the CIDRs and ranges stay consistent in the future.

Why
----

Fixes the issue experienced on the last deployment where applications running in cloud foundry could no longer access aws secret manager.

How to review
-------------

This pull request has been tested in the dev01 environment, and it has been confirmed that the security group update will take effect on already running applications.

```
vcap@f35b8325-20e3-4761-7fde-2610:~$ curl https://secretsmanager.eu-west-1.amazonaws.com -v
* Rebuilt URL to: https://secretsmanager.eu-west-1.amazonaws.com/
*   Trying 10.0.79.24...
* TCP_NODELAY set
* connect to 10.0.79.24 port 443 failed: Connection refused
*   Trying 10.0.79.8...
* TCP_NODELAY set
* connect to 10.0.79.8 port 443 failed: Connection refused
*   Trying 10.0.79.38...
* TCP_NODELAY set
* connect to 10.0.79.38 port 443 failed: Connection refused
* Failed to connect to secretsmanager.eu-west-1.amazonaws.com port 443: Connection refused
* Closing connection 0
curl: (7) Failed to connect to secretsmanager.eu-west-1.amazonaws.com port 443: Connection refused
vcap@f35b8325-20e3-4761-7fde-2610:~$ curl https://secretsmanager.eu-west-1.amazonaws.com -v
* Rebuilt URL to: https://secretsmanager.eu-west-1.amazonaws.com/
*   Trying 10.0.79.24...
* TCP_NODELAY set
* Connected to secretsmanager.eu-west-1.amazonaws.com (10.0.79.24) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/certs/ca-certificates.crt
  CApath: /etc/ssl/certs
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Client hello (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN, server accepted to use http/1.1
* Server certificate:
*  subject: CN=secretsmanager.eu-west-1.amazonaws.com
*  start date: Jun 13 00:00:00 2022 GMT
*  expire date: Jun 12 23:59:59 2023 GMT
*  subjectAltName: host "secretsmanager.eu-west-1.amazonaws.com" matched cert's "secretsmanager.eu-west-1.amazonaws.com"
*  issuer: C=US; O=Amazon; OU=Server CA 1B; CN=Amazon
*  SSL certificate verify ok.
> GET / HTTP/1.1
> Host: secretsmanager.eu-west-1.amazonaws.com
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 404 Not Found
< x-amzn-RequestId: f1325c8f-191a-4050-9bdd-9ec956eb5017
< Content-Length: 29
< Date: Tue, 24 Jan 2023 14:28:17 GMT
< 
<UnknownOperationException/>
```

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
