### PR TITLE
cf manifest: decouple `cflinuxfs4-compat` release, bump 1.18.0 -> 1.29.0

### DIFF
--- a/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
+++ b/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
@@ -11,6 +11,6 @@
   path: /releases/name=cflinuxfs4-compat
   value:
     name: "cflinuxfs4-compat"
-    version: "1.18.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs4-compat-release?v=1.18.0"
-    sha1: "4d652590b5b3674052c57d6aadc03c6eeab12f27"
+    version: "1.29.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs4-compat-release?v=1.29.0"
+    sha1: "1ea75f4b434b9527869ef6745d15b40322929c7d"

--- a/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
+++ b/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
@@ -6,3 +6,11 @@
     version: "0.369.0"
     url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.369.0"
     sha1: "5463400cd5490e9d847326668d504a8833cf3e4e"
+
+- type: replace
+  path: /releases/name=cflinuxfs4-compat
+  value:
+    name: "cflinuxfs4-compat"
+    version: "1.18.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs4-compat-release?v=1.18.0"
+    sha1: "4d652590b5b3674052c57d6aadc03c6eeab12f27"


### PR DESCRIPTION
What
----

https://www.pivotaltracker.com/story/show/185686086

Straightforward. Luckily `229-cf-update_cflinuxfs_releases.yml` comes after `026-use-cflinuxfs4-compat-UPSTREAM.yml`, so we just have to choose a different release to point to.

I didn't find any spec tests we apply to cflinuxfs3 to use for cflinuxfs4. Nor could I think of any sensible ones.

How to review
-------------

Deploy to a dev env

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
