### PR TITLE
generate_buildpack_bump_pr workflow: update body and fix variable substitution

### DIFF
--- a/.github/workflows/automatic_buildpack_bump_pr_body.md
+++ b/.github/workflows/automatic_buildpack_bump_pr_body.md
@@ -9,7 +9,7 @@ When this PR is less than a week old, a human should check out this branch and:
 - [ ] Update the title of this PR to include the date on which it should be merged. The format isn't important, only that
 it's clear to others thast it shouldn't be merged until a certain date.
 
-*However* if this PR is more than around a week old it would probably be better to:
+**However** if this PR is more than around a week old it would probably be better to:
 
 - [ ] Close this PR.
 - [ ] Manually re-trigger the `generate_buildpack_bump_pr` github workflow to create a fresh PR.

--- a/.github/workflows/automatic_buildpack_bump_pr_body.md
+++ b/.github/workflows/automatic_buildpack_bump_pr_body.md
@@ -2,9 +2,14 @@ This is an automatically generated pull request.
 
 These are the results of running the `./scripts/update_buildpacks.sh` script against commit $GITHUB_SHA.
 
-A human should check out this branch and:
+When this PR is less than a week old, a human should check out this branch and:
 
 - [ ] Deploy it to a development environment to ensure the buildpack upgrades don't break any of our own applications.
 - [ ] Follow the instructions for [informing tenants about buildpack upgrades](https://team-manual.cloud.service.gov.uk/guides/upgrade_buildpacks/)
 - [ ] Update the title of this PR to include the date on which it should be merged. The format isn't important, only that
 it's clear to others thast it shouldn't be merged until a certain date.
+
+*However* if this PR is more than around a week old it would probably be better to:
+
+- [ ] Close this PR.
+- [ ] Manually re-trigger the `generate_buildpack_bump_pr` github workflow to create a fresh PR.

--- a/.github/workflows/generate_buildpack_bump_pr.yml
+++ b/.github/workflows/generate_buildpack_bump_pr.yml
@@ -21,6 +21,11 @@ jobs:
         with:
           submodules: true
 
+      - name: Install gettext
+        run: |
+          sudo apt install gettext
+          # for envsubst
+
       - name: "Install Go ${{env.GO_VERSION}}"
         uses: actions/setup-go@v2
         with:
@@ -45,8 +50,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GOVUK_PAAS_UNPRIVILEGED_BOT_PAT }}
         run: |
+          FINAL_BODY=$(mktemp)
+          envsubst < ./.github/workflows/automatic_buildpack_bump_pr_body.md > $FINAL_BODY
+
           gh pr create \
             --base main \
             --head "$NEW_BRANCH_NAME" \
             --title "Buildpack upgrades, $(date -u '+%B %Y')" \
-            --body-file "./.github/workflows/automatic_buildpack_bump_pr_body.md"
+            --body-file "$FINAL_BODY"


### PR DESCRIPTION
What
----

Firstly add a note to the buildpack PR body about regenerating the PR if it's more than a week old.

*Also* fix variable substitution in the markdown so we don't end up with literal `$GITHUB_SHA` in the body. This broke when the markdown got moved into a separate file.

How to review
-------------

See the test PR created with this @ #3168

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
