### PR TITLE
Remove govuk-notify's isolation segments

### DIFF
--- a/manifests/cf-manifest/isolation-segments/prod/govuk-notify-production.yml
+++ b/manifests/cf-manifest/isolation-segments/prod/govuk-notify-production.yml
@@ -1,4 +1,4 @@
 ---
-number_of_cells: 30
+number_of_cells: 0
 isolation_segment_name: govuk-notify-production
 vm_type: high_cpu_cell

--- a/manifests/cf-manifest/isolation-segments/prod/govuk-notify-staging.yml
+++ b/manifests/cf-manifest/isolation-segments/prod/govuk-notify-staging.yml
@@ -1,4 +1,4 @@
 ---
-number_of_cells: 18
+number_of_cells: 0
 isolation_segment_name: govuk-notify-staging
 vm_type: high_cpu_cell

--- a/manifests/cf-manifest/spec/manifest/isolation_segment_spec.rb
+++ b/manifests/cf-manifest/spec/manifest/isolation_segment_spec.rb
@@ -288,7 +288,7 @@ RSpec.describe "isolation_segments" do
         expect(segs.count).to be >= 1
         seg = segs.select { |s| s["name"] == "diego-cell-iso-seg-govuk-notify-production" }.first
         expect(seg).not_to be_nil
-        expect(seg["instances"]).to be >= 1
+        expect(seg["instances"]).to be >= 0
         expect(seg["jobs"].find { |j| j["name"] == "coredns" }).to be_nil
       end
     end


### PR DESCRIPTION
What
----

Notify has now decommissioned. Time to '0' the isolation segments to save money.

How to review
-------------

Look at the changes.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
