### PR TITLE
Add more prod-lon diego-cells

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -2,7 +2,7 @@
 uaa_instances: 3
 nats_instances: 3
 diego_api_instances: 3
-cell_instances: 147
+cell_instances: 150
 router_instances: 30
 api_instances: 15
 doppler_instances: 39


### PR DESCRIPTION
What
----

Add more prod-lon diego-cells to resolve DiegoCellRepsReachingTotalMemoryCapacity alert

How to review
-------------

Consider the production deployment.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
