### PR TITLE
[#184537961] Moved personal static ips to paas-trusted-people

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -1219,6 +1219,28 @@ jobs:
           - get: vpc-tfstate
           - get: concourse-tfstate
           - get: cf-tfstate
+          - get: paas-trusted-people
+
+      - task: create-static-cdrs
+        tags: [colocated-with-web]
+        config:
+          platform: linux
+          image_resource: *ruby-slim-image-resource
+          inputs:
+            - name: paas-cf
+            - name: paas-trusted-people
+          outputs:
+            - name: static-cidrs-tfvars
+          params:
+            AWS_ACCOUNT: ((aws_account))
+          run:
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              cd paas-trusted-people
+              ruby ../paas-cf/concourse/scripts/get_static_cidrs.rb > ../static-cidrs-tfvars/user_static_cidrs.tfvars
 
       - task: extract-terraform-variables
         tags: [colocated-with-web]
@@ -1267,6 +1289,7 @@ jobs:
             - name: terraform-variables
             - name: paas-cf
             - name: cf-tfstate
+            - name: static-cidrs-tfvars
           outputs:
             - name: updated-tfstate
           params:
@@ -1292,6 +1315,7 @@ jobs:
 
                 terraform apply \
                   -auto-approve=true \
+                  -var-file="../../../static-cidrs-tfvars/user_static_cidrs.tfvars" \
                   -var-file="../../../paas-cf/terraform/((aws_account)).tfvars" \
                   -var-file="../../../paas-cf/terraform/cloudfoundry/((aws_account)).tfvars" \
                   -var-file="../../../paas-cf/terraform/((aws_region)).tfvars" \

--- a/concourse/scripts/get_static_cidrs.rb
+++ b/concourse/scripts/get_static_cidrs.rb
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "yaml"
+
+users = YAML.load_file("users.yml", aliases: true)
+
+deploy_env = ENV["AWS_ACCOUNT"]
+
+# Collect static IPs for users with the ssh-access role in the specified environment
+static_ips = users["users"].select { |user| user["roles"]&.dig(deploy_env)&.any? { |role| role["role"] == "aws-access" } }.map { |user| user["static_ip"] }.compact
+
+# Format the static IPs as a Terraform command line variable
+terraform_var = static_ips.empty? ? "" : "user_static_cidrs=[\"#{static_ips.join('/32","')}/32\"]"
+
+# Print the Terraform variable
+puts terraform_var

--- a/terraform/cloudfoundry/prometheus.tf
+++ b/terraform/cloudfoundry/prometheus.tf
@@ -31,7 +31,8 @@ resource "aws_security_group" "prometheus-lb" {
 
     cidr_blocks = concat(
       compact(var.admin_cidrs),
-      ["${var.concourse_elastic_ip}/32"]
+      ["${var.concourse_elastic_ip}/32"],
+      var.user_static_cidrs,
     )
   }
 

--- a/terraform/cloudfoundry/security-groups.tf
+++ b/terraform/cloudfoundry/security-groups.tf
@@ -30,6 +30,7 @@ resource "aws_security_group" "cf_api_elb" {
       compact(var.api_access_cidrs),
       ["${var.concourse_elastic_ip}/32"],
       formatlist("%s/32", aws_eip.cf.*.public_ip),
+      var.user_static_cidrs,
     )
   }
 
@@ -101,6 +102,7 @@ resource "aws_security_group" "sshproxy" {
       compact(var.admin_cidrs),
       compact(var.api_access_cidrs),
       ["${var.concourse_elastic_ip}/32"],
+      var.user_static_cidrs,
     )
   }
 

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -13,8 +13,12 @@ variable "admin_cidrs" {
     "213.86.153.237/32",
     "51.149.8.0/25",     # New DR VPN
     "51.149.8.128/29",   # New DR BYOD VPN
-    "82.71.58.244/32",   # LP remote
-    "51.148.163.199/32", # TW remote
+    "90.155.48.192/26",  # ITHC 2023
+    "81.2.127.144/28",   # ITHC 2023
+    "81.187.169.170/32", # ITHC 2023
+    "88.97.60.11/32",    # ITHC 2023
+    "3.10.4.97/32",      # ITHC 2023
+    "51.104.217.191/32", # ITHC 2023
   ]
 }
 
@@ -136,4 +140,9 @@ variable "zone_count" {
 variable "zones" {
   description = "AWS availability zones"
   type        = map(string)
+}
+
+variable "user_static_cidrs" {
+  description = "user static_cidrs populated with values from paas-trusted-people"
+  default     = []
 }


### PR DESCRIPTION
What
----

Moved personal static ips from paas-aws-account-wide-terraform, paas-bootstrap and paas-cf as required by this  [pivotal tracker storey](https://www.pivotaltracker.com/n/projects/1275640/stories/184537961). Made related changes to [paas-aws-account-wide-terraform](https://github.com/alphagov/paas-aws-account-wide-terraform/pull/352), [paas-bootstrap](https://github.com/alphagov/paas-bootstrap/pull/591) and [paas-trusted-people](https://github.com/alphagov/paas-trusted-people/pull/116) repos.

How to review
-------------

Run this branch into a dev env.

Ensure that the PAAS_TRUSTED_PEOPLE_BRANCH var is set to the related branch in the paas-trusted-people repo before uploading the secrets.

Ensure that you have the connectivity to the dev env that you had previously.

Who can review
---

Anyone with a static ip in the paas-trusted-people repository.

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
