### PR TITLE
185827634 - Remove HTTP listener test for PaaS product pages

### DIFF
--- a/platform-tests/acceptance/plain_http_test.go
+++ b/platform-tests/acceptance/plain_http_test.go
@@ -55,16 +55,6 @@ var _ = Describe("plain HTTP requests", func() {
 				Expect(err.(net.Error).Timeout()).To(BeTrue(), "should timeout")
 			})
 		})
-
-		Describe("for the product page", func() {
-			It("has the connection refused", func() {
-				systemDomain := GetConfigFromEnvironment("SYSTEM_DNS_ZONE_NAME")
-				uri := fmt.Sprintf("www.%s:80", systemDomain)
-				_, err := net.DialTimeout("tcp", uri, CONNECTION_TIMEOUT)
-				Expect(err).To(HaveOccurred(), "should not connect")
-				Expect(err.(net.Error).Timeout()).To(BeTrue(), "should timeout")
-			})
-		})
 	})
 
 	Context("to the apps domain", func() {


### PR DESCRIPTION
Description:
----
- Product pages which has been migrated to GitHub pages has a HTTP listener on port 80 which redirects to HTTPs rather than connection refused which means the test is incorrect and can be removed


🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
