### PR TITLE
Updated script to handle large number of users

### DIFF
--- a/scripts/decommission_organisation.rb
+++ b/scripts/decommission_organisation.rb
@@ -82,7 +82,7 @@ def lookup_users(user_guids)
   user_guids.each_slice(20) do |batch|
     guids_csv = batch.join(",")
     batch_users = cf_api_get("/v3/users?guids=#{guids_csv}&per_page=5000")
-    users.merge! batch_users["resources"].to_h { |usr| [usr["guid"], usr["username"]] }
+    users.merge! (batch_users["resources"].to_h { |usr| [usr["guid"], usr["username"]] })
   end
   users
 end

--- a/scripts/decommission_organisation.rb
+++ b/scripts/decommission_organisation.rb
@@ -78,10 +78,13 @@ def roles_in_org(org_guid)
 end
 
 def lookup_users(user_guids)
-  guids_csv = user_guids.join(",")
-  users = cf_api_get("/v3/users?guids=#{guids_csv}&per_page=5000")
-
-  users["resources"].to_h { |usr| [usr["guid"], usr["username"]] }
+  users = {}
+  user_guids.each_slice(20) do |batch|
+    guids_csv = batch.join(",")
+    batch_users = cf_api_get("/v3/users?guids=#{guids_csv}&per_page=5000")
+    users.merge! batch_users["resources"].to_h { |usr| [usr["guid"], usr["username"]] }
+  end
+  users
 end
 
 def try_remove_role(role_guid)

--- a/scripts/decommission_organisation.rb
+++ b/scripts/decommission_organisation.rb
@@ -82,7 +82,7 @@ def lookup_users(user_guids)
   user_guids.each_slice(20) do |batch|
     guids_csv = batch.join(",")
     batch_users = cf_api_get("/v3/users?guids=#{guids_csv}&per_page=5000")
-    users.merge! (batch_users["resources"].to_h { |usr| [usr["guid"], usr["username"]] })
+    users.merge! { batch_users["resources"].to_h { |usr| [usr["guid"], usr["username"]] } }
   end
   users
 end


### PR DESCRIPTION
What
----

The decommission_organisation.rb has been updated so that it does not error when processing a large number of cf org users. It was found to error when decommissioning an org with 185 users. 

```
/Users/malcolm.saunders/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/json-2.6.2/lib/json/common.rb:216:in `parse': 859: unexpected token at '<html>\r (JSON::ParserError)
<head><title>414 Request-URI Too Large</title></head>\r
<body>\r
<center><h1>414 Request-URI Too Large</h1></center>\r
<hr><center>nginx</center>\r
</body>\r
</html>\r

'
	from /Users/malcolm.saunders/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/json-2.6.2/lib/json/common.rb:216:in `parse'
	from ./scripts/decommission_organisation.rb:36:in `cf_api_get'
	from ./scripts/decommission_organisation.rb:82:in `lookup_users'
	from ./scripts/decommission_organisation.rb:162:in `<main>'
```
The function `lookup_users` was amended to process any number of organisational users.

How to review
-------------

1. Review the code.
2. Deploy to a dev env and run it on a test org.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
