### PR TITLE
Switch elasticache broker to use https

### DIFF
--- a/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
+++ b/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
@@ -61,9 +61,9 @@
   path: /releases/-
   value:
     name: elasticache-broker
-    version: 0.1.22
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/elasticache-broker-0.1.22.tgz
-    sha1: 4b1c88aac9513cc5f9907c0efb79b50a4a0746a4
+    version: 0.0.1697719524
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/elasticache-broker-0.0.1697719524.tgz
+    sha1: 9684bc0251ca16ac562fd1c041d466f5a21eb947
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-
@@ -95,6 +95,9 @@
             secrets_manager_path: elasticache-broker/((environment))
             region: "((terraform_outputs_region))"
             cache_subnet_group_name: ((terraform_outputs_elasticache_broker_subnet_group_name))
+            host: "0.0.0.0"
+            port: 443
+            tls: ((secrets_elasticache_broker_tls_cert))
             vpc_security_group_ids:
             - ((terraform_outputs_elasticache_broker_instances_security_group_id))
 
@@ -703,3 +706,15 @@
   value:
     name: secrets_elasticache_broker_admin_password
     type: password
+
+- type: replace
+  path: /variables/-
+  value:
+    name: secrets_elasticache_broker_tls_cert
+    type: certificate
+    update_mode: converge
+    options:
+      ca: broker_tls_ca
+      common_name: "elasticache-broker.service.cf.internal"
+      alternative_names:
+        - "elasticache-broker.service.cf.internal"

--- a/terraform/cloudfoundry/elasticache_broker.tf
+++ b/terraform/cloudfoundry/elasticache_broker.tf
@@ -13,7 +13,7 @@ resource "aws_elb" "elasticache_broker" {
   }
 
   health_check {
-    target              = "HTTP:80/healthcheck"
+    target              = "HTTPS:443/healthcheck"
     interval            = var.health_check_interval
     timeout             = var.health_check_timeout
     healthy_threshold   = var.health_check_healthy
@@ -21,8 +21,8 @@ resource "aws_elb" "elasticache_broker" {
   }
 
   listener {
-    instance_port      = 80
-    instance_protocol  = "http"
+    instance_port      = 443
+    instance_protocol  = "https"
     lb_port            = 443
     lb_protocol        = "https"
     ssl_certificate_id = data.aws_acm_certificate.system.arn


### PR DESCRIPTION
What
----

Switch elasticache broker to use https

How to review
-------------

- Ideally deploy to a dev environment once the other two PRs have been merged

Notes
----

This is going to cause an elasticache outage between the time of the terraform run and the bosh-deploy. We should plan when this gets executed in production to minimise the affects on our users.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
