### PR TITLE
18504128 - Update docker images

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -115,7 +115,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/alpine
-              tag: b25554b10d0efb9da2aef192f9a890199863f59e
+              tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
           inputs:
             - name: paas-cf
           params:
@@ -142,7 +142,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/bosh-cli-v2
-              tag: b25554b10d0efb9da2aef192f9a890199863f59e
+              tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
           run:
             path: sh
             args:
@@ -178,7 +178,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/awscli
-              tag: b25554b10d0efb9da2aef192f9a890199863f59e
+              tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
           run:
             path: ./paas-cf/concourse/scripts/rds_instances.sh
             args:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -11,32 +11,32 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/alpine
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
     psql: &psql-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/psql
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
     node: &node-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/node
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
     node-chromium: &node-chromium-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/node-chromium
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
     awscli: &awscli-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
     cf-acceptance-tests: &cf-acceptance-tests-image-resource
       type: registry-image
       source:
@@ -46,37 +46,37 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/cf-cli
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
     cf-uaac: &cf-uaac-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/cf-uaac
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
     git-ssh: &git-ssh-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/git-ssh
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
     ruby-slim: &ruby-slim-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/ruby
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
     golang: &golang-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/golang
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
     terraform: &terraform-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
     curl-ssl: &curl-ssl-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/curl-ssl
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 
 
   tasks:
@@ -272,7 +272,7 @@ resource_types:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/concourse-pool-resource
-    tag: b25554b10d0efb9da2aef192f9a890199863f59e
+    tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 
 - name: s3-iam
   type: registry-image
@@ -835,7 +835,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: b25554b10d0efb9da2aef192f9a890199863f59e
+              tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 
           inputs:
             - name: paas-cf
@@ -5397,7 +5397,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/spruce
-              tag: b25554b10d0efb9da2aef192f9a890199863f59e
+              tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 
           inputs:
             - name: paas-cf
@@ -6468,7 +6468,7 @@ jobs:
           type: registry-image
           source:
             repository: ghcr.io/alphagov/paas/cf-uaac
-            tag: b25554b10d0efb9da2aef192f9a890199863f59e
+            tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 
         inputs:
           - name: passwords

--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -41,7 +41,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/alpine
-              tag: b25554b10d0efb9da2aef192f9a890199863f59e
+              tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
           inputs:
             - name: paas-cf
             - name: deployment-timer
@@ -71,7 +71,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/awscli
-              tag: b25554b10d0efb9da2aef192f9a890199863f59e
+              tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 
           run:
             path: ./paas-cf/concourse/scripts/rds_instances.sh
@@ -86,7 +86,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: b25554b10d0efb9da2aef192f9a890199863f59e
+              tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 
           inputs:
             - name: paas-cf
@@ -119,7 +119,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: b25554b10d0efb9da2aef192f9a890199863f59e
+              tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 
           inputs:
             - name: paas-cf

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -99,7 +99,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: b25554b10d0efb9da2aef192f9a890199863f59e
+              tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 
           inputs:
             - name: paas-cf
@@ -189,7 +189,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/bosh-cli-v2
-              tag: b25554b10d0efb9da2aef192f9a890199863f59e
+              tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 
           inputs:
             - name: bosh-vars-store
@@ -243,7 +243,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/ruby
-              tag: b25554b10d0efb9da2aef192f9a890199863f59e
+              tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
           inputs:
             - name: paas-cf
             - name: cf-tfstate
@@ -286,7 +286,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/terraform
-              tag: b25554b10d0efb9da2aef192f9a890199863f59e
+              tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 
           inputs:
             - name: terraform-variables

--- a/concourse/pipelines/monitor-remote.yml
+++ b/concourse/pipelines/monitor-remote.yml
@@ -57,7 +57,7 @@ jobs:
         type: registry-image
         source:
           repository: ghcr.io/alphagov/paas/self-update-pipelines
-          tag: b25554b10d0efb9da2aef192f9a890199863f59e
+          tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 
       inputs:
       - name: paas-cf

--- a/concourse/pipelines/test-certificate-rotation.yml
+++ b/concourse/pipelines/test-certificate-rotation.yml
@@ -5,25 +5,25 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 
     cf-acceptance-tests: &cf-acceptance-tests-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 
     cf-cli: &cf-cli-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/cf-cli
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 
 
 resource_types:
@@ -40,7 +40,7 @@ resource_types:
     type: registry-image
     source:
       repository: ghcr.io/alphagov/paas/olhtbr-metadata-resource
-      tag: b25554b10d0efb9da2aef192f9a890199863f59e
+      tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 
   - name: s3-iam
     type: registry-image

--- a/concourse/tasks/aiven-broker-acceptance-tests-run.yml
+++ b/concourse/tasks/aiven-broker-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: b25554b10d0efb9da2aef192f9a890199863f59e
+    tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 inputs:
   - name: paas-cf
   - name: test-config

--- a/concourse/tasks/app-autoscaler-acceptance-tests-run.yml
+++ b/concourse/tasks/app-autoscaler-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: b25554b10d0efb9da2aef192f9a890199863f59e
+    tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 inputs:
   - name: paas-cf
   - name: admin-creds

--- a/concourse/tasks/check-az-is-enabled-in-manifest.yml
+++ b/concourse/tasks/check-az-is-enabled-in-manifest.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: b25554b10d0efb9da2aef192f9a890199863f59e
+    tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 params:
   DEPLOY_ENV:
   BOSH_ENVIRONMENT:

--- a/concourse/tasks/check-az-is-enabled-in-vpc.yml
+++ b/concourse/tasks/check-az-is-enabled-in-vpc.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: b25554b10d0efb9da2aef192f9a890199863f59e
+    tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 params:
   AWS_DEFAULT_REGION:
   EXPECTED_ACL_NAME:

--- a/concourse/tasks/check-billing-comparison-with-cf.yml
+++ b/concourse/tasks/check-billing-comparison-with-cf.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: b25554b10d0efb9da2aef192f9a890199863f59e
+    tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 inputs:
   - name: paas-billing
 params:

--- a/concourse/tasks/configure-grafana.yml
+++ b/concourse/tasks/configure-grafana.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/ruby
-    tag: b25554b10d0efb9da2aef192f9a890199863f59e
+    tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 inputs:
   - name: paas-trusted-people
 run:

--- a/concourse/tasks/create_admin.yml
+++ b/concourse/tasks/create_admin.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-uaac
-    tag: b25554b10d0efb9da2aef192f9a890199863f59e
+    tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 inputs:
   - name: paas-cf
   - name: cf-manifest

--- a/concourse/tasks/cronitor-monitor-ping-action.yml
+++ b/concourse/tasks/cronitor-monitor-ping-action.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: b25554b10d0efb9da2aef192f9a890199863f59e
+    tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 run:
   path: sh
   args:

--- a/concourse/tasks/curl-az-healthcheck.yml
+++ b/concourse/tasks/curl-az-healthcheck.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/curl-ssl
-    tag: b25554b10d0efb9da2aef192f9a890199863f59e
+    tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 params:
   AVAILABILITY_ZONE:
   ENABLE_AZ_HEALTHCHECK:

--- a/concourse/tasks/custom-acceptance-tests-run.yml
+++ b/concourse/tasks/custom-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: b25554b10d0efb9da2aef192f9a890199863f59e
+    tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 inputs:
   - name: paas-cf
   - name: test-config

--- a/concourse/tasks/custom-broker-acceptance-tests-run.yml
+++ b/concourse/tasks/custom-broker-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: b25554b10d0efb9da2aef192f9a890199863f59e
+    tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 inputs:
   - name: paas-cf
   - name: test-config

--- a/concourse/tasks/delete_admin.yml
+++ b/concourse/tasks/delete_admin.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
-    tag: b25554b10d0efb9da2aef192f9a890199863f59e
+    tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 inputs:
   - name: paas-cf
   - name: cf-manifest

--- a/concourse/tasks/forget-access-keys.yml
+++ b/concourse/tasks/forget-access-keys.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/terraform
-    tag: b25554b10d0efb9da2aef192f9a890199863f59e
+    tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 inputs:
   - name: paas-cf
   - name: cf-tfstate

--- a/concourse/tasks/generate-git-keys.yml
+++ b/concourse/tasks/generate-git-keys.yml
@@ -3,7 +3,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: b25554b10d0efb9da2aef192f9a890199863f59e
+    tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 run:
   path: sh
   args:

--- a/concourse/tasks/generate-test-config.yml
+++ b/concourse/tasks/generate-test-config.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: b25554b10d0efb9da2aef192f9a890199863f59e
+    tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 inputs:
   - name: paas-cf
   - name: admin-creds

--- a/concourse/tasks/get-cf-cli-config.yml
+++ b/concourse/tasks/get-cf-cli-config.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/ruby
-    tag: b25554b10d0efb9da2aef192f9a890199863f59e
+    tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 inputs:
   - name: paas-cf
   - name: cf-manifest

--- a/concourse/tasks/remove-db.yml
+++ b/concourse/tasks/remove-db.yml
@@ -7,7 +7,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
-    tag: b25554b10d0efb9da2aef192f9a890199863f59e
+    tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 run:
   path: sh
   args:

--- a/concourse/tasks/send-nagging-email-alert.yml
+++ b/concourse/tasks/send-nagging-email-alert.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: b25554b10d0efb9da2aef192f9a890199863f59e
+    tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 inputs:
   - name: paas-cf
 params:

--- a/concourse/tasks/smoke-tests-run.yml
+++ b/concourse/tasks/smoke-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: b25554b10d0efb9da2aef192f9a890199863f59e
+    tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 inputs:
   - name: paas-cf
   - name: cf-smoke-tests-release

--- a/concourse/tasks/tag-repo.yml
+++ b/concourse/tasks/tag-repo.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/git-ssh
-    tag: b25554b10d0efb9da2aef192f9a890199863f59e
+    tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 inputs:
   - name: git-repo
 params:

--- a/concourse/tasks/upload-test-artifacts.yml
+++ b/concourse/tasks/upload-test-artifacts.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: b25554b10d0efb9da2aef192f9a890199863f59e
+    tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 inputs:
   - name: paas-cf
   - name: artifacts

--- a/concourse/tasks/wait-for-api-availability-tests.yml
+++ b/concourse/tasks/wait-for-api-availability-tests.yml
@@ -11,7 +11,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: b25554b10d0efb9da2aef192f9a890199863f59e
+    tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 run:
   path: sh
   args:

--- a/concourse/tasks/wait-for-app-availability-tests.yml
+++ b/concourse/tasks/wait-for-app-availability-tests.yml
@@ -13,7 +13,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
-    tag: b25554b10d0efb9da2aef192f9a890199863f59e
+    tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
 run:
   path: sh
   args:


### PR DESCRIPTION
Description:
- Updates all docker images to the latest ghcr version see [https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/276](https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/276)
- See [here](https://deployer.dev03.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry) for a clean run

How to review
-------------

Describe the steps required to test the changes.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
