### PR TITLE
Update to go 1.21

### DIFF
--- a/.github/workflows/generate_buildpack_bump_pr.yml
+++ b/.github/workflows/generate_buildpack_bump_pr.yml
@@ -4,7 +4,7 @@ on:
     - cron: "0 9 1 * *"
 
 env:
-  GO_VERSION: "1.20"
+  GO_VERSION: "1.21"
   GIT_AUTHOR_NAME: github-actions
   GIT_AUTHOR_EMAIL: github-actions@github.com
   GITHUB_UNPRIV_USERNAME: ${{ secrets.GOVUK_PAAS_UNPRIVILEGED_BOT_USERNAME }}

--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -6,7 +6,7 @@ env:
   PROMETHEUS_VERSION: "2.42.0"
   DEPLOY_ENV: "github"
   SHELLCHECK_VERSION: "0.7.1"
-  GO_VERSION: "1.20"
+  GO_VERSION: "1.21"
   RUBY_VERSION: "3.1.0"
 
 jobs:

--- a/common-go/basic_logit_client/go.mod
+++ b/common-go/basic_logit_client/go.mod
@@ -1,5 +1,5 @@
 module github.com/alphagov/paas-cf/common-go/basic_logit_client
 
-go 1.20
+go 1.21
 
 require code.cloudfoundry.org/lager v2.0.0+incompatible // indirect

--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -27,7 +27,6 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-cf.git
       branch: ((branch_name))
-      tag_filter: ((paas_cf_tag_filter))
       commit_verification_keys: ((gpg_public_keys))
 
   - name: cf-manifest

--- a/concourse/pipelines/autodelete-cloudfoundry.yml
+++ b/concourse/pipelines/autodelete-cloudfoundry.yml
@@ -27,6 +27,7 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-cf.git
       branch: ((branch_name))
+      tag_filter: ((paas_cf_tag_filter))
       commit_verification_keys: ((gpg_public_keys))
 
   - name: cf-manifest

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -316,7 +316,8 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-cf.git
-      branch: 187200424-update-to-go-1-21
+      branch: ((branch_name))
+      tag_filter: ((paas_cf_tag_filter))
       commit_verification_keys: ((gpg_public_keys))
 
   - name: vpc-tfstate
@@ -644,27 +645,31 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-aiven-broker.git
-      branch: 187200424-update-to-go-1-21
+      branch: main
+      tag_filter: ((deploy_env_tag_prefix))
       commit_verification_keys: ((gpg_public_keys))
 
   - name: paas-billing
     type: git
     source:
       uri: https://github.com/alphagov/paas-billing.git
-      branch: 187200424-update-to-go-1-21
+      branch: main
+      tag_filter: ((deploy_env_tag_prefix))
       commit_verification_keys: ((gpg_public_keys))
 
   - name: paas-accounts
     type: git
     source:
       uri: https://github.com/alphagov/paas-accounts.git
-      branch: 187200424-update-to-go-1-21
+      branch: main
+      tag_filter: v0.25.0
 
   - name: paas-auditor
     type: git
     source:
       uri: https://github.com/alphagov/paas-auditor.git
-      branch: 187200424-update-to-go-1-21
+      branch: main
+      tag_filter: v0.75.0
 
   - name: paas-admin
     type: git
@@ -678,7 +683,8 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-prometheus-endpoints.git
-      branch: 187200424-update-to-go-1-21
+      branch: main
+      tag_filter: v0.19.0
 
   - name: prometheus-manifest-pre-vars
     type: s3-iam

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -316,8 +316,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-cf.git
-      branch: ((branch_name))
-      tag_filter: ((paas_cf_tag_filter))
+      branch: 187200424-update-to-go-1-21
       commit_verification_keys: ((gpg_public_keys))
 
   - name: vpc-tfstate
@@ -645,31 +644,27 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-aiven-broker.git
-      branch: main
-      tag_filter: ((deploy_env_tag_prefix))
+      branch: 187200424-update-to-go-1-21
       commit_verification_keys: ((gpg_public_keys))
 
   - name: paas-billing
     type: git
     source:
       uri: https://github.com/alphagov/paas-billing.git
-      branch: main
-      tag_filter: ((deploy_env_tag_prefix))
+      branch: 187200424-update-to-go-1-21
       commit_verification_keys: ((gpg_public_keys))
 
   - name: paas-accounts
     type: git
     source:
       uri: https://github.com/alphagov/paas-accounts.git
-      branch: main
-      tag_filter: v0.25.0
+      branch: 187200424-update-to-go-1-21
 
   - name: paas-auditor
     type: git
     source:
       uri: https://github.com/alphagov/paas-auditor.git
-      branch: main
-      tag_filter: v0.75.0
+      branch: 187200424-update-to-go-1-21
 
   - name: paas-admin
     type: git
@@ -683,8 +678,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-prometheus-endpoints.git
-      branch: main
-      tag_filter: v0.19.0
+      branch: 187200424-update-to-go-1-21
 
   - name: prometheus-manifest-pre-vars
     type: s3-iam

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -662,14 +662,14 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-accounts.git
       branch: main
-      tag_filter: v0.25.0
+      tag_filter: v0.34.0
 
   - name: paas-auditor
     type: git
     source:
       uri: https://github.com/alphagov/paas-auditor.git
       branch: main
-      tag_filter: v0.75.0
+      tag_filter: v0.76.0
 
   - name: paas-admin
     type: git
@@ -684,7 +684,7 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-prometheus-endpoints.git
       branch: main
-      tag_filter: v0.19.0
+      tag_filter: v0.20.0
 
   - name: prometheus-manifest-pre-vars
     type: s3-iam

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -317,7 +317,6 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-cf.git
       branch: ((branch_name))
-      tag_filter: ((paas_cf_tag_filter))
       commit_verification_keys: ((gpg_public_keys))
 
   - name: vpc-tfstate
@@ -646,7 +645,6 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-aiven-broker.git
       branch: 187200424-update-to-go-1-21
-      tag_filter: ((deploy_env_tag_prefix))
       commit_verification_keys: ((gpg_public_keys))
 
   - name: paas-billing
@@ -654,7 +652,6 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-billing.git
       branch: 187200424-update-to-go-1-21
-      tag_filter: ((deploy_env_tag_prefix))
       commit_verification_keys: ((gpg_public_keys))
 
   - name: paas-accounts
@@ -662,14 +659,12 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-accounts.git
       branch: 187200424-update-to-go-1-21
-      tag_filter: v0.25.0
 
   - name: paas-auditor
     type: git
     source:
       uri: https://github.com/alphagov/paas-auditor.git
       branch: 187200424-update-to-go-1-21
-      tag_filter: v0.75.0
 
   - name: paas-admin
     type: git

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -678,8 +678,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-prometheus-endpoints.git
-      branch: main
-      tag_filter: v0.19.0
+      branch: 187200424-update-to-go-1-21
 
   - name: prometheus-manifest-pre-vars
     type: s3-iam

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -645,7 +645,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-aiven-broker.git
-      branch: main
+      branch: 187200424-update-to-go-1-21
       tag_filter: ((deploy_env_tag_prefix))
       commit_verification_keys: ((gpg_public_keys))
 
@@ -653,7 +653,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-billing.git
-      branch: main
+      branch: 187200424-update-to-go-1-21
       tag_filter: ((deploy_env_tag_prefix))
       commit_verification_keys: ((gpg_public_keys))
 
@@ -661,14 +661,14 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-accounts.git
-      branch: main
+      branch: 187200424-update-to-go-1-21
       tag_filter: v0.25.0
 
   - name: paas-auditor
     type: git
     source:
       uri: https://github.com/alphagov/paas-auditor.git
-      branch: main
+      branch: 187200424-update-to-go-1-21
       tag_filter: v0.75.0
 
   - name: paas-admin

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -3285,7 +3285,7 @@ jobs:
                         - logit-syslog-drain
                       env:
                         GO_INSTALL_PACKAGE_SPEC: github.com/nerdswords/yet-another-cloudwatch-exporter/cmd/yace
-                        GOVERSION: go1.20
+                        GOVERSION: go1.21
                   EOF
 
                   cat << EOF > manifest.yml

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -317,6 +317,7 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-cf.git
       branch: ((branch_name))
+      tag_filter: ((paas_cf_tag_filter))
       commit_verification_keys: ((gpg_public_keys))
 
   - name: vpc-tfstate
@@ -644,27 +645,31 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-aiven-broker.git
-      branch: 187200424-update-to-go-1-21
+      branch: main
+      tag_filter: ((deploy_env_tag_prefix))
       commit_verification_keys: ((gpg_public_keys))
 
   - name: paas-billing
     type: git
     source:
       uri: https://github.com/alphagov/paas-billing.git
-      branch: 187200424-update-to-go-1-21
+      branch: main
+      tag_filter: ((deploy_env_tag_prefix))
       commit_verification_keys: ((gpg_public_keys))
 
   - name: paas-accounts
     type: git
     source:
       uri: https://github.com/alphagov/paas-accounts.git
-      branch: 187200424-update-to-go-1-21
+      branch: main
+      tag_filter: v0.25.0
 
   - name: paas-auditor
     type: git
     source:
       uri: https://github.com/alphagov/paas-auditor.git
-      branch: 187200424-update-to-go-1-21
+      branch: main
+      tag_filter: v0.75.0
 
   - name: paas-admin
     type: git
@@ -678,7 +683,8 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-prometheus-endpoints.git
-      branch: 187200424-update-to-go-1-21
+      branch: main
+      tag_filter: v0.19.0
 
   - name: prometheus-manifest-pre-vars
     type: s3-iam

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-cf
 
-go 1.20
+go 1.21
 
 require (
 	github.com/ProtonMail/gopenpgp/v2 v2.5.2

--- a/platform-tests/example-apps/app-autoscaler-cpu-usage/manifest.yml
+++ b/platform-tests/example-apps/app-autoscaler-cpu-usage/manifest.yml
@@ -15,7 +15,7 @@ applications:
     command: "./bin/app-autoscaler-cpu-usage"
 
     env:
-      GOVERSION: go1.20
+      GOVERSION: go1.21
       GOPACKAGENAME: github.com/alphagov/paas-cf/platform-tests/example-apps/app-autoscaler-cpu-usage
 
       DURATION: 11m
@@ -29,7 +29,7 @@ applications:
     no-route: true
 
     env:
-      GOVERSION: go1.20
+      GOVERSION: go1.21
       GOPACKAGENAME: github.com/alphagov/paas-cf/platform-tests/example-apps/app-autoscaler-cpu-usage
 
       DURATION: 13m

--- a/platform-tests/example-apps/healthcheck-pinger/manifest.yml
+++ b/platform-tests/example-apps/healthcheck-pinger/manifest.yml
@@ -8,6 +8,6 @@ applications:
     buildpacks: [go_buildpack]
     stack: cflinuxfs4
     env:
-      GOVERSION: go1.20
+      GOVERSION: go1.21
       GOPACKAGENAME: github.com/alphagov/paas-cf/platform-tests/example-apps/healthcheck-pinger
       UPSTREAM: http://healthcheck-ponger.apps.internal:8080

--- a/platform-tests/example-apps/healthcheck-ponger/manifest.yml
+++ b/platform-tests/example-apps/healthcheck-ponger/manifest.yml
@@ -9,7 +9,7 @@ applications:
     stack: cflinuxfs4
 
     env:
-      GOVERSION: go1.20
+      GOVERSION: go1.21
       GOPACKAGENAME: github.com/alphagov/paas-cf/platform-tests/example-apps/healthcheck-ponger
 
     routes:

--- a/platform-tests/example-apps/healthcheck/go.mod
+++ b/platform-tests/example-apps/healthcheck/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-cf/platform-tests/example-apps/healthcheck
 
-go 1.20
+go 1.21
 
 require (
 	github.com/aws/aws-sdk-go v1.43.37

--- a/platform-tests/example-apps/healthcheck/manifest.yml
+++ b/platform-tests/example-apps/healthcheck/manifest.yml
@@ -8,5 +8,5 @@ applications:
    buildpacks: [go_buildpack]
    stack: cflinuxfs4
    env:
-     GOVERSION: go1.20
+     GOVERSION: go1.21
      GOPACKAGENAME: github.com/alphagov/paas-cf/platform-tests/example-apps/healthcheck

--- a/platform-tests/example-apps/http-tester/go.mod
+++ b/platform-tests/example-apps/http-tester/go.mod
@@ -1,3 +1,3 @@
 module github.com/alphagov/paas-cf/platform-tests/example-apps/http-tester
 
-go 1.20
+go 1.21

--- a/platform-tests/example-apps/http-tester/manifest.yml
+++ b/platform-tests/example-apps/http-tester/manifest.yml
@@ -8,4 +8,4 @@ applications:
     buildpacks: [go_buildpack]
     command: ./bin/http-tester; sleep 1; echo 'done'
     env:
-      GOVERSION: go1.20
+      GOVERSION: go1.21

--- a/platform-tests/example-apps/logging-pipeline/manifest.yml
+++ b/platform-tests/example-apps/logging-pipeline/manifest.yml
@@ -8,5 +8,5 @@ applications:
    buildpacks: [go_buildpack]
    stack: cflinuxfs4
    env:
-     GOVERSION: go1.20
+     GOVERSION: go1.21
      GOPACKAGENAME: github.com/alphagov/paas-cf/platform-tests/example-apps/logging-pipeline

--- a/tools/metrics/go.mod
+++ b/tools/metrics/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-cf/tools/metrics
 
-go 1.20
+go 1.21
 
 require (
 	code.cloudfoundry.org/lager v2.0.0+incompatible

--- a/tools/metrics/manifest.yml
+++ b/tools/metrics/manifest.yml
@@ -7,6 +7,6 @@ applications:
     buildpack: go_buildpack
     stack: cflinuxfs4
     env:
-      GOVERSION: go1.20
+      GOVERSION: go1.21
       GOPACKAGENAME: github.com/alphagov/paas-cf/tools/metrics
     command: ./bin/metrics

--- a/tools/pipecleaner/go.mod
+++ b/tools/pipecleaner/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-cf/tools/pipecleaner
 
-go 1.20
+go 1.21
 
 require (
 	github.com/concourse/concourse v1.6.1-0.20201028190452-248606d42c17

--- a/tools/user_emails/go.mod
+++ b/tools/user_emails/go.mod
@@ -35,4 +35,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.20
+go 1.21


### PR DESCRIPTION
What
----

Update go to 1.21 from 1.20.

Related PRs
----
https://github.com/alphagov/paas-aiven-broker/pull/54
https://github.com/alphagov/paas-billing/pull/196
https://github.com/alphagov/paas-accounts/pull/39
https://github.com/alphagov/paas-auditor/pull/25
https://github.com/alphagov/paas-rubbernecker/pull/99
https://github.com/alphagov/paas-bootstrap/pull/740
https://github.com/alphagov/paas-elasticache-broker/pull/52
https://github.com/alphagov/paas-rds-broker/pull/195
https://github.com/alphagov/paas-cdn-broker/pull/82
https://github.com/alphagov/paas-s3-broker/pull/63
https://github.com/alphagov/paas-sqs-broker/pull/40


How to review
-------------

* Deploy this branch to a dev env and update the branch/tag filters on the other repo resources to point to the go 1.21 branch.
* Ensure that the pipeline runs and the tests succeed.
* Ensure that apps are using go 1.21 by running `cf env <app> | grep GOVERSION`, e.g.
```
❯ cf env paas-prometheus-endpoint-redis | grep GOVERSION
GOVERSION: go1.21
```
---

🚨⚠️ The related PRs need to be merged first before this one, and then the tag filters on this PR will need to be updated ⚠️🚨

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
