### PR TITLE
Update notify-staging dms process to TRUNCATE_BEFORE_LOAD

### DIFF
--- a/terraform/prod.dms.json
+++ b/terraform/prod.dms.json
@@ -21,7 +21,7 @@
             "migration_type": "full-load-and-cdc",
             "settings_overrides": {
                 "FullLoadSettings": {
-                    "TargetTablePrepMode": "DO_NOTHING"
+                    "TargetTablePrepMode": "TRUNCATE_BEFORE_LOAD"
                 }
             },
             "table_mappings": null


### PR DESCRIPTION
What
----

Update notify-staging dms process to TRUNCATE_BEFORE_LOAD

Why
----

This is a much more sensible choice for operation in the case of failure for notify. We want to be able to do a full retry of the db load. Truncate the target tables makes sense when managing the schema outside of dms.

How to review
-------------

Look at the changes.
---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
