### PR TITLE
Updates to DMS config

### DIFF
--- a/terraform/dms/default_task_settings.json
+++ b/terraform/dms/default_task_settings.json
@@ -18,7 +18,7 @@
     "ParallelApplyQueuesPerThread": 0
   },
   "FullLoadSettings": {
-    "TargetTablePrepMode": "DROP_AND_CREATE",
+    "TargetTablePrepMode": "DO_NOTHING",
     "CreatePkAfterFullLoad": false,
     "StopTaskCachedChangesApplied": false,
     "StopTaskCachedChangesNotApplied": false,
@@ -109,12 +109,12 @@
     ]
   },
   "ControlTablesSettings": {
-    "ControlSchema": "",
+    "ControlSchema": "public",
     "HistoryTimeslotInMinutes": 5,
-    "HistoryTableEnabled": false,
-    "SuspendedTablesTableEnabled": false,
-    "StatusTableEnabled": false,
-    "FullLoadExceptionTableEnabled": false
+    "HistoryTableEnabled": true,
+    "SuspendedTablesTableEnabled": true,
+    "StatusTableEnabled": true,
+    "FullLoadExceptionTableEnabled": true
   },
   "StreamBufferSettings": {
     "StreamBufferCount": 3,
@@ -171,5 +171,22 @@
     "EnableTT": false,
     "TTRecordSettings": null,
     "TTS3Settings": null
+  },
+  "ValidationSettings": {
+    "ValidationPartialLobSize": 0,
+    "PartitionSize": 10000,
+    "RecordFailureDelayLimitInMinutes": 0,
+    "SkipLobColumns": false,
+    "FailureMaxCount": 10000,
+    "HandleCollationDiff": false,
+    "ValidationQueryCdcDelaySeconds": 0,
+    "ValidationMode": "ROW_LEVEL",
+    "TableFailureMaxCount": 1000,
+    "RecordFailureDelayInMinutes": 5,
+    "MaxKeyColumnSize": 8096,
+    "EnableValidation": true,
+    "ThreadCount": 5,
+    "RecordSuspendDelayInMinutes": 30,
+    "ValidationOnly": false
   }
 }

--- a/terraform/prod.dms.json
+++ b/terraform/prod.dms.json
@@ -47,7 +47,7 @@
             "multi_az": false,
             "preferred_maintenance_window": "mon:22:40-mon:23:20",
             "publicly_accessible": false,
-            "replication_instance_class": "dms.c6i.large"
+            "replication_instance_class": "dms.c6i.xlarge"
         },
         "task": {
             "migration_type": "full-load-and-cdc",


### PR DESCRIPTION
What
----

- Change TargetTablePrepMode to DO_NOTHING. DMS should not be trusted to handle any part of the schema.
- Enable validation. This might be disabled later, but at the moment this gives us more confidence about the cutover.
- Enable additional dms target db tables. These give us all sorts of useful info on the state of the dms process.
- Upgrade preview replication instance to have enough memory for the validation.

How to review
-------------

Look at the changes.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
