### PR TITLE
Add service checking, usage info and org filtering to decommission query script

### DIFF
--- a/scripts/decommission_organisation.rb
+++ b/scripts/decommission_organisation.rb
@@ -6,6 +6,8 @@ require "cli/ui/prompt"
 require "json"
 require "optparse"
 
+@errors = []
+
 # Helpers
 def puts_ok(msg)
   puts "✅ #{msg}"
@@ -13,6 +15,7 @@ end
 
 def puts_err(msg)
   puts "❌ #{msg}"
+  @errors << msg
 end
 
 def puts_dry_run(msg)
@@ -100,7 +103,7 @@ parser = OptionParser.new { |opts|
   end
 
   opts.on("--dry-run", TrueClass) do |dry_run|
-    puts "Dry run? #{dry_run}"
+    puts CLI::UI.fmt "Dry run? #{dry_run ? '{{green:Yes}}' : '{{red:No}}}'}"
     options[:dry_run] = dry_run
   end
 
@@ -173,11 +176,14 @@ end
 
 unless can_decommission
   puts "\n"
-  puts "Cannot decommission org '#{options[:org]}'. It may have one or more apps, service instances, and spaces, or it may not be suspended"
+  puts CLI::UI.fmt "{{red:BLOCKED:}} Cannot decommission org '#{options[:org]}'."
+  @errors.each do |err|
+    puts CLI::UI.fmt "  -> {{red:#{err}}}"
+  end
   exit 1
 end
 
-continue = CLI::UI::Prompt.confirm("Continue to decomission org '#{options[:org]}'?")
+continue = CLI::UI::Prompt.confirm(CLI::UI.fmt("Continue to decommission org '{{bold:#{options[:org]}}}'?"))
 unless continue
   exit 1
 end

--- a/scripts/get-decommission-details.sh
+++ b/scripts/get-decommission-details.sh
@@ -14,6 +14,13 @@
 #
 # The ready_for_decommission column will be "yes" if there are no running or non-running apps, and no services.
 # The suspended column will be "true" if the org is suspended, and "false" if it is not.
+#
+# I run it like this:
+#
+# cf login -a api.london.cloud.service.gov.uk --sso
+# ./scripts/get-decommission-details.sh > ~/Desktop/status.csv
+# cf login -a api.cloud.service.gov.uk --sso
+# ./scripts/get-decommission-details.sh >> ~/Desktop/status.csv
 
 set -e
 

--- a/scripts/get-decommission-details.sh
+++ b/scripts/get-decommission-details.sh
@@ -1,4 +1,19 @@
 #!/usr/bin/env bash
+#
+# This script gathers information on all orgs in the current CF environment.
+# Use it to find orgs that are ready for decommissioning, and orgs that already are.
+# It will output a CSV with the following columns:
+#
+# - organization_name
+# - running_app_count
+# - non_running_app_count
+# - service_count
+# - owner
+# - ready_for_decommission
+# - suspended
+#
+# The ready_for_decommission column will be "yes" if there are no running or non-running apps, and no services.
+# The suspended column will be "true" if the org is suspended, and "false" if it is not.
 
 set -e
 


### PR DESCRIPTION
What
----

I've added:

- Usage help info
- Ability to filter org guids from the list instead of doing all
- Checking how many services are running for each org

Examples:

```sh
❯ ./scripts/get-decommission-details.sh -h
Usage: ./scripts/get-decommission-details.sh [comma separated list of org guids]
If no orgs are specified, all orgs will be checked
```

```sh
❯ ./scripts/get-decommission-details.sh some-org-guid
Filtering to a comma separated list of orgs: some-org-guid
organization_name,running_app_count,non_running_app_count,service_count,owner,ready_for_decommission
some-org,18,2,10,"Org Name",no
```

How to review
-------------

Log in to cf and run the script

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
