### PR TITLE
[chore] Add a script to simplify suspending cf orgs

### DIFF
--- a/scripts/suspend-org.sh
+++ b/scripts/suspend-org.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ORG_TO_SUSPEND=${1:-}
+
+SUSPENDED="true"
+
+function usage() {
+  local error_message=${1:-}
+  if [ -n "${error_message}" ]; then
+    echo -e "ERROR: ${error_message}\n"
+  fi
+  echo "Usage: $0 <org-name>"
+  echo "If you want to unsuspend an org, set the UNSUSPEND env var to 'true'"
+  exit 1
+}
+
+if [ -z "${ORG_TO_SUSPEND}" ]; then
+  usage "You must specify an org name"
+fi
+
+verb="Suspending"
+
+case "${UNSUSPEND:-false}" in
+  "true" | "1")
+    SUSPENDED="false"
+    verb="Unsuspending"
+    ;;
+  "false" | "0")
+    SUSPENDED="true"
+    ;;
+  *)
+    usage "UNSUSPEND must be set to 'true' or 'false'"
+    ;;
+esac
+
+ORG_GUID=$(cf org "${ORG_TO_SUSPEND}" --guid)
+ENDPOINT_URL=$(cf curl / | jq -r .links.self.href)
+
+echo "${verb} org ${ORG_TO_SUSPEND} (${ORG_GUID}) at ${ENDPOINT_URL}"
+read -p "Is this correct? [yN] " -n 1 -r
+echo
+if [[ ! ${REPLY:-N} =~ ^[Yy]$ ]]; then
+  echo "Aborting"
+  exit 1
+fi
+if which jq >/dev/null; then
+  cf curl -X PATCH -d '{"suspended": '"${SUSPENDED}"'}' "/v3/organizations/${ORG_GUID}" | jq .
+else
+  cf curl -X PATCH -d '{"suspended": '"${SUSPENDED}"'}' "/v3/organizations/${ORG_GUID}"
+fi


### PR DESCRIPTION
What
----

Allows suspending an org by name, and includes a 'hidden' unsupend method.

This will make suspension simpler, as we won't have to copy and paste from the docs or remember the syntax.

There is also a sanity check step to make sure you're suspending the right org in the right environment.

How to review
-------------

1. Log in to a cf instance
1. Choose an org to suspend
1. Check suspending works: `scripts/suspend-org.sh $ORG_NAME` (should return '"suspended": true' and show 'SUSPENDED' in paasmin)
1. Check unsuspending works: `UNSUSPEND=1 scripts/suspend-org.sh $ORG_NAME` (should return '"suspended": false' and no longer show 'SUSPENDED' in paasmin)

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
