### PR TITLE
log-cache: increase `prunes_per_gc` from 3 -> 5

### DIFF
--- a/manifests/cf-manifest/operations.d/235-log-cache-tuning.yml
+++ b/manifests/cf-manifest/operations.d/235-log-cache-tuning.yml
@@ -2,3 +2,7 @@
 - type: replace
   path: /instance_groups/name=log-cache/jobs/name=log-cache/properties/memory_limit_percent?
   value: 65
+
+- type: replace
+  path: /instance_groups/name=log-cache/jobs/name=log-cache/properties/prunes_per_gc?
+  value: 5


### PR DESCRIPTION
What
----

https://www.pivotaltracker.com/story/show/184518513

This should reduce the frequency at which go's garbage collector has to scan the whole process memory for unreachable objects, which is quite taxing and probably a significant CPU burden.


How to review
-------------

Can check it _works_ on a dev env (example deployment https://deployer.dev05.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/cf-deploy/builds/3). Probably can't check whether it has a beneficial effect to production on anything except production.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
