### PR TITLE
Switch to using the bosh-prometheus new 7.0 firehose

### DIFF
--- a/manifests/cf-manifest/operations.d/009-add-prometheus-uaa-clients-attic.yml
+++ b/manifests/cf-manifest/operations.d/009-add-prometheus-uaa-clients-attic.yml
@@ -1,1 +1,0 @@
-../../prometheus/upstream/manifests/operators/deprecated/cf/add-prometheus-uaa-clients-attic.yml

--- a/manifests/cf-manifest/operations.d/030-bosh-dns.yml
+++ b/manifests/cf-manifest/operations.d/030-bosh-dns.yml
@@ -8,7 +8,7 @@
     sha1: "e4949efdf353742360955316d69e3c1d59a6cdf0"
 
 - type: replace
-  path: /addons/-
+  path: /addons?/-
   value:
     name: bosh-dns
     jobs:

--- a/manifests/prometheus/dashboards.d/logging-demand.json
+++ b/manifests/prometheus/dashboards.d/logging-demand.json
@@ -204,7 +204,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "(\n  (sum(firehose_value_metric_rep_log_rate{bosh_deployment=~\"$bosh_deployment\"}) by (app_id, app_name, space_name, organization_name))\n  + on (app_id) group_left() (\n    (512 * sum(label_replace(firehose_http_start_stop_requests, \"app_id\", \"$1\", \"application_id\", \"(.+)\")) by (app_id)/60)\n    or on (app_id) ((sum(firehose_value_metric_rep_log_rate{bosh_deployment=~\"$bosh_deployment\"}) by (app_id, app_name, space_name, organization_name)) * 0) # hack to get a vector of 0\n  )\n)",
+          "expr": "(\n  (sum(firehose_value_metric_rep_log_rate{bosh_deployment=~\"$bosh_deployment\"}) by (app_id, app_name, space_name, organization_name))\n  + on (app_id) group_left() (\n    (512 * sum(label_replace(rate(firehose_http_total[10m]), \"app_id\", \"$1\", \"application_id\", \"(.+)\")) by (app_id))\n    or on (app_id) ((sum(firehose_value_metric_rep_log_rate{bosh_deployment=~\"$bosh_deployment\"}) by (app_id, app_name, space_name, organization_name)) * 0) # hack to get a vector of 0\n  )\n)",
           "interval": "1m",
           "legendFormat": "{{ organization_name }}/{{ space_name }}/{{ app_name }}",
           "range": true,

--- a/manifests/prometheus/dashboards.d/usage-by-organization.json
+++ b/manifests/prometheus/dashboards.d/usage-by-organization.json
@@ -285,7 +285,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(sum(firehose_http_start_stop_requests{environment=~\"$environment\", bosh_deployment=~\"$bosh_deployment\", status_code=~\"$status_codes_pattern\", method=~\"$methods_pattern\"}) by (application_id) * on(application_id) group_right group(cf_application_info{organization_name!~\"[A-Z]+-.*\"}) by (application_id, organization_name)) by (organization_name) / 60",
+          "expr": "sum(sum(rate(firehose_http_total{environment=~\"$environment\", status_code=~\"$status_codes_pattern\", method=~\"$methods_pattern\"}[10m])) by (application_id) * on(application_id) group_right group(cf_application_info{organization_name!~\"[A-Z]+-.*\"}) by (application_id, organization_name)) by (organization_name)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ organization_name }}",
@@ -480,7 +480,7 @@
         "type": "prometheus",
         "uid": "P1809F7CD0C75ACF3"
       },
-      "description": "Total amount of http connection time used during a time period (i.e. 60 * 1s connections would be 1 minute).\n\nUnit is seconds, but telling grafana that makes it list large values in weeks etc. - not very useful.\n\nSorry, no status-code filtering here.",
+      "description": "Total amount of http connection time used during a 1 second period.\n\nUnit is seconds, but telling grafana that makes it list large values in weeks etc. - not very useful.\n\nSorry, no status-code filtering here.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -559,14 +559,14 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "exemplar": true,
-          "expr": "sum(sum(firehose_http_start_stop_server_request_duration_seconds_sum{environment=~\"$environment\", bosh_deployment=~\"$bosh_deployment\", method=~\"$methods_pattern\"}) by (application_id) * on(application_id) group_right group(cf_application_info{organization_name!~\"[A-Z]+-.*\"}) by (application_id, organization_name)) by (organization_name)",
+          "expr": "sum(sum(rate(firehose_http_duration_seconds_sum{environment=~\"$environment\", method=~\"$methods_pattern\", source_id!=\"gorouter\"}[10m])) by (application_id) * on(application_id) group_right group(cf_application_info{organization_name!~\"[A-Z]+-.*\"}) by (application_id, organization_name)) by (organization_name)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ organization_name }}",
           "refId": "A"
         }
       ],
-      "title": "Total request time ($methods_pattern)",
+      "title": "Total request time per second ($methods_pattern)",
       "type": "timeseries"
     }
   ],
@@ -656,7 +656,7 @@
         "name": "bosh_deployment",
         "options": [],
         "query": {
-          "query": "label_values(bosh_job_healthy{environment=~\"$environment\",bosh_name=~\"$bosh_director\",bosh_deployment!=\"bosh-health-check\"}, bosh_deployment)",
+          "query": "label_values(bosh_job_healthy{environment=~\"$environment\",bosh_name=~\"$bosh_director\",bosh_deployment!~\"(bosh-health-check|concourse|app-autoscaler|prometheus)\"}, bosh_deployment)",
           "refId": "prometheus-bosh_deployment-Variable-Query"
         },
         "refresh": 1,
@@ -748,7 +748,7 @@
             "$__all"
           ]
         },
-        "definition": "label_values(firehose_http_start_stop_server_request_duration_seconds_sum, method)",
+        "definition": "label_values(firehose_http_duration_seconds_sum, method)",
         "description": "",
         "hide": 0,
         "includeAll": true,
@@ -757,7 +757,7 @@
         "name": "methods_pattern",
         "options": [],
         "query": {
-          "query": "label_values(firehose_http_start_stop_server_request_duration_seconds_sum, method)",
+          "query": "label_values(firehose_http_duration_seconds_sum, method)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/manifests/prometheus/dashboards.d/usage-by-space.json
+++ b/manifests/prometheus/dashboards.d/usage-by-space.json
@@ -278,7 +278,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(sum(firehose_http_start_stop_requests{environment=~\"$environment\", bosh_deployment=~\"$bosh_deployment\", status_code=~\"$status_codes_pattern\", method=~\"$methods_pattern\"}) by (application_id) * on(application_id) group_right group(cf_application_info{organization_name=\"$organization_name\"}) by (application_id, space_name)) by (space_name) / 60",
+          "expr": "sum(sum(rate(firehose_http_total{environment=~\"$environment\", status_code=~\"$status_codes_pattern\", method=~\"$methods_pattern\"}[10m])) by (application_id) * on(application_id) group_right group(cf_application_info{organization_name=\"$organization_name\"}) by (application_id, space_name)) by (space_name)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ space_name }}",
@@ -472,7 +472,7 @@
         "type": "prometheus",
         "uid": "P1809F7CD0C75ACF3"
       },
-      "description": "Total amount of http connection time used during a time period (i.e. 60 * 1s connections would be 1 minute).\n\nUnit is seconds, but telling grafana that makes it list large values in weeks etc. - not very useful.\n\nSorry, no status-code filtering here.",
+      "description": "Total amount of http connection time used during a 1 second period.\n\nUnit is seconds, but telling grafana that makes it list large values in weeks etc. - not very useful.\n\nSorry, no status-code filtering here.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -551,7 +551,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "exemplar": true,
-          "expr": "sum(sum(firehose_http_start_stop_server_request_duration_seconds_sum{environment=~\"$environment\", bosh_deployment=~\"$bosh_deployment\", method=~\"$methods_pattern\"}) by (application_id) * on(application_id) group_right group(cf_application_info{organization_name=\"$organization_name\"}) by (application_id, space_name)) by (space_name)",
+          "expr": "sum(sum(rate(firehose_http_duration_seconds_sum{environment=~\"$environment\", method=~\"$methods_pattern\", source_id!=\"gorouter\"}[10m])) by (application_id) * on(application_id) group_right group(cf_application_info{organization_name=\"$organization_name\"}) by (application_id, space_name)) by (space_name)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ space_name }}",
@@ -648,7 +648,7 @@
         "name": "bosh_deployment",
         "options": [],
         "query": {
-          "query": "label_values(bosh_job_healthy{environment=~\"$environment\",bosh_name=~\"$bosh_director\",bosh_deployment!=\"bosh-health-check\"}, bosh_deployment)",
+          "query": "label_values(bosh_job_healthy{environment=~\"$environment\",bosh_name=~\"$bosh_director\",bosh_deployment!~\"(bosh-health-check|concourse|app-autoscaler|prometheus)\"}, bosh_deployment)",
           "refId": "prometheus-bosh_deployment-Variable-Query"
         },
         "refresh": 1,
@@ -768,7 +768,7 @@
             "$__all"
           ]
         },
-        "definition": "label_values(firehose_http_start_stop_server_request_duration_seconds_sum, method)",
+        "definition": "label_values(firehose_http_duration_seconds_sum, method)",
         "description": "",
         "hide": 0,
         "includeAll": true,
@@ -777,7 +777,7 @@
         "name": "methods_pattern",
         "options": [],
         "query": {
-          "query": "label_values(firehose_http_start_stop_server_request_duration_seconds_sum, method)",
+          "query": "label_values(firehose_http_duration_seconds_sum, method)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/manifests/prometheus/operations.d/030-bosh-dns.yml
+++ b/manifests/prometheus/operations.d/030-bosh-dns.yml
@@ -1,0 +1,1 @@
+../../cf-manifest/operations.d/030-bosh-dns.yml

--- a/manifests/prometheus/operations.d/221-monitor-cf-attic-UPSTREAM.yml
+++ b/manifests/prometheus/operations.d/221-monitor-cf-attic-UPSTREAM.yml
@@ -1,1 +1,0 @@
-../upstream/manifests/operators/deprecated/monitor-cf-attic.yml

--- a/manifests/prometheus/operations.d/222-monitor-cf.yml
+++ b/manifests/prometheus/operations.d/222-monitor-cf.yml
@@ -8,7 +8,7 @@
   value: high_cpu_xlarge
 
 - type: replace
-  path: /instance_groups/name=firehose/jobs/name=firehose_exporter-attic/properties/firehose_exporter/doppler/idle_timeout?
+  path: /instance_groups/name=firehose/jobs/name=firehose_exporter/properties/firehose_exporter/doppler/idle_timeout?
   value: 5m
 
 - type: replace
@@ -21,3 +21,7 @@
   path: /instance_groups/name=prometheus2/jobs/name=cf_exporter/properties/cf_exporter/filter?
   value:
     collectors: Applications,Organizations,Routes,ServiceBindings,ServiceInstances,ServicePlans,Services,Spaces
+
+- type: replace
+  path: /instance_groups/name=firehose/jobs/name=firehose_exporter/consumes/reverse_log_proxy/deployment
+  value: ((metrics_environment))

--- a/manifests/prometheus/operations.d/223-unique-firehose-subscription-id.yml
+++ b/manifests/prometheus/operations.d/223-unique-firehose-subscription-id.yml
@@ -1,5 +1,5 @@
 ---
 
 - type: replace
-  path: /instance_groups/name=firehose/jobs/name=firehose_exporter-attic/properties/firehose_exporter/doppler/use_unique_subscription_id?
+  path: /instance_groups/name=firehose/jobs/name=firehose_exporter/properties/firehose_exporter/doppler/use_unique_subscription_id?
   value: true

--- a/manifests/prometheus/scripts/generate-manifest.sh
+++ b/manifests/prometheus/scripts/generate-manifest.sh
@@ -40,6 +40,7 @@ app_domain: $APPS_DNS_ZONE_NAME
 metron_deployment_name: $DEPLOY_ENV
 skip_ssl_verify: false
 traffic_controller_external_port: 443
+loggregator_ca_name: /$DEPLOY_ENV/$DEPLOY_ENV/loggregator_ca
 uaa_clients_cf_exporter_secret: $UAA_CLIENTS_CF_EXPORTER_SECRET
 uaa_clients_firehose_exporter_secret: $UAA_CLIENTS_FIREHOSE_EXPORTER_SECRET
 aws_account: $AWS_ACCOUNT

--- a/manifests/prometheus/spec/operations/monitor_cf_spec.rb
+++ b/manifests/prometheus/spec/operations/monitor_cf_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe "Monitor CF" do
     expect(cf_exporter_config).not_to be_nil
   end
 
-  it "adds the cloudfoundry_dashboards-attic job" do
+  it "adds the cloudfoundry_dashboards job" do
     cf_dashboards_config = manifest_with_defaults.get(
-      "instance_groups.grafana.jobs.cloudfoundry_dashboards-attic",
+      "instance_groups.grafana.jobs.cloudfoundry_dashboards",
     )
 
     expect(cf_dashboards_config).not_to be_nil

--- a/manifests/runtime-config/operations.d/510-add-prometheus-blackbox-exporter.yml
+++ b/manifests/runtime-config/operations.d/510-add-prometheus-blackbox-exporter.yml
@@ -14,7 +14,6 @@
     exclude:
       deployments:
         - concourse # from paas-bootstrap
-        - prometheus # has a separate version
     jobs:
       - name: blackbox_exporter
         release: prometheus


### PR DESCRIPTION
What
----

Switch to using the bosh-prometheus new 7.0 firehose.

The new jobs require bosh dns in order to function so adding it as part of this PR.

This PR also fixes our dashboards as the metrics have been changed as part of the firehose 7.0 release.

How to review
-------------

Review the changes
Deploy to an environment.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
