### PR TITLE
cloud controller: set `default_app_log_rate_limit_in_bytes_per_second`

### DIFF
--- a/manifests/cf-manifest/operations.d/325-cc-set-default-app-log-rate-limit.yml
+++ b/manifests/cf-manifest/operations.d/325-cc-set-default-app-log-rate-limit.yml
@@ -1,0 +1,12 @@
+---
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/default_app_log_rate_limit_in_bytes_per_second?
+  value: 1_048_576
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/default_app_log_rate_limit_in_bytes_per_second?
+  value: 1_048_576
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/default_app_log_rate_limit_in_bytes_per_second?
+  value: 1_048_576

--- a/manifests/cf-manifest/spec/manifest/cc_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/cc_spec.rb
@@ -19,6 +19,17 @@ RSpec.describe "cloud controller" do
     end
   end
 
+  describe "defaults" do
+    let(:cc_ng_value) { manifest.fetch("instance_groups.api.jobs.cloud_controller_ng.properties.cc.default_app_log_rate_limit_in_bytes_per_second") }
+    let(:cc_worker_value) { manifest.fetch("instance_groups.cc-worker.jobs.cloud_controller_worker.properties.cc.default_app_log_rate_limit_in_bytes_per_second") }
+    let(:cc_scheduler_value) { manifest.fetch("instance_groups.scheduler.jobs.cloud_controller_clock.properties.cc.default_app_log_rate_limit_in_bytes_per_second") }
+
+    it "has the same default_app_log_rate_limit_in_bytes_per_second value set for all three cc components" do
+      expect(cc_ng_value).to be == cc_worker_value
+      expect(cc_ng_value).to be == cc_scheduler_value
+    end
+  end
+
   describe "broker" do
     let(:cc_ng_props) { manifest.fetch("instance_groups.api.jobs.cloud_controller_ng.properties.cc") }
     let(:cc_worker_props) { manifest.fetch("instance_groups.cc-worker.jobs.cloud_controller_worker.properties.cc") }


### PR DESCRIPTION
What
----
https://www.pivotaltracker.com/story/show/184235512

A value of 1M should be enough for 99.9...% of apps.

This itself won't stop people raising it beyond 1M but they would have to go out of their way to do so for new apps. I think if we set this and wait a month for it to gradually kick in (as people re-deploy their apps) we'd have a much easier time if we did decide to introduce an actual quota (via e.g. #3074).

The current effective setting for this is `-1`.

How to review
-------------

Deploy to dev env

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
