### PR TITLE
Remove notify vpc peers after decommissioning

### DIFF
--- a/terraform/prod.vpc_peering.json
+++ b/terraform/prod.vpc_peering.json
@@ -4,50 +4,5 @@
         "account_id": "430354129336",
         "vpc_id": "vpc-9e62bcf8",
         "subnet_cidr": "10.200.0.0/16"
-    },
-    {
-        "peer_name": "notify-preview",
-        "account_id": "302763885840",
-        "vpc_id": "vpc-041c16b2b4cbb93bd",
-        "subnet_cidr": "10.201.0.0/16",
-        "backing_service_routing": true,
-        "bindings": [
-            {
-                "org_name": "govuk-notify",
-                "spaces": [
-                    "preview"
-                ]
-            }
-        ]
-    },
-    {
-        "peer_name": "notify-staging",
-        "account_id": "608850477283",
-        "vpc_id": "vpc-0d11704be8c6202d5",
-        "subnet_cidr": "10.202.0.0/16",
-        "backing_service_routing": true,
-        "bindings": [
-            {
-                "org_name": "govuk-notify",
-                "spaces": [
-                    "staging"
-                ]
-            }
-        ]
-    },
-    {
-        "peer_name": "notify-production",
-        "account_id": "888450439860",
-        "vpc_id": "vpc-02646a06ea82ddc8a",
-        "subnet_cidr": "10.203.0.0/16",
-        "backing_service_routing": true,
-        "bindings": [
-            {
-                "org_name": "govuk-notify",
-                "spaces": [
-                    "production"
-                ]
-            }
-        ]
     }
 ]


### PR DESCRIPTION
What
----

Remove notify vpc peers 

Why
----

Notify has now been fully migrated to ECS.

How to review
-------------

Look at the changes.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
