### PR TITLE
Increase prod-lon log-cache nodes to 30

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -6,7 +6,7 @@ cell_instances: 147
 router_instances: 30
 api_instances: 15
 doppler_instances: 39
-log_cache_instances: 24
+log_cache_instances: 30
 log_api_instances: 21
 scheduler_instances: 10
 cc_worker_instances: 12


### PR DESCRIPTION
What
----

After getting a number of BoshHighCPUUtilisation alerts for log-cache, we have decided to increase the number of nodes.

How to review
-------------

Look at the change.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
