### PR TITLE
Update brokers to latest releases which use go 1.21

### DIFF
--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 1.57.0
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-1.57.0.tgz
-    sha1: 76ae3dd70ff4709007bdcde59e861d863b3efb02
+    version: 1.58.0
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-1.58.0.tgz
+    sha1: 040dac3fdb9829bd45c7a4c2caa532d7e9e61fd0
 
 - type: replace
   path: /instance_groups/-

--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 1.58.0
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-1.58.0.tgz
-    sha1: 040dac3fdb9829bd45c7a4c2caa532d7e9e61fd0
+    version: 1.59.0
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-1.59.0.tgz
+    sha1: 47118798e14c97cacaaf3677d4a1e6ec15483d26
 
 - type: replace
   path: /instance_groups/-

--- a/manifests/cf-manifest/operations.d/720-cdn-broker.yml
+++ b/manifests/cf-manifest/operations.d/720-cdn-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: cdn-broker
-    version: 0.1.59
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.59.tgz
-    sha1: 24d94f9cbc56b9fc434a1c53896f2c9853b6e189
+    version: 0.1.60
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.60.tgz
+    sha1: 3f03eb36917c5339164e9db324bb74078cc8a598
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-

--- a/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
+++ b/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
@@ -61,9 +61,9 @@
   path: /releases/-
   value:
     name: elasticache-broker
-    version: 0.1.26
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/elasticache-broker-0.1.26.tgz
-    sha1: e5d2aea0e275fdbe07a62d969063007f7ff009a6
+    version: 0.1.27
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/elasticache-broker-0.1.27.tgz
+    sha1: 7fe32b77f3229f6db86c7cebf91f3587bf102ded
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-

--- a/manifests/cf-manifest/operations.d/750-s3-broker.yml
+++ b/manifests/cf-manifest/operations.d/750-s3-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: s3-broker
-    version: 0.1.25
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/s3-broker-0.1.25.tgz
-    sha1: 3a9f71131b7f37c8b0c74d795e652823c8de13df
+    version: 0.1.26
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/s3-broker-0.1.26.tgz
+    sha1: 1cbb3a22dc0a2e4636b91ec14fe9dd178c6b4fc9
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-

--- a/manifests/cf-manifest/operations.d/760-sqs-broker.yml
+++ b/manifests/cf-manifest/operations.d/760-sqs-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: sqs-broker
-    version: 0.1.19
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/sqs-broker-0.1.19.tgz
-    sha1: 3f77c4ea5bf79d4bc1559c388012baaf0e35ec9a
+    version: 0.1.20
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/sqs-broker-0.1.20.tgz
+    sha1: 2c535865d925b64211571b56fbff30d4b8259f7b
 
 
 - type: replace


### PR DESCRIPTION
What
----

This PR updates the brokers to the latest releases which use go 1.21. We need to do this as go 1.20 is EOL and removed from the latest go buildpack.

This PR also includes v1.59.0 of the RDS broker, which removes MySQL 5.7 usage from integration tests, as this is now only available through RDS extended support, and has been removed from the service catalogue

Related PRs:
---
* https://github.com/alphagov/paas-rds-broker/pull/195
* https://github.com/alphagov/paas-rds-broker/pull/196
* https://github.com/alphagov/paas-elasticache-broker-boshrelease/pull/31
* https://github.com/alphagov/paas-cdn-broker-boshrelease/pull/69
* https://github.com/alphagov/paas-s3-broker-boshrelease/pull/31
* https://github.com/alphagov/paas-sqs-broker-boshrelease/pull/21

How to review
-------------

Confirm that the details for the new broker releases match those emitted by the CI build release jobs

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
