### PR TITLE
Use boshrelease of cdn broker using brokerapi v10

### DIFF
--- a/manifests/cf-manifest/operations.d/720-cdn-broker.yml
+++ b/manifests/cf-manifest/operations.d/720-cdn-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: cdn-broker
-    version: 0.1.60
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.60.tgz
-    sha1: 3f03eb36917c5339164e9db324bb74078cc8a598
+    version: 0.1.61
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.61.tgz
+    sha1: 3ecd3afd760607277dcea4eaf05abc05f54c9589
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-


### PR DESCRIPTION
What
----

This uses the boshrelease of the cdn broker using the newer brokerapi (v10)

Related PRs: 
* https://github.com/alphagov/paas-cdn-broker/pull/84
* https://github.com/alphagov/paas-cdn-broker-boshrelease/pull/77

Build job to make the boshrelease tarball: https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/cdn-broker-release/jobs/build-dev-release/builds/114

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
