### PR TITLE
Add TLS listener and config for s3 broker

### DIFF
--- a/manifests/cf-manifest/operations.d/700-broker-ca.yml
+++ b/manifests/cf-manifest/operations.d/700-broker-ca.yml
@@ -1,0 +1,8 @@
+- type: replace
+  path: /variables/-
+  value:
+    name: broker_tls_ca
+    type: certificate
+    options:
+      is_ca: true
+      common_name: "PaaS Broker CA"

--- a/manifests/cf-manifest/operations.d/750-s3-broker.yml
+++ b/manifests/cf-manifest/operations.d/750-s3-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: s3-broker
-    version: 0.1.19
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/s3-broker-0.1.19.tgz
-    sha1: 91f190c89d77cc7aa1fc23c49209c742f4b31955
+    version: 0.1.21 
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/s3-broker-0.1.21.tgz
+    sha1: 31818e98cd5b420a64c9c695f866a97d7d8497f7
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-
@@ -31,7 +31,7 @@
         release: s3-broker
         properties:
           s3-broker:
-            port: 80
+            port: 443
             basic_auth_username: s3-broker
             basic_auth_password: ((secrets_s3_broker_admin_password))
             log_level: INFO
@@ -40,6 +40,7 @@
             iam_user_path: "/paas-s3-broker/"
             iam_ip_restriction_policy_arn: "((terraform_outputs_s3_broker_ip_restriction_policy_arn))"
             deploy_environment: "((environment))"
+            tls: ((secrets_s3_broker_tls_cert))
             locket:
               api_location: "locket.service.cf.internal:8891"
               ca_cert: "((diego_locket_client.ca))"
@@ -87,3 +88,14 @@
   value:
     name: secrets_s3_broker_admin_password
     type: password
+- type: replace
+  path: /variables/-
+  value:
+    name: secrets_s3_broker_tls_cert
+    type: certificate
+    update_mode: converge
+    options:
+      ca: broker_tls_ca
+      common_name: "s3-broker.service.cf.internal"
+      alternative_names:
+        - "s3-broker.service.cf.internal"

--- a/terraform/cloudfoundry/s3_broker.tf
+++ b/terraform/cloudfoundry/s3_broker.tf
@@ -13,7 +13,7 @@ resource "aws_elb" "s3_broker" {
   }
 
   health_check {
-    target              = "HTTP:80/healthcheck"
+    target              = "HTTPS:443/healthcheck"
     interval            = var.health_check_interval
     timeout             = var.health_check_timeout
     healthy_threshold   = var.health_check_healthy
@@ -21,8 +21,8 @@ resource "aws_elb" "s3_broker" {
   }
 
   listener {
-    instance_port      = 80
-    instance_protocol  = "http"
+    instance_port      = 443
+    instance_protocol  = "https"
     lb_port            = 443
     lb_protocol        = "https"
     ssl_certificate_id = data.aws_acm_certificate.system.arn
@@ -47,4 +47,3 @@ resource "aws_iam_policy" "s3_broker_user_ip_restriction" {
   name        = "${var.env}S3BrokerUserIpRestriction"
   description = "Restricts S3 API Access to just the NAT Gateway IPs"
 }
-


### PR DESCRIPTION
What
----

add bosh-signed TLS CA variables, and config to the manifest
updated s3 broker release version
added TLS listener in terraform

How to review
-------------
look at the code
deploy branch to a dev env and test s3 broker functionality

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
