### PR TITLE
187651125 promotheus bosh release upgrade

### DIFF
--- a/manifests/cf-manifest/operations.d/500-prometheus.yml
+++ b/manifests/cf-manifest/operations.d/500-prometheus.yml
@@ -4,7 +4,7 @@
     name: "prometheus"
     version: "30.4.0"
     url: "https://github.com/cloudfoundry/prometheus-boshrelease/releases/download/v30.4.0/prometheus-30.4.0.tgz"
-    sha1: "8bf23e5fc727003ca0a37ad8ecdafc63937fc92a9a6374e0360fe56e0dd39649"
+    sha1: "c06ed70a72153575dabdc1ff67b785cc06bb3225"
 
 - type: replace
   path: /releases/-

--- a/manifests/cf-manifest/operations.d/500-prometheus.yml
+++ b/manifests/cf-manifest/operations.d/500-prometheus.yml
@@ -2,9 +2,9 @@
   path: /releases/-
   value:
     name: "prometheus"
-    version: "29.6.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=29.6.0"
-    sha1: "16b8f917f7b0966e492f40618b94e0a1f00a5634"
+    version: "30.4.0"
+    url: "https://github.com/cloudfoundry/prometheus-boshrelease/releases/download/v30.4.0/prometheus-30.4.0.tgz"
+    sha1: "8bf23e5fc727003ca0a37ad8ecdafc63937fc92a9a6374e0360fe56e0dd39649"
 
 - type: replace
   path: /releases/-

--- a/manifests/runtime-config/operations.d/510-add-prometheus-blackbox-exporter.yml
+++ b/manifests/runtime-config/operations.d/510-add-prometheus-blackbox-exporter.yml
@@ -3,10 +3,9 @@
   path: /releases/-
   value:
     name: "prometheus"
-    version: "29.6.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=29.6.0"
-    sha1: "16b8f917f7b0966e492f40618b94e0a1f00a5634"
-
+    version: "30.4.0"
+    url: "https://github.com/cloudfoundry/prometheus-boshrelease/releases/download/v30.4.0/prometheus-30.4.0.tgz"
+    sha1: "c06ed70a72153575dabdc1ff67b785cc06bb3225"
 - type: replace
   path: /addons?/-
   value:

--- a/manifests/runtime-config/operations.d/510-add-prometheus-blackbox-exporter.yml
+++ b/manifests/runtime-config/operations.d/510-add-prometheus-blackbox-exporter.yml
@@ -6,6 +6,7 @@
     version: "30.4.0"
     url: "https://github.com/cloudfoundry/prometheus-boshrelease/releases/download/v30.4.0/prometheus-30.4.0.tgz"
     sha1: "c06ed70a72153575dabdc1ff67b785cc06bb3225"
+
 - type: replace
   path: /addons?/-
   value:


### PR DESCRIPTION
What
----

Update prometheus boshrelase from 29.6.0 to 30.4.0. Note that newer prometheus boshrelease packages are now hosted on github releases and not `bosh.io`.

This has been deployed to dev03 successfully. Job details: https://deployer.dev03.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/cf-deploy/builds/113

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
