### PR TITLE
stacks dashboard: exclude docker-based apps

### DIFF
--- a/manifests/prometheus/dashboards.d/stacks.json
+++ b/manifests/prometheus/dashboards.d/stacks.json
@@ -108,7 +108,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum(cf_application_info{environment=\"$environment\",deployment=\"$bosh_deployment\",stack_id=\"$stack_id\", organization_name!~\"$test_orgs_nre\",state!~\"$stopped_apps_nre\"}) by (organization_id, organization_name)",
+          "expr": "sum(cf_application_info{detected_buildpack!=\"\",environment=\"$environment\",deployment=\"$bosh_deployment\",stack_id=\"$stack_id\", organization_name!~\"$test_orgs_nre\",state!~\"$stopped_apps_nre\"}) by (organization_id, organization_name)",
           "legendFormat": "{{organization_name}}",
           "range": true,
           "refId": "A"


### PR DESCRIPTION
What
----
Turns out these show up as having the default "stack id" even though this is basically meaningless for docker apps.

How to review
-------------

:eyes: dev03 where this has been deployed

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
