### PR TITLE
prod-lon: reduce number of log caches 18 -> 15

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -6,7 +6,7 @@ cell_instances: 147
 router_instances: 30
 api_instances: 15
 doppler_instances: 39
-log_cache_instances: 18
+log_cache_instances: 15
 log_api_instances: 21
 scheduler_instances: 10
 cc_worker_instances: 12


### PR DESCRIPTION
What
----

This brings us back to half what we had before vertically scaling the instances, returning us to approximately the same spend as with 30 log-caches. The log caches are currently peaking at ~30% cpu so there should be plenty of headroom for this.

How to review
-------------

Can't really

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
