### PR TITLE
Update dms table config to ignore the spatial_ref_sys table if it exists. 

### DIFF
--- a/terraform/dms/default_table_mappings.json
+++ b/terraform/dms/default_table_mappings.json
@@ -9,6 +9,16 @@
                 "table-name": "%"
             },
             "rule-action": "include"
+        },
+        {
+            "rule-type": "selection",
+            "rule-id": "2",
+            "rule-name": "2",
+            "object-locator": {
+                "schema-name": "public",
+                "table-name": "spatial_ref_sys"
+            },
+            "rule-action": "exclude"
         }
     ]
 }


### PR DESCRIPTION
What
----

Updating the default dms table config to ignore the spatial_ref_sys table if it exists.

This table  is managed by the postgis extension and should not be replicated

How to review
-------------

Look at the changes.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
