### PR TITLE
Upgrade to prometheus 29.2.0

### DIFF
--- a/manifests/cf-manifest/operations.d/009-add-prometheus-uaa-clients-attic.yml
+++ b/manifests/cf-manifest/operations.d/009-add-prometheus-uaa-clients-attic.yml
@@ -1,0 +1,1 @@
+../../prometheus/upstream/manifests/operators/deprecated/cf/add-prometheus-uaa-clients-attic.yml

--- a/manifests/cf-manifest/operations.d/500-prometheus.yml
+++ b/manifests/cf-manifest/operations.d/500-prometheus.yml
@@ -2,9 +2,9 @@
   path: /releases/-
   value:
     name: "prometheus"
-    version: "28.1.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=28.1.0"
-    sha1: "1dd0d099a5f1d948f2a7f5d188baf91d8d71a19f"
+    version: "29.2.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=29.2.0"
+    sha1: "cd4d0aede89e1c073f7a9e11740f6006acb3d46a"
 
 - type: replace
   path: /releases/-

--- a/manifests/prometheus/operations.d/225-monitor-cf-attic.yml
+++ b/manifests/prometheus/operations.d/225-monitor-cf-attic.yml
@@ -1,0 +1,1 @@
+../upstream/manifests/operators/deprecated/monitor-cf-attic.yml

--- a/manifests/prometheus/spec/operations/monitor_cf_spec.rb
+++ b/manifests/prometheus/spec/operations/monitor_cf_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe "Monitor CF" do
     expect(cf_exporter_config).not_to be_nil
   end
 
-  it "adds the cloudfoundry_dashboards job" do
+  it "adds the cloudfoundry_dashboards-attic job" do
     cf_dashboards_config = manifest_with_defaults.get(
-      "instance_groups.grafana.jobs.cloudfoundry_dashboards",
+      "instance_groups.grafana.jobs.cloudfoundry_dashboards-attic",
     )
 
     expect(cf_dashboards_config).not_to be_nil

--- a/manifests/runtime-config/operations.d/510-add-prometheus-blackbox-exporter.yml
+++ b/manifests/runtime-config/operations.d/510-add-prometheus-blackbox-exporter.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: "prometheus"
-    version: "28.1.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=28.1.0"
-    sha1: "1dd0d099a5f1d948f2a7f5d188baf91d8d71a19f"
+    version: "29.2.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=29.2.0"
+    sha1: "cd4d0aede89e1c073f7a9e11740f6006acb3d46a"
 
 - type: replace
   path: /addons?/-


### PR DESCRIPTION
What
----

Upgrade to prometheus 29.2.0. 

We are using the 'attic' setting for now. There [is a separate ticket](https://www.pivotaltracker.com/story/show/185099769) to migrate to the latest firehose.

How to review
-------------

I deployed to dev03 in dev05.

Please deploy into a different dev environment and check it deploys okay.

Issue
----

I saw an issue when deploying that was hard to reproduce. Namely the error:

"Database locked, sleeping then retrying"

In the grafana log. My suspicion is that this problem is related to the monit change to use bpm in this release. There might be a timing issue where we end up with two grafana's running for a short amount of time. I resolved this when I saw it with a "bosh recreate".

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
