### PR TITLE
Reduce London cell count to 69

### DIFF
--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -2,7 +2,7 @@
 uaa_instances: 3
 nats_instances: 3
 diego_api_instances: 3
-cell_instances: 123
+cell_instances: 75
 router_instances: 30
 api_instances: 15
 doppler_instances: 39

--- a/manifests/cf-manifest/env-specific/prod-lon.yml
+++ b/manifests/cf-manifest/env-specific/prod-lon.yml
@@ -2,7 +2,7 @@
 uaa_instances: 3
 nats_instances: 3
 diego_api_instances: 3
-cell_instances: 75
+cell_instances: 69
 router_instances: 30
 api_instances: 15
 doppler_instances: 39


### PR DESCRIPTION
What
----

Reduces London cell count down to 75, because we're overprovisioned

<img width="967" alt="image" src="https://github.com/alphagov/paas-cf/assets/1747386/df0bb1b4-4875-4266-9662-70ff194c0b73">


How to review
-------------
Agree with the count?
---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
