### PR TITLE
[#186779486] Added service operation levels dashboard

### DIFF
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -709,6 +709,15 @@ resources:
       # v0.53.0
       ref: 2fd8cd322931aeb5a39c457ede31022e67f479b9
 
+  - name: pingdom-exporter
+    type: git
+    source:
+      uri: https://github.com/jusbrasil/pingdom-exporter
+      fetch_tags: true
+    version:
+      # v1.4.0
+      ref: 162b570480a101ae9697658faae57dc42ff3c5db
+
   - name: grafana-overview-annotation-id
     type: s3-iam
     source:
@@ -3078,6 +3087,7 @@ jobs:
           - get: cf-tfstate
           - get: yet-another-cloudwatch-exporter
           - get: paas-trusted-people
+          - get: pingdom-exporter
 
       - task: extract-terraform-outputs
         tags: [colocated-with-web]
@@ -3319,6 +3329,58 @@ jobs:
                   cf push cloudwatch-exporter -f manifest.yml --droplet droplet.tgz --strategy rolling 2>&1 | \
                     sed -r "s/AWS_SECRET_ACCESS_KEY: .+/AWS_SECRET_ACCESS_KEY: ********/g"
 
+        - task: deploy-pingdom-exporter
+          tags: [colocated-with-web]
+          config:
+            platform: linux
+            image_resource: *cf-cli-image-resource
+            params:
+              DEPLOY_ENV: ((deploy_env))
+              AWS_REGION: ((aws_region))
+              API_ENDPOINT: ((api_endpoint))
+              CF_ADMIN: ((cf_admin))
+              CF_PASS: ((cf_pass))
+            inputs:
+              - name: paas-cf
+              - name: config
+              - name: pingdom-exporter
+            run:
+              path: bash
+              args:
+                - -e
+                - -c
+                - |
+                  if [[ "${DEPLOY_ENV}" == dev* ]]; then
+                    echo "pingdom exporter is not deployed in dev because dev urls are not configured in pingdom"
+                    exit 0
+                  fi
+
+                  . ./config/config.sh
+                  cf api "${API_ENDPOINT}"
+                  cf auth "${CF_ADMIN}" "${CF_PASS}"
+
+                  cf target -o admin -s monitoring
+
+                  cd pingdom-exporter
+
+                  cat << EOF > manifest.yml
+                  ---
+                  applications:
+                  - name: pingdom-exporter
+                    env:
+                      GO_INSTALL_PACKAGE_SPEC: github.com/jusbrasil/pingdom-exporter/cmd/pingdom-exporter
+                      PINGDOM_API_TOKEN: ((pingdom_api_token))
+                    readiness-health-check-type: http
+                    readiness-health-check-http-endpoint: /healthz
+                    buildpacks: [go_buildpack]
+                    stack: cflinuxfs4
+                    command: ./bin/pingdom-exporter -port 8080
+                  EOF
+
+                  cf cancel-deployment pingdom-exporter || true
+                  cf push pingdom-exporter --strategy rolling 2>&1  | \
+                    sed -r "s/PINGDOM_API_TOKEN: .+/PINGDOM_API_TOKEN: ********/g"
+
         - task: upload-grafana-dashboards
           tags: [colocated-with-web]
           config:
@@ -3326,6 +3388,7 @@ jobs:
             image_resource: *curl-ssl-image-resource
             params:
               SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+              APPS_DNS_ZONE_NAME: ((apps_dns_zone_name))
               DEPLOY_ENV: ((deploy_env))
               SLIM_DEV_DEPLOYMENT: ((slim_dev_deployment))
               GRAFANA_PASS: ((grafana_password))
@@ -3360,6 +3423,7 @@ jobs:
                       echo "Uploading ${f} to grafana-${az}.${SYSTEM_DNS_ZONE_NAME}"
 
                       sed "s/__SYSTEM_DNS_ZONE_NAME__/${SYSTEM_DNS_ZONE_NAME}/g" "${f}" \
+                      | sed "s/__APPS_DNS_ZONE_NAME__/${APPS_DNS_ZONE_NAME}/g" \
                       | sed "s/__DEPLOY_ENV__/${DEPLOY_ENV}/g" \
                       | jq '{"dashboard": ., "overwrite": true, "folderId": 0}' \
                       | curl "https://grafana-${az}.${SYSTEM_DNS_ZONE_NAME}/api/dashboards/db" \

--- a/manifests/prometheus/dashboards.d/service-operation-levels.json
+++ b/manifests/prometheus/dashboards.d/service-operation-levels.json
@@ -18,7 +18,7 @@
     "editable": true,
     "fiscalYearStartMonth": 0,
     "graphTooltip": 0,
-    "id": 76,
+    "id": null,
     "links": [],
     "liveNow": false,
     "panels": [

--- a/manifests/prometheus/dashboards.d/service-operation-levels.json
+++ b/manifests/prometheus/dashboards.d/service-operation-levels.json
@@ -1,0 +1,509 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 76,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
+        "description": "provides uptime of cf api, cf rtr and paas-admin",
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "color": {
+              "mode": "continuous-GrYlRd"
+            },
+            "decimals": 0,
+            "unit": "percent"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 15,
+        "options": {
+          "reduceOptions": {
+            "values": false,
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": ""
+          },
+          "orientation": "auto",
+          "textMode": "value_and_name",
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto"
+        },
+        "pluginVersion": "9.5.13",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "editorMode": "code",
+            "expr": "100 * avg_over_time(pingdom_uptime_status{hostname=\"api.__SYSTEM_DNS_ZONE_NAME__\"}[$__range])",
+            "format": "time_series",
+            "legendFormat": "cf api",
+            "range": true,
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "100 * avg_over_time(pingdom_uptime_status{hostname=\"admin.__SYSTEM_DNS_ZONE_NAME__\"}[$__range])",
+            "hide": false,
+            "legendFormat": "paas-admin",
+            "range": true,
+            "refId": "B"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "editorMode": "code",
+            "expr": "100 * avg_over_time(pingdom_uptime_status{hostname=\"healthcheck.__APPS_DNS_ZONE_NAME__\",name=\"PaaS HTTPS - prod-lon\"}[$__range])",
+            "format": "time_series",
+            "hide": false,
+            "legendFormat": "cf apps",
+            "range": true,
+            "refId": "C"
+          }
+        ],
+        "title": "% URL Uptime",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
+        "description": "Shows the percentage of memory of a Diego Cell",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "drawStyle": "line",
+              "lineInterpolation": "linear",
+              "barAlignment": 0,
+              "lineWidth": 1,
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "spanNulls": false,
+              "showPoints": "auto",
+              "pointSize": 5,
+              "stacking": {
+                "mode": "none",
+                "group": "A"
+              },
+              "axisPlacement": "auto",
+              "axisLabel": "",
+              "axisColorMode": "text",
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "axisCenteredZero": false,
+              "hideFrom": {
+                "tooltip": false,
+                "viz": false,
+                "legend": false
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "color": {
+              "mode": "palette-classic"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 8
+        },
+        "id": 1,
+        "options": {
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          },
+          "legend": {
+            "showLegend": true,
+            "displayMode": "list",
+            "placement": "bottom",
+            "calcs": []
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "editorMode": "code",
+            "expr": "avg(bosh_job_mem_percent{bosh_job_name=\"diego-cell\"})",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Cell Utilisation Rate",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
+        "description": "Number of Application Instances",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "drawStyle": "bars",
+              "lineInterpolation": "linear",
+              "barAlignment": 0,
+              "lineWidth": 1,
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "spanNulls": false,
+              "showPoints": "auto",
+              "pointSize": 5,
+              "stacking": {
+                "mode": "none",
+                "group": "A"
+              },
+              "axisPlacement": "auto",
+              "axisLabel": "",
+              "axisColorMode": "text",
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "axisCenteredZero": false,
+              "hideFrom": {
+                "tooltip": false,
+                "viz": false,
+                "legend": false
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              },
+              "axisSoftMax": 100
+            },
+            "color": {
+              "mode": "palette-classic"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "max": 100,
+            "min": 0,
+            "noValue": "null as zero",
+            "unit": "percent"
+          },
+          "overrides": [
+            {
+              "__systemRef": "hideSeriesFrom",
+              "matcher": {
+                "id": "byNames",
+                "options": {
+                  "mode": "exclude",
+                  "names": [
+                    "Desired"
+                  ],
+                  "prefix": "All except:",
+                  "readOnly": true
+                }
+              },
+              "properties": [
+                {
+                  "id": "custom.hideFrom",
+                  "value": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 0
+        },
+        "id": 12,
+        "links": [],
+        "options": {
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          },
+          "legend": {
+            "showLegend": false,
+            "displayMode": "list",
+            "placement": "bottom",
+            "calcs": []
+          }
+        },
+        "pluginVersion": "9.5.13",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "editorMode": "code",
+            "expr": "100 * (sum by (environment) (sum_over_time(cf_application_instances_running[1h])) / sum by (environment) (sum_over_time(cf_application_instances[1h])))",
+            "format": "time_series",
+            "interval": "",
+            "intervalFactor": 2,
+            "legendFormat": "Desired",
+            "range": true,
+            "refId": "A",
+            "step": 10
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "editorMode": "code",
+            "expr": "",
+            "format": "time_series",
+            "hide": false,
+            "interval": "",
+            "intervalFactor": 2,
+            "legendFormat": "Running",
+            "range": true,
+            "refId": "B",
+            "step": 10
+          }
+        ],
+        "title": "% Application Instances Running",
+        "transparent": true,
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
+        "description": "Average rate of http status 5xx responses",
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "color": {
+              "mode": "thresholds"
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 16
+        },
+        "id": 13,
+        "options": {
+          "reduceOptions": {
+            "values": false,
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": ""
+          },
+          "orientation": "auto",
+          "textMode": "auto",
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto"
+        },
+        "pluginVersion": "9.5.13",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "editorMode": "code",
+            "expr": "sum(firehose_value_metric_cc_http_status_5_xx)",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "HTTP 5xx errors",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "color": {
+              "mode": "thresholds"
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 8
+        },
+        "id": 14,
+        "options": {
+          "reduceOptions": {
+            "values": false,
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": ""
+          },
+          "orientation": "auto",
+          "textMode": "auto",
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto"
+        },
+        "pluginVersion": "9.5.13",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "editorMode": "code",
+            "expr": "avg(rate(firehose_counter_event_loggregator_doppler_dropped_total[1h]))",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Average dropped log message rate",
+        "type": "stat"
+      }
+    ],
+    "refresh": "",
+    "schemaVersion": 38,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Service Operation Levels",
+    "uid": "ae1f02b8-1593-4f9b-9ee6-4be8cef86596",
+    "version": 6,
+    "weekStart": ""
+  }
+  

--- a/manifests/prometheus/operations.d/305-scrape-pingdom-metrics.yml
+++ b/manifests/prometheus/operations.d/305-scrape-pingdom-metrics.yml
@@ -1,0 +1,10 @@
+---
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  value:
+    job_name: pingdom-exporter
+    scrape_interval: 5m
+    scheme: https
+    static_configs:
+      - targets:
+          - pingdom-exporter.((app_domain))


### PR DESCRIPTION
What
----

A new dashboard has been added to Grafana to display the Service Operation Levels.

How to review
-------------

1 - Review the code changes.
2 - Run into a dev env and check the new dashboard - "Service Operation Levels". Run the bare metric/s in Prometheus to ensure the data associated with that metric resembles the graphs that you see in the new dashboard.
3 - The "% URL Uptime" panel will display "No data" in dev because there are no pingdom URLs configured for the dev env.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
