### PR TITLE
[#183932518] Change VPN configuration to meet supported Azure configuration

### DIFF
--- a/terraform/vpn/vpn.tf
+++ b/terraform/vpn/vpn.tf
@@ -36,13 +36,13 @@ resource "aws_vpn_connection" "default" {
   tunnel_inside_ip_version = each.value.aws_vpn_connection.tunnel_inside_ip_version
   tunnel1_preshared_key    = var.vpn_key_data[each.key].tunnel1_preshared_key
   tunnel2_preshared_key    = var.vpn_key_data[each.key].tunnel2_preshared_key
-
+  
   tunnel1_dpd_timeout_action           = "clear"
   tunnel1_ike_versions                 = ["ikev2"]
-  tunnel1_phase1_dh_group_numbers      = [19]
-  tunnel1_phase2_dh_group_numbers      = [19]
-  tunnel1_phase1_encryption_algorithms = ["AES128-GCM-16"]
-  tunnel1_phase2_encryption_algorithms = ["AES128-GCM-16"]
+  tunnel1_phase1_dh_group_numbers      = [14]
+  tunnel1_phase2_dh_group_numbers      = [2]
+  tunnel1_phase1_encryption_algorithms = ["AES128"]
+  tunnel1_phase2_encryption_algorithms = ["AES128"]
   tunnel1_phase1_lifetime_seconds      = 28800
   tunnel1_phase2_lifetime_seconds      = 3600
   tunnel1_phase1_integrity_algorithms  = ["SHA2-256"]
@@ -51,10 +51,10 @@ resource "aws_vpn_connection" "default" {
 
   tunnel2_dpd_timeout_action           = "clear"
   tunnel2_ike_versions                 = ["ikev2"]
-  tunnel2_phase1_dh_group_numbers      = [19]
-  tunnel2_phase2_dh_group_numbers      = [19]
-  tunnel2_phase1_encryption_algorithms = ["AES128-GCM-16"]
-  tunnel2_phase2_encryption_algorithms = ["AES128-GCM-16"]
+  tunnel2_phase1_dh_group_numbers      = [14]
+  tunnel2_phase2_dh_group_numbers      = [2]
+  tunnel2_phase1_encryption_algorithms = ["AES128"]
+  tunnel2_phase2_encryption_algorithms = ["AES128"]
   tunnel2_phase1_lifetime_seconds      = 28800
   tunnel2_phase2_lifetime_seconds      = 3600
   tunnel2_phase1_integrity_algorithms  = ["SHA2-256"]


### PR DESCRIPTION
What
----
The NCSC profile
(https://www.ncsc.gov.uk/guidance/using-ipsec-protect-data) suggests Diffie-Hellman groups 19 or 14 for both phases.

However, Azure's site-to-site VPN service does not support those options. The matching groups are 14 for phase 1 and 2 for phase 2.

Equally `AES128-GCM-16` is not supported by Azure, so we fall back to `AES128`.

How to review
-------------
Check I didn't break the Terraform syntax

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
