### PR TITLE
Increase memory allocation of cloudwatch exporter to 3gb

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -3397,7 +3397,7 @@ jobs:
                   ---
                   applications:
                     - name: cloudwatch-exporter
-                      memory: 2048M
+                      memory: 3072M
                       disk_quota: 256M
                       instances: 1
                       buildpacks: [go_buildpack]


### PR DESCRIPTION
What
----

Increase memory allocation of cloudwatch exporter to 3gb.

Why
----

It looks like all the dependencies for the cloudwatch exporter need a lot of memory to compile. Seeing the following staging error in staging:

```
   2023-07-28T11:33:32.02+0100 [STG/0] ERR [github.com/aws/aws-sdk-go-v2/service/ec2](http://github.com/aws/aws-sdk-go-v2/service/ec2): /tmp/contents2275605378/deps/0/go1.20.5/pkg/tool/linux_amd64/compile: signal: killed
   2023-07-28T11:33:32.12+0100 [STG/0] OUT **ERROR** Unable to compile application: exit status 1
   2023-07-28T11:33:32.61+0100 [STG/0] ERR Failed to compile droplet: Failed to run finalize script: exit status 12
   2023-07-28T11:33:32.61+0100 [STG/0] OUT Exit status 223 (out of memory)
```

How to review
-------------

Check the changes.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
