### PR TITLE
vpc peers: add ability for some peers to be able to get traffic routed back from backing service subnets

### DIFF
--- a/terraform/cloudfoundry/backing_services.tf
+++ b/terraform/cloudfoundry/backing_services.tf
@@ -1,0 +1,14 @@
+resource "aws_route_table" "aws_backing_services" {
+  vpc_id = var.vpc_id
+  tags = {
+    Name = "${var.env}-aws-backing-services"
+  }
+
+  # the vpc-peering may add entries
+}
+
+resource "aws_route_table_association" "aws_backing_services" {
+  count          = length(var.aws_backing_service_cidrs)
+  subnet_id      = aws_subnet.aws_backing_services[count.index].id
+  route_table_id = aws_route_table.aws_backing_services.id
+}

--- a/terraform/vpc-peering/variables.tf
+++ b/terraform/vpc-peering/variables.tf
@@ -4,6 +4,7 @@ variable "vpc_peers" {
     account_id  = string
     vpc_id      = string
     subnet_cidr = string
+    backing_service_routing = optional(bool)
   }))
   default = []
   validation {

--- a/terraform/vpc-peering/vpc_peering.tf
+++ b/terraform/vpc-peering/vpc_peering.tf
@@ -37,6 +37,13 @@ resource "aws_vpc_peering_connection" "vpc_peer" {
   peer_owner_id = each.value.account_id
   peer_vpc_id   = each.value.vpc_id
   vpc_id        = var.vpc_id
+
+  # possibly irritating for us, but it will be more irritating to our tenants if
+  # we accidentally re-create an existing peering, leaving them to re-accept it
+  # and reconfigure their route tables
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_route" "vpc_peer_route_0" {


### PR DESCRIPTION
What
----

https://www.pivotaltracker.com/story/show/184840850

Firstly this switches backing service subnets to use a custom VPC route table rather than the default one, allowing us finer grained control.

Then, based on Ben's #3134, this optionally adds an entry to the ~default VPC~ backing service subnet's routing table to allow packets to be routed _to_ a peer VPC. ~While the rule itself is quite general, this actually affects little more than our backing-services subnets because our infra subnet uses a custom route table as do our cell subnets.~

Security groups remain in place on individual machines, which have the main responsibility for policing access - for backing services, these only allow traffic from cells and brokers . Backing services also have no outbound rules so shouldn't be able to make outgoing connections _to_ the peered VPCs.

I'd still love it if we could get e.g. VPC flow logging in place before we use this in prod.

How to review
-------------

You might need me to show you.

 - Deploy to a dev env with an entry in `<env>.vpc_peering.json` pointing to a VPC in our experimental account and `"backing_service_routing": true`.
 - Accept the peering request from our experimental account through the AWS console.
 - Set up a routing table entry in the experimental VPC to allow traffic to go to 10.x.x.x through the VPC peering.
 - Find the login credentials for a brokered database in the dev env.
 - Clickops-create a security group in the dev env VPC allowing ingress from the peered VPC subnet & add it to the chosen brokered database.
 - Try to connect to the database from a throwaway EC2 machine in the experimental VPC.

I already have most of the required things set up in the experimental account, so just ask me for all the details if you like.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
