### PR TITLE
prometheus-boshrelease: 28.0.0 -> 28.1.0

### DIFF
--- a/manifests/cf-manifest/operations.d/500-prometheus.yml
+++ b/manifests/cf-manifest/operations.d/500-prometheus.yml
@@ -2,9 +2,9 @@
   path: /releases/-
   value:
     name: "prometheus"
-    version: "28.0.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=28.0.0"
-    sha1: "441b258c58c257ca251b3bae577621c66c045b58"
+    version: "28.1.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=28.1.0"
+    sha1: "1dd0d099a5f1d948f2a7f5d188baf91d8d71a19f"
 
 - type: replace
   path: /releases/-
@@ -70,7 +70,7 @@
             scrape_configs:
               - job_name: prometheus
                 static_configs:
-                  - targets: ['localhost:9090']
+                  - targets: ["localhost:9090"]
 
               - job_name: aiven
                 scheme: https
@@ -97,23 +97,23 @@
 
                   - source_labels: [aiven_cloud]
                     separator: ;
-                    regex: 'aws-((terraform_outputs_region))'
+                    regex: "aws-((terraform_outputs_region))"
                     action: keep
 
                 metric_relabel_configs:
                   - source_labels: [__name__]
                     separator: ;
-                    regex: 'elasticsearch_(breakers|thread|fs|indices|os)_.*'
+                    regex: "elasticsearch_(breakers|thread|fs|indices|os)_.*"
                     action: drop
 
                   - source_labels: [__name__]
                     separator: ;
-                    regex: 'net_(icmp|udplite)_.*'
+                    regex: "net_(icmp|udplite)_.*"
                     action: drop
 
                   - source_labels: [__name__]
                     separator: ;
-                    regex: 'prometheus_sd_(consul|kubernetes)_.*'
+                    regex: "prometheus_sd_(consul|kubernetes)_.*"
                     action: drop
 
       - name: route_registrar

--- a/manifests/runtime-config/operations.d/510-add-prometheus-blackbox-exporter.yml
+++ b/manifests/runtime-config/operations.d/510-add-prometheus-blackbox-exporter.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: "prometheus"
-    version: "28.0.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=28.0.0"
-    sha1: "441b258c58c257ca251b3bae577621c66c045b58"
+    version: "28.1.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=28.1.0"
+    sha1: "1dd0d099a5f1d948f2a7f5d188baf91d8d71a19f"
 
 - type: replace
   path: /addons?/-


### PR DESCRIPTION
What
----

https://www.pivotaltracker.com/story/show/184821965

This should hopefully resolve issues we've had with the `cf_exporter` since 28.0.0 (due to  https://github.com/bosh-prometheus/cf_exporter/issues/82)

How to review
-------------

Deploy to a dev env, see how reliable the `cf_exporter` process in the `prometheus2` job of the prometheus instances is. Though problems may only be visible in prod where we have an extensive enough cf database that scraping requests can take long enough (I've tried my best by filling dev05 with spaces and routes but it's not enough and we need to get a move on with this - look at [this period](https://grafana-1.dev05.dev.cloudpipeline.digital/d/usage-by-organization/usage-by-organisation?orgId=1&var-environment=dev05&var-bosh_director=dev05&var-bosh_deployment=dev05&var-diego_bosh_job_name=All&var-status_codes_pattern=All&var-methods_pattern=All&from=1682606393212&to=1682609684860) and its gap-less-ness when dev05 was running the new code with a non-slim deployment and ~100 dummy spaces and ~500 dummy routes)

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
