### PR TITLE
Upgrade to prometheus-boshrelease 29.6.0

### DIFF
--- a/manifests/cf-manifest/operations.d/500-prometheus.yml
+++ b/manifests/cf-manifest/operations.d/500-prometheus.yml
@@ -2,9 +2,9 @@
   path: /releases/-
   value:
     name: "prometheus"
-    version: "29.5.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=29.5.0"
-    sha1: "d6a43080c9f2ac342d11c0d9d13e55dc52d1fb3b"
+    version: "29.6.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=29.6.0"
+    sha1: "16b8f917f7b0966e492f40618b94e0a1f00a5634"
 
 - type: replace
   path: /releases/-

--- a/manifests/runtime-config/operations.d/510-add-prometheus-blackbox-exporter.yml
+++ b/manifests/runtime-config/operations.d/510-add-prometheus-blackbox-exporter.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: "prometheus"
-    version: "29.5.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=29.5.0"
-    sha1: "d6a43080c9f2ac342d11c0d9d13e55dc52d1fb3b"
+    version: "29.6.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=29.6.0"
+    sha1: "16b8f917f7b0966e492f40618b94e0a1f00a5634"
 
 - type: replace
   path: /addons?/-


### PR DESCRIPTION
What
----

Upgrade to prometheus-boshrelease 29.6.0

Why
----

This upgrade is getting bumped up the priority list to deal with this issue:

https://github.com/bosh-prometheus/prometheus-boshrelease/issues/485

How to review
-------------

Look at the changes.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
