### PR TITLE
Upgrade Go version to 1.22

### DIFF
--- a/.github/workflows/generate_buildpack_bump_pr.yml
+++ b/.github/workflows/generate_buildpack_bump_pr.yml
@@ -4,7 +4,7 @@ on:
     - cron: "0 9 1 * *"
 
 env:
-  GO_VERSION: "1.21"
+  GO_VERSION: "1.23"
   GIT_AUTHOR_NAME: github-actions
   GIT_AUTHOR_EMAIL: github-actions@github.com
   GITHUB_UNPRIV_USERNAME: ${{ secrets.GOVUK_PAAS_UNPRIVILEGED_BOT_USERNAME }}

--- a/.github/workflows/generate_buildpack_bump_pr.yml
+++ b/.github/workflows/generate_buildpack_bump_pr.yml
@@ -4,7 +4,7 @@ on:
     - cron: "0 9 1 * *"
 
 env:
-  GO_VERSION: "1.23"
+  GO_VERSION: "1.22"
   GIT_AUTHOR_NAME: github-actions
   GIT_AUTHOR_EMAIL: github-actions@github.com
   GITHUB_UNPRIV_USERNAME: ${{ secrets.GOVUK_PAAS_UNPRIVILEGED_BOT_USERNAME }}

--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -6,7 +6,7 @@ env:
   PROMETHEUS_VERSION: "2.42.0"
   DEPLOY_ENV: "github"
   SHELLCHECK_VERSION: "0.7.1"
-  GO_VERSION: "1.23"
+  GO_VERSION: "1.22"
   RUBY_VERSION: "3.1.0"
 
 jobs:

--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -6,7 +6,7 @@ env:
   PROMETHEUS_VERSION: "2.42.0"
   DEPLOY_ENV: "github"
   SHELLCHECK_VERSION: "0.7.1"
-  GO_VERSION: "1.21"
+  GO_VERSION: "1.23"
   RUBY_VERSION: "3.1.0"
 
 jobs:

--- a/common-go/basic_logit_client/go.mod
+++ b/common-go/basic_logit_client/go.mod
@@ -1,5 +1,5 @@
 module github.com/alphagov/paas-cf/common-go/basic_logit_client
 
-go 1.21
+go 1.23
 
 require code.cloudfoundry.org/lager v2.0.0+incompatible // indirect

--- a/common-go/basic_logit_client/go.mod
+++ b/common-go/basic_logit_client/go.mod
@@ -1,5 +1,5 @@
 module github.com/alphagov/paas-cf/common-go/basic_logit_client
 
-go 1.23
+go 1.22
 
 require code.cloudfoundry.org/lager v2.0.0+incompatible // indirect

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -3263,7 +3263,7 @@ jobs:
                         - logit-syslog-drain
                       env:
                         GO_INSTALL_PACKAGE_SPEC: github.com/nerdswords/yet-another-cloudwatch-exporter/cmd/yace
-                        GOVERSION: go1.23
+                        GOVERSION: go1.22
                   EOF
 
                   cat << EOF > manifest.yml

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -640,14 +640,14 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-accounts.git
       branch: main
-      tag_filter: v0.34.0
+      tag_filter: v0.37.0
 
   - name: paas-auditor
     type: git
     source:
       uri: https://github.com/alphagov/paas-auditor.git
       branch: main
-      tag_filter: v0.76.0
+      tag_filter: v0.77.0
 
   - name: paas-admin
     type: git
@@ -662,7 +662,7 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-prometheus-endpoints.git
       branch: main
-      tag_filter: v0.20.0
+      tag_filter: v0.21.0
 
   - name: prometheus-manifest-pre-vars
     type: s3-iam

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -684,8 +684,8 @@ resources:
       uri: https://github.com/nerdswords/yet-another-cloudwatch-exporter.git
       fetch_tags: true
     version:
-      # v0.53.0
-      ref: 2fd8cd322931aeb5a39c457ede31022e67f479b9
+      # v0.61.2
+      ref: 43c09fe4ed3e93449121765462433ed924d679a2
 
   - name: pingdom-exporter
     type: git

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -3271,7 +3271,7 @@ jobs:
                   applications:
                     - name: cloudwatch-exporter
                       memory: 128M
-                      disk_quota: 100M
+                      disk_quota: 256M
                       instances: 1
                       health-check-type: http
                       health-check-http-endpoint: /

--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -3263,7 +3263,7 @@ jobs:
                         - logit-syslog-drain
                       env:
                         GO_INSTALL_PACKAGE_SPEC: github.com/nerdswords/yet-another-cloudwatch-exporter/cmd/yace
-                        GOVERSION: go1.21
+                        GOVERSION: go1.23
                   EOF
 
                   cat << EOF > manifest.yml

--- a/config/cloudwatch-exporter/config.yml
+++ b/config/cloudwatch-exporter/config.yml
@@ -2,12 +2,12 @@
 apiVersion: v1alpha1
 discovery:
   exportedTagsOnMetrics:
-    ec2:
+    AWS/EC2:
       - Name
-    rds:
+    AWS/RDS:
       - Name
   jobs:
-    - type: "ec2"
+    - type: "AWS/EC2"
       regions:
         - (( grab $AWS_REGION ))
       searchTags:
@@ -20,7 +20,7 @@ discovery:
           period: 60
           length: 600
       addCloudwatchTimestamp: true
-    - type: "rds"
+    - type: "AWS/RDS"
       regions:
         - (( grab $AWS_REGION ))
       searchTags:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-cf
 
-go 1.23
+go 1.22
 
 require (
 	github.com/ProtonMail/gopenpgp/v2 v2.5.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-cf
 
-go 1.21
+go 1.23
 
 require (
 	github.com/ProtonMail/gopenpgp/v2 v2.5.2

--- a/manifests/cf-manifest/operations.d/710-rds-broker.yml
+++ b/manifests/cf-manifest/operations.d/710-rds-broker.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: rds-broker
-    version: 1.61.0
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-1.61.0.tgz
-    sha1: 9fbe47bcbdb35c788db4513c6e829a969161264b
+    version: 1.62.0
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/rds-broker-1.62.0.tgz
+    sha1: 488a1f2005a82dc862c66d095d563278efb6847a
 
 - type: replace
   path: /instance_groups/-

--- a/manifests/cf-manifest/operations.d/720-cdn-broker.yml
+++ b/manifests/cf-manifest/operations.d/720-cdn-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: cdn-broker
-    version: 0.1.61
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.61.tgz
-    sha1: 3ecd3afd760607277dcea4eaf05abc05f54c9589
+    version: 0.1.62
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/cdn-broker-0.1.62.tgz
+    sha1: b6dc0380cbc7d0878a491d6b49c24c8a80c9d705
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-

--- a/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
+++ b/manifests/cf-manifest/operations.d/730-elasticache-broker.yml
@@ -61,9 +61,9 @@
   path: /releases/-
   value:
     name: elasticache-broker
-    version: 0.1.28
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/elasticache-broker-0.1.28.tgz
-    sha1: 556c5eabf5044db3fc0548e160a51519daeebdcc
+    version: 0.1.29
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/elasticache-broker-0.1.29.tgz
+    sha1: 40d0916b78de057937e1136ef2091d648fb2cde3
 
 - type: replace
   path: /addons/name=loggregator_agent/exclude/jobs/-

--- a/manifests/cf-manifest/operations.d/760-sqs-broker.yml
+++ b/manifests/cf-manifest/operations.d/760-sqs-broker.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: sqs-broker
-    version: 0.1.20
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/sqs-broker-0.1.20.tgz
-    sha1: 2c535865d925b64211571b56fbff30d4b8259f7b
+    version: 0.1.21
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/sqs-broker-0.1.21.tgz
+    sha1: 533cfb82d0f6c481474f90a835773cca605ca75e
 
 
 - type: replace

--- a/platform-tests/example-apps/app-autoscaler-cpu-usage/manifest.yml
+++ b/platform-tests/example-apps/app-autoscaler-cpu-usage/manifest.yml
@@ -15,7 +15,7 @@ applications:
     command: "./bin/app-autoscaler-cpu-usage"
 
     env:
-      GOVERSION: go1.23
+      GOVERSION: go1.22
       GOPACKAGENAME: github.com/alphagov/paas-cf/platform-tests/example-apps/app-autoscaler-cpu-usage
 
       DURATION: 11m
@@ -29,7 +29,7 @@ applications:
     no-route: true
 
     env:
-      GOVERSION: go1.23
+      GOVERSION: go1.22
       GOPACKAGENAME: github.com/alphagov/paas-cf/platform-tests/example-apps/app-autoscaler-cpu-usage
 
       DURATION: 13m

--- a/platform-tests/example-apps/app-autoscaler-cpu-usage/manifest.yml
+++ b/platform-tests/example-apps/app-autoscaler-cpu-usage/manifest.yml
@@ -29,7 +29,7 @@ applications:
     no-route: true
 
     env:
-      GOVERSION: go1.21
+      GOVERSION: go1.23
       GOPACKAGENAME: github.com/alphagov/paas-cf/platform-tests/example-apps/app-autoscaler-cpu-usage
 
       DURATION: 13m

--- a/platform-tests/example-apps/app-autoscaler-cpu-usage/manifest.yml
+++ b/platform-tests/example-apps/app-autoscaler-cpu-usage/manifest.yml
@@ -15,7 +15,7 @@ applications:
     command: "./bin/app-autoscaler-cpu-usage"
 
     env:
-      GOVERSION: go1.21
+      GOVERSION: go1.23
       GOPACKAGENAME: github.com/alphagov/paas-cf/platform-tests/example-apps/app-autoscaler-cpu-usage
 
       DURATION: 11m

--- a/platform-tests/example-apps/healthcheck-pinger/manifest.yml
+++ b/platform-tests/example-apps/healthcheck-pinger/manifest.yml
@@ -8,6 +8,6 @@ applications:
     buildpacks: [go_buildpack]
     stack: cflinuxfs4
     env:
-      GOVERSION: go1.21
+      GOVERSION: go1.23
       GOPACKAGENAME: github.com/alphagov/paas-cf/platform-tests/example-apps/healthcheck-pinger
       UPSTREAM: http://healthcheck-ponger.apps.internal:8080

--- a/platform-tests/example-apps/healthcheck-pinger/manifest.yml
+++ b/platform-tests/example-apps/healthcheck-pinger/manifest.yml
@@ -8,6 +8,6 @@ applications:
     buildpacks: [go_buildpack]
     stack: cflinuxfs4
     env:
-      GOVERSION: go1.23
+      GOVERSION: go1.22
       GOPACKAGENAME: github.com/alphagov/paas-cf/platform-tests/example-apps/healthcheck-pinger
       UPSTREAM: http://healthcheck-ponger.apps.internal:8080

--- a/platform-tests/example-apps/healthcheck-ponger/manifest.yml
+++ b/platform-tests/example-apps/healthcheck-ponger/manifest.yml
@@ -9,7 +9,7 @@ applications:
     stack: cflinuxfs4
 
     env:
-      GOVERSION: go1.21
+      GOVERSION: go1.23
       GOPACKAGENAME: github.com/alphagov/paas-cf/platform-tests/example-apps/healthcheck-ponger
 
     routes:

--- a/platform-tests/example-apps/healthcheck-ponger/manifest.yml
+++ b/platform-tests/example-apps/healthcheck-ponger/manifest.yml
@@ -9,7 +9,7 @@ applications:
     stack: cflinuxfs4
 
     env:
-      GOVERSION: go1.23
+      GOVERSION: go1.22
       GOPACKAGENAME: github.com/alphagov/paas-cf/platform-tests/example-apps/healthcheck-ponger
 
     routes:

--- a/platform-tests/example-apps/healthcheck/go.mod
+++ b/platform-tests/example-apps/healthcheck/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-cf/platform-tests/example-apps/healthcheck
 
-go 1.21
+go 1.23
 
 require (
 	github.com/aws/aws-sdk-go v1.43.37

--- a/platform-tests/example-apps/healthcheck/go.mod
+++ b/platform-tests/example-apps/healthcheck/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-cf/platform-tests/example-apps/healthcheck
 
-go 1.23
+go 1.22
 
 require (
 	github.com/aws/aws-sdk-go v1.43.37

--- a/platform-tests/example-apps/healthcheck/manifest.yml
+++ b/platform-tests/example-apps/healthcheck/manifest.yml
@@ -8,5 +8,5 @@ applications:
    buildpacks: [go_buildpack]
    stack: cflinuxfs4
    env:
-     GOVERSION: go1.21
+     GOVERSION: go1.23
      GOPACKAGENAME: github.com/alphagov/paas-cf/platform-tests/example-apps/healthcheck

--- a/platform-tests/example-apps/healthcheck/manifest.yml
+++ b/platform-tests/example-apps/healthcheck/manifest.yml
@@ -8,5 +8,5 @@ applications:
    buildpacks: [go_buildpack]
    stack: cflinuxfs4
    env:
-     GOVERSION: go1.23
+     GOVERSION: go1.22
      GOPACKAGENAME: github.com/alphagov/paas-cf/platform-tests/example-apps/healthcheck

--- a/platform-tests/example-apps/http-tester/go.mod
+++ b/platform-tests/example-apps/http-tester/go.mod
@@ -1,3 +1,3 @@
 module github.com/alphagov/paas-cf/platform-tests/example-apps/http-tester
 
-go 1.23
+go 1.22

--- a/platform-tests/example-apps/http-tester/go.mod
+++ b/platform-tests/example-apps/http-tester/go.mod
@@ -1,3 +1,3 @@
 module github.com/alphagov/paas-cf/platform-tests/example-apps/http-tester
 
-go 1.21
+go 1.23

--- a/platform-tests/example-apps/http-tester/manifest.yml
+++ b/platform-tests/example-apps/http-tester/manifest.yml
@@ -8,4 +8,4 @@ applications:
     buildpacks: [go_buildpack]
     command: ./bin/http-tester; sleep 1; echo 'done'
     env:
-      GOVERSION: go1.23
+      GOVERSION: go1.22

--- a/platform-tests/example-apps/http-tester/manifest.yml
+++ b/platform-tests/example-apps/http-tester/manifest.yml
@@ -8,4 +8,4 @@ applications:
     buildpacks: [go_buildpack]
     command: ./bin/http-tester; sleep 1; echo 'done'
     env:
-      GOVERSION: go1.21
+      GOVERSION: go1.23

--- a/platform-tests/example-apps/logging-pipeline/manifest.yml
+++ b/platform-tests/example-apps/logging-pipeline/manifest.yml
@@ -8,5 +8,5 @@ applications:
    buildpacks: [go_buildpack]
    stack: cflinuxfs4
    env:
-     GOVERSION: go1.21
+     GOVERSION: go1.23
      GOPACKAGENAME: github.com/alphagov/paas-cf/platform-tests/example-apps/logging-pipeline

--- a/platform-tests/example-apps/logging-pipeline/manifest.yml
+++ b/platform-tests/example-apps/logging-pipeline/manifest.yml
@@ -8,5 +8,5 @@ applications:
    buildpacks: [go_buildpack]
    stack: cflinuxfs4
    env:
-     GOVERSION: go1.23
+     GOVERSION: go1.22
      GOPACKAGENAME: github.com/alphagov/paas-cf/platform-tests/example-apps/logging-pipeline

--- a/tools/metrics/go.mod
+++ b/tools/metrics/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-cf/tools/metrics
 
-go 1.23
+go 1.22
 
 require (
 	code.cloudfoundry.org/lager v2.0.0+incompatible

--- a/tools/metrics/go.mod
+++ b/tools/metrics/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-cf/tools/metrics
 
-go 1.21
+go 1.23
 
 require (
 	code.cloudfoundry.org/lager v2.0.0+incompatible

--- a/tools/metrics/manifest.yml
+++ b/tools/metrics/manifest.yml
@@ -7,6 +7,6 @@ applications:
     buildpack: go_buildpack
     stack: cflinuxfs4
     env:
-      GOVERSION: go1.21
+      GOVERSION: go1.23
       GOPACKAGENAME: github.com/alphagov/paas-cf/tools/metrics
     command: ./bin/metrics

--- a/tools/metrics/manifest.yml
+++ b/tools/metrics/manifest.yml
@@ -7,6 +7,6 @@ applications:
     buildpack: go_buildpack
     stack: cflinuxfs4
     env:
-      GOVERSION: go1.23
+      GOVERSION: go1.22
       GOPACKAGENAME: github.com/alphagov/paas-cf/tools/metrics
     command: ./bin/metrics

--- a/tools/pipecleaner/go.mod
+++ b/tools/pipecleaner/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-cf/tools/pipecleaner
 
-go 1.23
+go 1.22
 
 require (
 	github.com/concourse/concourse v1.6.1-0.20201028190452-248606d42c17

--- a/tools/pipecleaner/go.mod
+++ b/tools/pipecleaner/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-cf/tools/pipecleaner
 
-go 1.21
+go 1.23
 
 require (
 	github.com/concourse/concourse v1.6.1-0.20201028190452-248606d42c17

--- a/tools/user_emails/go.mod
+++ b/tools/user_emails/go.mod
@@ -35,4 +35,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.23
+go 1.22

--- a/tools/user_emails/go.mod
+++ b/tools/user_emails/go.mod
@@ -35,4 +35,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.21
+go 1.23


### PR DESCRIPTION
What
----
Update go from 1.21 to 1.22

> Initially intended to upgrade go to 1.23, but reverted to 1.22 due to current buildpack compatibility. Buildpack doesn't yet support 1.23.

Related PRs
----

https://github.com/alphagov/paas-cf/pull/3975 
https://github.com/alphagov/paas-bootstrap/pull/900 
https://github.com/alphagov/paas-prometheus-endpoints/pull/17 
https://github.com/alphagov/paas-auditor/pull/28 
https://github.com/alphagov/paas-accounts/pull/49 
https://github.com/alphagov/paas-elasticache-broker-boshrelease/pull/40 
https://github.com/alphagov/paas-cdn-broker-boshrelease/pull/78
https://github.com/alphagov/paas-s3-broker-boshrelease/commit/ae18cbe3f5cca94a498bcd9ea01c7d52b39d5b6c  
https://github.com/alphagov/paas-sqs-broker-boshrelease/pull/29  

How to review
-------------

* Deploy this branch to a dev env and update the branch/tag filters on the other repo resources to point to the go 1.22 branch.
* Ensure that the pipeline runs and the tests succeed.
* Ensure that apps are using go 1.22 by running `cf env <app> | grep GOVERSION`, e.g.
```
❯ cf env paas-prometheus-endpoint-redis | grep GOVERSION
GOVERSION: go1.22
```
---

🚨⚠️ The related PRs need to be merged first before this one, and then the tag filters on this PR will need to be updated ⚠️🚨

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
