### PR TITLE
custom-acceptance-tests aws endpoint check: remove SMS service, add cloudwatch

### DIFF
--- a/platform-tests/acceptance/aws_endpoint_check_test.go
+++ b/platform-tests/acceptance/aws_endpoint_check_test.go
@@ -65,6 +65,9 @@ var _ = Describe("AWS Endpoint Check", Ordered, func() {
 			Entry("should connect to cassandra endpoint", "cassandra", "404"),
 			Entry("should connect to sqs endpoint", "sqs", "404"),
 			Entry("should connect to sns endpoint", "sns", "404"),
+			Entry("should connect to cloudwatch monitoring endpoint", "monitoring", "404"),
+			Entry("should connect to cloudwatch events endpoint", "events", "404"),
+			Entry("should connect to cloudwatch logs endpoint", "logs", "404"),
 		)
 
 		It("should connect to cloudfront endpoint", func() {

--- a/platform-tests/acceptance/aws_endpoint_check_test.go
+++ b/platform-tests/acceptance/aws_endpoint_check_test.go
@@ -62,7 +62,6 @@ var _ = Describe("AWS Endpoint Check", Ordered, func() {
 			Entry("should connect to rekognition endpoint", "rekognition", "404"),
 			Entry("should connect to s3 endpoint", "s3", "405"),
 			Entry("should connect to ses endpoint", "email", "404"),
-			Entry("should connect to sms endpoint", "sms", "404"),
 			Entry("should connect to cassandra endpoint", "cassandra", "404"),
 			Entry("should connect to sqs endpoint", "sqs", "404"),
 			Entry("should connect to sns endpoint", "sns", "404"),


### PR DESCRIPTION
What
----

The AWS endpoint-poking tests in the `custom-acceptance-tests` are intended to check there isn't any weird aws configuration we've added that would stop our tenants being able to use these services on their own terms from within apps.

AWS SMS ("Server Migration Service") was included in these but since the service was retired recently its endpoint has disappeared, preventing these tests from passing.

In its place I've added CloudWatch endpoints as I'm fairly certain at least one of our tenants feeds metrics/logs to CloudWatch from their apps.

How to review
-------------

Deploy to dev env, check tests pass?

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
