### PR TITLE
[#180362804] Logit flatline alerts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1406,6 +1406,7 @@ GEM
       hashdiff
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-21
 
 DEPENDENCIES

--- a/Makefile
+++ b/Makefile
@@ -484,8 +484,16 @@ logit-filters:
 		-v $(CURDIR):/mnt:ro \
 		-v $(CURDIR)/config/logit/output:/output:rw \
 		-w /mnt \
+		--platform linux/amd64 \
 		jruby:9.2-alpine ./scripts/generate_logit_filters.sh $(LOGSEARCH_BOSHRELEASE_TAG) $(LOGSEARCH_FOR_CLOUDFOUNDRY_TAG)
 	@echo "updated $(CURDIR)/config/logit/output/generated_logit_filters.conf"
+
+.PHONY: logit-alerts
+logit-alerts:
+	$(if ${DEPLOY_ENV},,$(error Must pass DEPLOY_ENV=<name>))
+	$(if $(wildcard ${PAAS_PASSWORD_STORE_DIR}),,$(error Password store ${PAAS_PASSWORD_STORE_DIR} (PAAS_PASSWORD_STORE_DIR) does not exist))
+	$(eval export PASSWORD_STORE_DIR=${PAAS_PASSWORD_STORE_DIR})
+	@ruby ./scripts/generate_logit_alerts.rb
 
 .PHONY: show-tenant-comms-addresses
 show-tenant-comms-addresses:

--- a/config/logit/alerts.d/flatline.yaml.erb
+++ b/config/logit/alerts.d/flatline.yaml.erb
@@ -1,0 +1,24 @@
+---
+name: "Flatline alert: source.deployment:<%= deploy_env %>"
+type: flatline
+index: "logstash-*"
+
+threshold: 1200
+
+timeframe:
+  minutes: 10
+
+filter:
+- query:
+    query_string:
+      query: "@source.deployment:<%= deploy_env %>"
+
+use_count_query: true
+
+doc_type: logs
+
+alert:
+  - "pagerduty"
+
+pagerduty_service_key: "<%= pagerduty_service_key %>"
+pagerduty_client_name: "<%= pagerduty_client_name %>"

--- a/scripts/generate_logit_alerts.rb
+++ b/scripts/generate_logit_alerts.rb
@@ -1,0 +1,54 @@
+#!/usr/bin/env ruby
+
+require "erb"
+require "English"
+
+def retrieve_from_paas_pass(path)
+  result = `pass #{path}`.strip
+
+  unless $CHILD_STATUS.success?
+    raise "Failed to retrieve #{path} with `pass`."
+  end
+
+  result
+end
+
+deploy_env = ENV["DEPLOY_ENV"]
+
+if deploy_env.nil?
+  raise "$DEPLOY_ENV not set"
+end
+
+secret_env = ENV["MAKEFILE_ENV_TARGET"]
+
+if secret_env.nil?
+  raise "$MAKEFILE_ENV_TARGET not set"
+end
+
+logit_env = case secret_env
+            when /^prod.*/
+              "prod"
+            else
+              secret_env
+            end
+
+logit_account_uuid = retrieve_from_paas_pass("logit/account_id")
+stack_id = retrieve_from_paas_pass("logit/#{logit_env}/stack_id")
+
+logit_alert_url = "https://dashboard.logit.io/a/#{logit_account_uuid}/s/#{stack_id}/logs-settings/elastalert/viewrules"
+pagerduty_service_key = retrieve_from_paas_pass("pagerduty/#{secret_env}/missing_logs_service_key")
+
+pagerduty_client_name = "GOV.UK PaaS #{secret_env} Logit alerts"
+
+warn "The following must be added to the logit config manually on the logit dashboard."
+warn "Logit `#{logit_env}` stack alerting rules: #{logit_alert_url}"
+warn "Either update the existing files or create new ones."
+
+Dir.foreach("config/logit/alerts.d") do |file|
+  next unless file.end_with?(".yaml.erb")
+
+  template = ERB.new(File.read("config/logit/alerts.d/#{file}"))
+  warn "Filename: #{deploy_env}__#{file.gsub(/\.erb$/, '')}"
+  warn "Contents:\n\n"
+  puts template.result(binding)
+end

--- a/scripts/generate_logit_filters.sh
+++ b/scripts/generate_logit_filters.sh
@@ -46,14 +46,14 @@ wget -q -O /tmp/syslog_standard.conf "https://raw.githubusercontent.com/cloudfou
 
 echo "filter {" > /output/generated_logit_filters.conf
 {
-    sed 's/^/  /' < /mnt/config/logit/10_base.conf
+    sed 's/^/  /' < /mnt/config/logit/filters.d/10_base.conf
     sed 's/^/  /' < /tmp/redact_passwords.conf
     sed 's/^/  /' < /tmp/syslog_standard.conf
-    sed 's/^/  /' < /mnt/config/logit/11_app_syslog_drain.conf
+    sed 's/^/  /' < /mnt/config/logit/filters.d/11_app_syslog_drain.conf
     sed 's/^/  /' < /tmp/logsearch-for-cloudfoundry/src/logsearch-config/target/logstash-filters-default.conf
-    sed 's/^/  /' < /mnt/config/logit/20_custom_cf_filters.conf
-    sed 's/^/  /' < /mnt/config/logit/21_paas_billing_filters.conf
-    sed 's/^/  /' < /mnt/config/logit/30_various_timestamps.conf
+    sed 's/^/  /' < /mnt/config/logit/filters.d/20_custom_cf_filters.conf
+    sed 's/^/  /' < /mnt/config/logit/filters.d/21_paas_billing_filters.conf
+    sed 's/^/  /' < /mnt/config/logit/filters.d/30_various_timestamps.conf
     echo "}"
 } >> /output/generated_logit_filters.conf
 

--- a/tools/cops/backtick_cop.rb
+++ b/tools/cops/backtick_cop.rb
@@ -9,7 +9,22 @@ module RuboCop
         def on_xstr(node)
           return if node.heredoc?
 
-          add_offense(node) unless node&.parent&.type == :lvasgn
+          current_node = node
+          has_lvasgn_ancestor = false
+          loop do
+            break if current_node.nil?
+            break if current_node.type == :begin
+
+            if current_node.type == :lvasgn
+              has_lvasgn_ancestor = true
+              break
+            end
+            current_node = current_node.parent
+          end
+
+          unless has_lvasgn_ancestor
+            add_offense(node)
+          end
         end
       end
 

--- a/tools/cops/spec/backtick_cop_spec.rb
+++ b/tools/cops/spec/backtick_cop_spec.rb
@@ -36,6 +36,17 @@ RSpec.describe RuboCop::Cop::CustomCops::MustCaptureXStr do
 
         expect(cop.offenses).to be_empty
       end
+
+      context "but is worked on first" do
+        it "detects no offenses" do
+          inspect_source <<~RUBY
+            my_var = `echo hello world`.strip
+            my_other_var = `echo hello world`.strip.upcase.strip
+          RUBY
+
+          expect(cop.offenses).to be_empty
+        end
+      end
     end
   end
 


### PR DESCRIPTION
What
----

Add script to create the content of alert yaml files for logit

The one alert I've created is for a flatline alert - if fewer than 1200 log entries are received in 10 minutes, the alert will fire.

This alert is sent to pagerduty. Currently the pagerduty alert is only for GOV.UK PaaS Email only - this is changed from within PagerDuty, though.

Also, I've fixed the `backtick` custom cop - it didn't allow me to do a thing (which it should have) so I have fixed that.

This is blocked by https://github.com/alphagov/paas-credentials/pull/242 - as currently the secrets are only present on my local machine.

How to review
-------------

- Code Review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
