### PR TITLE
185509385 - Pin GitHub Actions to specific hashes

### DIFF
--- a/.github/workflows/check_gpg_keys.yml
+++ b/.github/workflows/check_gpg_keys.yml
@@ -10,7 +10,7 @@ jobs:
     outputs:
       key_ids: ${{ steps.extract-key-ids.outputs.key_ids }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
       - name: Extract key ids from .gpg-id and output as a json list
         id: extract-key-ids
         run: echo "key_ids=$(jq -c --raw-input --slurp 'split("\n") | map(select(. != ""))' .gpg-id)" >> $GITHUB_OUTPUT
@@ -25,6 +25,6 @@ jobs:
     env:
       GPG_KEY_ID: ${{ matrix.key_id }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
       - name: Import key from keyserver
         run: make .download-gpg-key

--- a/.github/workflows/generate_buildpack_bump_pr.yml
+++ b/.github/workflows/generate_buildpack_bump_pr.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       ## Setup
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
           submodules: true
 
@@ -27,7 +27,7 @@ jobs:
           # for envsubst
 
       - name: "Install Go ${{env.GO_VERSION}}"
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
         with:
           go-version: "${{env.GO_VERSION}}"
 

--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       ## Setup
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
           submodules: true
 
@@ -57,7 +57,7 @@ jobs:
           promtool --version
 
       - name: "Install Go ${{env.GO_VERSION}}"
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
         with:
           go-version: "${{env.GO_VERSION}}"
 
@@ -68,7 +68,7 @@ jobs:
         run: pip install --user yamllint
 
       - name: Install Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@d3c9825d67b0d8720afdfdde5af56c79fdb38d16
         with:
           ruby-version: "${{env.RUBY_VERSION}}"
 


### PR DESCRIPTION
Description:
-------------
- Currently we pin to versions which means that we automatically pull in the latest changes which presents a security risk as we don't know which code is running in our build pipeline.
- This PR fixes this by pinning to a specific hash
- A future PR will configure dependabot to raise PR's automatically for later versions of GitHub Actions against their hashes

How to review
-------------

Verify if the GitHub actions have passed.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
