### PR TITLE
186518458 update s3 broker users with permissions boundary policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -592,7 +592,8 @@ update-concourse-gpg-keys: .download-gpg-keys ## Update vars file for concourse 
 enable_vpc_peer_db_access: ## Update vars file for concourse with the latest GPG keys
 	@ruby scripts/enable_vpc_peer_db_access.rb
 
-POLICY_NAME := S3BrokerUserPermissionsBoundary
+BOUNDARY_POLICY_NAME := S3BrokerUserPermissionsBoundary
+IDENTITY_POLICY_NAME := S3BrokerUserCommon
 .PHONY: add_permissions_boundary_to_existing_s3_broker_users
 add_permissions_boundary_to_existing_s3_broker_users:
-	@ruby ./scripts/add_permissions_boundary_to_existing_s3_broker_users.rb --env=$(DEPLOY_ENV) --policy_name=${POLICY_NAME} $(ARGS)
+	@ruby ./scripts/add_permissions_boundary_to_existing_s3_broker_users.rb --env=$(DEPLOY_ENV) --identity_policy_name=${IDENTITY_POLICY_NAME} --boundary_policy_name=${BOUNDARY_POLICY_NAME} $(ARGS)

--- a/scripts/add_permissions_boundary_to_existing_s3_broker_users.rb
+++ b/scripts/add_permissions_boundary_to_existing_s3_broker_users.rb
@@ -3,6 +3,15 @@
 require "aws-sdk-iam"
 require "optparse"
 
+class PolicyNotFoundError < StandardError
+end
+
+def get_account_id
+  sts_client = Aws::STS::Client.new
+  response = sts_client.get_caller_identity
+  response.account
+end
+
 def get_permissions_boundary_arn(iam_client, permissions_boundary_name)
   policies = iam_client.list_policies(scope: "Local", only_attached: false).policies
 
@@ -11,37 +20,68 @@ def get_permissions_boundary_arn(iam_client, permissions_boundary_name)
   permissions_boundary&.arn
 end
 
-def add_permissions_boundary_to_user(iam_client, username, permissions_boundary_arn, dry_run)
-  user = iam_client.get_user(user_name: username).user
-  current_permissions_boundary = user.permissions_boundary&.permissions_boundary_arn
+def get_identity_policy_arn(iam_client, identity_policy_name)
+  account_id = get_account_id
+  response = iam_client.get_policy({
+    policy_arn: "arn:aws:iam::#{account_id}:policy/#{identity_policy_name}",
+  })
 
+  response.policy.arn
+end
+
+def add_permissions_boundary_to_user(iam_client, user, permissions_boundary_arn, dry_run)
+  current_permissions_boundary = user.permissions_boundary&.permissions_boundary_arn
   if current_permissions_boundary.nil? || current_permissions_boundary != permissions_boundary_arn
     unless dry_run
       iam_client.put_user_permissions_boundary(
-        user_name:            username,
+        user_name: user.user_name,
         permissions_boundary: permissions_boundary_arn,
       )
     end
-    puts "Permissions_boundary added successfully to user #{username}."
+    puts "Permissions_boundary added successfully to user #{user.user_name}."
   else
-    puts "User #{username} already has the permissions_boundary."
+    puts "User #{user.user_name} already has the permissions_boundary."
   end
 end
 
-def main(env, policy_name, dry_run)
+def add_identity_policy(iam_client, user, identity_policy_arn, dry_run)
+  attached_policies = iam_client.list_attached_user_policies({ user_name: user.user_name }).attached_policies
+
+  if attached_policies.none? { |policy| policy.policy_arn == identity_policy_arn }
+    unless dry_run
+      iam_client.attach_user_policy({
+        user_name: user.user_name,
+        policy_arn: identity_policy_arn,
+      })
+    end
+    puts "Identity policy #{identity_policy_arn} successfully added to user #{user.user_name}."
+  else
+    puts "User #{user.user_name} already has the desired identity policy."
+  end
+end
+
+def main(env, identity_policy_name, boundary_policy_name, dry_run)
   iam_client = Aws::IAM::Client.new
 
-  permissions_boundary_arn = get_permissions_boundary_arn(iam_client, policy_name)
+  identity_policy_name = env + identity_policy_name
 
-  if permissions_boundary_arn.nil?
-    puts "Permissions boundary policy with name #{policy_name} not found"
-  else
-    paas_s3_broker_users = iam_client.list_users.users.select { |user| user.user_name.start_with?("paas-s3-broker-#{env}") }
+  permissions_boundary_arn = get_permissions_boundary_arn(iam_client, boundary_policy_name)
+  identity_policy_arn = get_identity_policy_arn(iam_client, identity_policy_name)
 
-    paas_s3_broker_users.each do |user|
-      add_permissions_boundary_to_user(iam_client, user.user_name, permissions_boundary_arn, dry_run)
-    end
+  paas_s3_broker_users = iam_client.list_users.users.select do |user|
+    guid_regex = /\b[a-f0-9]{8}\b-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-\b[a-f0-9]{12}\b/
+    env_regex = /paas-s3-broker-#{env}-#{guid_regex}/
+    user.user_name.match?(env_regex)
   end
+
+  paas_s3_broker_users.each do |user|
+    detailed_user = iam_client.get_user({ user_name: user.user_name }).user
+    add_permissions_boundary_to_user(iam_client, detailed_user, permissions_boundary_arn, dry_run)
+    add_identity_policy(iam_client, detailed_user, identity_policy_arn, dry_run)
+  end
+rescue PolicyNotFoundError => e
+  puts "Error: #{e.message}"
+  exit(1)
 end
 
 ARGV << "-h" if ARGV.empty?
@@ -54,8 +94,12 @@ parser = OptionParser.new { |opts|
     options[:env] = env
   end
 
-  opts.on("--policy_name POLICY_NAME", String, "Specify the policy that will be added to the s3 broker users") do |policy_name|
-    options[:policy_name] = policy_name
+  opts.on("--identity_policy_name IDENTITY_POLICY_NAME", String, "Specify the identity policy that will be added to the s3 broker users") do |identity_policy_name|
+    options[:identity_policy_name] = identity_policy_name
+  end
+
+  opts.on("--boundary_policy_name BOUNDARY_POLICY_NAME", String, "Specify the boundary policy that will be added to the s3 broker users") do |boundary_policy_name|
+    options[:boundary_policy_name] = boundary_policy_name
   end
 
   opts.on("--dry-run", TrueClass, "Specify --dry-run if you want to run the script without changing anything") do |dry_run|
@@ -70,8 +114,8 @@ parser = OptionParser.new { |opts|
 }.parse!
 parser.parse!
 
-if options[:env].nil? || options[:policy_name].nil?
-  raise "--env and --policy_name are mandatory"
+if options[:env].nil? || options[:identity_policy_name].nil? || options[:boundary_policy_name].nil?
+  raise "--env, --identity_policy_name and --boundary_policy_name are mandatory"
 end
 
-main(options[:env], options[:policy_name], options[:dry_run]) if $PROGRAM_NAME == __FILE__
+main(options[:env], options[:identity_policy_name], options[:boundary_policy_name], options[:dry_run]) if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
What
----

Created ruby script to add s3BrokerUserPermission policy and s3BrokerUserCommon policy to pre-existing s3 users.

How to review
-------------

1 - In a dev env provide s3 users without the permission boundary policy or user common policy and then run script.
2 - Check that the users have both policies.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
