### PR TITLE
grafana dashboards: update usage-by-(org/space) with request time panel

### DIFF
--- a/manifests/prometheus/dashboards.d/usage-by-organization.json
+++ b/manifests/prometheus/dashboards.d/usage-by-organization.json
@@ -22,49 +22,81 @@
     "links": [],
     "panels": [
       {
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": null,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
         "fieldConfig": {
-          "defaults": {},
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 100,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 0,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "bytes"
+          },
           "overrides": []
         },
-        "fill": 10,
-        "fillGradient": 0,
         "gridPos": {
           "h": 10,
           "w": 8,
           "x": 0,
           "y": 0
         },
-        "hiddenSeries": false,
         "id": 2,
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 0,
-        "nullPointMode": "null as zero",
         "options": {
-          "alertThreshold": true
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
         },
-        "percentage": false,
-        "pluginVersion": "7.5.16",
-        "pointradius": 2,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": true,
-        "steppedLine": false,
+        "pluginVersion": "8.5.15",
         "targets": [
           {
             "exemplar": true,
@@ -75,94 +107,85 @@
             "refId": "A"
           }
         ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
         "title": "Total container memory",
-        "tooltip": {
-          "shared": true,
-          "sort": 2,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "$$hashKey": "object:80",
-            "format": "bytes",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": "0",
-            "show": true
-          },
-          {
-            "$$hashKey": "object:81",
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
+        "type": "timeseries"
       },
       {
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": null,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
         "description": "Lacking a real (and sufficiently-labeled) metric for containers being started, this actually measures the number of very young containers attributable to an organization.\n\nA surge of apparent container starts *could* indicate a lot of crashes and attempted restarts.\n\nAttempted container starts that don't even manage to live for a minute will probably get missed from this plot.",
         "fieldConfig": {
-          "defaults": {},
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 100,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 0,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "cpm"
+          },
           "overrides": []
         },
-        "fill": 10,
-        "fillGradient": 0,
         "gridPos": {
           "h": 10,
           "w": 8,
           "x": 8,
           "y": 0
         },
-        "hiddenSeries": false,
         "id": 8,
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 0,
-        "nullPointMode": "null as zero",
         "options": {
-          "alertThreshold": true
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
         },
-        "percentage": false,
-        "pluginVersion": "7.5.16",
-        "pointradius": 2,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": true,
-        "steppedLine": false,
+        "pluginVersion": "8.5.15",
         "targets": [
           {
             "exemplar": false,
@@ -173,58 +196,17 @@
             "refId": "A"
           }
         ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
         "title": "Total container start rate (approx)",
-        "tooltip": {
-          "shared": true,
-          "sort": 2,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "$$hashKey": "object:65",
-            "format": "cpm",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          },
-          {
-            "$$hashKey": "object:66",
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
+        "type": "timeseries"
       },
       {
         "aliasColors": {},
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": null,
-        "fieldConfig": {
-          "defaults": {},
-          "overrides": []
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
         },
         "fill": 10,
         "fillGradient": 0,
@@ -252,7 +234,7 @@
           "alertThreshold": true
         },
         "percentage": false,
-        "pluginVersion": "7.5.16",
+        "pluginVersion": "8.5.15",
         "pointradius": 2,
         "points": false,
         "renderer": "flot",
@@ -263,7 +245,7 @@
         "targets": [
           {
             "exemplar": true,
-            "expr": "sum(sum(rate(firehose_http_start_stop_requests{environment=~\"$environment\", bosh_deployment=~\"$bosh_deployment\", status_code=~\"$status_codes_pattern\"}[5m])) by (application_id) * on(application_id) group_right group(cf_application_info{organization_name!~\"[A-Z]+-.*\"}) by (application_id, organization_name)) by (organization_name)",
+            "expr": "sum(sum(rate(firehose_http_start_stop_requests{environment=~\"$environment\", bosh_deployment=~\"$bosh_deployment\", status_code=~\"$status_codes_pattern\", method=~\"$methods_pattern\"}[5m])) by (application_id) * on(application_id) group_right group(cf_application_info{organization_name!~\"[A-Z]+-.*\"}) by (application_id, organization_name)) by (organization_name)",
             "interval": "",
             "intervalFactor": 2,
             "legendFormat": "{{ organization_name }}",
@@ -271,10 +253,8 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
         "timeRegions": [],
-        "timeShift": null,
-        "title": "Total request rate ($status_codes_pattern)",
+        "title": "Total request rate ($status_codes_pattern, $methods_pattern)",
         "tooltip": {
           "shared": true,
           "sort": 2,
@@ -282,9 +262,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -292,71 +270,97 @@
           {
             "$$hashKey": "object:80",
             "format": "reqps",
-            "label": null,
             "logBase": 1,
-            "max": null,
             "min": "0",
             "show": true
           },
           {
             "$$hashKey": "object:81",
             "format": "short",
-            "label": null,
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ],
         "yaxis": {
-          "align": false,
-          "alignLevel": null
+          "align": false
         }
       },
       {
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": null,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
         "fieldConfig": {
-          "defaults": {},
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 100,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 0,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "short"
+          },
           "overrides": []
         },
-        "fill": 10,
-        "fillGradient": 0,
         "gridPos": {
           "h": 10,
           "w": 8,
           "x": 0,
           "y": 10
         },
-        "hiddenSeries": false,
         "id": 3,
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 0,
-        "nullPointMode": "null as zero",
         "options": {
-          "alertThreshold": true
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
         },
-        "percentage": false,
-        "pluginVersion": "7.5.16",
-        "pointradius": 2,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": true,
-        "steppedLine": false,
+        "pluginVersion": "8.5.15",
         "targets": [
           {
             "exemplar": true,
@@ -367,93 +371,86 @@
             "refId": "A"
           }
         ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
         "title": "Total container instances",
-        "tooltip": {
-          "shared": true,
-          "sort": 2,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "$$hashKey": "object:80",
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": "0",
-            "show": true
-          },
-          {
-            "$$hashKey": "object:81",
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
+        "type": "timeseries"
       },
       {
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": null,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
+        "description": "Doesn't include logs from gorouter, which will be approximately proportional to the request rate.",
         "fieldConfig": {
-          "defaults": {},
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 100,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 0,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "binBps"
+          },
           "overrides": []
         },
-        "fill": 10,
-        "fillGradient": 0,
         "gridPos": {
           "h": 10,
           "w": 8,
           "x": 8,
           "y": 10
         },
-        "hiddenSeries": false,
         "id": 6,
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 0,
-        "nullPointMode": "null as zero",
         "options": {
-          "alertThreshold": true
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
         },
-        "percentage": false,
-        "pluginVersion": "7.5.16",
-        "pointradius": 2,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": true,
-        "steppedLine": false,
+        "pluginVersion": "8.5.15",
         "targets": [
           {
             "exemplar": true,
@@ -464,145 +461,102 @@
             "refId": "A"
           }
         ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
         "title": "Total log rate",
-        "tooltip": {
-          "shared": true,
-          "sort": 2,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "$$hashKey": "object:80",
-            "format": "binBps",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": "0",
-            "show": true
-          },
-          {
-            "$$hashKey": "object:81",
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
+        "type": "timeseries"
       },
       {
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": null,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
+        "description": "Total amount of http connection time used during a time period (i.e. 60 * 1s connections would be 1 minute).\n\nUnit is seconds, but telling grafana that makes it list large values in weeks etc. - not very useful.\n\nSorry, no status-code filtering here.",
         "fieldConfig": {
-          "defaults": {},
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 100,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 0,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "short"
+          },
           "overrides": []
         },
-        "fill": 10,
-        "fillGradient": 0,
         "gridPos": {
           "h": 10,
           "w": 8,
           "x": 16,
           "y": 10
         },
-        "hiddenSeries": false,
-        "id": 5,
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 0,
-        "nullPointMode": "null as zero",
+        "id": 9,
         "options": {
-          "alertThreshold": true
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
         },
-        "percentage": false,
-        "pluginVersion": "7.5.16",
-        "pointradius": 2,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": true,
-        "steppedLine": false,
+        "pluginVersion": "8.5.15",
         "targets": [
           {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
             "exemplar": true,
-            "expr": "sum(sum(group(cf_service_plan_info{service_id=~\"$service_id\"}) without (instance) * on (service_plan_id) group_right group(cf_service_instance_info{environment=~\"$environment\", deployment=~\"$bosh_deployment\"}) without (instance)) by (space_id) * on (space_id) group_right group(cf_space_info) without (instance)) by (organization_id) * on(organization_id) group_right group(cf_organization_info{organization_name!~\"[A-Z]+-.*\"}) without (instance)",
+            "expr": "sum(sum(firehose_http_start_stop_server_request_duration_seconds_sum{environment=~\"$environment\", bosh_deployment=~\"$bosh_deployment\", method=~\"$methods_pattern\"}) by (application_id) * on(application_id) group_right group(cf_application_info{organization_name!~\"[A-Z]+-.*\"}) by (application_id, organization_name)) by (organization_name)",
             "interval": "",
-            "intervalFactor": 5,
+            "intervalFactor": 2,
             "legendFormat": "{{ organization_name }}",
             "refId": "A"
           }
         ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
-        "title": "Total service instances ($service_id)",
-        "tooltip": {
-          "shared": true,
-          "sort": 2,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "$$hashKey": "object:80",
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": "0",
-            "show": true
-          },
-          {
-            "$$hashKey": "object:81",
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
+        "title": "Total request time ($methods_pattern)",
+        "type": "timeseries"
       }
     ],
     "refresh": false,
@@ -614,16 +568,16 @@
     "templating": {
       "list": [
         {
-          "allValue": null,
           "current": {
             "selected": false,
             "text": "prod-lon",
             "value": "prod-lon"
           },
-          "datasource": "prometheus",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
           "definition": "",
-          "description": null,
-          "error": null,
           "hide": 0,
           "includeAll": false,
           "label": "Environment",
@@ -639,22 +593,21 @@
           "skipUrlSync": false,
           "sort": 1,
           "tagValuesQuery": "",
-          "tags": [],
           "tagsQuery": "",
           "type": "query",
           "useTags": false
         },
         {
-          "allValue": null,
           "current": {
             "selected": false,
             "text": "prod-lon",
             "value": "prod-lon"
           },
-          "datasource": "prometheus",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
           "definition": "",
-          "description": null,
-          "error": null,
           "hide": 0,
           "includeAll": false,
           "label": "Director",
@@ -670,22 +623,21 @@
           "skipUrlSync": false,
           "sort": 1,
           "tagValuesQuery": "",
-          "tags": [],
           "tagsQuery": "",
           "type": "query",
           "useTags": false
         },
         {
-          "allValue": null,
           "current": {
             "selected": false,
             "text": "prod-lon",
             "value": "prod-lon"
           },
-          "datasource": "prometheus",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
           "definition": "",
-          "description": null,
-          "error": null,
           "hide": 0,
           "includeAll": false,
           "label": "Deployment",
@@ -700,23 +652,20 @@
           "regex": "",
           "skipUrlSync": false,
           "sort": 1,
-          "tagValuesQuery": null,
-          "tags": [],
-          "tagsQuery": null,
           "type": "query",
           "useTags": false
         },
         {
-          "allValue": null,
           "current": {
             "selected": false,
             "text": "All",
             "value": "$__all"
           },
-          "datasource": "prometheus",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
           "definition": "label_values(bosh_job_healthy{environment=~\"$environment\",bosh_name=~\"$bosh_director\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\".*diego-cell.*\"}, bosh_job_name)",
-          "description": null,
-          "error": null,
           "hide": 0,
           "includeAll": true,
           "label": "Diego Job",
@@ -731,55 +680,19 @@
           "regex": "",
           "skipUrlSync": false,
           "sort": 1,
-          "tagValuesQuery": null,
-          "tags": [],
-          "tagsQuery": null,
           "type": "query",
           "useTags": false
         },
         {
-          "allValue": null,
-          "current": {
-            "selected": false,
-            "text": "All",
-            "value": "$__all"
-          },
-          "datasource": null,
-          "definition": "query_result(cf_service_info and on(service_id) (cf_service_plan_info and on(service_plan_id) cf_service_instance_info))",
-          "description": null,
-          "error": null,
-          "hide": 0,
-          "includeAll": true,
-          "label": "Services",
-          "multi": true,
-          "name": "service_id",
-          "options": [],
-          "query": {
-            "query": "query_result(cf_service_info and on(service_id) (cf_service_plan_info and on(service_plan_id) cf_service_instance_info))",
-            "refId": "StandardVariableQuery"
-          },
-          "refresh": 2,
-          "regex": "/.*service_id=\"(?<value>.+)\".*service_label=\"(?<text>.+)\".*/",
-          "skipUrlSync": false,
-          "sort": 0,
-          "tagValuesQuery": "",
-          "tags": [],
-          "tagsQuery": "",
-          "type": "query",
-          "useTags": false
-        },
-        {
-          "allValue": null,
           "current": {
             "selected": true,
             "text": "All",
             "value": ".*"
           },
-          "description": "Accepts regex patterns",
-          "error": null,
+          "description": "Applies to \"request rate\" panel. Accepts regex patterns",
           "hide": 0,
           "includeAll": false,
-          "label": "Request status codes",
+          "label": "Request status codes (rate)",
           "multi": false,
           "name": "status_codes_pattern",
           "options": [
@@ -813,6 +726,34 @@
           "queryValue": "",
           "skipUrlSync": false,
           "type": "custom"
+        },
+        {
+          "current": {
+            "selected": true,
+            "text": [
+              "All"
+            ],
+            "value": [
+              "$__all"
+            ]
+          },
+          "definition": "label_values(firehose_http_start_stop_server_request_duration_seconds_sum, method)",
+          "description": "",
+          "hide": 0,
+          "includeAll": true,
+          "label": "Request methods",
+          "multi": true,
+          "name": "methods_pattern",
+          "options": [],
+          "query": {
+            "query": "label_values(firehose_http_start_stop_server_request_duration_seconds_sum, method)",
+            "refId": "StandardVariableQuery"
+          },
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 0,
+          "type": "query"
         }
       ]
     },

--- a/manifests/prometheus/dashboards.d/usage-by-space.json
+++ b/manifests/prometheus/dashboards.d/usage-by-space.json
@@ -22,49 +22,81 @@
     "links": [],
     "panels": [
       {
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": null,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
         "fieldConfig": {
-          "defaults": {},
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 100,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 0,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "bytes"
+          },
           "overrides": []
         },
-        "fill": 10,
-        "fillGradient": 0,
         "gridPos": {
           "h": 10,
           "w": 8,
           "x": 0,
           "y": 0
         },
-        "hiddenSeries": false,
         "id": 2,
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 0,
-        "nullPointMode": "null as zero",
         "options": {
-          "alertThreshold": true
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
         },
-        "percentage": false,
-        "pluginVersion": "7.5.16",
-        "pointradius": 2,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": true,
-        "steppedLine": false,
+        "pluginVersion": "8.5.15",
         "targets": [
           {
             "exemplar": true,
@@ -75,94 +107,85 @@
             "refId": "A"
           }
         ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
         "title": "Total container memory",
-        "tooltip": {
-          "shared": true,
-          "sort": 2,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "$$hashKey": "object:80",
-            "format": "bytes",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": "0",
-            "show": true
-          },
-          {
-            "$$hashKey": "object:81",
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
+        "type": "timeseries"
       },
       {
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": null,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
         "description": "Lacking a real (and sufficiently-labeled) metric for containers being started, this actually measures the number of very young containers attributable to a space.\n\nA surge of apparent container starts *could* indicate a lot of crashes and attempted restarts.\n\nAttempted container starts that don't even manage to live for a minute will probably get missed from this plot.",
         "fieldConfig": {
-          "defaults": {},
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 100,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 0,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "cpm"
+          },
           "overrides": []
         },
-        "fill": 10,
-        "fillGradient": 0,
         "gridPos": {
           "h": 10,
           "w": 8,
           "x": 8,
           "y": 0
         },
-        "hiddenSeries": false,
         "id": 8,
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 0,
-        "nullPointMode": "null as zero",
         "options": {
-          "alertThreshold": true
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
         },
-        "percentage": false,
-        "pluginVersion": "7.5.16",
-        "pointradius": 2,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": true,
-        "steppedLine": false,
+        "pluginVersion": "8.5.15",
         "targets": [
           {
             "exemplar": false,
@@ -173,191 +196,175 @@
             "refId": "A"
           }
         ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
         "title": "Total container start rate (approx)",
-        "tooltip": {
-          "shared": true,
-          "sort": 2,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "$$hashKey": "object:65",
-            "format": "cpm",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          },
-          {
-            "$$hashKey": "object:66",
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
+        "type": "timeseries"
       },
       {
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": null,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
         "description": "",
         "fieldConfig": {
-          "defaults": {},
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 100,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 0,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "reqps"
+          },
           "overrides": []
         },
-        "fill": 10,
-        "fillGradient": 0,
         "gridPos": {
           "h": 10,
           "w": 8,
           "x": 16,
           "y": 0
         },
-        "hiddenSeries": false,
         "id": 4,
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 0,
-        "nullPointMode": "null as zero",
         "options": {
-          "alertThreshold": true
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
         },
-        "percentage": false,
-        "pluginVersion": "7.5.16",
-        "pointradius": 2,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": true,
-        "steppedLine": false,
+        "pluginVersion": "8.5.15",
         "targets": [
           {
             "exemplar": true,
-            "expr": "sum(sum(rate(firehose_http_start_stop_requests{environment=~\"$environment\", bosh_deployment=~\"$bosh_deployment\", status_code=~\"$status_codes_pattern\"}[5m])) by (application_id) * on(application_id) group_right group(cf_application_info{organization_name=\"$organization_name\"}) by (application_id, space_name)) by (space_name)",
+            "expr": "sum(sum(rate(firehose_http_start_stop_requests{environment=~\"$environment\", bosh_deployment=~\"$bosh_deployment\", status_code=~\"$status_codes_pattern\", method=~\"$methods_pattern\"}[5m])) by (application_id) * on(application_id) group_right group(cf_application_info{organization_name=\"$organization_name\"}) by (application_id, space_name)) by (space_name)",
             "interval": "",
             "intervalFactor": 2,
             "legendFormat": "{{ space_name }}",
             "refId": "A"
           }
         ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
-        "title": "Total request rate ($status_codes_pattern)",
-        "tooltip": {
-          "shared": true,
-          "sort": 2,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "$$hashKey": "object:80",
-            "format": "reqps",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": "0",
-            "show": true
-          },
-          {
-            "$$hashKey": "object:81",
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
+        "title": "Total request rate ($status_codes_pattern, $methods_pattern)",
+        "type": "timeseries"
       },
       {
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": null,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
         "fieldConfig": {
-          "defaults": {},
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 100,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 0,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "short"
+          },
           "overrides": []
         },
-        "fill": 10,
-        "fillGradient": 0,
         "gridPos": {
           "h": 10,
           "w": 8,
           "x": 0,
           "y": 10
         },
-        "hiddenSeries": false,
         "id": 3,
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 0,
-        "nullPointMode": "null as zero",
         "options": {
-          "alertThreshold": true
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
         },
-        "percentage": false,
-        "pluginVersion": "7.5.16",
-        "pointradius": 2,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": true,
-        "steppedLine": false,
+        "pluginVersion": "8.5.15",
         "targets": [
           {
             "exemplar": true,
@@ -368,93 +375,86 @@
             "refId": "A"
           }
         ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
         "title": "Total container instances",
-        "tooltip": {
-          "shared": true,
-          "sort": 2,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "$$hashKey": "object:80",
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": "0",
-            "show": true
-          },
-          {
-            "$$hashKey": "object:81",
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
+        "type": "timeseries"
       },
       {
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": null,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
+        "description": "Doesn't include logs from gorouter, which will be approximately proportional to the request rate.",
         "fieldConfig": {
-          "defaults": {},
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 100,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 0,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "binBps"
+          },
           "overrides": []
         },
-        "fill": 10,
-        "fillGradient": 0,
         "gridPos": {
           "h": 10,
           "w": 8,
           "x": 8,
           "y": 10
         },
-        "hiddenSeries": false,
         "id": 6,
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 0,
-        "nullPointMode": "null as zero",
         "options": {
-          "alertThreshold": true
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
         },
-        "percentage": false,
-        "pluginVersion": "7.5.16",
-        "pointradius": 2,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": true,
-        "steppedLine": false,
+        "pluginVersion": "8.5.15",
         "targets": [
           {
             "exemplar": true,
@@ -465,145 +465,102 @@
             "refId": "A"
           }
         ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
         "title": "Total log rate",
-        "tooltip": {
-          "shared": true,
-          "sort": 2,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "$$hashKey": "object:80",
-            "format": "binBps",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": "0",
-            "show": true
-          },
-          {
-            "$$hashKey": "object:81",
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
+        "type": "timeseries"
       },
       {
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": null,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
+        "description": "Total amount of http connection time used during a time period (i.e. 60 * 1s connections would be 1 minute).\n\nUnit is seconds, but telling grafana that makes it list large values in weeks etc. - not very useful.\n\nSorry, no status-code filtering here.",
         "fieldConfig": {
-          "defaults": {},
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 100,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 0,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "short"
+          },
           "overrides": []
         },
-        "fill": 10,
-        "fillGradient": 0,
         "gridPos": {
           "h": 10,
           "w": 8,
           "x": 16,
           "y": 10
         },
-        "hiddenSeries": false,
-        "id": 5,
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 0,
-        "nullPointMode": "null as zero",
+        "id": 9,
         "options": {
-          "alertThreshold": true
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
         },
-        "percentage": false,
-        "pluginVersion": "7.5.16",
-        "pointradius": 2,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": true,
-        "steppedLine": false,
+        "pluginVersion": "8.5.15",
         "targets": [
           {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
             "exemplar": true,
-            "expr": "sum(sum(group(cf_service_plan_info{service_id=~\"$service_id\"}) without (instance) * on (service_plan_id) group_right group(cf_service_instance_info{environment=~\"$environment\", deployment=~\"$bosh_deployment\"}) without (instance)) by (space_id) * on (space_id) group_right group(cf_space_info) without (instance)) by (organization_id, space_name) * on(organization_id) group_left group(cf_organization_info{organization_name=\"$organization_name\"}) without (instance)",
+            "expr": "sum(sum(firehose_http_start_stop_server_request_duration_seconds_sum{environment=~\"$environment\", bosh_deployment=~\"$bosh_deployment\", method=~\"$methods_pattern\"}) by (application_id) * on(application_id) group_right group(cf_application_info{organization_name=\"$organization_name\"}) by (application_id, space_name)) by (space_name)",
             "interval": "",
-            "intervalFactor": 5,
+            "intervalFactor": 2,
             "legendFormat": "{{ space_name }}",
             "refId": "A"
           }
         ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
-        "title": "Total service instances ($service_id)",
-        "tooltip": {
-          "shared": true,
-          "sort": 2,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "$$hashKey": "object:80",
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": "0",
-            "show": true
-          },
-          {
-            "$$hashKey": "object:81",
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
+        "title": "Total request time ($methods_pattern)",
+        "type": "timeseries"
       }
     ],
     "refresh": false,
@@ -615,16 +572,16 @@
     "templating": {
       "list": [
         {
-          "allValue": null,
           "current": {
             "selected": false,
             "text": "prod-lon",
             "value": "prod-lon"
           },
-          "datasource": "prometheus",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
           "definition": "",
-          "description": null,
-          "error": null,
           "hide": 0,
           "includeAll": false,
           "label": "Environment",
@@ -640,22 +597,21 @@
           "skipUrlSync": false,
           "sort": 1,
           "tagValuesQuery": "",
-          "tags": [],
           "tagsQuery": "",
           "type": "query",
           "useTags": false
         },
         {
-          "allValue": null,
           "current": {
             "selected": false,
             "text": "prod-lon",
             "value": "prod-lon"
           },
-          "datasource": "prometheus",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
           "definition": "",
-          "description": null,
-          "error": null,
           "hide": 0,
           "includeAll": false,
           "label": "Director",
@@ -671,22 +627,21 @@
           "skipUrlSync": false,
           "sort": 1,
           "tagValuesQuery": "",
-          "tags": [],
           "tagsQuery": "",
           "type": "query",
           "useTags": false
         },
         {
-          "allValue": null,
           "current": {
             "selected": false,
             "text": "prod-lon",
             "value": "prod-lon"
           },
-          "datasource": "prometheus",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
           "definition": "",
-          "description": null,
-          "error": null,
           "hide": 0,
           "includeAll": false,
           "label": "Deployment",
@@ -701,23 +656,20 @@
           "regex": "",
           "skipUrlSync": false,
           "sort": 1,
-          "tagValuesQuery": null,
-          "tags": [],
-          "tagsQuery": null,
           "type": "query",
           "useTags": false
         },
         {
-          "allValue": null,
           "current": {
             "selected": true,
-            "text": "admin",
-            "value": "admin"
+            "text": "trade-tariff",
+            "value": "trade-tariff"
           },
-          "datasource": "prometheus",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
           "definition": "label_values(cf_organization_info{environment=~\"$environment\",deployment=\"$bosh_deployment\",organization_name!~\"[A-Z]+-.*\"}, organization_name)",
-          "description": null,
-          "error": null,
           "hide": 0,
           "includeAll": false,
           "label": "Organization",
@@ -732,23 +684,20 @@
           "regex": "",
           "skipUrlSync": false,
           "sort": 1,
-          "tagValuesQuery": null,
-          "tags": [],
-          "tagsQuery": null,
           "type": "query",
           "useTags": false
         },
         {
-          "allValue": null,
           "current": {
-            "selected": true,
+            "selected": false,
             "text": "All",
             "value": "$__all"
           },
-          "datasource": "prometheus",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
           "definition": "label_values(bosh_job_healthy{environment=~\"$environment\",bosh_name=~\"$bosh_director\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\".*diego-cell.*\"}, bosh_job_name)",
-          "description": null,
-          "error": null,
           "hide": 0,
           "includeAll": true,
           "label": "Diego Job",
@@ -763,60 +712,19 @@
           "regex": "",
           "skipUrlSync": false,
           "sort": 1,
-          "tagValuesQuery": null,
-          "tags": [],
-          "tagsQuery": null,
           "type": "query",
           "useTags": false
         },
         {
-          "allValue": null,
           "current": {
-            "selected": true,
-            "tags": [],
-            "text": [
-              "All"
-            ],
-            "value": [
-              "$__all"
-            ]
-          },
-          "datasource": null,
-          "definition": "query_result(cf_service_info and on(service_id) (cf_service_plan_info and on(service_plan_id) cf_service_instance_info))",
-          "description": null,
-          "error": null,
-          "hide": 0,
-          "includeAll": true,
-          "label": "Services",
-          "multi": true,
-          "name": "service_id",
-          "options": [],
-          "query": {
-            "query": "query_result(cf_service_info and on(service_id) (cf_service_plan_info and on(service_plan_id) cf_service_instance_info))",
-            "refId": "StandardVariableQuery"
-          },
-          "refresh": 2,
-          "regex": "/.*service_id=\"(?<value>.+)\".*service_label=\"(?<text>.+)\".*/",
-          "skipUrlSync": false,
-          "sort": 0,
-          "tagValuesQuery": "",
-          "tags": [],
-          "tagsQuery": "",
-          "type": "query",
-          "useTags": false
-        },
-        {
-          "allValue": null,
-          "current": {
-            "selected": true,
+            "selected": false,
             "text": "All",
             "value": ".*"
           },
-          "description": "Accepts regex patterns",
-          "error": null,
+          "description": "Applies to \"request rate\" panel. Accepts regex patterns",
           "hide": 0,
           "includeAll": false,
-          "label": "Request status codes",
+          "label": "Request status codes (rate)",
           "multi": false,
           "name": "status_codes_pattern",
           "options": [
@@ -850,6 +758,34 @@
           "queryValue": "",
           "skipUrlSync": false,
           "type": "custom"
+        },
+        {
+          "current": {
+            "selected": true,
+            "text": [
+              "All"
+            ],
+            "value": [
+              "$__all"
+            ]
+          },
+          "definition": "label_values(firehose_http_start_stop_server_request_duration_seconds_sum, method)",
+          "description": "",
+          "hide": 0,
+          "includeAll": true,
+          "label": "Request methods",
+          "multi": true,
+          "name": "methods_pattern",
+          "options": [],
+          "query": {
+            "query": "label_values(firehose_http_start_stop_server_request_duration_seconds_sum, method)",
+            "refId": "StandardVariableQuery"
+          },
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 0,
+          "type": "query"
         }
       ]
     },


### PR DESCRIPTION
What
----

This replaces the "Total service instances" panel with "Total request time", which exposes tenants with a lot of long-running connections (which can set off gorouter alerts for us, so it's useful to be able to narrow down apparently odd gorouter metrics to a specific tenant's activity).

Sad thing about the "Total request time" panel is it doesn't break down by status code like "Total request rate" does, so I've tried to make it as obvious as possible that the status code selector doesn't apply to it.

The service panel was never quite a fit here, because e.g. suddenly adding a large number of services isn't something we're likely to see and it doesn't put a particular strain on shared infrastructure. Could always bring it back via git history and hide it under a collapsing row or something.

This also switches existing panels to new "time series" plot type which is less glitchy in corner cases (particularly for container start rate panel).

How to review
-------------

Deploy to a dev env or look at dev05 where this has recently been deployed.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
