### PR TITLE
[#181970904] Add smtp-alert to prometheus

### DIFF
--- a/manifests/prometheus/operations.d/311-add-smtp-alert.yml
+++ b/manifests/prometheus/operations.d/311-add-smtp-alert.yml
@@ -1,0 +1,22 @@
+- type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=smtp_alert?/properties/smtp_alert?
+  value:
+    auth_username: ((terraform_outputs_ses_smtp_aws_access_key_id))
+    auth_password: ((terraform_outputs_ses_smtp_password))
+    smarthost:  ((terraform_outputs_ses_smtp_host))
+    from: "govpaas-alerting-((aws_account))@digital.cabinet-office.gov.uk"
+    pager_duty_service_key: ((missing_alerts_service_key))
+    metrics_environment: ((metrics_environment))
+    crontab_schedule:
+
+- type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=smtp_alert?/release
+  value: generic
+
+- type: replace
+  path: /releases/name=generic?
+  value:
+    name: generic
+    version: 0.1.3
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/generic-0.1.3.tgz
+    sha1: 3f91158bd9be224cbbc9f356e6bd95aefbf2c0c4

--- a/scripts/upload-secrets/upload-pagerduty-secrets.rb
+++ b/scripts/upload-secrets/upload-pagerduty-secrets.rb
@@ -16,9 +16,11 @@ credhub_namespaces = [
 
 alertmanager_pagerduty_24_7_service_key = ENV["ALERTMANAGER_PAGERDUTY_24_7_SERVICE_KEY"] || get_secret("pagerduty/#{ENV['MAKEFILE_ENV_TARGET']}/alertmanager_pagerduty_24_7_service_key")
 alertmanager_pagerduty_in_hours_service_key = ENV["ALERTMANAGER_PAGERDUTY_IN_HOURS_SERVICE_KEY"] || get_secret("pagerduty/#{ENV['MAKEFILE_ENV_TARGET']}/alertmanager_pagerduty_in_hours_service_key")
+missing_alerts_service_key = ENV["MISSING_ALERTS_SERVICE_KEY"] || get_secret("pagerduty/#{ENV['MAKEFILE_ENV_TARGET']}/missing_alerts_service_key")
 
 upload_secrets(
   credhub_namespaces,
   "alertmanager_pagerduty_24_7_service_key" => alertmanager_pagerduty_24_7_service_key,
   "alertmanager_pagerduty_in_hours_service_key" => alertmanager_pagerduty_in_hours_service_key,
+  "missing_alerts_service_key" => missing_alerts_service_key,
 )


### PR DESCRIPTION
What
----

This change is to satisfy the requirements of ticket [alerts for missing alerts](https://www.pivotaltracker.com/n/projects/1275640/stories/181970904). A new boshrelease has been created and added to the prometheus manifest.

The smtp_alert script runs every 15 mins.

How to review
-------------

1. The new pagerduty secrets have to be put into credhub for each env: ```make dev04 upload-pagerduty-secrets```. This operation needs to run with the new branch checked out so that the updated upload-pagerduty-secrets.rb script is used.
1. Run the branch into a dev env.
1. ssh onto the alertmanager vm.
1. Check for an smtp_alert file in /etc/cron.d.
1. Change the "pass" var in smtp_alert.rb to raise an incident on pagerduty.
1. Set the "pass" var back to the correct password and check that the pagerduty incident has been resolved.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
