### PR TITLE
[#184917692] Remove AWS vpns

### DIFF
--- a/terraform/prod-lon.vpn.json
+++ b/terraform/prod-lon.vpn.json
@@ -1,26 +1,2 @@
 [
-  {
-    "name": "bjss-prod-vpn",
-    "aws_customer_gateway": {
-      "bgp_asn": 65000,
-      "ip_address": "20.254.38.220"
-    },
-    "aws_vpn_connection": {
-      "destination_cidr_blocks": [
-        "172.28.32.0/21"
-      ]
-    }
-  },
-  {
-    "name": "bjss-pre-prod-vpn",
-    "aws_customer_gateway": {
-      "bgp_asn": 65000,
-      "ip_address": "51.11.166.6"
-    },
-    "aws_vpn_connection": {
-      "destination_cidr_blocks": [
-        "172.28.24.0/21"
-      ]
-    }
-  }
 ]

--- a/terraform/stg-lon.vpn.json
+++ b/terraform/stg-lon.vpn.json
@@ -1,14 +1,2 @@
 [
-    {
-        "name": "test-vpn1",
-        "aws_customer_gateway": {
-            "bgp_asn": 65000,
-            "ip_address": "35.177.73.214"
-        },
-        "aws_vpn_connection": {
-            "destination_cidr_blocks": [
-                "172.20.0.0/24"
-            ]
-        }
-    }
 ]


### PR DESCRIPTION
What
----

The changes are associated with pivotal tracker ticket [184917692](https://www.pivotaltracker.com/n/projects/1275640/stories/184917692). The configuration has been removed for the vpns created in staging and production. That will cause the vpn-terraform job in the create-cloudfoundry pipeline to remove the vpns when it is run in those environments.

Pivotal tracker ticket [185156797](https://www.pivotaltracker.com/n/projects/1275640/stories/185156797) is related to this work and will remove the vpn code and configuration. That PR should not be merged until this change has successfully passed through production.

How to review
-------------

The changes will only impact the staging and production environment as there is no vpn config for dev.

Review code changes and run into a dev env.

The vpn-terraform job will fail in dev because it attempts to create an rds parameter group that has been manually added (I can see that the parameter group has been created in staging and prod because I viewed the vpn-state files in those environments). The pipeline should complete without any other failures.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
