### PR TITLE
[#184950003] Block cf deploy if failing az-healthcheck node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,7 @@ dev%: dev
 	$(eval export DEPLOY_ENV=$@)
 	$(eval export ENABLE_AUTODELETE=false)
 	$(eval export ENABLE_AZ_HEALTHCHECK ?= false)
+	$(eval export DISABLE_AZ_HEALTHCHECK_BLOCK ?= false)
 	@true
 
 .PHONY: stg-lon
@@ -247,6 +248,7 @@ stg-lon: ## Set Environment to stg-lon
 	$(eval export PERSISTENT_ENVIRONMENT=true)
 	$(eval export ENABLE_AUTO_DEPLOY=true)
 	$(eval export ENABLE_AZ_HEALTHCHECK=true)
+	$(eval export DISABLE_AZ_HEALTHCHECK_BLOCK ?= false)
 	$(eval export OUTPUT_TAG_PREFIX=prod-)
 	$(eval export SYSTEM_DNS_ZONE_NAME=london.staging.cloudpipeline.digital)
 	$(eval export APPS_DNS_ZONE_NAME=london.staging.cloudpipelineapps.digital)
@@ -273,6 +275,7 @@ prod: ## Set Environment to Production
 	$(eval export PERSISTENT_ENVIRONMENT=true)
 	$(eval export ENABLE_AUTO_DEPLOY=true)
 	$(eval export ENABLE_AZ_HEALTHCHECK=true)
+	$(eval export DISABLE_AZ_HEALTHCHECK_BLOCK ?= false)
 	$(eval export INPUT_TAG_PREFIX=prod-)
 	$(eval export SYSTEM_DNS_ZONE_NAME=cloud.service.gov.uk)
 	$(eval export APPS_DNS_ZONE_NAME=cloudapps.digital)
@@ -299,6 +302,7 @@ prod-lon: ## Set Environment to prod-lon
 	$(eval export PERSISTENT_ENVIRONMENT=true)
 	$(eval export ENABLE_AUTO_DEPLOY=true)
 	$(eval export ENABLE_AZ_HEALTHCHECK=true)
+	$(eval export DISABLE_AZ_HEALTHCHECK_BLOCK ?= false)
 	$(eval export INPUT_TAG_PREFIX=prod-)
 	$(eval export SYSTEM_DNS_ZONE_NAME=london.cloud.service.gov.uk)
 	$(eval export APPS_DNS_ZONE_NAME=london.cloudapps.digital)

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -140,6 +140,9 @@ groups:
       - cf-terraform
       - psn-terraform
       - az-healthcheck-terraform
+      - az-a-healthcheck
+      - az-b-healthcheck
+      - az-c-healthcheck
       - vpc-peering-terraform
       - dms-terraform
       - generate-cf-config
@@ -2425,6 +2428,9 @@ jobs:
             passed: ['az-healthcheck-terraform']
           - get: az-healthcheck-tfstate
             passed: ['az-healthcheck-terraform']
+          - get: pipeline-trigger
+            passed: ['az-healthcheck-terraform']
+            trigger: true
 
       - task: extract-terraform-variables
         tags: [colocated-with-web]
@@ -2479,6 +2485,9 @@ jobs:
             passed: ['az-healthcheck-terraform']
           - get: az-healthcheck-tfstate
             passed: ['az-healthcheck-terraform']
+          - get: pipeline-trigger
+            passed: ['az-healthcheck-terraform']
+            trigger: true
 
       - task: extract-terraform-variables
         tags: [colocated-with-web]
@@ -2533,6 +2542,9 @@ jobs:
             passed: ['az-healthcheck-terraform']
           - get: az-healthcheck-tfstate
             passed: ['az-healthcheck-terraform']
+          - get: pipeline-trigger
+            passed: ['az-healthcheck-terraform']
+            trigger: true
 
       - task: extract-terraform-variables
         tags: [colocated-with-web]
@@ -2584,7 +2596,11 @@ jobs:
       - *add-grafana-job-annotation
       - in_parallel:
           - get: pipeline-trigger
-            passed: ['cf-terraform']
+            passed:
+              - cf-terraform
+              - az-a-healthcheck
+              - az-b-healthcheck
+              - az-c-healthcheck
             trigger: true
           - <<: *get-paas-cf
             passed: ['cf-terraform']

--- a/concourse/tasks/curl-az-healthcheck.yml
+++ b/concourse/tasks/curl-az-healthcheck.yml
@@ -20,7 +20,7 @@ run:
       echo "Checking the ability to perform tests on ${AVAILABILITY_ZONE}..."
 
       if [ "${ENABLE_AZ_HEALTHCHECK:-}" = "false" ]; then
-        echo "Availabilty Zone Healthchecks have been disabled."
+        echo "Availability Zone Healthchecks instances do not exist."
         exit 0
       fi
 
@@ -30,4 +30,26 @@ run:
 
       # shellcheck disable=SC2154
       echo "Attempting to get a response from the healthcheck in ${AVAILABILITY_ZONE} at ${HEALTHCHECK_IP}..."
-      curl "http://${HEALTHCHECK_IP}:3000"
+      # if the DISABLE_AZ_HEALTHCHECK_BLOCK flag is set, we don't care about the response
+      if [ "${DISABLE_AZ_HEALTHCHECK_BLOCK:-}" = "true" ]; then
+        echo "Availability Zone Healthchecks have been disabled."
+        exit 0
+      fi
+
+      for attempt in $(seq 12); do
+        echo "Attempt ${attempt}..."
+        if curl -s -o /dev/null -w "%{http_code}" "http://${HEALTHCHECK_IP}:3000" -m 5 | grep -q 200; then
+          echo "Availability Zone Healthchecks are up. Double checking..."
+          if curl -s -o /dev/null -w "%{http_code}" "http://${HEALTHCHECK_IP}:3000" -m 5 | grep -q 200; then
+            echo "Success!"
+            exit 0
+          else
+            echo "Double check failed!"
+            exit 1
+          fi
+        fi
+        sleep 5
+      done
+
+      echo "Availability Zone Healthchecks are not working in this zone."
+      exit 1


### PR DESCRIPTION
What
----

X can be a,b or c

- Block deployments if the `az-X-healthcheck` tasks are failing
- Allow an override to be used to ignore failing healthchecks (`DISABLE_AZ_HEALTHCHECK_BLOCK`)
  - This gives us the ability to override the checks and work around the az outage if we have an az outage

How to review
-------------

Deploy cloudfoundry with the following flags set:

- Enable availability zone healthchecks `ENABLE_AZ_HEALTHCHECK=true`
- Disable availability zone healthchecks block `DISABLE_AZ_HEALTHCHECK_BLOCK=false`

We need to simulate an az being down and we can do that by simply hopping into the AWS console and stopping an az healthcheck instance. The healthcheck node will fail the curl against that instance and we should see deploys blocked.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
