### PR TITLE
[#185765129] Add tls to cdn broker

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 1.55.0
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-1.55.0.tgz
-    sha1: b58a7376431595e20ff2a3aa3acff9fff422dc57
+    version: 1.56.0
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-1.56.0.tgz
+    sha1: ce6bb398a79a8e59346db739ef1a858a7c44a5d4
 
 - type: replace
   path: /instance_groups/-

--- a/manifests/cf-manifest/operations.d/720-cdn-broker.yml
+++ b/manifests/cf-manifest/operations.d/720-cdn-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: cdn-broker
-    version: 0.1.54
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.54.tgz
-    sha1: e97a99e35400160fb09ed4129b57d129040d27ae
+    version: 0.0.1703150653
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.0.1703150653.tgz
+    sha1: 443c27ff4f6b2eca1b0449a18f05744a1ae6a9dd
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-
@@ -32,9 +32,6 @@
             broker_username: "cdn-broker"
             broker_password: ((secrets_cdn_broker_admin_password))
             database_url: ((terraform_outputs_cdn_db_connection_string))
-            email: "the-multi-cloud-paas-team@digital.cabinet-office.gov.uk"
-            acme_url: "https://acme-v01.api.letsencrypt.org/directory"
-            bucket: gds-paas-((environment))-cdn-broker-challenge
             iam_path_prefix: ((environment))-letsencrypt
             cloudfront_prefix: ((environment))-cdn
             aws_access_key_id: ""
@@ -45,6 +42,10 @@
             default_origin: ((terraform_outputs_cf_apps_domain))
             aws_region: "((terraform_outputs_region))"
             extra_request_headers: "x-cf-instanceid:x-paas-xff-auth-((waf_xff_auth_key))"
+            host: "0.0.0.0"
+            port: "443"
+            tls: ((secrets_cdn_broker_tls_cert))
+
       - name: cdn-cron
         release: cdn-broker
         properties: *cdn-broker-properties
@@ -56,3 +57,14 @@
   value:
     name: secrets_cdn_broker_admin_password
     type: password
+- type: replace
+  path: /variables/-
+  value:
+    name: secrets_cdn_broker_tls_cert
+    type: certificate
+    update_mode: converge
+    options:
+      ca: broker_tls_ca
+      common_name: "cdn-broker.service.cf.internal"
+      alternative_names:
+        - "cdn-broker.service.cf.internal"

--- a/platform-tests/broker-acceptance/cdn_broker_test.go
+++ b/platform-tests/broker-acceptance/cdn_broker_test.go
@@ -88,16 +88,14 @@ var _ = Describe("CDN broker", func() {
 		})
 
 		It("refuses to create a CDN for a domain without a cf create-domain", func() {
+			orgName := testContext.TestSpace.OrganizationName()
 			domainName := generator.PrefixedRandomName(testConfig.GetNamePrefix(), "cdn-broker") + ".net"
 			domainNameList := fmt.Sprintf(`{"domain": "%s"}`, domainName)
 
 			serviceInstanceName = generator.PrefixedRandomName(testConfig.GetNamePrefix(), "test-cdn")
 
-			// best effort tidyup - we don't really care if these pass or fail.
-			// currently this kind of failure doesn't actually stop the service
-			// being "created".
-			defer pollForServiceDeletionCompletion(serviceInstanceName)
-			defer cf.Cf("delete-service", serviceInstanceName, "-f")
+			// purge as service-instance has not been successfully provisioned
+			defer serviceInstancePurge(serviceInstanceName, orgName)
 
 			By("attempting to create a CDN instance: "+serviceInstanceName, func() {
 				cf_create_service := cf.Cf("create-service", serviceName, serviceName, serviceInstanceName, "-c", domainNameList).Wait(testConfig.DefaultTimeoutDuration())
@@ -107,17 +105,15 @@ var _ = Describe("CDN broker", func() {
 		})
 
 		It("refuses to create a CDN for a domain with wrong ownership", func() {
+			orgName := testContext.TestSpace.OrganizationName()
 			domainName := generator.PrefixedRandomName(testConfig.GetNamePrefix(), "cdn-broker") + ".net"
 			domainNameList := fmt.Sprintf(`{"domain": "%s"}`, domainName)
 
 			serviceInstanceName = generator.PrefixedRandomName(testConfig.GetNamePrefix(), "test-cdn")
 
-			// best effort tidyup - we don't really care if these pass or fail.
-			// currently this kind of failure doesn't actually stop the service
-			// being "created".
-			defer pollForServiceDeletionCompletion(serviceInstanceName)
-			defer cf.Cf("delete-domain", domainName, "-f")
-			defer cf.Cf("delete-service", serviceInstanceName, "-f")
+			defer cf.Cf("delete-domain", altOrgName, domainName, "-f")
+			// purge as service-instance has not been successfully provisioned
+			defer serviceInstancePurge(serviceInstanceName, orgName)
 
 			By("attempting to create a CDN instance: "+serviceInstanceName, func() {
 				Expect(cf.Cf("create-domain", altOrgName, domainName).Wait(testConfig.DefaultTimeoutDuration())).To(Exit(0))

--- a/platform-tests/broker-acceptance/init_test.go
+++ b/platform-tests/broker-acceptance/init_test.go
@@ -181,6 +181,15 @@ func pollForServiceUnbound(dbInstanceName, boundAppName string) {
 	fmt.Fprint(GinkgoWriter, "done\n")
 }
 
+func serviceInstancePurge(serviceInstanceName string, orgName string) {
+	workflowhelpers.AsUser(testContext.AdminUserContext(), testContext.ShortTimeout(), func() {
+		command := cf.Cf("target", "-o", orgName).Wait(testConfig.DefaultTimeoutDuration())
+		Expect(command).To(Exit(0))
+		command = cf.Cf("purge-service-instance", serviceInstanceName, "-f").Wait(testConfig.DefaultTimeoutDuration())
+		Expect(command).To(Exit(0))
+	})
+}
+
 type basicAuthRoundTripper struct {
 	username string
 	password string


### PR DESCRIPTION
What
----

Added cdn broker that has been updated to enable tls between the load balancer and the broker.
Removed artefacts related to redundant Let's Encrypt usage.

How to review
-------------

1. Run the branch into a dev env.
2. After the updated broker has been installed check the state of the vm and cdn-broker logs using bosh.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
