### PR TITLE
[#180635817] Improve tests

### DIFF
--- a/manifests/cf-manifest/isolation-segments/prod-lon/egress-restricted-1.yml
+++ b/manifests/cf-manifest/isolation-segments/prod-lon/egress-restricted-1.yml
@@ -1,5 +1,5 @@
 ---
-number_of_cells: 2
+number_of_cells: 3
 isolation_segment_name: egress-restricted-1
 isolation_segment_size: small
 restricted_egress: true

--- a/manifests/cf-manifest/spec/manifest/instance_type_counts_in_envs_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/instance_type_counts_in_envs_spec.rb
@@ -5,11 +5,17 @@ end
 RSpec.shared_examples "evenly distributable" do |group_name|
   it "by ensuring instance count is a multiple of AZ count" do
     expect(group_name).not_to be_nil
-    ig = subject.fetch("instance_groups.#{group_name}")
-    az_count = ig.fetch("azs").size
-    instance_count = ig.fetch("instances")
-    expect(instance_count % az_count).to eq(0),
-      group_name + " instance count (#{instance_count}) is not divisible by AZ count (#{az_count})"
+
+    # The loop ensures that both diego-cell and diego-cell-* are covered
+    subject.fetch("instance_groups").each do |ig|
+      ig_name = ig["name"]
+      next unless ig_name.start_with?(group_name)
+
+      az_count = ig.fetch("azs").size
+      instance_count = ig.fetch("instances")
+      expect(instance_count % az_count).to eq(0),
+        ig_name + " instance count (#{instance_count}) is not divisible by AZ count (#{az_count})"
+    end
   end
 end
 
@@ -39,15 +45,10 @@ RSpec.describe "Instance counts in different environments" do
           cc_worker_ig = env_manifest.fetch("instance_groups.cc-worker")
           api_instance_count = env_manifest.fetch("instance_groups.api")["instances"].to_f
           cc_worker_instances_count = cc_worker_ig["instances"].to_f
-          # Comment out check for overreaching instance count for now:
-          # This check does not consider cells in isolation segments
-          # cc_worker_az_count = cc_worker_ig.fetch("azs").size
 
           half = api_instance_count / 2
-          # half_with_headroom = round_up(half, cc_worker_az_count) + cc_worker_az_count
 
           expect(cc_worker_instances_count).to be >= half, "cc-worker instance count #{cc_worker_instances_count} is wrong. Rule of thumb is there should be at least half the count of api in cc-workers. Currently set to #{cc_worker_instances_count}, expecting at least #{half}."
-          # expect(cc_worker_instances_count).to be <= half_with_headroom, "cc-worker instance count #{cc_worker_instances_count} is too high. There is no need to allow more headroom than a single set of #{cc_worker_az_count}. Currently set to #{cc_worker_instances_count}, expecting at least #{half_with_headroom}."
         end
       end
 
@@ -56,15 +57,10 @@ RSpec.describe "Instance counts in different environments" do
           scheduler_ig = env_manifest.fetch("instance_groups.scheduler")
           api_instance_count = env_manifest.fetch("instance_groups.api")["instances"].to_f
           scheduler_instances_count = scheduler_ig["instances"].to_f
-          # Comment out check for overreaching instance count for now:
-          # This check does not consider cells in isolation segments
-          # scheduler_az_count = scheduler_ig.fetch("azs").size
 
           half = api_instance_count / 2
-          # half_with_headroom = round_up(half, scheduler_az_count) + scheduler_az_count
 
           expect(scheduler_instances_count).to be >= half, "scheduler instance count #{scheduler_instances_count} is wrong. Rule of thumb is there should be at least half the count of api in schedulers. Currently set to #{scheduler_instances_count}, expecting at least #{half}."
-          # expect(scheduler_instances_count).to be <= half_with_headroom, "log-api instance count #{scheduler_instances_count} is too high. There is no need to allow more headroom than a single set of #{scheduler_az_count}. Currently set to #{scheduler_instances_count}, expecting at least #{half_with_headroom}."
         end
       end
     end

--- a/manifests/cf-manifest/spec/manifest/isolation_segment_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/isolation_segment_spec.rb
@@ -299,7 +299,7 @@ RSpec.describe "isolation_segments" do
       it "contains an non-empty egress restricted isolation segment" do
         expect(segs.count).to eq(1)
         seg = segs.first
-        expect(seg["instances"]).to eq(2)
+        expect(seg["instances"]).to be >= 2
         expect(seg["jobs"].find { |j| j["name"] == "coredns" }).not_to be_nil
       end
     end


### PR DESCRIPTION
## What

### Improve instance_type_counts tests

- when checking for evenly distributable instance groups, check all
  instance groups that start with the given name, not just the first one
  that matches. This means we take isolation segment diego-cell count
  into account

- remove commented out code - we have managed to last for a while
  without it, so should be fine to remove it

###  Increase number of cells in egress-restricted-1

This is required because we are now testing the number of cells in isolation segments, and 2 is not divisible by 3.

## How to review

- ensure the tests run correctly in GHA
- code review :eyes:

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
