### PR TITLE
Upgrade app-autoscaler to v10.0.0

### DIFF
--- a/concourse/tasks/app-autoscaler-acceptance-tests-run.yml
+++ b/concourse/tasks/app-autoscaler-acceptance-tests-run.yml
@@ -26,6 +26,8 @@ run:
       echo "Generating configuration"
       CONFIG="$(pwd)/config.json"
       export CONFIG
+      # TODO: setting node_memory_limit to 256MB is a workaround for https://github.com/cloudfoundry/app-autoscaler-release/issues/1059
+      #       remove once this is fixed.
       cat <<EOF > "$CONFIG"
       {
         "service_name": "autoscaler",
@@ -36,7 +38,7 @@ run:
 
         "default_timeout": 60,
         "sleep_timeout": 60,
-
+        "node_memory_limit": 256,
         "api": "api.$SYSTEM_DOMAIN",
         "autoscaler_api": "autoscaler.$SYSTEM_DOMAIN",
         "apps_domain": "$APPS_DOMAIN",
@@ -56,6 +58,7 @@ run:
 
       echo "Running tests"
       cd paas-cf/manifests/app-autoscaler/upstream
-      source .envrc
+      PATH=$(go env GOPATH)/bin:${PATH}
+      export PATH
       cd src/acceptance
       ./bin/test_default -procs 4 --compilers 4 --poll-progress-after=120s --poll-progress-interval=30s

--- a/manifests/app-autoscaler/operations.d/001-release.yml
+++ b/manifests/app-autoscaler/operations.d/001-release.yml
@@ -4,6 +4,6 @@
   path: /releases/name=app-autoscaler?
   value:
     name: app-autoscaler
-    version: "8.0.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=8.0.0"
-    sha1: "6ffb5a1abad93ea11ffbacd00fe418538307b008"
+    version: "10.0.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=10.0.0"
+    sha1: "f691986b6f14e5bc1974e8c0b02996e9e2497a61"

--- a/manifests/app-autoscaler/operations.d/900-temp-fix-for-v10.0.0.yml
+++ b/manifests/app-autoscaler/operations.d/900-temp-fix-for-v10.0.0.yml
@@ -1,0 +1,11 @@
+# We have experienced an issue with the v10.0.0 upgrade
+# See https://github.com/cloudfoundry/app-autoscaler-release/issues/1461 .
+# This file is a temp workaround and can be removed for the next release.
+
+- type: replace
+  path: /releases/name=postgres?
+  value:
+    name: "postgres"
+    version: "44"
+    url: "https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=44"
+    sha1: "582b1de9522077102dfa44ff7164cd8f499dbfc8"

--- a/manifests/app-autoscaler/operations.d/910-add-plan-options.yml
+++ b/manifests/app-autoscaler/operations.d/910-add-plan-options.yml
@@ -1,0 +1,7 @@
+- type: replace
+  path: /instance_groups/name=asapi/jobs/name=golangapiserver/properties/autoscaler/apiserver/broker/server/catalog/services/name=autoscaler/instances_retrievable?
+  value: true
+
+- type: replace
+  path: /instance_groups/name=asapi/jobs/name=golangapiserver/properties/autoscaler/apiserver/broker/server/catalog/services/name=autoscaler/bindings_retrievable?
+  value: true


### PR DESCRIPTION
What
----

Upgrade autoscaler to v10.0.0.

A few issues were discovered during the upgrade:
- They've switched their .envrc file to be "not bash". So I've just put in the PATH changes into our pipeline.
- They failed to update the release url in our deployment template. [Here is the issue.](https://github.com/cloudfoundry/app-autoscaler-release/issues/1461)
- They failed to add the settings instances_retrievable and bindings_retrievable to the [app-autoscaler-deployment.yml](https://github.com/cloudfoundry/app-autoscaler-release/blob/main/templates/app-autoscaler-deployment.yml) template. We should look to migrate to their "tested" template [app-autoscaler.yml](https://github.com/cloudfoundry/app-autoscaler-release/blob/main/templates/app-autoscaler.yml).
- They have broken the memory tests when only using 128mb of memory. [Here is the issue](https://github.com/cloudfoundry/app-autoscaler-release/issues/1059). I've increase the node memory size to 256 to workaround this. 

How to review
-------------

[Tested in dev02](https://deployer.dev02.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/pipeline-lock/builds/389)

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
