### PR TITLE
Explicitly enable app autoscaler tests in staging and production

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,6 +285,7 @@ stg-lon: ## Set Environment to stg-lon
 	$(eval export AWS_REGION=eu-west-2)
 	$(eval export CA_ROTATION_EXPIRY_DAYS=335)
 	$(eval export ENABLE_PAAS_ADMIN_CONTINUOUS_DEPLOY ?= true)
+	$(eval export DISABLE_APP_AUTOSCALER_ACCEPTANCE_TESTS ?= false)
 	$(eval export DISABLED_AZS)
 	@true
 
@@ -311,6 +312,7 @@ prod: ## Set Environment to Production
 	$(eval export AWS_REGION=eu-west-1)
 	$(eval export CA_ROTATION_EXPIRY_DAYS=30)
 	$(eval export ENABLE_PAAS_ADMIN_CONTINUOUS_DEPLOY ?= true)
+	$(eval export DISABLE_APP_AUTOSCALER_ACCEPTANCE_TESTS ?= false)
 	$(eval export DISABLED_AZS)
 	@true
 
@@ -337,6 +339,7 @@ prod-lon: ## Set Environment to prod-lon
 	$(eval export AWS_REGION=eu-west-2)
 	$(eval export CA_ROTATION_EXPIRY_DAYS=30)
 	$(eval export ENABLE_PAAS_ADMIN_CONTINUOUS_DEPLOY ?= true)
+	$(eval export DISABLE_APP_AUTOSCALER_ACCEPTANCE_TESTS ?= false)
 	$(eval export DISABLED_AZS)
 	@true
 


### PR DESCRIPTION
What
----

Explicitly enable app autoscaler tests in staging and production.

Why
----

It looks like the app autoscaler tests were accidentally disabled by [this change](https://github.com/alphagov/paas-cf/pull/3047/files#diff-c761195c5ba6a7652ca048b1fd6425ceb1c3505dd1f9cb690a11a1bfd5badfceR103).

How to review
-------------

No way to test. Just look at the changes

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
