### PR TITLE
[#184769368] Increase maximum disk space an app can request to 10gb

### DIFF
--- a/manifests/cf-manifest/operations.d/320-cc-increase-max-app-disk.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-increase-max-app-disk.yml
@@ -1,15 +1,15 @@
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/maximum_app_disk_in_mb?
-  value: 8192
+  value: 10240
 
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/maximum_app_disk_in_mb?
-  value: 8192
+  value: 10240
 
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/maximum_app_disk_in_mb?
-  value: 8192
+  value: 10240
 
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/cc/maximum_app_disk_in_mb?
-  value: 8192
+  value: 10240


### PR DESCRIPTION
What
----

One of our users has requested an increase of the maximum app disk space to 10gb.

How to review
-------------

Tested in dev03

Before:

```
cf scale benc-test-app -k 9GB
...
disk_quota too much disk requested (requested 9216 MB - must be less than 8192 MB)
FAILED
```

After:

```
cf scale benc-test-app -k 9GB
...
#0   running   2023-03-22T15:55:39Z   0.0%   38.2K of 1G   75M of 9G   0/s of 1M/s  
```


---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
