### PR TITLE
remove `uaa_clients_firehose_exporter_secret` handling in pipelines & scripts

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -3134,7 +3134,6 @@ jobs:
                 PAAS_PROMETHEUS_ENDPOINTS_AWS_ACCESS_KEY_ID=$($VAL_FROM_YAML terraform_outputs_paas_prometheus_endpoints_aws_access_key_id cf-terraform-outputs.yml)
                 PAAS_PROMETHEUS_ENDPOINTS_AWS_SECRET_ACCESS_KEY=$($VAL_FROM_YAML terraform_outputs_paas_prometheus_endpoints_aws_secret_access_key cf-terraform-outputs.yml)
                 UAA_CLIENTS_CF_EXPORTER_SECRET=$(credhub get -q -n "${BOSH_NS}/uaa_clients_cf_exporter_secret")
-                UAA_CLIENTS_FIREHOSE_EXPORTER_SECRET=$(credhub get -q -n "${BOSH_NS}/uaa_clients_firehose_exporter_secret")
                 RDS_BROKER_PASS=$(credhub get -q -n "${BOSH_NS}/secrets_rds_broker_admin_password")
                 CDN_BROKER_PASS=$(credhub get -q -n "${BOSH_NS}/secrets_cdn_broker_admin_password")
                 AIVEN_BROKER_PASS=$(credhub get -q -n "${BOSH_NS}/secrets_aiven_broker_admin_password")
@@ -3170,7 +3169,6 @@ jobs:
                 credhub set --name="${PIPELINE_NS}/paas_prometheus_endpoints_aws_access_key_id" --type password --password "${PAAS_PROMETHEUS_ENDPOINTS_AWS_ACCESS_KEY_ID}"
                 credhub set --name="${PIPELINE_NS}/paas_prometheus_endpoints_aws_secret_access_key" --type password --password "${PAAS_PROMETHEUS_ENDPOINTS_AWS_SECRET_ACCESS_KEY}"
                 credhub set --name="${PIPELINE_NS}/uaa_clients_cf_exporter_secret" --type password --password "${UAA_CLIENTS_CF_EXPORTER_SECRET}"
-                credhub set --name="${PIPELINE_NS}/uaa_clients_firehose_exporter_secret" --type password --password "${UAA_CLIENTS_FIREHOSE_EXPORTER_SECRET}"
                 credhub set --name="${PIPELINE_NS}/secrets_rds_broker_admin_password" --type password --password "${RDS_BROKER_PASS}"
                 credhub set --name="${PIPELINE_NS}/secrets_cdn_broker_admin_password" --type password --password "${CDN_BROKER_PASS}"
                 credhub set --name="${PIPELINE_NS}/secrets_aiven_broker_admin_password" --type password --password "${AIVEN_BROKER_PASS}"
@@ -3250,7 +3248,6 @@ jobs:
             GRAFANA_AUTH_GOOGLE_CLIENT_ID: ((grafana_auth_google_client_id))
             GRAFANA_AUTH_GOOGLE_CLIENT_SECRET: ((grafana_auth_google_client_secret))
             UAA_CLIENTS_CF_EXPORTER_SECRET: ((uaa_clients_cf_exporter_secret))
-            UAA_CLIENTS_FIREHOSE_EXPORTER_SECRET: ((uaa_clients_firehose_exporter_secret))
             BOSH_CA_CERT: ((bosh-ca-cert))
             BOSH_EXPORTER_PASSWORD: ((bosh-exporter-password))
             VCAP_PASSWORD: ((vcap-password))
@@ -6697,7 +6694,6 @@ jobs:
               credhub generate -n "${BOSH_NS}/secrets_uaa_clients_cdn_broker_secret" -t password
               credhub generate -n "${BOSH_NS}/uaa_clients_cf_exporter_secret" -t password
               credhub generate -n "${BOSH_NS}/uaa_clients_cf_smoke_tests_secret" -t password
-              credhub generate -n "${BOSH_NS}/uaa_clients_firehose_exporter_secret" -t password
 
               credhub get -n "${BOSH_NS}/uaa_jwt_signing_key" -k private_key | sed '/^$/d' > old_key
               credhub get -n "${BOSH_NS}/uaa_jwt_signing_key" -k public_key | sed '/^$/d' > old_pub

--- a/manifests/prometheus/scripts/generate-manifest.sh
+++ b/manifests/prometheus/scripts/generate-manifest.sh
@@ -42,7 +42,6 @@ skip_ssl_verify: false
 traffic_controller_external_port: 443
 loggregator_ca_name: /$DEPLOY_ENV/$DEPLOY_ENV/loggregator_ca
 uaa_clients_cf_exporter_secret: $UAA_CLIENTS_CF_EXPORTER_SECRET
-uaa_clients_firehose_exporter_secret: $UAA_CLIENTS_FIREHOSE_EXPORTER_SECRET
 aws_account: $AWS_ACCOUNT
 aws_region: $AWS_REGION
 grafana_auth_google_client_id: $GRAFANA_AUTH_GOOGLE_CLIENT_ID

--- a/manifests/prometheus/spec/support/manifest_helpers.rb
+++ b/manifests/prometheus/spec/support/manifest_helpers.rb
@@ -33,7 +33,6 @@ private
     env["GRAFANA_AUTH_GOOGLE_CLIENT_ID"] = "google-client-id"
     env["GRAFANA_AUTH_GOOGLE_CLIENT_SECRET"] = "google-client-secret"
     env["UAA_CLIENTS_CF_EXPORTER_SECRET"] = "uaa_clients_cf_exporter_secret"
-    env["UAA_CLIENTS_FIREHOSE_EXPORTER_SECRET"] = "uaa_clients_firehose_exporter_secret"
     env["BOSH_CA_CERT"] = "bosh-ca-cert"
     env["BOSH_EXPORTER_PASSWORD"] = "bosh-exporter-password"
     env["VCAP_PASSWORD"] = "vcap-password"

--- a/manifests/shared/spec/fixtures/cf-vars-store.yml
+++ b/manifests/shared/spec/fixtures/cf-vars-store.yml
@@ -1,2 +1,1 @@
 uaa_clients_cf_exporter_secret: dummy_cf_exporter_secret
-uaa_clients_firehose_exporter_secret: dummy_firehose_exporter_secret


### PR DESCRIPTION
What
----

Looks like this is no longer needed since the "new" firehose_exporter (switched-to in #3276), and a pipeline expecting it to exist will choke when it hasn't been generated. e.g. when a newly-created env is brought up.

How to review
-------------

Deploy to a dev env? Look at dev03 which was brought up with this (commit applied to another branch...). dev04 had this change deployed to it directly (without a rebuild) and it seems happy.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
