### PR TITLE
Update docker images to include cf-cli 8.6.0

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -4,19 +4,19 @@ resource_types:
   # version of the resource_type `git`. As a temporary fix we have docker image
   # of the resource. This resource_type can be deleted when the issue is resolved
 - name: git
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/git-resource
     tag: 1f84d4a76b4a2491283e0107ae7ed4bc83c84d1b
 
 - name: s3-iam
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/s3-resource
     tag: 96b47010a10ca13b40bc604b49b4ab9158cfe2c7
 
 - name: semver-iam
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/semver-resource
     tag: f2a80c95481056aa57d837e3b14f0012b542fdb3
@@ -112,7 +112,7 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/alpine
               tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
@@ -139,7 +139,7 @@ jobs:
           outputs:
             - name: deployed-healthcheck
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/bosh-cli-v2
               tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
@@ -175,7 +175,7 @@ jobs:
             AWS_DEFAULT_REGION: ((aws_region))
             DEPLOY_ENV: ((deploy_env))
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/awscli
               tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -115,7 +115,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/alpine
-              tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+              tag: b25554b10d0efb9da2aef192f9a890199863f59e
           inputs:
             - name: paas-cf
           params:
@@ -142,7 +142,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/bosh-cli-v2
-              tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+              tag: b25554b10d0efb9da2aef192f9a890199863f59e
           run:
             path: sh
             args:
@@ -178,7 +178,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/awscli
-              tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+              tag: b25554b10d0efb9da2aef192f9a890199863f59e
           run:
             path: ./paas-cf/concourse/scripts/rds_instances.sh
             args:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -11,72 +11,72 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/alpine
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
     psql: &psql-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/psql
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
     node: &node-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/node
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
     node-chromium: &node-chromium-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/node-chromium
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
     awscli: &awscli-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
     cf-acceptance-tests: &cf-acceptance-tests-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
     cf-cli: &cf-cli-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/cf-cli
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
     cf-uaac: &cf-uaac-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/cf-uaac
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
     git-ssh: &git-ssh-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/git-ssh
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
     ruby-slim: &ruby-slim-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/ruby
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
     golang: &golang-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/golang
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
     terraform: &terraform-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
     curl-ssl: &curl-ssl-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/curl-ssl
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
 
 
   tasks:
@@ -275,7 +275,7 @@ resource_types:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/concourse-pool-resource
-    tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+    tag: b25554b10d0efb9da2aef192f9a890199863f59e
 
 - name: s3-iam
   type: registry-image
@@ -845,7 +845,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+              tag: b25554b10d0efb9da2aef192f9a890199863f59e
 
           inputs:
             - name: paas-cf
@@ -5414,7 +5414,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/spruce
-              tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+              tag: b25554b10d0efb9da2aef192f9a890199863f59e
 
           inputs:
             - name: paas-cf
@@ -6688,7 +6688,7 @@ jobs:
           type: registry-image
           source:
             repository: ghcr.io/alphagov/paas/cf-uaac
-            tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+            tag: b25554b10d0efb9da2aef192f9a890199863f59e
 
         inputs:
           - name: passwords

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -8,72 +8,72 @@ meta:
 
   containers:
     alpine: &alpine-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/alpine
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
     psql: &psql-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/psql
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
     node: &node-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/node
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
     node-chromium: &node-chromium-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/node-chromium
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
     awscli: &awscli-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
     cf-acceptance-tests: &cf-acceptance-tests-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/cf-acceptance-tests
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
     cf-cli: &cf-cli-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/cf-cli
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
     cf-uaac: &cf-uaac-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/cf-uaac
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
     git-ssh: &git-ssh-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/git-ssh
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
     ruby-slim: &ruby-slim-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/ruby
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
     golang: &golang-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/golang
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
     terraform: &terraform-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
     curl-ssl: &curl-ssl-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/curl-ssl
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
@@ -266,37 +266,37 @@ resource_types:
   # version of the resource_type `git`. As a temporary fix we have docker image
   # of the resource. This resource_type can be deleted when the issue is resolved
 - name: git
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/git-resource
     tag: 1f84d4a76b4a2491283e0107ae7ed4bc83c84d1b
 
 - name: pinned-pool
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/concourse-pool-resource
     tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
 
 - name: s3-iam
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/s3-resource
     tag: 96b47010a10ca13b40bc604b49b4ab9158cfe2c7
 
 - name: semver-iam
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/semver-resource
     tag: f2a80c95481056aa57d837e3b14f0012b542fdb3
 
 - name: grafana-annotation
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/grafana-annotation-resource
     tag: 140506423e1194319fc1e2ed7f8d04a36ca61ae3
 
 - name: slack-notification-resource
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/slack-notification-resource
     tag: edd15a5700df670874871fe03fa098e28d89faea
@@ -842,7 +842,7 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
               tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
@@ -5411,7 +5411,7 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/spruce
               tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
@@ -6685,7 +6685,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: ghcr.io/alphagov/paas/cf-uaac
             tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -41,7 +41,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/alpine
-              tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+              tag: b25554b10d0efb9da2aef192f9a890199863f59e
           inputs:
             - name: paas-cf
             - name: deployment-timer
@@ -71,7 +71,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/awscli
-              tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+              tag: b25554b10d0efb9da2aef192f9a890199863f59e
 
           run:
             path: ./paas-cf/concourse/scripts/rds_instances.sh
@@ -86,7 +86,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+              tag: b25554b10d0efb9da2aef192f9a890199863f59e
 
           inputs:
             - name: paas-cf
@@ -119,7 +119,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+              tag: b25554b10d0efb9da2aef192f9a890199863f59e
 
           inputs:
             - name: paas-cf

--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -4,7 +4,7 @@ resource_types:
   # version of the resource_type `git`. As a temporary fix we have docker image
   # of the resource. This resource_type can be deleted when the issue is resolved
   - name: git
-    type: docker-image
+    type: registry-image
     source:
       repository: ghcr.io/alphagov/paas/git-resource
       tag: 1f84d4a76b4a2491283e0107ae7ed4bc83c84d1b
@@ -38,7 +38,7 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/alpine
               tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
@@ -68,7 +68,7 @@ jobs:
             AWS_DEFAULT_REGION: ((aws_region))
             DEPLOY_ENV: ((deploy_env))
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/awscli
               tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
@@ -83,7 +83,7 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
               tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
@@ -116,7 +116,7 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
               tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -4,19 +4,19 @@ resource_types:
   # version of the resource_type `git`. As a temporary fix we have docker image
   # of the resource. This resource_type can be deleted when the issue is resolved
 - name: git
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/git-resource
     tag: 1f84d4a76b4a2491283e0107ae7ed4bc83c84d1b
 
 - name: s3-iam
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/s3-resource
     tag: 96b47010a10ca13b40bc604b49b4ab9158cfe2c7
 
 - name: semver-iam
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/semver-resource
     tag: f2a80c95481056aa57d837e3b14f0012b542fdb3
@@ -96,7 +96,7 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
               tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
@@ -141,7 +141,7 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/cf-cli
               tag: 1b0fef4a74c771a23dbdf67cd830dc08b9c49258
@@ -186,7 +186,7 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/bosh-cli-v2
               tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
@@ -240,7 +240,7 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/ruby
               tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
@@ -283,7 +283,7 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/terraform
               tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -99,7 +99,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+              tag: b25554b10d0efb9da2aef192f9a890199863f59e
 
           inputs:
             - name: paas-cf
@@ -189,7 +189,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/bosh-cli-v2
-              tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+              tag: b25554b10d0efb9da2aef192f9a890199863f59e
 
           inputs:
             - name: bosh-vars-store
@@ -243,7 +243,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/ruby
-              tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+              tag: b25554b10d0efb9da2aef192f9a890199863f59e
           inputs:
             - name: paas-cf
             - name: cf-tfstate
@@ -286,7 +286,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/terraform
-              tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+              tag: b25554b10d0efb9da2aef192f9a890199863f59e
 
           inputs:
             - name: terraform-variables

--- a/concourse/pipelines/monitor-remote.yml
+++ b/concourse/pipelines/monitor-remote.yml
@@ -4,13 +4,13 @@ resource_types:
   # version of the resource_type `git`. As a temporary fix we have docker image
   # of the resource. This resource_type can be deleted when the issue is resolved
 - name: git
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/git-resource
     tag: 1f84d4a76b4a2491283e0107ae7ed4bc83c84d1b
 
 - name: s3-iam
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/s3-resource
     tag: 96b47010a10ca13b40bc604b49b4ab9158cfe2c7
@@ -54,7 +54,7 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
           repository: ghcr.io/alphagov/paas/self-update-pipelines
           tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/pipelines/monitor-remote.yml
+++ b/concourse/pipelines/monitor-remote.yml
@@ -57,7 +57,7 @@ jobs:
         type: registry-image
         source:
           repository: ghcr.io/alphagov/paas/self-update-pipelines
-          tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+          tag: b25554b10d0efb9da2aef192f9a890199863f59e
 
       inputs:
       - name: paas-cf

--- a/concourse/pipelines/test-certificate-rotation.yml
+++ b/concourse/pipelines/test-certificate-rotation.yml
@@ -2,25 +2,25 @@
 meta:
   containers:
     awscli: &awscli-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
 
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
 
     cf-acceptance-tests: &cf-acceptance-tests-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/cf-acceptance-tests
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
 
     cf-cli: &cf-cli-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/cf-cli
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
@@ -31,25 +31,25 @@ resource_types:
   # version of the resource_type `git`. As a temporary fix we have docker image
   # of the resource. This resource_type can be deleted when the issue is resolved
   - name: git
-    type: docker-image
+    type: registry-image
     source:
       repository: ghcr.io/alphagov/paas/git-resource
       tag: 1f84d4a76b4a2491283e0107ae7ed4bc83c84d1b
 
   - name: metadata
-    type: docker-image
+    type: registry-image
     source:
       repository: ghcr.io/alphagov/paas/olhtbr-metadata-resource
       tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
 
   - name: s3-iam
-    type: docker-image
+    type: registry-image
     source:
       repository: ghcr.io/alphagov/paas/s3-resource
       tag: 96b47010a10ca13b40bc604b49b4ab9158cfe2c7
 
   - name: semver-iam
-    type: docker-image
+    type: registry-image
     source:
       repository: ghcr.io/alphagov/paas/semver-resource
       tag: f2a80c95481056aa57d837e3b14f0012b542fdb3

--- a/concourse/pipelines/test-certificate-rotation.yml
+++ b/concourse/pipelines/test-certificate-rotation.yml
@@ -5,25 +5,25 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
 
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
 
     cf-acceptance-tests: &cf-acceptance-tests-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
 
     cf-cli: &cf-cli-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/cf-cli
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
 
 
 resource_types:
@@ -40,7 +40,7 @@ resource_types:
     type: registry-image
     source:
       repository: ghcr.io/alphagov/paas/olhtbr-metadata-resource
-      tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+      tag: b25554b10d0efb9da2aef192f9a890199863f59e
 
   - name: s3-iam
     type: registry-image

--- a/concourse/scripts/environment.sh
+++ b/concourse/scripts/environment.sh
@@ -28,9 +28,7 @@ case $TARGET_CONCOURSE in
     ;;
 esac
 
-if [ "$USER" == "root" ] ; then
-  # We are running in Concourse
-  : "${CONCOURSE_WEB_PASSWORD:?CONCOURSE_WEB_PASSWORD must be set}"
+if [[ -n "$CONCOURSE_WEB_PASSWORD" ]] ;then
   cat <<EOF
 export CONCOURSE_WEB_USER=${CONCOURSE_WEB_USER:-admin}
 export CONCOURSE_WEB_PASSWORD=${CONCOURSE_WEB_PASSWORD}

--- a/concourse/tasks/aiven-broker-acceptance-tests-run.yml
+++ b/concourse/tasks/aiven-broker-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+    tag: b25554b10d0efb9da2aef192f9a890199863f59e
 inputs:
   - name: paas-cf
   - name: test-config

--- a/concourse/tasks/aiven-broker-acceptance-tests-run.yml
+++ b/concourse/tasks/aiven-broker-acceptance-tests-run.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
     tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/tasks/app-autoscaler-acceptance-tests-run.yml
+++ b/concourse/tasks/app-autoscaler-acceptance-tests-run.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
     tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/tasks/app-autoscaler-acceptance-tests-run.yml
+++ b/concourse/tasks/app-autoscaler-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+    tag: b25554b10d0efb9da2aef192f9a890199863f59e
 inputs:
   - name: paas-cf
   - name: admin-creds

--- a/concourse/tasks/check-az-is-enabled-in-manifest.yml
+++ b/concourse/tasks/check-az-is-enabled-in-manifest.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
     tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/tasks/check-az-is-enabled-in-manifest.yml
+++ b/concourse/tasks/check-az-is-enabled-in-manifest.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+    tag: b25554b10d0efb9da2aef192f9a890199863f59e
 params:
   DEPLOY_ENV:
   BOSH_ENVIRONMENT:

--- a/concourse/tasks/check-az-is-enabled-in-vpc.yml
+++ b/concourse/tasks/check-az-is-enabled-in-vpc.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
     tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/tasks/check-az-is-enabled-in-vpc.yml
+++ b/concourse/tasks/check-az-is-enabled-in-vpc.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+    tag: b25554b10d0efb9da2aef192f9a890199863f59e
 params:
   AWS_DEFAULT_REGION:
   EXPECTED_ACL_NAME:

--- a/concourse/tasks/check-billing-comparison-with-cf.yml
+++ b/concourse/tasks/check-billing-comparison-with-cf.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
     tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/tasks/check-billing-comparison-with-cf.yml
+++ b/concourse/tasks/check-billing-comparison-with-cf.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+    tag: b25554b10d0efb9da2aef192f9a890199863f59e
 inputs:
   - name: paas-billing
 params:

--- a/concourse/tasks/configure-grafana.yml
+++ b/concourse/tasks/configure-grafana.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/ruby
     tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/tasks/configure-grafana.yml
+++ b/concourse/tasks/configure-grafana.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/ruby
-    tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+    tag: b25554b10d0efb9da2aef192f9a890199863f59e
 inputs:
   - name: paas-trusted-people
 run:

--- a/concourse/tasks/create_admin.yml
+++ b/concourse/tasks/create_admin.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-uaac
-    tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+    tag: b25554b10d0efb9da2aef192f9a890199863f59e
 inputs:
   - name: paas-cf
   - name: cf-manifest

--- a/concourse/tasks/create_admin.yml
+++ b/concourse/tasks/create_admin.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-uaac
     tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/tasks/cronitor-monitor-ping-action.yml
+++ b/concourse/tasks/cronitor-monitor-ping-action.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
     tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/tasks/cronitor-monitor-ping-action.yml
+++ b/concourse/tasks/cronitor-monitor-ping-action.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+    tag: b25554b10d0efb9da2aef192f9a890199863f59e
 run:
   path: sh
   args:

--- a/concourse/tasks/curl-az-healthcheck.yml
+++ b/concourse/tasks/curl-az-healthcheck.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/curl-ssl
     tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/tasks/curl-az-healthcheck.yml
+++ b/concourse/tasks/curl-az-healthcheck.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/curl-ssl
-    tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+    tag: b25554b10d0efb9da2aef192f9a890199863f59e
 params:
   AVAILABILITY_ZONE:
   ENABLE_AZ_HEALTHCHECK:

--- a/concourse/tasks/custom-acceptance-tests-run.yml
+++ b/concourse/tasks/custom-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+    tag: b25554b10d0efb9da2aef192f9a890199863f59e
 inputs:
   - name: paas-cf
   - name: test-config

--- a/concourse/tasks/custom-acceptance-tests-run.yml
+++ b/concourse/tasks/custom-acceptance-tests-run.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
     tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/tasks/custom-broker-acceptance-tests-run.yml
+++ b/concourse/tasks/custom-broker-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+    tag: b25554b10d0efb9da2aef192f9a890199863f59e
 inputs:
   - name: paas-cf
   - name: test-config

--- a/concourse/tasks/custom-broker-acceptance-tests-run.yml
+++ b/concourse/tasks/custom-broker-acceptance-tests-run.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
     tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/tasks/delete_admin.yml
+++ b/concourse/tasks/delete_admin.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
     tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/tasks/delete_admin.yml
+++ b/concourse/tasks/delete_admin.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
-    tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+    tag: b25554b10d0efb9da2aef192f9a890199863f59e
 inputs:
   - name: paas-cf
   - name: cf-manifest

--- a/concourse/tasks/forget-access-keys.yml
+++ b/concourse/tasks/forget-access-keys.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/terraform
     tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/tasks/forget-access-keys.yml
+++ b/concourse/tasks/forget-access-keys.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/terraform
-    tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+    tag: b25554b10d0efb9da2aef192f9a890199863f59e
 inputs:
   - name: paas-cf
   - name: cf-tfstate

--- a/concourse/tasks/generate-git-keys.yml
+++ b/concourse/tasks/generate-git-keys.yml
@@ -3,7 +3,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+    tag: b25554b10d0efb9da2aef192f9a890199863f59e
 run:
   path: sh
   args:

--- a/concourse/tasks/generate-git-keys.yml
+++ b/concourse/tasks/generate-git-keys.yml
@@ -1,6 +1,6 @@
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
     tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/tasks/generate-test-config.yml
+++ b/concourse/tasks/generate-test-config.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
     tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/tasks/generate-test-config.yml
+++ b/concourse/tasks/generate-test-config.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+    tag: b25554b10d0efb9da2aef192f9a890199863f59e
 inputs:
   - name: paas-cf
   - name: admin-creds

--- a/concourse/tasks/get-cf-cli-config.yml
+++ b/concourse/tasks/get-cf-cli-config.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/ruby
     tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/tasks/get-cf-cli-config.yml
+++ b/concourse/tasks/get-cf-cli-config.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/ruby
-    tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+    tag: b25554b10d0efb9da2aef192f9a890199863f59e
 inputs:
   - name: paas-cf
   - name: cf-manifest

--- a/concourse/tasks/remove-db.yml
+++ b/concourse/tasks/remove-db.yml
@@ -7,7 +7,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
-    tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+    tag: b25554b10d0efb9da2aef192f9a890199863f59e
 run:
   path: sh
   args:

--- a/concourse/tasks/remove-db.yml
+++ b/concourse/tasks/remove-db.yml
@@ -4,7 +4,7 @@ inputs:
   - name: paas-cf
   - name: config
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
     tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/tasks/send-nagging-email-alert.yml
+++ b/concourse/tasks/send-nagging-email-alert.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
     tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/tasks/send-nagging-email-alert.yml
+++ b/concourse/tasks/send-nagging-email-alert.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+    tag: b25554b10d0efb9da2aef192f9a890199863f59e
 inputs:
   - name: paas-cf
 params:

--- a/concourse/tasks/smoke-tests-run.yml
+++ b/concourse/tasks/smoke-tests-run.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
     tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/tasks/smoke-tests-run.yml
+++ b/concourse/tasks/smoke-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+    tag: b25554b10d0efb9da2aef192f9a890199863f59e
 inputs:
   - name: paas-cf
   - name: cf-smoke-tests-release

--- a/concourse/tasks/tag-repo.yml
+++ b/concourse/tasks/tag-repo.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/git-ssh
-    tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+    tag: b25554b10d0efb9da2aef192f9a890199863f59e
 inputs:
   - name: git-repo
 params:

--- a/concourse/tasks/tag-repo.yml
+++ b/concourse/tasks/tag-repo.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/git-ssh
     tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/tasks/upload-test-artifacts.yml
+++ b/concourse/tasks/upload-test-artifacts.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
     tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/tasks/upload-test-artifacts.yml
+++ b/concourse/tasks/upload-test-artifacts.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+    tag: b25554b10d0efb9da2aef192f9a890199863f59e
 inputs:
   - name: paas-cf
   - name: artifacts

--- a/concourse/tasks/wait-for-api-availability-tests.yml
+++ b/concourse/tasks/wait-for-api-availability-tests.yml
@@ -11,7 +11,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+    tag: b25554b10d0efb9da2aef192f9a890199863f59e
 run:
   path: sh
   args:

--- a/concourse/tasks/wait-for-app-availability-tests.yml
+++ b/concourse/tasks/wait-for-app-availability-tests.yml
@@ -13,7 +13,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
-    tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+    tag: b25554b10d0efb9da2aef192f9a890199863f59e
 run:
   path: sh
   args:


### PR DESCRIPTION
What
----

Update docker images to include cf cli 8.6.0

I had issues with the new images and docker-image. The images would fail to download with the error ['version is missing from previous step'](https://deployer.dev05.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse/jobs/update-pipeline/builds/3#L63efb5b9/image-check:1). I've switched to the new and improved 'registry-image' resource to resolve this issue.

How to review
-------------

[Tested in dev05](https://deployer.dev05.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/pipeline-lock/builds/38)

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
