### PR TITLE
create-concourse: add nonadmin user creation, use for billing acceptance tests

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -5829,43 +5829,74 @@ jobs:
             PREFIX: billing-acctests-admin
             DISABLE_ADMIN_USER_CREATION: false
             UAA_ADMIN_CLIENT_PASS: ((uaa_admin_client_secret))
-        - task: paas-billing-acceptance-tests
-          tags: [colocated-with-web]
-          config:
-            platform: linux
-            image_resource: *cf-acceptance-tests-image-resource
+        - do:
+          - task: create-temp-nonadmin
+            tags: [colocated-with-web]
+            file: paas-cf/concourse/tasks/create_nonadmin.yml
             params:
-              SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
-              DEPLOY_ENV: ((deploy_env))
+              PREFIX: billing-acctests-nonadmin
               API_ENDPOINT: ((api_endpoint))
               CF_ADMIN: ((cf_admin))
               CF_PASS: ((cf_pass))
-            inputs:
-              - name: paas-cf
-              - name: admin-creds
-              - name: paas-billing
-                path: src/github.com/alphagov/paas-billing
-            run:
-              path: sh
-              args:
-                - -e
-                - -u
-                - -c
-                - |
-                  cf api "${API_ENDPOINT}"
+              BILLING_MANAGER_ORG: admin  # we know this will exist
+          - task: paas-billing-acceptance-tests
+            tags: [colocated-with-web]
+            config:
+              platform: linux
+              image_resource: *cf-acceptance-tests-image-resource
+              params:
+                SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+                DEPLOY_ENV: ((deploy_env))
+                API_ENDPOINT: ((api_endpoint))
+                CF_ADMIN: ((cf_admin))
+                CF_PASS: ((cf_pass))
+              inputs:
+                - name: paas-cf
+                - name: admin-creds
+                - name: nonadmin-creds
+                - name: paas-billing
+                  path: src/github.com/alphagov/paas-billing
+              run:
+                path: sh
+                args:
+                  - -e
+                  - -u
+                  - -c
+                  - |
+                    cf api "${API_ENDPOINT}"
 
-                  cf auth "$(cat admin-creds/username)" "$(cat admin-creds/password)"
-                  # if we don't target a space with these creds we will run into
-                  # https://github.com/cloudfoundry/cli/issues/2086 and not be able to
-                  # delete the account
-                  cf target -o admin -s billing
-                  export CF_ADMIN_BEARER_TOKEN="$(cf oauth-token | cut -d' ' -f2)"
+                    cf auth "$(cat admin-creds/username)" "$(cat admin-creds/password)"
+                    # if we don't target a space with these creds we will run into
+                    # https://github.com/cloudfoundry/cli/issues/2086 and not be able to
+                    # delete the account
+                    cf target -o admin -s billing
+                    CF_ADMIN_BEARER_TOKEN="$(cf oauth-token | cut -d' ' -f2)"
+                    export CF_ADMIN_BEARER_TOKEN
 
-                  export BILLING_API_URL="https://billing.${SYSTEM_DNS_ZONE_NAME}"
-                  export METRICSPROXY_API_URL="https://billing-metrics-proxy.${SYSTEM_DNS_ZONE_NAME}"
-                  cd src/github.com/alphagov/paas-billing
+                    cf auth "$(cat nonadmin-creds/username)" "$(cat nonadmin-creds/password)"
+                    CF_NONADMIN_BEARER_TOKEN="$(cf oauth-token | cut -d' ' -f2)"
+                    export CF_NONADMIN_BEARER_TOKEN
+                    if [ -e nonadmin-creds/billing-manager-org-guid ] ; then
+                      CF_NONADMIN_BILLING_MANAGER_ORG_GUID="$(cat nonadmin-creds/billing-manager-org-guid)"
+                      export CF_NONADMIN_BILLING_MANAGER_ORG_GUID
+                    fi
 
-                  make acceptance
+                    export BILLING_API_URL="https://billing.${SYSTEM_DNS_ZONE_NAME}"
+                    export METRICSPROXY_API_URL="https://billing-metrics-proxy.${SYSTEM_DNS_ZONE_NAME}"
+                    cd src/github.com/alphagov/paas-billing
+
+                    make acceptance
+          ensure:
+            task: remove-temp-nonadmin
+            tags: [colocated-with-web]
+            file: paas-cf/concourse/tasks/delete_user.yml
+            timeout: 5m
+            input_mapping:
+              user-creds: nonadmin-creds
+            params:
+              API_ENDPOINT: ((api_endpoint))
+              CF_ADMIN: ((cf_admin))
+              CF_PASS: ((cf_pass))
         ensure:
           task: remove-temp-admin
           tags: [colocated-with-web]

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -5526,6 +5526,9 @@ jobs:
           trigger: true
           passed: ['post-deploy']
 
+        - get: cf-manifest
+          passed: ['post-deploy']
+
       # this tests the "integration" of this paas-billing revision with the
       # configuration in this paas-cf revision, performed before deployment
       # to give us a chance to avoid deploying a broken combination.
@@ -5818,38 +5821,62 @@ jobs:
                   sleep 10
                 done
 
-      - task: paas-billing-acceptance-tests
-        tags: [colocated-with-web]
-        config:
-          platform: linux
-          image_resource: *cf-acceptance-tests-image-resource
+      - do:
+        - task: create-temp-admin
+          tags: [colocated-with-web]
+          file: paas-cf/concourse/tasks/create_admin.yml
           params:
-            SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
-            DEPLOY_ENV: ((deploy_env))
+            PREFIX: billing-acctests-admin
+            DISABLE_ADMIN_USER_CREATION: false
+            UAA_ADMIN_CLIENT_PASS: ((uaa_admin_client_secret))
+        - task: paas-billing-acceptance-tests
+          tags: [colocated-with-web]
+          config:
+            platform: linux
+            image_resource: *cf-acceptance-tests-image-resource
+            params:
+              SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+              DEPLOY_ENV: ((deploy_env))
+              API_ENDPOINT: ((api_endpoint))
+              CF_ADMIN: ((cf_admin))
+              CF_PASS: ((cf_pass))
+            inputs:
+              - name: paas-cf
+              - name: admin-creds
+              - name: paas-billing
+                path: src/github.com/alphagov/paas-billing
+            run:
+              path: sh
+              args:
+                - -e
+                - -u
+                - -c
+                - |
+                  cf api "${API_ENDPOINT}"
+
+                  cf auth "$(cat admin-creds/username)" "$(cat admin-creds/password)"
+                  # if we don't target a space with these creds we will run into
+                  # https://github.com/cloudfoundry/cli/issues/2086 and not be able to
+                  # delete the account
+                  cf target -o admin -s billing
+                  export CF_ADMIN_BEARER_TOKEN="$(cf oauth-token | cut -d' ' -f2)"
+
+                  export BILLING_API_URL="https://billing.${SYSTEM_DNS_ZONE_NAME}"
+                  export METRICSPROXY_API_URL="https://billing-metrics-proxy.${SYSTEM_DNS_ZONE_NAME}"
+                  cd src/github.com/alphagov/paas-billing
+
+                  make acceptance
+        ensure:
+          task: remove-temp-admin
+          tags: [colocated-with-web]
+          file: paas-cf/concourse/tasks/delete_user.yml
+          timeout: 5m
+          input_mapping:
+            user-creds: admin-creds
+          params:
             API_ENDPOINT: ((api_endpoint))
             CF_ADMIN: ((cf_admin))
             CF_PASS: ((cf_pass))
-          inputs:
-            - name: paas-cf
-            - name: paas-billing
-              path: src/github.com/alphagov/paas-billing
-          run:
-            path: sh
-            args:
-              - -e
-              - -u
-              - -c
-              - |
-                cf api "${API_ENDPOINT}"
-                cf auth "${CF_ADMIN}" "${CF_PASS}"
-
-                cf target -o admin -s billing
-
-                export BILLING_API_URL="https://billing.${SYSTEM_DNS_ZONE_NAME}"
-                export METRICSPROXY_API_URL="https://billing-metrics-proxy.${SYSTEM_DNS_ZONE_NAME}"
-                cd src/github.com/alphagov/paas-billing
-
-                make acceptance
 
       - task: tag-repo
         tags: [colocated-with-web]

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -4801,8 +4801,10 @@ jobs:
         ensure:
           task: remove-temp-user
           tags: [colocated-with-web]
-          file: paas-cf/concourse/tasks/delete_admin.yml
+          file: paas-cf/concourse/tasks/delete_user.yml
           timeout: 5m
+          input_mapping:
+            user-creds: admin-creds
           params:
             API_ENDPOINT: ((api_endpoint))
             CF_ADMIN: ((cf_admin))
@@ -4866,8 +4868,10 @@ jobs:
           ensure:
             task: remove-temp-user
             tags: [colocated-with-web]
-            file: paas-cf/concourse/tasks/delete_admin.yml
+            file: paas-cf/concourse/tasks/delete_user.yml
             timeout: 5m
+            input_mapping:
+              user-creds: admin-creds
             params:
               DISABLE_ADMIN_USER_CREATION: ((disable_cf_acceptance_tests))
               API_ENDPOINT: ((api_endpoint))
@@ -4932,8 +4936,10 @@ jobs:
         ensure:
           task: remove-temp-user
           tags: [colocated-with-web]
-          file: paas-cf/concourse/tasks/delete_admin.yml
+          file: paas-cf/concourse/tasks/delete_user.yml
           timeout: 5m
+          input_mapping:
+            user-creds: admin-creds
           params:
             DISABLE_ADMIN_USER_CREATION: ((disable_custom_acceptance_tests))
             API_ENDPOINT: ((api_endpoint))
@@ -4993,8 +4999,10 @@ jobs:
         ensure:
           task: remove-temp-user
           tags: [colocated-with-web]
-          file: paas-cf/concourse/tasks/delete_admin.yml
+          file: paas-cf/concourse/tasks/delete_user.yml
           timeout: 5m
+          input_mapping:
+            user-creds: admin-creds
           params:
             DISABLE_ADMIN_USER_CREATION: ((disable_custom_acceptance_tests))
             API_ENDPOINT: ((api_endpoint))
@@ -5082,8 +5090,10 @@ jobs:
         ensure:
           task: remove-temp-user
           tags: [colocated-with-web]
-          file: paas-cf/concourse/tasks/delete_admin.yml
+          file: paas-cf/concourse/tasks/delete_user.yml
           timeout: 5m
+          input_mapping:
+            user-creds: admin-creds
           params:
             DISABLE_ADMIN_USER_CREATION: ((disable_app_autoscaler_acceptance_tests))
             API_ENDPOINT: ((api_endpoint))
@@ -5480,8 +5490,10 @@ jobs:
         ensure:
           task: remove-temp-user
           tags: [colocated-with-web]
-          file: paas-cf/concourse/tasks/delete_admin.yml
+          file: paas-cf/concourse/tasks/delete_user.yml
           timeout: 5m
+          input_mapping:
+            user-creds: admin-creds
           params:
             API_ENDPOINT: ((api_endpoint))
             CF_ADMIN: ((cf_admin))
@@ -6241,8 +6253,10 @@ jobs:
         ensure:
           task: remove-temp-user
           tags: [colocated-with-web]
-          file: paas-cf/concourse/tasks/delete_admin.yml
+          file: paas-cf/concourse/tasks/delete_user.yml
           timeout: 5m
+          input_mapping:
+            user-creds: admin-creds
           params:
             DISABLE_ADMIN_USER_CREATION: ((disable_custom_acceptance_tests))
             API_ENDPOINT: ((api_endpoint))
@@ -7002,8 +7016,10 @@ jobs:
           in_parallel:
             - task: remove-temp-user
               tags: [colocated-with-web]
-              file: paas-cf/concourse/tasks/delete_admin.yml
+              file: paas-cf/concourse/tasks/delete_user.yml
               timeout: 5m
+              input_mapping:
+                user-creds: admin-creds
               params:
                 API_ENDPOINT: ((api_endpoint))
                 CF_ADMIN: ((cf_admin))
@@ -7124,8 +7140,10 @@ jobs:
           in_parallel:
             - task: remove-temp-user
               tags: [colocated-with-web]
-              file: paas-cf/concourse/tasks/delete_admin.yml
+              file: paas-cf/concourse/tasks/delete_user.yml
               timeout: 5m
+              input_mapping:
+                user-creds: admin-creds
               params:
                 API_ENDPOINT: ((api_endpoint))
                 CF_ADMIN: ((cf_admin))

--- a/concourse/tasks/create_nonadmin.yml
+++ b/concourse/tasks/create_nonadmin.yml
@@ -1,0 +1,42 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: ghcr.io/alphagov/paas/cf-cli
+    tag: 826b547c6411b0fd22ac0b07bde11eed5523879c
+inputs:
+  - name: paas-cf
+outputs:
+  - name: nonadmin-creds
+params:
+  BILLING_MANAGER_ORG:
+run:
+  path: sh
+  args:
+    - -e
+    - -c
+    - |
+      [ -z "${PREFIX}" ] && echo "You need to specify \$PREFIX" && exit 1
+      [ -z "${CF_ADMIN}" ] && echo "You need to specify \$CF_ADMIN" && exit 1
+      [ -z "${CF_PASS}" ] && echo "You need to specify \$CF_PASS" && exit 1
+      [ -z "${API_ENDPOINT}" ] && echo "You need to specify \$API_ENDPOINT" && exit 1
+
+      SUFFIX=$(tr -cd '[:alpha:]0-9' < /dev/urandom | head -c10)
+      PASSWORD=$(tr -cd '[:alpha:]0-9' < /dev/urandom | head -c32)
+      NAME=${PREFIX}-${SUFFIX}
+
+      echo "Creating user $NAME"
+
+      cf api "${API_ENDPOINT}"
+      cf auth "${CF_ADMIN}" "${CF_PASS}"
+
+      cf create-user "${NAME}" "${PASSWORD}"
+
+      echo "${NAME}" > nonadmin-creds/username
+      echo "${PASSWORD}" > nonadmin-creds/password
+
+      if [ -n "${BILLING_MANAGER_ORG:-}" ]; then
+        cf set-org-role "${NAME}" "${BILLING_MANAGER_ORG}" BillingManager
+        cf curl -f "/v3/organizations?names=${BILLING_MANAGER_ORG}" | jq -r '.resources[0].guid' > nonadmin-creds/billing-manager-org-guid
+      fi

--- a/concourse/tasks/delete_user.yml
+++ b/concourse/tasks/delete_user.yml
@@ -8,7 +8,7 @@ image_resource:
 inputs:
   - name: paas-cf
   - name: cf-manifest
-  - name: admin-creds
+  - name: user-creds
 run:
   path: sh
   args:
@@ -21,7 +21,7 @@ run:
         exit 0
       fi
 
-      USERNAME=$(cat admin-creds/username)
+      USERNAME=$(cat user-creds/username)
 
       echo "Removing user ${USERNAME}"
 


### PR DESCRIPTION
What
----

https://www.pivotaltracker.com/story/show/185167233

This expands the way we create/delete temporary cf users in the `create-cloudfoundry` pipeline to also be able to create non-admin users (which can optionally be made a billing manager of a named org).

It then uses both admin and non-admin accounts generated this way for the billing acceptance tests. 

How to review
-------------

Deploy to a dev env, see existing acceptance tests passing and billing acceptance tests passing following a deploy.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
