### PR TITLE
[#184446148] Increase delete timeout for cdn services in platform-tests

### DIFF
--- a/platform-tests/broker-acceptance/cdn_broker_test.go
+++ b/platform-tests/broker-acceptance/cdn_broker_test.go
@@ -2,6 +2,8 @@ package broker_acceptance_test
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/cloudfoundry/cf-test-helpers/cf"
 	"github.com/cloudfoundry/cf-test-helpers/generator"
 	. "github.com/onsi/ginkgo/v2"
@@ -54,7 +56,7 @@ var _ = Describe("CDN broker", func() {
 			By("deleting a standard CDN service", func() {
 				Expect(cf.Cf("delete-service", serviceInstanceName, "-f").Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
 				Expect(cf.Cf("delete-domain", domainName, "-f").Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))
-				pollForServiceDeletionCompletion(serviceInstanceName)
+				pollForServiceDeletionCompletionTimeout(serviceInstanceName, 45*time.Minute)
 			})
 		})
 

--- a/platform-tests/broker-acceptance/init_test.go
+++ b/platform-tests/broker-acceptance/init_test.go
@@ -139,10 +139,14 @@ func pollForServiceUpdateCompletion(dbInstanceName string) {
 }
 
 func pollForServiceDeletionCompletion(dbInstanceName string) {
+	pollForServiceDeletionCompletionTimeout(dbInstanceName, testConfig.DefaultTimeoutDuration())
+}
+
+func pollForServiceDeletionCompletionTimeout(dbInstanceName string, timeout time.Duration) {
 	fmt.Fprint(GinkgoWriter, "Polling for service destruction to complete")
 	Eventually(func() *Buffer {
 		fmt.Fprint(GinkgoWriter, ".")
-		command := quietCf("cf", "services").Wait(testConfig.DefaultTimeoutDuration())
+		command := quietCf("cf", "services").Wait(timeout)
 		Expect(command).To(Exit(0), fmt.Sprint("Error calling cf services: ", string(command.Out.Contents())))
 		return command.Out
 	}, DB_CREATE_TIMEOUT, 15*time.Second).ShouldNot(Say(dbInstanceName))


### PR DESCRIPTION
What
----

Increase the delete timeout of cdn services to be 45 minutes as part of the platform tests.

Why
----

Sadly cloudfront distributions can occasionally be very slow to remove. 

How to review
-------------

Tested in dev02

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
