### PR TITLE
185509385 - Configure dependabot to track GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -78,3 +78,9 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "terraform"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: github-action


### PR DESCRIPTION
Description:
-------------
- Dependabot will raise a PR for GitHub actions with a hash for the newer version
- Currently set to weekly to follow the current practice but this can be changed later pending an RFC

How to review
-------------

Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
