### PR TITLE
186172165 - upload-mailchimp and upload-psn only run in production environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -412,7 +412,7 @@ upload-splunk-secrets: check-env ## Decrypt and upload Splunk HEC Tokens to Cred
 upload-mailchimp-secrets: check-env ## Decrypt and upload MailChimp Credentials to Credhub
 	$(if $(wildcard ${PAAS_PASSWORD_STORE_DIR}),,$(error Password store ${PAAS_PASSWORD_STORE_DIR} (PAAS_PASSWORD_STORE_DIR) does not exist))
 	$(eval export PASSWORD_STORE_DIR=${PAAS_PASSWORD_STORE_DIR})
-	@scripts/upload-secrets/upload-mailchimp-secrets.rb
+	$(if $(findstring prod, $(DEPLOY_ENV)),@scripts/upload-secrets/upload-mailchimp-secrets.rb,$(info upload-mailchimp-secrets only runs in prod or prod-lon))
 
 .PHONY: upload-cronitor-secrets
 upload-cronitor-secrets: check-env ## Decrypt and upload Cronitor secrets to Credhub
@@ -470,7 +470,7 @@ upload-pingdom-secrets: check-env ## Decrypt and upload Pingdom Credentials to C
 upload-psn-secrets: check-env ## Decrypt and upload PSN secrets to Credhub
 	$(if $(wildcard ${PAAS_PASSWORD_STORE_DIR}),,$(error Password store ${PAAS_PASSWORD_STORE_DIR} (PAAS_PASSWORD_STORE_DIR) does not exist))
 	$(eval export PASSWORD_STORE_DIR=${PAAS_PASSWORD_STORE_DIR})
-	@scripts/upload-secrets/upload-psn-secrets.rb
+	$(if $(findstring prod, $(DEPLOY_ENV)),@scripts/upload-secrets/upload-psn-secrets.rb,$(info upload-psn-secrets only runs in prod))
 
 .PHONY: upload-slack-secrets
 upload-slack-secrets: check-env ## Decrypt and upload Slack credentials to Credhub
@@ -557,7 +557,6 @@ buildpack-upgrade:
 
 .PHONY: .download-gpg-keys
 .download-gpg-keys: check-gpg-keys
-
 
 .PHONY: check-gpg-keys
 check-gpg-keys: ## Check all GPG keys specified in .gpg-id are present on the keyserver


### PR DESCRIPTION
Description:
----
- These 2 Makefile targets only run in the production environment
- Conditionally execute these targets if 'prod' is found as a substring in `DEPLOY_ENV`

How to review
-------------

Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
