### PR TITLE
alerts: allow log-cache instances to reach 80% cpu util before warning

### DIFF
--- a/manifests/prometheus/alerts.d/bosh-high-cpu-utilisation.yml
+++ b/manifests/prometheus/alerts.d/bosh-high-cpu-utilisation.yml
@@ -10,7 +10,15 @@
         expr: avg_over_time(bosh_job_cpu_sys{bosh_job_name!="diego-cell",bosh_job_name!~"^concourse.*",bosh_job_name!~"^compilation-.*"}[1h]) + avg_over_time(bosh_job_cpu_user{bosh_job_name!="diego-cell",bosh_job_name!~"^concourse.*",bosh_job_name!~"^compilation-.*"}[1h]) + avg_over_time(bosh_job_cpu_wait{bosh_job_name!="diego-cell",bosh_job_name!~"^concourse.*",bosh_job_name!~"^compilation-.*"}[1h])
 
       - alert: BoshHighCPUUtilisation
-        expr: "bosh_job:bosh_job_cpu:avg1h > 70"
+        expr: bosh_job:bosh_job_cpu:avg1h{bosh_job_name!="log-cache"} > 70
+        labels:
+          severity: warning
+        annotations:
+          summary: "High cpu utilisation on {{ $labels.bosh_job_name }}/{{ $labels.bosh_job_index }}"
+          description: "{{ $labels.bosh_job_name }}/{{ $labels.bosh_job_index }} CPU utilisation was over {{ $value | printf \"%.0f\" }}% in the last hour on average"
+
+      - alert: BoshHighCPUUtilisationLogCache
+        expr: bosh_job:bosh_job_cpu:avg1h{bosh_job_name="log-cache"} > 80
         labels:
           severity: warning
         annotations:

--- a/manifests/prometheus/spec/alerts/bosh-high-cpu-utilisation.test.yml
+++ b/manifests/prometheus/spec/alerts/bosh-high-cpu-utilisation.test.yml
@@ -6,13 +6,13 @@ rule_files:
 evaluation_interval: 1m
 
 tests:
-  # When CPU usage is above 80% for >= 60m
+  # When CPU usage is above 71% for >= 60m
   # when the VM is not a compilation VM
   # then an alert should fire with the name of the VM
   - interval: 1h
     input_series:
       - series: "bosh_job_cpu_sys{bosh_job_name='test',bosh_job_index='0'}"
-        values: 60 80 95
+        values: 60 71 95
 
       - series: "bosh_job_cpu_user{bosh_job_name='test',bosh_job_index='0'}"
         values: 0 0 0 0 0
@@ -33,15 +33,31 @@ tests:
               bosh_job_index: '0'
             exp_annotations:
               summary: "High cpu utilisation on test/0"
-              description: "test/0 CPU utilisation was over 80% in the last hour on average"
+              description: "test/0 CPU utilisation was over 71% in the last hour on average"
+      - eval_time: 121m
+        alertname: BoshHighCPUUtilisation
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              bosh_job_name: 'test'
+              bosh_job_index: '0'
+            exp_annotations:
+              summary: "High cpu utilisation on test/0"
+              description: "test/0 CPU utilisation was over 95% in the last hour on average"
+      - eval_time: 30m
+        alertname: BoshHighCPUUtilisationLogCache
+      - eval_time: 61m
+        alertname: BoshHighCPUUtilisationLogCache
+      - eval_time: 121m
+        alertname: BoshHighCPUUtilisationLogCache
 
-  # When CPU usage is above 80% for >= 60m
+  # When CPU usage is above 71% for >= 60m
   # when the VM is a compilation VM
   # then no alerts should fire
   - interval: 1h
     input_series:
       - series: "bosh_job_cpu_sys{bosh_job_name='compilation-00000000',bosh_job_index='0'}"
-        values: 60 80 95
+        values: 60 71 95
 
       - series: "bosh_job_cpu_user{bosh_job_name='compilation-00000000',bosh_job_index='0'}"
         values: 0 0 0 0 0
@@ -55,14 +71,22 @@ tests:
         alertname: BoshHighCPUUtilisation
       - eval_time: 61m
         alertname: BoshHighCPUUtilisation
+      - eval_time: 121m
+        alertname: BoshHighCPUUtilisation
+      - eval_time: 30m
+        alertname: BoshHighCPUUtilisationLogCache
+      - eval_time: 61m
+        alertname: BoshHighCPUUtilisationLogCache
+      - eval_time: 121m
+        alertname: BoshHighCPUUtilisationLogCache
 
-  # When CPU usage is above 80% for >= 60m
+  # When CPU usage is above 71% for >= 60m
   # when the VM is a concourse VM
   # then no alerts should fire
   - interval: 1h
     input_series:
       - series: "bosh_job_cpu_sys{bosh_job_name='concourse',bosh_job_index='0'}"
-        values: 60 80 95
+        values: 60 71 95
 
       - series: "bosh_job_cpu_user{bosh_job_name='concourse',bosh_job_index='0'}"
         values: 0 0 0 0 0
@@ -76,14 +100,22 @@ tests:
         alertname: BoshHighCPUUtilisation
       - eval_time: 61m
         alertname: BoshHighCPUUtilisation
+      - eval_time: 121m
+        alertname: BoshHighCPUUtilisation
+      - eval_time: 30m
+        alertname: BoshHighCPUUtilisationLogCache
+      - eval_time: 61m
+        alertname: BoshHighCPUUtilisationLogCache
+      - eval_time: 121m
+        alertname: BoshHighCPUUtilisationLogCache
 
-  # When CPU usage is above 80% for >= 60m
+  # When CPU usage is above 71% for >= 60m
   # when the VM is a concourse-worker VM
   # then no alerts should fire
   - interval: 1h
     input_series:
       - series: "bosh_job_cpu_sys{bosh_job_name='concourse-worker',bosh_job_index='0'}"
-        values: 60 80 95
+        values: 60 71 95
 
       - series: "bosh_job_cpu_user{bosh_job_name='concourse-worker',bosh_job_index='0'}"
         values: 0 0 0 0 0
@@ -97,14 +129,22 @@ tests:
         alertname: BoshHighCPUUtilisation
       - eval_time: 61m
         alertname: BoshHighCPUUtilisation
+      - eval_time: 121m
+        alertname: BoshHighCPUUtilisation
+      - eval_time: 30m
+        alertname: BoshHighCPUUtilisationLogCache
+      - eval_time: 61m
+        alertname: BoshHighCPUUtilisationLogCache
+      - eval_time: 121m
+        alertname: BoshHighCPUUtilisationLogCache
 
-  # When CPU usage is above 80% for >= 60m
+  # When CPU usage is above 71% for >= 60m
   # when the VM is a diego-cell VM
   # then no alerts should fire
   - interval: 1h
     input_series:
       - series: "bosh_job_cpu_sys{bosh_job_name='diego-cell',bosh_job_index='0'}"
-        values: 60 80 95
+        values: 60 71 95
 
       - series: "bosh_job_cpu_user{bosh_job_name='diego-cell',bosh_job_index='0'}"
         values: 0 0 0 0 0
@@ -118,3 +158,95 @@ tests:
         alertname: BoshHighCPUUtilisation
       - eval_time: 61m
         alertname: BoshHighCPUUtilisation
+      - eval_time: 121m
+        alertname: BoshHighCPUUtilisation
+      - eval_time: 30m
+        alertname: BoshHighCPUUtilisationLogCache
+      - eval_time: 61m
+        alertname: BoshHighCPUUtilisationLogCache
+      - eval_time: 121m
+        alertname: BoshHighCPUUtilisationLogCache
+
+  # When CPU usage is above 71% for >= 60m
+  # when the VM is a log-cache VM
+  # then no alerts should fire until after
+  # the usage has reached >80%
+  - interval: 1h
+    input_series:
+      - series: "bosh_job_cpu_sys{bosh_job_name='log-cache',bosh_job_index='0'}"
+        values: 60 71 95
+
+      - series: "bosh_job_cpu_user{bosh_job_name='log-cache',bosh_job_index='0'}"
+        values: 0 0 0 0 0
+
+      - series: "bosh_job_cpu_wait{bosh_job_name='log-cache',bosh_job_index='0'}"
+        values: 0 0 0 0 0
+
+
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: BoshHighCPUUtilisation
+      - eval_time: 61m
+        alertname: BoshHighCPUUtilisation
+      - eval_time: 121m
+        alertname: BoshHighCPUUtilisation
+      - eval_time: 30m
+        alertname: BoshHighCPUUtilisationLogCache
+      - eval_time: 61m
+        alertname: BoshHighCPUUtilisationLogCache
+      - eval_time: 121m
+        alertname: BoshHighCPUUtilisationLogCache
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              bosh_job_name: 'log-cache'
+              bosh_job_index: '0'
+            exp_annotations:
+              summary: "High cpu utilisation on log-cache/0"
+              description: "log-cache/0 CPU utilisation was over 95% in the last hour on average"
+
+  # When CPU usage is above 81% for >= 60m
+  # when the VM is a log-cache VM
+  # then BoshHighCPUUtilisationLogCache should
+  # fire, but not BoshHighCPUUtilisation
+  - interval: 1h
+    input_series:
+      - series: "bosh_job_cpu_sys{bosh_job_name='log-cache',bosh_job_index='0'}"
+        values: 60 81 95
+
+      - series: "bosh_job_cpu_user{bosh_job_name='log-cache',bosh_job_index='0'}"
+        values: 0 0 0 0 0
+
+      - series: "bosh_job_cpu_wait{bosh_job_name='log-cache',bosh_job_index='0'}"
+        values: 0 0 0 0 0
+
+
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: BoshHighCPUUtilisation
+      - eval_time: 61m
+        alertname: BoshHighCPUUtilisation
+      - eval_time: 121m
+        alertname: BoshHighCPUUtilisation
+      - eval_time: 30m
+        alertname: BoshHighCPUUtilisationLogCache
+      - eval_time: 61m
+        alertname: BoshHighCPUUtilisationLogCache
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              bosh_job_name: 'log-cache'
+              bosh_job_index: '0'
+            exp_annotations:
+              summary: "High cpu utilisation on log-cache/0"
+              description: "log-cache/0 CPU utilisation was over 81% in the last hour on average"
+      - eval_time: 121m
+        alertname: BoshHighCPUUtilisationLogCache
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              bosh_job_name: 'log-cache'
+              bosh_job_index: '0'
+            exp_annotations:
+              summary: "High cpu utilisation on log-cache/0"
+              description: "log-cache/0 CPU utilisation was over 95% in the last hour on average"


### PR DESCRIPTION
What
----
https://www.pivotaltracker.com/story/show/184518513

log-caches can surge to high utilization occasionally and it appears to be "fine", at least to the point we would like to quieten down this warning until we can decide on a proper fix.

How to review
-------------

:eyes: at pre-merge tests and see it going out on a dev env without bringing everything down in flames. Actually trying to force a dev env's log cache to exceed the alert limits might not be a productive way to spend an afternoon.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
