### PR TITLE
upgraded cflinuxfs4-compat to latest version 1.98.0

### DIFF
--- a/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
+++ b/manifests/cf-manifest/operations.d/229-cf-update_cflinuxfs_releases.yml
@@ -11,6 +11,6 @@
   path: /releases/name=cflinuxfs4-compat
   value:
     name: "cflinuxfs4-compat"
-    version: "1.95.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs4-compat-release?v=1.95.0"
-    sha1: "811eeb1b8832159d90997e9c0134f8e6cea0b164"
+    version: "1.98.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs4-compat-release?v=1.98.0"
+    sha1: "629ef237e32189dc3b636d28aed0a85c34579e2f"


### PR DESCRIPTION
What
----

There is a new cflinuxfs4-compat release 1.98.0. This PR applies this version.

How to review
-------------

Deploy the branch on a dev env:

verify that the new version is applied
see all concourse ci jobs go green

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
