### PR TITLE
Upgrade cf-deployment, stemcell and cflinuxfs3

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -562,13 +562,13 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-acceptance-tests
-      branch: cf26.1
+      branch: cf26.5
 
   - name: cf-smoke-tests-release
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-smoke-tests-release
-      tag_filter: "42.0.46"
+      tag_filter: "42.0.51"
       submodules:
       - "src/smoke_tests"
 

--- a/concourse/pipelines/monitor-remote.yml
+++ b/concourse/pipelines/monitor-remote.yml
@@ -28,7 +28,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloudfoundry/cf-smoke-tests-release
-    tag_filter: "42.0.46"
+    tag_filter: "42.0.51"
     submodules:
       - "src/smoke_tests"
 

--- a/manifests/app-autoscaler/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/app-autoscaler/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-jammy
-      version: "1.80"
+      version: "1.83"

--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-jammy
-      version: "1.80"
+      version: "1.83"

--- a/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
+++ b/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
@@ -3,6 +3,6 @@
   path: /releases/name=cflinuxfs3
   value:
     name: "cflinuxfs3"
-    version: "0.350.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.350.0"
-    sha1: "f97285d75a0fa696d80157ce9d079ced80bb2bf4"
+    version: "0.352.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.352.0"
+    sha1: "7e33fc1207aed7616e76cdc2fc3f68919ebe256a"

--- a/manifests/cf-manifest/operations.d/320-cc-release.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-release.yml
@@ -3,6 +3,6 @@
   path: /releases/name=capi
   value:
     name: "capi"
-    version: "1.144.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.144.0"
-    sha1: "210276007858bd0ca18359439f933a85f16d0a62"
+    version: "1.146.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.146.0"
+    sha1: "eacdee032b7a78aa04af1e37a20fc0543790c2a1"

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe "release versions" do
     expect(monitor_remote_smoke_tests_resource_version).to eq(cf_smoke_tests_resource_version)
   end
 
-  pinned_cf_acceptance_tests_version = "26.1"
+  pinned_cf_acceptance_tests_version = "26.5"
   specify "cf-acceptance-tests version should be the same as the CF manifest version" do
     cf_manifest_version = cf_deployment_manifest
       .fetch("manifest_version")


### PR DESCRIPTION
What
----

- Upgrade cf-deployment to v26.5.0
- Upgrade cflinuxfs3 to 0.352.0
- Upgrade jammy stemcell to 1.83

Notes:

- No uaa update this time.

How to review
-------------

[Tested in dev-02.](https://deployer.dev02.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/cf-deploy/builds/365#L63f75b8d:1)

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
