### PR TITLE
184602179 healthcheck cloudinit refactor

### DIFF
--- a/concourse/tasks/curl-az-healthcheck.yml
+++ b/concourse/tasks/curl-az-healthcheck.yml
@@ -29,5 +29,5 @@ run:
       export HEALTHCHECK_IP
 
       # shellcheck disable=SC2154
-      echo "Getting a response from the healthcheck in ${AVAILABILITY_ZONE} at ${HEALTHCHECK_IP}..."
+      echo "Attempting to get a response from the healthcheck in ${AVAILABILITY_ZONE} at ${HEALTHCHECK_IP}..."
       curl "http://${HEALTHCHECK_IP}:3000"

--- a/terraform/az-monitoring/module/main.tf
+++ b/terraform/az-monitoring/module/main.tf
@@ -62,13 +62,35 @@ resource "aws_instance" "healthcheck" {
   user_data = <<-EOF
     #!/bin/bash
     set -ex
-    sudo yum update -y
-    sudo amazon-linux-extras install docker -y
-    sudo service docker start
-    sudo usermod -a -G docker ec2-user
-    su - ec2-user
-    docker run -d -p 3000:3000 ghcr.io/alphagov/paas/simple-healthcheck
+
+    echo '
+[Unit]
+Description=simple-healthcheck-service
+Requires=docker.service
+After=docker.service
+[Service]
+Restart=always
+ExecStartPre=/bin/bash -c "/usr/bin/docker ps -q -f name=simple-healthcheck | grep -q . && /usr/bin/docker stop simple-healthcheck || true"
+ExecStartPre=/bin/bash -c "/usr/bin/docker ps -aq -f name=simple-healthcheck | grep -q . && /usr/bin/docker rm simple-healthcheck || true"
+ExecStart=/usr/bin/su ec2-user -c "/usr/bin/docker run --name simple-healthcheck -p 3000:3000 ghcr.io/alphagov/paas/simple-healthcheck"
+Restart=on-failure
+RestartSec=12s
+[Install]
+WantedBy=multi-user.target
+' >/etc/systemd/system/simple-healthcheck.service
+
+    systemctl daemon-reload
+ 
+    yum update -y --setopt=retries=0
+    amazon-linux-extras install docker -y --setopt=retries=0
+    service docker start
+    usermod -a -G docker ec2-user 
+  
+    sudo systemctl enable simple-healthcheck
+    sudo systemctl start simple-healthcheck
+
   EOF
+  user_data_replace_on_change = true
 
   tags = {
     Name = "az-healthcheck/${var.zone}"


### PR DESCRIPTION
What
----

Move the docker run startup command for the az-healthcheck app out of cloudinit and in to its own systemd startup script. Also add terraform config to replace the healthcheck nodes upon a change to the contents of userdata

How to review
-------------
👀  and test in dev/stage. Make sure that the healthcheck nodes are replaced and that the az-healthchecks are green after the deploy (in the health group of the create-cloudfoundry concourse view)

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
