### PR TITLE
fix: fix uid for 'Billing compared to spending (new billing metrics)' dashboard

### DIFF
--- a/manifests/prometheus/dashboards.d/billing-compared-to-spending-new_metrics.json
+++ b/manifests/prometheus/dashboards.d/billing-compared-to-spending-new_metrics.json
@@ -1111,7 +1111,7 @@
   },
   "timezone": "",
   "title": "Billing compared to spending (new billing metrics)",
-  "uid": "billing-compared-to-spending--new-metrics",
+  "uid": "billing-compared-to-spending-new-metrics",
   "version": 5,
   "weekStart": ""
 }

--- a/manifests/prometheus/spec/dashboard_validation_spec.rb
+++ b/manifests/prometheus/spec/dashboard_validation_spec.rb
@@ -1,35 +1,38 @@
 require "json"
 
-RSpec.describe "grafana dashboards" do
+RSpec.describe "grafana dashboard" do
   grafana_dashboards.each do |dashboard_name, dashboard_contents|
-    it "ends in .json" do
-      expect(dashboard_name).to match(/[.]json$/)
-    end
+    context dashboard_name do
+      it "ends in .json" do
+        expect(dashboard_name).to match(/[.]json$/)
+      end
 
-    it "is valid json" do
-      expect { JSON.parse dashboard_contents }.not_to raise_error
-    end
+      it "is valid json" do
+        expect { JSON.parse dashboard_contents }.not_to raise_error
+      end
 
-    it "has a title and uid" do
-      dashboard = JSON.parse(dashboard_contents)
+      it "has a title and uid" do
+        dashboard = JSON.parse(dashboard_contents)
 
-      title = dashboard["title"]
-      uid = dashboard["uid"]
+        title = dashboard["title"]
+        uid = dashboard["uid"]
 
-      expect(title).to be_kind_of(String)
-      expect(uid).to be_kind_of(String)
+        expect(title).to be_kind_of(String)
+        expect(uid).to be_kind_of(String)
 
-      expect(title).to match(/[-A-Za-z0-9]+/)
-      expect(uid).to match(/^[-a-z0-9]+$/)
-    end
+        expect(title).to match(/[-A-Za-z0-9]+/)
+        expect(uid).to match(/^[-a-z0-9]+$/)
+        expect(uid.length).to be <= 40
+      end
 
-    it "has a null id" do
-      dashboard = JSON.parse(dashboard_contents)
+      it "has a null id" do
+        dashboard = JSON.parse(dashboard_contents)
 
-      id_exists = dashboard.key?("id")
-      id = dashboard["id"]
-      expect(id_exists).to(be(true), "must include an 'id' key")
-      expect(id).to(be(nil), "must specify id: null")
+        id_exists = dashboard.key?("id")
+        id = dashboard["id"]
+        expect(id_exists).to(be(true), "must include an 'id' key")
+        expect(id).to(be(nil), "must specify id: null")
+      end
     end
   end
 end


### PR DESCRIPTION
What
----

Dashboard UIDs should be <= 40 characters in length. The UID for this dashboard was 41 characters.

I've removed a character.

Also, added a test to prevent this in future.

Context: I changed the UID after the last deploy attempt, and before it was deployed to staging, so missed it - sorry!

How to review
-------------

👀

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
