### PR TITLE
[186031839] cflinuxfs4-compat upgraded to 1.38.0

### DIFF
--- a/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
+++ b/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
@@ -11,6 +11,6 @@
   path: /releases/name=cflinuxfs4-compat
   value:
     name: "cflinuxfs4-compat"
-    version: "1.32.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs4-compat-release?v=1.32.0"
-    sha1: "8de16cd66aed7233c6abefa175dca946cd9a91ba"
+    version: "1.38.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs4-compat-release?v=1.38.0"
+    sha1: "78e01703efa7ea719afc51d912c77b2eade8b90e"


### PR DESCRIPTION
What
----

There is a new cflinuxfs4-compat release 1.38.0. This PR applies this version.

How to review
-------------

Deploy the branch on a dev env:
- verify that the new version is applied
- see all concourse ci jobs go green

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
