### PR TITLE
Add nginx-host-reload to nginx boxes as part of the prometheus deployment

### DIFF
--- a/manifests/prometheus/operations.d/600-nginx-hosts-reload.yml
+++ b/manifests/prometheus/operations.d/600-nginx-hosts-reload.yml
@@ -1,0 +1,22 @@
+# REMOVE file if https://github.com/bosh-prometheus/prometheus-boshrelease/pull/454 gets merged
+# This is a temporary fix to the issue.
+
+- type: replace
+  path: /releases/-
+  value:
+    name: paas-nginx-hosts-reload
+    version: 1.1.0
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/paas-nginx-hosts-reload-1.1.0.tgz
+    sha1: 6f242a8bb1cb48d96bfa1cb66b17cbd4618a0e9c
+
+- type: replace
+  path: /instance_groups/name=nginx_z1/jobs/-
+  value:
+    name: nginx-hosts-reload
+    release: paas-nginx-hosts-reload
+
+- type: replace
+  path: /instance_groups/name=nginx_z2/jobs/-
+  value:
+    name: nginx-hosts-reload
+    release: paas-nginx-hosts-reload

--- a/manifests/prometheus/spec/operations/add_nginx_per_az_spec.rb
+++ b/manifests/prometheus/spec/operations/add_nginx_per_az_spec.rb
@@ -10,13 +10,17 @@ RSpec.describe "adding VMs to the load balancer" do
   end
 
   it "sets the same jobs and properties for both instance groups" do
-    expect(manifest_with_defaults.get("instance_groups.nginx_z1.jobs").length).to eq(1)
+    expect(manifest_with_defaults.get("instance_groups.nginx_z1.jobs").length).to eq(2)
     expect(manifest_with_defaults.get("instance_groups.nginx_z1.jobs.0.name")).to eq("nginx")
     expect(manifest_with_defaults.get("instance_groups.nginx_z1.jobs.0.release")).to eq("prometheus")
+    expect(manifest_with_defaults.get("instance_groups.nginx_z1.jobs.1.name")).to eq("nginx-hosts-reload")
+    expect(manifest_with_defaults.get("instance_groups.nginx_z1.jobs.1.release")).to eq("paas-nginx-hosts-reload")
 
-    expect(manifest_with_defaults.get("instance_groups.nginx_z2.jobs").length).to eq(1)
+    expect(manifest_with_defaults.get("instance_groups.nginx_z2.jobs").length).to eq(2)
     expect(manifest_with_defaults.get("instance_groups.nginx_z2.jobs.0.name")).to eq("nginx")
     expect(manifest_with_defaults.get("instance_groups.nginx_z2.jobs.0.release")).to eq("prometheus")
+    expect(manifest_with_defaults.get("instance_groups.nginx_z1.jobs.1.name")).to eq("nginx-hosts-reload")
+    expect(manifest_with_defaults.get("instance_groups.nginx_z1.jobs.1.release")).to eq("paas-nginx-hosts-reload")
 
     z1_nginx_props = manifest_with_defaults.get("instance_groups.nginx_z1.jobs.0.properties")
     expect(manifest_with_defaults.get("instance_groups.nginx_z2.jobs.0.properties")).to eq(z1_nginx_props)


### PR DESCRIPTION
What
----

Add nginx-host-reload to nginx boxes as part of the prometheus deployment

How to review
-------------

Tested in dev02

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
