### PR TITLE
alerts: internalize "ephemeral disk full" alerts with higher threshold for concourse

### DIFF
--- a/manifests/prometheus/alerts.d/bosh-job-ephemeral-disk-full.yml
+++ b/manifests/prometheus/alerts.d/bosh-job-ephemeral-disk-full.yml
@@ -1,0 +1,33 @@
+# Source: bosh-exporter
+---
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: BOSHJobEphemeralDiskFull
+    rules:
+      - alert: BOSHJobEphemeralDiskFull
+        expr: avg(bosh_job_ephemeral_disk_percent{bosh_job_name!~"^(compilation|concourse-worker).*",bosh_deployment!="bosh-health-check"}) by(environment, bosh_name, bosh_deployment, bosh_job_name, bosh_job_index) > 80
+        for: 30m
+        labels:
+          service: bosh-job
+          severity: warning
+        annotations:
+          summary: "BOSH Job `{{$labels.environment}}/{{$labels.bosh_name}}/{{$labels.bosh_deployment}}/{{$labels.bosh_job_name}}/{{$labels.bosh_job_index}}` is running out of ephemeral disk"
+          description: "BOSH Job `{{$labels.environment}}/{{$labels.bosh_name}}/{{$labels.bosh_deployment}}/{{$labels.bosh_job_name}}/{{$labels.bosh_job_index}}` has used more than 80% of its ephemeral disk for 30m"
+
+      - alert: BOSHJobEphemeralDiskFullConcourseWorker
+        expr: avg(bosh_job_ephemeral_disk_percent{bosh_job_name=~"^concourse-worker.*",bosh_deployment!="bosh-health-check"}) by(environment, bosh_name, bosh_deployment, bosh_job_name, bosh_job_index) > 90
+        for: 30m
+        labels:
+          service: bosh-job
+          severity: warning
+        annotations:
+          summary: "BOSH Job `{{$labels.environment}}/{{$labels.bosh_name}}/{{$labels.bosh_deployment}}/{{$labels.bosh_job_name}}/{{$labels.bosh_job_index}}` is running out of ephemeral disk"
+          description: "BOSH Job `{{$labels.environment}}/{{$labels.bosh_name}}/{{$labels.bosh_deployment}}/{{$labels.bosh_job_name}}/{{$labels.bosh_job_index}}` has used more than 90% of its ephemeral disk for 30m"
+
+# FIXME: there is no easy way currently to remove upstream alerts
+# This effectively disables the upstream disk-full alert by increasing the threshold to an impossible value
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=bosh_alerts/properties?/bosh_alerts/job_ephemeral_disk_full/threshold
+  value: 10000

--- a/manifests/prometheus/alerts.d/bosh-job-ephemeral-disk-predict-will-fill.yml
+++ b/manifests/prometheus/alerts.d/bosh-job-ephemeral-disk-predict-will-fill.yml
@@ -1,0 +1,33 @@
+# Source: bosh-exporter
+---
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: BOSHJobEphemeralDiskPredictWillFill
+    rules:
+      - alert: BOSHJobEphemeralDiskPredictWillFill
+        expr: predict_linear(bosh_job_ephemeral_disk_percent{bosh_job_name!~"^(compilation|smoke-tests|concourse-worker).*"}[1h], 14400) > 80
+        for: 30m
+        labels:
+          service: bosh-job
+          severity: warning
+        annotations:
+          summary: "BOSH Job `{{$labels.environment}}/{{$labels.bosh_name}}/{{$labels.bosh_deployment}}/{{$labels.bosh_job_name}}/{{$labels.bosh_job_index}}` will run out of ephemeral disk in {{humanizeDuration 14400}}"
+          description: "BOSH Job `{{$labels.environment}}/{{$labels.bosh_name}}/{{$labels.bosh_deployment}}/{{$labels.bosh_job_name}}/{{$labels.bosh_job_index}}` ephemeral disk will be used more than 80% in {{humanizeDuration 14400}}"
+
+      - alert: BOSHJobEphemeralDiskPredictWillFillConcourseWorker
+        expr: predict_linear(bosh_job_ephemeral_disk_percent{bosh_job_name=~"^concourse-worker.*"}[1h], 14400) > 90
+        for: 30m
+        labels:
+          service: bosh-job
+          severity: warning
+        annotations:
+          summary: "BOSH Job `{{$labels.environment}}/{{$labels.bosh_name}}/{{$labels.bosh_deployment}}/{{$labels.bosh_job_name}}/{{$labels.bosh_job_index}}` will run out of ephemeral disk in {{humanizeDuration 14400}}"
+          description: "BOSH Job `{{$labels.environment}}/{{$labels.bosh_name}}/{{$labels.bosh_deployment}}/{{$labels.bosh_job_name}}/{{$labels.bosh_job_index}}` ephemeral disk will be used more than 90% in {{humanizeDuration 14400}}"
+
+# FIXME: there is no easy way currently to remove upstream alerts
+# This effectively disables the upstream disk-will-fill alert by increasing the threshold to a near-impossible value
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=bosh_alerts/properties?/bosh_alerts/job_predict_ephemeral_disk_full/threshold
+  value: 10000


### PR DESCRIPTION
What
----

Concourse's disk usage pattern falsely triggers this all the time when it has a remotely full disk, even though concourse's garbage collector will generally kick in and prevent it actually running out of space. Increase the threshold for these alerts to 90% for concourse-worker nodes.

Here we have to do the same trick we did previously in the `BoshHighCPUUtilisation` upstream alerts which we wanted to alter - disable upstream's one with a very high threshold and then add our own with the same name.

Consciously no tests for this - it's a copypasta of upstream and upstream doesn't have any tests, What's more it seems the deeper you dig into the specifics of prometheus' `predict_linear` behaviour the less sane it shows itself to be.

How to review
-------------

:eyes: ? See it having been deployed to `dev05` @ https://deployer.dev05.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/prometheus-deploy/builds/36

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
