### PR TITLE
Upgrade to cf-deployment v27.2.0

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -559,13 +559,13 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-acceptance-tests
-      branch: cf26.5
+      branch: cf27.2
 
   - name: cf-smoke-tests-release
     type: git
     source:
       uri: https://github.com/cloudfoundry/cf-smoke-tests-release
-      tag_filter: "42.0.51"
+      tag_filter: "42.0.62"
       submodules:
       - "src/smoke_tests"
 

--- a/concourse/pipelines/monitor-remote.yml
+++ b/concourse/pipelines/monitor-remote.yml
@@ -28,7 +28,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloudfoundry/cf-smoke-tests-release
-    tag_filter: "42.0.51"
+    tag_filter: "42.0.62"
     submodules:
       - "src/smoke_tests"
 

--- a/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
+++ b/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
@@ -5,4 +5,4 @@
     name: "cflinuxfs3"
     version: "0.364.0"
     url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.364.0"
-    sha1: "1b003d688621577608c64b3700ede7021432f6b7"
+    sha1: "575fe120f1767625be78f694bd9a8c210a107d8c"

--- a/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
+++ b/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
@@ -5,4 +5,4 @@
     name: "cflinuxfs3"
     version: "0.364.0"
     url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.364.0"
-    sha1: "575fe120f1767625be78f694bd9a8c210a107d8c"
+    sha1: "1b003d688621577608c64b3700ede7021432f6b7"

--- a/manifests/cf-manifest/operations.d/320-cc-release.yml
+++ b/manifests/cf-manifest/operations.d/320-cc-release.yml
@@ -3,6 +3,6 @@
   path: /releases/name=capi
   value:
     name: "capi"
-    version: "1.146.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.146.0"
-    sha1: "eacdee032b7a78aa04af1e37a20fc0543790c2a1"
+    version: "1.148.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.148.0"
+    sha1: "9e6683176603e9fcdbe58944266409e49c6bbf04"

--- a/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/base_properties_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "base properties" do
       expect(default["os"]).to eq("ubuntu-jammy")
     end
 
-    it "stemcell version is not older than the one in cf-deployment **iff they're the same major version**" do
+    it "stemcell version is not older than the one in cf-deployment **if they're the same major version**" do
       default = stemcells.find { |s| s["alias"] == "default" }
       cf_deployment_default = cf_deployment_manifest.fetch("stemcells").find { |s| s["alias"] == "default" }
 

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "release versions" do
     # - attempted login using an unknown/unrelated Google account
     #
     # these are tricky to automate due to their reliance on SSO and/or email.
-    tested_uaa_version = "76.5.0"
+    tested_uaa_version = "76.8.0"
     manifest_releases = get_manifest_releases
 
     expect(manifest_releases).to have_key("uaa"), "expected release for uaa to be found in manifest"
@@ -118,7 +118,7 @@ RSpec.describe "release versions" do
     expect(monitor_remote_smoke_tests_resource_version).to eq(cf_smoke_tests_resource_version)
   end
 
-  pinned_cf_acceptance_tests_version = "26.5"
+  pinned_cf_acceptance_tests_version = nil #"26.5"
   specify "cf-acceptance-tests version should be the same as the CF manifest version" do
     cf_manifest_version = cf_deployment_manifest
       .fetch("manifest_version")

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe "release versions" do
     expect(monitor_remote_smoke_tests_resource_version).to eq(cf_smoke_tests_resource_version)
   end
 
-  pinned_cf_acceptance_tests_version = 27.2
+  pinned_cf_acceptance_tests_version = "27.2"
   specify "cf-acceptance-tests version should be the same as the CF manifest version" do
     cf_manifest_version = cf_deployment_manifest
       .fetch("manifest_version")

--- a/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/release_versions_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe "release versions" do
     expect(monitor_remote_smoke_tests_resource_version).to eq(cf_smoke_tests_resource_version)
   end
 
-  pinned_cf_acceptance_tests_version = nil #"26.5"
+  pinned_cf_acceptance_tests_version = 27.2
   specify "cf-acceptance-tests version should be the same as the CF manifest version" do
     cf_manifest_version = cf_deployment_manifest
       .fetch("manifest_version")


### PR DESCRIPTION
What
----

Upgrading cf-deployment to v27.2.0 and the associated manifest changes.

How to review
-------------

Run through the upgrade procedure in our internal docs: https://team-manual.cloud.service.gov.uk/guides/upgrade_cf-deployment/

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
