### PR TITLE
s3 bucket terraform: enable ACL mode via ownership_controls BucketOwnerPreferred

### DIFF
--- a/terraform/cloudfoundry/buckets.tf
+++ b/terraform/cloudfoundry/buckets.tf
@@ -4,9 +4,18 @@ resource "aws_s3_bucket" "droplets-s3" {
   force_destroy = var.bucket_force_destroy
 }
 
+resource "aws_s3_bucket_ownership_controls" "droplets-s3" {
+  bucket = aws_s3_bucket.droplets-s3.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "droplets-s3" {
   bucket = aws_s3_bucket.droplets-s3.id
   acl    = "private"
+
+  depends_on = [aws_s3_bucket_ownership_controls.droplets-s3]
 }
 
 resource "aws_s3_bucket_versioning" "droplets-s3" {
@@ -49,9 +58,18 @@ resource "aws_s3_bucket" "buildpacks-s3" {
   force_destroy = var.bucket_force_destroy
 }
 
+resource "aws_s3_bucket_ownership_controls" "buildpacks-s3" {
+  bucket = aws_s3_bucket.buildpacks-s3.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "buildpacks-s3" {
   bucket = aws_s3_bucket.buildpacks-s3.id
   acl    = "private"
+
+  depends_on = [aws_s3_bucket_ownership_controls.buildpacks-s3]
 }
 
 resource "aws_s3_bucket_versioning" "buildpacks-s3" {
@@ -94,9 +112,18 @@ resource "aws_s3_bucket" "packages-s3" {
   force_destroy = var.bucket_force_destroy
 }
 
+resource "aws_s3_bucket_ownership_controls" "packages-s3" {
+  bucket = aws_s3_bucket.packages-s3.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "packages-s3" {
   bucket = aws_s3_bucket.packages-s3.id
   acl    = "private"
+
+  depends_on = [aws_s3_bucket_ownership_controls.packages-s3]
 }
 
 resource "aws_s3_bucket_versioning" "packages-s3" {
@@ -138,9 +165,18 @@ resource "aws_s3_bucket" "resources-s3" {
   force_destroy = var.bucket_force_destroy
 }
 
+resource "aws_s3_bucket_ownership_controls" "resources-s3" {
+  bucket = aws_s3_bucket.resources-s3.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "resources-s3" {
   bucket = aws_s3_bucket.resources-s3.id
   acl    = "private"
+
+  depends_on = [aws_s3_bucket_ownership_controls.resources-s3]
 }
 
 resource "aws_s3_bucket_versioning" "resources-s3" {
@@ -181,9 +217,18 @@ resource "aws_s3_bucket" "test-artifacts" {
   force_destroy = "true"
 }
 
+resource "aws_s3_bucket_ownership_controls" "test-artifacts" {
+  bucket = aws_s3_bucket.test-artifacts.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "test-artifacts" {
   bucket = aws_s3_bucket.test-artifacts.id
   acl    = "private"
+
+  depends_on = [aws_s3_bucket_ownership_controls.test-artifacts]
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "test-artifacts" {
@@ -210,9 +255,18 @@ resource "aws_s3_bucket" "elb_access_log" {
   force_destroy = "true"
 }
 
+resource "aws_s3_bucket_ownership_controls" "elb_access_log" {
+  bucket = aws_s3_bucket.elb_access_log.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "elb_access_log" {
   bucket = aws_s3_bucket.elb_access_log.id
   acl    = "private"
+
+  depends_on = [aws_s3_bucket_ownership_controls.elb_access_log]
 }
 
 resource "aws_s3_bucket_policy" "elb_access_log" {

--- a/terraform/cloudfoundry/cdn_broker.tf
+++ b/terraform/cloudfoundry/cdn_broker.tf
@@ -42,9 +42,31 @@ resource "aws_lb_ssl_negotiation_policy" "cdn_broker" {
 
 resource "aws_s3_bucket" "cdn_broker_bucket" {
   bucket        = "gds-paas-${var.env}-cdn-broker-challenge"
-  acl           = "private"
   force_destroy = "true"
+}
 
+resource "aws_s3_bucket_public_access_block" "cdn_broker_bucket" {
+  bucket = aws_s3_bucket.cdn_broker_bucket.id
+
+  block_public_policy = false
+}
+
+resource "aws_s3_bucket_ownership_controls" "cdn_broker_bucket" {
+  bucket = aws_s3_bucket.cdn_broker_bucket.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_acl" "cdn_broker_bucket" {
+  bucket = aws_s3_bucket.cdn_broker_bucket.id
+  acl    = "private"
+
+  depends_on = [aws_s3_bucket_ownership_controls.cdn_broker_bucket]
+}
+
+resource "aws_s3_bucket_policy" "cdn_broker_bucket" {
+  bucket = aws_s3_bucket.cdn_broker_bucket.id
   policy = <<POLICY
 {
   "Version": "2012-10-17",
@@ -61,6 +83,7 @@ resource "aws_s3_bucket" "cdn_broker_bucket" {
 }
 POLICY
 
+  depends_on = [aws_s3_bucket_public_access_block.cdn_broker_bucket]
 }
 
 resource "aws_db_subnet_group" "cdn_rds" {


### PR DESCRIPTION
What
----

Necessary since https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/ otherwise bringing up an env from scratch will fail with Access Denied when attempting to set up the buckets.

Uses `depends_on` in an attempt to ensure settings are put in place early enough. I *think* I'm doing the right thing with `aws_s3_bucket_public_access_block` for `cdn_broker_bucket` but would love if someone would confirm this for me.

How to review
-------------

Bring up a fresh dev env using this?

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
