### PR TITLE
[#185156395] Upgrade stemcell to v1.108

### DIFF
--- a/manifests/app-autoscaler/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/app-autoscaler/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-jammy
-      version: "1.102"
+      version: "1.108"

--- a/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
+++ b/manifests/cf-manifest/operations.d/020-bosh-set-stemcells.yml
@@ -4,4 +4,4 @@
   value:
     - alias: default
       os: ubuntu-jammy
-      version: "1.102"
+      version: "1.108"


### PR DESCRIPTION
What
----

Upgrade stemcell to 1.108. This is being expedited due [this issue](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/287) in 1.102.

How to review
-------------

tbd

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
