### PR TITLE
182889567 - Deprecate Redis 3.2 from marketplace

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -4697,6 +4697,14 @@ jobs:
                   cf create-service-broker elasticache-broker elasticache-broker "${ELASTICACHE_BROKER_PASS}" "https://${ELASTICACHE_BROKER_SERVER}"
                 fi
                 cf enable-service-access redis -b elasticache-broker
+                # Disable deprecated Redis 3.2 plans
+                cat <<EOF | xargs -n1 cf disable-service-access redis -p
+                tiny-clustered-3.2
+                tiny-3.2
+                tiny-ha-3.2
+                small-ha-3.2
+                medium-ha-3.2
+                EOF
 
       - task: remove-unused-iam-access-keys
         tags: [colocated-with-web]

--- a/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
+++ b/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
@@ -139,11 +139,10 @@
                         displayName: Clustered Tiny
                         AdditionalMetadata:
                           version: '3.2'
-
-                    # 3.2
                     - id: c84d1bef-9500-4ce9-88b2-c0bd421bbf8a
                       name: tiny-3.2
-                      description: "568MB RAM, single node, no failover, daily backups (for instances created after 21/1/2019). Free for trial orgs. Costs for billable orgs."
+                      active: false
+                      description: "DEPRECATED - do not use, 568MB RAM, single node, no failover, daily backups (for instances created after 21/1/2019). Free for trial orgs. Costs for billable orgs."
                       free: true
                       metadata:
                         displayName: Tiny
@@ -157,7 +156,8 @@
                           version: '3.2'
                     - id: ea5c8cc3-74e6-4b15-bd61-bbe244cfe63d
                       name: tiny-ha-3.2
-                      description: 1.5GB RAM, highly-available, daily backups
+                      active: false
+                      description: DEPRECATED - do not use, 1.5GB RAM, highly-available, daily backups
                       free: false
                       metadata:
                         displayName: Tiny
@@ -171,7 +171,8 @@
                           version: '3.2'
                     - id: 9162ed5b-0c88-4f43-bcaf-c6d4a45dd243
                       name: small-ha-3.2
-                      description: 3GB RAM, highly-available, daily backups
+                      active: false
+                      description: DEPRECATED - do not use, 3GB RAM, highly-available, daily backups
                       free: false
                       metadata:
                         displayName: Small
@@ -185,7 +186,8 @@
                           version: '3.2'
                     - id: b6949ea7-5c98-4c69-b981-4b5318ea8b7c
                       name: medium-ha-3.2
-                      description: 6.37GB RAM, highly-available, daily backups
+                      active: false
+                      description: DEPRECATED - do not use, 6.37GB RAM, highly-available, daily backups
                       free: false
                       metadata:
                         displayName: Medium

--- a/platform-tests/broker-acceptance/redis_service_test.go
+++ b/platform-tests/broker-acceptance/redis_service_test.go
@@ -16,18 +16,12 @@ import (
 var _ = Describe("Redis backing service", func() {
 	var (
 		plansToTestAgainst = []string{
-			"tiny-3.2",
 			"tiny-4.x",
 			"tiny-5.x",
 			"tiny-6.x",
 		}
 
 		knownPlanNames = []string{
-			"tiny-clustered-3.2",
-			"tiny-3.2",
-			"tiny-ha-3.2",
-			"small-ha-3.2",
-			"medium-ha-3.2",
 			"tiny-4.x",
 			"tiny-ha-4.x",
 			"small-ha-4.x",


### PR DESCRIPTION
Description:
----
- Removes Redis 3.2 offering so tenants can no longer spin up Redis 3.2 as AWS will not offer this come end of June

How to review
-------------

See successful run in dev02 and verify that running `cf marketplace -e redis` doesn't show Redis 3.2 plans

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
