### PR TITLE
waf: migrate to WAF v2, adding ability to conditionally obey `x-forwarded-for`

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -894,6 +894,7 @@ jobs:
                     external_uaa_database_password
                     external_silk_controller_database_password
                     external_policy_server_database_password
+                    waf_xff_auth_key
                   )
 
                   app_autoscaler_credentials=(
@@ -1279,6 +1280,7 @@ jobs:
                 export TF_VAR_external_silk_controller_database_password="((external_silk_controller_database_password))"
                 export TF_VAR_external_policy_server_database_password="((external_policy_server_database_password))"
                 export TF_VAR_external_app_autoscaler_database_password="((external_app_autoscaler_database_password))"
+                export TF_VAR_waf_xff_auth_key="((waf_xff_auth_key))"
                 EOF
 
                 cat <<EOF > terraform-variables/cyber-secrets.tfvars.sh

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -276,6 +276,7 @@ jobs:
                 export TF_VAR_external_uaa_database_password="((external_uaa_database_password))"
                 export TF_VAR_external_silk_controller_database_password="((external_silk_controller_database_password))"
                 export TF_VAR_external_policy_server_database_password="((external_policy_server_database_password))"
+                export TF_VAR_waf_xff_auth_key="((waf_xff_auth_key))"
                 EOF
 
       - task: cf-terraform-destroy

--- a/config/cloudwatch-exporter/config.yml
+++ b/config/cloudwatch-exporter/config.yml
@@ -40,3 +40,27 @@ discovery:
       dimensionNameRequirements:
       - DBInstanceIdentifier
       addCloudwatchTimestamp: true
+    - type: "AWS/WAFV2"
+      regions:
+        - (( grab $AWS_REGION ))
+      searchTags:
+        - key: deploy_env
+          value: (( concat "^" $DEPLOY_ENV "$" ))
+      metrics:
+        - name: AllowedRequests
+          statistics:
+            - Average
+            - Maximum
+          period: 60
+          length: 600
+        - name: BlockedRequests
+          statistics:
+            - Average
+            - Maximum
+          period: 60
+          length: 600
+      dimensionNameRequirements:
+      - WebACL
+      - Rule
+      - Region
+      addCloudwatchTimestamp: true

--- a/manifests/prometheus/alerts.d/wafv2.yml
+++ b/manifests/prometheus/alerts.d/wafv2.yml
@@ -1,0 +1,18 @@
+# Source: yet-another-cloudwatch-exporter
+---
+
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: WafThrottlingIPsMaxRate
+    rules:
+      - alert: WafThrottlingIPsMaxRate
+        # the cloudwatch exporter should already restrict the metrics available
+        # to those of our deploy_env
+        expr: (aws_wafv2_blocked_requests_maximum{dimension_WebACL=~".+-rtr-lbs-web-acl$", dimension_Rule=~".+-rtr-lbs-max-request-rate-xff-blocked$"} > 0) or (aws_wafv2_blocked_requests_maximum{dimension_WebACL=~".+-rtr-lbs-web-acl$", dimension_Rule=~".+-rtr-lbs-max-request-rate-direct-blocked$"} > 0)
+        labels:
+          severity: warning
+          service: elb
+        annotations:
+          summary: "WAFv2 throttling some IPs due to excessive request rate"
+          description: "At least 1 IP has hit its per-IP request-rate limit for the gorouter-bound load balancer(s) and is having some of its requests blocked. The AWS console can show a sample of these blocked requests."

--- a/manifests/prometheus/spec/alerts/waf-throttling-ips-max-rate.test.yml
+++ b/manifests/prometheus/spec/alerts/waf-throttling-ips-max-rate.test.yml
@@ -1,0 +1,58 @@
+---
+rule_files:
+  # See alerts_validation_spec.rb for details of how stdin gets set:
+  - fixtures/rules.yml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 5m
+    input_series:
+      - series: 'aws_wafv2_blocked_requests_maximum{dimension_WebACL="foo-rtr-lbs-web-acl",dimension_Rule="foo-rtr-lbs-max-request-rate-xff-blocked"}'
+        values: 123
+      - series: 'aws_wafv2_blocked_requests_maximum{dimension_WebACL="foo-rtr-lbs-web-acl",dimension_Rule="foo-rtr-lbs-max-request-rate-direct-blocked"}'
+        values: _
+
+    alert_rule_test:
+      - alertname: WafThrottlingIPsMaxRate
+        eval_time: 5m
+        exp_alerts:
+          - exp_annotations:
+              summary: "WAFv2 throttling some IPs due to excessive request rate"
+              description: "At least 1 IP has hit its per-IP request-rate limit for the gorouter-bound load balancer(s) and is having some of its requests blocked. The AWS console can show a sample of these blocked requests."
+            exp_labels:
+              severity: warning
+              service: elb
+              dimension_WebACL: "foo-rtr-lbs-web-acl"
+              dimension_Rule: "foo-rtr-lbs-max-request-rate-xff-blocked"
+
+  - interval: 5m
+    input_series:
+      - series: 'aws_wafv2_blocked_requests_maximum{dimension_WebACL="foo-rtr-lbs-web-acl",dimension_Rule="foo-rtr-lbs-max-request-rate-xff-blocked"}'
+        values: _
+      - series: 'aws_wafv2_blocked_requests_maximum{dimension_WebACL="foo-rtr-lbs-web-acl",dimension_Rule="foo-rtr-lbs-max-request-rate-direct-blocked"}'
+        values: 123
+
+    alert_rule_test:
+      - alertname: WafThrottlingIPsMaxRate
+        eval_time: 5m
+        exp_alerts:
+          - exp_annotations:
+              summary: "WAFv2 throttling some IPs due to excessive request rate"
+              description: "At least 1 IP has hit its per-IP request-rate limit for the gorouter-bound load balancer(s) and is having some of its requests blocked. The AWS console can show a sample of these blocked requests."
+            exp_labels:
+              severity: warning
+              service: elb
+              dimension_WebACL: "foo-rtr-lbs-web-acl"
+              dimension_Rule: "foo-rtr-lbs-max-request-rate-direct-blocked"
+
+  - interval: 5m
+    input_series:
+      - series: 'aws_wafv2_blocked_requests_maximum{dimension_WebACL="foo-rtr-lbs-web-acl",dimension_Rule="foo-rtr-lbs-max-request-rate-xff-blocked"}'
+        values: 0
+      - series: 'aws_wafv2_blocked_requests_maximum{dimension_WebACL="foo-rtr-lbs-web-acl",dimension_Rule="foo-rtr-lbs-max-request-rate-direct-blocked"}'
+        values: _
+      - series: 'aws_wafv2_blocked_requests_maximum{dimension_WebACL="foo-rtr-lbs-web-acl-bar",dimension_Rule="foo-rtr-lbs-max-request-rate-direct-blocked"}'
+        values: 111
+
+    alert_rule_test: []

--- a/terraform/cloudfoundry/shield_and_waf.tf
+++ b/terraform/cloudfoundry/shield_and_waf.tf
@@ -5,6 +5,10 @@ resource "aws_shield_protection" "shield_for_app_gorouter_alb" {
   lifecycle {
     create_before_destroy = true
   }
+
+  tags = {
+    deploy_env = var.env
+  }
 }
 
 resource "aws_shield_protection" "shield_for_system_gorouter_alb" {
@@ -14,42 +18,253 @@ resource "aws_shield_protection" "shield_for_system_gorouter_alb" {
   lifecycle {
     create_before_destroy = true
   }
+
+  tags = {
+    deploy_env = var.env
+  }
 }
 
-resource "aws_wafregional_rate_based_rule" "wafregional_max_request_rate_rule" {
-  name        = "${var.env}-waf-max-request-rate"
-  metric_name = "${replace(var.env, "-", "")}WafMaxRequestRate"
+resource "aws_wafv2_ip_set" "self_egress_ips" {
+  name = "${var.env}-egress-ips"
+  description = "${var.env}s own cloudfoundry egress IPs"
+  scope = "REGIONAL"
+  ip_address_version = "IPV4"
 
-  rate_key   = "IP"
-  rate_limit = "600000"
+  addresses = [for eip in aws_eip.cf : "${eip.public_ip}/32"]
+
+  tags = {
+    deploy_env = var.env
+  }
 }
 
-resource "aws_wafregional_web_acl" "wafregional_web_acl" {
-  name        = "${var.env}-waf-web-acl"
-  metric_name = "${replace(var.env, "-", "")}WafWebACL"
+resource "aws_wafv2_ip_set" "self_sys_ips" {
+  name = "${var.env}-sys-ips"
+  description = "${var.env}s own system egress IPs"
+  scope = "REGIONAL"
+  ip_address_version = "IPV4"
+
+  addresses = [
+    "${var.concourse_elastic_ip}/32",
+  ]
+
+  tags = {
+    deploy_env = var.env
+  }
+}
+
+resource "aws_wafv2_web_acl" "rtr_lbs_acl" {
+  name = "${var.env}-rtr-lbs-web-acl"
+  description = "Web ACL for requests hitting ${var.env}s gorouter-bound load-balancers"
+  scope = "REGIONAL"
 
   default_action {
-    type = "ALLOW"
+    allow {}
   }
 
   rule {
+    name = "${var.env}-rtr-lbs-allow-self-sys-ips"
+    priority = 10
+
     action {
-      type = "BLOCK"
+      allow {}
+      # terminate processing
     }
 
-    priority = 1
-    rule_id  = aws_wafregional_rate_based_rule.wafregional_max_request_rate_rule.id
-    type     = "RATE_BASED"
+    statement {
+      ip_set_reference_statement {
+        arn = aws_wafv2_ip_set.self_sys_ips.arn
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.env}-rtr-lbs-self-sys-ips-allowed"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  rule {
+    name = "${var.env}-rtr-lbs-allow-self-egress-ips"
+    priority = 20
+
+    action {
+      allow {}
+      # terminate processing
+    }
+
+    statement {
+      or_statement {
+        statement {
+          ip_set_reference_statement {
+            arn = aws_wafv2_ip_set.self_egress_ips.arn
+          }
+        }
+
+        statement {
+          and_statement {
+            statement {
+              ip_set_reference_statement {
+                arn = aws_wafv2_ip_set.self_egress_ips.arn
+
+                ip_set_forwarded_ip_config {
+                  fallback_behavior = "NO_MATCH"
+                  header_name = "X-Forwarded-For"
+                  position = "LAST"
+                }
+              }
+            }
+
+            statement {
+              byte_match_statement {
+                field_to_match {
+                  single_header {
+                    # chosen because we know the gorouter will overwrite it
+                    # before delivering to tenant
+                    name = "x-cf-instanceid"
+                  }
+                }
+                positional_constraint = "EXACTLY"
+                search_string = "x-paas-xff-auth-${var.waf_xff_auth_key}"
+
+                text_transformation {
+                  priority = 10
+                  type = "COMPRESS_WHITE_SPACE"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.env}-rtr-lbs-self-egress-ips-allowed"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  rule {
+    name = "${var.env}-rtr-lbs-max-request-rate-direct"
+    priority = 30
+
+    action {
+      block {
+        custom_response {
+          response_code = "429"
+        }
+      }
+      # terminate processing, but only when rate limit
+      # is hit
+    }
+
+    statement {
+      rate_based_statement {
+        limit = "${var.waf_per_ip_rate_limit_5m}"
+        aggregate_key_type = "IP"
+
+        scope_down_statement {
+          not_statement {
+            statement {
+              byte_match_statement {
+                field_to_match {
+                  single_header {
+                    # chosen because we know the gorouter will overwrite it
+                    # before delivering to tenant
+                    name = "x-cf-instanceid"
+                  }
+                }
+                positional_constraint = "EXACTLY"
+                search_string = "x-paas-xff-auth-${var.waf_xff_auth_key}"
+
+                text_transformation {
+                  priority = 10
+                  type = "COMPRESS_WHITE_SPACE"
+                }
+              }
+            }
+          }
+        }
+      }
+
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.env}-rtr-lbs-max-request-rate-direct-blocked"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name = "${var.env}-rtr-lbs-max-request-rate-xff"
+    priority = 40
+
+    action {
+      block {
+        custom_response {
+          response_code = "429"
+        }
+      }
+      # terminate processing, but only when rate limit
+      # is hit
+    }
+
+    statement {
+      rate_based_statement {
+        limit = "${var.waf_per_ip_rate_limit_5m}"
+        aggregate_key_type = "FORWARDED_IP"
+
+        forwarded_ip_config {
+          fallback_behavior = "NO_MATCH"
+          header_name = "X-Forwarded-For"
+        }
+
+        scope_down_statement {
+          byte_match_statement {
+            field_to_match {
+              single_header {
+                # chosen because we know the gorouter will overwrite it
+                # before delivering to tenant
+                name = "x-cf-instanceid"
+              }
+            }
+            positional_constraint = "EXACTLY"
+            search_string = "x-paas-xff-auth-${var.waf_xff_auth_key}"
+
+            text_transformation {
+              priority = 10
+              type = "COMPRESS_WHITE_SPACE"
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.env}-rtr-lbs-max-request-rate-xff-blocked"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  tags = {
+    deploy_env = var.env
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.env}-rtr-lbs"
+    sampled_requests_enabled   = false
   }
 }
 
-resource "aws_wafregional_web_acl_association" "wafregional_acl_app_alb_association" {
+resource "aws_wafv2_web_acl_association" "rtr_app_lb_acl_assoc" {
   resource_arn = aws_lb.cf_router_app_domain.arn
-  web_acl_id   = aws_wafregional_web_acl.wafregional_web_acl.id
+  web_acl_arn = aws_wafv2_web_acl.rtr_lbs_acl.arn
 }
 
-resource "aws_wafregional_web_acl_association" "wafregional_acl_system_alb_association" {
+resource "aws_wafv2_web_acl_association" "rtr_system_lb_acl_assoc" {
   resource_arn = aws_lb.cf_router_system_domain.arn
-  web_acl_id   = aws_wafregional_web_acl.wafregional_web_acl.id
+  web_acl_arn = aws_wafv2_web_acl.rtr_lbs_acl.arn
 }
-

--- a/terraform/cloudfoundry/variables.tf
+++ b/terraform/cloudfoundry/variables.tf
@@ -168,3 +168,14 @@ variable "bucket_force_destroy" {
   description = "Force destroy aws s3 buckets"
   default = false
 }
+
+variable "waf_per_ip_rate_limit_5m" {
+  description = "Number of requests per 5m for waf to allow per client IP"
+  default = 600000
+}
+
+variable "waf_xff_auth_key" {
+  description = "Secret value to expect after x-paas-xff-auth- to enable interpretation of x-forwarded-for."
+  type = string
+  sensitive = true
+}

--- a/terraform/cloudfoundry/variables.tf
+++ b/terraform/cloudfoundry/variables.tf
@@ -148,10 +148,12 @@ variable "router_cidrs" {
 
 variable "secrets_cdn_db_master_password" {
   description = "Master password for CDN database"
+  sensitive = true
 }
 
 variable "secrets_cf_db_master_password" {
   description = "Master password for CF database"
+  sensitive = true
 }
 
 variable "system_dns_zone_id" {


### PR DESCRIPTION
What
----

https://www.pivotaltracker.com/story/show/185574049

This depends on https://github.com/alphagov/paas-aws-account-wide-terraform/pull/372, #3342 ~and (tangentially) #3341~

WAF v2 gives us the ability to use more complex sets of rules for configuration of rate limiting.

Firstly we exclude an environment's own egress IPs and "system" (currently just concourse) IPs from rate limiting to prevent us blocking either our own tests or tenants that are using externally routed inter-app requests.

We then have a rate limit rule for requests we've determined should *not* have `x-forwarded-for` respected. We determine this by looking for a header with a "secret" value only set by our blessed CDNs. So that the header is not visible to tenant apps we abuse the header `x-cf-instanceid` for this. This is because neither load balancers or the gorouter have the ability to remove arbitrary headers from forwarded requests, so instead we have to choose one that we know will be blindly overwritten by the gorouter.

Finally there is a similar rate limit rule for requests that *should* have `x-forwarded-for` respected. these are expressed as two separate rules with the same header-checking condition inverted because abort-early/fall-through logic won't behave as we want it to here - a rate-limiting rule will only make processing abort for a request when the rate limit is tripped.

The secret for `x-forwarded-for` enablement is generated by credhub and woven through the creation pipeline. This will presumably be needed by the cdn broker to eventually be able to set the appropriate header. until that is done, the waf should continue to work as it always previously has, not obeying `x-forwarded-for`, so there's no race to set up both ends of this at the same time.

How to review
-------------

Describe the steps required to test the changes.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
