### PR TITLE
Specify URL and version for cloudfoundry postgres release for app-autoscaler.

### DIFF
--- a/manifests/app-autoscaler/operations.d/060-add-postgres-release.yml
+++ b/manifests/app-autoscaler/operations.d/060-add-postgres-release.yml
@@ -1,0 +1,8 @@
+---
+ - type: replace
+   path: /releases/name=postgres
+   value:
+     name: "postgres"
+     version: "44"
+     url: "https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=44"
+     sha1: "582b1de9522077102dfa44ff7164cd8f499dbfc8"


### PR DESCRIPTION
What
----

We need to specify a URL for the postgres release in order to deploy app-autoscaler

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
