### PR TITLE
Enable backing service routing for notify vpc peers in prod

### DIFF
--- a/terraform/prod.vpc_peering.json
+++ b/terraform/prod.vpc_peering.json
@@ -9,18 +9,21 @@
         "peer_name": "notify-preview",
         "account_id": "302763885840",
         "vpc_id": "vpc-041c16b2b4cbb93bd",
-        "subnet_cidr": "10.201.0.0/16"
+        "subnet_cidr": "10.201.0.0/16",
+        "backing_service_routing": true
     },
     {
         "peer_name": "notify-staging",
         "account_id": "608850477283",
         "vpc_id": "vpc-0d11704be8c6202d5",
-        "subnet_cidr": "10.202.0.0/16"
+        "subnet_cidr": "10.202.0.0/16",
+        "backing_service_routing": true
     },
     {
         "peer_name": "notify-production",
         "account_id": "888450439860",
         "vpc_id": "vpc-02646a06ea82ddc8a",
-        "subnet_cidr": "10.203.0.0/16"
+        "subnet_cidr": "10.203.0.0/16",
+        "backing_service_routing": true
     }
 ]


### PR DESCRIPTION
What
----

- Enable backing service routing for notify vpc peers in prod
- Fix vpc_peering_test so it works with the new vpc_peer option (backing_service_routing)

How to Review
-------------

Check the changes.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
