### PR TITLE
create_buildpacks_email.sh: use `HEAD` instead of `head` for git ref

### DIFF
--- a/scripts/create_buildpacks_email.sh
+++ b/scripts/create_buildpacks_email.sh
@@ -32,6 +32,6 @@ fi
 cd "${root_dir}/tools/buildpacks"
 
 EMAIL_OUT="email-$(date "+%Y-%m-%d").txt"
-go run email.go structs.go -old <(git show "$previous_commit:config/buildpacks.yml") -new <(git show "head:config/buildpacks.yml") -out "${EMAIL_OUT}"
+go run email.go structs.go -old <(git show "$previous_commit:config/buildpacks.yml") -new <(git show "HEAD:config/buildpacks.yml") -out "${EMAIL_OUT}"
 
 echo "Email content writen to: $(pwd)/${EMAIL_OUT}"


### PR DESCRIPTION
What
----

https://www.pivotaltracker.com/story/show/184821954

Lowercase `head` doesn't appear to be an alias on all systems


How to review
-------------

:eyes: 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
