### PR TITLE
[#186110481] Reinstate 51.149.0.0/24 range VPN IP ranges

### DIFF
--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -7,6 +7,8 @@ variable "admin_cidrs" {
     "217.196.229.81/32", # GDS BYOD VPN 2 (Sep 2023)
     "217.196.229.77/32", # GovWifi (Sep 2023)
     "217.196.229.79/32", # Brattain (Sep 2023)
+    "51.149.8.0/25",     # GDS Managed VPN 1 (Sep 2023)
+    "51.149.8.128/29"    # GDS BYOD VPN 3 (Sep 2023)
   ]
 }
 


### PR DESCRIPTION
What
----

We previously removed these in #3436, but we did so in error.

How to review
-------------
Are they correct according to the GDS IT wiki?
---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
