### PR TITLE
Revert "vpc peering: mark vpc peers with prevent_destroy = true"

### DIFF
--- a/terraform/vpc-peering/vpc_peering.tf
+++ b/terraform/vpc-peering/vpc_peering.tf
@@ -37,13 +37,6 @@ resource "aws_vpc_peering_connection" "vpc_peer" {
   peer_owner_id = each.value.account_id
   peer_vpc_id   = each.value.vpc_id
   vpc_id        = var.vpc_id
-
-  # possibly irritating for us, but it will be more irritating to our tenants if
-  # we accidentally re-create an existing peering, leaving them to re-accept it
-  # and reconfigure their route tables
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "aws_route" "vpc_peer_route_0" {


### PR DESCRIPTION
What
----

This reverts commit a0cb044e7f9d4b25a266dcd3fdef108a0f48f96e.

We need to allow VPC peering removal for when/if we change VPC peers.

How to review
-------------

👀 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
