### PR TITLE
make cflinuxfs4 the default stack

### DIFF
--- a/manifests/cf-manifest/operations.d/010-set-cflinuxfs3-default-stack.yml
+++ b/manifests/cf-manifest/operations.d/010-set-cflinuxfs3-default-stack.yml
@@ -1,7 +1,0 @@
----
-- type: replace
-  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/default_stack?
-  value: cflinuxfs3
-- type: replace
-  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/diego/docker_staging_stack
-  value: cflinuxfs3

--- a/platform-tests/acceptance/cf_push_test.go
+++ b/platform-tests/acceptance/cf_push_test.go
@@ -29,6 +29,7 @@ var _ = Describe("cf push", func() {
 				// The contents of this directory are pushed, but not served
 				// See the buildpack for details.
 				"-p", "../example-apps/static-app/",
+				"-s", "cflinuxfs4",
 				"--no-start",
 				"--no-manifest",
 			).Wait(testConfig.CfPushTimeoutDuration())).To(Exit(0))


### PR DESCRIPTION
What
----

make cflinuxfs4 the default stack as 3 is out of support 

How to review
-------------

deploy to a dev and and test that an app without a stack defined defaults to 4

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
