### PR TITLE
paas-s3-broker: bump to ..., provide with common user policy, expand custom-broker-acceptance-tests

### DIFF
--- a/manifests/cf-manifest/operations.d/750-s3-broker.yml
+++ b/manifests/cf-manifest/operations.d/750-s3-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: s3-broker
-    version: 0.0.1697806230
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/s3-broker-0.0.1697806230.tgz
-    sha1: f35d6a6c418c1bcd6e47d3c18224d72f7025b105
+    version: 0.1.25
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/s3-broker-0.1.25.tgz
+    sha1: 3a9f71131b7f37c8b0c74d795e652823c8de13df
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-

--- a/manifests/cf-manifest/operations.d/750-s3-broker.yml
+++ b/manifests/cf-manifest/operations.d/750-s3-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: s3-broker
-    version: 0.1.21 
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/s3-broker-0.1.21.tgz
-    sha1: 31818e98cd5b420a64c9c695f866a97d7d8497f7
+    version: 0.0.1697806230
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/s3-broker-0.0.1697806230.tgz
+    sha1: f35d6a6c418c1bcd6e47d3c18224d72f7025b105
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-
@@ -39,6 +39,8 @@
             resource_prefix: "paas-s3-broker-((environment))-"
             iam_user_path: "/paas-s3-broker/"
             iam_ip_restriction_policy_arn: "((terraform_outputs_s3_broker_ip_restriction_policy_arn))"
+            iam_common_user_policy_arn: "((terraform_outputs_s3_broker_common_user_policy_arn))"
+            iam_user_permissions_boundary_arn: "((terraform_outputs_s3_broker_user_permissions_boundary_arn))"
             deploy_environment: "((environment))"
             tls: ((secrets_s3_broker_tls_cert))
             locket:

--- a/platform-tests/example-apps/healthcheck/s3.go
+++ b/platform-tests/example-apps/healthcheck/s3.go
@@ -52,7 +52,7 @@ func testS3BucketAccess() error {
 		Bucket: aws.String(vcapService.BucketName),
 	})
 	if err != nil {
-		return err
+		return errors.Wrap(err, "ListObjects")
 	}
 
 	_, err = s3Client.PutObject(&s3.PutObjectInput{
@@ -61,7 +61,7 @@ func testS3BucketAccess() error {
 		Body:   strings.NewReader(testS3Content),
 	})
 	if err != nil {
-		return err
+		return errors.Wrap(err, "PutObject")
 	}
 
 	getObjectOutput, err := s3Client.GetObject(&s3.GetObjectInput{
@@ -69,12 +69,12 @@ func testS3BucketAccess() error {
 		Key:    aws.String(testS3File),
 	})
 	if err != nil {
-		return err
+		return errors.Wrap(err, "GetObject")
 	}
 
 	content, err := ioutil.ReadAll(getObjectOutput.Body)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "ioutil.ReadAll")
 	}
 	defer getObjectOutput.Body.Close()
 
@@ -87,7 +87,7 @@ func testS3BucketAccess() error {
 		Key:    aws.String(testS3File),
 	})
 	if err != nil {
-		return err
+		return errors.Wrap(err, "DeleteObject")
 	}
 
 	return nil

--- a/platform-tests/example-apps/healthcheck/s3.go
+++ b/platform-tests/example-apps/healthcheck/s3.go
@@ -78,6 +78,17 @@ func testS3BucketAccess() error {
 	}
 	defer getObjectOutput.Body.Close()
 
+	taggingOutput, err := s3Client.GetObjectTagging(&s3.GetObjectTaggingInput{
+		Bucket: aws.String(vcapService.BucketName),
+		Key:    aws.String(testS3File),
+	})
+	if err != nil {
+		return errors.Wrap(err, "GetObjectTagging")
+	}
+	if len(taggingOutput.TagSet) != 0 {
+		return fmt.Errorf("expected empty TagSet for %q, but was %q", testS3File, taggingOutput.TagSet)
+	}
+
 	if string(content) != testS3Content {
 		return fmt.Errorf("content mismatch, was writing %q but read %q", testS3Content, string(content))
 	}

--- a/terraform/cloudfoundry/outputs.tf
+++ b/terraform/cloudfoundry/outputs.tf
@@ -145,6 +145,14 @@ output "s3_broker_ip_restriction_policy_arn" {
   value = aws_iam_policy.s3_broker_user_ip_restriction.arn
 }
 
+output "s3_broker_common_user_policy_arn" {
+  value = aws_iam_policy.s3_broker_user_common.arn
+}
+
+output "s3_broker_user_permissions_boundary_arn" {
+  value = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/S3BrokerUserPermissionsBoundary"
+}
+
 output "restrict_to_local_ips_policy_arn" {
   value = aws_iam_policy.restrict_to_local_ips.arn
 }

--- a/terraform/cloudfoundry/policies/s3_broker_user_common.json.tpl
+++ b/terraform/cloudfoundry/policies/s3_broker_user_common.json.tpl
@@ -1,0 +1,15 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "s3:*",
+            "Resource": "*",
+            "Condition": {
+                "StringNotEquals": {
+                    "aws:ResourceAccount": ${platform_aws_account_id}
+                }
+            }
+        }
+    ]
+}

--- a/terraform/cloudfoundry/s3_broker.tf
+++ b/terraform/cloudfoundry/s3_broker.tf
@@ -47,3 +47,11 @@ resource "aws_iam_policy" "s3_broker_user_ip_restriction" {
   name        = "${var.env}S3BrokerUserIpRestriction"
   description = "Restricts S3 API Access to just the NAT Gateway IPs"
 }
+
+resource "aws_iam_policy" "s3_broker_user_common" {
+  policy = templatefile("${path.module}/policies/s3_broker_user_common.json.tpl", {
+    platform_aws_account_id = jsonencode(tostring(data.aws_caller_identity.current.account_id))
+  })
+  name        = "${var.env}S3BrokerUserCommon"
+  description = "Common policy for all S3 broker IAM users: allows access to all S3 resources not owned by our AWS account"
+}

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -25,6 +25,7 @@ variable "assets_prefix" {
 
 variable "aws_account" {
   description = "the AWS account being deployed to"
+  type        = string
 }
 
 # See https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#tls-security-policies
@@ -58,6 +59,7 @@ variable "elb_account_ids" {
     us-gov-west-1  = "048591011584"
     cn-north-1     = "638102146993"
   }
+  type = map(string)
 }
 
 variable "env" {


### PR DESCRIPTION
What
----
https://www.pivotaltracker.com/story/show/186090782

Roll this change out to cf, also making our custom-broker-acceptance-tests check they can successfully call `s3:GetObjectTagging`. In an ideal world we would have actually set a tag on the object to more completely test this works, but then we'd need to add `s3:PutObjectTagging` which we currently can avoid. So here we just test for the returned `TagSet`'s emptiness.

How to review
-------------

:eyes: https://deployer.dev03.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/custom-acceptance-tests/builds/21 ?

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
