### PR TITLE
Upgrading app-autoscaler to latest release 13.1.0

### DIFF
--- a/manifests/app-autoscaler/operations.d/001-release.yml
+++ b/manifests/app-autoscaler/operations.d/001-release.yml
@@ -12,6 +12,6 @@
   path: /releases/name=app-autoscaler?
   value:
     name: "app-autoscaler"
-    version: "11.4.2"
-    url: "https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=11.4.2"
-    sha1: "e3e3c292122acd8f14b825f24051ad4b7330ffd5"
+    version: "13.1.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=13.1.0"
+    sha1: "e04ffa6b5300e04de00a3fe750f51b798f49fe62"


### PR DESCRIPTION
What
----

There is a new app-autoscaler release 13.1.0 This PR applies this version.

How to review
-------------

Deploy the branch on a dev env:

verify that the new version is applied
see all concourse ci jobs go green

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
