### PR TITLE
Remove old cdn-broker lets-encrypt config

### DIFF
--- a/manifests/cf-manifest/operations.d/720-cdn-broker.yml
+++ b/manifests/cf-manifest/operations.d/720-cdn-broker.yml
@@ -32,10 +32,6 @@
             broker_username: "cdn-broker"
             broker_password: ((secrets_cdn_broker_admin_password))
             database_url: ((terraform_outputs_cdn_db_connection_string))
-            email: "the-multi-cloud-paas-team@digital.cabinet-office.gov.uk"
-            acme_url: "https://acme-v01.api.letsencrypt.org/directory"
-            bucket: gds-paas-((environment))-cdn-broker-challenge
-            iam_path_prefix: ((environment))-letsencrypt
             cloudfront_prefix: ((environment))-cdn
             aws_access_key_id: ""
             aws_secret_access_key: ""

--- a/terraform/cloudfoundry/cdn_broker.tf
+++ b/terraform/cloudfoundry/cdn_broker.tf
@@ -40,52 +40,6 @@ resource "aws_lb_ssl_negotiation_policy" "cdn_broker" {
   }
 }
 
-resource "aws_s3_bucket" "cdn_broker_bucket" {
-  bucket        = "gds-paas-${var.env}-cdn-broker-challenge"
-  force_destroy = "true"
-}
-
-resource "aws_s3_bucket_public_access_block" "cdn_broker_bucket" {
-  bucket = aws_s3_bucket.cdn_broker_bucket.id
-
-  block_public_policy = false
-}
-
-resource "aws_s3_bucket_ownership_controls" "cdn_broker_bucket" {
-  bucket = aws_s3_bucket.cdn_broker_bucket.id
-  rule {
-    object_ownership = "BucketOwnerPreferred"
-  }
-}
-
-resource "aws_s3_bucket_acl" "cdn_broker_bucket" {
-  bucket = aws_s3_bucket.cdn_broker_bucket.id
-  acl    = "private"
-
-  depends_on = [aws_s3_bucket_ownership_controls.cdn_broker_bucket]
-}
-
-resource "aws_s3_bucket_policy" "cdn_broker_bucket" {
-  bucket = aws_s3_bucket.cdn_broker_bucket.id
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "s3:GetObject"
-      ],
-      "Effect": "Allow",
-	  "Resource": "arn:aws:s3:::gds-paas-${var.env}-cdn-broker-challenge/*",
-      "Principal": "*"
-    }
-  ]
-}
-POLICY
-
-  depends_on = [aws_s3_bucket_public_access_block.cdn_broker_bucket]
-}
-
 resource "aws_db_subnet_group" "cdn_rds" {
   name        = "${var.env}-cdn"
   description = "Subnet group for CF CDN"


### PR DESCRIPTION
What
----

Remove old cdn-broker lets-encrypt config. This was removed a long time ago.

Remove old letsencrypt s3 bucket.

Why
----

This functionality is no longer used and we get security alerts about having a public bucket.

How to review
-------------

Look at the changes.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
