### PR TITLE
[186049138] Pipelines do not need to run apk

### DIFF
--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -115,7 +115,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/alpine
-              tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+              tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
           inputs:
             - name: paas-cf
           params:
@@ -142,7 +142,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/bosh-cli-v2
-              tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+              tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
           run:
             path: sh
             args:
@@ -178,7 +178,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/awscli
-              tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+              tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
           run:
             path: ./paas-cf/concourse/scripts/rds_instances.sh
             args:

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -11,77 +11,77 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/alpine
-        tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
     psql: &psql-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/psql
-        tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
     node: &node-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/node
-        tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
     node-chromium: &node-chromium-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/node-chromium
-        tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
     awscli: &awscli-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
     concourse-tools: &concourse-tools-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/concourse-tools
-        tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03 
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
     cf-acceptance-tests: &cf-acceptance-tests-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-        tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
     cf-cli: &cf-cli-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/cf-cli
-        tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
     cf-uaac: &cf-uaac-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/cf-uaac
-        tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
     git-ssh: &git-ssh-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/git-ssh
-        tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
     ruby-slim: &ruby-slim-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/ruby
-        tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
     golang: &golang-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/golang
-        tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
     terraform: &terraform-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
     curl-ssl: &curl-ssl-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/curl-ssl
-        tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 
 
   tasks:
@@ -263,6 +263,7 @@ groups:
       - rotate-prometheus-credentials
       - expire-aws-keys
       - rotate-cf-admin-password
+
 resource_types:
   # FIX ME: The server certificate verification fails when using the concourse
   # version of the resource_type `git`. As a temporary fix we have docker image
@@ -827,7 +828,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+              tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 
           inputs:
             - name: paas-cf
@@ -2965,7 +2966,7 @@ jobs:
             CREDHUB_CLIENT_SECRET: ((bosh-credhub-admin))
             CREDHUB_CA_CERT: ((bosh-credhub-ca-cert))
             DEPLOY_ENV: ((deploy_env))
-            BOSH_EXPORTER_PASSWORD: ((bosh-exporter-password)) 
+            BOSH_EXPORTER_PASSWORD: ((bosh-exporter-password))
           run:
             path: sh
             args:
@@ -3343,7 +3344,7 @@ jobs:
                   fi
 
                   for az in $(seq 1 $AZ_COUNT); do
-    
+
                     # iterate through dashboards to remove.
                     for dashboard in "billing-slis" "billing-compared-to-spending"; do
                       echo "Removing ${dashboard} from grafana-${az}.${SYSTEM_DNS_ZONE_NAME}"
@@ -4419,7 +4420,6 @@ jobs:
               - -e
               - -c
               - |
-                apk add --quiet --no-progress --no-cache g++ musl-dev make
                 uaac target "${UAA_API_URL}"
                 uaac token client get admin -s "${UAA_ADMIN_CLIENT_SECRET}"
                 CF_TOKEN="bearer $(uaac contexts | awk '$1 ~ /access_token/ {print $2}')"
@@ -4620,7 +4620,7 @@ jobs:
       - *add-grafana-job-annotation
       - in_parallel:
         - get: pipeline-trigger
-          passed: 
+          passed:
             - post-cf-deploy
             - prometheus-deploy
             - app-autoscaler-deploy
@@ -4683,8 +4683,8 @@ jobs:
 
                   delete_unused_keys ses_smtp_aws_access_key_id "ses-smtp-${DEPLOY_ENV}"
                   delete_unused_keys metrics_exporter_aws_access_key_id "metrics-exporter-${DEPLOY_ENV}"
-                  delete_unused_keys yace_aws_access_key_id "yace-${DEPLOY_ENV}"          
-      
+                  delete_unused_keys yace_aws_access_key_id "yace-${DEPLOY_ENV}"
+
       - *end-grafana-job-annotation
 
   - name: smoke-tests
@@ -4817,7 +4817,7 @@ jobs:
             trigger: true
           - <<: *get-paas-cf
             passed: *smoke-tests-resource-passed
-          - get: cf-manifest            
+          - get: cf-manifest
           - get: cf-acceptance-tests
 
       - do:
@@ -5280,7 +5280,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/spruce
-              tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+              tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 
           inputs:
             - name: paas-cf
@@ -5487,12 +5487,6 @@ jobs:
 
                 cp "paas-cf/config/billing/output/${AWS_REGION}.json" ./src/github.com/alphagov/paas-billing/config.json
                 cp "paas-cf/config/billing/tests/${AWS_REGION}_billing_rds_charges.feature" ./src/github.com/alphagov/paas-billing/gherkin/features/
-
-                wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-                echo "deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
-
-                apt-get -q update
-                apt-get -q -y install postgresql-12 postgresql-client-12
 
                 cat > /etc/postgresql/12/main/pg_hba.conf <<-EOF
                 local   all   postgres   trust
@@ -6541,7 +6535,7 @@ jobs:
           type: registry-image
           source:
             repository: ghcr.io/alphagov/paas/cf-uaac
-            tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+            tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 
         inputs:
           - name: passwords

--- a/concourse/pipelines/deployment-kick-off.yml
+++ b/concourse/pipelines/deployment-kick-off.yml
@@ -41,7 +41,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/alpine
-              tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+              tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
           inputs:
             - name: paas-cf
             - name: deployment-timer
@@ -71,7 +71,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/awscli
-              tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+              tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 
           run:
             path: ./paas-cf/concourse/scripts/rds_instances.sh
@@ -86,7 +86,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+              tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 
           inputs:
             - name: paas-cf
@@ -119,7 +119,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+              tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 
           inputs:
             - name: paas-cf

--- a/concourse/pipelines/destroy-cloudfoundry.yml
+++ b/concourse/pipelines/destroy-cloudfoundry.yml
@@ -99,7 +99,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+              tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 
           inputs:
             - name: paas-cf
@@ -144,7 +144,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/cf-cli
-              tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+              tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
           inputs:
             - name: paas-cf
             - name: config
@@ -189,7 +189,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/bosh-cli-v2
-              tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+              tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 
           inputs:
             - name: bosh-vars-store
@@ -243,7 +243,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/ruby
-              tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+              tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
           inputs:
             - name: paas-cf
             - name: cf-tfstate
@@ -287,7 +287,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/terraform
-              tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+              tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 
           inputs:
             - name: terraform-variables

--- a/concourse/pipelines/fast-startup-and-shutdown-cf-env.yml
+++ b/concourse/pipelines/fast-startup-and-shutdown-cf-env.yml
@@ -102,7 +102,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+              tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
           inputs:
             - name: paas-cf
           params:
@@ -166,7 +166,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/fast-startup-and-shutdown
-              tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+              tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
           run:
             path: bash
             args:
@@ -207,7 +207,7 @@ jobs:
             type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/fast-startup-and-shutdown
-              tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+              tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
           run:
             path: bash
             args:

--- a/concourse/pipelines/monitor-remote.yml
+++ b/concourse/pipelines/monitor-remote.yml
@@ -57,7 +57,7 @@ jobs:
         type: registry-image
         source:
           repository: ghcr.io/alphagov/paas/self-update-pipelines
-          tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+          tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 
       inputs:
       - name: paas-cf

--- a/concourse/pipelines/test-certificate-rotation.yml
+++ b/concourse/pipelines/test-certificate-rotation.yml
@@ -5,25 +5,25 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 
     cf-acceptance-tests: &cf-acceptance-tests-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-        tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 
     cf-cli: &cf-cli-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/cf-cli
-        tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 
 
 resource_types:

--- a/concourse/tasks/aiven-broker-acceptance-tests-run.yml
+++ b/concourse/tasks/aiven-broker-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+    tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 inputs:
   - name: paas-cf
   - name: test-config

--- a/concourse/tasks/app-autoscaler-acceptance-tests-run.yml
+++ b/concourse/tasks/app-autoscaler-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+    tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 inputs:
   - name: paas-cf
   - name: admin-creds

--- a/concourse/tasks/check-az-is-enabled-in-manifest.yml
+++ b/concourse/tasks/check-az-is-enabled-in-manifest.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+    tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 params:
   DEPLOY_ENV:
   BOSH_ENVIRONMENT:

--- a/concourse/tasks/check-az-is-enabled-in-vpc.yml
+++ b/concourse/tasks/check-az-is-enabled-in-vpc.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+    tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 params:
   AWS_DEFAULT_REGION:
   EXPECTED_ACL_NAME:

--- a/concourse/tasks/check-billing-comparison-with-cf.yml
+++ b/concourse/tasks/check-billing-comparison-with-cf.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+    tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 inputs:
   - name: paas-billing
 params:

--- a/concourse/tasks/configure-grafana.yml
+++ b/concourse/tasks/configure-grafana.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/ruby
-    tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+    tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 inputs:
   - name: paas-trusted-people
 run:

--- a/concourse/tasks/create_admin.yml
+++ b/concourse/tasks/create_admin.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-uaac
-    tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+    tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 inputs:
   - name: paas-cf
   - name: cf-manifest

--- a/concourse/tasks/create_nonadmin.yml
+++ b/concourse/tasks/create_nonadmin.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
-    tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+    tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 inputs:
   - name: paas-cf
 outputs:

--- a/concourse/tasks/cronitor-monitor-ping-action.yml
+++ b/concourse/tasks/cronitor-monitor-ping-action.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+    tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 run:
   path: sh
   args:

--- a/concourse/tasks/curl-az-healthcheck.yml
+++ b/concourse/tasks/curl-az-healthcheck.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/curl-ssl
-    tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+    tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 params:
   AVAILABILITY_ZONE:
   ENABLE_AZ_HEALTHCHECK:

--- a/concourse/tasks/custom-acceptance-tests-run.yml
+++ b/concourse/tasks/custom-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+    tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 inputs:
   - name: paas-cf
   - name: test-config

--- a/concourse/tasks/custom-broker-acceptance-tests-run.yml
+++ b/concourse/tasks/custom-broker-acceptance-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+    tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 inputs:
   - name: paas-cf
   - name: test-config

--- a/concourse/tasks/delete_user.yml
+++ b/concourse/tasks/delete_user.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
-    tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+    tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 inputs:
   - name: paas-cf
   - name: cf-manifest

--- a/concourse/tasks/forget-access-keys.yml
+++ b/concourse/tasks/forget-access-keys.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/terraform
-    tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+    tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 inputs:
   - name: paas-cf
   - name: cf-tfstate

--- a/concourse/tasks/generate-git-keys.yml
+++ b/concourse/tasks/generate-git-keys.yml
@@ -3,7 +3,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+    tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 run:
   path: sh
   args:

--- a/concourse/tasks/generate-test-config.yml
+++ b/concourse/tasks/generate-test-config.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+    tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 inputs:
   - name: paas-cf
   - name: admin-creds

--- a/concourse/tasks/get-cf-cli-config.yml
+++ b/concourse/tasks/get-cf-cli-config.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/ruby
-    tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+    tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 inputs:
   - name: paas-cf
   - name: cf-manifest

--- a/concourse/tasks/remove-db.yml
+++ b/concourse/tasks/remove-db.yml
@@ -7,7 +7,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
-    tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+    tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 run:
   path: sh
   args:

--- a/concourse/tasks/send-nagging-email-alert.yml
+++ b/concourse/tasks/send-nagging-email-alert.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+    tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 inputs:
   - name: paas-cf
 params:

--- a/concourse/tasks/smoke-tests-run.yml
+++ b/concourse/tasks/smoke-tests-run.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
-    tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+    tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 inputs:
   - name: paas-cf
   - name: cf-smoke-tests-release

--- a/concourse/tasks/tag-repo.yml
+++ b/concourse/tasks/tag-repo.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/git-ssh
-    tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+    tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 inputs:
   - name: git-repo
 params:

--- a/concourse/tasks/upload-test-artifacts.yml
+++ b/concourse/tasks/upload-test-artifacts.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+    tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 inputs:
   - name: paas-cf
   - name: artifacts

--- a/concourse/tasks/wait-for-api-availability-tests.yml
+++ b/concourse/tasks/wait-for-api-availability-tests.yml
@@ -11,7 +11,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+    tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 run:
   path: sh
   args:

--- a/concourse/tasks/wait-for-app-availability-tests.yml
+++ b/concourse/tasks/wait-for-app-availability-tests.yml
@@ -13,7 +13,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/cf-cli
-    tag: c95d8a764a2784fd2707ac631ecc27ad66cd2c03
+    tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 run:
   path: sh
   args:


### PR DESCRIPTION
What
----

This PR replaces [this PR](https://github.com/alphagov/paas-cf/pull/3465). The build images already contain openssh-client so there is no need to install it.

How to review
-------------

Use this branch on a dev environment and see `sync-admin-users` `post-cf-deploy` job task in the create-cloudfoundry pipeline go green.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
