### PR TITLE
[#184749358] Fix intermittent failure on test cases caused by timing issue.

### DIFF
--- a/tools/metrics/fakes/http.go
+++ b/tools/metrics/fakes/http.go
@@ -1,6 +1,7 @@
 package fakes
 
 import (
+	"net"
 	"net/http"
 	"time"
 )
@@ -18,6 +19,12 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func ListenAndServeHTTP(listenAddr string) *http.Server {
 	server := &http.Server{Addr: listenAddr, Handler: &httpHandler{}}
-	go server.ListenAndServe()
+
+	ln, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		return server
+	}
+	go server.Serve(ln)
+
 	return server
 }

--- a/tools/metrics/gauges_elb_test.go
+++ b/tools/metrics/gauges_elb_test.go
@@ -66,7 +66,7 @@ var _ = Describe("ELB Gauges", Ordered, func() {
 			Resolvers: resolvers,
 			Timeout:   1 * time.Second,
 		}
-		gauge := ELBNodeFailureCountGauge(logger, config, 1*time.Second)
+		gauge := ELBNodeFailureCountGauge(logger, config, 2*time.Second)
 		metric, err := gauge.ReadMetric()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(metric.Name).To(Equal("aws.elb.unhealthy_node_count"))


### PR DESCRIPTION
What
----

Fixing a timing issue in the elb gauges test code. [Example failure](https://github.com/alphagov/paas-cf/actions/runs/4467412084/jobs/7846839945#step:12:58).

This is happening because of the nonblocking:

`go server.ListenAndServe()` 

If the listener doesn't start before we start the tests we will get a failure.

The fix starts the port listen non-blocking. 

For extra safety I'm also increasing the http request timeout to 2 seconds. 

How to review
-------------

The unit tests will run as part of the PR. So look at the code.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
