### PR TITLE
Add go buildpack for cflinuxfs4 back to rolling buildpacks

### DIFF
--- a/config/buildpacks.rolling.yml
+++ b/config/buildpacks.rolling.yml
@@ -640,6 +640,62 @@ buildpacks:
       version: "80"
       cf_stacks:
         - cflinuxfs4
+- name: go_buildpack
+  repo_name: go-buildpack
+  stack: cflinuxfs4
+  version: v1.10.16
+  sha: 0648b5a2f291e8b9a9a34de8166cbc5f74110ee8bb6ca892bb58a1bc26d9652a
+  filename: go-buildpack-cflinuxfs4-v1.10.16.zip
+  url: https://github.com/cloudfoundry/go-buildpack/releases/download/v1.10.16/go-buildpack-cflinuxfs4-v1.10.16.zip
+  dependencies:
+  - name: dep
+    version: 0.5.4
+    cf_stacks:
+    - cflinuxfs3
+  - name: dep
+    version: 0.5.4
+    cf_stacks:
+    - cflinuxfs4
+  - name: glide
+    version: 0.13.3
+    cf_stacks:
+    - cflinuxfs3
+  - name: glide
+    version: 0.13.3
+    cf_stacks:
+    - cflinuxfs4
+  - name: go
+    version: 1.20.14
+    cf_stacks:
+    - cflinuxfs3
+  - name: go
+    version: 1.20.14
+    cf_stacks:
+    - cflinuxfs4
+  - name: go
+    version: 1.21.7
+    cf_stacks:
+    - cflinuxfs3
+  - name: go
+    version: 1.21.7
+    cf_stacks:
+    - cflinuxfs4
+  - name: go
+    version: 1.22.0
+    cf_stacks:
+    - cflinuxfs3
+  - name: go
+    version: 1.22.0
+    cf_stacks:
+    - cflinuxfs4
+  - name: godep
+    version: "80"
+    cf_stacks:
+    - cflinuxfs3
+  - name: godep
+    version: "80"
+    cf_stacks:
+    - cflinuxfs4
 - name: java_buildpack
   repo_name: java-buildpack
   stack: cflinuxfs4


### PR DESCRIPTION
This was missing from https://github.com/alphagov/paas-cf/pull/3953/files#diff-e02231d36fc76404aceec38b69132c6a89f38442c69ad4424aa3de29f9a62ad9

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
