### PR TITLE
[#184314123] Upgrade cloud foundry release to v26.1.0

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -562,13 +562,13 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-acceptance-tests
-      branch: cf24.6
+      branch: cf26.1
 
   - name: cf-smoke-tests-release
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-smoke-tests-release
-      tag_filter: "42.0.37"
+      tag_filter: "42.0.46"
       submodules:
       - "src/smoke_tests"
 

--- a/concourse/pipelines/monitor-remote.yml
+++ b/concourse/pipelines/monitor-remote.yml
@@ -28,7 +28,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloudfoundry/cf-smoke-tests-release
-    tag_filter: "42.0.37"
+    tag_filter: "42.0.46"
     submodules:
       - "src/smoke_tests"
 

--- a/manifests/app-autoscaler/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/app-autoscaler/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-jammy
-      version: "1.75"
+      version: "1.80"

--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-jammy
-      version: "1.75"
+      version: "1.80"

--- a/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
+++ b/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
@@ -3,6 +3,6 @@
   path: /releases/name=cflinuxfs3
   value:
     name: "cflinuxfs3"
-    version: "0.346.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.346.0"
-    sha1: "e4097636b50472ce742e23f59cf9f2cb902d3ecc"
+    version: "0.350.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.350.0"
+    sha1: "f97285d75a0fa696d80157ce9d079ced80bb2bf4"

--- a/manifests/cf-manifest/operations.d/320-cc-release.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-release.yml
@@ -3,6 +3,6 @@
   path: /releases/name=capi
   value:
     name: "capi"
-    version: "1.143.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.143.0"
-    sha1: "ee1208d40968bb125601038fcf83b2ef12214d30"
+    version: "1.144.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.144.0"
+    sha1: "210276007858bd0ca18359439f933a85f16d0a62"

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe "release versions" do
     expect(monitor_remote_smoke_tests_resource_version).to eq(cf_smoke_tests_resource_version)
   end
 
-  pinned_cf_acceptance_tests_version = "24.6"
+  pinned_cf_acceptance_tests_version = "26.1"
   specify "cf-acceptance-tests version should be the same as the CF manifest version" do
     cf_manifest_version = cf_deployment_manifest
       .fetch("manifest_version")

--- a/platform-tests/upstream/run_acceptance_tests.sh
+++ b/platform-tests/upstream/run_acceptance_tests.sh
@@ -15,6 +15,7 @@ SLOW_SPEC_THRESHOLD=120s
 SKIP_REGEX="${SKIP_REGEX:+${SKIP_REGEX}|}routing.API"
 SKIP_REGEX="${SKIP_REGEX}|Adding a wildcard route to a domain"
 SKIP_REGEX="${SKIP_REGEX}|when app has multiple ports mapped"
+SKIP_REGEX="${SKIP_REGEX}|Syslog drains"
 SKIP_REGEX="${SKIP_REGEX// /\\s}" # Replace ' ' with \s
 
 export CONFIG


### PR DESCRIPTION
What
----

- Upgrade cloud foundry release to v26.1.0
- Upgrade stemcell to 1.80
- Upgrade cflinuxfs3 to 0.350.0
- Disable syslog drain test has it now has a dependency on the tcp router

How to review
-------------

Upgrade has been tested in dev01

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
