### PR TITLE
Update paas docker images to pick up new bosh-cli-v2

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -11,72 +11,72 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/alpine
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
     psql: &psql-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/psql
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
     node: &node-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/node
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
     node-chromium: &node-chromium-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/node-chromium
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
     awscli: &awscli-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
     cf-acceptance-tests: &cf-acceptance-tests-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
     cf-cli: &cf-cli-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/cf-cli
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
     cf-uaac: &cf-uaac-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/cf-uaac
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
     git-ssh: &git-ssh-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/git-ssh
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
     ruby-slim: &ruby-slim-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/ruby
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
     golang: &golang-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/golang
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
     terraform: &terraform-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
     curl-ssl: &curl-ssl-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/curl-ssl
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 
 
   tasks:
@@ -272,7 +272,7 @@ resource_types:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/concourse-pool-resource
-    tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 
 - name: s3-iam
   type: registry-image
@@ -822,7 +822,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+              tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 
           inputs:
             - name: paas-cf
@@ -5373,7 +5373,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/spruce
-              tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+              tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 
           inputs:
             - name: paas-cf
@@ -6638,7 +6638,7 @@ jobs:
           type: registry-image
           source:
             repository: ghcr.io/alphagov/paas/cf-uaac
-            tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+            tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 
         inputs:
           - name: passwords

--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -41,7 +41,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/alpine
-              tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+              tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
           inputs:
             - name: paas-cf
             - name: deployment-timer
@@ -71,7 +71,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/awscli
-              tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+              tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 
           run:
             path: ./paas-cf/concourse/scripts/rds_instances.sh
@@ -86,7 +86,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+              tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 
           inputs:
             - name: paas-cf
@@ -119,7 +119,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+              tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 
           inputs:
             - name: paas-cf

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -99,7 +99,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 540813b98e23f9865b33c206a840a8d5633287e9
+              tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 
           inputs:
             - name: paas-cf
@@ -144,7 +144,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/cf-cli
-              tag: 540813b98e23f9865b33c206a840a8d5633287e9
+              tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
           inputs:
             - name: paas-cf
             - name: config
@@ -189,7 +189,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/bosh-cli-v2
-              tag: 540813b98e23f9865b33c206a840a8d5633287e9
+              tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 
           inputs:
             - name: bosh-vars-store
@@ -243,7 +243,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/ruby
-              tag: 540813b98e23f9865b33c206a840a8d5633287e9
+              tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
           inputs:
             - name: paas-cf
             - name: cf-tfstate
@@ -287,7 +287,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/terraform
-              tag: 540813b98e23f9865b33c206a840a8d5633287e9
+              tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 
           inputs:
             - name: terraform-variables

--- a/concourse/pipelines/fast-startup-and-shutdown-cf-env.yml
+++ b/concourse/pipelines/fast-startup-and-shutdown-cf-env.yml
@@ -102,7 +102,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 540813b98e23f9865b33c206a840a8d5633287e9
+              tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
           inputs:
             - name: paas-cf
           params:
@@ -166,7 +166,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/fast-startup-and-shutdown
-              tag: 6e1f473dd3902fddd6f74bbcd788fb1ec5390ce3
+              tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
           run:
             path: bash
             args:
@@ -207,7 +207,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/fast-startup-and-shutdown
-              tag: 6e1f473dd3902fddd6f74bbcd788fb1ec5390ce3
+              tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
           run:
             path: bash
             args:

--- a/concourse/pipelines/monitor-remote.yml
+++ b/concourse/pipelines/monitor-remote.yml
@@ -57,7 +57,7 @@ jobs:
         type: registry-image
         source:
           repository: ghcr.io/alphagov/paas/self-update-pipelines
-          tag: 540813b98e23f9865b33c206a840a8d5633287e9
+          tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 
       inputs:
       - name: paas-cf

--- a/concourse/pipelines/test-certificate-rotation.yml
+++ b/concourse/pipelines/test-certificate-rotation.yml
@@ -5,25 +5,25 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 
     cf-acceptance-tests: &cf-acceptance-tests-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 
     cf-cli: &cf-cli-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/cf-cli
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 
 
 resource_types:

--- a/concourse/tasks/aiven-broker-acceptance-tests-run.yml
+++ b/concourse/tasks/aiven-broker-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 540813b98e23f9865b33c206a840a8d5633287e9
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 inputs:
   - name: paas-cf
   - name: test-config

--- a/concourse/tasks/app-autoscaler-acceptance-tests-run.yml
+++ b/concourse/tasks/app-autoscaler-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 540813b98e23f9865b33c206a840a8d5633287e9
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 inputs:
   - name: paas-cf
   - name: admin-creds

--- a/concourse/tasks/check-az-is-enabled-in-manifest.yml
+++ b/concourse/tasks/check-az-is-enabled-in-manifest.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: 540813b98e23f9865b33c206a840a8d5633287e9
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 params:
   DEPLOY_ENV:
   BOSH_ENVIRONMENT:

--- a/concourse/tasks/check-az-is-enabled-in-vpc.yml
+++ b/concourse/tasks/check-az-is-enabled-in-vpc.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: 540813b98e23f9865b33c206a840a8d5633287e9
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 params:
   AWS_DEFAULT_REGION:
   EXPECTED_ACL_NAME:

--- a/concourse/tasks/check-billing-comparison-with-cf.yml
+++ b/concourse/tasks/check-billing-comparison-with-cf.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 540813b98e23f9865b33c206a840a8d5633287e9
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 inputs:
   - name: paas-billing
 params:

--- a/concourse/tasks/configure-grafana.yml
+++ b/concourse/tasks/configure-grafana.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/ruby
-    tag: 540813b98e23f9865b33c206a840a8d5633287e9
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 inputs:
   - name: paas-trusted-people
 run:

--- a/concourse/tasks/create_admin.yml
+++ b/concourse/tasks/create_admin.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-uaac
-    tag: 540813b98e23f9865b33c206a840a8d5633287e9
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 inputs:
   - name: paas-cf
   - name: cf-manifest

--- a/concourse/tasks/create_nonadmin.yml
+++ b/concourse/tasks/create_nonadmin.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
-    tag: 540813b98e23f9865b33c206a840a8d5633287e9
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 inputs:
   - name: paas-cf
 outputs:

--- a/concourse/tasks/cronitor-monitor-ping-action.yml
+++ b/concourse/tasks/cronitor-monitor-ping-action.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 540813b98e23f9865b33c206a840a8d5633287e9
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 run:
   path: sh
   args:

--- a/concourse/tasks/curl-az-healthcheck.yml
+++ b/concourse/tasks/curl-az-healthcheck.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/curl-ssl
-    tag: 540813b98e23f9865b33c206a840a8d5633287e9
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 params:
   AVAILABILITY_ZONE:
   ENABLE_AZ_HEALTHCHECK:

--- a/concourse/tasks/custom-acceptance-tests-run.yml
+++ b/concourse/tasks/custom-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 540813b98e23f9865b33c206a840a8d5633287e9
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 inputs:
   - name: paas-cf
   - name: test-config

--- a/concourse/tasks/custom-broker-acceptance-tests-run.yml
+++ b/concourse/tasks/custom-broker-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 540813b98e23f9865b33c206a840a8d5633287e9
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 inputs:
   - name: paas-cf
   - name: test-config

--- a/concourse/tasks/delete_user.yml
+++ b/concourse/tasks/delete_user.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
-    tag: 540813b98e23f9865b33c206a840a8d5633287e9
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 inputs:
   - name: paas-cf
   - name: cf-manifest

--- a/concourse/tasks/forget-access-keys.yml
+++ b/concourse/tasks/forget-access-keys.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/terraform
-    tag: 540813b98e23f9865b33c206a840a8d5633287e9
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 inputs:
   - name: paas-cf
   - name: cf-tfstate

--- a/concourse/tasks/generate-git-keys.yml
+++ b/concourse/tasks/generate-git-keys.yml
@@ -3,7 +3,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: 540813b98e23f9865b33c206a840a8d5633287e9
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 run:
   path: sh
   args:

--- a/concourse/tasks/generate-test-config.yml
+++ b/concourse/tasks/generate-test-config.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: 540813b98e23f9865b33c206a840a8d5633287e9
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 inputs:
   - name: paas-cf
   - name: admin-creds

--- a/concourse/tasks/get-cf-cli-config.yml
+++ b/concourse/tasks/get-cf-cli-config.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/ruby
-    tag: 540813b98e23f9865b33c206a840a8d5633287e9
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 inputs:
   - name: paas-cf
   - name: cf-manifest

--- a/concourse/tasks/remove-db.yml
+++ b/concourse/tasks/remove-db.yml
@@ -7,7 +7,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
-    tag: 540813b98e23f9865b33c206a840a8d5633287e9
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 run:
   path: sh
   args:

--- a/concourse/tasks/send-nagging-email-alert.yml
+++ b/concourse/tasks/send-nagging-email-alert.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: 540813b98e23f9865b33c206a840a8d5633287e9
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 inputs:
   - name: paas-cf
 params:

--- a/concourse/tasks/smoke-tests-run.yml
+++ b/concourse/tasks/smoke-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: 540813b98e23f9865b33c206a840a8d5633287e9
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 inputs:
   - name: paas-cf
   - name: cf-smoke-tests-release

--- a/concourse/tasks/tag-repo.yml
+++ b/concourse/tasks/tag-repo.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/git-ssh
-    tag: 540813b98e23f9865b33c206a840a8d5633287e9
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 inputs:
   - name: git-repo
 params:

--- a/concourse/tasks/upload-test-artifacts.yml
+++ b/concourse/tasks/upload-test-artifacts.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: 540813b98e23f9865b33c206a840a8d5633287e9
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 inputs:
   - name: paas-cf
   - name: artifacts

--- a/concourse/tasks/wait-for-api-availability-tests.yml
+++ b/concourse/tasks/wait-for-api-availability-tests.yml
@@ -11,7 +11,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: 540813b98e23f9865b33c206a840a8d5633287e9
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 run:
   path: sh
   args:

--- a/concourse/tasks/wait-for-app-availability-tests.yml
+++ b/concourse/tasks/wait-for-app-availability-tests.yml
@@ -13,7 +13,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
-    tag: 540813b98e23f9865b33c206a840a8d5633287e9
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 run:
   path: sh
   args:


### PR DESCRIPTION
What
----

Update paas docker images to pick up new bosh-cli-v2

How to review
-------------

Deployed in dev-04

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
