### PR TITLE
Increase sql execute timeout to 1 hour for notify dms config

### DIFF
--- a/terraform/prod.dms.json
+++ b/terraform/prod.dms.json
@@ -2,9 +2,9 @@
     {
         "name": "govuk-notify-test-migration",
         "source_secret_name": "dms-secrets/notify-test/source",
-        "source_extra_connection_attributes": "executeTimeout=600;",
+        "source_extra_connection_attributes": "executeTimeout=3600;",
         "target_secret_name": "dms-secrets/notify-test/destination",
-        "target_extra_connection_attributes": "executeTimeout=600;",
+        "target_extra_connection_attributes": "executeTimeout=3600;",
         "instance": {
             "allocated_storage": "6144",
             "allow_major_version_upgrade": false,
@@ -34,9 +34,9 @@
     {
         "name": "govuk-notify-preview-migration",
         "source_secret_name": "dms-secrets/notify-preview/source",
-        "source_extra_connection_attributes": "executeTimeout=600;",
+        "source_extra_connection_attributes": "executeTimeout=3600;",
         "target_secret_name": "dms-secrets/notify-preview/destination",
-        "target_extra_connection_attributes": "executeTimeout=600;",
+        "target_extra_connection_attributes": "executeTimeout=3600;",
         "instance": {
             "allocated_storage": "6144",
             "allow_major_version_upgrade": false,


### PR DESCRIPTION
What
----

Increase notify dms sql execute timeout to 1 hour.

Why
----

During previous successful tests this has been set at 1 hour. It was reduced to 10 mins to see if that was enough. It was not.

```
RetCode: SQL_ERROR SqlState: 57014 NativeError: 1 Message: ERROR: canceling statement due to statement timeout; Error while fetching the next result [1022502] (ar_odbc_stmt.c:3329)
```

How to review
-------------

This will only change the production environment. So just the change for obvious mistakes.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
