### PR TITLE
[#185166925] Allow auto update of minor version of cf rds

### DIFF
--- a/terraform/cloudfoundry/cf_rds.tf
+++ b/terraform/cloudfoundry/cf_rds.tf
@@ -56,7 +56,7 @@ resource "aws_db_instance" "cf" {
   vpc_security_group_ids    = [aws_security_group.cf_rds.id]
 
   allow_major_version_upgrade = false
-  auto_minor_version_upgrade  = false
+  auto_minor_version_upgrade  = true
   apply_immediately           = false
 
   tags = {


### PR DESCRIPTION
What
----

The ITHC noted that the cf RDS instance was not enabled to permit an automatic minor version update of the instance engine. This change permits that to happen.

How to review
-------------

1 - Check that the cf RDS instance associated with your development environment has its "Auto minor version upgrade" option set to "Disabled". The option can be found under the "Maintenance and backups" tab.
2 - Run the branch into the development environment.
3 - After the cf-deploy job has completed check that the "Auto minor version upgrade" option is set to "Enabled"

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
