### PR TITLE
grafana: add "stacks" dashboard

### DIFF
--- a/manifests/prometheus/dashboards.d/stacks.json
+++ b/manifests/prometheus/dashboards.d/stacks.json
@@ -1,0 +1,312 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "stepBefore",
+            "lineWidth": 0,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "repeat": "stack_id",
+      "repeatDirection": "v",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "sum(cf_application_info{environment=\"$environment\",deployment=\"$bosh_deployment\",stack_id=\"$stack_id\", organization_name!~\"$test_orgs_nre\",state!~\"$stopped_apps_nre\"}) by (organization_id, organization_name)",
+          "legendFormat": "{{organization_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Applications using stack $stack_id",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "cf"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "prod-lon",
+          "value": "prod-lon"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
+        "definition": "",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Environment",
+        "multi": false,
+        "name": "environment",
+        "options": [],
+        "query": {
+          "query": "label_values(bosh_job_healthy, environment)",
+          "refId": "prometheus-environment-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "prod-lon",
+          "value": "prod-lon"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
+        "definition": "",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Director",
+        "multi": false,
+        "name": "bosh_director",
+        "options": [],
+        "query": {
+          "query": "label_values(bosh_job_healthy{environment=~\"$environment\"}, bosh_name)",
+          "refId": "prometheus-bosh_director-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "prod-lon",
+          "value": "prod-lon"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
+        "definition": "",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Deployment",
+        "multi": false,
+        "name": "bosh_deployment",
+        "options": [],
+        "query": {
+          "query": "label_values(bosh_job_healthy{environment=~\"$environment\",bosh_name=~\"$bosh_director\",bosh_deployment!~\"(bosh-health-check|concourse|app-autoscaler|prometheus)\"}, bosh_deployment)",
+          "refId": "prometheus-bosh_deployment-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
+        "definition": "label_values(cf_application_info,stack_id)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": false,
+        "name": "stack_id",
+        "options": [],
+        "query": {
+          "query": "label_values(cf_application_info,stack_id)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "exclude",
+          "value": "[A-Z]+-.*"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Test orgs",
+        "multi": false,
+        "name": "test_orgs_nre",
+        "options": [
+          {
+            "selected": false,
+            "text": "include",
+            "value": "xx_nonexistent_xx"
+          },
+          {
+            "selected": true,
+            "text": "exclude",
+            "value": "[A-Z]+-.*"
+          }
+        ],
+        "query": "include : xx_nonexistent_xx, exclude : [A-Z]+-.*",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "exclude",
+          "value": "STOPPED"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Stopped apps",
+        "multi": false,
+        "name": "stopped_apps_nre",
+        "options": [
+          {
+            "selected": false,
+            "text": "include",
+            "value": "xx_nonexistent_xx"
+          },
+          {
+            "selected": true,
+            "text": "exclude",
+            "value": "STOPPED"
+          }
+        ],
+        "query": "include : xx_nonexistent_xx , exclude : STOPPED",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Stacks",
+  "uid": "stacks",
+  "version": 14,
+  "weekStart": ""
+}


### PR DESCRIPTION
What
----

Adds a new dashboard that allows us to monitor the cf app stacks our tenants are using. Helpful to see progress of tenants transitioning to cflinuxfs4.

![stacks-dashboard-ed](https://github.com/alphagov/paas-cf/assets/807447/446d8de4-f57b-4adc-9066-1c65e8c3af49)

No you don't get stack names because `cf_exporter` neglected to include them.

How to review
-------------

:eyes: , or look at the "Stacks (noodling)" dashboard on prod-lon grafana.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
