### PR TITLE
Temporarily remove DLUHC VPC peering

### DIFF
--- a/terraform/prod-lon.vpc_peering.json
+++ b/terraform/prod-lon.vpc_peering.json
@@ -52,11 +52,5 @@
         "account_id": "516242164884",
         "vpc_id": "vpc-0d61ec34a97c33898",
         "subnet_cidr": "172.18.16.0/22"
-    },
-    {
-        "peer_name": "dluhc-energy-performance",
-        "account_id": "058191034505",
-        "vpc_id": "vpc-031a4486bb2861981",
-        "subnet_cidr": "172.18.20.0/22"
     }
 ]


### PR DESCRIPTION
What
----

The team at DLUHC are re-creating their VPC, which means their VPC ID will change and our peering will be broken. We're removing our side of the peering while they re-create their shiny new VPC.

How to review
-------------

Is the file still valid? Did I miss anything?

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
