### PR TITLE
uaa: re-enable passcode copy button despite CSP

### DIFF
--- a/manifests/cf-manifest/operations.d/330-uaa.yml
+++ b/manifests/cf-manifest/operations.d/330-uaa.yml
@@ -353,6 +353,13 @@
   value: true
 
 - type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/csp?/script-src?
+  value:
+    - "'self'"
+    # SRI hash of our uaa-customized's `application.min.js`
+    - "'sha256-0EjrOAFUD7PfcL1fVdExK2Tcc2sR9IOEEu9But6mW7A='"
+
+- type: replace
   path: /releases/-
   value:
     name: uaa-customized

--- a/manifests/cf-manifest/operations.d/330-uaa.yml
+++ b/manifests/cf-manifest/operations.d/330-uaa.yml
@@ -363,9 +363,9 @@
   path: /releases/-
   value:
     name: uaa-customized
-    version: 0.1.36
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-customized-0.1.36.tgz
-    sha1: c9ef95b064a6490fff219cd812018739392ef94e
+    version: 0.1.38
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/uaa-customized-0.1.38.tgz
+    sha1: 924d6ecec406e587768396c34de714a6bc01bf27
 
 - type: replace
   path: /instance_groups/name=uaa/jobs/-


### PR DESCRIPTION
What
----
https://www.pivotaltracker.com/story/show/185263720

Fixing this involved some rearranging of the script injected in `uaa-customized` and adding its hash to UAA's `script-src` CSP statement.

How to review
-------------

Deploy to dev env. Log in to the dev env's tenant facing "front door" and try to retrieve a passcode. See copy button work.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
