### PR TITLE
app-autoscaler upgrade to latest release 13.2.0

### DIFF
--- a/manifests/app-autoscaler/diffs/patch_dynamic_policy_test.patch
+++ b/manifests/app-autoscaler/diffs/patch_dynamic_policy_test.patch
@@ -2,12 +2,13 @@ diff --git a/src/acceptance/app/dynamic_policy_test.go b/src/acceptance/app/dyna
 index 1339ff514..ff0a2fe47 100644
 --- a/src/acceptance/app/dynamic_policy_test.go
 +++ b/src/acceptance/app/dynamic_policy_test.go
-@@ -50,7 +50,7 @@ var _ = Describe("AutoScaler dynamic policy", func() {
+@@ -52,7 +52,7 @@ var _ = Describe("AutoScaler dynamic policy", func() {
  
- 			It("should scale out and then back in.", Label(acceptance.LabelSmokeTests), func() {
- 				By(fmt.Sprintf("Use heap %d mb of heap on app", heapToUse))
+ 			It("should scale out and then back in.", func() {
+ 				By(fmt.Sprintf("Use heap %d MB of heap on app", heapToUse))
 -				CurlAppInstance(cfg, appName, 0, fmt.Sprintf("/memory/%d/5", heapToUse))
 +				CurlAppInstance(cfg, appName, 0, fmt.Sprintf("/memory/%d/5", heapToUse+20))
- 
+
  				By("wait for scale to 2")
  				WaitForNInstancesRunning(appGUID, 2, 5*time.Minute)
+

--- a/manifests/app-autoscaler/operations.d/001-release.yml
+++ b/manifests/app-autoscaler/operations.d/001-release.yml
@@ -12,6 +12,6 @@
   path: /releases/name=app-autoscaler?
   value:
     name: "app-autoscaler"
-    version: "11.4.2"
-    url: "https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=11.4.2"
-    sha1: "e3e3c292122acd8f14b825f24051ad4b7330ffd5"
+    version: "13.2.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=13.2.0"
+    sha1: "3534cea96ec896a75882138c9154bc2a65d84738"


### PR DESCRIPTION
What
----

There is a new app-autoscaler release 13.2.0 This PR applies this version.

How to review
-------------

Deploy the branch on a dev env:

verify that the new version is applied
see all concourse ci jobs go green

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
