### PR TITLE
Add dms optional extra connection attributes to dms endpoint configuration

### DIFF
--- a/terraform/dms/dms.tf
+++ b/terraform/dms/dms.tf
@@ -12,6 +12,7 @@ resource "aws_dms_endpoint" "source" {
   ssl_mode                        = "require"
   secrets_manager_arn             = try(data.aws_secretsmanager_secret.source[each.key].arn, null)
   secrets_manager_access_role_arn = data.aws_iam_role.secrets_manager.arn
+  extra_connection_attributes     = try(each.value.source_extra_connection_attributes, "")
 
   tags = {
     Build       = "terraform"
@@ -31,6 +32,7 @@ resource "aws_dms_endpoint" "target" {
   ssl_mode                        = "require"
   secrets_manager_arn             = try(data.aws_secretsmanager_secret.target[each.key].arn, null)
   secrets_manager_access_role_arn = data.aws_iam_role.secrets_manager.arn
+  extra_connection_attributes     = try(each.value.target_extra_connection_attributes, "")
 
   tags = {
     Build       = "terraform"

--- a/terraform/dms/locals.tf
+++ b/terraform/dms/locals.tf
@@ -9,6 +9,8 @@ locals {
       name               = migration.name
       source_secret_name = migration.source_secret_name
       target_secret_name = migration.target_secret_name
+      source_extra_connection_attributes = migration.source_extra_connection_attributes
+      target_extra_connection_attributes = migration.target_extra_connection_attributes
       instance           = migration.instance
       task               = migration.task
     }

--- a/terraform/dms/variables.tf
+++ b/terraform/dms/variables.tf
@@ -2,7 +2,9 @@ variable "dms_data" {
   type = list(object({
     name               = string
     source_secret_name = string
+    source_extra_connection_attributes = optional(string)
     target_secret_name = string
+    target_extra_connection_attributes = optional(string)
     instance = object({
       allocated_storage            = number
       allow_major_version_upgrade  = bool

--- a/terraform/prod.dms.json
+++ b/terraform/prod.dms.json
@@ -2,7 +2,9 @@
     {
         "name": "govuk-notify-test-migration",
         "source_secret_name": "dms-secrets/notify-test/source",
+        "source_extra_connection_attributes": "executeTimeout=600;",
         "target_secret_name": "dms-secrets/notify-test/destination",
+        "target_extra_connection_attributes": "executeTimeout=600;",
         "instance": {
             "allocated_storage": "6144",
             "allow_major_version_upgrade": false,
@@ -32,7 +34,9 @@
     {
         "name": "govuk-notify-preview-migration",
         "source_secret_name": "dms-secrets/notify-preview/source",
+        "source_extra_connection_attributes": "executeTimeout=600;",
         "target_secret_name": "dms-secrets/notify-preview/destination",
+        "target_extra_connection_attributes": "executeTimeout=600;",
         "instance": {
             "allocated_storage": "6144",
             "allow_major_version_upgrade": false,


### PR DESCRIPTION
What
----

Add extra connection attributes to dms configuration.

Why
----

We have seen some connection timeouts during the dms replication process. The default query timeout is 60 seconds. 

This needs to be increased via the terraform "extra_connection_attributes" attribute on the aws_dms_endpoint resource.

How to review
-------------

Look at the change.

This change has been "planned" against prod to verify it.

Notes
------

- The terraform may fail to apply if the dms processes affected are in a state of "Running". They will need to be stopped while this change is applied. 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
