### PR TITLE
Updated test_on_pr.yml with new bosh cli version and fixed download url

### DIFF
--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -2,7 +2,7 @@ on: pull_request
 
 env:
   TF_VERSION: "1.5.2"
-  BOSH_CLI_VERSION: "2.0.48"
+  BOSH_CLI_VERSION: "6.1.1"
   PROMETHEUS_VERSION: "2.42.0"
   DEPLOY_ENV: "github"
   SHELLCHECK_VERSION: "0.7.1"
@@ -43,10 +43,10 @@ jobs:
           chmod +x ./terraform
           sudo mv -f ./terraform /usr/local/bin
 
-      - name: Install Bosh CLI v2
+      - name: Install Bosh CLI
         run: |
           set -e
-          wget -q "https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-${BOSH_CLI_VERSION}-linux-amd64"
+          wget -q "https://github.com/cloudfoundry/bosh-cli/releases/download/v${BOSH_CLI_VERSION}/bosh-cli-${BOSH_CLI_VERSION}-linux-amd64"
           sudo mv "bosh-cli-${BOSH_CLI_VERSION}-linux-amd64" /usr/local/bin/bosh && sudo chmod +x /usr/local/bin/bosh
           set +e
 


### PR DESCRIPTION
What
----
- Changed to use v6.1.1 of the BOSH CLI which is used in paas-bootstrap
- Fixed the download URL and now uses GitHub releases link

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
