### PR TITLE
[#185529919] Work associated with AWS retirement of db-instance-classes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1408,6 +1408,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-darwin-21
   x86_64-linux
 

--- a/manifests/cf-manifest/operations.d/712-rds-broker-mysql57-plans.yml
+++ b/manifests/cf-manifest/operations.d/712-rds-broker-mysql57-plans.yml
@@ -19,21 +19,21 @@
       engine_family: "mysql5.7"
 
     tiny_plan_rds_properties: &tiny_plan_rds_properties
-      db_instance_class: "db.t2.micro"
+      db_instance_class: "db.t3.micro"
       allocated_storage: 5
       backup_retention_period: 0
       skip_final_snapshot: true
     small_plan_rds_properties: &small_plan_rds_properties
-      db_instance_class: "db.t2.small"
+      db_instance_class: "db.t3.small"
       allocated_storage: 20
     medium_plan_rds_properties: &medium_plan_rds_properties
-      db_instance_class: "db.m4.large"
+      db_instance_class: "db.m5.large"
       allocated_storage: 100
     large_plan_rds_properties: &large_plan_rds_properties
-      db_instance_class: "db.m4.2xlarge"
+      db_instance_class: "db.m5.2xlarge"
       allocated_storage: 512
     xlarge_plan_rds_properties: &xlarge_plan_rds_properties
-      db_instance_class: "db.m4.4xlarge"
+      db_instance_class: "db.m5.4xlarge"
       allocated_storage: 2048
 
 - type: replace
@@ -41,14 +41,14 @@
   value:
     id: 69977068-8ef5-4172-bfdb-e8cea3c14d01
     name: "tiny-unencrypted-5.7"
-    description: "5GB Storage, NOT BACKED UP, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.t2.micro. Free for trial orgs. Costs for billable orgs."
+    description: "5GB Storage, NOT BACKED UP, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.t3.micro. Free for trial orgs. Costs for billable orgs."
     free: true
     metadata:
       AdditionalMetadata:
         backups: false
         encrypted: false
         highlyAvailable: false
-        instanceClass: db.t2.micro
+        instanceClass: db.t3.micro
         storage:
           amount: 5
           unit: GB
@@ -66,14 +66,14 @@
   value:
     id: "b0ccc8c9-09b0-4c3e-9880-091cc41c2ab5"
     name: "small-5.7"
-    description: "20GB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.t2.small."
+    description: "20GB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.t3.small."
     free: false
     metadata:
       AdditionalMetadata:
         backups: true
         encrypted: true
         highlyAvailable: false
-        instanceClass: db.t2.small
+        instanceClass: db.t3.small
         storage:
           amount: 20
           unit: GB
@@ -93,14 +93,14 @@
   value:
     id: "6aa563c1-5aeb-46a1-9509-badcf5995c96"
     name: "small-ha-5.7"
-    description: "20GB Storage, Dedicated Instance, Highly Available. Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.t2.small."
+    description: "20GB Storage, Dedicated Instance, Highly Available. Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.t3.small."
     free: false
     metadata:
       AdditionalMetadata:
         backups: true
         encrypted: true
         highlyAvailable: true
-        instanceClass: db.t2.small
+        instanceClass: db.t3.small
         storage:
           amount: 20
           unit: GB
@@ -120,14 +120,14 @@
   value:
     id: "29cdedeb-e910-4a7a-b606-2c4e42eea478"
     name: "medium-5.7"
-    description: "100GB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.large."
+    description: "100GB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m5.large."
     free: false
     metadata:
       AdditionalMetadata:
         backups: true
         encrypted: true
         highlyAvailable: false
-        instanceClass: db.m4.large
+        instanceClass: db.m5.large
         storage:
           amount: 100
           unit: GB
@@ -147,14 +147,14 @@
   value:
     id: "8d139b9e-bc82-4749-8ad6-7733980292d6"
     name: "medium-ha-5.7"
-    description: "100GB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.large."
+    description: "100GB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m5.large."
     free: false
     metadata:
       AdditionalMetadata:
         backups: true
         encrypted: true
         highlyAvailable: true
-        instanceClass: db.m4.large
+        instanceClass: db.m5.large
         storage:
           amount: 100
           unit: GB
@@ -175,14 +175,14 @@
   value:
     id: "98a9b7cf-e067-4915-8190-ce8224dd04dc"
     name: "large-5.7"
-    description: "512GB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.2xlarge."
+    description: "512GB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m5.2xlarge."
     free: false
     metadata:
       AdditionalMetadata:
         backups: true
         encrypted: true
         highlyAvailable: false
-        instanceClass: db.m4.2xlarge
+        instanceClass: db.m5.2xlarge
         storage:
           amount: 512
           unit: GB
@@ -202,14 +202,14 @@
   value:
     id: "d5efbf83-5e00-47a5-a668-2ef1307d5a23"
     name: "large-ha-5.7"
-    description: "512GB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.2xlarge."
+    description: "512GB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m5.2xlarge."
     free: false
     metadata:
       AdditionalMetadata:
         backups: true
         encrypted: true
         highlyAvailable: true
-        instanceClass: db.m4.2xlarge
+        instanceClass: db.m5.2xlarge
         storage:
           amount: 512
           unit: GB
@@ -230,14 +230,14 @@
   value:
     id: "e03020e8-eaed-49c2-bd58-23b7cb871c22"
     name: "xlarge-5.7"
-    description: "2TB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.4xlarge."
+    description: "2TB Storage, Dedicated Instance, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m5.4xlarge."
     free: false
     metadata:
       AdditionalMetadata:
         backups: true
         encrypted: true
         highlyAvailable: false
-        instanceClass: db.m4.4xlarge
+        instanceClass: db.m5.4xlarge
         storage:
           amount: 2
           unit: TB
@@ -257,14 +257,14 @@
   value:
     id: "4edc975c-3f07-46f1-bd87-ecb35b76298f"
     name: "xlarge-ha-5.7"
-    description: "2TB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m4.4xlarge."
+    description: "2TB Storage, Dedicated Instance, Highly Available, Storage Encrypted. MySQL Version 5.7. DB Instance Class: db.m5.4xlarge."
     free: false
     metadata:
       AdditionalMetadata:
         backups: true
         encrypted: true
         highlyAvailable: true
-        instanceClass: db.m4.4xlarge
+        instanceClass: db.m5.4xlarge
         storage:
           amount: 2
           unit: TB
@@ -287,7 +287,7 @@
   value:
     id: "72279ebd-6001-4e38-aaef-72b68c4fa6fd"
     name: "small-ha-unencrypted-5.7"
-    description: "20GB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.t2.small."
+    description: "20GB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.t3.small."
     free: false
     active: false
     metadata:
@@ -305,7 +305,7 @@
   value:
     id: "4eb35ca9-a7ec-46c6-b137-d819848536cd"
     name: "medium-unencrypted-5.7"
-    description: "100GB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.m4.large."
+    description: "100GB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.m5.large."
     free: false
     active: false
     metadata:
@@ -322,7 +322,7 @@
   value:
     id: "e60edf62-b701-4e38-846f-b0b3db728349"
     name: "medium-ha-unencrypted-5.7"
-    description: "100GB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.m4.large."
+    description: "100GB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.m5.large."
     free: false
     active: false
     metadata:
@@ -340,7 +340,7 @@
   value:
     id: "6725bf1f-71e8-447a-b6a1-659247fcc03c"
     name: "large-unencrypted-5.7"
-    description: "512GB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.m4.2xlarge."
+    description: "512GB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.m5.2xlarge."
     free: false
     active: false
     metadata:
@@ -357,7 +357,7 @@
   value:
     id: "63cdac92-9e44-42a6-ba3f-7be3dccf5dc6"
     name: "large-ha-unencrypted-5.7"
-    description: "512GB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.m4.2xlarge."
+    description: "512GB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.m5.2xlarge."
     free: false
     active: false
     metadata:
@@ -375,7 +375,7 @@
   value:
     id: "a37144bf-4e05-451b-87ba-0a2c57a23a91"
     name: "xlarge-unencrypted-5.7"
-    description: "2TB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.m4.4xlarge."
+    description: "2TB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.m5.4xlarge."
     free: false
     active: false
     metadata:
@@ -392,7 +392,7 @@
   value:
     id: "065a7de5-28e8-4de1-8a39-4b4f752e2f2f"
     name: "xlarge-ha-unencrypted-5.7"
-    description: "2TB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.m4.4xlarge."
+    description: "2TB Storage, Dedicated Instance, Highly Available. MySQL Version 5.7. DB Instance Class: db.m5.4xlarge."
     free: false
     active: false
     metadata:
@@ -410,7 +410,7 @@
   value:
     id: "7fdde6ea-cc27-466c-86aa-46181fc20d25"
     name: "small-unencrypted-5.7"
-    description: "20GB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.t2.small."
+    description: "20GB Storage, Dedicated Instance. MySQL Version 5.7. DB Instance Class: db.t3.small."
     free: false
     active: false
     metadata:

--- a/manifests/cf-manifest/operations.d/715-rds-broker-postgres10-plans.yml
+++ b/manifests/cf-manifest/operations.d/715-rds-broker-postgres10-plans.yml
@@ -81,24 +81,24 @@
     ] 
 
     tiny_plan_rds_properties: &tiny_plan_rds_properties
-      db_instance_class: "db.t2.micro"
+      db_instance_class: "db.t3.micro"
       allocated_storage: 5
       backup_retention_period: 0
       skip_final_snapshot: true
     small_plan_rds_properties: &small_plan_rds_properties
-      db_instance_class: "db.t2.small"
+      db_instance_class: "db.t3.small"
       allocated_storage: 20
     medium_plan_rds_properties: &medium_plan_rds_properties
-      db_instance_class: "db.m4.large"
+      db_instance_class: "db.m5.large"
       allocated_storage: 100
     old_large_plan_rds_properties: &old_large_plan_rds_properties
-      db_instance_class: "db.m4.2xlarge"
+      db_instance_class: "db.m5.2xlarge"
       allocated_storage: 512
     large_plan_rds_properties: &large_plan_rds_properties
-      db_instance_class: "db.m4.2xlarge"
+      db_instance_class: "db.m5.2xlarge"
       allocated_storage: 564
     xlarge_plan_rds_properties: &xlarge_plan_rds_properties
-      db_instance_class: "db.m4.4xlarge"
+      db_instance_class: "db.m5.4xlarge"
       allocated_storage: 2048
 
 - type: replace
@@ -106,7 +106,7 @@
   value:
     id: "11f779fa-425c-4c86-9530-d0aebcb3c3e6"
     name: "tiny-unencrypted-10"
-    description: "5GB Storage, NOT BACKED UP, Dedicated Instance, Max 50 Concurrent Connections. Postgres Version 10. DB Instance Class: db.t2.micro. Free for trial orgs. Costs for billable orgs."
+    description: "5GB Storage, NOT BACKED UP, Dedicated Instance, Max 50 Concurrent Connections. Postgres Version 10. DB Instance Class: db.t3.micro. Free for trial orgs. Costs for billable orgs."
     free: true
     metadata:
       AdditionalMetadata:
@@ -114,7 +114,7 @@
         concurrentConnections: 50
         encrypted: false
         highlyAvailable: false
-        instanceClass: db.t2.micro
+        instanceClass: db.t3.micro
         storage:
           amount: 5
           unit: GB
@@ -132,7 +132,7 @@
   value:
     id: "a68e4934-6c37-4f10-89b2-6388df093221"
     name: "small-10"
-    description: "20GB Storage, Dedicated Instance, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 10. DB Instance Class: db.t2.small."
+    description: "20GB Storage, Dedicated Instance, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 10. DB Instance Class: db.t3.small."
     free: false
     metadata:
       AdditionalMetadata:
@@ -140,7 +140,7 @@
         concurrentConnections: 200
         encrypted: true
         highlyAvailable: false
-        instanceClass: db.t2.small
+        instanceClass: db.t3.small
         storage:
           amount: 20
           unit: GB
@@ -160,7 +160,7 @@
   value:
     id: "b2ef068e-5937-4522-ab97-758f6e9ce0ff"
     name: "small-ha-10"
-    description: "20GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 10. DB Instance Class: db.t2.small."
+    description: "20GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 200 Concurrent Connections. Postgres Version 10. DB Instance Class: db.t3.small."
     free: false
     metadata:
       AdditionalMetadata:
@@ -168,7 +168,7 @@
         concurrentConnections: 200
         encrypted: true
         highlyAvailable: true
-        instanceClass: db.t2.small
+        instanceClass: db.t3.small
         storage:
           amount: 20
           unit: GB
@@ -188,7 +188,7 @@
   value:
     id: "d9e7b133-e584-4a9b-bef9-c53c2f2142f6"
     name: "medium-10"
-    description: "100GB Storage, Dedicated Instance, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m4.large."
+    description: "100GB Storage, Dedicated Instance, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m5.large."
     free: false
     metadata:
       AdditionalMetadata:
@@ -196,7 +196,7 @@
         concurrentConnections: 500
         encrypted: true
         highlyAvailable: false
-        instanceClass: db.m4.large
+        instanceClass: db.m5.large
         storage:
           amount: 100
           unit: GB
@@ -216,7 +216,7 @@
   value:
     id: "0c89ea29-e6b3-44be-9b39-85cd42c3911e"
     name: "medium-ha-10"
-    description: "100GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m4.large."
+    description: "100GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 500 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m5.large."
     free: false
     metadata:
       AdditionalMetadata:
@@ -224,7 +224,7 @@
         concurrentConnections: 500
         encrypted: true
         highlyAvailable: true
-        instanceClass: db.m4.large
+        instanceClass: db.m5.large
         storage:
           amount: 100
           unit: GB
@@ -245,7 +245,7 @@
   value:
     id: "82e268a4-f714-4525-be7c-cb265458ddbe"
     name: "large-10"
-    description: "564GB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m4.2xlarge."
+    description: "564GB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m5.2xlarge."
     free: false
     metadata:
       AdditionalMetadata:
@@ -253,7 +253,7 @@
         concurrentConnections: 5000
         encrypted: true
         highlyAvailable: false
-        instanceClass: db.m4.2xlarge
+        instanceClass: db.m5.2xlarge
         storage:
           amount: 564
           unit: GB
@@ -273,7 +273,7 @@
   value:
     id: "da44b024-52bd-459f-8078-38591d574c90"
     name: "large-10-old"
-    description: "512GB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m4.2xlarge."
+    description: "512GB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m5.2xlarge."
     free: false
     metadata:
       AdditionalMetadata:
@@ -281,7 +281,7 @@
         concurrentConnections: 5000
         encrypted: true
         highlyAvailable: false
-        instanceClass: db.m4.2xlarge
+        instanceClass: db.m5.2xlarge
         storage:
           amount: 512
           unit: GB
@@ -301,7 +301,7 @@
   value:
     id: "c10a4d53-0cfb-40c3-b0b6-183498343707"
     name: "large-ha-10"
-    description: "564GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m4.2xlarge."
+    description: "564GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m5.2xlarge."
     free: false
     metadata:
       AdditionalMetadata:
@@ -309,7 +309,7 @@
         concurrentConnections: 5000
         encrypted: true
         highlyAvailable: true
-        instanceClass: db.m4.2xlarge
+        instanceClass: db.m5.2xlarge
         storage:
           amount: 564
           unit: GB
@@ -330,7 +330,7 @@
   value:
     id: "4140d479-601a-4585-ae1e-df67a9fa6b36"
     name: "large-ha-10-old"
-    description: "512GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m4.2xlarge."
+    description: "512GB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m5.2xlarge."
     free: false
     metadata:
       AdditionalMetadata:
@@ -338,7 +338,7 @@
         concurrentConnections: 5000
         encrypted: true
         highlyAvailable: true
-        instanceClass: db.m4.2xlarge
+        instanceClass: db.m5.2xlarge
         storage:
           amount: 512
           unit: GB
@@ -359,7 +359,7 @@
   value:
     id: "43b01f78-0c9f-482e-b77f-e28189ccd870"
     name: "xlarge-10"
-    description: "2TB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m4.4xlarge."
+    description: "2TB Storage, Dedicated Instance, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m5.4xlarge."
     free: false
     metadata:
       AdditionalMetadata:
@@ -367,7 +367,7 @@
         concurrentConnections: 5000
         encrypted: true
         highlyAvailable: false
-        instanceClass: db.m4.4xlarge
+        instanceClass: db.m5.4xlarge
         storage:
           amount: 2
           unit: TB
@@ -387,7 +387,7 @@
   value:
     id: "2f6df103-8216-4bc4-bb38-a6422e03c981"
     name: "xlarge-ha-10"
-    description: "2TB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m4.4xlarge."
+    description: "2TB Storage, Dedicated Instance, Highly Available, Storage Encrypted, Max 5000 Concurrent Connections. Postgres Version 10. DB Instance Class: db.m5.4xlarge."
     free: false
     metadata:
       AdditionalMetadata:
@@ -395,7 +395,7 @@
         concurrentConnections: 5000
         encrypted: true
         highlyAvailable: true
-        instanceClass: db.m4.4xlarge
+        instanceClass: db.m5.4xlarge
         storage:
           amount: 2
           unit: TB

--- a/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/rds_broker_spec.rb
@@ -78,9 +78,9 @@ RSpec.describe "RDS broker properties" do
       end
     end
 
-    shared_examples "plans using t2 and m4 instances" do
+    shared_examples "plans using t3 and m5 instances" do
       it { expect(rds_properties).to have_key("db_instance_class") }
-      it { expect(rds_properties["db_instance_class"]).to match(/^db\.t2\.[a-z]+$/).or match(/^db\.m4\.[a-z0-9]+$/) }
+      it { expect(rds_properties["db_instance_class"]).to match(/^db\.t3\.[a-z]+$/).or match(/^db\.m5\.[a-z0-9]+$/) }
     end
 
     shared_examples "plans using t3 and m5 instances" do
@@ -336,7 +336,7 @@ RSpec.describe "RDS broker properties" do
             expect(rds_properties["engine_version"]).to eq("10")
           end
 
-          include_examples "plans using t2 and m4 instances"
+          include_examples "plans using t3 and m5 instances"
         end
 
         shared_examples "postgres 10 high iops plans" do
@@ -1352,7 +1352,7 @@ RSpec.describe "RDS broker properties" do
             )
           end
 
-          include_examples "plans using t2 and m4 instances"
+          include_examples "plans using t3 and m5 instances"
         end
 
         shared_examples "mysql 5.7 high iops plans" do

--- a/scripts/upgrade_instance_class.rb
+++ b/scripts/upgrade_instance_class.rb
@@ -1,0 +1,242 @@
+#!/usr/bin/env ruby
+
+require "aws-sdk-rds"
+require "logger"
+require "singleton"
+require "optparse"
+require "rubygems/version"
+
+class MyLogger
+  include Singleton
+
+  def initialize
+    @logger = Logger.new($stdout)
+    @logger.level = Logger::WARN
+  end
+
+  def log_info(message)
+    @logger.info(message)
+  end
+
+  def log_warn(message)
+    @logger.warn(message)
+  end
+
+  def log_fatal(message)
+    @logger.fatal(message)
+  end
+end
+
+def display_help
+  puts "Usage: upgrade_instance_types.rb [options]"
+  puts "Options:"
+  puts " -h, --help   Display this help message"
+  puts " --dry-run    Run the script in dry-run mode"
+end
+
+def closest_compatible_version(current_version, compatible_versions)
+  current_version_obj = Gem::Version.new(current_version)
+  compatible_versions = compatible_versions.map { |v| Gem::Version.new(v) }
+
+  closest_version = nil
+  min_difference = Float::INFINITY
+
+  compatible_versions.each do |version|
+    next if version <= current_version_obj
+
+    difference = version.segments.map(&:to_i).zip(current_version_obj.segments.map(&:to_i)).map { |a, b| (a - b).abs }.sum
+
+    if difference < min_difference
+      min_difference = difference
+      closest_version = version.to_s
+    end
+  end
+
+  closest_version
+end
+
+# Upgrade the rds instance during the maintenance window with the new db instance class and potentially the new engine version if the new db instance class requires it
+def modify_instance(rds_client, instance, target_class, the_engine_version, dry_run)
+  unless dry_run
+    rds_client.modify_db_instance({
+      db_instance_identifier: instance.db_instance_identifier,
+      db_instance_class: target_class,
+      engine_version: the_engine_version,
+      apply_immediately: false,
+    })
+  end
+
+  MyLogger.instance.log_info("Update request submitted.")
+end
+
+def manage_instance_state(rds_client, instance)
+  case instance.db_instance_status
+  when /modifying|rebooting/
+    MyLogger.instance.log_info("Instance #{instance.db_instance_identifier} is in a transitional state. Waiting for it to become available ...")
+    rds_client.wait_until(:db_instance_available, db_instance_identifier: instance.db_instance_identifier)
+    "available"
+  when "available"
+    MyLogger.instance.log_info("Instance #{instance.db_instance_identifier} is available.")
+    "available"
+  else
+    MyLogger.instance.log_warn("Instance #{instance.db_instance_identifier} is in a state that can't be modified. Moving on ...")
+    "abort"
+  end
+end
+
+# Get the RDS instances
+def get_instances(rds_client)
+  instances = []
+  next_token = nil
+
+  loop do
+    response = rds_client.describe_db_instances({
+      max_records: 100,
+      marker: next_token,
+    })
+    instances += response.db_instances
+    next_token = response.marker
+
+    break unless next_token
+  end
+  instances
+end
+
+def get_available_class_options(rds_client, instance)
+  available_options = []
+  next_token = nil
+
+  loop do
+    options_response = rds_client.describe_orderable_db_instance_options({
+      engine: instance.engine,
+      engine_version: instance.engine_version,
+      max_records: 100,
+      marker: next_token,
+    })
+    available_options += options_response.orderable_db_instance_options
+    next_token = options_response.marker
+    break unless next_token
+  end
+  available_options
+end
+
+def get_available_engine_version_options(rds_client, instance, target_class)
+  available_versions = []
+  next_token = nil
+
+  loop do
+    available_versions_response = rds_client.describe_orderable_db_instance_options({
+      engine: instance.engine,
+      db_instance_class: target_class,
+      max_records: 100,
+      marker: next_token,
+    })
+    available_versions += available_versions_response.orderable_db_instance_options
+    next_token = available_versions_response.marker
+    break unless next_token
+  end
+  available_versions
+end
+
+def process_instance(rds_client, instance, target_class, dry_run)
+  # Get available instance class options for the current engine and engine version
+  options = get_available_class_options(rds_client, instance)
+  # Check if the target instance class is available for this engine and engine version
+  compatible = options.any? do |option|
+    option.db_instance_class == target_class
+  end
+
+  if compatible
+    MyLogger.instance.log_info("Updating instance #{instance.db_instance_identifier} from #{instance.db_instance_class} to #{target_class} db_instance_class during maintenance window...")
+
+    state = manage_instance_state(rds_client, instance)
+
+    if state == "abort"
+      "abort"
+    else
+      MyLogger.instance.log_warn("Updating instance #{instance.db_instance_identifier}.")
+
+      modify_instance(rds_client, instance, target_class, instance.engine_version, dry_run)
+    end
+  else
+    MyLogger.instance.log_info("Target instance class #{target_class} is not compatible with the current engine version.")
+    MyLogger.instance.log_info("... trying to find a suitable engine upgrade.")
+
+    engine_version_options = get_available_engine_version_options(rds_client, instance, target_class)
+
+    compatible_versions = engine_version_options.map(&:engine_version)
+    closest_version = closest_compatible_version(instance.engine_version, compatible_versions)
+
+    if closest_version.nil?
+      MyLogger.instance.log_warn("No compatible engine version upgrade found for target db instance #{target_class}.")
+      return
+    end
+
+    comparison_result = Gem::Version.new(instance.engine_version) <=> Gem::Version.new(closest_version)
+
+    if comparison_result >= 0
+      MyLogger.instance.log_info("The current engine version is already at least as new as the closest available version.")
+      return
+    end
+
+    state = manage_instance_state(rds_client, instance)
+
+    if state == "abort"
+      return
+    end
+
+    MyLogger.instance.log_info("Updating instance #{instance.db_instance_identifier} with class: #{target_class} and engine version: #{closest_version}.")
+    modify_instance(rds_client, instance, target_class, closest_version, dry_run)
+  end
+end
+
+def main(deploy_env, dry_run)
+  instance_class_mapping = {
+    "db.t2." => "db.t3.",
+    "db.m4." => "db.m5.",
+    "db.r4." => "db.r5.",
+  }
+  rds_client = Aws::RDS::Client.new
+
+  instances = get_instances(rds_client)
+
+  instances.each do |instance|
+    instance.tag_list.each do |tag|
+      if tag[:key] == "deploy_env" && tag[:value] == deploy_env
+        # Is the instance class of interest?
+        if instance_class_mapping.key? instance.db_instance_class[0..5]
+          target_class = instance.db_instance_class.sub(instance.db_instance_class[0..5], instance_class_mapping.fetch(instance.db_instance_class[0..5]))
+          process_instance(rds_client, instance, target_class, dry_run)
+        else
+          MyLogger.instance.log_info("Instance #{instance.db_instance_identifier} doesn't have a db instance class that needs replacing.")
+        end
+      end
+    end
+  end
+rescue Aws::RDS::Errors::ServiceError => e
+  MyLogger.instance.log_fatal("Caught #{e.class}, exiting")
+end
+
+ARGV << "-h" if ARGV.empty?
+
+options = {}
+parser = OptionParser.new { |opts|
+  opts.banner = "Usage: ./upgrade_instance_class.rb [options]"
+
+  opts.on("--env DEPLOY_ENV", String, "Specify the env this script should operate on") do |env|
+    options[:env] = env
+  end
+
+  opts.on("--dry-run", TrueClass) do |dry_run|
+    puts "Dry run? #{dry_run}"
+    options[:dry_run] = true
+  end
+
+  opts.on_tail("-h", "--help", "Show help") do
+    puts opts
+    exit
+  end
+}.parse!
+parser.parse!
+
+main(options[:env], options[:dry_run]) if $PROGRAM_NAME == __FILE__

--- a/terraform/cloudfoundry/cdn_broker.tf
+++ b/terraform/cloudfoundry/cdn_broker.tf
@@ -128,7 +128,7 @@ resource "aws_db_instance" "cdn" {
   allocated_storage    = 10
   engine               = "postgres"
   engine_version       = "12"
-  instance_class       = "db.t2.small"
+  instance_class       = "db.t3.small"
   db_name              = "cdn"
   username             = "dbadmin"
   password             = var.secrets_cdn_db_master_password


### PR DESCRIPTION
What
----

We have received a notification that AWS will retire the t2, m4 and r4 db instance classes by April 2024. This PR replaces the deprecated classes with t3, m5 and r5 classes as appropriate in the affected marketplace offerings.

This change also contains a script - upgrade_instance_class.rb - which will upgrade the instance class in existing rds instances where appropriate.

How to review
-------------

1. Review the code. Any feedback gratefully received.
2. Run the branch into a dev env.
3. Check that no cf rds marketplace services offer any of the deprecated instance classes.
4. Using aws ro credentials run the script in "--dry-run" mode. You should see no "not authorized" errors meaning the script is not attempting to update any aws resources.
5. I have changed the terraform for the cdn broker instances so that they use a t3 class instead of a t2 class. Consequently, you will see that the cdn broker instance in the dev env that you are using will not need to be upgraded by the script.
6. When the script is run with aws admin creds and without the --dry-run flag it will set those rds instances that use a deprecated class to be upgraded during the next maintenance window. The upgrade can be viewed under the "Maintenance & backups" tab, within the "Maintenance" section under "Pending modifications" of the impacted rds instance.
7. The logger class within the script is currently set to INFO.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
