### PR TITLE
Add image tag to concourse-keyval-resource in startup/shutdown pipelines

### DIFF
--- a/concourse/pipelines/fast-startup-and-shutdown-cf-env.yml
+++ b/concourse/pipelines/fast-startup-and-shutdown-cf-env.yml
@@ -25,6 +25,7 @@ resource_types:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/concourse-keyval-resource
+    tag: 272908a4012b68c01301d9af9270d3fdf2b1d978
 
 groups:
   - name: fast-startup-cf-env


### PR DESCRIPTION
dev03 was failing to fetch the image without this tag, but works with it

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
