### PR TITLE
firehose instance: move from `high_cpu_xlarge` -> `xlarge`

### DIFF
--- a/manifests/prometheus/operations.d/222-monitor-cf.yml
+++ b/manifests/prometheus/operations.d/222-monitor-cf.yml
@@ -5,7 +5,7 @@
 
 - type: replace
   path: /instance_groups/name=firehose/vm_type
-  value: high_cpu_xlarge
+  value: xlarge
 
 - type: replace
   path: /instance_groups/name=firehose/jobs/name=firehose_exporter/properties/firehose_exporter/doppler/idle_timeout?

--- a/manifests/prometheus/spec/operations/monitor_cf_spec.rb
+++ b/manifests/prometheus/spec/operations/monitor_cf_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "Monitor CF" do
   it "adds the firehose instance_group" do
     firehose = manifest_with_defaults.get("instance_groups.firehose")
     expect(firehose).not_to be_nil
-    expect(firehose["vm_type"]).to eq("high_cpu_xlarge")
+    expect(firehose["vm_type"]).to eq("xlarge")
     expect(firehose["networks"]).to eq([{ "name" => "cf" }])
   end
 


### PR DESCRIPTION

What
----
In reality this just gives it more memory and only a very slight cpu downgrade. Hopefully this will prevent the issues we've had with the firehose-exporter going into swap occasionally since we moved to the new version.

How to review
-------------

:eyes: 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
