### PR TITLE
log-caches: vertically scale rather than horizontally

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -6,7 +6,7 @@ cell_instances: 147
 router_instances: 30
 api_instances: 15
 doppler_instances: 39
-log_cache_instances: 30
+log_cache_instances: 18
 log_api_instances: 21
 scheduler_instances: 10
 cc_worker_instances: 12

--- a/manifests/cf-manifest/env-specific/prod.yml
+++ b/manifests/cf-manifest/env-specific/prod.yml
@@ -6,7 +6,7 @@ cell_instances: 21
 router_instances: 33
 api_instances: 9
 doppler_instances: 21
-log_cache_instances: 15
+log_cache_instances: 9
 log_api_instances: 12
 scheduler_instances: 12
 cc_worker_instances: 12

--- a/manifests/cf-manifest/operations.d/100-cf-update-vm-types.yml
+++ b/manifests/cf-manifest/operations.d/100-cf-update-vm-types.yml
@@ -16,7 +16,7 @@
   value: high_cpu_xlarge
 - type: replace
   path: /instance_groups/name=log-cache/vm_type
-  value: high_mem_large
+  value: high_mem_xlarge
 - type: replace
   path: /instance_groups/name=nats/vm_type
   value: medium

--- a/manifests/cloud-config/paas-cf-cloud-config.yml
+++ b/manifests/cloud-config/paas-cf-cloud-config.yml
@@ -205,6 +205,13 @@ vm_types:
       size: 10240
       type: gp3
 
+- name: high_mem_xlarge
+  cloud_properties:
+    instance_type: ((high_mem_xlarge_vm_instance_type))
+    ephemeral_disk:
+      size: 10240
+      type: gp3
+
 - name: high_cpu_xlarge
   cloud_properties:
     instance_type: ((high_cpu_xlarge_vm_instance_type))

--- a/manifests/variables.yml
+++ b/manifests/variables.yml
@@ -20,6 +20,8 @@ high_cpu_large_vm_instance_type: c5.large
 
 high_mem_large_vm_instance_type: r5.large
 
+high_mem_xlarge_vm_instance_type: r5.xlarge
+
 high_cpu_xlarge_vm_instance_type: c5.xlarge
 
 cell_instance_type: r5.xlarge


### PR DESCRIPTION
What
----

We're currently seeing log-cache instances frequently having >70% cpu usage while other instances are sitting near-idle.

At the same time, according to metrics, at any one time we only appear to have ~10 app ids actively logging during any one minute (london region). Given that one app_id's logging is handled by a single log-cache instance at any one time, this suggests that attempting to horizontally scale much more than 10 instances is not going to be successful in avoiding these high CPU spikes. To do this we need to reduce the degree to which our compute power is partitioned.

This PR doubles the size of log-cache instances and approximately halves their number (if this change is successful we can go on to reduce it further, possibly *under* half). The intention being that any one log-cache should have twice the CPU available to it (to allow it to handle chatty app_ids), but we should end up with approximately the same amount of total memory for the log-caches giving us a similar length of log retention.

The final cost should be similar because all r5 instances look the same to our savings plans.

This still shouldn't bring us near the supposed 10k envelopes/s/instance "scaling limit" that other cloudfoundry users have reported.

How to review
-------------

Deploy to a dev env, check logging is still working fine.

Alternatively look at https://deployer.dev01.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/cf-deploy/builds/343 where this was deployed with its subsequent tests passing

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
