### PR TITLE
[#185500801] Upgrade cf cli

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -115,7 +115,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/alpine
-              tag: 540813b98e23f9865b33c206a840a8d5633287e9
+              tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
           inputs:
             - name: paas-cf
           params:
@@ -142,7 +142,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/bosh-cli-v2
-              tag: 540813b98e23f9865b33c206a840a8d5633287e9
+              tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
           run:
             path: sh
             args:
@@ -178,7 +178,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/awscli
-              tag: 540813b98e23f9865b33c206a840a8d5633287e9
+              tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
           run:
             path: ./paas-cf/concourse/scripts/rds_instances.sh
             args:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -11,72 +11,72 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/alpine
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
     psql: &psql-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/psql
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
     node: &node-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/node
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
     node-chromium: &node-chromium-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/node-chromium
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
     awscli: &awscli-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
     cf-acceptance-tests: &cf-acceptance-tests-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
     cf-cli: &cf-cli-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/cf-cli
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
     cf-uaac: &cf-uaac-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/cf-uaac
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
     git-ssh: &git-ssh-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/git-ssh
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
     ruby-slim: &ruby-slim-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/ruby
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
     golang: &golang-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/golang
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
     terraform: &terraform-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
     curl-ssl: &curl-ssl-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/curl-ssl
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
 
 
   tasks:
@@ -270,7 +270,7 @@ resource_types:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/concourse-pool-resource
-    tag: 540813b98e23f9865b33c206a840a8d5633287e9
+    tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
 
 - name: s3-iam
   type: registry-image
@@ -817,7 +817,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 540813b98e23f9865b33c206a840a8d5633287e9
+              tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
 
           inputs:
             - name: paas-cf
@@ -5356,7 +5356,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/spruce
-              tag: 540813b98e23f9865b33c206a840a8d5633287e9
+              tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
 
           inputs:
             - name: paas-cf
@@ -6626,7 +6626,7 @@ jobs:
           type: registry-image
           source:
             repository: ghcr.io/alphagov/paas/cf-uaac
-            tag: 540813b98e23f9865b33c206a840a8d5633287e9
+            tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
 
         inputs:
           - name: passwords

--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -41,7 +41,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/alpine
-              tag: 540813b98e23f9865b33c206a840a8d5633287e9
+              tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
           inputs:
             - name: paas-cf
             - name: deployment-timer
@@ -71,7 +71,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/awscli
-              tag: 540813b98e23f9865b33c206a840a8d5633287e9
+              tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
 
           run:
             path: ./paas-cf/concourse/scripts/rds_instances.sh
@@ -86,7 +86,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 540813b98e23f9865b33c206a840a8d5633287e9
+              tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
 
           inputs:
             - name: paas-cf
@@ -119,7 +119,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 540813b98e23f9865b33c206a840a8d5633287e9
+              tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
 
           inputs:
             - name: paas-cf


### PR DESCRIPTION
What
----

The cf cli has been upgraded to v8.7.1 as requested in Pivotal Tracker storey 185500801.
All images created by github actions in paas-docker-cloudfoundry-tools have had their tag updated.

How to review
-------------

1 - Run the branch into a dev env.
2 - Confirm that the new version of the cf cli has been installed by hijacking a relevant container and checking the version of the cf cli.
3 - Confirm that there are no errors related to the cf cli within the pipeline.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
